### PR TITLE
 Fix stray & in index-vars.css for Page and Typography

### DIFF
--- a/tasks/build-css.js
+++ b/tasks/build-css.js
@@ -106,6 +106,7 @@ function getProcessors(keepVars = false) {
     require('./lib/postcss-custom-properties-passthrough')(),
     require('postcss-calc'),
     keepVars ? require('./lib/postcss-custom-properties-mapping') : null,
+    keepVars ? notnested({ replace: '.spectrum' }) : null,
     require('postcss-svg'),
     require('postcss-functions')({
       functions: {

--- a/tasks/lib/postcss-notnested.js
+++ b/tasks/lib/postcss-notnested.js
@@ -15,7 +15,7 @@ module.exports = postcss.plugin('postcss-notnested', function (opts) {
   opts = opts || {};
 
   // Match ampersands at the start of a given selector
-  var re = /^&.*/;
+  var re = /^&/;
 
   return function (root, result) {
     root.walkRules((rule, ruleIndex) => {
@@ -25,6 +25,11 @@ module.exports = postcss.plugin('postcss-notnested', function (opts) {
           var selectors = rule.selectors.map(selector => {
             if (re.test(selector)) {
               replaced = true;
+              // Handle special case where the replacement selector === the existing selector
+              if (selector.replace(re, '') === opts.replace) {
+                return opts.replace;
+              }
+
               return selector.replace(re, opts.replace);
             }
             else {
@@ -33,6 +38,11 @@ module.exports = postcss.plugin('postcss-notnested', function (opts) {
           });
 
           if (replaced) {
+            // De-dupe selectors
+            selectors = selectors.filter((selector, index) => {
+              return selectors.indexOf(selector) === index;
+            });
+
             rule.selectors = selectors;
           }
         }


### PR DESCRIPTION
## Description

Use `notnested` to make sure stray `&` doesn't appear for Typography and Page, also fix `notnested` to be a little smarter about replacing complex selectors.

## Related Issue

#134 

## How Has This Been Tested?

Built the project and diffed the output directories, ensuring that the change fixed only the problem at hand (`gulp; cp -r dist distnew; git checkout master; gulp; diff -rq dist distnew;` returns only two files)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Bug fix (non-breaking change which fixes an issue)
