### PR TITLE
Issue-109 Rating: add readOnly state

### DIFF
--- a/docs/rating/rating.yml
+++ b/docs/rating/rating.yml
@@ -110,7 +110,7 @@ components:
     status: Verified
     description: The readOnly state of the Rating element.
     markup: |
-      <div class="spectrum-Rating is-readonly">
+      <div class="spectrum-Rating is-readOnly">
         <input class="spectrum-Rating-input" type="range" min="0" max="5" value="0" readOnly aria-label="Rating">
 
         <span class="spectrum-Rating-icon is-selected">
@@ -266,7 +266,7 @@ components:
     name: Quiet readOnly
     status: Verified
     markup: |
-      <div class="spectrum-Rating spectrum-Rating--quiet is-readonly">
+      <div class="spectrum-Rating spectrum-Rating--quiet is-readOnly">
         <input class="spectrum-Rating-input" type="range" min="0" max="5" value="0" readOnly aria-label="Rating">
 
         <span class="spectrum-Rating-icon is-selected">

--- a/docs/rating/rating.yml
+++ b/docs/rating/rating.yml
@@ -105,6 +105,59 @@ components:
           </svg>
         </span>
       </div>
+  rating-readonly:
+    name: readOnly
+    status: Verified
+    description: The readOnly state of the Rating element.
+    markup: |
+      <div class="spectrum-Rating is-readonly">
+        <input class="spectrum-Rating-input" type="range" min="0" max="5" value="0" readOnly aria-label="Rating">
+
+        <span class="spectrum-Rating-icon is-selected">
+          <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
+            <use xlink:href="#spectrum-css-icon-Star"></use>
+          </svg>
+          <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
+            <use xlink:href="#spectrum-css-icon-StarOutline"></use>
+          </svg>
+        </span>
+
+        <span class="spectrum-Rating-icon is-selected">
+          <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
+            <use xlink:href="#spectrum-css-icon-Star"></use>
+          </svg>
+          <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
+            <use xlink:href="#spectrum-css-icon-StarOutline"></use>
+          </svg>
+        </span>
+
+        <span class="spectrum-Rating-icon is-selected is-currentValue">
+          <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
+            <use xlink:href="#spectrum-css-icon-Star"></use>
+          </svg>
+          <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
+            <use xlink:href="#spectrum-css-icon-StarOutline"></use>
+          </svg>
+        </span>
+
+        <span class="spectrum-Rating-icon">
+          <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
+            <use xlink:href="#spectrum-css-icon-Star"></use>
+          </svg>
+          <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
+            <use xlink:href="#spectrum-css-icon-StarOutline"></use>
+          </svg>
+        </span>
+
+        <span class="spectrum-Rating-icon">
+          <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
+            <use xlink:href="#spectrum-css-icon-Star"></use>
+          </svg>
+          <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
+            <use xlink:href="#spectrum-css-icon-StarOutline"></use>
+          </svg>
+        </span>
+      </div>
   rating-quiet:
     name: Quiet
     status: Verified
@@ -161,8 +214,60 @@ components:
     name: Quiet Selected
     status: Verified
     markup: |
-      <div class="spectrum-Rating">
+      <div class="spectrum-Rating spectrum-Rating--quiet">
         <input class="spectrum-Rating-input" type="range" min="0" max="5" value="0" aria-label="Rating">
+
+        <span class="spectrum-Rating-icon is-selected">
+          <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
+            <use xlink:href="#spectrum-css-icon-Star"></use>
+          </svg>
+          <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
+            <use xlink:href="#spectrum-css-icon-StarOutline"></use>
+          </svg>
+        </span>
+
+        <span class="spectrum-Rating-icon is-selected">
+          <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
+            <use xlink:href="#spectrum-css-icon-Star"></use>
+          </svg>
+          <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
+            <use xlink:href="#spectrum-css-icon-StarOutline"></use>
+          </svg>
+        </span>
+
+        <span class="spectrum-Rating-icon is-selected is-currentValue">
+          <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
+            <use xlink:href="#spectrum-css-icon-Star"></use>
+          </svg>
+          <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
+            <use xlink:href="#spectrum-css-icon-StarOutline"></use>
+          </svg>
+        </span>
+
+        <span class="spectrum-Rating-icon">
+          <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
+            <use xlink:href="#spectrum-css-icon-Star"></use>
+          </svg>
+          <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
+            <use xlink:href="#spectrum-css-icon-StarOutline"></use>
+          </svg>
+        </span>
+
+        <span class="spectrum-Rating-icon">
+          <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
+            <use xlink:href="#spectrum-css-icon-Star"></use>
+          </svg>
+          <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
+            <use xlink:href="#spectrum-css-icon-StarOutline"></use>
+          </svg>
+        </span>
+      </div>
+  rating-quiet-readonly:
+    name: Quiet readOnly
+    status: Verified
+    markup: |
+      <div class="spectrum-Rating spectrum-Rating--quiet is-readonly">
+        <input class="spectrum-Rating-input" type="range" min="0" max="5" value="0" readOnly aria-label="Rating">
 
         <span class="spectrum-Rating-icon is-selected">
           <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
@@ -261,4 +366,3 @@ components:
           </svg>
         </span>
       </div>
-

--- a/src/rating/index.css
+++ b/src/rating/index.css
@@ -31,7 +31,8 @@
 
   cursor: pointer;
 
-  &.is-disabled {
+  &.is-disabled,
+  &.is-readonly {
     cursor: default;
     pointer-events: none;
   }

--- a/src/rating/index.css
+++ b/src/rating/index.css
@@ -32,7 +32,7 @@
   cursor: pointer;
 
   &.is-disabled,
-  &.is-readonly {
+  &.is-readOnly {
     cursor: default;
     pointer-events: none;
   }


### PR DESCRIPTION
## Description
In some use cases, a Rating component needs to be `readOnly`, and simply show the current rating. When `readOnly` is true, the Rating should not respond to hover events.

### Sample Code that illustrates the problem
```css
.spectrum-Rating {
  &.is-disabled {
    cursor: default;
    pointer-events: none;
  }
}
```
Should be:
```css
.spectrum-Rating {
  &.is-disabled,
  &.is-readonly {
    cursor: default;
    pointer-events: none;
  }
}
```

## Related Issue
#109 

## Motivation and Context
In some use cases, a Rating component needs to be `readOnly`, and simply show the current rating. When `readOnly` is true, the Rating should not respond to hover events.


## How Has This Been Tested?
Tested in React Spectrum. And Spectrum-CSS docs.

Also, see working prototype: https://codepen.io/mijordan/pen/KEVEKO

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [NA] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
