### PR TITLE
Fixed #88

### DIFF
--- a/tasks/build-css.js
+++ b/tasks/build-css.js
@@ -106,7 +106,7 @@ var processors = [
   require('autoprefixer')({
     'browsers': [
       'IE >= 10',
-      'last 2 Chrome versions',
+      'Chrome >= 41',
       'last 2 Firefox versions',
       'last 2 Safari versions',
       'last 2 iOS versions'


### PR DESCRIPTION
Provides compatibility for Chromium 41.x which is required for CEP7 and lower

## Description
Changed the autoprefixer configuration

## Related Issue
#88 

## Motivation and Context
It should work in CC 2017 apps

## How Has This Been Tested?
Built the project and loaded it in Chromium 41.0.2272.118

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
