### PR TITLE
Use flexbox to position Calendar day of week headings, fixes #99

### DIFF
--- a/src/calendar/index.css
+++ b/src/calendar/index.css
@@ -73,10 +73,10 @@
 }
 
 .spectrum-Calendar-dayOfWeek {
-  position: absolute;
-  bottom: var(--spectrum-calendar-day-padding);
-
-  display: block;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  height: 100%;
 
   width: var(--spectrum-calendar-day-width);
 


### PR DESCRIPTION

## Description

Fix calendar rendering in Edge

## Related Issue

#99 

## How Has This Been Tested?

Manually checked both Edge and Chrome, rendering in both is identical to previous version in Chrome.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/201344/53363391-3345d880-38f1-11e9-850e-4e287e638a1d.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Bug fix (non-breaking change which fixes an issue)
