### PR TITLE
Fix Dropdown label truncation when text too long, fixes #121

### DIFF
--- a/src/dropdown/index.css
+++ b/src/dropdown/index.css
@@ -48,8 +48,8 @@
 }
 
 .spectrum-Dropdown-label {
-  /* Be the biggest! */
-  flex: 1 0 auto;
+  /* Be the biggest, but also shrink! */
+  flex: 1 1 auto;
 
   white-space: nowrap;
   overflow: hidden;


### PR DESCRIPTION
## Description

/title

## Related Issue

#121

## Motivation and Context

is bug

## How Has This Been Tested?

mad scrolling in Chrome and IE 11

## Screenshots (if appropriate):

Chrome:
![image](https://user-images.githubusercontent.com/201344/54400518-6c67a200-4680-11e9-9e4a-db0b77a197e2.png)

IE11:
![image](https://user-images.githubusercontent.com/201344/54400620-fd3e7d80-4680-11e9-9939-54831125951f.png)


## Types of changes

- Bug fix (non-breaking change which fixes an issue)
