### PR TITLE
updated name to @adobe/spectrum-css

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@spectrum/spectrum-css",
+  "name": "@adobe/spectrum-css",
   "version": "2.6.0",
   "scripts": {
     "build": "gulp",


### PR DESCRIPTION
Preparing to release version 2.6.0 on npm. I've updated the name in `package.json` to `@adobe/spectrum-css`. 

## Related Issue
https://github.com/adobe/spectrum-css/issues/21

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We need to release this publicly to npm. The `spectrum-css` namespace is already taken. We own the [NPM Adobe org](https://npmjs.com/org/adobe). Makes sense to scope this under adobe and release it there. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Confirmed it still builds

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
