### PR TITLE
Issue-105 Card: display focus ring when a parent row element has focus

### DIFF
--- a/docs/card/card-asset.yml
+++ b/docs/card/card-asset.yml
@@ -3,7 +3,7 @@ description: Standard cards will full-sized asset previews are not supported, do
 status: Unsupported
 markup: |
   <div style="width: 208px;">
-    <div class="spectrum-Card">
+    <div class="spectrum-Card" tabindex="0" role="figure">
       <div class="spectrum-Card-preview">
         <div class="spectrum-Asset">
           <img class="spectrum-Asset-image" src="img/example-card-portrait.jpg" />
@@ -19,7 +19,7 @@ markup: |
       </div>
       <div class="spectrum-QuickActions spectrum-Card-quickActions">
         <div class="spectrum-Checkbox">
-          <input type="checkbox" class="spectrum-Checkbox-input" aria-checked="false" title="Select" value="">
+          <input type="checkbox" class="spectrum-Checkbox-input" title="Select" value="">
           <span class="spectrum-Checkbox-box">
             <svg class="spectrum-Icon spectrum-UIIcon-CheckmarkSmall spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
               <use xlink:href="#spectrum-css-icon-CheckmarkSmall" />

--- a/docs/card/card-gallery.yml
+++ b/docs/card/card-gallery.yml
@@ -3,7 +3,7 @@ description: A spectrum gallery card for an image
 status: Beta
 markup: |
   <div style="width: 532px; height: 224px;">
-    <div class="spectrum-Card spectrum-Card--gallery">
+    <div class="spectrum-Card spectrum-Card--gallery" tabindex="0" role="figure">
       <div class="spectrum-Card-preview">
         <div class="spectrum-Asset">
           <img class="spectrum-Asset-image" src="img/example-card-landscape.jpeg" />
@@ -27,7 +27,7 @@ markup: |
       </div>
       <div class="spectrum-QuickActions spectrum-Card-quickActions">
         <div class="spectrum-Checkbox">
-          <input type="checkbox" class="spectrum-Checkbox-input" aria-checked="false" title="Select" value="">
+          <input type="checkbox" class="spectrum-Checkbox-input" title="Select" value="">
           <span class="spectrum-Checkbox-box">
             <svg class="spectrum-Icon spectrum-UIIcon-CheckmarkSmall spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
               <use xlink:href="#spectrum-css-icon-CheckmarkSmall" />

--- a/docs/card/card-quiet-file.yml
+++ b/docs/card/card-quiet-file.yml
@@ -4,7 +4,7 @@ description: A spectrum Quiet Card for a file asset
 status: Beta
 markup: |
   <div style="width: 208px; height: 264px;">
-    <div class="spectrum-Card spectrum-Card--quiet">
+    <div class="spectrum-Card spectrum-Card--quiet" tabindex="0" role="figure">
       <div class="spectrum-Card-preview">
         <div class="spectrum-Asset">
           <svg viewBox="0 0 128 128" class="spectrum-Asset-file">
@@ -23,7 +23,7 @@ markup: |
       </div>
       <div class="spectrum-QuickActions spectrum-Card-quickActions">
         <div class="spectrum-Checkbox">
-          <input type="checkbox" class="spectrum-Checkbox-input" aria-checked="false" title="Select" value="">
+          <input type="checkbox" class="spectrum-Checkbox-input" title="Select" value="">
             <span class="spectrum-Checkbox-box">
             <svg class="spectrum-Icon spectrum-UIIcon-CheckmarkSmall spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
               <use xlink:href="#spectrum-css-icon-CheckmarkSmall" />

--- a/docs/card/card-quiet-folder.yml
+++ b/docs/card/card-quiet-folder.yml
@@ -4,7 +4,7 @@ description: A spectrum Quiet Card for a folder asset
 status: Beta
 markup: |
   <div style="width: 208px; height: 264px;">
-    <div class="spectrum-Card spectrum-Card--quiet">
+    <div class="spectrum-Card spectrum-Card--quiet" tabindex="0" role="figure">
       <div class="spectrum-Card-preview">
         <div class="spectrum-Asset">
           <svg viewBox="0 0 32 32" class="spectrum-Asset-folder">
@@ -23,7 +23,7 @@ markup: |
       </div>
       <div class="spectrum-QuickActions spectrum-Card-quickActions">
         <div class="spectrum-Checkbox">
-          <input type="checkbox" class="spectrum-Checkbox-input" aria-checked="false" title="Select" value="">
+          <input type="checkbox" class="spectrum-Checkbox-input" title="Select" value="">
           <span class="spectrum-Checkbox-box">
             <svg class="spectrum-Icon spectrum-UIIcon-CheckmarkSmall spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
               <use xlink:href="#spectrum-css-icon-CheckmarkSmall" />

