### PR TITLE
Fix text alignment when text < min-width in Safari 10

### DIFF
--- a/src/button/index.css
+++ b/src/button/index.css
@@ -166,6 +166,9 @@ a.spectrum-ActionButton {
   justify-content: center;
   align-items: center;
 
+  /* @safari10 Workaround for https://bugs.webkit.org/show_bug.cgi?id=169700 */
+  width: 100%;
+
   &:empty {
     display: none;
   }


### PR DESCRIPTION
## Description

A hacky little workaround (the best kind)  for a good 'ol Safari 10 issue: https://bugs.webkit.org/show_bug.cgi?id=169700

## Related Issue

#76 

## How Has This Been Tested?

I checked it in Safari 10, then tested the following to make sure there were no weird side effects:

* Chrome
* Firefox 
* IE 11
* Safari 11

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Bug fix (non-breaking change which fixes an issue)

