### PR TITLE
📝 use code tags instead of p tags for code typography example in docs

### DIFF
--- a/docs/typography/typography-code.yml
+++ b/docs/typography/typography-code.yml
@@ -5,8 +5,12 @@ description: Typographic styles for computer code.
 status: Verified
 ignoreDNA: true
 markup: |
-  <p class="spectrum-Code1">Code1 Text <strong>Strong</strong></p>
-  <p class="spectrum-Code2">Code2 Text <strong>Strong</strong></p>
-  <p class="spectrum-Code3">Code3 Text <strong>Strong</strong></p>
-  <p class="spectrum-Code4">Code4 Text <strong>Strong</strong></p>
-  <p class="spectrum-Code5">Code5 Text <strong>Strong</strong></p>
+  <code class="spectrum-Code1">Code1 Text <strong>Strong</strong></code>
+  <code class="spectrum-Code2">Code2 Text <strong>Strong</strong></code>
+  <code class="spectrum-Code3">Code3 Text <strong>Strong</strong></code>
+  <code class="spectrum-Code4">Code4 Text <strong>Strong</strong></code>
+  <code class="spectrum-Code5">Code5 Text <strong>Strong</strong></code>
+  <pre><code class="spectrum-Code3">Code3 Text Wrapped in:
+  pre tags for
+  multiline
+  goodness</code></pre>


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
… also try to show off a multiline example. It's weird because the different sizing variants now all show up in the same line (see screenshot below). Probably needs some work.

This closes #47.

## Related Issue
 #47 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

<img width="942" alt="screen shot 2018-12-12 at 11 40 48 am" src="https://user-images.githubusercontent.com/52645/49894448-cac38100-fe02-11e8-8d98-a0fb682150f5.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
