### PR TITLE
Fix stray & in build output due to assumptions about nesting

### DIFF
--- a/src/typography/index.css
+++ b/src/typography/index.css
@@ -154,6 +154,8 @@
 /* topdoc
 {{ typography/typography-code.yml }}
 */
+&.spectrum,
+&.spectrum-Body,
 .spectrum,
 .spectrum-Body {
   font-size: var(--spectrum-body-4-text-size);

--- a/tasks/build-css.js
+++ b/tasks/build-css.js
@@ -89,6 +89,7 @@ var processors = [
     noValueNotifications: 'error'
   }),
   require('./lib/postcss-custom-properties-passthrough')(),
+  require('./lib/postcss-notnested')(),
   require('postcss-calc'),
   require('postcss-svg'),
   require('postcss-functions')({
@@ -318,7 +319,7 @@ gulp.task('build-css:concat-standalone-md', function() {
     ])
       // .pipe(concat('spectrum-' + colorStop + '-md.css'))
       .pipe(concat('spectrum-' + colorStop + '.css'))
-      // Replace instances of & that refer to the colorstop selector with .secptrum
+      // Replace instances of & that refer to the colorstop selector with .spectrum
       .pipe(replace(/^&/gm, '.spectrum'))
       .pipe(gulp.dest('dist/standalone'));
   }
@@ -333,7 +334,7 @@ gulp.task('build-css:concat-standalone-lg', function() {
       'dist/spectrum-' + colorStop + '.css'
     ])
       .pipe(concat('spectrum-' + colorStop + '-lg.css'))
-      // Replace instances of & that refer to the colorstop selector with .secptrum
+      // Replace instances of & that refer to the colorstop selector with .spectrum
       .pipe(replace(/^&/gm, '.spectrum'))
       .pipe(gulp.dest('dist/standalone'));
   }

--- a/tasks/build-css.js
+++ b/tasks/build-css.js
@@ -7,6 +7,7 @@ var insert = require('gulp-insert');
 var concat = require('gulp-concat');
 var merge = require('merge-stream');
 var plumb = require('./lib/plumb.js');
+var notnested = require('./lib/postcss-notnested');
 
 var colorStops = [
   'darkest',
@@ -89,7 +90,6 @@ var processors = [
     noValueNotifications: 'error'
   }),
   require('./lib/postcss-custom-properties-passthrough')(),
