### PR TITLE
[IE11] fix dropdown and menu width

### DIFF
--- a/src/dropdown/index.css
+++ b/src/dropdown/index.css
@@ -49,7 +49,7 @@
 
 .spectrum-Dropdown-label {
   /* Be the biggest! */
-  flex: 1;
+  flex: 1 0 auto;
 
   white-space: nowrap;
   overflow: hidden;

--- a/src/menu/index.css
+++ b/src/menu/index.css
@@ -94,7 +94,7 @@
 }
 
 .spectrum-Menu-itemLabel {
-  flex: 1 1 0;
+  flex: 1 1 auto;
 }
 
 .spectrum-Menu-itemLabel--wrapping {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Motivation and Context
IE11 compatibility for dropdowns.

## Issue
#74 

## How Has This Been Tested?
In VM (Windows 10 IE11), OS X (Chrome latest)

## Screenshots (if appropriate):
![screen shot 2019-01-16 at 10 58 13 am](https://user-images.githubusercontent.com/3268477/51273531-c8b08d00-1981-11e9-9bcf-ccc271e24f2f.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.