### PR TITLE
✨ RSP-631 InputGroup: add Datepicker range variant

### DIFF
--- a/docs/dropdown/dropdown.yml
+++ b/docs/dropdown/dropdown.yml
@@ -4,7 +4,7 @@ markup: |
   <h4>Closed</h4>
   <div class="spectrum-Dropdown" style="width: 240px;">
     <button class="spectrum-FieldButton spectrum-Dropdown-trigger" aria-haspopup="true">
-      <span class="spectrum-Dropdown-label is-placeholder">Select a Country</span>
+      <span class="spectrum-Dropdown-label is-placeholder">Select a Country with a very long label, too long in fact</span>
       <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
         <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />
       </svg>

--- a/docs/inputgroup/datepicker-range-quiet.yml
+++ b/docs/inputgroup/datepicker-range-quiet.yml
@@ -2,9 +2,9 @@ name: Date Picker - Range Quiet
 description: A date picker uses the input group component to display a field with a button next to it
 markup: |
   <div class="spectrum-InputGroup spectrum-InputGroup--quiet spectrum-Datepicker spectrum-Datepicker--range" role="combobox" aria-expanded="false" aria-haspopup="dialog">
-    <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field" placeholder="mm/dd/yyyy" name="start" value="2018-10-01">
+    <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field spectrum-Datepicker-field--start" placeholder="mm/dd/yyyy" name="start" value="2018-10-01">
     <div class="spectrum-Datepicker--rangeDash"></div>
-    <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field" placeholder="mm/dd/yyyy" name="end" value="2018-10-30">
+    <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field spectrum-Datepicker-field--start" placeholder="mm/dd/yyyy" name="end" value="2018-10-30">
     <button type="button" class="spectrum-FieldButton spectrum-FieldButton--quiet" tabindex="-1" aria-label="Calendar">
       <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
         <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />
@@ -17,9 +17,9 @@ markup: |
   <p />
 
   <div aria-invalid="true" class="spectrum-InputGroup spectrum-InputGroup--quiet spectrum-Datepicker spectrum-Datepicker--range is-invalid" role="combobox" aria-expanded="false" aria-haspopup="dialog">
-    <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field" aria-invalid="true" placeholder="mm/dd/yyyy" name="start" value="2018-10-01">
+    <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field spectrum-Datepicker-field--start" aria-invalid="true" placeholder="mm/dd/yyyy" name="start" value="2018-10-01">
     <div class="spectrum-Datepicker--rangeDash"></div>
-    <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field is-invalid" aria-invalid="true" placeholder="mm/dd/yyyy" name="end" value="2018-10-30">
+    <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field spectrum-Datepicker-field--end is-invalid" aria-invalid="true" placeholder="mm/dd/yyyy" name="end" value="2018-10-30">
     <button type="button" class="spectrum-FieldButton spectrum-FieldButton--quiet is-invalid" tabindex="-1" aria-expanded="false" aria-haspopup="dialog" aria-label="Calendar">
       <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
         <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />
@@ -32,9 +32,9 @@ markup: |
   <p />
 
   <div aria-disabled="true" class="spectrum-InputGroup spectrum-InputGroup--quiet spectrum-Datepicker spectrum-Datepicker--range is-disabled" role="combobox" aria-expanded="false" aria-haspopup="dialog">
-    <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field" placeholder="mm/dd/yyyy" name="start" value="2018-10-01" disabled>
+    <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field spectrum-Datepicker-field--start" placeholder="mm/dd/yyyy" name="start" value="2018-10-01" disabled>
     <div class="spectrum-Datepicker--rangeDash"></div>
-    <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field" placeholder="mm/dd/yyyy" name="end" value="2018-10-30" disabled>
+    <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field spectrum-Datepicker-field--end" placeholder="mm/dd/yyyy" name="end" value="2018-10-30" disabled>
     <button type="button" class="spectrum-FieldButton spectrum-FieldButton--quiet" tabindex="-1" disabled aria-expanded="false" aria-haspopup="dialog" aria-label="Calendar">
       <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
         <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />
@@ -46,9 +46,9 @@ markup: |
   <p/>
 
   <div class="spectrum-InputGroup spectrum-InputGroup--quiet spectrum-Datepicker spectrum-Datepicker--range  spectrum-Datepicker--datetimeRange" role="combobox" aria-expanded="false" aria-haspopup="dialog">
-    <input type="text" class="spectrum-Textfield  spectrum-Textfield--quiet spectrum-InputGroup-field" aria-invalid="false" placeholder="mm/dd/yyyy hh:mm a" name="start" value="">
+    <input type="text" class="spectrum-Textfield  spectrum-Textfield--quiet spectrum-InputGroup-field spectrum-Datepicker-field--start" aria-invalid="false" placeholder="mm/dd/yyyy hh:mm a" name="start" value="">
     <div class="spectrum-Datepicker--rangeDash"></div>
-    <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet  spectrum-InputGroup-field" aria-invalid="false" placeholder="mm/dd/yyyy hh:mm a" name="end" value="">
+    <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet  spectrum-InputGroup-field spectrum-Datepicker-field--end" aria-invalid="false" placeholder="mm/dd/yyyy hh:mm a" name="end" value="">
     <button type="button" class="spectrum-FieldButton spectrum-FieldButton--quiet" tabindex="-1" aria-expanded="false" aria-haspopup="dialog" aria-label="Calendar">
       <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
         <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />

--- a/docs/inputgroup/datepicker-range-quiet.yml
+++ b/docs/inputgroup/datepicker-range-quiet.yml
@@ -3,7 +3,7 @@ description: A date picker uses the input group component to display a field wit
 markup: |
   <div class="spectrum-InputGroup spectrum-InputGroup--quiet spectrum-Datepicker spectrum-Datepicker--range" role="combobox" aria-expanded="false" aria-haspopup="dialog">
     <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field" placeholder="mm/dd/yyyy" name="start" value="2018-10-01">
-    <div class="spectrum-Datepicker--range-dash"></div>
+    <div class="spectrum-Datepicker--rangeDash"></div>
     <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field" placeholder="mm/dd/yyyy" name="end" value="2018-10-30">
     <button type="button" class="spectrum-FieldButton spectrum-FieldButton--quiet" tabindex="-1" aria-label="Calendar">
       <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
@@ -18,7 +18,7 @@ markup: |
 
   <div aria-invalid="true" class="spectrum-InputGroup spectrum-InputGroup--quiet spectrum-Datepicker spectrum-Datepicker--range is-invalid" role="combobox" aria-expanded="false" aria-haspopup="dialog">
     <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field" aria-invalid="true" placeholder="mm/dd/yyyy" name="start" value="2018-10-01">
-    <div class="spectrum-Datepicker--range-dash"></div>
+    <div class="spectrum-Datepicker--rangeDash"></div>
     <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field is-invalid" aria-invalid="true" placeholder="mm/dd/yyyy" name="end" value="2018-10-30">
     <button type="button" class="spectrum-FieldButton spectrum-FieldButton--quiet is-invalid" tabindex="-1" aria-expanded="false" aria-haspopup="dialog" aria-label="Calendar">
       <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
@@ -33,7 +33,7 @@ markup: |
 
   <div aria-disabled="true" class="spectrum-InputGroup spectrum-InputGroup--quiet spectrum-Datepicker spectrum-Datepicker--range is-disabled" role="combobox" aria-expanded="false" aria-haspopup="dialog">
     <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field" placeholder="mm/dd/yyyy" name="start" value="2018-10-01" disabled>
-    <div class="spectrum-Datepicker--range-dash"></div>
+    <div class="spectrum-Datepicker--rangeDash"></div>
     <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field" placeholder="mm/dd/yyyy" name="end" value="2018-10-30" disabled>
     <button type="button" class="spectrum-FieldButton spectrum-FieldButton--quiet" tabindex="-1" disabled aria-expanded="false" aria-haspopup="dialog" aria-label="Calendar">
       <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
@@ -47,7 +47,7 @@ markup: |
 
   <div class="spectrum-InputGroup spectrum-InputGroup--quiet spectrum-Datepicker spectrum-Datepicker--range  spectrum-Datepicker--datetimeRange" role="combobox" aria-expanded="false" aria-haspopup="dialog">
     <input type="text" class="spectrum-Textfield  spectrum-Textfield--quiet spectrum-InputGroup-field" aria-invalid="false" placeholder="mm/dd/yyyy hh:mm a" name="start" value="">
-    <div class="spectrum-Datepicker--range-dash"></div>
+    <div class="spectrum-Datepicker--rangeDash"></div>
     <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet  spectrum-InputGroup-field" aria-invalid="false" placeholder="mm/dd/yyyy hh:mm a" name="end" value="">
     <button type="button" class="spectrum-FieldButton spectrum-FieldButton--quiet" tabindex="-1" aria-expanded="false" aria-haspopup="dialog" aria-label="Calendar">
       <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">

--- a/docs/inputgroup/datepicker-range-quiet.yml
+++ b/docs/inputgroup/datepicker-range-quiet.yml
@@ -2,9 +2,9 @@ name: Date Picker - Range Quiet
 description: A date picker uses the input group component to display a field with a button next to it
 markup: |
   <div class="spectrum-InputGroup spectrum-InputGroup--quiet spectrum-Datepicker spectrum-Datepicker--range" role="combobox" aria-expanded="false" aria-haspopup="dialog">
-    <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field spectrum-Datepicker-field--start" placeholder="mm/dd/yyyy" name="start" value="2018-10-01">
+    <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field spectrum-Datepicker-startField" placeholder="mm/dd/yyyy" name="start" value="2018-10-01">
     <div class="spectrum-Datepicker--rangeDash"></div>
-    <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field spectrum-Datepicker-field--start" placeholder="mm/dd/yyyy" name="end" value="2018-10-30">
+    <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field spectrum-Datepicker-startField" placeholder="mm/dd/yyyy" name="end" value="2018-10-30">
     <button type="button" class="spectrum-FieldButton spectrum-FieldButton--quiet" tabindex="-1" aria-label="Calendar">
       <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
         <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />
@@ -17,9 +17,9 @@ markup: |
   <p />
 
   <div aria-invalid="true" class="spectrum-InputGroup spectrum-InputGroup--quiet spectrum-Datepicker spectrum-Datepicker--range is-invalid" role="combobox" aria-expanded="false" aria-haspopup="dialog">
-    <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field spectrum-Datepicker-field--start" aria-invalid="true" placeholder="mm/dd/yyyy" name="start" value="2018-10-01">
+    <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field spectrum-Datepicker-startField" aria-invalid="true" placeholder="mm/dd/yyyy" name="start" value="2018-10-01">
     <div class="spectrum-Datepicker--rangeDash"></div>
-    <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field spectrum-Datepicker-field--end is-invalid" aria-invalid="true" placeholder="mm/dd/yyyy" name="end" value="2018-10-30">
+    <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field spectrum-Datepicker-endField is-invalid" aria-invalid="true" placeholder="mm/dd/yyyy" name="end" value="2018-10-30">
     <button type="button" class="spectrum-FieldButton spectrum-FieldButton--quiet is-invalid" tabindex="-1" aria-expanded="false" aria-haspopup="dialog" aria-label="Calendar">
       <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
         <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />
@@ -32,9 +32,9 @@ markup: |
   <p />
 
   <div aria-disabled="true" class="spectrum-InputGroup spectrum-InputGroup--quiet spectrum-Datepicker spectrum-Datepicker--range is-disabled" role="combobox" aria-expanded="false" aria-haspopup="dialog">
-    <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field spectrum-Datepicker-field--start" placeholder="mm/dd/yyyy" name="start" value="2018-10-01" disabled>
+    <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field spectrum-Datepicker-startField" placeholder="mm/dd/yyyy" name="start" value="2018-10-01" disabled>
     <div class="spectrum-Datepicker--rangeDash"></div>
