### PR TITLE
Fix deletable tag icon alignment in Safari 10, fixes #66

### DIFF
--- a/src/button/index.css
+++ b/src/button/index.css
@@ -253,6 +253,11 @@ a.spectrum-ActionButton {
   margin: 0;
 
   border: none;
+
+  > .spectrum-Icon {
+    /* @safari10 Workaround for https://bugs.webkit.org/show_bug.cgi?id=169700 */
+    margin: 0 auto;
+  }
 }
 
 .spectrum-ClearButton--small {


### PR DESCRIPTION
## Description

For icons in deletable tags, fall back to how we used to center things to appease the Safari 10 gods.

## Related Issue

#66 

## How Has This Been Tested?

A quick scroll through in:
* Safari 10
* Chrome

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Bug fix (non-breaking change which fixes an issue)
