### PR TITLE
Fix tabs too many focus ring

### DIFF
--- a/docs/tabs/tabs-toomany.yml
+++ b/docs/tabs/tabs-toomany.yml
@@ -13,7 +13,7 @@ components:
       <h4>Closed</h4>
       <div class="spectrum-Tabs spectrum-Tabs--horizontal" style="width: 409px">
           <div class="spectrum-Dropdown spectrum-Dropdown--quiet">
-            <button class="spectrum-FieldButton spectrum-FieldButton--quiet spectrum-Dropdown-trigger is-selected" aria-haspopup="true">
+            <button class="spectrum-FieldButton spectrum-FieldButton--quiet spectrum-Dropdown-trigger is-selected spectrum-Tabs-dropdown" aria-haspopup="true">
               <span class="spectrum-Dropdown-label">Tab 1</span>
               <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
                 <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />
@@ -26,7 +26,7 @@ components:
       <h4 style="margin-top: 62px;">Open</h4>
       <div class="spectrum-Tabs spectrum-Tabs--horizontal" style="width: 409px">
           <div class="spectrum-Dropdown spectrum-Dropdown--quiet is-open">
-            <button class="spectrum-FieldButton spectrum-FieldButton--quiet spectrum-Dropdown-trigger is-selected" aria-haspopup="true">
+            <button class="spectrum-FieldButton spectrum-FieldButton--quiet spectrum-Dropdown-trigger is-selected spectrum-Tabs-dropdown" aria-haspopup="true">
               <span class="spectrum-Dropdown-label">Tab 1</span>
               <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
                 <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />
@@ -66,7 +66,7 @@ components:
       <h4>Closed</h4>
       <div class="spectrum-Tabs spectrum-Tabs--horizontal spectrum-Tabs--quiet spectrum-Tabs--compact" style="width: 409px">
           <div class="spectrum-Dropdown spectrum-Dropdown--quiet">
-            <button class="spectrum-FieldButton spectrum-FieldButton--quiet spectrum-Dropdown-trigger is-selected" aria-haspopup="true">
+            <button class="spectrum-FieldButton spectrum-FieldButton--quiet spectrum-Dropdown-trigger is-selected spectrum-Tabs-dropdown" aria-haspopup="true">
               <span class="spectrum-Dropdown-label">Tab 1</span>
               <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
                 <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />
@@ -79,7 +79,7 @@ components:
       <h4 style="margin-top: 62px;">Open</h4>
       <div class="spectrum-Tabs spectrum-Tabs--horizontal spectrum-Tabs--quiet spectrum-Tabs--compact" style="width: 409px">
           <div class="spectrum-Dropdown spectrum-Dropdown--quiet is-open">
-            <button class="spectrum-FieldButton spectrum-FieldButton--quiet spectrum-Dropdown-trigger is-selected" aria-haspopup="true">
+            <button class="spectrum-FieldButton spectrum-FieldButton--quiet spectrum-Dropdown-trigger is-selected spectrum-Tabs-dropdown" aria-haspopup="true">
               <span class="spectrum-Dropdown-label">Tab 1</span>
               <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
                 <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />

--- a/docs/tabs/tabs-toomany.yml
+++ b/docs/tabs/tabs-toomany.yml
@@ -12,6 +12,7 @@ components:
     markup: |
       <h4>Closed</h4>
       <div class="spectrum-Tabs spectrum-Tabs--horizontal" style="width: 409px">
+        <div class="spectrum-Tab-item">
           <div class="spectrum-Dropdown spectrum-Dropdown--quiet">
             <button class="spectrum-FieldButton spectrum-FieldButton--quiet spectrum-Dropdown-trigger is-selected spectrum-Tabs-dropdown" aria-haspopup="true">
               <span class="spectrum-Dropdown-label">Tab 1</span>
@@ -20,11 +21,13 @@ components:
               </svg>
             </button>
           </div>
+        </div>
         <div class="spectrum-Tabs-selectionIndicator" style="width: 50px; left: 8px;"></div>
       </div>
 
       <h4 style="margin-top: 62px;">Open</h4>
       <div class="spectrum-Tabs spectrum-Tabs--horizontal" style="width: 409px">
+        <div class="spectrum-Tab-item">
           <div class="spectrum-Dropdown spectrum-Dropdown--quiet is-open">
             <button class="spectrum-FieldButton spectrum-FieldButton--quiet spectrum-Dropdown-trigger is-selected spectrum-Tabs-dropdown" aria-haspopup="true">
               <span class="spectrum-Dropdown-label">Tab 1</span>
