### PR TITLE
Strip comments in built output

### DIFF
--- a/.topdocrc
+++ b/.topdocrc
@@ -1,5 +1,5 @@
 {
-  "source": "temp/topdoc/spectrum-light.css",
+  "source": "temp/topdoc/spectrum-css.css",
   "destination": "dist/docs",
   "template": "./topdoc",
   "assetDirectory": false

--- a/src/inputgroup/index.css
+++ b/src/inputgroup/index.css
@@ -98,7 +98,7 @@ governing permissions and limitations under the License.
       border-radius: var(--spectrum-combobox-quiet-fieldbutton-border-radius);
     }
   }
-  /** Datetime Range **/
+  /* Datetime Range */
   &.spectrum-Datepicker--datetimeRange {
     /* Inputs */
     .spectrum-InputGroup-field {

--- a/tasks/build-css.js
+++ b/tasks/build-css.js
@@ -118,7 +118,7 @@ function getProcessors(keepVars = false) {
         }
       }
     }),
-    require('./lib/postcss-strip-comments')({ preserveTopdoc: true }),
+    require('./lib/postcss-strip-comments')({ preserveTopdoc: false }),
     require('postcss-focus-ring'),
     require('autoprefixer')({
       'browsers': [

--- a/tasks/build-css.js
+++ b/tasks/build-css.js
@@ -118,6 +118,7 @@ function getProcessors(keepVars = false) {
         }
       }
     }),
+    require('./lib/postcss-strip-comments')({ preserveTopdoc: true }),
     require('postcss-focus-ring'),
     require('autoprefixer')({
       'browsers': [

--- a/tasks/build-docs.js
+++ b/tasks/build-docs.js
@@ -16,6 +16,7 @@ var fs = require('fs');
 var path = require('path');
 var rename = require('gulp-rename');
 var plumb = require('./lib/plumb.js');
+var concat = require('gulp-concat');
 
 gulp.task('build-docs:topdoc', function(cb) {
   var exePath = path.resolve('node_modules', '.bin', 'topdoc');
@@ -29,8 +30,9 @@ gulp.task('build-docs:topdoc', function(cb) {
 
 gulp.task('build-docs:inject-topdoc', function() {
   return gulp.src([
-    'dist/standalone/spectrum-light.css'
+    'src/**/*.css'
   ])
+    .pipe(concat('spectrum-css.css'))
     .pipe(plumb())
     .pipe(replace(/\{\{\s*(.*?)\s*\}}/g, function(match, docPath) {
       var filePath = path.resolve('docs', docPath);

--- a/tasks/build-docs.js
+++ b/tasks/build-docs.js
@@ -30,8 +30,9 @@ gulp.task('build-docs:topdoc', function(cb) {
 
 gulp.task('build-docs:inject-topdoc', function() {
   return gulp.src([
-    'src/components.css',
-    'src/component-skins.css'
+    'src/**/*.css',
+    '!src/components.css',
+    '!src/component-skins.css'
   ])
     .pipe(concat('spectrum-css.css'))
     .pipe(plumb())

--- a/tasks/build-docs.js
+++ b/tasks/build-docs.js
@@ -30,7 +30,8 @@ gulp.task('build-docs:topdoc', function(cb) {
 
 gulp.task('build-docs:inject-topdoc', function() {
   return gulp.src([
-    'src/**/*.css'
+    'src/components.css',
+    'src/component-skins.css'
   ])
     .pipe(concat('spectrum-css.css'))
     .pipe(plumb())

--- a/tasks/lib/postcss-strip-comments.js
+++ b/tasks/lib/postcss-strip-comments.js
@@ -1,0 +1,24 @@
+const postcss = require('postcss');
+
+module.exports = postcss.plugin('postcss-strip-comments', (opts = {}) => {
+  return css => {
+    css.walk(node => {
+      if (node.type === 'comment') {
+        if (node.text.trim().indexOf('topdoc') === 0 && opts.preserveTopdoc) {
+          return;
+        }
+
+        // Get a refernce to the parent before the node is removed
+        let parent = node.parent;
+
+        node.remove();
+
+        // If the comment was the last thing left in its parent, remove the parent
+        if (parent && parent.nodes && parent.nodes.length === 0) {
+          parent.remove();
+        }
+        return;
+      }
+    });
+  };
+});


### PR DESCRIPTION
## Description

This kills the Apache headers, dead comments, and other bits in output.

## Related Issue

Closes #68 
Closes #145 

## How Has This Been Tested?

Build output diffed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Bug fix (non-breaking change which fixes an issue)