-    <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field spectrum-Datepicker-field--end" placeholder="mm/dd/yyyy" name="end" value="2018-10-30" disabled>
+    <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field spectrum-Datepicker-endField" placeholder="mm/dd/yyyy" name="end" value="2018-10-30" disabled>
     <button type="button" class="spectrum-FieldButton spectrum-FieldButton--quiet" tabindex="-1" disabled aria-expanded="false" aria-haspopup="dialog" aria-label="Calendar">
       <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
         <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />
@@ -46,9 +46,9 @@ markup: |
   <p/>
 
   <div class="spectrum-InputGroup spectrum-InputGroup--quiet spectrum-Datepicker spectrum-Datepicker--range  spectrum-Datepicker--datetimeRange" role="combobox" aria-expanded="false" aria-haspopup="dialog">
-    <input type="text" class="spectrum-Textfield  spectrum-Textfield--quiet spectrum-InputGroup-field spectrum-Datepicker-field--start" aria-invalid="false" placeholder="mm/dd/yyyy hh:mm a" name="start" value="">
+    <input type="text" class="spectrum-Textfield  spectrum-Textfield--quiet spectrum-InputGroup-field spectrum-Datepicker-startField" aria-invalid="false" placeholder="mm/dd/yyyy hh:mm a" name="start" value="">
     <div class="spectrum-Datepicker--rangeDash"></div>
-    <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet  spectrum-InputGroup-field spectrum-Datepicker-field--end" aria-invalid="false" placeholder="mm/dd/yyyy hh:mm a" name="end" value="">
+    <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet  spectrum-InputGroup-field spectrum-Datepicker-endField" aria-invalid="false" placeholder="mm/dd/yyyy hh:mm a" name="end" value="">
     <button type="button" class="spectrum-FieldButton spectrum-FieldButton--quiet" tabindex="-1" aria-expanded="false" aria-haspopup="dialog" aria-label="Calendar">
       <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
         <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />

--- a/docs/inputgroup/datepicker-range-quiet.yml
+++ b/docs/inputgroup/datepicker-range-quiet.yml
@@ -1,0 +1,47 @@
+name: Date Picker - Range Quiet
+description: A date picker uses the input group component to display a field with a button next to it
+markup: |
+  <div class="spectrum-InputGroup spectrum-InputGroup--quiet spectrum-Datepicker spectrum-Datepicker--range" role="combobox" aria-expanded="false" aria-haspopup="dialog">
+    <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field" placeholder="mm/dd/yyyy" name="start" value="2018-10-01">
+    <hr />
+    <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field" placeholder="mm/dd/yyyy" name="end" value="2018-10-30">
+    <button type="button" class="spectrum-FieldButton spectrum-FieldButton--quiet" tabindex="-1">
+      <svg viewBox="0 0 36 36" focusable="false" aria-hidden="true" role="img" class="spectrum-Icon spectrum-Icon--sizeS"><path d="M33 6h-5V3a1 1 0 0 0-1-1h-2a1 1 0 0 0-1 1v3H10V3a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1v3H1a1 1 0 0 0-1 1v26a1 1 0 0 0 1 1h32a1 1 0 0 0 1-1V7a1 1 0 0 0-1-1zm-1 26H2V8h4v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h14v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h4z"></path><path d="M6 12h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 18h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 24h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4z"></path></svg>
+    </button>
+    <div class="spectrum-Datepicker-focusRing"></div>
+  </div>
+
+  <p />
+
+  <div aria-invalid="true" class="spectrum-InputGroup spectrum-InputGroup--quiet spectrum-Datepicker spectrum-Datepicker--range is-invalid" role="combobox" aria-expanded="false" aria-haspopup="dialog">
+    <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field" aria-invalid="true" placeholder="mm/dd/yyyy" name="start" value="2018-10-01">
+    <hr />
+    <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field is-invalid" aria-invalid="true" placeholder="mm/dd/yyyy" name="end" value="2018-10-30">
+    <button type="button" class="spectrum-FieldButton spectrum-FieldButton--quiet is-invalid" tabindex="-1" aria-expanded="false" aria-haspopup="dialog">
+      <svg viewBox="0 0 36 36" focusable="false" aria-hidden="true" role="img" class="spectrum-Icon spectrum-Icon--sizeS"><path d="M33 6h-5V3a1 1 0 0 0-1-1h-2a1 1 0 0 0-1 1v3H10V3a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1v3H1a1 1 0 0 0-1 1v26a1 1 0 0 0 1 1h32a1 1 0 0 0 1-1V7a1 1 0 0 0-1-1zm-1 26H2V8h4v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h14v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h4z"></path><path d="M6 12h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 18h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 24h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4z"></path></svg>
+    </button>
+    <div class="spectrum-Datepicker-focusRing"></div>
+  </div>
+
+  <p />
+
+  <div aria-disabled="true" class="spectrum-InputGroup spectrum-InputGroup--quiet spectrum-Datepicker spectrum-Datepicker--range is-disabled" role="combobox" aria-expanded="false" aria-haspopup="dialog">
+    <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field" placeholder="mm/dd/yyyy" name="start" value="2018-10-01" disabled>
+    <hr />
+    <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field" placeholder="mm/dd/yyyy" name="end" value="2018-10-30" disabled>
+    <button type="button" class="spectrum-FieldButton spectrum-FieldButton--quiet" tabindex="-1" disabled aria-expanded="false" aria-haspopup="dialog">
+      <svg viewBox="0 0 36 36" focusable="false" aria-hidden="true" role="img" class="spectrum-Icon spectrum-Icon--sizeS"><path d="M33 6h-5V3a1 1 0 0 0-1-1h-2a1 1 0 0 0-1 1v3H10V3a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1v3H1a1 1 0 0 0-1 1v26a1 1 0 0 0 1 1h32a1 1 0 0 0 1-1V7a1 1 0 0 0-1-1zm-1 26H2V8h4v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h14v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h4z"></path><path d="M6 12h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 18h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 24h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4z"></path></svg>
+    </button>
+    <div class="spectrum-Datepicker-focusRing"></div>
+  </div>
+  <p/>
+
+  <div class="spectrum-InputGroup spectrum-InputGroup--quiet spectrum-Datepicker spectrum-Datepicker--range  spectrum-Datepicker--datetimeRange" role="combobox" aria-expanded="false" aria-haspopup="dialog">
+    <input type="text" class="spectrum-Textfield  spectrum-Textfield--quiet spectrum-InputGroup-field" aria-invalid="false" placeholder="mm/dd/yyyy hh:mm a" name="start" value="">
+    <hr />
+    <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet  spectrum-InputGroup-field" aria-invalid="false" placeholder="mm/dd/yyyy hh:mm a" name="end" value="">
+    <button type="button" class="spectrum-FieldButton spectrum-FieldButton--quiet" tabindex="-1" aria-expanded="false" aria-haspopup="dialog">
+      <svg viewBox="0 0 36 36" focusable="false" aria-hidden="true" role="img" class="spectrum-Icon spectrum-Icon--sizeS"><path d="M33 6h-5V3a1 1 0 0 0-1-1h-2a1 1 0 0 0-1 1v3H10V3a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1v3H1a1 1 0 0 0-1 1v26a1 1 0 0 0 1 1h32a1 1 0 0 0 1-1V7a1 1 0 0 0-1-1zm-1 26H2V8h4v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h14v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h4z"></path><path d="M6 12h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 18h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 24h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4z"></path></svg>
+    </button>
+    <div class="spectrum-Datepicker-focusRing"></div>
+  </div>

--- a/docs/inputgroup/datepicker-range-quiet.yml
+++ b/docs/inputgroup/datepicker-range-quiet.yml
@@ -10,7 +10,8 @@ markup: |
         <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />
       </svg>
     </button>
-    <div class="spectrum-Datepicker-focusRing"></div>
+    <!-- To render focus ring around entire input group when one of the inputs has keyboard focus, we need this: -->
+    <div class="spectrum-Datepicker-focusRing" role="presentation"></div>
   </div>
 
   <p />
@@ -24,7 +25,8 @@ markup: |
         <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />
       </svg>
     </button>
-    <div class="spectrum-Datepicker-focusRing"></div>
+    <!-- To render focus ring around entire input group when one of the inputs has keyboard focus, we need this: -->
+    <div class="spectrum-Datepicker-focusRing" role="presentation"></div>
   </div>
 
   <p />
@@ -38,7 +40,8 @@ markup: |
         <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />
       </svg>
     </button>
-    <div class="spectrum-Datepicker-focusRing"></div>
+    <!-- To render focus ring around entire input group when one of the inputs has keyboard focus, we need this: -->
+    <div class="spectrum-Datepicker-focusRing" role="presentation"></div>
   </div>
   <p/>
 
@@ -51,5 +54,6 @@ markup: |
         <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />
       </svg>
     </button>
-    <div class="spectrum-Datepicker-focusRing"></div>
+    <!-- To render focus ring around entire input group when one of the inputs has keyboard focus, we need this: -->
+    <div class="spectrum-Datepicker-focusRing" role="presentation"></div>
   </div>

--- a/docs/inputgroup/datepicker-range-quiet.yml
+++ b/docs/inputgroup/datepicker-range-quiet.yml
@@ -3,7 +3,7 @@ description: A date picker uses the input group component to display a field wit
 markup: |
   <div class="spectrum-InputGroup spectrum-InputGroup--quiet spectrum-Datepicker spectrum-Datepicker--range" role="combobox" aria-expanded="false" aria-haspopup="dialog">
     <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field" placeholder="mm/dd/yyyy" name="start" value="2018-10-01">
-    <hr />
+    <div class="spectrum-Datepicker--range-dash"></div>
     <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field" placeholder="mm/dd/yyyy" name="end" value="2018-10-30">
     <button type="button" class="spectrum-FieldButton spectrum-FieldButton--quiet" tabindex="-1">
       <svg viewBox="0 0 36 36" focusable="false" aria-hidden="true" role="img" class="spectrum-Icon spectrum-Icon--sizeS"><path d="M33 6h-5V3a1 1 0 0 0-1-1h-2a1 1 0 0 0-1 1v3H10V3a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1v3H1a1 1 0 0 0-1 1v26a1 1 0 0 0 1 1h32a1 1 0 0 0 1-1V7a1 1 0 0 0-1-1zm-1 26H2V8h4v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h14v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h4z"></path><path d="M6 12h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 18h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 24h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4z"></path></svg>
@@ -15,7 +15,7 @@ markup: |
 
   <div aria-invalid="true" class="spectrum-InputGroup spectrum-InputGroup--quiet spectrum-Datepicker spectrum-Datepicker--range is-invalid" role="combobox" aria-expanded="false" aria-haspopup="dialog">
     <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field" aria-invalid="true" placeholder="mm/dd/yyyy" name="start" value="2018-10-01">
-    <hr />
+    <div class="spectrum-Datepicker--range-dash"></div>
     <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field is-invalid" aria-invalid="true" placeholder="mm/dd/yyyy" name="end" value="2018-10-30">
     <button type="button" class="spectrum-FieldButton spectrum-FieldButton--quiet is-invalid" tabindex="-1" aria-expanded="false" aria-haspopup="dialog">
       <svg viewBox="0 0 36 36" focusable="false" aria-hidden="true" role="img" class="spectrum-Icon spectrum-Icon--sizeS"><path d="M33 6h-5V3a1 1 0 0 0-1-1h-2a1 1 0 0 0-1 1v3H10V3a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1v3H1a1 1 0 0 0-1 1v26a1 1 0 0 0 1 1h32a1 1 0 0 0 1-1V7a1 1 0 0 0-1-1zm-1 26H2V8h4v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h14v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h4z"></path><path d="M6 12h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 18h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 24h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4z"></path></svg>
