### PR TITLE
Fix topdoc link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The Spectrum CSS project can build both a 'multi-stop' and 'single-stop' version
 
 Spectrum CSS organizes the CSS source files in the `src` folder.   Each Spectrum element has it's own folder.  That folder contains an `index.css` file for the basic structual CSS for all variants of an element.  There is also a `skin.css` file to hold the values that change when the colorstop of the element is specified.
 
-The CSS source files also contain [Topdoc][https://github.com/Topdoc/topdoc] comments with a placeholder for documentation values that are injected at build time.  The source of those injected values is found in the YAML formatted files in the `docs` folder.  A key part of the docs data is the `markup` node, which contains the HTML elements needed to apply the corresponding element selectors and render the elements as generated Topdoc output.
+The CSS source files also contain [Topdoc](https://github.com/Topdoc/topdoc) comments with a placeholder for documentation values that are injected at build time.  The source of those injected values is found in the YAML formatted files in the `docs` folder.  A key part of the docs data is the `markup` node, which contains the HTML elements needed to apply the corresponding element selectors and render the elements as generated Topdoc output.
 
 A successful build will create a `dist` folder.  The `dist/docs` folder is where the Topdoc output and related template files will end up.
 


### PR DESCRIPTION
First pull request on the public repo woo!

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix a broken link in the README.

## Related Issue
None

## Motivation and Context
The text wasn't rendered as a link.

## How Has This Been Tested?
I looked at the rendered README on Github.

## Screenshots (if appropriate):
None.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
