### PR TITLE
Issue117: Fix show markup in toast documentation

### DIFF
--- a/docs/toast/toast.yml
+++ b/docs/toast/toast.yml
@@ -1,9 +1,9 @@
 ---
 name: Toast
+ignoreDNA: true
+status: Verified
 components:
-  toast:
-    status: Verified
-    markup: |
+  toast: |
       <div class="spectrum-Toast">
         <div class="spectrum-Toast-body">
           <div class="spectrum-Toast-content">Button.xd has been archived</div>
@@ -19,10 +19,7 @@ components:
           </button>
         </div>
       </div>
-
-  toast-info:
-    status: Verified
-    markup: |
+  toast-info: |
       <div class="spectrum-Toast spectrum-Toast--info">
         <svg class="spectrum-Icon spectrum-UIIcon-InfoMedium spectrum-Toast-typeIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-css-icon-InfoMedium" />
@@ -38,10 +35,7 @@ components:
           </button>
         </div>
       </div>
-
-  toast-negative:
-    status: Verified
-    markup: |
+  toast-negative: |
       <div class="spectrum-Toast spectrum-Toast--negative">
         <svg class="spectrum-Icon spectrum-UIIcon-AlertMedium spectrum-Toast-typeIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-css-icon-AlertMedium" />
@@ -60,10 +54,7 @@ components:
           </button>
         </div>
       </div>
-
-  toast-positive:
-    status: Verified
-    markup: |
+  toast-positive: |
       <div class="spectrum-Toast spectrum-Toast--positive">
         <svg class="spectrum-Icon spectrum-UIIcon-SuccessMedium spectrum-Toast-typeIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-css-icon-SuccessMedium" />
@@ -82,12 +73,7 @@ components:
           </button>
         </div>
       </div>
-
-  toast-wrapping:
-    name: Toast Wrapping Behavior
-    status: Verified
-    markup: |
-
+  toast-wrapping: |
       <div class="spectrum-Toast spectrum-Toast--info">
         <svg class="spectrum-Icon spectrum-UIIcon-InfoMedium spectrum-Toast-typeIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-css-icon-InfoMedium" />
@@ -169,10 +155,7 @@ components:
           </button>
         </div>
       </div>
-
-  toast-error:
-    details: Use `negative` variant instead
-    markup: |
+  toast-error: |
       <div class="spectrum-Toast spectrum-Toast--error">
         <svg class="spectrum-Icon spectrum-UIIcon-AlertMedium spectrum-Toast-typeIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-css-icon-AlertMedium" />
@@ -191,11 +174,7 @@ components:
           </button>
         </div>
       </div>
-
-  toast-warning:
-    details: Use `negative` variant instead
-    status: Deprecated
-    markup: |
+  toast-warning: |
       <div class="spectrum-Toast spectrum-Toast--warning">
         <svg class="spectrum-Icon spectrum-UIIcon-AlertMedium spectrum-Toast-typeIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-css-icon-AlertMedium" />
@@ -214,10 +193,7 @@ components:
           </button>
         </div>
       </div>
-
-  toast-success:
-    details: Use `positive` variant instead
-    markup: |
+  toast-success: |
       <div class="spectrum-Toast spectrum-Toast--success">
         <svg class="spectrum-Icon spectrum-UIIcon-SuccessMedium spectrum-Toast-typeIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-css-icon-SuccessMedium" />
@@ -236,12 +212,7 @@ components:
           </button>
         </div>
       </div>
-
-  toast-oldmarkup:
-    name: Deprecated Markup
-    status: Deprecated
-    description: The old markup for Toast (no `.spectrum-Toast-body` and both buttons inside of `.spectrum-Toast-buttons`) still works, but will be removed in the next major version.
-    markup: |
+  toast-oldmarkup: |
       <div class="spectrum-Toast">
         <div class="spectrum-Toast-content">Button.xd has been archived</div>
         <div class="spectrum-Toast-buttons">


### PR DESCRIPTION
## Description
Fix `Show Markup` functionality in Toast component by rearranging `toast.yml` file to follow the structure of other functional .yml documentation files, as the current version is broken. 

## Related Issue
https://github.com/adobe/spectrum-css/issues/117

## Motivation and Context
This fixes the `Show Markup` functionality which is very useful to have when using spectrum css, and has been a pain point for me in implementing new features, when these `Show Markup` buttons are broken. It seems the logic to pull from the .yml files to build out the documentation requires a different structure than the current file structure.

If folks approve this PR I am happy to make the same changes in other files where the `Show Markup` is not working as expected like all the Checkbox files, Coach Mark, Dialogue, Drop Zone, Link, etc. 

## How Has This Been Tested?
Ran build locally and manually tested across browsers.

## Screenshots (if appropriate):
Before changes (from this PR in `Toast`):
<img width="1153" alt="before-changes" src="https://user-images.githubusercontent.com/23532036/55740397-00672800-59f9-11e9-89ba-7bb269f35ccd.png">

After changes (from this PR in `Toast`):
<img width="1144" alt="after-changes" src="https://user-images.githubusercontent.com/23532036/55740413-09f09000-59f9-11e9-920d-18a139aed4c8.png">

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.

Thanks 😄 