### PR TITLE
Fixes #132, removes native up/down step control buttons in Firefox

### DIFF
--- a/src/textfield/index.css
+++ b/src/textfield/index.css
@@ -65,8 +65,8 @@ governing permissions and limitations under the License.
 
   /* removes the native spin buttons in firefox. -mox-appearance: none has no effect */
   /* http://stackoverflow.com/questions/23372903/hide-spinner-in-input-number-firefox-29 */
-  -moz-appearance: textfield;
   -webkit-appearance: none;
+  -moz-appearance: textfield;
 
   &::placeholder {
     font-weight: var(--spectrum-textfield-placeholder-text-font-weight);


### PR DESCRIPTION
## Description
The fix flips ` -moz-appearance` and `-webkit-appearance` in Textfield's css so that the native up/down step control buttons don't appear in Firefox. Thanks to @jnurthen for the fix suggestion.

## Related Issue
Closes https://github.com/adobe/spectrum-css/issues/132. Should also resolve https://github.com/adobe/react-spectrum/issues/508.

## Motivation and Context
Steppers in Firefox were showing two sets of step control buttons without this fix.

## How Has This Been Tested?
Checked http://localhost:8080/docs/index.html#stepper in Firefox, Chrome, and Safari. Also confirmed that this change would fix the RSP issue as well

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