--- a/docs/card/card-quiet-large.yml
+++ b/docs/card/card-quiet-large.yml
@@ -4,7 +4,7 @@ description: A spectrum Quiet Card for an image
 status: Beta
 markup: |
   <div style="width: 208px; height: 264px;">
-    <div class="spectrum-Card spectrum-Card--quiet">
+    <div class="spectrum-Card spectrum-Card--quiet" tabindex="0" role="figure">
       <div class="spectrum-Card-preview">
         <div class="spectrum-Asset">
           <img class="spectrum-Asset-image" src="img/example-ava.jpg" style="max-width: 75%; max-height: 75%; object-fit: contain;">
@@ -30,7 +30,7 @@ markup: |
       </div>
       <div class="spectrum-QuickActions spectrum-Card-quickActions">
         <div class="spectrum-Checkbox">
-          <input type="checkbox" class="spectrum-Checkbox-input" aria-checked="false" title="Select" value="">
+          <input type="checkbox" class="spectrum-Checkbox-input" title="Select" value="">
           <span class="spectrum-Checkbox-box">
             <svg class="spectrum-Icon spectrum-UIIcon-CheckmarkSmall spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
               <use xlink:href="#spectrum-css-icon-CheckmarkSmall" />

--- a/docs/card/card-quiet-small.yml
+++ b/docs/card/card-quiet-small.yml
@@ -4,7 +4,7 @@ description: A spectrum Quiet Card for an image
 status: Beta
 markup: |
   <div style="width: 112px; height: 136px;">
-    <div class="spectrum-Card spectrum-Card--quiet spectrum-Card--small">
+    <div class="spectrum-Card spectrum-Card--quiet spectrum-Card--small" tabindex="0" role="figure">
       <div class="spectrum-Card-preview">
         <div class="spectrum-Asset">
           <img class="spectrum-Asset-image" src="img/example-ava.jpg" style="max-width: 75%; max-height: 75%; object-fit: contain;">
@@ -29,7 +29,7 @@ markup: |
       </div>
       <div class="spectrum-QuickActions spectrum-Card-quickActions">
         <div class="spectrum-Checkbox">
-          <input type="checkbox" class="spectrum-Checkbox-input" aria-checked="false" title="Select" value="">
+          <input type="checkbox" class="spectrum-Checkbox-input" aria-checked="false" title="Select" value="" tabindex="-1">
           <span class="spectrum-Checkbox-box">
             <svg class="spectrum-Icon spectrum-UIIcon-CheckmarkSmall spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
               <use xlink:href="#spectrum-css-icon-CheckmarkSmall" />
@@ -38,6 +38,49 @@ markup: |
               <use xlink:href="#spectrum-css-icon-DashSmall" />
             </svg>
           </span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <h2>Focused Card item within a grid</h3>
+  <div role="grid">
+    <div style="width: 112px; height: 136px; outline: 0;" role="row">
+      <div class="spectrum-Card spectrum-Card--quiet spectrum-Card--small is-focused" role="rowheader" tabindex="0">
+        <div class="spectrum-Card-preview">
+          <div class="spectrum-Asset">
+            <img class="spectrum-Asset-image" src="img/example-ava.jpg" style="max-width: 75%; max-height: 75%; object-fit: contain;">
+          </div>
+        </div>
+        <div class="spectrum-Card-body">
+          <div class="spectrum-Card-header">
+            <div class="spectrum-Card-title">Name</div>
+          </div>
+          <div class="spectrum-Card-content">
+            <div class="spectrum-Card-subtitle">jpg</div>
+          </div>
+        </div>
+        <div class="spectrum-QuickActions spectrum-Card-actions">
+          <div style="display: inline-block;">
+            <button aria-haspopup="true" class="spectrum-ActionButton spectrum-ActionButton--quiet">
+              <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-icon-18-More" />
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div class="spectrum-QuickActions spectrum-Card-quickActions">
+          <div class="spectrum-Checkbox">
+            <input type="checkbox" class="spectrum-Checkbox-input" title="Select" value="" tabindex="-1">
+            <span class="spectrum-Checkbox-box">
+              <svg class="spectrum-Icon spectrum-UIIcon-CheckmarkSmall spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-CheckmarkSmall" />
+              </svg>
+              <svg class="spectrum-Icon spectrum-UIIcon-DashSmall spectrum-Checkbox-partialCheckmark" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-DashSmall" />
+              </svg>
+            </span>
+          </div>
         </div>
       </div>
     </div>

--- a/docs/card/card-small.yml
+++ b/docs/card/card-small.yml
@@ -3,7 +3,7 @@ description: Small cards are not supported, don't do this.
 status: Unsupported
 markup: |
   <div style="width: 208px;">
-    <div class="spectrum-Card spectrum-Card--small">
+    <div class="spectrum-Card spectrum-Card--small" tabindex="0" role="figure">
       <div class="spectrum-Card-coverPhoto" style="background-image: url(img/example-card-portrait.jpg)"></div>
       <div class="spectrum-Card-body">
         <div class="spectrum-Card-header">
