### PR TITLE
 🐛 disable hover highlight for table header

### DIFF
--- a/src/table/skin.css
+++ b/src/table/skin.css
@@ -75,7 +75,42 @@ tbody.spectrum-Table-body {
   border: none;
 
   .spectrum-Table-row {
+    background-color: var(--spectrum-table-row-background-color);
+    border-bottom: 1px solid var(--spectrum-table-cell-border-color);
     border-top: none;
+
+    &:hover {
+      background-color: var(--spectrum-table-row-background-color-hover);
+    }
+
+    &:focus-ring,
+    &.is-focused {
+      background-color: var(--spectrum-table-row-background-color-hover);
+    }
+
+    &:active {
+      background-color: var(--spectrum-table-row-background-color-down);
+    }
+
+    &.is-selected {
+      background-color: var(--spectrum-table-row-background-color-selected);
+
+      &:hover {
+        background-color: var(--spectrum-table-row-background-color-selected-hover);
+      }
+
+      &:focus-ring,
+      &.is-focused {
+        background-color: var(--spectrum-table-row-background-color-selected-key-focus);
+      }
+    }
+
+    &.is-drop-target {
+      &::before {
+        box-shadow: inset 0 0 0 2px var(--spectrum-alias-border-color-focus);
+        background-color: var(--spectrum-alias-highlight-selected);
+      }
+    }
   }
 
   .spectrum-Table-cell {
@@ -92,44 +127,6 @@ tbody.spectrum-Table-body {
 
   .spectrum-Table-row:last-child .spectrum-Table-cell {
     border-bottom: 1px solid var(--spectrum-table-cell-border-color);
-  }
-}
-
-.spectrum-Table-row {
-  border-bottom: 1px solid var(--spectrum-table-cell-border-color);
-  background-color: var(--spectrum-table-row-background-color);
-
-  &:hover {
-    background-color: var(--spectrum-table-row-background-color-hover);
-  }
-
-  &:focus-ring,
-  &.is-focused {
-    background-color: var(--spectrum-table-row-background-color-hover);
-  }
-
-  &:active {
-    background-color: var(--spectrum-table-row-background-color-down);
-  }
-
-  &.is-selected {
-    background-color: var(--spectrum-table-row-background-color-selected);
-
-    &:hover {
-      background-color: var(--spectrum-table-row-background-color-selected-hover);
-    }
-
-    &:focus-ring,
-    &.is-focused {
-      background-color: var(--spectrum-table-row-background-color-selected-key-focus);
-    }
-  }
-
-  &.is-drop-target {
-    &::before {
-      box-shadow: inset 0 0 0 2px var(--spectrum-alias-border-color-focus);
-      background-color: var(--spectrum-alias-highlight-selected);
-    }
   }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When `class="spectrum-Table-row"` is added to the `tr` of `thead`, header shows highlight on hovering.

## Related Issue
https://jira.corp.adobe.com/projects/CORAL/issues/CORAL-156

## Motivation and Context
https://jira.corp.adobe.com/projects/CORAL/issues/CORAL-156, coral-spectrum has a temporary fix for it, but we would like the fix happening in spectrum-css.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually test, hosted on my machine, added `class="spectrum-Table-row"` to the `tr` of `thead`, and applying hover state to the `tr`, header row is not highlighted.

## Screenshots (if appropriate):
As you can see after adding `class="spectrum-Table-row"` to the `tr` of `thead`, and applying hover state to the `tr`, header row is not highlighted.
![Screen Shot 2019-03-22 at 4 45 36 PM](https://user-images.githubusercontent.com/4250728/54959958-17e1e380-4f18-11e9-9d5e-cf5d8ab73118.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