@@ -27,7 +27,7 @@ markup: |
 
   <div aria-disabled="true" class="spectrum-InputGroup spectrum-InputGroup--quiet spectrum-Datepicker spectrum-Datepicker--range is-disabled" role="combobox" aria-expanded="false" aria-haspopup="dialog">
     <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field" placeholder="mm/dd/yyyy" name="start" value="2018-10-01" disabled>
-    <hr />
+    <div class="spectrum-Datepicker--range-dash"></div>
     <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field" placeholder="mm/dd/yyyy" name="end" value="2018-10-30" disabled>
     <button type="button" class="spectrum-FieldButton spectrum-FieldButton--quiet" tabindex="-1" disabled aria-expanded="false" aria-haspopup="dialog">
       <svg viewBox="0 0 36 36" focusable="false" aria-hidden="true" role="img" class="spectrum-Icon spectrum-Icon--sizeS"><path d="M33 6h-5V3a1 1 0 0 0-1-1h-2a1 1 0 0 0-1 1v3H10V3a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1v3H1a1 1 0 0 0-1 1v26a1 1 0 0 0 1 1h32a1 1 0 0 0 1-1V7a1 1 0 0 0-1-1zm-1 26H2V8h4v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h14v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h4z"></path><path d="M6 12h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 18h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 24h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4z"></path></svg>
@@ -38,7 +38,7 @@ markup: |
 
   <div class="spectrum-InputGroup spectrum-InputGroup--quiet spectrum-Datepicker spectrum-Datepicker--range  spectrum-Datepicker--datetimeRange" role="combobox" aria-expanded="false" aria-haspopup="dialog">
     <input type="text" class="spectrum-Textfield  spectrum-Textfield--quiet spectrum-InputGroup-field" aria-invalid="false" placeholder="mm/dd/yyyy hh:mm a" name="start" value="">
-    <hr />
+    <div class="spectrum-Datepicker--range-dash"></div>
     <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet  spectrum-InputGroup-field" aria-invalid="false" placeholder="mm/dd/yyyy hh:mm a" name="end" value="">
     <button type="button" class="spectrum-FieldButton spectrum-FieldButton--quiet" tabindex="-1" aria-expanded="false" aria-haspopup="dialog">
       <svg viewBox="0 0 36 36" focusable="false" aria-hidden="true" role="img" class="spectrum-Icon spectrum-Icon--sizeS"><path d="M33 6h-5V3a1 1 0 0 0-1-1h-2a1 1 0 0 0-1 1v3H10V3a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1v3H1a1 1 0 0 0-1 1v26a1 1 0 0 0 1 1h32a1 1 0 0 0 1-1V7a1 1 0 0 0-1-1zm-1 26H2V8h4v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h14v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h4z"></path><path d="M6 12h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 18h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 24h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4z"></path></svg>

--- a/docs/inputgroup/datepicker-range-quiet.yml
+++ b/docs/inputgroup/datepicker-range-quiet.yml
@@ -5,8 +5,10 @@ markup: |
     <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field" placeholder="mm/dd/yyyy" name="start" value="2018-10-01">
     <div class="spectrum-Datepicker--range-dash"></div>
     <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field" placeholder="mm/dd/yyyy" name="end" value="2018-10-30">
-    <button type="button" class="spectrum-FieldButton spectrum-FieldButton--quiet" tabindex="-1">
-      <svg viewBox="0 0 36 36" focusable="false" aria-hidden="true" role="img" class="spectrum-Icon spectrum-Icon--sizeS"><path d="M33 6h-5V3a1 1 0 0 0-1-1h-2a1 1 0 0 0-1 1v3H10V3a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1v3H1a1 1 0 0 0-1 1v26a1 1 0 0 0 1 1h32a1 1 0 0 0 1-1V7a1 1 0 0 0-1-1zm-1 26H2V8h4v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h14v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h4z"></path><path d="M6 12h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 18h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 24h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4z"></path></svg>
+    <button type="button" class="spectrum-FieldButton spectrum-FieldButton--quiet" tabindex="-1" aria-label="Calendar">
+      <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
+        <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />
+      </svg>
     </button>
     <div class="spectrum-Datepicker-focusRing"></div>
   </div>
@@ -17,8 +19,10 @@ markup: |
     <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field" aria-invalid="true" placeholder="mm/dd/yyyy" name="start" value="2018-10-01">
     <div class="spectrum-Datepicker--range-dash"></div>
     <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field is-invalid" aria-invalid="true" placeholder="mm/dd/yyyy" name="end" value="2018-10-30">
-    <button type="button" class="spectrum-FieldButton spectrum-FieldButton--quiet is-invalid" tabindex="-1" aria-expanded="false" aria-haspopup="dialog">
-      <svg viewBox="0 0 36 36" focusable="false" aria-hidden="true" role="img" class="spectrum-Icon spectrum-Icon--sizeS"><path d="M33 6h-5V3a1 1 0 0 0-1-1h-2a1 1 0 0 0-1 1v3H10V3a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1v3H1a1 1 0 0 0-1 1v26a1 1 0 0 0 1 1h32a1 1 0 0 0 1-1V7a1 1 0 0 0-1-1zm-1 26H2V8h4v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h14v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h4z"></path><path d="M6 12h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 18h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 24h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4z"></path></svg>
+    <button type="button" class="spectrum-FieldButton spectrum-FieldButton--quiet is-invalid" tabindex="-1" aria-expanded="false" aria-haspopup="dialog" aria-label="Calendar">
+      <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
+        <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />
+      </svg>
     </button>
     <div class="spectrum-Datepicker-focusRing"></div>
   </div>
@@ -29,8 +33,10 @@ markup: |
     <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field" placeholder="mm/dd/yyyy" name="start" value="2018-10-01" disabled>
     <div class="spectrum-Datepicker--range-dash"></div>
     <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field" placeholder="mm/dd/yyyy" name="end" value="2018-10-30" disabled>
-    <button type="button" class="spectrum-FieldButton spectrum-FieldButton--quiet" tabindex="-1" disabled aria-expanded="false" aria-haspopup="dialog">
-      <svg viewBox="0 0 36 36" focusable="false" aria-hidden="true" role="img" class="spectrum-Icon spectrum-Icon--sizeS"><path d="M33 6h-5V3a1 1 0 0 0-1-1h-2a1 1 0 0 0-1 1v3H10V3a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1v3H1a1 1 0 0 0-1 1v26a1 1 0 0 0 1 1h32a1 1 0 0 0 1-1V7a1 1 0 0 0-1-1zm-1 26H2V8h4v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h14v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h4z"></path><path d="M6 12h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 18h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 24h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4z"></path></svg>
+    <button type="button" class="spectrum-FieldButton spectrum-FieldButton--quiet" tabindex="-1" disabled aria-expanded="false" aria-haspopup="dialog" aria-label="Calendar">
+      <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
+        <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />
+      </svg>
     </button>
     <div class="spectrum-Datepicker-focusRing"></div>
   </div>
@@ -40,8 +46,10 @@ markup: |
     <input type="text" class="spectrum-Textfield  spectrum-Textfield--quiet spectrum-InputGroup-field" aria-invalid="false" placeholder="mm/dd/yyyy hh:mm a" name="start" value="">
     <div class="spectrum-Datepicker--range-dash"></div>
     <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet  spectrum-InputGroup-field" aria-invalid="false" placeholder="mm/dd/yyyy hh:mm a" name="end" value="">
-    <button type="button" class="spectrum-FieldButton spectrum-FieldButton--quiet" tabindex="-1" aria-expanded="false" aria-haspopup="dialog">
-      <svg viewBox="0 0 36 36" focusable="false" aria-hidden="true" role="img" class="spectrum-Icon spectrum-Icon--sizeS"><path d="M33 6h-5V3a1 1 0 0 0-1-1h-2a1 1 0 0 0-1 1v3H10V3a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1v3H1a1 1 0 0 0-1 1v26a1 1 0 0 0 1 1h32a1 1 0 0 0 1-1V7a1 1 0 0 0-1-1zm-1 26H2V8h4v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h14v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h4z"></path><path d="M6 12h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 18h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 24h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4z"></path></svg>
+    <button type="button" class="spectrum-FieldButton spectrum-FieldButton--quiet" tabindex="-1" aria-expanded="false" aria-haspopup="dialog" aria-label="Calendar">
+      <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
+        <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />
+      </svg>
     </button>
     <div class="spectrum-Datepicker-focusRing"></div>
   </div>

--- a/docs/inputgroup/datepicker-range.yml
+++ b/docs/inputgroup/datepicker-range.yml
@@ -3,7 +3,7 @@ description: A date picker uses the input group component to display a field wit
 markup: |
   <div aria-invalid="false" class="spectrum-InputGroup spectrum-Datepicker spectrum-Datepicker--range" role="combobox" aria-expanded="false" aria-haspopup="dialog">
     <input type="text" class="spectrum-Textfield spectrum-InputGroup-field" placeholder="mm/dd/yyyy" name="start" value="">
-    <hr>
+    <div class="spectrum-Datepicker--range-dash"></div>
     <input type="text" class="spectrum-Textfield spectrum-InputGroup-field" placeholder="mm/dd/yyyy" name="end" value="">
     <button type="button" class="spectrum-FieldButton" tabindex="-1" aria-expanded="false" aria-haspopup="dialog">
       <svg viewBox="0 0 36 36" focusable="false" aria-hidden="true" role="img" class="spectrum-Icon spectrum-Icon--sizeS"><path d="M33 6h-5V3a1 1 0 0 0-1-1h-2a1 1 0 0 0-1 1v3H10V3a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1v3H1a1 1 0 0 0-1 1v26a1 1 0 0 0 1 1h32a1 1 0 0 0 1-1V7a1 1 0 0 0-1-1zm-1 26H2V8h4v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h14v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h4z"></path><path d="M6 12h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 18h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 24h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4z"></path></svg>
@@ -15,7 +15,7 @@ markup: |
 
   <div aria-invalid="true" class="spectrum-InputGroup spectrum-Datepicker spectrum-Datepicker--range is-invalid" role="combobox" aria-expanded="false" aria-haspopup="dialog">
     <input type="text" class="spectrum-Textfield spectrum-InputGroup-field" aria-invalid="true" placeholder="mm/dd/yyyy" name="start" value="">
-    <hr>
+    <div class="spectrum-Datepicker--range-dash"></div>
     <input type="text" class="spectrum-Textfield spectrum-InputGroup-field is-invalid" aria-invalid="true" placeholder="mm/dd/yyyy" name="end" value="">
     <button type="button" class="spectrum-FieldButton is-invalid" tabindex="-1" aria-expanded="false" aria-haspopup="dialog">
       <svg viewBox="0 0 36 36" focusable="false" aria-hidden="true" role="img" class="spectrum-Icon spectrum-Icon--sizeS"><path d="M33 6h-5V3a1 1 0 0 0-1-1h-2a1 1 0 0 0-1 1v3H10V3a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1v3H1a1 1 0 0 0-1 1v26a1 1 0 0 0 1 1h32a1 1 0 0 0 1-1V7a1 1 0 0 0-1-1zm-1 26H2V8h4v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h14v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h4z"></path><path d="M6 12h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 18h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 24h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4z"></path></svg>
@@ -27,7 +27,7 @@ markup: |
 
   <div aria-disabled="true" class="spectrum-InputGroup spectrum-Datepicker spectrum-Datepicker--range is-disabled" role="combobox" aria-expanded="false" aria-haspopup="dialog">
     <input type="text" class="spectrum-Textfield spectrum-InputGroup-field" placeholder="mm/dd/yyyy" name="start" value="" disabled>
