### PR TITLE
Accordion: Update implementation to follow WAI-ARIA 1.1 design pattern (#81)

### DIFF
--- a/docs/accordion/accordion.yml
+++ b/docs/accordion/accordion.yml
@@ -1,33 +1,41 @@
 ---
 name: Accordion
 markup: |
-  <div class="spectrum-Accordion">
-    <div class="spectrum-Accordion-item is-open">
-      <div class="spectrum-Accordion-itemHeader" tabindex="0">Header 1</div>
-      <svg class="spectrum-Icon spectrum-UIIcon-ChevronRightMedium spectrum-Accordion-itemIndicator" focusable="false" aria-hidden="true">
-        <use xlink:href="#spectrum-css-icon-ChevronRightMedium" />
-      </svg>
-      <div class="spectrum-Accordion-itemContent">Item 1</div>
+  <div class="spectrum-Accordion" role="region">
+    <div class="spectrum-Accordion-item is-open" role="presentation">
+      <h3 class="spectrum-Accordion-itemHeading">
+        <button class="spectrum-Accordion-itemHeader" type="button" id="spectrum-accordion-item-0-header" aria-controls="spectrum-accordion-item-0-content" aria-expanded="true">Header 1</button>
+        <svg class="spectrum-Icon spectrum-UIIcon-ChevronRightMedium spectrum-Accordion-itemIndicator" focusable="false" aria-hidden="true">
+          <use xlink:href="#spectrum-css-icon-ChevronRightMedium" />
+        </svg>
+      </h3>
+      <div class="spectrum-Accordion-itemContent" role="region" id="spectrum-accordion-item-0-content" aria-labelledby="spectrum-accordion-item-0-header">Item 1</div>
     </div>
-    <div class="spectrum-Accordion-item is-disabled">
-      <div class="spectrum-Accordion-itemHeader">Header 2</div>
-      <svg class="spectrum-Icon spectrum-UIIcon-ChevronRightMedium spectrum-Accordion-itemIndicator" focusable="false" aria-hidden="true">
-        <use xlink:href="#spectrum-css-icon-ChevronRightMedium" />
-      </svg>
-      <div class="spectrum-Accordion-itemContent">Item 1</div>
+    <div class="spectrum-Accordion-item is-disabled" role="presentation">
+      <h3 class="spectrum-Accordion-itemHeading">
+        <button class="spectrum-Accordion-itemHeader" type="button" disabled id="spectrum-accordion-item-1-header" aria-controls="spectrum-accordion-item-1-content" aria-expanded="false">Header 2</button>
+        <svg class="spectrum-Icon spectrum-UIIcon-ChevronRightMedium spectrum-Accordion-itemIndicator" focusable="false" aria-hidden="true">
+          <use xlink:href="#spectrum-css-icon-ChevronRightMedium" />
+        </svg>
+      </h3>
+      <div class="spectrum-Accordion-itemContent" role="region" id="spectrum-accordion-item-1-content" aria-labelledby="spectrum-accordion-item-1-header">Item 2</div>
     </div>
-    <div class="spectrum-Accordion-item">
-      <div class="spectrum-Accordion-itemHeader" tabindex="0">Header 2</div>
-      <svg class="spectrum-Icon spectrum-UIIcon-ChevronRightMedium spectrum-Accordion-itemIndicator" focusable="false" aria-hidden="true">
-        <use xlink:href="#spectrum-css-icon-ChevronRightMedium" />
-      </svg>
-      <div class="spectrum-Accordion-itemContent">Item 1</div>
+    <div class="spectrum-Accordion-item" role="presentation">
+      <h3 class="spectrum-Accordion-itemHeading">
+        <button class="spectrum-Accordion-itemHeader" type="button" id="spectrum-accordion-item-2-header" aria-controls="spectrum-accordion-item-2-content" aria-expanded="false">Header 3</button>
+        <svg class="spectrum-Icon spectrum-UIIcon-ChevronRightMedium spectrum-Accordion-itemIndicator" focusable="false" aria-hidden="true">
+          <use xlink:href="#spectrum-css-icon-ChevronRightMedium" />
+        </svg>
+      </h3>
+      <div class="spectrum-Accordion-itemContent" role="region" id="spectrum-accordion-item-2-content" aria-labelledby="spectrum-accordion-item-2-header">Item 3</div>
     </div>
-    <div class="spectrum-Accordion-item">
-      <div class="spectrum-Accordion-itemHeader" tabindex="0">Header 3</div>
-      <svg class="spectrum-Icon spectrum-UIIcon-ChevronRightMedium spectrum-Accordion-itemIndicator" focusable="false" aria-hidden="true">
-        <use xlink:href="#spectrum-css-icon-ChevronRightMedium" />
-      </svg>
-      <div class="spectrum-Accordion-itemContent">Item 1</div>
+    <div class="spectrum-Accordion-item" role="presentation">
+      <h3 class="spectrum-Accordion-itemHeading">
+        <button class="spectrum-Accordion-itemHeader" type="button" id="spectrum-accordion-item-3-header" aria-controls="spectrum-accordion-item-3-content" aria-expanded="false">Header 4</button>
+        <svg class="spectrum-Icon spectrum-UIIcon-ChevronRightMedium spectrum-Accordion-itemIndicator" focusable="false" aria-hidden="true">
+          <use xlink:href="#spectrum-css-icon-ChevronRightMedium" />
+        </svg>
+      </h3>
+      <div class="spectrum-Accordion-itemContent" role="region" id="spectrum-accordion-item-3-content" aria-labelledby="spectrum-accordion-item-3-header">Item 4</div>
     </div>
   </div>

--- a/src/accordion/index.css
+++ b/src/accordion/index.css
@@ -44,6 +44,10 @@
   }
 }
 