@@ -33,6 +36,7 @@ components:
               </svg>
             </button>
           </div>
+        </div>
         <div class="spectrum-Tabs-selectionIndicator" style="width: 50px; left: 8px;"></div>
       </div>
       <div class="spectrum-Popover spectrum-Popover--bottom spectrum-Dropdown-popover spectrum-Dropdown-popover--quiet is-open" style="margin-left: -5px; margin-top: -9px;">
@@ -65,6 +69,7 @@ components:
     markup: |
       <h4>Closed</h4>
       <div class="spectrum-Tabs spectrum-Tabs--horizontal spectrum-Tabs--quiet spectrum-Tabs--compact" style="width: 409px">
+        <div class="spectrum-Tab-item">
           <div class="spectrum-Dropdown spectrum-Dropdown--quiet">
             <button class="spectrum-FieldButton spectrum-FieldButton--quiet spectrum-Dropdown-trigger is-selected spectrum-Tabs-dropdown" aria-haspopup="true">
               <span class="spectrum-Dropdown-label">Tab 1</span>
@@ -73,11 +78,13 @@ components:
               </svg>
             </button>
           </div>
+        </div>
         <div class="spectrum-Tabs-selectionIndicator" style="width: 50px; left: 8px;"></div>
       </div>
 
       <h4 style="margin-top: 62px;">Open</h4>
       <div class="spectrum-Tabs spectrum-Tabs--horizontal spectrum-Tabs--quiet spectrum-Tabs--compact" style="width: 409px">
+        <div class="spectrum-Tab-item">
           <div class="spectrum-Dropdown spectrum-Dropdown--quiet is-open">
             <button class="spectrum-FieldButton spectrum-FieldButton--quiet spectrum-Dropdown-trigger is-selected spectrum-Tabs-dropdown" aria-haspopup="true">
               <span class="spectrum-Dropdown-label">Tab 1</span>
@@ -86,6 +93,7 @@ components:
               </svg>
             </button>
           </div>
+        </div>
         <div class="spectrum-Tabs-selectionIndicator" style="width: 50px; left: 8px;"></div>
       </div>
       <br>

--- a/src/tabs/index.css
+++ b/src/tabs/index.css
@@ -87,6 +87,25 @@ governing permissions and limitations under the License.
   }
 }
 
+.spectrum-Tabs-dropdown {
+  &::before {
+    content: '';
+    position: absolute;
+    top: 50%;
+
+    box-sizing: border-box;
+
+    height: var(--spectrum-tabs-focus-ring-height);
+    margin-top: calc(calc(var(--spectrum-tabs-focus-ring-height) / -2) + calc(var(--spectrum-tabs-rule-height) / 2));
+    left: calc(-1 * var(--spectrum-tabs-focus-ring-padding-x));
+    right: calc(-1 * var(--spectrum-tabs-focus-ring-padding-x));
+    border: var(--spectrum-tabs-focus-ring-size) solid transparent;
+    border-radius: var(--spectrum-tabs-focus-ring-border-radius);
+
+    pointer-events: none;
+ }
+}
+
 .spectrum-Tabs-itemLabel {
   cursor: pointer;
   vertical-align: top;

--- a/src/tabs/index.css
+++ b/src/tabs/index.css
@@ -88,6 +88,8 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Tabs-dropdown {
+  display: block;
+
   &::before {
     content: '';
     position: absolute;

--- a/src/tabs/skin.css
+++ b/src/tabs/skin.css
@@ -102,3 +102,11 @@ governing permissions and limitations under the License.
     }
   }
 }
+
+.spectrum-Tabs-dropdown {
+  &:focus-ring {
+    &::before {
+       border-color: var(--spectrum-tabs-focus-ring-color);
+     }
+  }
+}

--- a/src/tabs/skin.css
+++ b/src/tabs/skin.css
@@ -105,6 +105,10 @@ governing permissions and limitations under the License.
 
 .spectrum-Tabs-dropdown {
   &:focus-ring {
+    &.is-selected {
+       box-shadow: none;
+    }
+     
     &::before {
        border-color: var(--spectrum-tabs-focus-ring-color);
      }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This adds the correct full border focus ring to the dropdown that covers the case of tabs too many.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/adobe/spectrum-css/issues/187

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We're working on tabs too many and need the css

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tried it out in my local spectrum css build

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