-    <hr>
+    <div class="spectrum-Datepicker--range-dash"></div>
     <input type="text" class="spectrum-Textfield spectrum-InputGroup-field" placeholder="mm/dd/yyyy" name="end" value="" disabled>
     <button type="button" class="spectrum-FieldButton" disabled tabindex="-1">
       <svg viewBox="0 0 36 36" focusable="false" aria-hidden="true" role="img" class="spectrum-Icon spectrum-Icon--sizeS"><path d="M33 6h-5V3a1 1 0 0 0-1-1h-2a1 1 0 0 0-1 1v3H10V3a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1v3H1a1 1 0 0 0-1 1v26a1 1 0 0 0 1 1h32a1 1 0 0 0 1-1V7a1 1 0 0 0-1-1zm-1 26H2V8h4v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h14v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h4z"></path><path d="M6 12h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 18h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 24h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4z"></path></svg>
@@ -37,9 +37,9 @@ markup: |
 
   <p/>
 
-  <div class="spectrum-InputGroup spectrum-Datepicker spectrum-Datepicker--range  spectrum-Datepicker--datetimeRange" role="combobox" aria-expanded="false" aria-haspopup="dialog">
+  <div class="spectrum-InputGroup spectrum-Datepicker spectrum-Datepicker--range spectrum-Datepicker--datetimeRange" role="combobox" aria-expanded="false" aria-haspopup="dialog">
     <input type="text" class="spectrum-Textfield spectrum-InputGroup-field" placeholder="mm/dd/yyyy hh:mm a" name="start" value="">
-    <hr>
+    <div class="spectrum-Datepicker--range-dash"></div>
     <input type="text" class="spectrum-Textfield spectrum-InputGroup-field" placeholder="mm/dd/yyyy hh:mm a" name="end" value="">
     <button type="button" class="spectrum-FieldButton" tabindex="-1" aria-expanded="false" aria-haspopup="dialog">
       <svg viewBox="0 0 36 36" focusable="false" aria-hidden="true" role="img" class="spectrum-Icon spectrum-Icon--sizeS"><path d="M33 6h-5V3a1 1 0 0 0-1-1h-2a1 1 0 0 0-1 1v3H10V3a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1v3H1a1 1 0 0 0-1 1v26a1 1 0 0 0 1 1h32a1 1 0 0 0 1-1V7a1 1 0 0 0-1-1zm-1 26H2V8h4v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h14v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h4z"></path><path d="M6 12h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 18h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 24h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4z"></path></svg>

--- a/docs/inputgroup/datepicker-range.yml
+++ b/docs/inputgroup/datepicker-range.yml
@@ -2,9 +2,9 @@ name: Date Picker - Range
 description: A date picker uses the input group component to display a field with a button next to it
 markup: |
   <div aria-invalid="false" class="spectrum-InputGroup spectrum-Datepicker spectrum-Datepicker--range" role="combobox" aria-expanded="false" aria-haspopup="dialog">
-    <input type="text" class="spectrum-Textfield spectrum-InputGroup-field spectrum-Datepicker-field--start" placeholder="mm/dd/yyyy" name="start" value="">
+    <input type="text" class="spectrum-Textfield spectrum-InputGroup-field spectrum-Datepicker-startField" placeholder="mm/dd/yyyy" name="start" value="">
     <div class="spectrum-Datepicker--rangeDash"></div>
-    <input type="text" class="spectrum-Textfield spectrum-InputGroup-field spectrum-Datepicker-field--end" placeholder="mm/dd/yyyy" name="end" value="">
+    <input type="text" class="spectrum-Textfield spectrum-InputGroup-field spectrum-Datepicker-endField" placeholder="mm/dd/yyyy" name="end" value="">
     <button type="button" class="spectrum-FieldButton" tabindex="-1" aria-expanded="false" aria-haspopup="dialog" aria-label="Calendar">
       <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
         <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />
@@ -17,9 +17,9 @@ markup: |
   <p/>
 
   <div aria-invalid="true" class="spectrum-InputGroup spectrum-Datepicker spectrum-Datepicker--range is-invalid" role="combobox" aria-expanded="false" aria-haspopup="dialog">
-    <input type="text" class="spectrum-Textfield spectrum-InputGroup-field spectrum-Datepicker-field--start" aria-invalid="true" placeholder="mm/dd/yyyy" name="start" value="">
+    <input type="text" class="spectrum-Textfield spectrum-InputGroup-field spectrum-Datepicker-startField" aria-invalid="true" placeholder="mm/dd/yyyy" name="start" value="">
     <div class="spectrum-Datepicker--rangeDash"></div>
-    <input type="text" class="spectrum-Textfield spectrum-InputGroup-field spectrum-Datepicker-field--end is-invalid" aria-invalid="true" placeholder="mm/dd/yyyy" name="end" value="">
+    <input type="text" class="spectrum-Textfield spectrum-InputGroup-field spectrum-Datepicker-endField is-invalid" aria-invalid="true" placeholder="mm/dd/yyyy" name="end" value="">
     <button type="button" class="spectrum-FieldButton is-invalid" tabindex="-1" aria-expanded="false" aria-haspopup="dialog" aria-label="Calendar">
       <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
         <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />
@@ -32,9 +32,9 @@ markup: |
   <p/>
 
   <div aria-disabled="true" class="spectrum-InputGroup spectrum-Datepicker spectrum-Datepicker--range is-disabled" role="combobox" aria-expanded="false" aria-haspopup="dialog">
-    <input type="text" class="spectrum-Textfield spectrum-InputGroup-field spectrum-Datepicker-field--start" placeholder="mm/dd/yyyy" name="start" value="" disabled>
+    <input type="text" class="spectrum-Textfield spectrum-InputGroup-field spectrum-Datepicker-startField" placeholder="mm/dd/yyyy" name="start" value="" disabled>
     <div class="spectrum-Datepicker--rangeDash"></div>
-    <input type="text" class="spectrum-Textfield spectrum-InputGroup-field spectrum-Datepicker-field--end" placeholder="mm/dd/yyyy" name="end" value="" disabled>
+    <input type="text" class="spectrum-Textfield spectrum-InputGroup-field spectrum-Datepicker-endField" placeholder="mm/dd/yyyy" name="end" value="" disabled>
     <button type="button" class="spectrum-FieldButton" disabled tabindex="-1" aria-label="Calendar">
       <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
         <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />
@@ -47,9 +47,9 @@ markup: |
   <p/>
 
   <div class="spectrum-InputGroup spectrum-Datepicker spectrum-Datepicker--range spectrum-Datepicker--datetimeRange" role="combobox" aria-expanded="false" aria-haspopup="dialog">
-    <input type="text" class="spectrum-Textfield spectrum-InputGroup-field spectrum-Datepicker-field--start" placeholder="mm/dd/yyyy hh:mm a" name="start" value="">
+    <input type="text" class="spectrum-Textfield spectrum-InputGroup-field spectrum-Datepicker-startField" placeholder="mm/dd/yyyy hh:mm a" name="start" value="">
     <div class="spectrum-Datepicker--rangeDash"></div>
-    <input type="text" class="spectrum-Textfield spectrum-InputGroup-field spectrum-Datepicker-field--end" placeholder="mm/dd/yyyy hh:mm a" name="end" value="">
+    <input type="text" class="spectrum-Textfield spectrum-InputGroup-field spectrum-Datepicker-endField" placeholder="mm/dd/yyyy hh:mm a" name="end" value="">
     <button type="button" class="spectrum-FieldButton" tabindex="-1" aria-expanded="false" aria-haspopup="dialog" aria-label="Calendar">
       <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
         <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />

--- a/docs/inputgroup/datepicker-range.yml
+++ b/docs/inputgroup/datepicker-range.yml
@@ -5,8 +5,10 @@ markup: |
     <input type="text" class="spectrum-Textfield spectrum-InputGroup-field" placeholder="mm/dd/yyyy" name="start" value="">
     <div class="spectrum-Datepicker--range-dash"></div>
     <input type="text" class="spectrum-Textfield spectrum-InputGroup-field" placeholder="mm/dd/yyyy" name="end" value="">
-    <button type="button" class="spectrum-FieldButton" tabindex="-1" aria-expanded="false" aria-haspopup="dialog">
-      <svg viewBox="0 0 36 36" focusable="false" aria-hidden="true" role="img" class="spectrum-Icon spectrum-Icon--sizeS"><path d="M33 6h-5V3a1 1 0 0 0-1-1h-2a1 1 0 0 0-1 1v3H10V3a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1v3H1a1 1 0 0 0-1 1v26a1 1 0 0 0 1 1h32a1 1 0 0 0 1-1V7a1 1 0 0 0-1-1zm-1 26H2V8h4v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h14v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h4z"></path><path d="M6 12h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 18h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 24h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4z"></path></svg>
+    <button type="button" class="spectrum-FieldButton" tabindex="-1" aria-expanded="false" aria-haspopup="dialog" aria-label="Calendar">
+      <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
+        <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />
+      </svg>
     </button>
     <div class="spectrum-Datepicker-focusRing" role="presentation"></div>
   </div>
@@ -17,8 +19,10 @@ markup: |
     <input type="text" class="spectrum-Textfield spectrum-InputGroup-field" aria-invalid="true" placeholder="mm/dd/yyyy" name="start" value="">
     <div class="spectrum-Datepicker--range-dash"></div>
     <input type="text" class="spectrum-Textfield spectrum-InputGroup-field is-invalid" aria-invalid="true" placeholder="mm/dd/yyyy" name="end" value="">
-    <button type="button" class="spectrum-FieldButton is-invalid" tabindex="-1" aria-expanded="false" aria-haspopup="dialog">
-      <svg viewBox="0 0 36 36" focusable="false" aria-hidden="true" role="img" class="spectrum-Icon spectrum-Icon--sizeS"><path d="M33 6h-5V3a1 1 0 0 0-1-1h-2a1 1 0 0 0-1 1v3H10V3a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1v3H1a1 1 0 0 0-1 1v26a1 1 0 0 0 1 1h32a1 1 0 0 0 1-1V7a1 1 0 0 0-1-1zm-1 26H2V8h4v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h14v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h4z"></path><path d="M6 12h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 18h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 24h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4z"></path></svg>
+    <button type="button" class="spectrum-FieldButton is-invalid" tabindex="-1" aria-expanded="false" aria-haspopup="dialog" aria-label="Calendar">
+      <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
+        <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />
+      </svg>
     </button>
     <div class="spectrum-Datepicker-focusRing" role="presentation"></div>
   </div>
@@ -29,8 +33,10 @@ markup: |
     <input type="text" class="spectrum-Textfield spectrum-InputGroup-field" placeholder="mm/dd/yyyy" name="start" value="" disabled>
     <div class="spectrum-Datepicker--range-dash"></div>
     <input type="text" class="spectrum-Textfield spectrum-InputGroup-field" placeholder="mm/dd/yyyy" name="end" value="" disabled>
-    <button type="button" class="spectrum-FieldButton" disabled tabindex="-1">
-      <svg viewBox="0 0 36 36" focusable="false" aria-hidden="true" role="img" class="spectrum-Icon spectrum-Icon--sizeS"><path d="M33 6h-5V3a1 1 0 0 0-1-1h-2a1 1 0 0 0-1 1v3H10V3a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1v3H1a1 1 0 0 0-1 1v26a1 1 0 0 0 1 1h32a1 1 0 0 0 1-1V7a1 1 0 0 0-1-1zm-1 26H2V8h4v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h14v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h4z"></path><path d="M6 12h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 18h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 24h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4z"></path></svg>
+    <button type="button" class="spectrum-FieldButton" disabled tabindex="-1" aria-label="Calendar">
+      <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
+        <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />
+      </svg>
     </button>
     <div class="spectrum-Datepicker-focusRing" role="presentation"></div>
   </div>