+.spectrum-Accordion-itemHeading {
+  margin: 0;
+}
+
 .spectrum-Accordion-itemHeader {
   position: relative;
 
@@ -62,6 +66,17 @@
   text-overflow: ellipsis;
   cursor: pointer;
   font-weight: 500;
+
+  /* reset styling if button element is used */
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: inherit;
+  border: 0;
+  display: block;
+  font-family: inherit;
+  text-align: start;
+  width: 100%;
 
   &:focus {
     outline: none;
@@ -86,6 +101,12 @@
 
 .spectrum-Accordion-item {
   &.is-open {
+    > .spectrum-Accordion-itemHeading {
+      > .spectrum-Accordion-itemIndicator {
+        transform: rotate(90deg);
+      }
+    }
+
     > .spectrum-Accordion-itemIndicator {
       transform: rotate(90deg);
     }


### PR DESCRIPTION
## Description
Fix for Issue #81, related to RSP-786

The WAI-ARIA design pattern for Accordion has changed from WAI-ARIA 1.0 to WAI-ARIA 1.1.

WAI-ARIA 1.0 implemented Accordion using role="tablist", which, in addition to being somewhat confusing to a keyboard user, was problematic for users of the JAWS screen reader. Basically, using role="tablist" on the Accordion switches JAWS into forms mode when an Accordion item header receives focus. In forms mode, content within the expanded panels cannot be accessed using the screen reader. One can exit forms mode to access panel content by pressing the Esc key, but if the Accordion happens to be a descendant of a Dialog, the Esc key will also close the Dialog. There doesn't seem to be a good workaround for this other than switching to the WAI-ARIA 1.1 design pattern that doesn't use role="tablist".

In WAI-ARIA 1.1, each Accordion header is presented as a button element wrapped in a header, h3 element. JAWS won't shift into forms mode when an item header receives focus and the panel content will be easier to access.

See: https://w3c.github.io/aria-practices/#accordion for more detail.

## Related Issue
#81 

## Motivation and Context
Fix for Issue #81, related to RSP-786

The WAI-ARIA design pattern for Accordion has changed from WAI-ARIA 1.0 to WAI-ARIA 1.1.

WAI-ARIA 1.0 implemented Accordion using role="tablist", which, in addition to being somewhat confusing to a keyboard user, was problematic for users of the JAWS screen reader. Basically, using role="tablist" on the Accordion switches JAWS into forms mode when an Accordion item header receives focus. In forms mode, content within the expanded panels cannot be accessed using the screen reader. One can exit forms mode to access panel content by pressing the Esc key, but if the Accordion happens to be a descendant of a Dialog, the Esc key will also close the Dialog. There doesn't seem to be a good workaround for this other than switching to the WAI-ARIA 1.1 design pattern that doesn't use role="tablist".

In WAI-ARIA 1.1, each Accordion header is presented as a button element wrapped in a header, h3 element. JAWS won't shift into forms mode when an item header receives focus and the panel content will be easier to access.

See: https://w3c.github.io/aria-practices/#accordion for more detail.

## How Has This Been Tested?
Tested against React-Spectrum. Style changes should be backward compatible.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