@@ -18,7 +18,7 @@ markup: |
       </div>
       <div class="spectrum-QuickActions spectrum-Card-quickActions">
         <div class="spectrum-Checkbox">
-          <input type="checkbox" class="spectrum-Checkbox-input" aria-checked="false" title="Select" value="">
+          <input type="checkbox" class="spectrum-Checkbox-input" title="Select" value="">
           <span class="spectrum-Checkbox-box">
             <svg class="spectrum-Icon spectrum-UIIcon-CheckmarkSmall spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
               <use xlink:href="#spectrum-css-icon-CheckmarkSmall" />

--- a/docs/card/card.yml
+++ b/docs/card/card.yml
@@ -2,7 +2,7 @@ name: Card
 description: The standard Card component with cover photo and footer.
 markup: |
   <div style="width: 208px;">
-    <div class="spectrum-Card">
+    <div class="spectrum-Card" tabindex="0" role="figure">
       <div class="spectrum-Card-coverPhoto" style="background-image: url(img/example-card-portrait.jpg)"></div>
       <div class="spectrum-Card-body">
         <div class="spectrum-Card-header">
@@ -33,6 +33,46 @@ markup: |
               <use xlink:href="#spectrum-css-icon-DashSmall" />
             </svg>
           </span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <h2>Focused Card item within a grid</h3>
+  <div role="grid">
+    <div style="width: 208px; outline: 0;" role="row">
+      <div class="spectrum-Card is-focused" role="rowheader" tabindex="0">
+        <div class="spectrum-Card-coverPhoto" style="background-image: url(img/example-card-portrait.jpg)"></div>
+        <div class="spectrum-Card-body">
+          <div class="spectrum-Card-header">
+            <div class="spectrum-Card-title">Card Title</div>
+            <div class="spectrum-Card-actionButton">
+              <button aria-haspopup="true" class="spectrum-ActionButton spectrum-ActionButton--quiet">
+                <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true">
+                  <use xlink:href="#spectrum-icon-18-More" />
+                </svg>
+              </button>
+            </div>
+          </div>
+          <div class="spectrum-Card-content">
+            <div class="spectrum-Card-subtitle">jpg</div>
+          </div>
+        </div>
+        <div class="spectrum-Card-footer">
+          Footer
+        </div>
+        <div class="spectrum-QuickActions spectrum-Card-quickActions">
+          <div class="spectrum-Checkbox">
+            <input type="checkbox" class="spectrum-Checkbox-input" title="Select" value="" tabindex="-1">
+            <span class="spectrum-Checkbox-box">
+              <svg class="spectrum-Icon spectrum-UIIcon-CheckmarkSmall spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-CheckmarkSmall" />
+              </svg>
+              <svg class="spectrum-Icon spectrum-UIIcon-DashSmall spectrum-Checkbox-partialCheckmark" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-DashSmall" />
+              </svg>
+            </span>
+          </div>
         </div>
       </div>
     </div>

--- a/src/card/index.css
+++ b/src/card/index.css
@@ -28,6 +28,7 @@
     outline: none;
   }
 
+  &.is-focused,
   &.is-selected,
   &:focus,
   &:hover {
@@ -189,6 +190,7 @@
     border-radius: var(--spectrum-card-quiet-border-radius);
     position: relative;
     transition: background-color var(--spectrum-global-animation-duration-100);
+    overflow: visible;
 
     /* Use a :before to show the selection outline so that the border doesn't
      * affect the layout of the content within the preview. */

--- a/src/card/skin.css
+++ b/src/card/skin.css
@@ -7,7 +7,7 @@
   }
 
   &.is-selected,
-  &:focus {
+  &:focus-ring {
     border-color: var(--spectrum-card-border-color-key-focus);
     box-shadow: 0 0 0 1px var(--spectrum-card-border-color-key-focus);
   }
@@ -49,7 +49,7 @@
   }
 
   &.is-selected,
-  &:focus {
+  &:focus-ring {
     border-color: transparent;
     box-shadow: none;
     .spectrum-Card-preview {
@@ -80,7 +80,7 @@
     .spectrum-Asset-fileBackground {
       fill: var(--spectrum-alias-highlight-selected);
     }
-    
+
     .spectrum-Asset-folderOutline,
     .spectrum-Asset-fileOutline {
       fill: var(--spectrum-card-quiet-border-color-selected);


### PR DESCRIPTION
`.spectrum-Card` only accounts for `:focus` style on the card itself.

## Description
Currently, `.spectrum-Card` only accounts for `:focus` style on the card itself.

This PR adds `:focus-ring` styles so that the `.spectrum-Card` will render focused style when its parent has focus.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#105 

## Motivation and Context
In a grid view, where the `.spectrum-Card` is has `role="gridcell"` within a parent element with `role="row"`, the`.spectrum-Card` should render its focus style when the parent row receives focus.

## How Has This Been Tested?
Tested against React-Spectrum PR #495

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