@@ -41,8 +47,10 @@ markup: |
     <input type="text" class="spectrum-Textfield spectrum-InputGroup-field" placeholder="mm/dd/yyyy hh:mm a" name="start" value="">
     <div class="spectrum-Datepicker--range-dash"></div>
     <input type="text" class="spectrum-Textfield spectrum-InputGroup-field" placeholder="mm/dd/yyyy hh:mm a" name="end" value="">
-    <button type="button" class="spectrum-FieldButton" tabindex="-1" aria-expanded="false" aria-haspopup="dialog">
-      <svg viewBox="0 0 36 36" focusable="false" aria-hidden="true" role="img" class="spectrum-Icon spectrum-Icon--sizeS"><path d="M33 6h-5V3a1 1 0 0 0-1-1h-2a1 1 0 0 0-1 1v3H10V3a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1v3H1a1 1 0 0 0-1 1v26a1 1 0 0 0 1 1h32a1 1 0 0 0 1-1V7a1 1 0 0 0-1-1zm-1 26H2V8h4v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h14v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h4z"></path><path d="M6 12h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 18h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 24h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4z"></path></svg>
+    <button type="button" class="spectrum-FieldButton" tabindex="-1" aria-expanded="false" aria-haspopup="dialog" aria-label="Calendar">
+      <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
+        <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />
+      </svg>
     </button>
     <div class="spectrum-Datepicker-focusRing" role="presentation"></div>
   </div>

--- a/docs/inputgroup/datepicker-range.yml
+++ b/docs/inputgroup/datepicker-range.yml
@@ -1,0 +1,48 @@
+name: Date Picker - Range
+description: A date picker uses the input group component to display a field with a button next to it
+markup: |
+  <div aria-invalid="false" class="spectrum-InputGroup spectrum-Datepicker spectrum-Datepicker--range" role="combobox" aria-expanded="false" aria-haspopup="dialog">
+    <input type="text" class="spectrum-Textfield spectrum-InputGroup-field" placeholder="mm/dd/yyyy" name="start" value="">
+    <hr>
+    <input type="text" class="spectrum-Textfield spectrum-InputGroup-field" placeholder="mm/dd/yyyy" name="end" value="">
+    <button type="button" class="spectrum-FieldButton" tabindex="-1" aria-expanded="false" aria-haspopup="dialog">
+      <svg viewBox="0 0 36 36" focusable="false" aria-hidden="true" role="img" class="spectrum-Icon spectrum-Icon--sizeS"><path d="M33 6h-5V3a1 1 0 0 0-1-1h-2a1 1 0 0 0-1 1v3H10V3a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1v3H1a1 1 0 0 0-1 1v26a1 1 0 0 0 1 1h32a1 1 0 0 0 1-1V7a1 1 0 0 0-1-1zm-1 26H2V8h4v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h14v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h4z"></path><path d="M6 12h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 18h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 24h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4z"></path></svg>
+    </button>
+    <div class="spectrum-Datepicker-focusRing" role="presentation"></div>
+  </div>
+
+  <p/>
+
+  <div aria-invalid="true" class="spectrum-InputGroup spectrum-Datepicker spectrum-Datepicker--range is-invalid" role="combobox" aria-expanded="false" aria-haspopup="dialog">
+    <input type="text" class="spectrum-Textfield spectrum-InputGroup-field" aria-invalid="true" placeholder="mm/dd/yyyy" name="start" value="">
+    <hr>
+    <input type="text" class="spectrum-Textfield spectrum-InputGroup-field is-invalid" aria-invalid="true" placeholder="mm/dd/yyyy" name="end" value="">
+    <button type="button" class="spectrum-FieldButton is-invalid" tabindex="-1" aria-expanded="false" aria-haspopup="dialog">
+      <svg viewBox="0 0 36 36" focusable="false" aria-hidden="true" role="img" class="spectrum-Icon spectrum-Icon--sizeS"><path d="M33 6h-5V3a1 1 0 0 0-1-1h-2a1 1 0 0 0-1 1v3H10V3a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1v3H1a1 1 0 0 0-1 1v26a1 1 0 0 0 1 1h32a1 1 0 0 0 1-1V7a1 1 0 0 0-1-1zm-1 26H2V8h4v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h14v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h4z"></path><path d="M6 12h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 18h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 24h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4z"></path></svg>
+    </button>
+    <div class="spectrum-Datepicker-focusRing" role="presentation"></div>
+  </div>
+
+  <p/>
+
+  <div aria-disabled="true" class="spectrum-InputGroup spectrum-Datepicker spectrum-Datepicker--range is-disabled" role="combobox" aria-expanded="false" aria-haspopup="dialog">
+    <input type="text" class="spectrum-Textfield spectrum-InputGroup-field" placeholder="mm/dd/yyyy" name="start" value="" disabled>
+    <hr>
+    <input type="text" class="spectrum-Textfield spectrum-InputGroup-field" placeholder="mm/dd/yyyy" name="end" value="" disabled>
+    <button type="button" class="spectrum-FieldButton" disabled tabindex="-1">
+      <svg viewBox="0 0 36 36" focusable="false" aria-hidden="true" role="img" class="spectrum-Icon spectrum-Icon--sizeS"><path d="M33 6h-5V3a1 1 0 0 0-1-1h-2a1 1 0 0 0-1 1v3H10V3a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1v3H1a1 1 0 0 0-1 1v26a1 1 0 0 0 1 1h32a1 1 0 0 0 1-1V7a1 1 0 0 0-1-1zm-1 26H2V8h4v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h14v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h4z"></path><path d="M6 12h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 18h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 24h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4z"></path></svg>
+    </button>
+    <div class="spectrum-Datepicker-focusRing" role="presentation"></div>
+  </div>
+
+  <p/>
+
+  <div class="spectrum-InputGroup spectrum-Datepicker spectrum-Datepicker--range  spectrum-Datepicker--datetimeRange" role="combobox" aria-expanded="false" aria-haspopup="dialog">
+    <input type="text" class="spectrum-Textfield spectrum-InputGroup-field" placeholder="mm/dd/yyyy hh:mm a" name="start" value="">
+    <hr>
+    <input type="text" class="spectrum-Textfield spectrum-InputGroup-field" placeholder="mm/dd/yyyy hh:mm a" name="end" value="">
+    <button type="button" class="spectrum-FieldButton" tabindex="-1" aria-expanded="false" aria-haspopup="dialog">
+      <svg viewBox="0 0 36 36" focusable="false" aria-hidden="true" role="img" class="spectrum-Icon spectrum-Icon--sizeS"><path d="M33 6h-5V3a1 1 0 0 0-1-1h-2a1 1 0 0 0-1 1v3H10V3a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1v3H1a1 1 0 0 0-1 1v26a1 1 0 0 0 1 1h32a1 1 0 0 0 1-1V7a1 1 0 0 0-1-1zm-1 26H2V8h4v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h14v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V8h4z"></path><path d="M6 12h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 18h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zM6 24h4v4H6zm6 0h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4z"></path></svg>
+    </button>
+    <div class="spectrum-Datepicker-focusRing" role="presentation"></div>
+  </div>

--- a/docs/inputgroup/datepicker-range.yml
+++ b/docs/inputgroup/datepicker-range.yml
@@ -2,9 +2,9 @@ name: Date Picker - Range
 description: A date picker uses the input group component to display a field with a button next to it
 markup: |
   <div aria-invalid="false" class="spectrum-InputGroup spectrum-Datepicker spectrum-Datepicker--range" role="combobox" aria-expanded="false" aria-haspopup="dialog">
-    <input type="text" class="spectrum-Textfield spectrum-InputGroup-field" placeholder="mm/dd/yyyy" name="start" value="">
+    <input type="text" class="spectrum-Textfield spectrum-InputGroup-field spectrum-Datepicker-field--start" placeholder="mm/dd/yyyy" name="start" value="">
     <div class="spectrum-Datepicker--rangeDash"></div>
-    <input type="text" class="spectrum-Textfield spectrum-InputGroup-field" placeholder="mm/dd/yyyy" name="end" value="">
+    <input type="text" class="spectrum-Textfield spectrum-InputGroup-field spectrum-Datepicker-field--end" placeholder="mm/dd/yyyy" name="end" value="">
     <button type="button" class="spectrum-FieldButton" tabindex="-1" aria-expanded="false" aria-haspopup="dialog" aria-label="Calendar">
       <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
         <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />
@@ -17,9 +17,9 @@ markup: |
   <p/>
 
   <div aria-invalid="true" class="spectrum-InputGroup spectrum-Datepicker spectrum-Datepicker--range is-invalid" role="combobox" aria-expanded="false" aria-haspopup="dialog">
-    <input type="text" class="spectrum-Textfield spectrum-InputGroup-field" aria-invalid="true" placeholder="mm/dd/yyyy" name="start" value="">
+    <input type="text" class="spectrum-Textfield spectrum-InputGroup-field spectrum-Datepicker-field--start" aria-invalid="true" placeholder="mm/dd/yyyy" name="start" value="">
     <div class="spectrum-Datepicker--rangeDash"></div>
-    <input type="text" class="spectrum-Textfield spectrum-InputGroup-field is-invalid" aria-invalid="true" placeholder="mm/dd/yyyy" name="end" value="">
+    <input type="text" class="spectrum-Textfield spectrum-InputGroup-field spectrum-Datepicker-field--end is-invalid" aria-invalid="true" placeholder="mm/dd/yyyy" name="end" value="">
     <button type="button" class="spectrum-FieldButton is-invalid" tabindex="-1" aria-expanded="false" aria-haspopup="dialog" aria-label="Calendar">
       <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
         <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />
@@ -32,9 +32,9 @@ markup: |
   <p/>
 
   <div aria-disabled="true" class="spectrum-InputGroup spectrum-Datepicker spectrum-Datepicker--range is-disabled" role="combobox" aria-expanded="false" aria-haspopup="dialog">
-    <input type="text" class="spectrum-Textfield spectrum-InputGroup-field" placeholder="mm/dd/yyyy" name="start" value="" disabled>
+    <input type="text" class="spectrum-Textfield spectrum-InputGroup-field spectrum-Datepicker-field--start" placeholder="mm/dd/yyyy" name="start" value="" disabled>
     <div class="spectrum-Datepicker--rangeDash"></div>
-    <input type="text" class="spectrum-Textfield spectrum-InputGroup-field" placeholder="mm/dd/yyyy" name="end" value="" disabled>
+    <input type="text" class="spectrum-Textfield spectrum-InputGroup-field spectrum-Datepicker-field--end" placeholder="mm/dd/yyyy" name="end" value="" disabled>
     <button type="button" class="spectrum-FieldButton" disabled tabindex="-1" aria-label="Calendar">
       <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
         <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />
@@ -47,9 +47,9 @@ markup: |
   <p/>
 
   <div class="spectrum-InputGroup spectrum-Datepicker spectrum-Datepicker--range spectrum-Datepicker--datetimeRange" role="combobox" aria-expanded="false" aria-haspopup="dialog">
-    <input type="text" class="spectrum-Textfield spectrum-InputGroup-field" placeholder="mm/dd/yyyy hh:mm a" name="start" value="">
+    <input type="text" class="spectrum-Textfield spectrum-InputGroup-field spectrum-Datepicker-field--start" placeholder="mm/dd/yyyy hh:mm a" name="start" value="">
     <div class="spectrum-Datepicker--rangeDash"></div>
-    <input type="text" class="spectrum-Textfield spectrum-InputGroup-field" placeholder="mm/dd/yyyy hh:mm a" name="end" value="">
+    <input type="text" class="spectrum-Textfield spectrum-InputGroup-field spectrum-Datepicker-field--end" placeholder="mm/dd/yyyy hh:mm a" name="end" value="">
     <button type="button" class="spectrum-FieldButton" tabindex="-1" aria-expanded="false" aria-haspopup="dialog" aria-label="Calendar">
       <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
         <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />

