### PR TITLE
WIP: Remove checkbox right margin

### DIFF
--- a/src/checkbox/index.css
+++ b/src/checkbox/index.css
@@ -9,9 +9,19 @@
   height: var(--spectrum-checkbox-height);
   max-width: 100%;
 
-  margin-right: calc(var(--spectrum-checkbox-cursor-hit-x) * 2);
+  /*margin-right: calc(var(--spectrum-checkbox-cursor-hit-x) * 2);*/
+  padding-right: var(--spectrum-checkbox-cursor-hit-x);
 
   vertical-align: top;
+
+  & + .spectrum-Checkbox {
+    padding-left: var(--spectrum-checkbox-cursor-hit-x);
+
+    .spectrum-Checkbox-input {
+      width: 100%;
+      left: 0;
+    }
+  }
 }
 
 .spectrum-Checkbox-input {
@@ -36,7 +46,7 @@
   position: absolute;
   top: 0;
   left: calc(var(--spectrum-checkbox-cursor-hit-x) * -1);
-  width: calc(100% + var(--spectrum-checkbox-cursor-hit-x) * 2);;
+  width: calc(100% + var(--spectrum-checkbox-cursor-hit-x));
   height: 100%;
 
   opacity: .0001;


### PR DESCRIPTION

# WIP, DO NOT MERGE

## Description

This PR removes the right margin that all Checkboxes have to they look nice when placed next to each other, fixing the usage of an individual checkbox as defined in #124. However, this has a side effect -- checkboxes that wrap get pushed to the left since they technically follow another checkbox, but don't appear on the same line...

This is the example from the docs, but with the `<br>` removed between the long checkbox and the 3 above it:

![image](https://user-images.githubusercontent.com/201344/54644628-fe8ff180-4a56-11e9-83b8-44568352053c.png)

This may not be a good solution to the issue, as the new bug it introduces could show up elsewhere. More digging is required before merging this.

## Related Issue

#124 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Bug fix (non-breaking change which fixes an issue)