-  require('./lib/postcss-notnested')(),
   require('postcss-calc'),
   require('postcss-svg'),
   require('postcss-functions')({
@@ -122,7 +122,7 @@ gulp.task('build-css:individual-components-md', function() {
     .pipe(plumb())
     .pipe(insert.prepend('@import "../../vars/spectrum-medium.css";'))
     .pipe(insert.prepend('@import "../../vars/spectrum-global.css";\n'))
-    .pipe(postcss(processors))
+    .pipe(postcss(processors.concat([notnested()])))
     // .pipe(rename(function(path) {
     //   path.basename += '-md';
     // }))
@@ -137,7 +137,7 @@ gulp.task('build-css:individual-components-lg', function() {
     .pipe(plumb())
     .pipe(insert.prepend('@import "../../vars/spectrum-large.css";'))
     .pipe(insert.prepend('@import "../../vars/spectrum-global.css";\n'))
-    .pipe(postcss(processors))
+    .pipe(postcss(processors.concat([notnested()])))
     .pipe(rename(function(path) {
       path.basename += '-lg';
     }))
@@ -211,8 +211,8 @@ function buildSkinFiles(colorStop, globs, prependString, appendString, dest) {
     .pipe(insert.prepend(`@import '../colorStops/spectrum-${colorStop}.css';${prependString}`))
     .pipe(insert.prepend('@import "../../dist/vars/spectrum-global.css";\n'))
     .pipe(insert.append(appendString))
-    .pipe(postcss(processors))
-    .pipe(replace(/^&/gm, '.spectrum')) // Any stray & in colorstops should just apply to .spectrum
+    // Any stray & in colorstops should just apply to .spectrum
+    .pipe(postcss(processors.concat([notnested({ replace: '.spectrum' })])))
     .pipe(rename(function(path) {
       path.dirname += '/colorStops';
       path.basename = colorStop;
@@ -267,7 +267,7 @@ gulp.task('build-css:core-md-multistops', function() {
     .pipe(plumb())
     .pipe(insert.prepend('@import "../vars/spectrum-medium.css";'))
     .pipe(insert.prepend('@import "../vars/spectrum-global.css";\n'))
-    .pipe(postcss(processors))
+    .pipe(postcss(processors.concat([notnested()])))
     // .pipe(rename(function(path) {
     //   path.basename += '-md';
     // }))
@@ -282,7 +282,7 @@ gulp.task('build-css:core-lg-multistops', function() {
     .pipe(plumb())
     .pipe(insert.prepend('@import "../vars/spectrum-large.css";'))
     .pipe(insert.prepend('@import "../vars/spectrum-global.css";\n'))
-    .pipe(postcss(processors))
+    .pipe(postcss(processors.concat([notnested()])))
     .pipe(rename(function(path) {
       path.basename += '-lg';
     }))
@@ -319,8 +319,6 @@ gulp.task('build-css:concat-standalone-md', function() {
     ])
       // .pipe(concat('spectrum-' + colorStop + '-md.css'))
       .pipe(concat('spectrum-' + colorStop + '.css'))
-      // Replace instances of & that refer to the colorstop selector with .spectrum
-      .pipe(replace(/^&/gm, '.spectrum'))
       .pipe(gulp.dest('dist/standalone'));
   }
 
@@ -334,8 +332,6 @@ gulp.task('build-css:concat-standalone-lg', function() {
       'dist/spectrum-' + colorStop + '.css'
     ])
       .pipe(concat('spectrum-' + colorStop + '-lg.css'))
-      // Replace instances of & that refer to the colorstop selector with .spectrum
-      .pipe(replace(/^&/gm, '.spectrum'))
       .pipe(gulp.dest('dist/standalone'));
   }
 

--- a/tasks/lib/postcss-notnested.js
+++ b/tasks/lib/postcss-notnested.js
@@ -4,7 +4,7 @@ module.exports = postcss.plugin('postcss-notnested', function (opts) {
   opts = opts || {};
 
   // Match ampersands at the start of a given selector
-  var re = /^&.*/m;
+  var re = /^&.*/;
 
   return function (root, result) {
     root.walkRules((rule, ruleIndex) => {

--- a/tasks/lib/postcss-notnested.js
+++ b/tasks/lib/postcss-notnested.js
@@ -1,0 +1,28 @@
+var postcss = require('postcss');
+
+module.exports = postcss.plugin('postcss-notnested', function (opts) {
+  opts = opts || {};
+
+  // Match ampersands at the start of a given selector
+  var re = /^&.*/m;
+
+  return function (root, result) {
+    root.walkRules((rule, ruleIndex) => {
+      var matchFound = false;
+      var selectors = rule.selectors;
+      if (selectors) {
+        for (var i = selectors.length - 1; i >= 0; i--) {
+          var selector = selectors[i];
+          if (re.test(selector)) {
+            // Kill the selector with the stray ampersand -- it's not nested!
+            selectors.splice(i, 1);
+            matchFound = true;
+          }
+        }
+        if (matchFound) {
+          rule.selectors = selectors;
+        }
+      }
+    });
+  }
+});

--- a/tasks/lib/postcss-notnested.js
+++ b/tasks/lib/postcss-notnested.js
@@ -8,16 +8,37 @@ module.exports = postcss.plugin('postcss-notnested', function (opts) {
 
   return function (root, result) {
     root.walkRules((rule, ruleIndex) => {
-      var matchFound = false;
       if (rule.selectors) {
-        var selectors = rule.selectors.filter(selector => {
-          // Kill the selector with the stray ampersand -- it's not nested!
-          return !re.test(selector)
-        });
+        if (opts.replace) {
+          var replaced = false;
+          var selectors = rule.selectors.map(selector => {
+            if (re.test(selector)) {
+              replaced = true;
+              return selector.replace(re, opts.replace);
+            }
+            else {
+              return selector;
+            }
+          });
 
-        // Only replace the selectors if we changed something (avoids extra work for every selector)
-        if (selectors.length != rule.selectors.length) {
-          rule.selectors = selectors;
+          if (replaced) {
+            rule.selectors = selectors;
+          }
+        }
+        else {
+          var selectors = rule.selectors.filter(selector => {
+            // Kill the selector with the stray ampersand -- it's not nested!
+            return !re.test(selector)
+          });
+
+          if (selectors.length == 0) {
+            // If no selectors remain, remove the rule completely
+            rule.remove();
+          }
+          else if (selectors.length != rule.selectors.length) {
+            // Only replace the selectors if we changed something (avoids extra work for every selector)
+            rule.selectors = selectors;
+          }
         }
       }
     });

--- a/tasks/lib/postcss-notnested.js
+++ b/tasks/lib/postcss-notnested.js
@@ -9,17 +9,14 @@ module.exports = postcss.plugin('postcss-notnested', function (opts) {
   return function (root, result) {
     root.walkRules((rule, ruleIndex) => {
       var matchFound = false;
-      var selectors = rule.selectors;
-      if (selectors) {
-        for (var i = selectors.length - 1; i >= 0; i--) {
-          var selector = selectors[i];
-          if (re.test(selector)) {
-            // Kill the selector with the stray ampersand -- it's not nested!
-            selectors.splice(i, 1);
-            matchFound = true;
-          }
-        }
-        if (matchFound) {
+      if (rule.selectors) {
+        var selectors = rule.selectors.filter(selector => {
+          // Kill the selector with the stray ampersand -- it's not nested!
+          return !re.test(selector)
+        });
+
+        // Only replace the selectors if we changed something (avoids extra work for every selector)
+        if (selectors.length != rule.selectors.length) {
           rule.selectors = selectors;
         }
       }


### PR DESCRIPTION
## Description

This PR adds a quick postcss plugin that removes selectors that make assumptions about nesting. This enables us to add behaviors that only apply when the interface is scaled. 

This PR also reverts d65d0ab2827285fbb5e931eb4270301f6c8cd786 (which fixes #34, but breaks 94ade838d3e84bb2279f6d71e6e7ecfcfa8443f2).

## Related Issue

#34 

## Motivation and Context

94ade838d3e84bb2279f6d71e6e7ecfcfa8443f2 introduced a fix that increased the specificity of a selector such that large interfaces would get the correct font size, but it broke this for non-scaled interfaces as the assumption of nesting resulted in an invalid selector.

This change removes the invalid selectors, making it possible to safely assume nesting in selectors.

After this change, if you use an `&` in `index.css` as follows:

```css
&.spectrum-Body,
.spectrum-Body {
  font-size: var(--spectrum-body-4-text-size);
}
```

For the standalone medium scale, this compiles to:

```css
.spectrum-Body {
  font-size: 14px;
}
```

And for the standalone large scale, this compiles to:

```css
.spectrum-Body {
  font-size: 17px;
}
```

However, for the diff scale (which is applied after medium), we get:
```css
.spectrum--large.spectrum-Body,
.spectrum--large .spectrum-Body {
  font-size: 17px;
}
```

This means the rule now takes effect for both a`.spectrum-Body` nested within `.spectrum--large` AND when both `.spectrum-Body` and `.spectrum--large` are present on the same element, which fixes the original issue 94ade838d3e84bb2279f6d71e6e7ecfcfa8443f2 was trying to fix without causing the issue described in #34.

Additionally, inside of `index.css` for any component, you can now write:

```css
&.spectrum-Component {
  width: var(--spectrum-global-dimension-size-6000); // must use a variable, otherwise the prop is stripped
}
```

And this will only show up if the component is scaled -- the rule is completely omitted for the standard, medium scale. I don't have a reason why we'd need to do this right now, but it is an interesting side effect of this fix.

Yes, this is disgusting. Yes, there is probably a better way. No, it is not a priority to explore that right now.

## How Has This Been Tested?

I diffed the output of the project against output generated before this commit to ensure the only thing that changed was the bug in question.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Bug fix (non-breaking change which fixes an issue)