--- a/docs/inputgroup/datepicker-range.yml
+++ b/docs/inputgroup/datepicker-range.yml
@@ -3,7 +3,7 @@ description: A date picker uses the input group component to display a field wit
 markup: |
   <div aria-invalid="false" class="spectrum-InputGroup spectrum-Datepicker spectrum-Datepicker--range" role="combobox" aria-expanded="false" aria-haspopup="dialog">
     <input type="text" class="spectrum-Textfield spectrum-InputGroup-field" placeholder="mm/dd/yyyy" name="start" value="">
-    <div class="spectrum-Datepicker--range-dash"></div>
+    <div class="spectrum-Datepicker--rangeDash"></div>
     <input type="text" class="spectrum-Textfield spectrum-InputGroup-field" placeholder="mm/dd/yyyy" name="end" value="">
     <button type="button" class="spectrum-FieldButton" tabindex="-1" aria-expanded="false" aria-haspopup="dialog" aria-label="Calendar">
       <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
@@ -18,7 +18,7 @@ markup: |
 
   <div aria-invalid="true" class="spectrum-InputGroup spectrum-Datepicker spectrum-Datepicker--range is-invalid" role="combobox" aria-expanded="false" aria-haspopup="dialog">
     <input type="text" class="spectrum-Textfield spectrum-InputGroup-field" aria-invalid="true" placeholder="mm/dd/yyyy" name="start" value="">
-    <div class="spectrum-Datepicker--range-dash"></div>
+    <div class="spectrum-Datepicker--rangeDash"></div>
     <input type="text" class="spectrum-Textfield spectrum-InputGroup-field is-invalid" aria-invalid="true" placeholder="mm/dd/yyyy" name="end" value="">
     <button type="button" class="spectrum-FieldButton is-invalid" tabindex="-1" aria-expanded="false" aria-haspopup="dialog" aria-label="Calendar">
       <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
@@ -33,7 +33,7 @@ markup: |
 
   <div aria-disabled="true" class="spectrum-InputGroup spectrum-Datepicker spectrum-Datepicker--range is-disabled" role="combobox" aria-expanded="false" aria-haspopup="dialog">
     <input type="text" class="spectrum-Textfield spectrum-InputGroup-field" placeholder="mm/dd/yyyy" name="start" value="" disabled>
-    <div class="spectrum-Datepicker--range-dash"></div>
+    <div class="spectrum-Datepicker--rangeDash"></div>
     <input type="text" class="spectrum-Textfield spectrum-InputGroup-field" placeholder="mm/dd/yyyy" name="end" value="" disabled>
     <button type="button" class="spectrum-FieldButton" disabled tabindex="-1" aria-label="Calendar">
       <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
@@ -48,7 +48,7 @@ markup: |
 
   <div class="spectrum-InputGroup spectrum-Datepicker spectrum-Datepicker--range spectrum-Datepicker--datetimeRange" role="combobox" aria-expanded="false" aria-haspopup="dialog">
     <input type="text" class="spectrum-Textfield spectrum-InputGroup-field" placeholder="mm/dd/yyyy hh:mm a" name="start" value="">
-    <div class="spectrum-Datepicker--range-dash"></div>
+    <div class="spectrum-Datepicker--rangeDash"></div>
     <input type="text" class="spectrum-Textfield spectrum-InputGroup-field" placeholder="mm/dd/yyyy hh:mm a" name="end" value="">
     <button type="button" class="spectrum-FieldButton" tabindex="-1" aria-expanded="false" aria-haspopup="dialog" aria-label="Calendar">
       <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">

--- a/docs/inputgroup/datepicker-range.yml
+++ b/docs/inputgroup/datepicker-range.yml
@@ -10,6 +10,7 @@ markup: |
         <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />
       </svg>
     </button>
+    <!-- To render focus ring around entire input group when one of the inputs has keyboard focus, we need this: -->
     <div class="spectrum-Datepicker-focusRing" role="presentation"></div>
   </div>
 
@@ -24,6 +25,7 @@ markup: |
         <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />
       </svg>
     </button>
+    <!-- To render focus ring around entire input group when one of the inputs has keyboard focus, we need this: -->
     <div class="spectrum-Datepicker-focusRing" role="presentation"></div>
   </div>
 
@@ -38,6 +40,7 @@ markup: |
         <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />
       </svg>
     </button>
+    <!-- To render focus ring around entire input group when one of the inputs has keyboard focus, we need this: -->
     <div class="spectrum-Datepicker-focusRing" role="presentation"></div>
   </div>
 
@@ -52,5 +55,6 @@ markup: |
         <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />
       </svg>
     </button>
+    <!-- To render focus ring around entire input group when one of the inputs has keyboard focus, we need this: -->
     <div class="spectrum-Datepicker-focusRing" role="presentation"></div>
   </div>

--- a/src/inputgroup/index.css
+++ b/src/inputgroup/index.css
@@ -25,7 +25,7 @@
   --spectrum-combobox-field-border-width-right: 0;
   --spectrum-combobox-quiet-fieldbutton-padding-right: 0;
   --spectrum-datepicker-input-width: calc(var(--spectrum-global-dimension-size-1600) -  2 * var(--spectrum-padding));
-  --spectrum-datepicker-datetime-input-width: calc(var(--spectrum-datepicker-input-width) + var(--spectrum-global-dimension-size-700));
+  --spectrum-datepicker-datetime-input-width: calc(var(--spectrum-datepicker-input-width) + var(--spectrum-global-dimension-size-700) - 0.5em);
 }
 
 .spectrum-InputGroup {
@@ -113,12 +113,14 @@
   /* Em dash */
   hr {
     border: 0;
-    margin: 4px 0;
+    margin: var(--spectrum-global-dimension-size-50) 0;
     width: 0;
     overflow: visible;
+    position: relative;
+    z-index: 1;
     &:before {
-      content: '–';
-      margin: 0 -4px;
+      content: '—';
+      margin-left: -0.5em;
     }
   }
   /* Focus ring */

--- a/src/inputgroup/index.css
+++ b/src/inputgroup/index.css
@@ -26,6 +26,7 @@
   --spectrum-combobox-quiet-fieldbutton-padding-right: 0;
   --spectrum-datepicker-input-width: calc(var(--spectrum-global-dimension-size-1600) -  2 * var(--spectrum-padding));
   --spectrum-datepicker-datetime-input-width: calc(var(--spectrum-datepicker-input-width) + var(--spectrum-global-dimension-size-700) - 0.5em);
+  --spectrum-datepicker-range-dash-margin-left: -0.5em;
 }
 
 .spectrum-InputGroup {
@@ -111,16 +112,14 @@
     }
   }
   /* Em dash */
-  hr {
-    border: 0;
+  .spectrum-Datepicker--range-dash {
     margin: var(--spectrum-global-dimension-size-50) 0;
     width: 0;
-    overflow: visible;
     position: relative;
     z-index: 1;
     &:before {
       content: '—';
-      margin-left: -0.5em;
+      margin-left: var(--spectrum-datepicker-range-dash-margin-left);
     }
   }
   /* Focus ring */
@@ -140,6 +139,11 @@
       .spectrum-Datepicker-focusRing {
         border-radius: var(--spectrum-combobox-quiet-fieldbutton-border-radius);
         top: auto;
+      }
+    }
+    .spectrum-Datepicker--range-dash {
+      &:before {
+        margin-left: var(--spectrum-datepicker-range-dash-margin-left);
       }
     }
   }

--- a/src/inputgroup/index.css
+++ b/src/inputgroup/index.css
@@ -27,6 +27,8 @@
   --spectrum-datepicker-input-width: calc(var(--spectrum-global-dimension-size-1600) -  2 * var(--spectrum-padding));
   --spectrum-datepicker-datetime-input-width: calc(var(--spectrum-datepicker-input-width) + var(--spectrum-global-dimension-size-700) - var(--spectrum-global-dimension-static-font-size-100) / 2);
   --spectrum-datepicker-range-dash-margin-left: calc(-0.5 * var(--spectrum-global-dimension-static-font-size-100));
