### PR TITLE
[Documentation] Accordion: Update implementation to follow WAI-ARIA 1.1 design pattern (#81)

### DIFF
--- a/docs/accordion/accordion.yml
+++ b/docs/accordion/accordion.yml
@@ -1,14 +1,22 @@
 ---
 name: Accordion
+description: While remaining backward compatible, the recommended markup has been updated to implement the [WAI-ARIA 1.1 Accordion design pattern](https://www.w3.org/TR/wai-aria-practices-1.1/#accordion) to better support accessibility for keyboard and screen reader users.
 markup: |
+  <!-- WAI-ARIA 1.1: Accordion container role changed from "tablist" to "region" -->
   <div class="spectrum-Accordion" role="region">
     <div class="spectrum-Accordion-item is-open" role="presentation">
+
+      <!-- WAI-ARIA 1.1: Item header is a <button> wrapped within a <h3> element, rather than a <div> element with role="tab" -->
       <h3 class="spectrum-Accordion-itemHeading">
+
+        <!-- WAI-ARIA 1.1: Item header <button> uses aria-expanded attribute to indicate expanded state. -->
         <button class="spectrum-Accordion-itemHeader" type="button" id="spectrum-accordion-item-0-header" aria-controls="spectrum-accordion-item-0-content" aria-expanded="true">Header 1</button>
         <svg class="spectrum-Icon spectrum-UIIcon-ChevronRightMedium spectrum-Accordion-itemIndicator" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-css-icon-ChevronRightMedium" />
         </svg>
       </h3>
+
+      <!-- WAI-ARIA 1.1: Item content role changed from "tabpanel" to "region" -->
       <div class="spectrum-Accordion-itemContent" role="region" id="spectrum-accordion-item-0-content" aria-labelledby="spectrum-accordion-item-0-header">Item 1</div>
     </div>
     <div class="spectrum-Accordion-item is-disabled" role="presentation">


### PR DESCRIPTION
Better document markup change from WAI-ARIA 1.0 to WAI-ARIA 1.1.

## Description
Add code comments to better explain backward-compatible markup change.

## Related Issue
#81 and #83

## Motivation and Context
Per comment https://github.com/adobe/spectrum-css/pull/83#issuecomment-467993470

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [NA] Bug fix (non-breaking change which fixes an issue)
- [NA] New feature (non-breaking change which adds functionality)
- [NA] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
