### PR TITLE
Fix Toast layout in IE11, fixes #64

### DIFF
--- a/src/toast/index.css
+++ b/src/toast/index.css
@@ -34,7 +34,7 @@
 }
 
 .spectrum-Toast-content {
-  flex: 1;
+  flex: 1 1 auto;
   display: inline-block;
   box-sizing: border-box;
   padding: var(--spectrum-toast-content-padding-top) var(--spectrum-toast-content-padding-right) var(--spectrum-toast-content-padding-bottom) 0;
@@ -44,8 +44,7 @@
 .spectrum-Toast-buttons {
   display: flex;
   flex: 0 0 auto;
-  align-items: flex-end;
-  flex-wrap: wrap-reverse;
+  align-items: flex-start;
 
   .spectrum-Button,
   .spectrum-ClearButton {
@@ -57,7 +56,7 @@
 }
 
 .spectrum-Toast-body {
-  flex: 1;
+  flex: 1 1 auto;
   align-self: center;
 
   .spectrum-Button {


### PR DESCRIPTION
## Description

Flex shorthand and some dead code broke IE 11.

## Related Issue

#64 

## How Has This Been Tested?

Opened it up in IE 11, success.

![image](https://user-images.githubusercontent.com/201344/50785577-f735b600-1265-11e9-8877-b74e1f76cf7d.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Bug fix (non-breaking change which fixes an issue)