+  --spectrum-datepicker-range-dash-padding-top: 3px;
+  --spectrum-datepicker-range-dash-line-height: calc(var(--spectrum-textfield-height) - var(--spectrum-global-dimension-static-size-125));
 }
 
 .spectrum-InputGroup {
@@ -114,15 +116,14 @@
   }
   /* Em dash */
   .spectrum-Datepicker--range-dash {
-    padding: var(--spectrum-textfield-padding-top) 0 var(--spectrum-textfield-padding-bottom);
+    line-height: var(--spectrum-datepicker-range-dash-line-height);
+    padding-top: var(--spectrum-datepicker-range-dash-padding-top);
     position: relative;
     width: 0;
     z-index: 1;
     &:before {
       content: '—';
       display: inline-block;
-      letter-spacing: 0;
-      line-height: var(--spectrum-text-body-line-height);
       margin: 0 var(--spectrum-datepicker-range-dash-margin-left);
       overflow: hidden;
       text-align: center;

--- a/src/inputgroup/index.css
+++ b/src/inputgroup/index.css
@@ -99,7 +99,7 @@
     width: var(--spectrum-datepicker-input-width);
     min-width: var(--spectrum-datepicker-input-width);
     flex: initial;
-    &:nth-of-type(1) {
+    &.spectrum-Datepicker-field--start {
       border-right: 0;
       padding-right: var(--spectrum-padding);
       &.is-invalid,
@@ -108,7 +108,7 @@
         padding-right: var(--spectrum-padding);
       }
     }
-    &:nth-of-type(2) {
+    &.spectrum-Datepicker-field--end {
       border-left: 0;
       border-radius: 0;
       padding-left: var(--spectrum-padding);

--- a/src/inputgroup/index.css
+++ b/src/inputgroup/index.css
@@ -99,7 +99,7 @@
     width: var(--spectrum-datepicker-input-width);
     min-width: var(--spectrum-datepicker-input-width);
     flex: initial;
-    &.spectrum-Datepicker-field--start {
+    &.spectrum-Datepicker-startField {
       border-right: 0;
       padding-right: var(--spectrum-padding);
       &.is-invalid,
@@ -108,7 +108,7 @@
         padding-right: var(--spectrum-padding);
       }
     }
-    &.spectrum-Datepicker-field--end {
+    &.spectrum-Datepicker-endField {
       border-left: 0;
       border-radius: 0;
       padding-left: var(--spectrum-padding);

--- a/src/inputgroup/index.css
+++ b/src/inputgroup/index.css
@@ -12,12 +12,20 @@
 /* topdoc
 {{ inputgroup/datepicker-quiet.yml }}
 */
+/* topdoc
+{{ inputgroup/datepicker-range.yml }}
+*/
+/* topdoc
+{{ inputgroup/datepicker-range-quiet.yml }}
+*/
 
 :root {
   /* Todo: move to DNA */
   --spectrum-combobox-quiet-fieldbutton-border-radius: 0;
   --spectrum-combobox-field-border-width-right: 0;
   --spectrum-combobox-quiet-fieldbutton-padding-right: 0;
+  --spectrum-datepicker-input-width: calc(var(--spectrum-global-dimension-size-1600) -  2 * var(--spectrum-padding));
+  --spectrum-datepicker-datetime-input-width: calc(var(--spectrum-datepicker-input-width) + var(--spectrum-global-dimension-size-700));
 }
 
 .spectrum-InputGroup {
@@ -26,6 +34,7 @@
   flex-direction: row;
   flex-wrap: nowrap;
   min-width: var(--spectrum-component-single-line-width);
+  border-radius: var(--spectrum-border-radius);
 
   .spectrum-FieldButton {
     padding: 0 var(--spectrum-dropdown-padding-x);
@@ -42,6 +51,7 @@
 }
 
 .spectrum-InputGroup--quiet {
+  border-radius: var(--spectrum-combobox-quiet-fieldbutton-border-radius);
   .spectrum-FieldButton {
     border-radius: var(--spectrum-combobox-quiet-fieldbutton-border-radius);
 
@@ -61,5 +71,74 @@
 
   .spectrum-InputGroup-icon {
     right: 0;
+  }
+}
+
+.spectrum-Datepicker--range {
+  border-radius: var(--spectrum-border-radius);
+  /* Input Group */
+  &.spectrum-InputGroup--quiet {
+    border-radius: var(--spectrum-combobox-quiet-fieldbutton-border-radius);
+    .spectrum-FieldButton {
+      border-radius: var(--spectrum-combobox-quiet-fieldbutton-border-radius);
+    }
+  }
+  /** Datetime Range **/
+  &.spectrum-Datepicker--datetimeRange {
+    /* Inputs */
+    .spectrum-InputGroup-field {
+      width: var(--spectrum-datepicker-datetime-input-width);
+      min-width: var(--spectrum-datepicker-datetime-input-width);
+    }
+  }
+  /* Inputs */
+  .spectrum-InputGroup-field {
+    width: var(--spectrum-datepicker-input-width);
+    min-width: var(--spectrum-datepicker-input-width);
+    &:nth-of-type(1) {
+      border-right: 0;
+      padding-right: var(--spectrum-padding);
+      &.is-invalid,
+      &:invalid {
+        background-image: none;
+        padding-right: var(--spectrum-padding);
+      }
+    }
+    &:nth-of-type(2) {
+      border-left: 0;
+      border-radius: 0;
+      padding-left: var(--spectrum-padding);
+    }
+  }
+  /* Em dash */
+  hr {
+    border: 0;
+    margin: 4px 0;
+    width: 0;
+    overflow: visible;
+    &:before {
+      content: '–';
+      margin: 0 -4px;
+    }
+  }
+  /* Focus ring */
+  &.is-focused {
+    .spectrum-Datepicker-focusRing {
+      position: absolute;
+      border-radius: var(--spectrum-border-radius);
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      pointer-events: none;
+    }
+  }
+  &.spectrum-InputGroup--quiet {
+    &.is-focused {
+      .spectrum-Datepicker-focusRing {
+        border-radius: var(--spectrum-combobox-quiet-fieldbutton-border-radius);
+        top: auto;
+      }
+    }
   }
 }

--- a/src/inputgroup/index.css
+++ b/src/inputgroup/index.css
@@ -27,8 +27,8 @@
   --spectrum-datepicker-input-width: calc(var(--spectrum-global-dimension-size-1600) -  2 * var(--spectrum-padding));
   --spectrum-datepicker-datetime-input-width: calc(var(--spectrum-datepicker-input-width) + var(--spectrum-global-dimension-size-700) - var(--spectrum-global-dimension-static-font-size-100) / 2);
   --spectrum-datepicker-range-dash-margin-left: calc(-0.5 * var(--spectrum-global-dimension-static-font-size-100));
-  --spectrum-datepicker-range-dash-padding-top: 3px;
-  --spectrum-datepicker-range-dash-line-height: calc(var(--spectrum-textfield-height) - var(--spectrum-global-dimension-static-size-125));
+  --spectrum-datepicker-range-dash-padding-top: 0;
+  --spectrum-datepicker-range-dash-line-height: calc(var(--spectrum-textfield-height) - var(--spectrum-global-dimension-size-100));
 }
 
 .spectrum-InputGroup {
@@ -115,10 +115,10 @@
     }
   }
   /* Em dash */
-  .spectrum-Datepicker--range-dash {
+  .spectrum-Datepicker--rangeDash {
     line-height: var(--spectrum-datepicker-range-dash-line-height);
     padding-top: var(--spectrum-datepicker-range-dash-padding-top);
-    position: relative;
+    flex: initial;
     width: 0;
     z-index: 1;
     &:before {
@@ -150,7 +150,7 @@
         top: auto;
       }
     }
-    .spectrum-Datepicker--range-dash {
+    .spectrum-Datepicker--rangeDash {
       &:before {
         margin-left: var(--spectrum-datepicker-range-dash-margin-left);
       }

--- a/src/inputgroup/index.css
+++ b/src/inputgroup/index.css
@@ -25,8 +25,8 @@
   --spectrum-combobox-field-border-width-right: 0;
   --spectrum-combobox-quiet-fieldbutton-padding-right: 0;
   --spectrum-datepicker-input-width: calc(var(--spectrum-global-dimension-size-1600) -  2 * var(--spectrum-padding));
-  --spectrum-datepicker-datetime-input-width: calc(var(--spectrum-datepicker-input-width) + var(--spectrum-global-dimension-size-700) - 0.5em);
-  --spectrum-datepicker-range-dash-margin-left: -0.5em;
+  --spectrum-datepicker-datetime-input-width: calc(var(--spectrum-datepicker-input-width) + var(--spectrum-global-dimension-size-700) - var(--spectrum-global-dimension-static-font-size-100) / 2);
+  --spectrum-datepicker-range-dash-margin-left: calc(-0.5 * var(--spectrum-global-dimension-static-font-size-100));
 }
 
 .spectrum-InputGroup {
@@ -96,6 +96,7 @@
   .spectrum-InputGroup-field {
     width: var(--spectrum-datepicker-input-width);
     min-width: var(--spectrum-datepicker-input-width);
+    flex: initial;
     &:nth-of-type(1) {
       border-right: 0;
       padding-right: var(--spectrum-padding);
@@ -113,13 +114,20 @@
   }
   /* Em dash */
   .spectrum-Datepicker--range-dash {
-    margin: var(--spectrum-global-dimension-size-50) 0;
-    width: 0;
+    padding: var(--spectrum-textfield-padding-top) 0 var(--spectrum-textfield-padding-bottom);
     position: relative;
+    width: 0;
     z-index: 1;
     &:before {
       content: '—';
-      margin-left: var(--spectrum-datepicker-range-dash-margin-left);
+      display: inline-block;
+      letter-spacing: 0;
+      line-height: var(--spectrum-text-body-line-height);
+      margin: 0 var(--spectrum-datepicker-range-dash-margin-left);
+      overflow: hidden;
+      text-align: center;
+      vertical-align: middle;
+      width: var(--spectrum-global-dimension-static-font-size-100);
     }
   }
   /* Focus ring */

--- a/src/inputgroup/skin.css
+++ b/src/inputgroup/skin.css
@@ -109,7 +109,7 @@
       box-shadow: none !important;
     }
     &[disabled] {
-      ~ hr {
+      ~ .spectrum-Datepicker--rangeDash {
         color: var(--spectrum-textfield-text-color-disabled);
       }
     }

--- a/src/inputgroup/skin.css
+++ b/src/inputgroup/skin.css
@@ -115,7 +115,7 @@
     }
   }
 
-  /* Focus ring */
+  /* Focus ring: When one of the inputs or the button has keyboard focus, render the focus ring border around the entire input group by styling an adjacent descendant element. */
   :focus-ring {
     ~ .spectrum-Datepicker-focusRing {
       box-shadow: 0 0 0 1px var(--spectrum-dropdown-border-color-key-focus);
@@ -135,6 +135,8 @@
     .spectrum-InputGroup-field {
       border-color: var(--spectrum-dropdown-border-color-error) !important;
     }
+
+    /* Focus ring: When one of the inputs or the button has keyboard focus, render the focus ring border around the entire input group by styling an adjacent descendant element. */
     :focus-ring {
       ~ .spectrum-Datepicker-focusRing {
         box-shadow: 0 0 0 1px var(--spectrum-dropdown-border-color-error);

--- a/src/inputgroup/skin.css
+++ b/src/inputgroup/skin.css
@@ -1,9 +1,27 @@
 .spectrum-InputGroup {
+  &.is-focused {
+    &:not(.is-invalid) {
+      .spectrum-InputGroup-field:not(:disabled):not(.is-invalid) {
+        border-color: var(--spectrum-textfield-border-color-key-focus);
+        ~ .spectrum-FieldButton {
+          border-color: var(--spectrum-textfield-border-color-key-focus);
+        }
+      }
+    }
+  }
   &:hover {
-    .spectrum-InputGroup-field:not(:disabled):not(.is-invalid):not(:focus) {
-      &,
-      & ~ .spectrum-FieldButton {
+    &:not(.is-invalid):not(.is-focused) {
+      .spectrum-InputGroup-field:not(:disabled):not(.is-invalid) {
         border-color: var(--spectrum-textfield-border-color-hover);
+        ~ .spectrum-FieldButton {
+          border-color: var(--spectrum-textfield-border-color-hover);
+        }
+        &:focus {
+          border-color: var(--spectrum-textfield-border-color-key-focus);
+          ~ .spectrum-FieldButton {
+            border-color: var(--spectrum-textfield-border-color-key-focus);
+          }
+        }
       }
     }
   }
@@ -51,10 +69,9 @@
     }
   }
 
-  &:hover {
+  &:hover:not(.is-invalid) {
     .spectrum-InputGroup-field:not(:disabled):not(.is-invalid):not(:focus) {
-      &,
-      & ~ .spectrum-FieldButton {
+      ~ .spectrum-FieldButton {
         border-color: var(--spectrum-textfield-quiet-border-color-hover);
       }
     }
@@ -63,7 +80,6 @@
   .spectrum-InputGroup-field {
     &.is-invalid,
     &:invalid {
-      &,
       ~ .spectrum-FieldButton {
         border-color: var(--spectrum-textfield-border-color-error);
       }
@@ -81,6 +97,80 @@
         ~ .spectrum-FieldButton {
           box-shadow: 0 1px 0 var(--spectrum-textfield-border-color-error);
           border-color: var(--spectrum-textfield-border-color-error);
+        }
+      }
+    }
+  }
+}
+
+.spectrum-Datepicker--range {
+  .spectrum-InputGroup-field {
+    &:focus-ring {
+      box-shadow: none !important;
+    }
+    &[disabled] {
+      ~ hr {
+        color: var(--spectrum-textfield-text-color-disabled);
+      }
+    }
+  }
+
+  /* Focus ring */
+  :focus-ring {
+    ~ .spectrum-Datepicker-focusRing {
+      box-shadow: 0 0 0 1px var(--spectrum-dropdown-border-color-key-focus);
+    }
+    &:invalid,
+    &.is-invalid {
+      ~ .spectrum-FieldButton {
+        box-shadow: 0 0 0 1px var(--spectrum-dropdown-border-color-error);
+      }
+      ~ .spectrum-Datepicker-focusRing {
+        box-shadow: 0 0 0 1px var(--spectrum-dropdown-border-color-error);
+      }
+    }
+  }
+
+  &.is-invalid {
+    .spectrum-InputGroup-field {
+      border-color: var(--spectrum-dropdown-border-color-error) !important;
+    }
+    :focus-ring {
+      ~ .spectrum-Datepicker-focusRing {
+        box-shadow: 0 0 0 1px var(--spectrum-dropdown-border-color-error);
+      }
+      ~ .spectrum-FieldButton {
+        border-color: var(--spectrum-dropdown-border-color-error);
+        box-shadow: 0 0 0 1px var(--spectrum-dropdown-border-color-error);
+      }
+    }
+    .spectrum-FieldButton {
+      border-color: var(--spectrum-dropdown-border-color-error);
+      &.is-invalid {
+        &:focus-ring {
+          border-color: var(--spectrum-dropdown-border-color-error);
+          box-shadow: 0 0 0 1px var(--spectrum-dropdown-border-color-error);
+        }
+      }
+    }
+  }
+  &.spectrum-InputGroup--quiet {
+    &.is-focused {
+      .spectrum-Datepicker-focusRing {
+        box-shadow: 0 0 0 1px var(--spectrum-dropdown-border-color-key-focus);
+      }
+      &.is-invalid {
+        .spectrum-FieldButton {
+          box-shadow: none;
+          border-color: var(--spectrum-dropdown-border-color-error);
+          &.is-invalid {
+            &:focus-ring {
+              box-shadow: 0 2px 0 0 var(--spectrum-dropdown-border-color-error);
+            }
+          }
+        }
+        .spectrum-Datepicker-focusRing {
+          box-shadow: 0 0 0 1px var(--spectrum-dropdown-border-color-error);
         }
       }
     }

--- a/topdoc/resources/js/docs.js
+++ b/topdoc/resources/js/docs.js
@@ -490,7 +490,7 @@ function makeRangeDatepicker(rangedatepicker) {
   function updateDashMarginStyle(event) {
     var textfieldNode = event.target;
     var dash = textfieldNode.nextElementSibling;
-    var isQuiet = textfieldNode.classList.contains('spectrum-TextField--quiet');
+    var isQuiet = textfieldNode.className.indexOf('spectrum-TextField--quiet') !== -1;
     var font = getFontShorthand(textfieldNode);
     var text = textfieldNode.value.trim();
     if (!text.length) {
@@ -498,19 +498,19 @@ function makeRangeDatepicker(rangedatepicker) {
     }
     var textWidth = getTextWidth(text, font);
     var computedStyle = window.getComputedStyle(textfieldNode, null);
-    var paddingLeft = parseFloat(computedStyle.paddingLeft);
-    var fieldWidth = parseFloat(computedStyle.width) - paddingLeft;
-    var emWidth = parseFloat(computedStyle.fontSize) / 2;
-    var offsetPadding = isQuiet ? parseInt(computedStyle.paddingRight) : paddingLeft;
-    var offset = Math.max(emWidth * 2, fieldWidth - textWidth - emWidth + offsetPadding) / 2;
-    dash.style.marginLeft =  emWidth - offset + 'px';
-    dash.style.marginRight = offset - emWidth + 'px';
+    const emWidth = parseFloat(computedStyle.fontSize) / 2;
+    const paddingRight = parseFloat(computedStyle.paddingRight);
+    const paddingLeft = parseFloat(computedStyle.paddingLeft);
+    const fieldWidth = parseFloat(computedStyle.width);
+    const offset = Math.max(emWidth / 2, fieldWidth - textWidth - paddingRight - paddingLeft + emWidth / 2) / 2;
+    dash.style.marginLeft = -offset + 'px';
+    dash.style.marginRight = offset + 'px';
   }
 
   startInput.addEventListener('input', updateDashMarginStyle);
   setTimeout(function() {
     updateDashMarginStyle({target: startInput});
-  }, 2000);
+  }, 5000);
 }
 
 window.addEventListener('DOMContentLoaded', function() {

--- a/topdoc/resources/js/docs.js
+++ b/topdoc/resources/js/docs.js
@@ -84,15 +84,29 @@ window.addEventListener('click', function(event) {
   }
 });
 
-// Display Slider focus style
-function toggleSliderFocus(event) {
-  if (!event.target.classList.contains('spectrum-Slider-input')) {
+// Display InputGroup focus style
+function toggleInputGroupFocus(event) {
+  var classList = event.target.classList;
+  var closestSelector;
+  // target within InputGroup
+  if (classList.contains('spectrum-InputGroup-field') ||
+      classList.contains('spectrum-FieldButton')) {
+    closestSelector = '.spectrum-InputGroup';
+  }
+  // target within a Slider
+  else if (classList.contains('spectrum-Slider-input')) {
+    closestSelector = '.spectrum-Slider-handle';
+  }
+  else {
     return;
   }
   var func = event.type === 'focus' ? 'add' : 'remove';
-  var handle = event.target.closest('.spectrum-Slider-handle');
-  handle.classList[func]('is-focused');
+  var closestElement = event.target.closest(closestSelector);
+  closestElement.classList[func]('is-focused');
 }
+
+document.addEventListener('focus', toggleInputGroupFocus, true);
+document.addEventListener('blur', toggleInputGroupFocus, true);
 
 var currentTitle = null;
 var titles;
@@ -255,9 +269,6 @@ window.addEventListener('DOMContentLoaded', function() {
     hashTimeout = setTimeout(setHashFromScroll, scrollTimeDelay);
   });
 });
-
-document.addEventListener('focus', toggleSliderFocus, true);
-document.addEventListener('blur', toggleSliderFocus, true);
 
 // Load and store references to icon SVGs
 // var mediumIcons;

--- a/topdoc/resources/js/docs.js
+++ b/topdoc/resources/js/docs.js
@@ -460,67 +460,11 @@ function makeDial(dial) {
   }
 }
 
-function getTextWidth(text, font) {
-  var canvas = getTextWidth.canvas || (getTextWidth.canvas = document.createElement('canvas'));
-  var context = canvas.getContext('2d');
-  if (context) {
-    context.font = font || '14px adobe-clean, Helvetica, Arial, sans-serif';
-    var metrics = context.measureText(text);
-    return metrics.width;
-  }
-  return 0;
-}
-
-function getFontShorthand(element) {
-  if (!element) {
-    element = document.body;
-  }
-  var prop = ['font-style', 'font-variant', 'font-weight', 'font-size', 'font-family'];
-  var props = [];
-  var computedStyle = window.getComputedStyle(element, null);
-  for (var x in prop) {
-    props.push(computedStyle.getPropertyValue(prop[x]));
-  }
-  return props.join(' ');
-}
-
-function makeRangeDatepicker(rangedatepicker) {
-  var startInput = rangedatepicker.querySelector('.spectrum-InputGroup-field');
-
-  function updateDashMarginStyle(event) {
-    var textfieldNode = event.target;
-    var dash = textfieldNode.nextElementSibling;
-    var isQuiet = textfieldNode.className.indexOf('spectrum-TextField--quiet') !== -1;
-    var font = getFontShorthand(textfieldNode);
-    var text = textfieldNode.value.trim();
-    if (!text.length) {
-      text = textfieldNode.getAttribute('placeholder').trim();
-    }
-    var textWidth = getTextWidth(text, font);
-    var computedStyle = window.getComputedStyle(textfieldNode, null);
-    const emWidth = parseFloat(computedStyle.fontSize) / 2;
-    const paddingRight = parseFloat(computedStyle.paddingRight);
-    const paddingLeft = parseFloat(computedStyle.paddingLeft);
-    const fieldWidth = parseFloat(computedStyle.width);
-    const offset = Math.max(emWidth / 2, fieldWidth - textWidth - paddingRight - paddingLeft + emWidth / 2) / 2;
-    dash.style.marginLeft = -offset + 'px';
-    dash.style.marginRight = offset + 'px';
-  }
-
-  startInput.addEventListener('input', updateDashMarginStyle);
-  setTimeout(function() {
-    updateDashMarginStyle({target: startInput});
-  }, 5000);
-}
-
 window.addEventListener('DOMContentLoaded', function() {
   Array.prototype.forEach.call(document.querySelectorAll('.spectrum-Slider'), function(slider) {
     makeSlider(slider);
   });
   Array.prototype.forEach.call(document.querySelectorAll('.spectrum-Dial'), function(dial) {
     makeDial(dial);
-  });
-  Array.prototype.forEach.call(document.querySelectorAll('.spectrum-Datepicker--range'), function(rangedatepicker) {
-    makeRangeDatepicker(rangedatepicker);
   });
 });

--- a/topdoc/resources/js/docs.js
+++ b/topdoc/resources/js/docs.js
@@ -460,11 +460,67 @@ function makeDial(dial) {
   }
 }
 
+function getTextWidth(text, font) {
+  var canvas = getTextWidth.canvas || (getTextWidth.canvas = document.createElement('canvas'));
+  var context = canvas.getContext('2d');
+  if (context) {
+    context.font = font || '14px adobe-clean, Helvetica, Arial, sans-serif';
+    var metrics = context.measureText(text);
+    return metrics.width;
+  }
+  return 0;
+}
+
+function getFontShorthand(element) {
+  if (!element) {
+    element = document.body;
+  }
+  var prop = ['font-style', 'font-variant', 'font-weight', 'font-size', 'font-family'];
+  var props = [];
+  var computedStyle = window.getComputedStyle(element, null);
+  for (var x in prop) {
+    props.push(computedStyle.getPropertyValue(prop[x]));
+  }
+  return props.join(' ');
+}
+
+function makeRangeDatepicker(rangedatepicker) {
+  var startInput = rangedatepicker.querySelector('.spectrum-InputGroup-field');
+
+  function updateDashMarginStyle(event) {
+    var textfieldNode = event.target;
+    var dash = textfieldNode.nextElementSibling;
+    var isQuiet = textfieldNode.classList.contains('spectrum-TextField--quiet');
+    var font = getFontShorthand(textfieldNode);
+    var text = textfieldNode.value.trim();
+    if (!text.length) {
+      text = textfieldNode.getAttribute('placeholder').trim();
+    }
+    var textWidth = getTextWidth(text, font);
+    var computedStyle = window.getComputedStyle(textfieldNode, null);
+    var paddingLeft = parseFloat(computedStyle.paddingLeft);
+    var fieldWidth = parseFloat(computedStyle.width) - paddingLeft;
+    var emWidth = parseFloat(computedStyle.fontSize) / 2;
+    var offsetPadding = isQuiet ? parseInt(computedStyle.paddingRight) : paddingLeft;
+    var offset = Math.max(emWidth * 2, fieldWidth - textWidth - emWidth + offsetPadding) / 2;
+    dash.style.marginLeft =  emWidth - offset + 'px';
+    dash.style.marginRight = offset - emWidth + 'px';
+  }
+
+  startInput.addEventListener('input', updateDashMarginStyle);
+  setTimeout(function() {
+    updateDashMarginStyle({target: startInput});
+  }, 2000);
+}
+
 window.addEventListener('DOMContentLoaded', function() {
   Array.prototype.forEach.call(document.querySelectorAll('.spectrum-Slider'), function(slider) {
     makeSlider(slider);
   });
   Array.prototype.forEach.call(document.querySelectorAll('.spectrum-Dial'), function(dial) {
     makeDial(dial);
+  });
+  Array.prototype.forEach.call(document.querySelectorAll('.spectrum-Datepicker--range'), function(rangedatepicker) {
+    makeRangeDatepicker(rangedatepicker);
   });
 });


### PR DESCRIPTION
Add Datepicker range variants to InputGroup to support date and datetime range.

## Description
Add `.spectrum-Datepicker--range` and `.spectrum-Datepicker--datetimeRange` to `.spectrum-InputGroup` style definitions.

Update docs to support adding `.is-focused` style to InputGroup on focus, similar to how we do it for `.spectrum-Slider`. 

## Related Issues
#54 
[✨ RSP-631: Datepicker range styles added](https://github.com/adobe/spectrum-css/pull/13)
Spectrum/spectrum-css/issues/663
JIRA issue RSP-631

## Motivation and Context
Calendar supports range selection but Datepicker component does not display the date range.

## How Has This Been Tested?
Tested in Spectrum docs and as part of a related React-Spectrum PR.

## Screenshots (if appropriate):
![Datepicker Range Input Group](https://user-images.githubusercontent.com/154077/49904357-e5fcb380-fe37-11e8-873b-2ff50aea20de.png)
![Datepicker Range Input Group (Quiet variant)](https://user-images.githubusercontent.com/154077/49904479-44299680-fe38-11e8-9514-b6faac7683a7.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
