### PR TITLE
Use adobe opensource workflow icons and fix #60

### DIFF
--- a/bundles/spectrum-css-compat/package-lock.json
+++ b/bundles/spectrum-css-compat/package-lock.json
@@ -1,3790 +1,5273 @@
 {
-	"name": "@adobe/spectrum-css",
-	"version": "2.14.0-alpha.9",
-	"lockfileVersion": 1,
-	"requires": true,
-	"dependencies": {
-		"@spectrum/spectrum-icons": {
-			"version": "2.3.0",
-			"resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-spectrum-release/@spectrum/spectrum-icons/-/@spectrum/spectrum-icons-2.3.0.tgz",
-			"integrity": "sha1-IlbN3PcBo3HJgtJX5bmIaDUktD4=",
-			"optional": true,
-			"requires": {
-				"gh-pages": "^2.0.1"
-			},
-			"dependencies": {
-				"array-union": {
-					"version": "1.0.2",
-					"resolved": "http://localhost:4873/array-union/-/array-union-1.0.2.tgz",
-					"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-					"optional": true,
-					"requires": {
-						"array-uniq": "^1.0.1"
-					}
-				},
-				"array-uniq": {
-					"version": "1.0.3",
-					"resolved": "http://localhost:4873/array-uniq/-/array-uniq-1.0.3.tgz",
-					"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-					"optional": true
-				},
-				"async": {
-					"version": "2.6.3",
-					"resolved": "http://localhost:4873/async/-/async-2.6.3.tgz",
-					"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-					"optional": true,
-					"requires": {
-						"lodash": "^4.17.14"
-					}
-				},
-				"balanced-match": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/balanced-match/-/balanced-match-1.0.0.tgz",
-					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-					"optional": true
-				},
-				"brace-expansion": {
-					"version": "1.1.11",
-					"resolved": "http://localhost:4873/brace-expansion/-/brace-expansion-1.1.11.tgz",
-					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-					"optional": true,
-					"requires": {
-						"balanced-match": "^1.0.0",
-						"concat-map": "0.0.1"
-					}
-				},
-				"commander": {
-					"version": "2.20.0",
-					"resolved": "http://localhost:4873/commander/-/commander-2.20.0.tgz",
-					"integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
-					"optional": true
-				},
-				"concat-map": {
-					"version": "0.0.1",
-					"resolved": "http://localhost:4873/concat-map/-/concat-map-0.0.1.tgz",
-					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-					"optional": true
-				},
-				"email-addresses": {
-					"version": "3.0.3",
-					"resolved": "http://localhost:4873/email-addresses/-/email-addresses-3.0.3.tgz",
-					"integrity": "sha512-kUlSC06PVvvjlMRpNIl3kR1NRXLEe86VQ7N0bQeaCZb2g+InShCeHQp/JvyYNTugMnRN2NvJhHlc3q12MWbbpg==",
-					"optional": true
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "http://localhost:4873/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-					"optional": true
-				},
-				"filename-reserved-regex": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz",
-					"integrity": "sha1-5hz4BfDeHJhFZ9A4bcXfUO5a9+Q=",
-					"optional": true
-				},
-				"filenamify": {
-					"version": "1.2.1",
-					"resolved": "http://localhost:4873/filenamify/-/filenamify-1.2.1.tgz",
-					"integrity": "sha1-qfL/0RxQO+0wABUCknI3jx8TZaU=",
-					"optional": true,
-					"requires": {
-						"filename-reserved-regex": "^1.0.0",
-						"strip-outer": "^1.0.0",
-						"trim-repeated": "^1.0.0"
-					}
-				},
-				"filenamify-url": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/filenamify-url/-/filenamify-url-1.0.0.tgz",
-					"integrity": "sha1-syvYExnvWGO3MHi+1Q9GpPeXX1A=",
-					"optional": true,
-					"requires": {
-						"filenamify": "^1.0.0",
-						"humanize-url": "^1.0.0"
-					}
-				},
-				"fs-extra": {
-					"version": "7.0.1",
-					"resolved": "http://localhost:4873/fs-extra/-/fs-extra-7.0.1.tgz",
-					"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-					"optional": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"fs.realpath": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/fs.realpath/-/fs.realpath-1.0.0.tgz",
-					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-					"optional": true
-				},
-				"gh-pages": {
-					"version": "2.1.0",
-					"resolved": "http://localhost:4873/gh-pages/-/gh-pages-2.1.0.tgz",
-					"integrity": "sha512-QmV1fh/2W5GZkfoLsG4g6dRTWiNYuCetMQmm8CL6Us8JVnAufYtS0uJPD8NYogmNB4UZzdRG44uPAL+jcBzEwQ==",
-					"optional": true,
-					"requires": {
-						"async": "^2.6.1",
-						"commander": "^2.18.0",
-						"email-addresses": "^3.0.1",
-						"filenamify-url": "^1.0.0",
-						"fs-extra": "^7.0.0",
-						"globby": "^6.1.0",
-						"graceful-fs": "^4.1.11",
-						"rimraf": "^2.6.2"
-					}
-				},
-				"glob": {
-					"version": "7.1.4",
-					"resolved": "http://localhost:4873/glob/-/glob-7.1.4.tgz",
-					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-					"optional": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"globby": {
-					"version": "6.1.0",
-					"resolved": "http://localhost:4873/globby/-/globby-6.1.0.tgz",
-					"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-					"optional": true,
-					"requires": {
-						"array-union": "^1.0.1",
-						"glob": "^7.0.3",
-						"object-assign": "^4.0.1",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"graceful-fs": {
-					"version": "4.2.0",
-					"resolved": "http://localhost:4873/graceful-fs/-/graceful-fs-4.2.0.tgz",
-					"integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
-					"optional": true
-				},
-				"humanize-url": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/humanize-url/-/humanize-url-1.0.1.tgz",
-					"integrity": "sha1-9KuZ4NKIF0yk4eUEB8VfuuRk7/8=",
-					"optional": true,
-					"requires": {
-						"normalize-url": "^1.0.0",
-						"strip-url-auth": "^1.0.0"
-					}
-				},
-				"inflight": {
-					"version": "1.0.6",
-					"resolved": "http://localhost:4873/inflight/-/inflight-1.0.6.tgz",
-					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-					"optional": true,
-					"requires": {
-						"once": "^1.3.0",
-						"wrappy": "1"
-					}
-				},
-				"inherits": {
-					"version": "2.0.4",
-					"resolved": "http://localhost:4873/inherits/-/inherits-2.0.4.tgz",
-					"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-					"optional": true
-				},
-				"is-plain-obj": {
-					"version": "1.1.0",
-					"resolved": "http://localhost:4873/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-					"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-					"optional": true
-				},
-				"jsonfile": {
-					"version": "4.0.0",
-					"resolved": "http://localhost:4873/jsonfile/-/jsonfile-4.0.0.tgz",
-					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-					"optional": true,
-					"requires": {
-						"graceful-fs": "^4.1.6"
-					}
-				},
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "http://localhost:4873/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-					"optional": true
-				},
-				"minimatch": {
-					"version": "3.0.4",
-					"resolved": "http://localhost:4873/minimatch/-/minimatch-3.0.4.tgz",
-					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-					"optional": true,
-					"requires": {
-						"brace-expansion": "^1.1.7"
-					}
-				},
-				"normalize-url": {
-					"version": "1.9.1",
-					"resolved": "http://localhost:4873/normalize-url/-/normalize-url-1.9.1.tgz",
-					"integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
-					"optional": true,
-					"requires": {
-						"object-assign": "^4.0.1",
-						"prepend-http": "^1.0.0",
-						"query-string": "^4.1.0",
-						"sort-keys": "^1.0.0"
-					}
-				},
-				"object-assign": {
-					"version": "4.1.1",
-					"resolved": "http://localhost:4873/object-assign/-/object-assign-4.1.1.tgz",
-					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-					"optional": true
-				},
-				"once": {
-					"version": "1.4.0",
-					"resolved": "http://localhost:4873/once/-/once-1.4.0.tgz",
-					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-					"optional": true,
-					"requires": {
-						"wrappy": "1"
-					}
-				},
-				"path-is-absolute": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-					"optional": true
-				},
-				"pify": {
-					"version": "2.3.0",
-					"resolved": "http://localhost:4873/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"optional": true
-				},
-				"pinkie": {
-					"version": "2.0.4",
-					"resolved": "http://localhost:4873/pinkie/-/pinkie-2.0.4.tgz",
-					"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-					"optional": true
-				},
-				"pinkie-promise": {
-					"version": "2.0.1",
-					"resolved": "http://localhost:4873/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-					"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-					"optional": true,
-					"requires": {
-						"pinkie": "^2.0.0"
-					}
-				},
-				"prepend-http": {
-					"version": "1.0.4",
-					"resolved": "http://localhost:4873/prepend-http/-/prepend-http-1.0.4.tgz",
-					"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-					"optional": true
-				},
-				"query-string": {
-					"version": "4.3.4",
-					"resolved": "http://localhost:4873/query-string/-/query-string-4.3.4.tgz",
-					"integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
-					"optional": true,
-					"requires": {
-						"object-assign": "^4.1.0",
-						"strict-uri-encode": "^1.0.0"
-					}
-				},
-				"rimraf": {
-					"version": "2.6.3",
-					"resolved": "http://localhost:4873/rimraf/-/rimraf-2.6.3.tgz",
-					"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-					"optional": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				},
-				"sort-keys": {
-					"version": "1.1.2",
-					"resolved": "http://localhost:4873/sort-keys/-/sort-keys-1.1.2.tgz",
-					"integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
-					"optional": true,
-					"requires": {
-						"is-plain-obj": "^1.0.0"
-					}
-				},
-				"strict-uri-encode": {
-					"version": "1.1.0",
-					"resolved": "http://localhost:4873/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-					"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-					"optional": true
-				},
-				"strip-outer": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/strip-outer/-/strip-outer-1.0.1.tgz",
-					"integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
-					"optional": true,
-					"requires": {
-						"escape-string-regexp": "^1.0.2"
-					}
-				},
-				"strip-url-auth": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/strip-url-auth/-/strip-url-auth-1.0.1.tgz",
-					"integrity": "sha1-IrD6OkE4WzO+PzMVUbu4N/oM164=",
-					"optional": true
-				},
-				"trim-repeated": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/trim-repeated/-/trim-repeated-1.0.0.tgz",
-					"integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
-					"optional": true,
-					"requires": {
-						"escape-string-regexp": "^1.0.2"
-					}
-				},
-				"universalify": {
-					"version": "0.1.2",
-					"resolved": "http://localhost:4873/universalify/-/universalify-0.1.2.tgz",
-					"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-					"optional": true
-				},
-				"wrappy": {
-					"version": "1.0.2",
-					"resolved": "http://localhost:4873/wrappy/-/wrappy-1.0.2.tgz",
-					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-					"optional": true
-				}
-			}
-		},
-		"gulp": {
-			"version": "4.0.2",
-			"resolved": "http://localhost:4873/gulp/-/gulp-4.0.2.tgz",
-			"integrity": "sha512-dvEs27SCZt2ibF29xYgmnwwCYZxdxhQ/+LFWlbAW8y7jt68L/65402Lz3+CKy0Ov4rOs+NERmDq7YlZaDqUIfA==",
-			"dev": true,
-			"requires": {
-				"glob-watcher": "^5.0.3",
-				"gulp-cli": "^2.2.0",
-				"undertaker": "^1.2.1",
-				"vinyl-fs": "^3.0.0"
-			},
-			"dependencies": {
-				"ansi-colors": {
-					"version": "1.1.0",
-					"resolved": "http://localhost:4873/ansi-colors/-/ansi-colors-1.1.0.tgz",
-					"integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
-					"dev": true,
-					"requires": {
-						"ansi-wrap": "^0.1.0"
-					}
-				},
-				"ansi-gray": {
-					"version": "0.1.1",
-					"resolved": "http://localhost:4873/ansi-gray/-/ansi-gray-0.1.1.tgz",
-					"integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
-					"dev": true,
-					"requires": {
-						"ansi-wrap": "0.1.0"
-					}
-				},
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "http://localhost:4873/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
-				},
-				"ansi-wrap": {
-					"version": "0.1.0",
-					"resolved": "http://localhost:4873/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
-					"integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
-					"dev": true
-				},
-				"anymatch": {
-					"version": "2.0.0",
-					"resolved": "http://localhost:4873/anymatch/-/anymatch-2.0.0.tgz",
-					"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
-					"dev": true,
-					"requires": {
-						"micromatch": "^3.1.4",
-						"normalize-path": "^2.1.1"
-					}
-				},
-				"append-buffer": {
-					"version": "1.0.2",
-					"resolved": "http://localhost:4873/append-buffer/-/append-buffer-1.0.2.tgz",
-					"integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
-					"dev": true,
-					"requires": {
-						"buffer-equal": "^1.0.0"
-					}
-				},
-				"archy": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/archy/-/archy-1.0.0.tgz",
-					"integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
-					"dev": true
-				},
-				"arr-diff": {
-					"version": "4.0.0",
-					"resolved": "http://localhost:4873/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-					"dev": true
-				},
-				"arr-filter": {
-					"version": "1.1.2",
-					"resolved": "http://localhost:4873/arr-filter/-/arr-filter-1.1.2.tgz",
-					"integrity": "sha1-Q/3d0JHo7xGqTEXZzcGOLf8XEe4=",
-					"dev": true,
-					"requires": {
-						"make-iterator": "^1.0.0"
-					}
-				},
-				"arr-flatten": {
-					"version": "1.1.0",
-					"resolved": "http://localhost:4873/arr-flatten/-/arr-flatten-1.1.0.tgz",
-					"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-					"dev": true
-				},
-				"arr-map": {
-					"version": "2.0.2",
-					"resolved": "http://localhost:4873/arr-map/-/arr-map-2.0.2.tgz",
-					"integrity": "sha1-Onc0X/wc814qkYJWAfnljy4kysQ=",
-					"dev": true,
-					"requires": {
-						"make-iterator": "^1.0.0"
-					}
-				},
-				"arr-union": {
-					"version": "3.1.0",
-					"resolved": "http://localhost:4873/arr-union/-/arr-union-3.1.0.tgz",
-					"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
-					"dev": true
-				},
-				"array-each": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/array-each/-/array-each-1.0.1.tgz",
-					"integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8=",
-					"dev": true
-				},
-				"array-initial": {
-					"version": "1.1.0",
-					"resolved": "http://localhost:4873/array-initial/-/array-initial-1.1.0.tgz",
-					"integrity": "sha1-L6dLJnOTccOUe9enrcc74zSz15U=",
-					"dev": true,
-					"requires": {
-						"array-slice": "^1.0.0",
-						"is-number": "^4.0.0"
-					},
-					"dependencies": {
-						"is-number": {
-							"version": "4.0.0",
-							"resolved": "http://localhost:4873/is-number/-/is-number-4.0.0.tgz",
-							"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-							"dev": true
-						}
-					}
-				},
-				"array-last": {
-					"version": "1.3.0",
-					"resolved": "http://localhost:4873/array-last/-/array-last-1.3.0.tgz",
-					"integrity": "sha512-eOCut5rXlI6aCOS7Z7kCplKRKyiFQ6dHFBem4PwlwKeNFk2/XxTrhRh5T9PyaEWGy/NHTZWbY+nsZlNFJu9rYg==",
-					"dev": true,
-					"requires": {
-						"is-number": "^4.0.0"
-					},
-					"dependencies": {
-						"is-number": {
-							"version": "4.0.0",
-							"resolved": "http://localhost:4873/is-number/-/is-number-4.0.0.tgz",
-							"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-							"dev": true
-						}
-					}
-				},
-				"array-slice": {
-					"version": "1.1.0",
-					"resolved": "http://localhost:4873/array-slice/-/array-slice-1.1.0.tgz",
-					"integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w==",
-					"dev": true
-				},
-				"array-sort": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/array-sort/-/array-sort-1.0.0.tgz",
-					"integrity": "sha512-ihLeJkonmdiAsD7vpgN3CRcx2J2S0TiYW+IS/5zHBI7mKUq3ySvBdzzBfD236ubDBQFiiyG3SWCPc+msQ9KoYg==",
-					"dev": true,
-					"requires": {
-						"default-compare": "^1.0.0",
-						"get-value": "^2.0.6",
-						"kind-of": "^5.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "5.1.0",
-							"resolved": "http://localhost:4873/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-							"dev": true
-						}
-					}
-				},
-				"array-unique": {
-					"version": "0.3.2",
-					"resolved": "http://localhost:4873/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-					"dev": true
-				},
-				"assign-symbols": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/assign-symbols/-/assign-symbols-1.0.0.tgz",
-					"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
-					"dev": true
-				},
-				"async-done": {
-					"version": "1.3.2",
-					"resolved": "http://localhost:4873/async-done/-/async-done-1.3.2.tgz",
-					"integrity": "sha512-uYkTP8dw2og1tu1nmza1n1CMW0qb8gWWlwqMmLb7MhBVs4BXrFziT6HXUd+/RlRA/i4H9AkofYloUbs1fwMqlw==",
-					"dev": true,
-					"requires": {
-						"end-of-stream": "^1.1.0",
-						"once": "^1.3.2",
-						"process-nextick-args": "^2.0.0",
-						"stream-exhaust": "^1.0.1"
-					}
-				},
-				"async-each": {
-					"version": "1.0.3",
-					"resolved": "http://localhost:4873/async-each/-/async-each-1.0.3.tgz",
-					"integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
-					"dev": true
-				},
-				"async-settle": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/async-settle/-/async-settle-1.0.0.tgz",
-					"integrity": "sha1-HQqRS7Aldb7IqPOnTlCA9yssDGs=",
-					"dev": true,
-					"requires": {
-						"async-done": "^1.2.2"
-					}
-				},
-				"atob": {
-					"version": "2.1.2",
-					"resolved": "http://localhost:4873/atob/-/atob-2.1.2.tgz",
-					"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-					"dev": true
-				},
-				"bach": {
-					"version": "1.2.0",
-					"resolved": "http://localhost:4873/bach/-/bach-1.2.0.tgz",
-					"integrity": "sha1-Szzpa/JxNPeaG0FKUcFONMO9mIA=",
-					"dev": true,
-					"requires": {
-						"arr-filter": "^1.1.1",
-						"arr-flatten": "^1.0.1",
-						"arr-map": "^2.0.0",
-						"array-each": "^1.0.0",
-						"array-initial": "^1.0.0",
-						"array-last": "^1.1.1",
-						"async-done": "^1.2.2",
-						"async-settle": "^1.0.0",
-						"now-and-later": "^2.0.0"
-					}
-				},
-				"balanced-match": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/balanced-match/-/balanced-match-1.0.0.tgz",
-					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-					"dev": true
-				},
-				"base": {
-					"version": "0.11.2",
-					"resolved": "http://localhost:4873/base/-/base-0.11.2.tgz",
-					"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
-					"dev": true,
-					"requires": {
-						"cache-base": "^1.0.1",
-						"class-utils": "^0.3.5",
-						"component-emitter": "^1.2.1",
-						"define-property": "^1.0.0",
-						"isobject": "^3.0.1",
-						"mixin-deep": "^1.2.0",
-						"pascalcase": "^0.1.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "1.0.0",
-							"resolved": "http://localhost:4873/define-property/-/define-property-1.0.0.tgz",
-							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-							"dev": true,
-							"requires": {
-								"is-descriptor": "^1.0.0"
-							}
-						},
-						"is-accessor-descriptor": {
-							"version": "1.0.0",
-							"resolved": "http://localhost:4873/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-							"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-							"dev": true,
-							"requires": {
-								"kind-of": "^6.0.0"
-							}
-						},
-						"is-data-descriptor": {
-							"version": "1.0.0",
-							"resolved": "http://localhost:4873/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-							"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-							"dev": true,
-							"requires": {
-								"kind-of": "^6.0.0"
-							}
-						},
-						"is-descriptor": {
-							"version": "1.0.2",
-							"resolved": "http://localhost:4873/is-descriptor/-/is-descriptor-1.0.2.tgz",
-							"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-							"dev": true,
-							"requires": {
-								"is-accessor-descriptor": "^1.0.0",
-								"is-data-descriptor": "^1.0.0",
-								"kind-of": "^6.0.2"
-							}
-						}
-					}
-				},
-				"binary-extensions": {
-					"version": "1.13.1",
-					"resolved": "http://localhost:4873/binary-extensions/-/binary-extensions-1.13.1.tgz",
-					"integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
-					"dev": true
-				},
-				"brace-expansion": {
-					"version": "1.1.11",
-					"resolved": "http://localhost:4873/brace-expansion/-/brace-expansion-1.1.11.tgz",
-					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-					"dev": true,
-					"requires": {
-						"balanced-match": "^1.0.0",
-						"concat-map": "0.0.1"
-					}
-				},
-				"braces": {
-					"version": "2.3.2",
-					"resolved": "http://localhost:4873/braces/-/braces-2.3.2.tgz",
-					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-					"dev": true,
-					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "http://localhost:4873/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"buffer-equal": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/buffer-equal/-/buffer-equal-1.0.0.tgz",
-					"integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74=",
-					"dev": true
-				},
-				"buffer-from": {
-					"version": "1.1.1",
-					"resolved": "http://localhost:4873/buffer-from/-/buffer-from-1.1.1.tgz",
-					"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-					"dev": true
-				},
-				"cache-base": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/cache-base/-/cache-base-1.0.1.tgz",
-					"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
-					"dev": true,
-					"requires": {
-						"collection-visit": "^1.0.0",
-						"component-emitter": "^1.2.1",
-						"get-value": "^2.0.6",
-						"has-value": "^1.0.0",
-						"isobject": "^3.0.1",
-						"set-value": "^2.0.0",
-						"to-object-path": "^0.3.0",
-						"union-value": "^1.0.0",
-						"unset-value": "^1.0.0"
-					}
-				},
-				"camelcase": {
-					"version": "3.0.0",
-					"resolved": "http://localhost:4873/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-					"dev": true
-				},
-				"chokidar": {
-					"version": "2.1.6",
-					"resolved": "http://localhost:4873/chokidar/-/chokidar-2.1.6.tgz",
-					"integrity": "sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==",
-					"dev": true,
-					"requires": {
-						"anymatch": "^2.0.0",
-						"async-each": "^1.0.1",
-						"braces": "^2.3.2",
-						"fsevents": "^1.2.7",
-						"glob-parent": "^3.1.0",
-						"inherits": "^2.0.3",
-						"is-binary-path": "^1.0.0",
-						"is-glob": "^4.0.0",
-						"normalize-path": "^3.0.0",
-						"path-is-absolute": "^1.0.0",
-						"readdirp": "^2.2.1",
-						"upath": "^1.1.1"
-					},
-					"dependencies": {
-						"normalize-path": {
-							"version": "3.0.0",
-							"resolved": "http://localhost:4873/normalize-path/-/normalize-path-3.0.0.tgz",
-							"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-							"dev": true
-						}
-					}
-				},
-				"class-utils": {
-					"version": "0.3.6",
-					"resolved": "http://localhost:4873/class-utils/-/class-utils-0.3.6.tgz",
-					"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
-					"dev": true,
-					"requires": {
-						"arr-union": "^3.1.0",
-						"define-property": "^0.2.5",
-						"isobject": "^3.0.0",
-						"static-extend": "^0.1.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "0.2.5",
-							"resolved": "http://localhost:4873/define-property/-/define-property-0.2.5.tgz",
-							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-							"dev": true,
-							"requires": {
-								"is-descriptor": "^0.1.0"
-							}
-						}
-					}
-				},
-				"cliui": {
-					"version": "3.2.0",
-					"resolved": "http://localhost:4873/cliui/-/cliui-3.2.0.tgz",
-					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-					"dev": true,
-					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wrap-ansi": "^2.0.0"
-					}
-				},
-				"clone": {
-					"version": "2.1.2",
-					"resolved": "http://localhost:4873/clone/-/clone-2.1.2.tgz",
-					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
-					"dev": true
-				},
-				"clone-buffer": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/clone-buffer/-/clone-buffer-1.0.0.tgz",
-					"integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
-					"dev": true
-				},
-				"clone-stats": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/clone-stats/-/clone-stats-1.0.0.tgz",
-					"integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
-					"dev": true
-				},
-				"cloneable-readable": {
-					"version": "1.1.3",
-					"resolved": "http://localhost:4873/cloneable-readable/-/cloneable-readable-1.1.3.tgz",
-					"integrity": "sha512-2EF8zTQOxYq70Y4XKtorQupqF0m49MBz2/yf5Bj+MHjvpG3Hy7sImifnqD6UA+TKYxeSV+u6qqQPawN5UvnpKQ==",
-					"dev": true,
-					"requires": {
-						"inherits": "^2.0.1",
-						"process-nextick-args": "^2.0.0",
-						"readable-stream": "^2.3.5"
-					}
-				},
-				"code-point-at": {
-					"version": "1.1.0",
-					"resolved": "http://localhost:4873/code-point-at/-/code-point-at-1.1.0.tgz",
-					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-					"dev": true
-				},
-				"collection-map": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/collection-map/-/collection-map-1.0.0.tgz",
-					"integrity": "sha1-rqDwb40mx4DCt1SUOFVEsiVa8Yw=",
-					"dev": true,
-					"requires": {
-						"arr-map": "^2.0.2",
-						"for-own": "^1.0.0",
-						"make-iterator": "^1.0.0"
-					}
-				},
-				"collection-visit": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/collection-visit/-/collection-visit-1.0.0.tgz",
-					"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
-					"dev": true,
-					"requires": {
-						"map-visit": "^1.0.0",
-						"object-visit": "^1.0.0"
-					}
-				},
-				"color-support": {
-					"version": "1.1.3",
-					"resolved": "http://localhost:4873/color-support/-/color-support-1.1.3.tgz",
-					"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-					"dev": true
-				},
-				"component-emitter": {
-					"version": "1.3.0",
-					"resolved": "http://localhost:4873/component-emitter/-/component-emitter-1.3.0.tgz",
-					"integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
-					"dev": true
-				},
-				"concat-map": {
-					"version": "0.0.1",
-					"resolved": "http://localhost:4873/concat-map/-/concat-map-0.0.1.tgz",
-					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-					"dev": true
-				},
-				"concat-stream": {
-					"version": "1.6.2",
-					"resolved": "http://localhost:4873/concat-stream/-/concat-stream-1.6.2.tgz",
-					"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-					"dev": true,
-					"requires": {
-						"buffer-from": "^1.0.0",
-						"inherits": "^2.0.3",
-						"readable-stream": "^2.2.2",
-						"typedarray": "^0.0.6"
-					}
-				},
-				"convert-source-map": {
-					"version": "1.6.0",
-					"resolved": "http://localhost:4873/convert-source-map/-/convert-source-map-1.6.0.tgz",
-					"integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.1"
-					}
-				},
-				"copy-descriptor": {
-					"version": "0.1.1",
-					"resolved": "http://localhost:4873/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-					"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
-					"dev": true
-				},
-				"copy-props": {
-					"version": "2.0.4",
-					"resolved": "http://localhost:4873/copy-props/-/copy-props-2.0.4.tgz",
-					"integrity": "sha512-7cjuUME+p+S3HZlbllgsn2CDwS+5eCCX16qBgNC4jgSTf49qR1VKy/Zhl400m0IQXl/bPGEVqncgUUMjrr4s8A==",
-					"dev": true,
-					"requires": {
-						"each-props": "^1.3.0",
-						"is-plain-object": "^2.0.1"
-					}
-				},
-				"core-util-is": {
-					"version": "1.0.2",
-					"resolved": "http://localhost:4873/core-util-is/-/core-util-is-1.0.2.tgz",
-					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-					"dev": true
-				},
-				"d": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/d/-/d-1.0.1.tgz",
-					"integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-					"dev": true,
-					"requires": {
-						"es5-ext": "^0.10.50",
-						"type": "^1.0.1"
-					}
-				},
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "http://localhost:4873/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"decamelize": {
-					"version": "1.2.0",
-					"resolved": "http://localhost:4873/decamelize/-/decamelize-1.2.0.tgz",
-					"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-					"dev": true
-				},
-				"decode-uri-component": {
-					"version": "0.2.0",
-					"resolved": "http://localhost:4873/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-					"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-					"dev": true
-				},
-				"default-compare": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/default-compare/-/default-compare-1.0.0.tgz",
-					"integrity": "sha512-QWfXlM0EkAbqOCbD/6HjdwT19j7WCkMyiRhWilc4H9/5h/RzTF9gv5LYh1+CmDV5d1rki6KAWLtQale0xt20eQ==",
-					"dev": true,
-					"requires": {
-						"kind-of": "^5.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "5.1.0",
-							"resolved": "http://localhost:4873/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-							"dev": true
-						}
-					}
-				},
-				"default-resolution": {
-					"version": "2.0.0",
-					"resolved": "http://localhost:4873/default-resolution/-/default-resolution-2.0.0.tgz",
-					"integrity": "sha1-vLgrqnKtebQmp2cy8aga1t8m1oQ=",
-					"dev": true
-				},
-				"define-properties": {
-					"version": "1.1.3",
-					"resolved": "http://localhost:4873/define-properties/-/define-properties-1.1.3.tgz",
-					"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-					"dev": true,
-					"requires": {
-						"object-keys": "^1.0.12"
-					}
-				},
-				"define-property": {
-					"version": "2.0.2",
-					"resolved": "http://localhost:4873/define-property/-/define-property-2.0.2.tgz",
-					"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
-					"dev": true,
-					"requires": {
-						"is-descriptor": "^1.0.2",
-						"isobject": "^3.0.1"
-					},
-					"dependencies": {
-						"is-accessor-descriptor": {
-							"version": "1.0.0",
-							"resolved": "http://localhost:4873/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-							"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-							"dev": true,
-							"requires": {
-								"kind-of": "^6.0.0"
-							}
-						},
-						"is-data-descriptor": {
-							"version": "1.0.0",
-							"resolved": "http://localhost:4873/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-							"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-							"dev": true,
-							"requires": {
-								"kind-of": "^6.0.0"
-							}
-						},
-						"is-descriptor": {
-							"version": "1.0.2",
-							"resolved": "http://localhost:4873/is-descriptor/-/is-descriptor-1.0.2.tgz",
-							"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-							"dev": true,
-							"requires": {
-								"is-accessor-descriptor": "^1.0.0",
-								"is-data-descriptor": "^1.0.0",
-								"kind-of": "^6.0.2"
-							}
-						}
-					}
-				},
-				"detect-file": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/detect-file/-/detect-file-1.0.0.tgz",
-					"integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
-					"dev": true
-				},
-				"duplexify": {
-					"version": "3.7.1",
-					"resolved": "http://localhost:4873/duplexify/-/duplexify-3.7.1.tgz",
-					"integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
-					"dev": true,
-					"requires": {
-						"end-of-stream": "^1.0.0",
-						"inherits": "^2.0.1",
-						"readable-stream": "^2.0.0",
-						"stream-shift": "^1.0.0"
-					}
-				},
-				"each-props": {
-					"version": "1.3.2",
-					"resolved": "http://localhost:4873/each-props/-/each-props-1.3.2.tgz",
-					"integrity": "sha512-vV0Hem3zAGkJAyU7JSjixeU66rwdynTAa1vofCrSA5fEln+m67Az9CcnkVD776/fsN/UjIWmBDoNRS6t6G9RfA==",
-					"dev": true,
-					"requires": {
-						"is-plain-object": "^2.0.1",
-						"object.defaults": "^1.1.0"
-					}
-				},
-				"end-of-stream": {
-					"version": "1.4.1",
-					"resolved": "http://localhost:4873/end-of-stream/-/end-of-stream-1.4.1.tgz",
-					"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-					"dev": true,
-					"requires": {
-						"once": "^1.4.0"
-					}
-				},
-				"error-ex": {
-					"version": "1.3.2",
-					"resolved": "http://localhost:4873/error-ex/-/error-ex-1.3.2.tgz",
-					"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-					"dev": true,
-					"requires": {
-						"is-arrayish": "^0.2.1"
-					}
-				},
-				"es5-ext": {
-					"version": "0.10.50",
-					"resolved": "http://localhost:4873/es5-ext/-/es5-ext-0.10.50.tgz",
-					"integrity": "sha512-KMzZTPBkeQV/JcSQhI5/z6d9VWJ3EnQ194USTUwIYZ2ZbpN8+SGXQKt1h68EX44+qt+Fzr8DO17vnxrw7c3agw==",
-					"dev": true,
-					"requires": {
-						"es6-iterator": "~2.0.3",
-						"es6-symbol": "~3.1.1",
-						"next-tick": "^1.0.0"
-					}
-				},
-				"es6-iterator": {
-					"version": "2.0.3",
-					"resolved": "http://localhost:4873/es6-iterator/-/es6-iterator-2.0.3.tgz",
-					"integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-					"dev": true,
-					"requires": {
-						"d": "1",
-						"es5-ext": "^0.10.35",
-						"es6-symbol": "^3.1.1"
-					}
-				},
-				"es6-symbol": {
-					"version": "3.1.1",
-					"resolved": "http://localhost:4873/es6-symbol/-/es6-symbol-3.1.1.tgz",
-					"integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-					"dev": true,
-					"requires": {
-						"d": "1",
-						"es5-ext": "~0.10.14"
-					}
-				},
-				"es6-weak-map": {
-					"version": "2.0.3",
-					"resolved": "http://localhost:4873/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
-					"integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
-					"dev": true,
-					"requires": {
-						"d": "1",
-						"es5-ext": "^0.10.46",
-						"es6-iterator": "^2.0.3",
-						"es6-symbol": "^3.1.1"
-					}
-				},
-				"expand-brackets": {
-					"version": "2.1.4",
-					"resolved": "http://localhost:4873/expand-brackets/-/expand-brackets-2.1.4.tgz",
-					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-					"dev": true,
-					"requires": {
-						"debug": "^2.3.3",
-						"define-property": "^0.2.5",
-						"extend-shallow": "^2.0.1",
-						"posix-character-classes": "^0.1.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "0.2.5",
-							"resolved": "http://localhost:4873/define-property/-/define-property-0.2.5.tgz",
-							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-							"dev": true,
-							"requires": {
-								"is-descriptor": "^0.1.0"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "http://localhost:4873/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"expand-tilde": {
-					"version": "2.0.2",
-					"resolved": "http://localhost:4873/expand-tilde/-/expand-tilde-2.0.2.tgz",
-					"integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
-					"dev": true,
-					"requires": {
-						"homedir-polyfill": "^1.0.1"
-					}
-				},
-				"extend": {
-					"version": "3.0.2",
-					"resolved": "http://localhost:4873/extend/-/extend-3.0.2.tgz",
-					"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-					"dev": true
-				},
-				"extend-shallow": {
-					"version": "3.0.2",
-					"resolved": "http://localhost:4873/extend-shallow/-/extend-shallow-3.0.2.tgz",
-					"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-					"dev": true,
-					"requires": {
-						"assign-symbols": "^1.0.0",
-						"is-extendable": "^1.0.1"
-					},
-					"dependencies": {
-						"is-extendable": {
-							"version": "1.0.1",
-							"resolved": "http://localhost:4873/is-extendable/-/is-extendable-1.0.1.tgz",
-							"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-							"dev": true,
-							"requires": {
-								"is-plain-object": "^2.0.4"
-							}
-						}
-					}
-				},
-				"extglob": {
-					"version": "2.0.4",
-					"resolved": "http://localhost:4873/extglob/-/extglob-2.0.4.tgz",
-					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-					"dev": true,
-					"requires": {
-						"array-unique": "^0.3.2",
-						"define-property": "^1.0.0",
-						"expand-brackets": "^2.1.4",
-						"extend-shallow": "^2.0.1",
-						"fragment-cache": "^0.2.1",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "1.0.0",
-							"resolved": "http://localhost:4873/define-property/-/define-property-1.0.0.tgz",
-							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-							"dev": true,
-							"requires": {
-								"is-descriptor": "^1.0.0"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "http://localhost:4873/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						},
-						"is-accessor-descriptor": {
-							"version": "1.0.0",
-							"resolved": "http://localhost:4873/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-							"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-							"dev": true,
-							"requires": {
-								"kind-of": "^6.0.0"
-							}
-						},
-						"is-data-descriptor": {
-							"version": "1.0.0",
-							"resolved": "http://localhost:4873/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-							"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-							"dev": true,
-							"requires": {
-								"kind-of": "^6.0.0"
-							}
-						},
-						"is-descriptor": {
-							"version": "1.0.2",
-							"resolved": "http://localhost:4873/is-descriptor/-/is-descriptor-1.0.2.tgz",
-							"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-							"dev": true,
-							"requires": {
-								"is-accessor-descriptor": "^1.0.0",
-								"is-data-descriptor": "^1.0.0",
-								"kind-of": "^6.0.2"
-							}
-						}
-					}
-				},
-				"fancy-log": {
-					"version": "1.3.3",
-					"resolved": "http://localhost:4873/fancy-log/-/fancy-log-1.3.3.tgz",
-					"integrity": "sha512-k9oEhlyc0FrVh25qYuSELjr8oxsCoc4/LEZfg2iJJrfEk/tZL9bCoJE47gqAvI2m/AUjluCS4+3I0eTx8n3AEw==",
-					"dev": true,
-					"requires": {
-						"ansi-gray": "^0.1.1",
-						"color-support": "^1.1.3",
-						"parse-node-version": "^1.0.0",
-						"time-stamp": "^1.0.0"
-					}
-				},
-				"fill-range": {
-					"version": "4.0.0",
-					"resolved": "http://localhost:4873/fill-range/-/fill-range-4.0.0.tgz",
-					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-					"dev": true,
-					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "http://localhost:4873/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"find-up": {
-					"version": "1.1.2",
-					"resolved": "http://localhost:4873/find-up/-/find-up-1.1.2.tgz",
-					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-					"dev": true,
-					"requires": {
-						"path-exists": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"findup-sync": {
-					"version": "3.0.0",
-					"resolved": "http://localhost:4873/findup-sync/-/findup-sync-3.0.0.tgz",
-					"integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
-					"dev": true,
-					"requires": {
-						"detect-file": "^1.0.0",
-						"is-glob": "^4.0.0",
-						"micromatch": "^3.0.4",
-						"resolve-dir": "^1.0.1"
-					}
-				},
-				"fined": {
-					"version": "1.2.0",
-					"resolved": "http://localhost:4873/fined/-/fined-1.2.0.tgz",
-					"integrity": "sha512-ZYDqPLGxDkDhDZBjZBb+oD1+j0rA4E0pXY50eplAAOPg2N/gUBSSk5IM1/QhPfyVo19lJ+CvXpqfvk+b2p/8Ng==",
-					"dev": true,
-					"requires": {
-						"expand-tilde": "^2.0.2",
-						"is-plain-object": "^2.0.3",
-						"object.defaults": "^1.1.0",
-						"object.pick": "^1.2.0",
-						"parse-filepath": "^1.0.1"
-					}
-				},
-				"flagged-respawn": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
-					"integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q==",
-					"dev": true
-				},
-				"flush-write-stream": {
-					"version": "1.1.1",
-					"resolved": "http://localhost:4873/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
-					"integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
-					"dev": true,
-					"requires": {
-						"inherits": "^2.0.3",
-						"readable-stream": "^2.3.6"
-					}
-				},
-				"for-in": {
-					"version": "1.0.2",
-					"resolved": "http://localhost:4873/for-in/-/for-in-1.0.2.tgz",
-					"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-					"dev": true
-				},
-				"for-own": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/for-own/-/for-own-1.0.0.tgz",
-					"integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
-					"dev": true,
-					"requires": {
-						"for-in": "^1.0.1"
-					}
-				},
-				"fragment-cache": {
-					"version": "0.2.1",
-					"resolved": "http://localhost:4873/fragment-cache/-/fragment-cache-0.2.1.tgz",
-					"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
-					"dev": true,
-					"requires": {
-						"map-cache": "^0.2.2"
-					}
-				},
-				"fs-mkdirp-stream": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz",
-					"integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.11",
-						"through2": "^2.0.3"
-					}
-				},
-				"fs.realpath": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/fs.realpath/-/fs.realpath-1.0.0.tgz",
-					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-					"dev": true
-				},
-				"fsevents": {
-					"version": "1.2.9",
-					"resolved": "http://localhost:4873/fsevents/-/fsevents-1.2.9.tgz",
-					"integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"nan": "^2.12.1",
-						"node-pre-gyp": "^0.12.0"
-					},
-					"dependencies": {
-						"abbrev": {
-							"version": "1.1.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"ansi-regex": {
-							"version": "2.1.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"aproba": {
-							"version": "1.2.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"are-we-there-yet": {
-							"version": "1.1.5",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"delegates": "^1.0.0",
-								"readable-stream": "^2.0.6"
-							}
-						},
-						"balanced-match": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"brace-expansion": {
-							"version": "1.1.11",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"balanced-match": "^1.0.0",
-								"concat-map": "0.0.1"
-							}
-						},
-						"chownr": {
-							"version": "1.1.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"code-point-at": {
-							"version": "1.1.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"concat-map": {
-							"version": "0.0.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"console-control-strings": {
-							"version": "1.1.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"core-util-is": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"debug": {
-							"version": "4.1.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"ms": "^2.1.1"
-							}
-						},
-						"deep-extend": {
-							"version": "0.6.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"delegates": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"detect-libc": {
-							"version": "1.0.3",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"fs-minipass": {
-							"version": "1.2.5",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"minipass": "^2.2.1"
-							}
-						},
-						"fs.realpath": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"gauge": {
-							"version": "2.7.4",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"aproba": "^1.0.3",
-								"console-control-strings": "^1.0.0",
-								"has-unicode": "^2.0.0",
-								"object-assign": "^4.1.0",
-								"signal-exit": "^3.0.0",
-								"string-width": "^1.0.1",
-								"strip-ansi": "^3.0.1",
-								"wide-align": "^1.1.0"
-							}
-						},
-						"glob": {
-							"version": "7.1.3",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"fs.realpath": "^1.0.0",
-								"inflight": "^1.0.4",
-								"inherits": "2",
-								"minimatch": "^3.0.4",
-								"once": "^1.3.0",
-								"path-is-absolute": "^1.0.0"
-							}
-						},
-						"has-unicode": {
-							"version": "2.0.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"iconv-lite": {
-							"version": "0.4.24",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"safer-buffer": ">= 2.1.2 < 3"
-							}
-						},
-						"ignore-walk": {
-							"version": "3.0.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"minimatch": "^3.0.4"
-							}
-						},
-						"inflight": {
-							"version": "1.0.6",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"once": "^1.3.0",
-								"wrappy": "1"
-							}
-						},
-						"inherits": {
-							"version": "2.0.3",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"ini": {
-							"version": "1.3.5",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"is-fullwidth-code-point": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"number-is-nan": "^1.0.0"
-							}
-						},
-						"isarray": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"minimatch": {
-							"version": "3.0.4",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"brace-expansion": "^1.1.7"
-							}
-						},
-						"minimist": {
-							"version": "0.0.8",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"minipass": {
-							"version": "2.3.5",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"safe-buffer": "^5.1.2",
-								"yallist": "^3.0.0"
-							}
-						},
-						"minizlib": {
-							"version": "1.2.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"minipass": "^2.2.1"
-							}
-						},
-						"mkdirp": {
-							"version": "0.5.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"minimist": "0.0.8"
-							}
-						},
-						"ms": {
-							"version": "2.1.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"needle": {
-							"version": "2.3.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"debug": "^4.1.0",
-								"iconv-lite": "^0.4.4",
-								"sax": "^1.2.4"
-							}
-						},
-						"node-pre-gyp": {
-							"version": "0.12.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"detect-libc": "^1.0.2",
-								"mkdirp": "^0.5.1",
-								"needle": "^2.2.1",
-								"nopt": "^4.0.1",
-								"npm-packlist": "^1.1.6",
-								"npmlog": "^4.0.2",
-								"rc": "^1.2.7",
-								"rimraf": "^2.6.1",
-								"semver": "^5.3.0",
-								"tar": "^4"
-							}
-						},
-						"nopt": {
-							"version": "4.0.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"abbrev": "1",
-								"osenv": "^0.1.4"
-							}
-						},
-						"npm-bundled": {
-							"version": "1.0.6",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"npm-packlist": {
-							"version": "1.4.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"ignore-walk": "^3.0.1",
-								"npm-bundled": "^1.0.1"
-							}
-						},
-						"npmlog": {
-							"version": "4.1.2",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"are-we-there-yet": "~1.1.2",
-								"console-control-strings": "~1.1.0",
-								"gauge": "~2.7.3",
-								"set-blocking": "~2.0.0"
-							}
-						},
-						"number-is-nan": {
-							"version": "1.0.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"object-assign": {
-							"version": "4.1.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"once": {
-							"version": "1.4.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"wrappy": "1"
-							}
-						},
-						"os-homedir": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"os-tmpdir": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"osenv": {
-							"version": "0.1.5",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"os-homedir": "^1.0.0",
-								"os-tmpdir": "^1.0.0"
-							}
-						},
-						"path-is-absolute": {
-							"version": "1.0.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"process-nextick-args": {
-							"version": "2.0.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"rc": {
-							"version": "1.2.8",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"deep-extend": "^0.6.0",
-								"ini": "~1.3.0",
-								"minimist": "^1.2.0",
-								"strip-json-comments": "~2.0.1"
-							},
-							"dependencies": {
-								"minimist": {
-									"version": "1.2.0",
-									"bundled": true,
-									"dev": true,
-									"optional": true
-								}
-							}
-						},
-						"readable-stream": {
-							"version": "2.3.6",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"core-util-is": "~1.0.0",
-								"inherits": "~2.0.3",
-								"isarray": "~1.0.0",
-								"process-nextick-args": "~2.0.0",
-								"safe-buffer": "~5.1.1",
-								"string_decoder": "~1.1.1",
-								"util-deprecate": "~1.0.1"
-							}
-						},
-						"rimraf": {
-							"version": "2.6.3",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"glob": "^7.1.3"
-							}
-						},
-						"safe-buffer": {
-							"version": "5.1.2",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"safer-buffer": {
-							"version": "2.1.2",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"sax": {
-							"version": "1.2.4",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"semver": {
-							"version": "5.7.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"set-blocking": {
-							"version": "2.0.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"signal-exit": {
-							"version": "3.0.2",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"string-width": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"code-point-at": "^1.0.0",
-								"is-fullwidth-code-point": "^1.0.0",
-								"strip-ansi": "^3.0.0"
-							}
-						},
-						"string_decoder": {
-							"version": "1.1.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"safe-buffer": "~5.1.0"
-							}
-						},
-						"strip-ansi": {
-							"version": "3.0.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"ansi-regex": "^2.0.0"
-							}
-						},
-						"strip-json-comments": {
-							"version": "2.0.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"tar": {
-							"version": "4.4.8",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"chownr": "^1.1.1",
-								"fs-minipass": "^1.2.5",
-								"minipass": "^2.3.4",
-								"minizlib": "^1.1.1",
-								"mkdirp": "^0.5.0",
-								"safe-buffer": "^5.1.2",
-								"yallist": "^3.0.2"
-							}
-						},
-						"util-deprecate": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"wide-align": {
-							"version": "1.1.3",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"string-width": "^1.0.2 || 2"
-							}
-						},
-						"wrappy": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"yallist": {
-							"version": "3.0.3",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						}
-					}
-				},
-				"function-bind": {
-					"version": "1.1.1",
-					"resolved": "http://localhost:4873/function-bind/-/function-bind-1.1.1.tgz",
-					"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-					"dev": true
-				},
-				"get-caller-file": {
-					"version": "1.0.3",
-					"resolved": "http://localhost:4873/get-caller-file/-/get-caller-file-1.0.3.tgz",
-					"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
-					"dev": true
-				},
-				"get-value": {
-					"version": "2.0.6",
-					"resolved": "http://localhost:4873/get-value/-/get-value-2.0.6.tgz",
-					"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
-					"dev": true
-				},
-				"glob": {
-					"version": "7.1.4",
-					"resolved": "http://localhost:4873/glob/-/glob-7.1.4.tgz",
-					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-					"dev": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"glob-parent": {
-					"version": "3.1.0",
-					"resolved": "http://localhost:4873/glob-parent/-/glob-parent-3.1.0.tgz",
-					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-					"dev": true,
-					"requires": {
-						"is-glob": "^3.1.0",
-						"path-dirname": "^1.0.0"
-					},
-					"dependencies": {
-						"is-glob": {
-							"version": "3.1.0",
-							"resolved": "http://localhost:4873/is-glob/-/is-glob-3.1.0.tgz",
-							"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-							"dev": true,
-							"requires": {
-								"is-extglob": "^2.1.0"
-							}
-						}
-					}
-				},
-				"glob-stream": {
-					"version": "6.1.0",
-					"resolved": "http://localhost:4873/glob-stream/-/glob-stream-6.1.0.tgz",
-					"integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
-					"dev": true,
-					"requires": {
-						"extend": "^3.0.0",
-						"glob": "^7.1.1",
-						"glob-parent": "^3.1.0",
-						"is-negated-glob": "^1.0.0",
-						"ordered-read-streams": "^1.0.0",
-						"pumpify": "^1.3.5",
-						"readable-stream": "^2.1.5",
-						"remove-trailing-separator": "^1.0.1",
-						"to-absolute-glob": "^2.0.0",
-						"unique-stream": "^2.0.2"
-					}
-				},
-				"glob-watcher": {
-					"version": "5.0.3",
-					"resolved": "http://localhost:4873/glob-watcher/-/glob-watcher-5.0.3.tgz",
-					"integrity": "sha512-8tWsULNEPHKQ2MR4zXuzSmqbdyV5PtwwCaWSGQ1WwHsJ07ilNeN1JB8ntxhckbnpSHaf9dXFUHzIWvm1I13dsg==",
-					"dev": true,
-					"requires": {
-						"anymatch": "^2.0.0",
-						"async-done": "^1.2.0",
-						"chokidar": "^2.0.0",
-						"is-negated-glob": "^1.0.0",
-						"just-debounce": "^1.0.0",
-						"object.defaults": "^1.1.0"
-					}
-				},
-				"global-modules": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/global-modules/-/global-modules-1.0.0.tgz",
-					"integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
-					"dev": true,
-					"requires": {
-						"global-prefix": "^1.0.1",
-						"is-windows": "^1.0.1",
-						"resolve-dir": "^1.0.0"
-					}
-				},
-				"global-prefix": {
-					"version": "1.0.2",
-					"resolved": "http://localhost:4873/global-prefix/-/global-prefix-1.0.2.tgz",
-					"integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
-					"dev": true,
-					"requires": {
-						"expand-tilde": "^2.0.2",
-						"homedir-polyfill": "^1.0.1",
-						"ini": "^1.3.4",
-						"is-windows": "^1.0.1",
-						"which": "^1.2.14"
-					}
-				},
-				"glogg": {
-					"version": "1.0.2",
-					"resolved": "http://localhost:4873/glogg/-/glogg-1.0.2.tgz",
-					"integrity": "sha512-5mwUoSuBk44Y4EshyiqcH95ZntbDdTQqA3QYSrxmzj28Ai0vXBGMH1ApSANH14j2sIRtqCEyg6PfsuP7ElOEDA==",
-					"dev": true,
-					"requires": {
-						"sparkles": "^1.0.0"
-					}
-				},
-				"graceful-fs": {
-					"version": "4.2.0",
-					"resolved": "http://localhost:4873/graceful-fs/-/graceful-fs-4.2.0.tgz",
-					"integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
-					"dev": true
-				},
-				"gulp-cli": {
-					"version": "2.2.0",
-					"resolved": "http://localhost:4873/gulp-cli/-/gulp-cli-2.2.0.tgz",
-					"integrity": "sha512-rGs3bVYHdyJpLqR0TUBnlcZ1O5O++Zs4bA0ajm+zr3WFCfiSLjGwoCBqFs18wzN+ZxahT9DkOK5nDf26iDsWjA==",
-					"dev": true,
-					"requires": {
-						"ansi-colors": "^1.0.1",
-						"archy": "^1.0.0",
-						"array-sort": "^1.0.0",
-						"color-support": "^1.1.3",
-						"concat-stream": "^1.6.0",
-						"copy-props": "^2.0.1",
-						"fancy-log": "^1.3.2",
-						"gulplog": "^1.0.0",
-						"interpret": "^1.1.0",
-						"isobject": "^3.0.1",
-						"liftoff": "^3.1.0",
-						"matchdep": "^2.0.0",
-						"mute-stdout": "^1.0.0",
-						"pretty-hrtime": "^1.0.0",
-						"replace-homedir": "^1.0.0",
-						"semver-greatest-satisfied-range": "^1.1.0",
-						"v8flags": "^3.0.1",
-						"yargs": "^7.1.0"
-					}
-				},
-				"gulplog": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/gulplog/-/gulplog-1.0.0.tgz",
-					"integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
-					"dev": true,
-					"requires": {
-						"glogg": "^1.0.0"
-					}
-				},
-				"has-symbols": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/has-symbols/-/has-symbols-1.0.0.tgz",
-					"integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
-					"dev": true
-				},
-				"has-value": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/has-value/-/has-value-1.0.0.tgz",
-					"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
-					"dev": true,
-					"requires": {
-						"get-value": "^2.0.6",
-						"has-values": "^1.0.0",
-						"isobject": "^3.0.0"
-					}
-				},
-				"has-values": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/has-values/-/has-values-1.0.0.tgz",
-					"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
-					"dev": true,
-					"requires": {
-						"is-number": "^3.0.0",
-						"kind-of": "^4.0.0"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "4.0.0",
-							"resolved": "http://localhost:4873/kind-of/-/kind-of-4.0.0.tgz",
-							"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-							"dev": true,
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
-				},
-				"homedir-polyfill": {
-					"version": "1.0.3",
-					"resolved": "http://localhost:4873/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
-					"integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
-					"dev": true,
-					"requires": {
-						"parse-passwd": "^1.0.0"
-					}
-				},
-				"hosted-git-info": {
-					"version": "2.7.1",
-					"resolved": "http://localhost:4873/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-					"integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
-					"dev": true
-				},
-				"inflight": {
-					"version": "1.0.6",
-					"resolved": "http://localhost:4873/inflight/-/inflight-1.0.6.tgz",
-					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-					"dev": true,
-					"requires": {
-						"once": "^1.3.0",
-						"wrappy": "1"
-					}
-				},
-				"inherits": {
-					"version": "2.0.4",
-					"resolved": "http://localhost:4873/inherits/-/inherits-2.0.4.tgz",
-					"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-					"dev": true
-				},
-				"ini": {
-					"version": "1.3.5",
-					"resolved": "http://localhost:4873/ini/-/ini-1.3.5.tgz",
-					"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-					"dev": true
-				},
-				"interpret": {
-					"version": "1.2.0",
-					"resolved": "http://localhost:4873/interpret/-/interpret-1.2.0.tgz",
-					"integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
-					"dev": true
-				},
-				"invert-kv": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/invert-kv/-/invert-kv-1.0.0.tgz",
-					"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-					"dev": true
-				},
-				"is-absolute": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/is-absolute/-/is-absolute-1.0.0.tgz",
-					"integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
-					"dev": true,
-					"requires": {
-						"is-relative": "^1.0.0",
-						"is-windows": "^1.0.1"
-					}
-				},
-				"is-accessor-descriptor": {
-					"version": "0.1.6",
-					"resolved": "http://localhost:4873/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-					"dev": true,
-					"requires": {
-						"kind-of": "^3.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "http://localhost:4873/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
-				},
-				"is-arrayish": {
-					"version": "0.2.1",
-					"resolved": "http://localhost:4873/is-arrayish/-/is-arrayish-0.2.1.tgz",
-					"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-					"dev": true
-				},
-				"is-binary-path": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/is-binary-path/-/is-binary-path-1.0.1.tgz",
-					"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-					"dev": true,
-					"requires": {
-						"binary-extensions": "^1.0.0"
-					}
-				},
-				"is-buffer": {
-					"version": "1.1.6",
-					"resolved": "http://localhost:4873/is-buffer/-/is-buffer-1.1.6.tgz",
-					"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-					"dev": true
-				},
-				"is-data-descriptor": {
-					"version": "0.1.4",
-					"resolved": "http://localhost:4873/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-					"dev": true,
-					"requires": {
-						"kind-of": "^3.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "http://localhost:4873/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
-				},
-				"is-descriptor": {
-					"version": "0.1.6",
-					"resolved": "http://localhost:4873/is-descriptor/-/is-descriptor-0.1.6.tgz",
-					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-					"dev": true,
-					"requires": {
-						"is-accessor-descriptor": "^0.1.6",
-						"is-data-descriptor": "^0.1.4",
-						"kind-of": "^5.0.0"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "5.1.0",
-							"resolved": "http://localhost:4873/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-							"dev": true
-						}
-					}
-				},
-				"is-extendable": {
-					"version": "0.1.1",
-					"resolved": "http://localhost:4873/is-extendable/-/is-extendable-0.1.1.tgz",
-					"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-					"dev": true
-				},
-				"is-extglob": {
-					"version": "2.1.1",
-					"resolved": "http://localhost:4873/is-extglob/-/is-extglob-2.1.1.tgz",
-					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-					"dev": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"is-glob": {
-					"version": "4.0.1",
-					"resolved": "http://localhost:4873/is-glob/-/is-glob-4.0.1.tgz",
-					"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-					"dev": true,
-					"requires": {
-						"is-extglob": "^2.1.1"
-					}
-				},
-				"is-negated-glob": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
-					"integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=",
-					"dev": true
-				},
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "http://localhost:4873/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"dev": true,
-					"requires": {
-						"kind-of": "^3.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "http://localhost:4873/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
-				},
-				"is-plain-object": {
-					"version": "2.0.4",
-					"resolved": "http://localhost:4873/is-plain-object/-/is-plain-object-2.0.4.tgz",
-					"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-					"dev": true,
-					"requires": {
-						"isobject": "^3.0.1"
-					}
-				},
-				"is-relative": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/is-relative/-/is-relative-1.0.0.tgz",
-					"integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
-					"dev": true,
-					"requires": {
-						"is-unc-path": "^1.0.0"
-					}
-				},
-				"is-unc-path": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/is-unc-path/-/is-unc-path-1.0.0.tgz",
-					"integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
-					"dev": true,
-					"requires": {
-						"unc-path-regex": "^0.1.2"
-					}
-				},
-				"is-utf8": {
-					"version": "0.2.1",
-					"resolved": "http://localhost:4873/is-utf8/-/is-utf8-0.2.1.tgz",
-					"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-					"dev": true
-				},
-				"is-valid-glob": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
-					"integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao=",
-					"dev": true
-				},
-				"is-windows": {
-					"version": "1.0.2",
-					"resolved": "http://localhost:4873/is-windows/-/is-windows-1.0.2.tgz",
-					"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-					"dev": true
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-					"dev": true
-				},
-				"isexe": {
-					"version": "2.0.0",
-					"resolved": "http://localhost:4873/isexe/-/isexe-2.0.0.tgz",
-					"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-					"dev": true
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "http://localhost:4873/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
-				},
-				"json-stable-stringify-without-jsonify": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-					"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
-					"dev": true
-				},
-				"just-debounce": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/just-debounce/-/just-debounce-1.0.0.tgz",
-					"integrity": "sha1-h/zPrv/AtozRnVX2cilD+SnqNeo=",
-					"dev": true
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "http://localhost:4873/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
-				},
-				"last-run": {
-					"version": "1.1.1",
-					"resolved": "http://localhost:4873/last-run/-/last-run-1.1.1.tgz",
-					"integrity": "sha1-RblpQsF7HHnHchmCWbqUO+v4yls=",
-					"dev": true,
-					"requires": {
-						"default-resolution": "^2.0.0",
-						"es6-weak-map": "^2.0.1"
-					}
-				},
-				"lazystream": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/lazystream/-/lazystream-1.0.0.tgz",
-					"integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
-					"dev": true,
-					"requires": {
-						"readable-stream": "^2.0.5"
-					}
-				},
-				"lcid": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/lcid/-/lcid-1.0.0.tgz",
-					"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-					"dev": true,
-					"requires": {
-						"invert-kv": "^1.0.0"
-					}
-				},
-				"lead": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/lead/-/lead-1.0.0.tgz",
-					"integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
-					"dev": true,
-					"requires": {
-						"flush-write-stream": "^1.0.2"
-					}
-				},
-				"liftoff": {
-					"version": "3.1.0",
-					"resolved": "http://localhost:4873/liftoff/-/liftoff-3.1.0.tgz",
-					"integrity": "sha512-DlIPlJUkCV0Ips2zf2pJP0unEoT1kwYhiiPUGF3s/jtxTCjziNLoiVVh+jqWOWeFi6mmwQ5fNxvAUyPad4Dfog==",
-					"dev": true,
-					"requires": {
-						"extend": "^3.0.0",
-						"findup-sync": "^3.0.0",
-						"fined": "^1.0.1",
-						"flagged-respawn": "^1.0.0",
-						"is-plain-object": "^2.0.4",
-						"object.map": "^1.0.0",
-						"rechoir": "^0.6.2",
-						"resolve": "^1.1.7"
-					}
-				},
-				"load-json-file": {
-					"version": "1.1.0",
-					"resolved": "http://localhost:4873/load-json-file/-/load-json-file-1.1.0.tgz",
-					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^2.2.0",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0",
-						"strip-bom": "^2.0.0"
-					}
-				},
-				"make-iterator": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/make-iterator/-/make-iterator-1.0.1.tgz",
-					"integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
-					"dev": true,
-					"requires": {
-						"kind-of": "^6.0.2"
-					}
-				},
-				"map-cache": {
-					"version": "0.2.2",
-					"resolved": "http://localhost:4873/map-cache/-/map-cache-0.2.2.tgz",
-					"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
-					"dev": true
-				},
-				"map-visit": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/map-visit/-/map-visit-1.0.0.tgz",
-					"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
-					"dev": true,
-					"requires": {
-						"object-visit": "^1.0.0"
-					}
-				},
-				"matchdep": {
-					"version": "2.0.0",
-					"resolved": "http://localhost:4873/matchdep/-/matchdep-2.0.0.tgz",
-					"integrity": "sha1-xvNINKDY28OzfCfui7yyfHd1WC4=",
-					"dev": true,
-					"requires": {
-						"findup-sync": "^2.0.0",
-						"micromatch": "^3.0.4",
-						"resolve": "^1.4.0",
-						"stack-trace": "0.0.10"
-					},
-					"dependencies": {
-						"findup-sync": {
-							"version": "2.0.0",
-							"resolved": "http://localhost:4873/findup-sync/-/findup-sync-2.0.0.tgz",
-							"integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
-							"dev": true,
-							"requires": {
-								"detect-file": "^1.0.0",
-								"is-glob": "^3.1.0",
-								"micromatch": "^3.0.4",
-								"resolve-dir": "^1.0.1"
-							}
-						},
-						"is-glob": {
-							"version": "3.1.0",
-							"resolved": "http://localhost:4873/is-glob/-/is-glob-3.1.0.tgz",
-							"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-							"dev": true,
-							"requires": {
-								"is-extglob": "^2.1.0"
-							}
-						}
-					}
-				},
-				"micromatch": {
-					"version": "3.1.10",
-					"resolved": "http://localhost:4873/micromatch/-/micromatch-3.1.10.tgz",
-					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-					"dev": true,
-					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
-					}
-				},
-				"minimatch": {
-					"version": "3.0.4",
-					"resolved": "http://localhost:4873/minimatch/-/minimatch-3.0.4.tgz",
-					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-					"dev": true,
-					"requires": {
-						"brace-expansion": "^1.1.7"
-					}
-				},
-				"mixin-deep": {
-					"version": "1.3.2",
-					"resolved": "http://localhost:4873/mixin-deep/-/mixin-deep-1.3.2.tgz",
-					"integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
-					"dev": true,
-					"requires": {
-						"for-in": "^1.0.2",
-						"is-extendable": "^1.0.1"
-					},
-					"dependencies": {
-						"is-extendable": {
-							"version": "1.0.1",
-							"resolved": "http://localhost:4873/is-extendable/-/is-extendable-1.0.1.tgz",
-							"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-							"dev": true,
-							"requires": {
-								"is-plain-object": "^2.0.4"
-							}
-						}
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "http://localhost:4873/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
-				},
-				"mute-stdout": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/mute-stdout/-/mute-stdout-1.0.1.tgz",
-					"integrity": "sha512-kDcwXR4PS7caBpuRYYBUz9iVixUk3anO3f5OYFiIPwK/20vCzKCHyKoulbiDY1S53zD2bxUpxN/IJ+TnXjfvxg==",
-					"dev": true
-				},
-				"nan": {
-					"version": "2.14.0",
-					"resolved": "http://localhost:4873/nan/-/nan-2.14.0.tgz",
-					"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-					"dev": true,
-					"optional": true
-				},
-				"nanomatch": {
-					"version": "1.2.13",
-					"resolved": "http://localhost:4873/nanomatch/-/nanomatch-1.2.13.tgz",
-					"integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
-					"dev": true,
-					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"fragment-cache": "^0.2.1",
-						"is-windows": "^1.0.2",
-						"kind-of": "^6.0.2",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
-					}
-				},
-				"next-tick": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/next-tick/-/next-tick-1.0.0.tgz",
-					"integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
-					"dev": true
-				},
-				"normalize-package-data": {
-					"version": "2.5.0",
-					"resolved": "http://localhost:4873/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-					"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-					"dev": true,
-					"requires": {
-						"hosted-git-info": "^2.1.4",
-						"resolve": "^1.10.0",
-						"semver": "2 || 3 || 4 || 5",
-						"validate-npm-package-license": "^3.0.1"
-					}
-				},
-				"normalize-path": {
-					"version": "2.1.1",
-					"resolved": "http://localhost:4873/normalize-path/-/normalize-path-2.1.1.tgz",
-					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-					"dev": true,
-					"requires": {
-						"remove-trailing-separator": "^1.0.1"
-					}
-				},
-				"now-and-later": {
-					"version": "2.0.1",
-					"resolved": "http://localhost:4873/now-and-later/-/now-and-later-2.0.1.tgz",
-					"integrity": "sha512-KGvQ0cB70AQfg107Xvs/Fbu+dGmZoTRJp2TaPwcwQm3/7PteUyN2BCgk8KBMPGBUXZdVwyWS8fDCGFygBm19UQ==",
-					"dev": true,
-					"requires": {
-						"once": "^1.3.2"
-					}
-				},
-				"number-is-nan": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/number-is-nan/-/number-is-nan-1.0.1.tgz",
-					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-					"dev": true
-				},
-				"object-copy": {
-					"version": "0.1.0",
-					"resolved": "http://localhost:4873/object-copy/-/object-copy-0.1.0.tgz",
-					"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
-					"dev": true,
-					"requires": {
-						"copy-descriptor": "^0.1.0",
-						"define-property": "^0.2.5",
-						"kind-of": "^3.0.3"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "0.2.5",
-							"resolved": "http://localhost:4873/define-property/-/define-property-0.2.5.tgz",
-							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-							"dev": true,
-							"requires": {
-								"is-descriptor": "^0.1.0"
-							}
-						},
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "http://localhost:4873/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
-				},
-				"object-keys": {
-					"version": "1.1.1",
-					"resolved": "http://localhost:4873/object-keys/-/object-keys-1.1.1.tgz",
-					"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-					"dev": true
-				},
-				"object-visit": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/object-visit/-/object-visit-1.0.1.tgz",
-					"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
-					"dev": true,
-					"requires": {
-						"isobject": "^3.0.0"
-					}
-				},
-				"object.assign": {
-					"version": "4.1.0",
-					"resolved": "http://localhost:4873/object.assign/-/object.assign-4.1.0.tgz",
-					"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
-					"dev": true,
-					"requires": {
-						"define-properties": "^1.1.2",
-						"function-bind": "^1.1.1",
-						"has-symbols": "^1.0.0",
-						"object-keys": "^1.0.11"
-					}
-				},
-				"object.defaults": {
-					"version": "1.1.0",
-					"resolved": "http://localhost:4873/object.defaults/-/object.defaults-1.1.0.tgz",
-					"integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
-					"dev": true,
-					"requires": {
-						"array-each": "^1.0.1",
-						"array-slice": "^1.0.0",
-						"for-own": "^1.0.0",
-						"isobject": "^3.0.0"
-					}
-				},
-				"object.map": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/object.map/-/object.map-1.0.1.tgz",
-					"integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
-					"dev": true,
-					"requires": {
-						"for-own": "^1.0.0",
-						"make-iterator": "^1.0.0"
-					}
-				},
-				"object.pick": {
-					"version": "1.3.0",
-					"resolved": "http://localhost:4873/object.pick/-/object.pick-1.3.0.tgz",
-					"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
-					"dev": true,
-					"requires": {
-						"isobject": "^3.0.1"
-					}
-				},
-				"object.reduce": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/object.reduce/-/object.reduce-1.0.1.tgz",
-					"integrity": "sha1-b+NI8qx/oPlcpiEiZZkJaCW7A60=",
-					"dev": true,
-					"requires": {
-						"for-own": "^1.0.0",
-						"make-iterator": "^1.0.0"
-					}
-				},
-				"once": {
-					"version": "1.4.0",
-					"resolved": "http://localhost:4873/once/-/once-1.4.0.tgz",
-					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-					"dev": true,
-					"requires": {
-						"wrappy": "1"
-					}
-				},
-				"ordered-read-streams": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz",
-					"integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
-					"dev": true,
-					"requires": {
-						"readable-stream": "^2.0.1"
-					}
-				},
-				"os-locale": {
-					"version": "1.4.0",
-					"resolved": "http://localhost:4873/os-locale/-/os-locale-1.4.0.tgz",
-					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-					"dev": true,
-					"requires": {
-						"lcid": "^1.0.0"
-					}
-				},
-				"parse-filepath": {
-					"version": "1.0.2",
-					"resolved": "http://localhost:4873/parse-filepath/-/parse-filepath-1.0.2.tgz",
-					"integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
-					"dev": true,
-					"requires": {
-						"is-absolute": "^1.0.0",
-						"map-cache": "^0.2.0",
-						"path-root": "^0.1.1"
-					}
-				},
-				"parse-json": {
-					"version": "2.2.0",
-					"resolved": "http://localhost:4873/parse-json/-/parse-json-2.2.0.tgz",
-					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-					"dev": true,
-					"requires": {
-						"error-ex": "^1.2.0"
-					}
-				},
-				"parse-node-version": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/parse-node-version/-/parse-node-version-1.0.1.tgz",
-					"integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==",
-					"dev": true
-				},
-				"parse-passwd": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/parse-passwd/-/parse-passwd-1.0.0.tgz",
-					"integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
-					"dev": true
-				},
-				"pascalcase": {
-					"version": "0.1.1",
-					"resolved": "http://localhost:4873/pascalcase/-/pascalcase-0.1.1.tgz",
-					"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
-					"dev": true
-				},
-				"path-dirname": {
-					"version": "1.0.2",
-					"resolved": "http://localhost:4873/path-dirname/-/path-dirname-1.0.2.tgz",
-					"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
-					"dev": true
-				},
-				"path-exists": {
-					"version": "2.1.0",
-					"resolved": "http://localhost:4873/path-exists/-/path-exists-2.1.0.tgz",
-					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-					"dev": true,
-					"requires": {
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"path-is-absolute": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-					"dev": true
-				},
-				"path-parse": {
-					"version": "1.0.6",
-					"resolved": "http://localhost:4873/path-parse/-/path-parse-1.0.6.tgz",
-					"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-					"dev": true
-				},
-				"path-root": {
-					"version": "0.1.1",
-					"resolved": "http://localhost:4873/path-root/-/path-root-0.1.1.tgz",
-					"integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
-					"dev": true,
-					"requires": {
-						"path-root-regex": "^0.1.0"
-					}
-				},
-				"path-root-regex": {
-					"version": "0.1.2",
-					"resolved": "http://localhost:4873/path-root-regex/-/path-root-regex-0.1.2.tgz",
-					"integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
-					"dev": true
-				},
-				"path-type": {
-					"version": "1.1.0",
-					"resolved": "http://localhost:4873/path-type/-/path-type-1.1.0.tgz",
-					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"pify": {
-					"version": "2.3.0",
-					"resolved": "http://localhost:4873/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
-				},
-				"pinkie": {
-					"version": "2.0.4",
-					"resolved": "http://localhost:4873/pinkie/-/pinkie-2.0.4.tgz",
-					"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-					"dev": true
-				},
-				"pinkie-promise": {
-					"version": "2.0.1",
-					"resolved": "http://localhost:4873/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-					"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-					"dev": true,
-					"requires": {
-						"pinkie": "^2.0.0"
-					}
-				},
-				"posix-character-classes": {
-					"version": "0.1.1",
-					"resolved": "http://localhost:4873/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-					"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
-					"dev": true
-				},
-				"pretty-hrtime": {
-					"version": "1.0.3",
-					"resolved": "http://localhost:4873/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
-					"integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
-					"dev": true
-				},
-				"process-nextick-args": {
-					"version": "2.0.1",
-					"resolved": "http://localhost:4873/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-					"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-					"dev": true
-				},
-				"pump": {
-					"version": "2.0.1",
-					"resolved": "http://localhost:4873/pump/-/pump-2.0.1.tgz",
-					"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-					"dev": true,
-					"requires": {
-						"end-of-stream": "^1.1.0",
-						"once": "^1.3.1"
-					}
-				},
-				"pumpify": {
-					"version": "1.5.1",
-					"resolved": "http://localhost:4873/pumpify/-/pumpify-1.5.1.tgz",
-					"integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
-					"dev": true,
-					"requires": {
-						"duplexify": "^3.6.0",
-						"inherits": "^2.0.3",
-						"pump": "^2.0.0"
-					}
-				},
-				"read-pkg": {
-					"version": "1.1.0",
-					"resolved": "http://localhost:4873/read-pkg/-/read-pkg-1.1.0.tgz",
-					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-					"dev": true,
-					"requires": {
-						"load-json-file": "^1.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^1.0.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-					"dev": true,
-					"requires": {
-						"find-up": "^1.0.0",
-						"read-pkg": "^1.0.0"
-					}
-				},
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "http://localhost:4873/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"readdirp": {
-					"version": "2.2.1",
-					"resolved": "http://localhost:4873/readdirp/-/readdirp-2.2.1.tgz",
-					"integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.11",
-						"micromatch": "^3.1.10",
-						"readable-stream": "^2.0.2"
-					}
-				},
-				"rechoir": {
-					"version": "0.6.2",
-					"resolved": "http://localhost:4873/rechoir/-/rechoir-0.6.2.tgz",
-					"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-					"dev": true,
-					"requires": {
-						"resolve": "^1.1.6"
-					}
-				},
-				"regex-not": {
-					"version": "1.0.2",
-					"resolved": "http://localhost:4873/regex-not/-/regex-not-1.0.2.tgz",
-					"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
-					"dev": true,
-					"requires": {
-						"extend-shallow": "^3.0.2",
-						"safe-regex": "^1.1.0"
-					}
-				},
-				"remove-bom-buffer": {
-					"version": "3.0.0",
-					"resolved": "http://localhost:4873/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz",
-					"integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
-					"dev": true,
-					"requires": {
-						"is-buffer": "^1.1.5",
-						"is-utf8": "^0.2.1"
-					}
-				},
-				"remove-bom-stream": {
-					"version": "1.2.0",
-					"resolved": "http://localhost:4873/remove-bom-stream/-/remove-bom-stream-1.2.0.tgz",
-					"integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
-					"dev": true,
-					"requires": {
-						"remove-bom-buffer": "^3.0.0",
-						"safe-buffer": "^5.1.0",
-						"through2": "^2.0.3"
-					}
-				},
-				"remove-trailing-separator": {
-					"version": "1.1.0",
-					"resolved": "http://localhost:4873/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-					"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-					"dev": true
-				},
-				"repeat-element": {
-					"version": "1.1.3",
-					"resolved": "http://localhost:4873/repeat-element/-/repeat-element-1.1.3.tgz",
-					"integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
-					"dev": true
-				},
-				"repeat-string": {
-					"version": "1.6.1",
-					"resolved": "http://localhost:4873/repeat-string/-/repeat-string-1.6.1.tgz",
-					"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-					"dev": true
-				},
-				"replace-ext": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/replace-ext/-/replace-ext-1.0.0.tgz",
-					"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
-					"dev": true
-				},
-				"replace-homedir": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/replace-homedir/-/replace-homedir-1.0.0.tgz",
-					"integrity": "sha1-6H9tUTuSjd6AgmDBK+f+xv9ueYw=",
-					"dev": true,
-					"requires": {
-						"homedir-polyfill": "^1.0.1",
-						"is-absolute": "^1.0.0",
-						"remove-trailing-separator": "^1.1.0"
-					}
-				},
-				"require-directory": {
-					"version": "2.1.1",
-					"resolved": "http://localhost:4873/require-directory/-/require-directory-2.1.1.tgz",
-					"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-					"dev": true
-				},
-				"require-main-filename": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/require-main-filename/-/require-main-filename-1.0.1.tgz",
-					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-					"dev": true
-				},
-				"resolve": {
-					"version": "1.12.0",
-					"resolved": "http://localhost:4873/resolve/-/resolve-1.12.0.tgz",
-					"integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
-					"dev": true,
-					"requires": {
-						"path-parse": "^1.0.6"
-					}
-				},
-				"resolve-dir": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/resolve-dir/-/resolve-dir-1.0.1.tgz",
-					"integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
-					"dev": true,
-					"requires": {
-						"expand-tilde": "^2.0.0",
-						"global-modules": "^1.0.0"
-					}
-				},
-				"resolve-options": {
-					"version": "1.1.0",
-					"resolved": "http://localhost:4873/resolve-options/-/resolve-options-1.1.0.tgz",
-					"integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
-					"dev": true,
-					"requires": {
-						"value-or-function": "^3.0.0"
-					}
-				},
-				"resolve-url": {
-					"version": "0.2.1",
-					"resolved": "http://localhost:4873/resolve-url/-/resolve-url-0.2.1.tgz",
-					"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
-					"dev": true
-				},
-				"ret": {
-					"version": "0.1.15",
-					"resolved": "http://localhost:4873/ret/-/ret-0.1.15.tgz",
-					"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
-					"dev": true
-				},
-				"safe-buffer": {
-					"version": "5.1.2",
-					"resolved": "http://localhost:4873/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-					"dev": true
-				},
-				"safe-regex": {
-					"version": "1.1.0",
-					"resolved": "http://localhost:4873/safe-regex/-/safe-regex-1.1.0.tgz",
-					"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
-					"dev": true,
-					"requires": {
-						"ret": "~0.1.10"
-					}
-				},
-				"semver": {
-					"version": "5.7.0",
-					"resolved": "http://localhost:4873/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-					"dev": true
-				},
-				"semver-greatest-satisfied-range": {
-					"version": "1.1.0",
-					"resolved": "http://localhost:4873/semver-greatest-satisfied-range/-/semver-greatest-satisfied-range-1.1.0.tgz",
-					"integrity": "sha1-E+jCZYq5aRywzXEJMkAoDTb3els=",
-					"dev": true,
-					"requires": {
-						"sver-compat": "^1.5.0"
-					}
-				},
-				"set-blocking": {
-					"version": "2.0.0",
-					"resolved": "http://localhost:4873/set-blocking/-/set-blocking-2.0.0.tgz",
-					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-					"dev": true
-				},
-				"set-value": {
-					"version": "2.0.1",
-					"resolved": "http://localhost:4873/set-value/-/set-value-2.0.1.tgz",
-					"integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
-					"dev": true,
-					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-extendable": "^0.1.1",
-						"is-plain-object": "^2.0.3",
-						"split-string": "^3.0.1"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "http://localhost:4873/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"snapdragon": {
-					"version": "0.8.2",
-					"resolved": "http://localhost:4873/snapdragon/-/snapdragon-0.8.2.tgz",
-					"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
-					"dev": true,
-					"requires": {
-						"base": "^0.11.1",
-						"debug": "^2.2.0",
-						"define-property": "^0.2.5",
-						"extend-shallow": "^2.0.1",
-						"map-cache": "^0.2.2",
-						"source-map": "^0.5.6",
-						"source-map-resolve": "^0.5.0",
-						"use": "^3.1.0"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "0.2.5",
-							"resolved": "http://localhost:4873/define-property/-/define-property-0.2.5.tgz",
-							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-							"dev": true,
-							"requires": {
-								"is-descriptor": "^0.1.0"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "http://localhost:4873/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"snapdragon-node": {
-					"version": "2.1.1",
-					"resolved": "http://localhost:4873/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
-					"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
-					"dev": true,
-					"requires": {
-						"define-property": "^1.0.0",
-						"isobject": "^3.0.0",
-						"snapdragon-util": "^3.0.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "1.0.0",
-							"resolved": "http://localhost:4873/define-property/-/define-property-1.0.0.tgz",
-							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-							"dev": true,
-							"requires": {
-								"is-descriptor": "^1.0.0"
-							}
-						},
-						"is-accessor-descriptor": {
-							"version": "1.0.0",
-							"resolved": "http://localhost:4873/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-							"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-							"dev": true,
-							"requires": {
-								"kind-of": "^6.0.0"
-							}
-						},
-						"is-data-descriptor": {
-							"version": "1.0.0",
-							"resolved": "http://localhost:4873/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-							"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-							"dev": true,
-							"requires": {
-								"kind-of": "^6.0.0"
-							}
-						},
-						"is-descriptor": {
-							"version": "1.0.2",
-							"resolved": "http://localhost:4873/is-descriptor/-/is-descriptor-1.0.2.tgz",
-							"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-							"dev": true,
-							"requires": {
-								"is-accessor-descriptor": "^1.0.0",
-								"is-data-descriptor": "^1.0.0",
-								"kind-of": "^6.0.2"
-							}
-						}
-					}
-				},
-				"snapdragon-util": {
-					"version": "3.0.1",
-					"resolved": "http://localhost:4873/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
-					"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
-					"dev": true,
-					"requires": {
-						"kind-of": "^3.2.0"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "http://localhost:4873/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "http://localhost:4873/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-					"dev": true
-				},
-				"source-map-resolve": {
-					"version": "0.5.2",
-					"resolved": "http://localhost:4873/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
-					"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
-					"dev": true,
-					"requires": {
-						"atob": "^2.1.1",
-						"decode-uri-component": "^0.2.0",
-						"resolve-url": "^0.2.1",
-						"source-map-url": "^0.4.0",
-						"urix": "^0.1.0"
-					}
-				},
-				"source-map-url": {
-					"version": "0.4.0",
-					"resolved": "http://localhost:4873/source-map-url/-/source-map-url-0.4.0.tgz",
-					"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
-					"dev": true
-				},
-				"sparkles": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/sparkles/-/sparkles-1.0.1.tgz",
-					"integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw==",
-					"dev": true
-				},
-				"spdx-correct": {
-					"version": "3.1.0",
-					"resolved": "http://localhost:4873/spdx-correct/-/spdx-correct-3.1.0.tgz",
-					"integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
-					"dev": true,
-					"requires": {
-						"spdx-expression-parse": "^3.0.0",
-						"spdx-license-ids": "^3.0.0"
-					}
-				},
-				"spdx-exceptions": {
-					"version": "2.2.0",
-					"resolved": "http://localhost:4873/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-					"integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
-					"dev": true
-				},
-				"spdx-expression-parse": {
-					"version": "3.0.0",
-					"resolved": "http://localhost:4873/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-					"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
-					"dev": true,
-					"requires": {
-						"spdx-exceptions": "^2.1.0",
-						"spdx-license-ids": "^3.0.0"
-					}
-				},
-				"spdx-license-ids": {
-					"version": "3.0.5",
-					"resolved": "http://localhost:4873/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-					"integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
-					"dev": true
-				},
-				"split-string": {
-					"version": "3.1.0",
-					"resolved": "http://localhost:4873/split-string/-/split-string-3.1.0.tgz",
-					"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
-					"dev": true,
-					"requires": {
-						"extend-shallow": "^3.0.0"
-					}
-				},
-				"stack-trace": {
-					"version": "0.0.10",
-					"resolved": "http://localhost:4873/stack-trace/-/stack-trace-0.0.10.tgz",
-					"integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
-					"dev": true
-				},
-				"static-extend": {
-					"version": "0.1.2",
-					"resolved": "http://localhost:4873/static-extend/-/static-extend-0.1.2.tgz",
-					"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
-					"dev": true,
-					"requires": {
-						"define-property": "^0.2.5",
-						"object-copy": "^0.1.0"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "0.2.5",
-							"resolved": "http://localhost:4873/define-property/-/define-property-0.2.5.tgz",
-							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-							"dev": true,
-							"requires": {
-								"is-descriptor": "^0.1.0"
-							}
-						}
-					}
-				},
-				"stream-exhaust": {
-					"version": "1.0.2",
-					"resolved": "http://localhost:4873/stream-exhaust/-/stream-exhaust-1.0.2.tgz",
-					"integrity": "sha512-b/qaq/GlBK5xaq1yrK9/zFcyRSTNxmcZwFLGSTG0mXgZl/4Z6GgiyYOXOvY7N3eEvFRAG1bkDRz5EPGSvPYQlw==",
-					"dev": true
-				},
-				"stream-shift": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/stream-shift/-/stream-shift-1.0.0.tgz",
-					"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
-					"dev": true
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "http://localhost:4873/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true,
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "http://localhost:4873/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "http://localhost:4873/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"strip-bom": {
-					"version": "2.0.0",
-					"resolved": "http://localhost:4873/strip-bom/-/strip-bom-2.0.0.tgz",
-					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"dev": true,
-					"requires": {
-						"is-utf8": "^0.2.0"
-					}
-				},
-				"sver-compat": {
-					"version": "1.5.0",
-					"resolved": "http://localhost:4873/sver-compat/-/sver-compat-1.5.0.tgz",
-					"integrity": "sha1-PPh9/rTQe0o/FIJ7wYaz/QxkXNg=",
-					"dev": true,
-					"requires": {
-						"es6-iterator": "^2.0.1",
-						"es6-symbol": "^3.1.1"
-					}
-				},
-				"through2": {
-					"version": "2.0.5",
-					"resolved": "http://localhost:4873/through2/-/through2-2.0.5.tgz",
-					"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-					"dev": true,
-					"requires": {
-						"readable-stream": "~2.3.6",
-						"xtend": "~4.0.1"
-					}
-				},
-				"through2-filter": {
-					"version": "3.0.0",
-					"resolved": "http://localhost:4873/through2-filter/-/through2-filter-3.0.0.tgz",
-					"integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
-					"dev": true,
-					"requires": {
-						"through2": "~2.0.0",
-						"xtend": "~4.0.0"
-					}
-				},
-				"time-stamp": {
-					"version": "1.1.0",
-					"resolved": "http://localhost:4873/time-stamp/-/time-stamp-1.1.0.tgz",
-					"integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
-					"dev": true
-				},
-				"to-absolute-glob": {
-					"version": "2.0.2",
-					"resolved": "http://localhost:4873/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
-					"integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
-					"dev": true,
-					"requires": {
-						"is-absolute": "^1.0.0",
-						"is-negated-glob": "^1.0.0"
-					}
-				},
-				"to-object-path": {
-					"version": "0.3.0",
-					"resolved": "http://localhost:4873/to-object-path/-/to-object-path-0.3.0.tgz",
-					"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
-					"dev": true,
-					"requires": {
-						"kind-of": "^3.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "http://localhost:4873/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
-				},
-				"to-regex": {
-					"version": "3.0.2",
-					"resolved": "http://localhost:4873/to-regex/-/to-regex-3.0.2.tgz",
-					"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
-					"dev": true,
-					"requires": {
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"regex-not": "^1.0.2",
-						"safe-regex": "^1.1.0"
-					}
-				},
-				"to-regex-range": {
-					"version": "2.1.1",
-					"resolved": "http://localhost:4873/to-regex-range/-/to-regex-range-2.1.1.tgz",
-					"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-					"dev": true,
-					"requires": {
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1"
-					}
-				},
-				"to-through": {
-					"version": "2.0.0",
-					"resolved": "http://localhost:4873/to-through/-/to-through-2.0.0.tgz",
-					"integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
-					"dev": true,
-					"requires": {
-						"through2": "^2.0.3"
-					}
-				},
-				"type": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/type/-/type-1.0.1.tgz",
-					"integrity": "sha512-MAM5dBMJCJNKs9E7JXo4CXRAansRfG0nlJxW7Wf6GZzSOvH31zClSaHdIMWLehe/EGMBkqeC55rrkaOr5Oo7Nw==",
-					"dev": true
-				},
-				"typedarray": {
-					"version": "0.0.6",
-					"resolved": "http://localhost:4873/typedarray/-/typedarray-0.0.6.tgz",
-					"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-					"dev": true
-				},
-				"unc-path-regex": {
-					"version": "0.1.2",
-					"resolved": "http://localhost:4873/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
-					"integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
-					"dev": true
-				},
-				"undertaker": {
-					"version": "1.2.1",
-					"resolved": "http://localhost:4873/undertaker/-/undertaker-1.2.1.tgz",
-					"integrity": "sha512-71WxIzDkgYk9ZS+spIB8iZXchFhAdEo2YU8xYqBYJ39DIUIqziK78ftm26eecoIY49X0J2MLhG4hr18Yp6/CMA==",
-					"dev": true,
-					"requires": {
-						"arr-flatten": "^1.0.1",
-						"arr-map": "^2.0.0",
-						"bach": "^1.0.0",
-						"collection-map": "^1.0.0",
-						"es6-weak-map": "^2.0.1",
-						"last-run": "^1.1.0",
-						"object.defaults": "^1.0.0",
-						"object.reduce": "^1.0.0",
-						"undertaker-registry": "^1.0.0"
-					}
-				},
-				"undertaker-registry": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/undertaker-registry/-/undertaker-registry-1.0.1.tgz",
-					"integrity": "sha1-XkvaMI5KiirlhPm5pDWaSZglzFA=",
-					"dev": true
-				},
-				"union-value": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/union-value/-/union-value-1.0.1.tgz",
-					"integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
-					"dev": true,
-					"requires": {
-						"arr-union": "^3.1.0",
-						"get-value": "^2.0.6",
-						"is-extendable": "^0.1.1",
-						"set-value": "^2.0.1"
-					}
-				},
-				"unique-stream": {
-					"version": "2.3.1",
-					"resolved": "http://localhost:4873/unique-stream/-/unique-stream-2.3.1.tgz",
-					"integrity": "sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==",
-					"dev": true,
-					"requires": {
-						"json-stable-stringify-without-jsonify": "^1.0.1",
-						"through2-filter": "^3.0.0"
-					}
-				},
-				"unset-value": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/unset-value/-/unset-value-1.0.0.tgz",
-					"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
-					"dev": true,
-					"requires": {
-						"has-value": "^0.3.1",
-						"isobject": "^3.0.0"
-					},
-					"dependencies": {
-						"has-value": {
-							"version": "0.3.1",
-							"resolved": "http://localhost:4873/has-value/-/has-value-0.3.1.tgz",
-							"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
-							"dev": true,
-							"requires": {
-								"get-value": "^2.0.3",
-								"has-values": "^0.1.4",
-								"isobject": "^2.0.0"
-							},
-							"dependencies": {
-								"isobject": {
-									"version": "2.1.0",
-									"resolved": "http://localhost:4873/isobject/-/isobject-2.1.0.tgz",
-									"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-									"dev": true,
-									"requires": {
-										"isarray": "1.0.0"
-									}
-								}
-							}
-						},
-						"has-values": {
-							"version": "0.1.4",
-							"resolved": "http://localhost:4873/has-values/-/has-values-0.1.4.tgz",
-							"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
-							"dev": true
-						}
-					}
-				},
-				"upath": {
-					"version": "1.1.2",
-					"resolved": "http://localhost:4873/upath/-/upath-1.1.2.tgz",
-					"integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==",
-					"dev": true
-				},
-				"urix": {
-					"version": "0.1.0",
-					"resolved": "http://localhost:4873/urix/-/urix-0.1.0.tgz",
-					"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
-					"dev": true
-				},
-				"use": {
-					"version": "3.1.1",
-					"resolved": "http://localhost:4873/use/-/use-3.1.1.tgz",
-					"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
-					"dev": true
-				},
-				"util-deprecate": {
-					"version": "1.0.2",
-					"resolved": "http://localhost:4873/util-deprecate/-/util-deprecate-1.0.2.tgz",
-					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-					"dev": true
-				},
-				"v8flags": {
-					"version": "3.1.3",
-					"resolved": "http://localhost:4873/v8flags/-/v8flags-3.1.3.tgz",
-					"integrity": "sha512-amh9CCg3ZxkzQ48Mhcb8iX7xpAfYJgePHxWMQCBWECpOSqJUXgY26ncA61UTV0BkPqfhcy6mzwCIoP4ygxpW8w==",
-					"dev": true,
-					"requires": {
-						"homedir-polyfill": "^1.0.1"
-					}
-				},
-				"validate-npm-package-license": {
-					"version": "3.0.4",
-					"resolved": "http://localhost:4873/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-					"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-					"dev": true,
-					"requires": {
-						"spdx-correct": "^3.0.0",
-						"spdx-expression-parse": "^3.0.0"
-					}
-				},
-				"value-or-function": {
-					"version": "3.0.0",
-					"resolved": "http://localhost:4873/value-or-function/-/value-or-function-3.0.0.tgz",
-					"integrity": "sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM=",
-					"dev": true
-				},
-				"vinyl": {
-					"version": "2.2.0",
-					"resolved": "http://localhost:4873/vinyl/-/vinyl-2.2.0.tgz",
-					"integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
-					"dev": true,
-					"requires": {
-						"clone": "^2.1.1",
-						"clone-buffer": "^1.0.0",
-						"clone-stats": "^1.0.0",
-						"cloneable-readable": "^1.0.0",
-						"remove-trailing-separator": "^1.0.1",
-						"replace-ext": "^1.0.0"
-					}
-				},
-				"vinyl-fs": {
-					"version": "3.0.3",
-					"resolved": "http://localhost:4873/vinyl-fs/-/vinyl-fs-3.0.3.tgz",
-					"integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
-					"dev": true,
-					"requires": {
-						"fs-mkdirp-stream": "^1.0.0",
-						"glob-stream": "^6.1.0",
-						"graceful-fs": "^4.0.0",
-						"is-valid-glob": "^1.0.0",
-						"lazystream": "^1.0.0",
-						"lead": "^1.0.0",
-						"object.assign": "^4.0.4",
-						"pumpify": "^1.3.5",
-						"readable-stream": "^2.3.3",
-						"remove-bom-buffer": "^3.0.0",
-						"remove-bom-stream": "^1.2.0",
-						"resolve-options": "^1.1.0",
-						"through2": "^2.0.0",
-						"to-through": "^2.0.0",
-						"value-or-function": "^3.0.0",
-						"vinyl": "^2.0.0",
-						"vinyl-sourcemap": "^1.1.0"
-					}
-				},
-				"vinyl-sourcemap": {
-					"version": "1.1.0",
-					"resolved": "http://localhost:4873/vinyl-sourcemap/-/vinyl-sourcemap-1.1.0.tgz",
-					"integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
-					"dev": true,
-					"requires": {
-						"append-buffer": "^1.0.2",
-						"convert-source-map": "^1.5.0",
-						"graceful-fs": "^4.1.6",
-						"normalize-path": "^2.1.1",
-						"now-and-later": "^2.0.0",
-						"remove-bom-buffer": "^3.0.0",
-						"vinyl": "^2.0.0"
-					}
-				},
-				"which": {
-					"version": "1.3.1",
-					"resolved": "http://localhost:4873/which/-/which-1.3.1.tgz",
-					"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-					"dev": true,
-					"requires": {
-						"isexe": "^2.0.0"
-					}
-				},
-				"which-module": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/which-module/-/which-module-1.0.0.tgz",
-					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
-					"dev": true
-				},
-				"wrap-ansi": {
-					"version": "2.1.0",
-					"resolved": "http://localhost:4873/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-					"dev": true,
-					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1"
-					}
-				},
-				"wrappy": {
-					"version": "1.0.2",
-					"resolved": "http://localhost:4873/wrappy/-/wrappy-1.0.2.tgz",
-					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-					"dev": true
-				},
-				"xtend": {
-					"version": "4.0.2",
-					"resolved": "http://localhost:4873/xtend/-/xtend-4.0.2.tgz",
-					"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-					"dev": true
-				},
-				"y18n": {
-					"version": "3.2.1",
-					"resolved": "http://localhost:4873/y18n/-/y18n-3.2.1.tgz",
-					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-					"dev": true
-				},
-				"yargs": {
-					"version": "7.1.0",
-					"resolved": "http://localhost:4873/yargs/-/yargs-7.1.0.tgz",
-					"integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
-					"dev": true,
-					"requires": {
-						"camelcase": "^3.0.0",
-						"cliui": "^3.2.0",
-						"decamelize": "^1.1.1",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^1.4.0",
-						"read-pkg-up": "^1.0.1",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^1.0.2",
-						"which-module": "^1.0.0",
-						"y18n": "^3.2.1",
-						"yargs-parser": "^5.0.0"
-					}
-				},
-				"yargs-parser": {
-					"version": "5.0.0",
-					"resolved": "http://localhost:4873/yargs-parser/-/yargs-parser-5.0.0.tgz",
-					"integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
-					"dev": true,
-					"requires": {
-						"camelcase": "^3.0.0"
-					}
-				}
-			}
-		}
-	}
+  "name": "@adobe/spectrum-css",
+  "version": "2.14.0-alpha.14",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@a4u/a4u-collection-react-spectrum-open-source-color-icons-release": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-a4u-release/@a4u/a4u-collection-react-spectrum-open-source-color-icons-release/-/@a4u/a4u-collection-react-spectrum-open-source-color-icons-release-2.0.0.tgz",
+      "integrity": "sha1-kv4I7ZfYfM7FqxXKIdqOjqqlifo=",
+      "dev": true,
+      "optional": true
+    },
+    "@a4u/a4u-collection-react-spectrum-open-source-release": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-a4u-release/@a4u/a4u-collection-react-spectrum-open-source-release/-/@a4u/a4u-collection-react-spectrum-open-source-release-2.1.0.tgz",
+      "integrity": "sha1-M3k3IC237cLOc6YW+x4sbTXMK8I=",
+      "dev": true,
+      "optional": true
+    },
+    "@a4u/a4u-collection-spectrum-css-release": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-a4u-release/@a4u/a4u-collection-spectrum-css-release/-/@a4u/a4u-collection-spectrum-css-release-2.1.0.tgz",
+      "integrity": "sha1-v1pzFqmZ1ndiBecyF3WIKH8nr+E=",
+      "dev": true,
+      "optional": true
+    },
+    "@adobe/spectrum-css-workflow-icons": {
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@adobe/spectrum-css-workflow-icons/-/spectrum-css-workflow-icons-1.0.0-beta.3.tgz",
+      "integrity": "sha512-ZyYV6meUzdZ5vJFt4YBXCg3o5s65MTKZmKGXHjUMYLUNVxecwYeZSjWP3DPW1bW/NjzIjRz1GoTgjMoIelQFRQ==",
+      "dev": true,
+      "requires": {
+        "@a4u/a4u-collection-react-spectrum-open-source-color-icons-release": "^2.0.0",
+        "@a4u/a4u-collection-react-spectrum-open-source-release": "^2.1.0",
+        "@a4u/a4u-collection-spectrum-css-release": "^2.1.0"
+      }
+    },
+    "@spectrum-css/accordion": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {
+                "@spectrum-css/bundle-builder": {}
+              }
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/actionbar": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/button": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {
+                "@spectrum-css/bundle-builder": {}
+              }
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {
+                "@spectrum-css/component-builder": {
+                  "dependencies": {}
+                },
+                "@spectrum-css/vars": {}
+              }
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/checkbox": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {
+                "@spectrum-css/bundle-builder": {}
+              }
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {
+                "@spectrum-css/component-builder": {
+                  "dependencies": {}
+                },
+                "@spectrum-css/vars": {}
+              }
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/popover": {
+          "dependencies": {
+            "@spectrum-css/button": {
+              "dependencies": {
+                "@spectrum-css/component-builder": {
+                  "dependencies": {}
+                },
+                "@spectrum-css/icons": {
+                  "dependencies": {}
+                },
+                "@spectrum-css/vars": {}
+              }
+            },
+            "@spectrum-css/component-builder": {
+              "dependencies": {
+                "@spectrum-css/bundle-builder": {}
+              }
+            },
+            "@spectrum-css/dialog": {
+              "dependencies": {
+                "@spectrum-css/button": {
+                  "dependencies": {
+                    "@spectrum-css/component-builder": {
+                      "dependencies": {}
+                    },
+                    "@spectrum-css/icons": {
+                      "dependencies": {}
+                    },
+                    "@spectrum-css/vars": {}
+                  }
+                },
+                "@spectrum-css/component-builder": {
+                  "dependencies": {
+                    "@spectrum-css/bundle-builder": {}
+                  }
+                },
+                "@spectrum-css/icons": {
+                  "dependencies": {
+                    "@spectrum-css/component-builder": {
+                      "dependencies": {}
+                    },
+                    "@spectrum-css/vars": {}
+                  }
+                },
+                "@spectrum-css/underlay": {
+                  "dependencies": {
+                    "@spectrum-css/component-builder": {
+                      "dependencies": {
+                        "@spectrum-css/bundle-builder": {}
+                      }
+                    },
+                    "@spectrum-css/vars": {}
+                  }
+                },
+                "@spectrum-css/vars": {}
+              }
+            },
+            "@spectrum-css/menu": {
+              "dependencies": {
+                "@spectrum-css/component-builder": {
+                  "dependencies": {
+                    "@spectrum-css/bundle-builder": {}
+                  }
+                },
+                "@spectrum-css/icons": {
+                  "dependencies": {
+                    "@spectrum-css/component-builder": {
+                      "dependencies": {}
+                    },
+                    "@spectrum-css/vars": {}
+                  }
+                },
+                "@spectrum-css/vars": {}
+              }
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/table": {
+          "dependencies": {
+            "@spectrum-css/checkbox": {
+              "dependencies": {
+                "@spectrum-css/component-builder": {
+                  "dependencies": {}
+                },
+                "@spectrum-css/icons": {
+                  "dependencies": {}
+                },
+                "@spectrum-css/vars": {}
+              }
+            },
+            "@spectrum-css/component-builder": {
+              "dependencies": {
+                "@spectrum-css/bundle-builder": {}
+              }
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {
+                "@spectrum-css/component-builder": {
+                  "dependencies": {}
+                },
+                "@spectrum-css/vars": {}
+              }
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/actionmenu": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/button": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/menu": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/popover": {
+          "dependencies": {
+            "@spectrum-css/button": {
+              "dependencies": {}
+            },
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/dialog": {
+              "dependencies": {}
+            },
+            "@spectrum-css/menu": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/alert": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/button": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/asset": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/assetlist": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/checkbox": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/avatar": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/banner": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/barloader": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/breadcrumb": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/button": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/bundle-builder": {
+      "version": "1.0.0-alpha.2",
+      "dev": true
+    },
+    "@spectrum-css/button": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {}
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {}
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/buttongroup": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/button": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/calendar": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/button": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/card": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/asset": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/button": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/checkbox": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/quickaction": {
+          "dependencies": {
+            "@spectrum-css/button": {
+              "dependencies": {
+                "@spectrum-css/component-builder": {
+                  "dependencies": {}
+                },
+                "@spectrum-css/icons": {
+                  "dependencies": {}
+                },
+                "@spectrum-css/vars": {}
+              }
+            },
+            "@spectrum-css/checkbox": {
+              "dependencies": {
+                "@spectrum-css/component-builder": {
+                  "dependencies": {}
+                },
+                "@spectrum-css/icons": {
+                  "dependencies": {}
+                },
+                "@spectrum-css/vars": {}
+              }
+            },
+            "@spectrum-css/component-builder": {
+              "dependencies": {
+                "@spectrum-css/bundle-builder": {}
+              }
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/checkbox": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {}
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {}
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/circleloader": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/coachmark": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/button": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/cyclebutton": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/button": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/decoratedtextfield": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/fieldlabel": {
+          "dependencies": {
+            "@spectrum-css/checkbox": {
+              "dependencies": {
+                "@spectrum-css/component-builder": {
+                  "dependencies": {}
+                },
+                "@spectrum-css/icons": {
+                  "dependencies": {}
+                },
+                "@spectrum-css/vars": {}
+              }
+            },
+            "@spectrum-css/component-builder": {
+              "dependencies": {
+                "@spectrum-css/bundle-builder": {}
+              }
+            },
+            "@spectrum-css/dropdown": {
+              "dependencies": {
+                "@spectrum-css/button": {
+                  "dependencies": {
+                    "@spectrum-css/component-builder": {
+                      "dependencies": {}
+                    },
+                    "@spectrum-css/icons": {
+                      "dependencies": {}
+                    },
+                    "@spectrum-css/vars": {}
+                  }
+                },
+                "@spectrum-css/component-builder": {
+                  "dependencies": {
+                    "@spectrum-css/bundle-builder": {}
+                  }
+                },
+                "@spectrum-css/icons": {
+                  "dependencies": {
+                    "@spectrum-css/component-builder": {
+                      "dependencies": {}
+                    },
+                    "@spectrum-css/vars": {}
+                  }
+                },
+                "@spectrum-css/menu": {
+                  "dependencies": {
+                    "@spectrum-css/component-builder": {
+                      "dependencies": {}
+                    },
+                    "@spectrum-css/icons": {
+                      "dependencies": {}
+                    },
+                    "@spectrum-css/vars": {}
+                  }
+                },
+                "@spectrum-css/popover": {
+                  "dependencies": {
+                    "@spectrum-css/button": {
+                      "dependencies": {}
+                    },
+                    "@spectrum-css/component-builder": {
+                      "dependencies": {}
+                    },
+                    "@spectrum-css/dialog": {
+                      "dependencies": {}
+                    },
+                    "@spectrum-css/menu": {
+                      "dependencies": {}
+                    },
+                    "@spectrum-css/vars": {}
+                  }
+                },
+                "@spectrum-css/vars": {}
+              }
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {
+                "@spectrum-css/component-builder": {
+                  "dependencies": {}
+                },
+                "@spectrum-css/vars": {}
+              }
+            },
+            "@spectrum-css/radio": {
+              "dependencies": {
+                "@spectrum-css/component-builder": {
+                  "dependencies": {
+                    "@spectrum-css/bundle-builder": {}
+                  }
+                },
+                "@spectrum-css/icons": {
+                  "dependencies": {
+                    "@spectrum-css/component-builder": {
+                      "dependencies": {}
+                    },
+                    "@spectrum-css/vars": {}
+                  }
+                },
+                "@spectrum-css/vars": {}
+              }
+            },
+            "@spectrum-css/stepper": {
+              "dependencies": {
+                "@spectrum-css/button": {
+                  "dependencies": {
+                    "@spectrum-css/component-builder": {
+                      "dependencies": {}
+                    },
+                    "@spectrum-css/icons": {
+                      "dependencies": {}
+                    },
+                    "@spectrum-css/vars": {}
+                  }
+                },
+                "@spectrum-css/component-builder": {
+                  "dependencies": {
+                    "@spectrum-css/bundle-builder": {}
+                  }
+                },
+                "@spectrum-css/icons": {
+                  "dependencies": {
+                    "@spectrum-css/component-builder": {
+                      "dependencies": {}
+                    },
+                    "@spectrum-css/vars": {}
+                  }
+                },
+                "@spectrum-css/textfield": {
+                  "dependencies": {
+                    "@spectrum-css/component-builder": {
+                      "dependencies": {
+                        "@spectrum-css/bundle-builder": {}
+                      }
+                    },
+                    "@spectrum-css/vars": {}
+                  }
+                },
+                "@spectrum-css/vars": {}
+              }
+            },
+            "@spectrum-css/textfield": {
+              "dependencies": {
+                "@spectrum-css/component-builder": {
+                  "dependencies": {}
+                },
+                "@spectrum-css/vars": {}
+              }
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/textfield": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/dialog": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/button": {
+          "dependencies": {}
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {}
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {}
+        },
+        "@spectrum-css/underlay": {
+          "dependencies": {}
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/dropdown": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/button": {
+          "dependencies": {}
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {}
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {}
+        },
+        "@spectrum-css/menu": {
+          "dependencies": {}
+        },
+        "@spectrum-css/popover": {
+          "dependencies": {}
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/dropindicator": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/dropzone": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/illustratedmessage": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {
+                "@spectrum-css/bundle-builder": {}
+              }
+            },
+            "@spectrum-css/typography": {
+              "dependencies": {
+                "@spectrum-css/component-builder": {
+                  "dependencies": {
+                    "@spectrum-css/bundle-builder": {}
+                  }
+                },
+                "@spectrum-css/vars": {}
+              }
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/link": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {
+                "@spectrum-css/bundle-builder": {}
+              }
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/fieldgroup": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/checkbox": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/radio": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/fieldlabel": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/checkbox": {
+          "dependencies": {}
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {}
+        },
+        "@spectrum-css/dropdown": {
+          "dependencies": {}
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {}
+        },
+        "@spectrum-css/radio": {
+          "dependencies": {}
+        },
+        "@spectrum-css/stepper": {
+          "dependencies": {}
+        },
+        "@spectrum-css/textfield": {
+          "dependencies": {}
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/icons": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {}
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/illustratedmessage": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {}
+        },
+        "@spectrum-css/typography": {
+          "dependencies": {}
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/inputgroup": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/button": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/menu": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/popover": {
+          "dependencies": {
+            "@spectrum-css/button": {
+              "dependencies": {}
+            },
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/dialog": {
+              "dependencies": {}
+            },
+            "@spectrum-css/menu": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/textfield": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/label": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/link": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {}
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/menu": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {}
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {}
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/miller": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/assetlist": {
+          "dependencies": {
+            "@spectrum-css/checkbox": {
+              "dependencies": {}
+            },
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/checkbox": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/page": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "requires": {
+        "@spectrum-css/vars": "^2.0.0-alpha.2"
+      },
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/vars": {
+          "version": "2.0.0-alpha.2",
+          "dev": true
+        }
+      }
+    },
+    "@spectrum-css/pagination": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/button": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/splitbutton": {
+          "dependencies": {
+            "@spectrum-css/button": {
+              "dependencies": {
+                "@spectrum-css/component-builder": {
+                  "dependencies": {}
+                },
+                "@spectrum-css/icons": {
+                  "dependencies": {}
+                },
+                "@spectrum-css/vars": {}
+              }
+            },
+            "@spectrum-css/component-builder": {
+              "dependencies": {
+                "@spectrum-css/bundle-builder": {}
+              }
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {
+                "@spectrum-css/component-builder": {
+                  "dependencies": {}
+                },
+                "@spectrum-css/vars": {}
+              }
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/textfield": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/popover": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/button": {
+          "dependencies": {}
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {}
+        },
+        "@spectrum-css/dialog": {
+          "dependencies": {}
+        },
+        "@spectrum-css/menu": {
+          "dependencies": {}
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/quickaction": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/button": {
+          "dependencies": {}
+        },
+        "@spectrum-css/checkbox": {
+          "dependencies": {}
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {}
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/radio": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {}
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {}
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/rating": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/rule": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "requires": {
+        "@spectrum-css/vars": "^2.0.0-alpha.2"
+      },
+      "dependencies": {
+        "@spectrum-css/button": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/vars": {
+          "version": "2.0.0-alpha.2",
+          "dev": true
+        }
+      }
+    },
+    "@spectrum-css/search": {
+      "version": "2.0.0-alpha.5",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/button": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/textfield": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/searchwithin": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "requires": {
+        "@spectrum-css/button": "^2.0.0-alpha.4",
+        "@spectrum-css/dropdown": "^2.0.0-alpha.4",
+        "@spectrum-css/icons": "^2.0.0-alpha.4",
+        "@spectrum-css/textfield": "^2.0.0-alpha.4",
+        "@spectrum-css/vars": "^2.0.0-alpha.2"
+      },
+      "dependencies": {
+        "@spectrum-css/button": {
+          "version": "2.0.0-alpha.4",
+          "dev": true,
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/dropdown": {
+          "version": "2.0.0-alpha.4",
+          "dev": true,
+          "dependencies": {
+            "@spectrum-css/button": {
+              "dependencies": {}
+            },
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/menu": {
+              "dependencies": {}
+            },
+            "@spectrum-css/popover": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "version": "2.0.0-alpha.4",
+          "dev": true,
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/textfield": {
+          "version": "2.0.0-alpha.4",
+          "dev": true,
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {
+          "version": "2.0.0-alpha.2",
+          "dev": true
+        }
+      }
+    },
+    "@spectrum-css/sidenav": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/slider": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/splitbutton": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/button": {
+          "dependencies": {}
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {}
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {}
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/splitview": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/statuslight": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/steplist": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/tooltip": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {
+                "@spectrum-css/bundle-builder": {}
+              }
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {
+                "@spectrum-css/component-builder": {
+                  "dependencies": {}
+                },
+                "@spectrum-css/vars": {}
+              }
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/stepper": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/button": {
+          "dependencies": {}
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {}
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {}
+        },
+        "@spectrum-css/textfield": {
+          "dependencies": {}
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/table": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/checkbox": {
+          "dependencies": {}
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {}
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {}
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/tabs": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/dropdown": {
+          "dependencies": {
+            "@spectrum-css/button": {
+              "dependencies": {}
+            },
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/menu": {
+              "dependencies": {}
+            },
+            "@spectrum-css/popover": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/menu": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/tags": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/avatar": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/button": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/textfield": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {}
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/toast": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/button": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/toggle": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/tooltip": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {}
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {}
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/treeview": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/typography": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {}
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/underlay": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {}
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/vars": {
+      "version": "2.0.0-alpha.2",
+      "dev": true
+    },
+    "@spectrum-css/well": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "ansi-colors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+      "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
+      "dev": true,
+      "requires": {
+        "ansi-wrap": "^0.1.0"
+      }
+    },
+    "ansi-gray": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+      "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+      "dev": true,
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
+    },
+    "ansi-wrap": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+      "dev": true
+    },
+    "anymatch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+      "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+      "dev": true,
+      "requires": {
+        "micromatch": "^3.1.4",
+        "normalize-path": "^2.1.1"
+      }
+    },
+    "append-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/append-buffer/-/append-buffer-1.0.2.tgz",
+      "integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
+      "dev": true,
+      "requires": {
+        "buffer-equal": "^1.0.0"
+      }
+    },
+    "archy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+      "dev": true
+    },
+    "arr-diff": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "dev": true
+    },
+    "arr-filter": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/arr-filter/-/arr-filter-1.1.2.tgz",
+      "integrity": "sha1-Q/3d0JHo7xGqTEXZzcGOLf8XEe4=",
+      "dev": true,
+      "requires": {
+        "make-iterator": "^1.0.0"
+      }
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true
+    },
+    "arr-map": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/arr-map/-/arr-map-2.0.2.tgz",
+      "integrity": "sha1-Onc0X/wc814qkYJWAfnljy4kysQ=",
+      "dev": true,
+      "requires": {
+        "make-iterator": "^1.0.0"
+      }
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true
+    },
+    "array-each": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
+      "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8=",
+      "dev": true
+    },
+    "array-initial": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/array-initial/-/array-initial-1.1.0.tgz",
+      "integrity": "sha1-L6dLJnOTccOUe9enrcc74zSz15U=",
+      "dev": true,
+      "requires": {
+        "array-slice": "^1.0.0",
+        "is-number": "^4.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
+        }
+      }
+    },
+    "array-last": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/array-last/-/array-last-1.3.0.tgz",
+      "integrity": "sha512-eOCut5rXlI6aCOS7Z7kCplKRKyiFQ6dHFBem4PwlwKeNFk2/XxTrhRh5T9PyaEWGy/NHTZWbY+nsZlNFJu9rYg==",
+      "dev": true,
+      "requires": {
+        "is-number": "^4.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
+        }
+      }
+    },
+    "array-slice": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
+      "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w==",
+      "dev": true
+    },
+    "array-sort": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-sort/-/array-sort-1.0.0.tgz",
+      "integrity": "sha512-ihLeJkonmdiAsD7vpgN3CRcx2J2S0TiYW+IS/5zHBI7mKUq3ySvBdzzBfD236ubDBQFiiyG3SWCPc+msQ9KoYg==",
+      "dev": true,
+      "requires": {
+        "default-compare": "^1.0.0",
+        "get-value": "^2.0.6",
+        "kind-of": "^5.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "array-unique": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "dev": true
+    },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
+    },
+    "async-done": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/async-done/-/async-done-1.3.2.tgz",
+      "integrity": "sha512-uYkTP8dw2og1tu1nmza1n1CMW0qb8gWWlwqMmLb7MhBVs4BXrFziT6HXUd+/RlRA/i4H9AkofYloUbs1fwMqlw==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.2",
+        "process-nextick-args": "^2.0.0",
+        "stream-exhaust": "^1.0.1"
+      }
+    },
+    "async-each": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+      "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
+      "dev": true
+    },
+    "async-settle": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-settle/-/async-settle-1.0.0.tgz",
+      "integrity": "sha1-HQqRS7Aldb7IqPOnTlCA9yssDGs=",
+      "dev": true,
+      "requires": {
+        "async-done": "^1.2.2"
+      }
+    },
+    "atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "dev": true
+    },
+    "bach": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/bach/-/bach-1.2.0.tgz",
+      "integrity": "sha1-Szzpa/JxNPeaG0FKUcFONMO9mIA=",
+      "dev": true,
+      "requires": {
+        "arr-filter": "^1.1.1",
+        "arr-flatten": "^1.0.1",
+        "arr-map": "^2.0.0",
+        "array-each": "^1.0.0",
+        "array-initial": "^1.0.0",
+        "array-last": "^1.1.1",
+        "async-done": "^1.2.2",
+        "async-settle": "^1.0.0",
+        "now-and-later": "^2.0.0"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "base": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "dev": true,
+      "requires": {
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "binary-extensions": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+      "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+      "dev": true,
+      "requires": {
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "buffer-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
+      "integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74=",
+      "dev": true
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "dev": true,
+      "requires": {
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
+      }
+    },
+    "chokidar": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+      "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+      "dev": true,
+      "requires": {
+        "anymatch": "^2.0.0",
+        "async-each": "^1.0.1",
+        "braces": "^2.3.2",
+        "fsevents": "^1.2.7",
+        "glob-parent": "^3.1.0",
+        "inherits": "^2.0.3",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^4.0.0",
+        "normalize-path": "^3.0.0",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.2.1",
+        "upath": "^1.1.1"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+          "dev": true
+        }
+      }
+    },
+    "class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
+    "cliui": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wrap-ansi": "^2.0.0"
+      }
+    },
+    "clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+      "dev": true
+    },
+    "clone-buffer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+      "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
+      "dev": true
+    },
+    "clone-stats": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+      "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+      "dev": true
+    },
+    "cloneable-readable": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.3.tgz",
+      "integrity": "sha512-2EF8zTQOxYq70Y4XKtorQupqF0m49MBz2/yf5Bj+MHjvpG3Hy7sImifnqD6UA+TKYxeSV+u6qqQPawN5UvnpKQ==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "process-nextick-args": "^2.0.0",
+        "readable-stream": "^2.3.5"
+      }
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
+    "collection-map": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-map/-/collection-map-1.0.0.tgz",
+      "integrity": "sha1-rqDwb40mx4DCt1SUOFVEsiVa8Yw=",
+      "dev": true,
+      "requires": {
+        "arr-map": "^2.0.2",
+        "for-own": "^1.0.0",
+        "make-iterator": "^1.0.0"
+      }
+    },
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "dev": true,
+      "requires": {
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
+      }
+    },
+    "color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true
+    },
+    "component-emitter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "convert-source-map": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+      "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
+    },
+    "copy-props": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/copy-props/-/copy-props-2.0.4.tgz",
+      "integrity": "sha512-7cjuUME+p+S3HZlbllgsn2CDwS+5eCCX16qBgNC4jgSTf49qR1VKy/Zhl400m0IQXl/bPGEVqncgUUMjrr4s8A==",
+      "dev": true,
+      "requires": {
+        "each-props": "^1.3.0",
+        "is-plain-object": "^2.0.1"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "dev": true,
+      "requires": {
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
+      }
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
+    },
+    "default-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/default-compare/-/default-compare-1.0.0.tgz",
+      "integrity": "sha512-QWfXlM0EkAbqOCbD/6HjdwT19j7WCkMyiRhWilc4H9/5h/RzTF9gv5LYh1+CmDV5d1rki6KAWLtQale0xt20eQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "^5.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "default-resolution": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/default-resolution/-/default-resolution-2.0.0.tgz",
+      "integrity": "sha1-vLgrqnKtebQmp2cy8aga1t8m1oQ=",
+      "dev": true
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
+    "define-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "dev": true,
+      "requires": {
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "detect-file": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
+      "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
+      "dev": true
+    },
+    "duplexify": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      }
+    },
+    "each-props": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/each-props/-/each-props-1.3.2.tgz",
+      "integrity": "sha512-vV0Hem3zAGkJAyU7JSjixeU66rwdynTAa1vofCrSA5fEln+m67Az9CcnkVD776/fsN/UjIWmBDoNRS6t6G9RfA==",
+      "dev": true,
+      "requires": {
+        "is-plain-object": "^2.0.1",
+        "object.defaults": "^1.1.0"
+      }
+    },
+    "end-of-stream": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "dev": true,
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "es5-ext": {
+      "version": "0.10.50",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.50.tgz",
+      "integrity": "sha512-KMzZTPBkeQV/JcSQhI5/z6d9VWJ3EnQ194USTUwIYZ2ZbpN8+SGXQKt1h68EX44+qt+Fzr8DO17vnxrw7c3agw==",
+      "dev": true,
+      "requires": {
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.1",
+        "next-tick": "^1.0.0"
+      }
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "es6-symbol": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
+    },
+    "es6-weak-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "expand-brackets": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+      "dev": true,
+      "requires": {
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "expand-tilde": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+      "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+      "dev": true,
+      "requires": {
+        "homedir-polyfill": "^1.0.1"
+      }
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
+    },
+    "extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "dev": true,
+      "requires": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "extglob": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+      "dev": true,
+      "requires": {
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "fancy-log": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.3.tgz",
+      "integrity": "sha512-k9oEhlyc0FrVh25qYuSELjr8oxsCoc4/LEZfg2iJJrfEk/tZL9bCoJE47gqAvI2m/AUjluCS4+3I0eTx8n3AEw==",
+      "dev": true,
+      "requires": {
+        "ansi-gray": "^0.1.1",
+        "color-support": "^1.1.3",
+        "parse-node-version": "^1.0.0",
+        "time-stamp": "^1.0.0"
+      }
+    },
+    "fill-range": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "findup-sync": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-3.0.0.tgz",
+      "integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
+      "dev": true,
+      "requires": {
+        "detect-file": "^1.0.0",
+        "is-glob": "^4.0.0",
+        "micromatch": "^3.0.4",
+        "resolve-dir": "^1.0.1"
+      }
+    },
+    "fined": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fined/-/fined-1.2.0.tgz",
+      "integrity": "sha512-ZYDqPLGxDkDhDZBjZBb+oD1+j0rA4E0pXY50eplAAOPg2N/gUBSSk5IM1/QhPfyVo19lJ+CvXpqfvk+b2p/8Ng==",
+      "dev": true,
+      "requires": {
+        "expand-tilde": "^2.0.2",
+        "is-plain-object": "^2.0.3",
+        "object.defaults": "^1.1.0",
+        "object.pick": "^1.2.0",
+        "parse-filepath": "^1.0.1"
+      }
+    },
+    "flagged-respawn": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
+      "integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q==",
+      "dev": true
+    },
+    "flush-write-stream": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
+      "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.3.6"
+      }
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
+    },
+    "for-own": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+      "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+      "dev": true,
+      "requires": {
+        "for-in": "^1.0.1"
+      }
+    },
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "dev": true,
+      "requires": {
+        "map-cache": "^0.2.2"
+      }
+    },
+    "fs-mkdirp-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz",
+      "integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.11",
+        "through2": "^2.0.3"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "fsevents": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+      "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "^2.12.1",
+        "node-pre-gyp": "^0.12.0"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "debug": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "deep-extend": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minimatch": "^3.0.4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "minipass": {
+          "version": "2.3.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "needle": {
+          "version": "2.3.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "^4.1.0",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.12.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.1",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.2.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "npm-packlist": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "^0.6.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "semver": {
+          "version": "5.7.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "4.4.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "wide-align": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "^1.0.2 || 2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "get-caller-file": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+      "dev": true
+    },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+      "dev": true,
+      "requires": {
+        "is-glob": "^3.1.0",
+        "path-dirname": "^1.0.0"
+      },
+      "dependencies": {
+        "is-glob": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.0"
+          }
+        }
+      }
+    },
+    "glob-stream": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-6.1.0.tgz",
+      "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
+      "dev": true,
+      "requires": {
+        "extend": "^3.0.0",
+        "glob": "^7.1.1",
+        "glob-parent": "^3.1.0",
+        "is-negated-glob": "^1.0.0",
+        "ordered-read-streams": "^1.0.0",
+        "pumpify": "^1.3.5",
+        "readable-stream": "^2.1.5",
+        "remove-trailing-separator": "^1.0.1",
+        "to-absolute-glob": "^2.0.0",
+        "unique-stream": "^2.0.2"
+      }
+    },
+    "glob-watcher": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-5.0.3.tgz",
+      "integrity": "sha512-8tWsULNEPHKQ2MR4zXuzSmqbdyV5PtwwCaWSGQ1WwHsJ07ilNeN1JB8ntxhckbnpSHaf9dXFUHzIWvm1I13dsg==",
+      "dev": true,
+      "requires": {
+        "anymatch": "^2.0.0",
+        "async-done": "^1.2.0",
+        "chokidar": "^2.0.0",
+        "is-negated-glob": "^1.0.0",
+        "just-debounce": "^1.0.0",
+        "object.defaults": "^1.1.0"
+      }
+    },
+    "global-modules": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+      "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+      "dev": true,
+      "requires": {
+        "global-prefix": "^1.0.1",
+        "is-windows": "^1.0.1",
+        "resolve-dir": "^1.0.0"
+      }
+    },
+    "global-prefix": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+      "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+      "dev": true,
+      "requires": {
+        "expand-tilde": "^2.0.2",
+        "homedir-polyfill": "^1.0.1",
+        "ini": "^1.3.4",
+        "is-windows": "^1.0.1",
+        "which": "^1.2.14"
+      }
+    },
+    "glogg": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.2.tgz",
+      "integrity": "sha512-5mwUoSuBk44Y4EshyiqcH95ZntbDdTQqA3QYSrxmzj28Ai0vXBGMH1ApSANH14j2sIRtqCEyg6PfsuP7ElOEDA==",
+      "dev": true,
+      "requires": {
+        "sparkles": "^1.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+      "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
+      "dev": true
+    },
+    "gulp": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/gulp/-/gulp-4.0.2.tgz",
+      "integrity": "sha512-dvEs27SCZt2ibF29xYgmnwwCYZxdxhQ/+LFWlbAW8y7jt68L/65402Lz3+CKy0Ov4rOs+NERmDq7YlZaDqUIfA==",
+      "dev": true,
+      "requires": {
+        "glob-watcher": "^5.0.3",
+        "gulp-cli": "^2.2.0",
+        "undertaker": "^1.2.1",
+        "vinyl-fs": "^3.0.0"
+      },
+      "dependencies": {
+        "gulp-cli": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.2.0.tgz",
+          "integrity": "sha512-rGs3bVYHdyJpLqR0TUBnlcZ1O5O++Zs4bA0ajm+zr3WFCfiSLjGwoCBqFs18wzN+ZxahT9DkOK5nDf26iDsWjA==",
+          "dev": true,
+          "requires": {
+            "ansi-colors": "^1.0.1",
+            "archy": "^1.0.0",
+            "array-sort": "^1.0.0",
+            "color-support": "^1.1.3",
+            "concat-stream": "^1.6.0",
+            "copy-props": "^2.0.1",
+            "fancy-log": "^1.3.2",
+            "gulplog": "^1.0.0",
+            "interpret": "^1.1.0",
+            "isobject": "^3.0.1",
+            "liftoff": "^3.1.0",
+            "matchdep": "^2.0.0",
+            "mute-stdout": "^1.0.0",
+            "pretty-hrtime": "^1.0.0",
+            "replace-homedir": "^1.0.0",
+            "semver-greatest-satisfied-range": "^1.1.0",
+            "v8flags": "^3.0.1",
+            "yargs": "^7.1.0"
+          }
+        }
+      }
+    },
+    "gulplog": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+      "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
+      "dev": true,
+      "requires": {
+        "glogg": "^1.0.0"
+      }
+    },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true
+    },
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "dev": true,
+      "requires": {
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "dev": true,
+      "requires": {
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "homedir-polyfill": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+      "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+      "dev": true,
+      "requires": {
+        "parse-passwd": "^1.0.0"
+      }
+    },
+    "hosted-git-info": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
+      "integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "dev": true
+    },
+    "interpret": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
+      "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
+      "dev": true
+    },
+    "invert-kv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "dev": true
+    },
+    "is-absolute": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
+      "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
+      "dev": true,
+      "requires": {
+        "is-relative": "^1.0.0",
+        "is-windows": "^1.0.1"
+      }
+    },
+    "is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-binary-path": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^1.0.0"
+      }
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
+    },
+    "is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "dev": true,
+      "requires": {
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "^1.0.0"
+      }
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-negated-glob": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
+      "integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=",
+      "dev": true
+    },
+    "is-number": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
+    "is-relative": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
+      "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
+      "dev": true,
+      "requires": {
+        "is-unc-path": "^1.0.0"
+      }
+    },
+    "is-unc-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
+      "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
+      "dev": true,
+      "requires": {
+        "unc-path-regex": "^0.1.2"
+      }
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
+    },
+    "is-valid-glob": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
+      "integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao=",
+      "dev": true
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "just-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/just-debounce/-/just-debounce-1.0.0.tgz",
+      "integrity": "sha1-h/zPrv/AtozRnVX2cilD+SnqNeo=",
+      "dev": true
+    },
+    "kind-of": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+      "dev": true
+    },
+    "last-run": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/last-run/-/last-run-1.1.1.tgz",
+      "integrity": "sha1-RblpQsF7HHnHchmCWbqUO+v4yls=",
+      "dev": true,
+      "requires": {
+        "default-resolution": "^2.0.0",
+        "es6-weak-map": "^2.0.1"
+      }
+    },
+    "lazystream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+      "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.0.5"
+      }
+    },
+    "lcid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "dev": true,
+      "requires": {
+        "invert-kv": "^1.0.0"
+      }
+    },
+    "lead": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lead/-/lead-1.0.0.tgz",
+      "integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
+      "dev": true,
+      "requires": {
+        "flush-write-stream": "^1.0.2"
+      }
+    },
+    "liftoff": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-3.1.0.tgz",
+      "integrity": "sha512-DlIPlJUkCV0Ips2zf2pJP0unEoT1kwYhiiPUGF3s/jtxTCjziNLoiVVh+jqWOWeFi6mmwQ5fNxvAUyPad4Dfog==",
+      "dev": true,
+      "requires": {
+        "extend": "^3.0.0",
+        "findup-sync": "^3.0.0",
+        "fined": "^1.0.1",
+        "flagged-respawn": "^1.0.0",
+        "is-plain-object": "^2.0.4",
+        "object.map": "^1.0.0",
+        "rechoir": "^0.6.2",
+        "resolve": "^1.1.7"
+      }
+    },
+    "make-iterator": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
+      "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
+      "dev": true,
+      "requires": {
+        "kind-of": "^6.0.2"
+      }
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true
+    },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "dev": true,
+      "requires": {
+        "object-visit": "^1.0.0"
+      }
+    },
+    "matchdep": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/matchdep/-/matchdep-2.0.0.tgz",
+      "integrity": "sha1-xvNINKDY28OzfCfui7yyfHd1WC4=",
+      "dev": true,
+      "requires": {
+        "findup-sync": "^2.0.0",
+        "micromatch": "^3.0.4",
+        "resolve": "^1.4.0",
+        "stack-trace": "0.0.10"
+      },
+      "dependencies": {
+        "findup-sync": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
+          "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+          "dev": true,
+          "requires": {
+            "detect-file": "^1.0.0",
+            "is-glob": "^3.1.0",
+            "micromatch": "^3.0.4",
+            "resolve-dir": "^1.0.1"
+          }
+        },
+        "is-glob": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.0"
+          }
+        }
+      }
+    },
+    "micromatch": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "mixin-deep": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+      "dev": true,
+      "requires": {
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "mute-stdout": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mute-stdout/-/mute-stdout-1.0.1.tgz",
+      "integrity": "sha512-kDcwXR4PS7caBpuRYYBUz9iVixUk3anO3f5OYFiIPwK/20vCzKCHyKoulbiDY1S53zD2bxUpxN/IJ+TnXjfvxg==",
+      "dev": true
+    },
+    "nan": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+      "dev": true,
+      "optional": true
+    },
+    "nanomatch": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      }
+    },
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+      "dev": true
+    },
+    "normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "dev": true,
+      "requires": {
+        "remove-trailing-separator": "^1.0.1"
+      }
+    },
+    "now-and-later": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/now-and-later/-/now-and-later-2.0.1.tgz",
+      "integrity": "sha512-KGvQ0cB70AQfg107Xvs/Fbu+dGmZoTRJp2TaPwcwQm3/7PteUyN2BCgk8KBMPGBUXZdVwyWS8fDCGFygBm19UQ==",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.2"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "dev": true,
+      "requires": {
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
+    },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.0"
+      }
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
+    },
+    "object.defaults": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
+      "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
+      "dev": true,
+      "requires": {
+        "array-each": "^1.0.1",
+        "array-slice": "^1.0.0",
+        "for-own": "^1.0.0",
+        "isobject": "^3.0.0"
+      }
+    },
+    "object.map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object.map/-/object.map-1.0.1.tgz",
+      "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
+      "dev": true,
+      "requires": {
+        "for-own": "^1.0.0",
+        "make-iterator": "^1.0.0"
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
+    "object.reduce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object.reduce/-/object.reduce-1.0.1.tgz",
+      "integrity": "sha1-b+NI8qx/oPlcpiEiZZkJaCW7A60=",
+      "dev": true,
+      "requires": {
+        "for-own": "^1.0.0",
+        "make-iterator": "^1.0.0"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "ordered-read-streams": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz",
+      "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.0.1"
+      }
+    },
+    "os-locale": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "dev": true,
+      "requires": {
+        "lcid": "^1.0.0"
+      }
+    },
+    "parse-filepath": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
+      "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
+      "dev": true,
+      "requires": {
+        "is-absolute": "^1.0.0",
+        "map-cache": "^0.2.0",
+        "path-root": "^0.1.1"
+      }
+    },
+    "parse-node-version": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.1.tgz",
+      "integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==",
+      "dev": true
+    },
+    "parse-passwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+      "dev": true
+    },
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "dev": true
+    },
+    "path-dirname": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "path-root": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
+      "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
+      "dev": true,
+      "requires": {
+        "path-root-regex": "^0.1.0"
+      }
+    },
+    "path-root-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
+      "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
+    },
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true
+    },
+    "pretty-hrtime": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+      "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
+    "pump": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+      "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "pumpify": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+      "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+      "dev": true,
+      "requires": {
+        "duplexify": "^3.6.0",
+        "inherits": "^2.0.3",
+        "pump": "^2.0.0"
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "readdirp": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+      "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.11",
+        "micromatch": "^3.1.10",
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
+    "regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "remove-bom-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz",
+      "integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
+      "dev": true,
+      "requires": {
+        "is-buffer": "^1.1.5",
+        "is-utf8": "^0.2.1"
+      }
+    },
+    "remove-bom-stream": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/remove-bom-stream/-/remove-bom-stream-1.2.0.tgz",
+      "integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
+      "dev": true,
+      "requires": {
+        "remove-bom-buffer": "^3.0.0",
+        "safe-buffer": "^5.1.0",
+        "through2": "^2.0.3"
+      }
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
+    },
+    "repeat-element": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+      "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+      "dev": true
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
+    "replace-ext": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+      "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+      "dev": true
+    },
+    "replace-homedir": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/replace-homedir/-/replace-homedir-1.0.0.tgz",
+      "integrity": "sha1-6H9tUTuSjd6AgmDBK+f+xv9ueYw=",
+      "dev": true,
+      "requires": {
+        "homedir-polyfill": "^1.0.1",
+        "is-absolute": "^1.0.0",
+        "remove-trailing-separator": "^1.1.0"
+      }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+      "dev": true
+    },
+    "resolve": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+      "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
+    },
+    "resolve-dir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+      "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+      "dev": true,
+      "requires": {
+        "expand-tilde": "^2.0.0",
+        "global-modules": "^1.0.0"
+      }
+    },
+    "resolve-options": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-options/-/resolve-options-1.1.0.tgz",
+      "integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
+      "dev": true,
+      "requires": {
+        "value-or-function": "^3.0.0"
+      }
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "dev": true
+    },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "dev": true,
+      "requires": {
+        "ret": "~0.1.10"
+      }
+    },
+    "semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true
+    },
+    "semver-greatest-satisfied-range": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/semver-greatest-satisfied-range/-/semver-greatest-satisfied-range-1.1.0.tgz",
+      "integrity": "sha1-E+jCZYq5aRywzXEJMkAoDTb3els=",
+      "dev": true,
+      "requires": {
+        "sver-compat": "^1.5.0"
+      }
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
+    "set-value": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "snapdragon": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "dev": true,
+      "requires": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "dev": true,
+      "requires": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.2.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
+    },
+    "source-map-resolve": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+      "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+      "dev": true,
+      "requires": {
+        "atob": "^2.1.1",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
+      }
+    },
+    "source-map-url": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "dev": true
+    },
+    "sparkles": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
+      "integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw==",
+      "dev": true
+    },
+    "spdx-correct": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+      "dev": true
+    },
+    "split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.0"
+      }
+    },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+      "dev": true
+    },
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "dev": true,
+      "requires": {
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
+    "stream-exhaust": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stream-exhaust/-/stream-exhaust-1.0.2.tgz",
+      "integrity": "sha512-b/qaq/GlBK5xaq1yrK9/zFcyRSTNxmcZwFLGSTG0mXgZl/4Z6GgiyYOXOvY7N3eEvFRAG1bkDRz5EPGSvPYQlw==",
+      "dev": true
+    },
+    "stream-shift": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
+      "dev": true
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
+      "requires": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "sver-compat": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/sver-compat/-/sver-compat-1.5.0.tgz",
+      "integrity": "sha1-PPh9/rTQe0o/FIJ7wYaz/QxkXNg=",
+      "dev": true,
+      "requires": {
+        "es6-iterator": "^2.0.1",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "dev": true,
+      "requires": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "through2-filter": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-3.0.0.tgz",
+      "integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
+      "dev": true,
+      "requires": {
+        "through2": "~2.0.0",
+        "xtend": "~4.0.0"
+      }
+    },
+    "time-stamp": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
+      "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
+      "dev": true
+    },
+    "to-absolute-glob": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
+      "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
+      "dev": true,
+      "requires": {
+        "is-absolute": "^1.0.0",
+        "is-negated-glob": "^1.0.0"
+      }
+    },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "dev": true,
+      "requires": {
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "dev": true,
+      "requires": {
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
+      }
+    },
+    "to-through": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-through/-/to-through-2.0.0.tgz",
+      "integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
+      "dev": true,
+      "requires": {
+        "through2": "^2.0.3"
+      }
+    },
+    "type": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.0.3.tgz",
+      "integrity": "sha512-51IMtNfVcee8+9GJvj0spSuFcZHe9vSib6Xtgsny1Km9ugyz2mbS08I3rsUIRYgJohFRFU1160sgRodYz378Hg==",
+      "dev": true
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "unc-path-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+      "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
+      "dev": true
+    },
+    "undertaker": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/undertaker/-/undertaker-1.2.1.tgz",
+      "integrity": "sha512-71WxIzDkgYk9ZS+spIB8iZXchFhAdEo2YU8xYqBYJ39DIUIqziK78ftm26eecoIY49X0J2MLhG4hr18Yp6/CMA==",
+      "dev": true,
+      "requires": {
+        "arr-flatten": "^1.0.1",
+        "arr-map": "^2.0.0",
+        "bach": "^1.0.0",
+        "collection-map": "^1.0.0",
+        "es6-weak-map": "^2.0.1",
+        "last-run": "^1.1.0",
+        "object.defaults": "^1.0.0",
+        "object.reduce": "^1.0.0",
+        "undertaker-registry": "^1.0.0"
+      }
+    },
+    "undertaker-registry": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/undertaker-registry/-/undertaker-registry-1.0.1.tgz",
+      "integrity": "sha1-XkvaMI5KiirlhPm5pDWaSZglzFA=",
+      "dev": true
+    },
+    "union-value": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^2.0.1"
+      }
+    },
+    "unique-stream": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.3.1.tgz",
+      "integrity": "sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==",
+      "dev": true,
+      "requires": {
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "through2-filter": "^3.0.0"
+      }
+    },
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "dev": true,
+      "requires": {
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "dev": true,
+          "requires": {
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "dev": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "dev": true
+        }
+      }
+    },
+    "upath": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.2.tgz",
+      "integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==",
+      "dev": true
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "dev": true
+    },
+    "use": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "v8flags": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.3.tgz",
+      "integrity": "sha512-amh9CCg3ZxkzQ48Mhcb8iX7xpAfYJgePHxWMQCBWECpOSqJUXgY26ncA61UTV0BkPqfhcy6mzwCIoP4ygxpW8w==",
+      "dev": true,
+      "requires": {
+        "homedir-polyfill": "^1.0.1"
+      }
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "value-or-function": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/value-or-function/-/value-or-function-3.0.0.tgz",
+      "integrity": "sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM=",
+      "dev": true
+    },
+    "vinyl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+      "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
+      "dev": true,
+      "requires": {
+        "clone": "^2.1.1",
+        "clone-buffer": "^1.0.0",
+        "clone-stats": "^1.0.0",
+        "cloneable-readable": "^1.0.0",
+        "remove-trailing-separator": "^1.0.1",
+        "replace-ext": "^1.0.0"
+      }
+    },
+    "vinyl-fs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-3.0.3.tgz",
+      "integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
+      "dev": true,
+      "requires": {
+        "fs-mkdirp-stream": "^1.0.0",
+        "glob-stream": "^6.1.0",
+        "graceful-fs": "^4.0.0",
+        "is-valid-glob": "^1.0.0",
+        "lazystream": "^1.0.0",
+        "lead": "^1.0.0",
+        "object.assign": "^4.0.4",
+        "pumpify": "^1.3.5",
+        "readable-stream": "^2.3.3",
+        "remove-bom-buffer": "^3.0.0",
+        "remove-bom-stream": "^1.2.0",
+        "resolve-options": "^1.1.0",
+        "through2": "^2.0.0",
+        "to-through": "^2.0.0",
+        "value-or-function": "^3.0.0",
+        "vinyl": "^2.0.0",
+        "vinyl-sourcemap": "^1.1.0"
+      }
+    },
+    "vinyl-sourcemap": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/vinyl-sourcemap/-/vinyl-sourcemap-1.1.0.tgz",
+      "integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
+      "dev": true,
+      "requires": {
+        "append-buffer": "^1.0.2",
+        "convert-source-map": "^1.5.0",
+        "graceful-fs": "^4.1.6",
+        "normalize-path": "^2.1.1",
+        "now-and-later": "^2.0.0",
+        "remove-bom-buffer": "^3.0.0",
+        "vinyl": "^2.0.0"
+      }
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "which-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+      "dev": true
+    },
+    "wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true
+    },
+    "y18n": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+      "dev": true
+    },
+    "yargs": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+      "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+      "dev": true,
+      "requires": {
+        "camelcase": "^3.0.0",
+        "cliui": "^3.2.0",
+        "decamelize": "^1.1.1",
+        "get-caller-file": "^1.0.1",
+        "os-locale": "^1.4.0",
+        "read-pkg-up": "^1.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^1.0.1",
+        "set-blocking": "^2.0.0",
+        "string-width": "^1.0.2",
+        "which-module": "^1.0.0",
+        "y18n": "^3.2.1",
+        "yargs-parser": "^5.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "dev": true
+        },
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
+          "requires": {
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "dev": true,
+          "requires": {
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "^0.2.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+          "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^3.0.0"
+          }
+        }
+      }
+    }
+  }
 }

--- a/bundles/spectrum-css-compat/package.json
+++ b/bundles/spectrum-css-compat/package.json
@@ -20,10 +20,8 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
-  "optionalDependencies": {
-    "@spectrum/spectrum-icons": "^2.3.0"
-  },
   "devDependencies": {
+    "@adobe/spectrum-css-workflow-icons": "^1.0.0-beta.3",
     "@spectrum-css/accordion": "^2.0.0-alpha.4",
     "@spectrum-css/actionbar": "^2.0.0-alpha.4",
     "@spectrum-css/actionmenu": "^2.0.0-alpha.4",

--- a/bundles/spectrum-css/package-lock.json
+++ b/bundles/spectrum-css/package-lock.json
@@ -1,4163 +1,5273 @@
 {
-	"name": "@spectrum-css/spectrum-css",
-	"version": "3.0.0-alpha.0",
-	"lockfileVersion": 1,
-	"requires": true,
-	"dependencies": {
-		"@spectrum-css/accordion": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2faccordion/-/accordion-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-X5cnqvipn29TlX+36DomYekyPnT1aSh0csG1Fimm0+ifVu811ArVGPlmfmKvq/SNTlK7AxIW9af5wnDaBOajMQ==",
-			"dev": true
-		},
-		"@spectrum-css/actionbar": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2factionbar/-/actionbar-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-0FAXaAZycYGJLRKySwOOEao44J+ETWk8eKWpYLYiBXKfCzs0DLaw7XSPtoo8B/ZBqF2FKdjYX89rsWICBALU8g==",
-			"dev": true
-		},
-		"@spectrum-css/actionmenu": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2factionmenu/-/actionmenu-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-0E5J15nY/Nl1e+BpCW8ufH8czCiaz8IaCGT4WB5y0W5pIjn5If4QzDSdeNQcxwIqgug8tvrtvzLGjvJ3v0jnOg==",
-			"dev": true
-		},
-		"@spectrum-css/alert": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2falert/-/alert-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-K3CKoqgyxy+XwHh7eOFrwXbb4veS7Q37kt3fbp8i9fne4FC4eMCJA2YiqnvlyM76lD7dDKDqeELxtXPCAEw2dA==",
-			"dev": true
-		},
-		"@spectrum-css/asset": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2fasset/-/asset-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-rh92IwaVFrw6GvVffikwry0KIXlCKGXglyrJNF9Px/poOK6ZoGGvJziR58JeTT/6yrqvFIpslaIbvSoMhaKDIw==",
-			"dev": true
-		},
-		"@spectrum-css/assetlist": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2fassetlist/-/assetlist-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-iqLo1+r36jKdYyalkQ75NYBdzxITFKy4KLmEhNQo0S/wyM7mg/g3lE30ZK1fAlhQPjBIL8kZA4SaD4Eh772Lnw==",
-			"dev": true
-		},
-		"@spectrum-css/avatar": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2favatar/-/avatar-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-Grk7F1aK8GSzJ74MIgphLoLKS1LXSFY4W8ELPtVX9/w1cb0lj47/h4QScWN+syK6RVz8joslLADSDE9FFcbZ2Q==",
-			"dev": true
-		},
-		"@spectrum-css/banner": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2fbanner/-/banner-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-eiQoyGmLQyjVUr1E6CCh5o2qn7PXRHU+vvBB10/V9a2kA+kx2T8AllBC/25rLGHOZ4teGRjJtyiZ2aznn0VjOQ==",
-			"dev": true
-		},
-		"@spectrum-css/barloader": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2fbarloader/-/barloader-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-vNMg5cCnEeTRhgQyCCGZR91EsivS0itW6K57lUGWIGRB5q5Z2rMtxfEXUYlTgTUy6LJG7C373kpbejoDm33tiA==",
-			"dev": true
-		},
-		"@spectrum-css/breadcrumb": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2fbreadcrumb/-/breadcrumb-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-nXjaDc7DIaAaVTmILSuI4cvhlaKKvTevcrPDXm+ervoyUmKDMrWAXg5kphN7ta1GOWjWS3qY7kww8tqSpv9/tg==",
-			"dev": true
-		},
-		"@spectrum-css/button": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2fbutton/-/button-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-N8wXowh9StrkisqO8Oypo9Szg6z7qm/l6xx9RbjoFTBEmhydgbbYCilYXFuye0KYxsqfENTrKB30A+omvAzN7Q==",
-			"dev": true
-		},
-		"@spectrum-css/buttongroup": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2fbuttongroup/-/buttongroup-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-6a3dFVdIrKGrO7lOr4or4tjmsrHGd/MPs+I1no46BEMIAE8iviyhJLQLIFAPjnKWFNxwAGTTWXmOWLn7HhSuKg==",
-			"dev": true
-		},
-		"@spectrum-css/calendar": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2fcalendar/-/calendar-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-88SIAH5Ha8Bq+qjWjodV2RyUJGAjjMfFSJ79q1ETunYc9OMVwZynBsto6jy+y+IeqK7dkjoxwe1D6YZwZDDc8Q==",
-			"dev": true
-		},
-		"@spectrum-css/card": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2fcard/-/card-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-JbrX/eHmeDzaDIVGZd3nwyYtPGXl5hPohUW3DTT1vXvZe2XJquYYt4j8p4aYDI0r8pYBpCR16L0VE7RWgCIc/w==",
-			"dev": true
-		},
-		"@spectrum-css/checkbox": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2fcheckbox/-/checkbox-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-z4rV8A+8enUQ1l/klqzG6FeG+xCrTMV13m3Vrg/NrE/IRXlKJORC+8plfMMGojUmNLPW/GnTBCmB6XOxihbPrg==",
-			"dev": true
-		},
-		"@spectrum-css/circleloader": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2fcircleloader/-/circleloader-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-twD+Jda1JOiN6f3L7Gr8Zj4t9pIkYigMwtMeSzKP9ou7dwCPwtSc0nOhLs6C31zW07PSSwvppt8OWq0QPnvWGQ==",
-			"dev": true
-		},
-		"@spectrum-css/coachmark": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2fcoachmark/-/coachmark-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-NXBr0hA6E1DFY7SNXhUHwWuU05C9pH/h42fcTuHJIex3syNGvg0TccedOWI90PIPxRlUp5y1H4AwUPDTu5jK/w==",
-			"dev": true
-		},
-		"@spectrum-css/cyclebutton": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2fcyclebutton/-/cyclebutton-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-DQKetJLfpeB3W7xnro6z/rrHZcN2td4YR3L2nn8XTLZXcX0nqdIX1CTheFtGQpmJi3gIby2/nR3uZsIlZDYMjQ==",
-			"dev": true
-		},
-		"@spectrum-css/decoratedtextfield": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2fdecoratedtextfield/-/decoratedtextfield-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-t9uCzRfRvxBmlR9rB3VWBUd930Jac7wPn/ln3NvbG+td3wFC/DnZy8OcmGTs0oRIEGFM6z224yxQa1AR7IQT0g==",
-			"dev": true
-		},
-		"@spectrum-css/dialog": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2fdialog/-/dialog-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-cNxU+F0hSQ9i5cNF3oTyXQBg1dtMonC7MYcTvQfk/CB7S1I/LY+pRrlA7rv8izQbXMjDB5ZhDITameUPiiyfgw==",
-			"dev": true
-		},
-		"@spectrum-css/dropdown": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2fdropdown/-/dropdown-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-WYlkXrUBLVM7Dr7zXZyJcE0Aj/3f5OBUAKtGl9LiJcIrn99JCyrBZcNPAxC+zmaY5YurmALwkFY698c4EFTO/w==",
-			"dev": true
-		},
-		"@spectrum-css/dropindicator": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2fdropindicator/-/dropindicator-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-ykD8VWb3CnPmTlXyRY7kZewlTBjWMgUg5LAG6K3fYpwvRT52ZZvPevvQy5n7okbOANb920OQgnNLJacgDUTUcQ==",
-			"dev": true
-		},
-		"@spectrum-css/dropzone": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2fdropzone/-/dropzone-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-aycTU+TXRz4K9rahbsZWMg/4loVJQFaOosVlxFuiZQJgU5ZlwP2jRzB7+A0rvQb/312uCZ38xoz+D6MzACUiTA==",
-			"dev": true
-		},
-		"@spectrum-css/fieldgroup": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2ffieldgroup/-/fieldgroup-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-rTsdIhe3mmE3k5M9QgUWb2iub62mKEcQy0wVtpUlu3jqjpSvYAJHQVlBXRGemK/vXjpPt0TLswh70Qqc3Iak6Q==",
-			"dev": true
-		},
-		"@spectrum-css/fieldlabel": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2ffieldlabel/-/fieldlabel-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-ELAhL7Fo3/bY+UwBjLmWz88yW6x5OEfL/IU0aomDtoVCInEHbZl/Qx4diocdWWXrP/sWR3fWE+4Pe0xpKIfV4w==",
-			"dev": true
-		},
-		"@spectrum-css/icons": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2ficons/-/icons-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-dEIoc7NCk7vSB5CLHKLbgN5n3+BIEoIgWOy7i9AejZgN8C7/8s0iBp2Drg66qhVsf/l827inPepbHYnPedMw4Q==",
-			"dev": true
-		},
-		"@spectrum-css/illustratedmessage": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2fillustratedmessage/-/illustratedmessage-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-eNyZHXkIoW9cWA19uPR2Y2/+ShSTnFxawpHoftUImaSq/rMXgy97sdaZJ3SMJEi4axueXuXF/wFHJnqUfL3faQ==",
-			"dev": true
-		},
-		"@spectrum-css/inputgroup": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2finputgroup/-/inputgroup-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-SENIFhQ/fjKZG9OEekcfcMRL0+R2MGBD4DDnwin6SSmxmlf27e2bOS2Q47yl2j3zPXiBHBL21CgO/eCdvy3KJw==",
-			"dev": true
-		},
-		"@spectrum-css/label": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2flabel/-/label-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-nOPrIfHvbvRidCjDZrkVh5mh2lZttOtML77gvx4RZDuMrAjXaIUa4CmPTNz0Bi8F+M+zOBcWxhHuHWKjjO0swg==",
-			"dev": true
-		},
-		"@spectrum-css/link": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2flink/-/link-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-jVJT7tUO4JFKmEZuVvjfXzIm4E+MKzwqNyxk8TZFmvwe62VLGwNkl32NSjdD9S8q+Emyi2nOLCNZFq/dLuYIlw==",
-			"dev": true
-		},
-		"@spectrum-css/menu": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2fmenu/-/menu-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-e35POghDuFx5r3CZErwSDddNbXuD+SIg6XFt1zfgovCZUOZrTE/A0XyaREurwhTK8Y779Uji3Bs3UaKLcAsObw==",
-			"dev": true
-		},
-		"@spectrum-css/miller": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2fmiller/-/miller-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-FZgRydCo9ynrxq/zgrpK/83hMgAwpU5jVT8/ji1nl4fOdRI/hIDK2jnR/kEZtXwMI+ciNP/GKiWs3ecNGcs1Fg==",
-			"dev": true
-		},
-		"@spectrum-css/page": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2fpage/-/page-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-1/s6L7+MLDFoyGvrgSw1yNzxTsanA8doXCeIuPtumfhWmTUxohclmtzpyUN4Y6aUnDmYOOvuelMdUmJYgmUJTw==",
-			"dev": true,
-			"requires": {
-				"@spectrum-css/vars": "^2.0.0-alpha.0"
-			}
-		},
-		"@spectrum-css/pagination": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2fpagination/-/pagination-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-vTV3MJJYTe4a2b1SVHb9o5LvGKCvWCDi7TebfPwsfVpOnHd/gFshNT5fZOsp880jr487ATejUUoUevPQZAEScQ==",
-			"dev": true
-		},
-		"@spectrum-css/popover": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2fpopover/-/popover-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-Q1gjlx4bD+CfiRATYxtgc/Sxa++89rC6On5q0U+BY6EDrqp7Ynok2x7aIXrpTHHgLEkb32Cu4dyCyjDpYzCicw==",
-			"dev": true
-		},
-		"@spectrum-css/quickaction": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2fquickaction/-/quickaction-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-HEs5g6lD3tGpL/vIJhVWr2pAGE/ainmA6NQd/B4B08fcSj+8kMQhTg11cCJppxIrohdFikriWdo14WDFQhzeAA==",
-			"dev": true
-		},
-		"@spectrum-css/radio": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2fradio/-/radio-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-R4oFLHYsz6xi/NKzN4TDn6pNSeI0Kxaa0eEy8ApADj9IBXGWusTPpECuKIj9okJiXu4ocNb6jEtqfbr5er1H/Q==",
-			"dev": true
-		},
-		"@spectrum-css/rating": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2frating/-/rating-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-m7DEAlQmF4dPLKGbaMQ7rEIGjlaoGQOT9UqSYVqoIOZs3Z+Od1B/QVVqGWTOpUUzNeyWkmQcEkPcRfLc7tdC2w==",
-			"dev": true
-		},
-		"@spectrum-css/rule": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2frule/-/rule-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-FRB6ZWusSX8o8RvdbWInO1IK8pXhCv58tU6rGOm5c2UhfBYLa83kcBkJH1ZkuEZVlH9hWGt58mvXm2YMgH32Bw==",
-			"dev": true,
-			"requires": {
-				"@spectrum-css/vars": "^2.0.0-alpha.0"
-			}
-		},
-		"@spectrum-css/search": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2fsearch/-/search-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-yc650pKjSleWPf4giVuESiD+/pJTUf6O2Xyljj/xQoVkJfATLneFPTQxbEP0mvA8yTnEuKVBscSNfMTuV50X+g==",
-			"dev": true
-		},
-		"@spectrum-css/searchwithin": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2fsearchwithin/-/searchwithin-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-eYy2b0UX0Zek1KWnxOQP0ETfk2Z6bSek7HatSxKeAS6i7+ATPGHZ8vP6kwtuuWYPuK8uBBqEeCzuQ2jTO/7QXw==",
-			"dev": true,
-			"requires": {
-				"@spectrum-css/button": "^2.0.0-alpha.0",
-				"@spectrum-css/dropdown": "^2.0.0-alpha.0",
-				"@spectrum-css/icons": "^2.0.0-alpha.0",
-				"@spectrum-css/textfield": "^2.0.0-alpha.0",
-				"@spectrum-css/vars": "^2.0.0-alpha.0"
-			}
-		},
-		"@spectrum-css/sidenav": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2fsidenav/-/sidenav-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-fedr/qZzNNmVBLixXhlNwsw+r7e8+KvFQrVZPuW5luwtNQKwml5Q6sTY9W3Hs/F07iKbPmiZDOaPY40PI14uGQ==",
-			"dev": true
-		},
-		"@spectrum-css/slider": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2fslider/-/slider-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-V6YVvNi4OCXoyWZB7L6VJzUGqZqET2VdjQsonh4kJuMokb61839FgrI8Ehd67D3qci2rd7gr8bPTT3k/05yfhg==",
-			"dev": true
-		},
-		"@spectrum-css/splitbutton": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2fsplitbutton/-/splitbutton-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-EN0k0ZGBoRmuJ7rffHiCuOOtN68CVHUSaRo0c+PGJb0Zc/OCxffkD9cOrqJDbRlO2+hEBOvXBxnH6UPYgLiCEQ==",
-			"dev": true
-		},
-		"@spectrum-css/splitview": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2fsplitview/-/splitview-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-97rFL0/398+saeboSxrxwRyZxb/GNKaso42hWhEBddOkDwD4kBB4CX/FdRTet7o7FDZki8ibCqXBLyI0l2NpOg==",
-			"dev": true
-		},
-		"@spectrum-css/statuslight": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2fstatuslight/-/statuslight-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-PW0j21Ymhbs3hswcLJo+NYh7ts3+rLycertdMJ0YOewiWWMCVp/hqPDPba+U1b/f8PDY+93JO5TJsQP5duE4IQ==",
-			"dev": true
-		},
-		"@spectrum-css/steplist": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2fsteplist/-/steplist-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-eJzp2wM+0/bBS4YNNPiUEn16TAOvtVO4yl38Yoe3fIcRXeVFCJVJar6TLVxF4WthQFa/PXoT3v3gb8iC54tGfA==",
-			"dev": true
-		},
-		"@spectrum-css/stepper": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2fstepper/-/stepper-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-5CWk9PX7IWvTpHCZlf8r8rlyU1SjuMDNelJQoM1NHfMtCQ5oHrNPqpYi9V4+agrasis1yOsNjfF2mj9jYvzqPw==",
-			"dev": true
-		},
-		"@spectrum-css/table": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2ftable/-/table-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-6ztkTN7rQMyanEqIUYbCuhrYQX/gnZ3rG5LPvnhmU7F5zjGM4/jp1vQXEDudHOSUdcxnPwpPG18mEdjnHpHk9A==",
-			"dev": true
-		},
-		"@spectrum-css/tabs": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2ftabs/-/tabs-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-OjyyYlXwYNKbxz/wEt6fzqGeW1zuWgJ/cu3lX5HotjjfkOk4cLW5LLkbqE01PWbWMR6n6ivchmMummPVtVL0dw==",
-			"dev": true
-		},
-		"@spectrum-css/tags": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2ftags/-/tags-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-nRVHkM28EsOFRXSr2BiMMNdcpacaejP2YlKrlRmDehANkh27OL3uPX3mHanNzuPnJDBtYKg55J/98H3v3xvT8g==",
-			"dev": true
-		},
-		"@spectrum-css/textfield": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2ftextfield/-/textfield-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-w8D/WMGepocLXEj4iKqYfj+ohxqFuWR5rzWHAqf2xquo4sWY3Qh1ZmqK3T+3CCW6LvfPbmxvADoSh8+l1wl2dg==",
-			"dev": true
-		},
-		"@spectrum-css/toast": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2ftoast/-/toast-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-uB406g+IRvPObKv/h2JuBAWV8VRFBj31Hh6lkZHbCM23n0txXqQhSob2IYCnHTsW+G+azn1Uwwj+rCjdMmMLGQ==",
-			"dev": true
-		},
-		"@spectrum-css/toggle": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2ftoggle/-/toggle-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-E1s4mO+ud9cHglxBdt/BvnTU2muNi74rRdzCGkZ7zApXoz6yhDNfMCE4L+/Wvfn1aGvpor0yoIL9KD0DD0mgOQ==",
-			"dev": true
-		},
-		"@spectrum-css/tooltip": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2ftooltip/-/tooltip-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-Daaw2hthk4mh93Q5Iz2esecW7HZZZM6sCrQzv+06VtE3GUEnNGnTsSAgTltkCMuJ+fkTL8EYdngjRB3FXJZUzg==",
-			"dev": true
-		},
-		"@spectrum-css/treeview": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2ftreeview/-/treeview-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-4vo54pEA7Ra2s9qB8hVEdSkmla3GCSjgryF+ULnSdN2UIcqdpAxPv80yPuXRhhzqiusPNFUYOvX3K3khqLJ6KA==",
-			"dev": true
-		},
-		"@spectrum-css/typography": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2ftypography/-/typography-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-Z7gFPZTRMP8eizmarVsbYKIxw7DKR2r/ZQ/GA2DX9fdOBG+l2z0AWZUvruBMU7UYPjW6KldYaZ0fTpG8AK9lEQ==",
-			"dev": true
-		},
-		"@spectrum-css/underlay": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2funderlay/-/underlay-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-55lYcip/A0p3AVVxX7R/2dCq33/lNT/DBBO4yvD0IdBM5dwNxB7KI7E9H9FYShFlaBT2EFQ6zil6a2Jx7qdvRw==",
-			"dev": true
-		},
-		"@spectrum-css/vars": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2fvars/-/vars-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-VL1c1YUWNHBNdIS+DIBuqO2SBnvAoOEO7w4/tWRHHyj69YUGYzRAvobxiD/+6b9p/u3FRmYKK9JtIsjTXhreaw==",
-			"dev": true
-		},
-		"@spectrum-css/well": {
-			"version": "2.0.0-alpha.0",
-			"resolved": "http://localhost:4873/@spectrum-css%2fwell/-/well-2.0.0-alpha.0.tgz",
-			"integrity": "sha512-nXsMhlkyI9UaoAvGbB5xzvxKKf8A7Sm1pyHIi0aLvLqM7hx5qL2HaYAdXIGPojHVDhr9Auam9ZYPF2EnrJJ5Bg==",
-			"dev": true
-		},
-		"@spectrum/spectrum-icons": {
-			"version": "2.3.0",
-			"resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-spectrum-release/@spectrum/spectrum-icons/-/@spectrum/spectrum-icons-2.3.0.tgz",
-			"integrity": "sha1-IlbN3PcBo3HJgtJX5bmIaDUktD4=",
-			"optional": true,
-			"requires": {
-				"gh-pages": "^2.0.1"
-			},
-			"dependencies": {
-				"array-union": {
-					"version": "1.0.2",
-					"resolved": "http://localhost:4873/array-union/-/array-union-1.0.2.tgz",
-					"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-					"optional": true,
-					"requires": {
-						"array-uniq": "^1.0.1"
-					}
-				},
-				"array-uniq": {
-					"version": "1.0.3",
-					"resolved": "http://localhost:4873/array-uniq/-/array-uniq-1.0.3.tgz",
-					"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-					"optional": true
-				},
-				"async": {
-					"version": "2.6.3",
-					"resolved": "http://localhost:4873/async/-/async-2.6.3.tgz",
-					"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-					"optional": true,
-					"requires": {
-						"lodash": "^4.17.14"
-					}
-				},
-				"balanced-match": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/balanced-match/-/balanced-match-1.0.0.tgz",
-					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-					"optional": true
-				},
-				"brace-expansion": {
-					"version": "1.1.11",
-					"resolved": "http://localhost:4873/brace-expansion/-/brace-expansion-1.1.11.tgz",
-					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-					"optional": true,
-					"requires": {
-						"balanced-match": "^1.0.0",
-						"concat-map": "0.0.1"
-					}
-				},
-				"commander": {
-					"version": "2.20.0",
-					"resolved": "http://localhost:4873/commander/-/commander-2.20.0.tgz",
-					"integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
-					"optional": true
-				},
-				"concat-map": {
-					"version": "0.0.1",
-					"resolved": "http://localhost:4873/concat-map/-/concat-map-0.0.1.tgz",
-					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-					"optional": true
-				},
-				"email-addresses": {
-					"version": "3.0.3",
-					"resolved": "http://localhost:4873/email-addresses/-/email-addresses-3.0.3.tgz",
-					"integrity": "sha512-kUlSC06PVvvjlMRpNIl3kR1NRXLEe86VQ7N0bQeaCZb2g+InShCeHQp/JvyYNTugMnRN2NvJhHlc3q12MWbbpg==",
-					"optional": true
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "http://localhost:4873/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-					"optional": true
-				},
-				"filename-reserved-regex": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz",
-					"integrity": "sha1-5hz4BfDeHJhFZ9A4bcXfUO5a9+Q=",
-					"optional": true
-				},
-				"filenamify": {
-					"version": "1.2.1",
-					"resolved": "http://localhost:4873/filenamify/-/filenamify-1.2.1.tgz",
-					"integrity": "sha1-qfL/0RxQO+0wABUCknI3jx8TZaU=",
-					"optional": true,
-					"requires": {
-						"filename-reserved-regex": "^1.0.0",
-						"strip-outer": "^1.0.0",
-						"trim-repeated": "^1.0.0"
-					}
-				},
-				"filenamify-url": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/filenamify-url/-/filenamify-url-1.0.0.tgz",
-					"integrity": "sha1-syvYExnvWGO3MHi+1Q9GpPeXX1A=",
-					"optional": true,
-					"requires": {
-						"filenamify": "^1.0.0",
-						"humanize-url": "^1.0.0"
-					}
-				},
-				"fs-extra": {
-					"version": "7.0.1",
-					"resolved": "http://localhost:4873/fs-extra/-/fs-extra-7.0.1.tgz",
-					"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-					"optional": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"fs.realpath": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/fs.realpath/-/fs.realpath-1.0.0.tgz",
-					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-					"optional": true
-				},
-				"gh-pages": {
-					"version": "2.1.0",
-					"resolved": "http://localhost:4873/gh-pages/-/gh-pages-2.1.0.tgz",
-					"integrity": "sha512-QmV1fh/2W5GZkfoLsG4g6dRTWiNYuCetMQmm8CL6Us8JVnAufYtS0uJPD8NYogmNB4UZzdRG44uPAL+jcBzEwQ==",
-					"optional": true,
-					"requires": {
-						"async": "^2.6.1",
-						"commander": "^2.18.0",
-						"email-addresses": "^3.0.1",
-						"filenamify-url": "^1.0.0",
-						"fs-extra": "^7.0.0",
-						"globby": "^6.1.0",
-						"graceful-fs": "^4.1.11",
-						"rimraf": "^2.6.2"
-					}
-				},
-				"glob": {
-					"version": "7.1.4",
-					"resolved": "http://localhost:4873/glob/-/glob-7.1.4.tgz",
-					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-					"optional": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"globby": {
-					"version": "6.1.0",
-					"resolved": "http://localhost:4873/globby/-/globby-6.1.0.tgz",
-					"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-					"optional": true,
-					"requires": {
-						"array-union": "^1.0.1",
-						"glob": "^7.0.3",
-						"object-assign": "^4.0.1",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"graceful-fs": {
-					"version": "4.2.0",
-					"resolved": "http://localhost:4873/graceful-fs/-/graceful-fs-4.2.0.tgz",
-					"integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
-					"optional": true
-				},
-				"humanize-url": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/humanize-url/-/humanize-url-1.0.1.tgz",
-					"integrity": "sha1-9KuZ4NKIF0yk4eUEB8VfuuRk7/8=",
-					"optional": true,
-					"requires": {
-						"normalize-url": "^1.0.0",
-						"strip-url-auth": "^1.0.0"
-					}
-				},
-				"inflight": {
-					"version": "1.0.6",
-					"resolved": "http://localhost:4873/inflight/-/inflight-1.0.6.tgz",
-					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-					"optional": true,
-					"requires": {
-						"once": "^1.3.0",
-						"wrappy": "1"
-					}
-				},
-				"inherits": {
-					"version": "2.0.4",
-					"resolved": "http://localhost:4873/inherits/-/inherits-2.0.4.tgz",
-					"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-					"optional": true
-				},
-				"is-plain-obj": {
-					"version": "1.1.0",
-					"resolved": "http://localhost:4873/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-					"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-					"optional": true
-				},
-				"jsonfile": {
-					"version": "4.0.0",
-					"resolved": "http://localhost:4873/jsonfile/-/jsonfile-4.0.0.tgz",
-					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-					"optional": true,
-					"requires": {
-						"graceful-fs": "^4.1.6"
-					}
-				},
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "http://localhost:4873/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-					"optional": true
-				},
-				"minimatch": {
-					"version": "3.0.4",
-					"resolved": "http://localhost:4873/minimatch/-/minimatch-3.0.4.tgz",
-					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-					"optional": true,
-					"requires": {
-						"brace-expansion": "^1.1.7"
-					}
-				},
-				"normalize-url": {
-					"version": "1.9.1",
-					"resolved": "http://localhost:4873/normalize-url/-/normalize-url-1.9.1.tgz",
-					"integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
-					"optional": true,
-					"requires": {
-						"object-assign": "^4.0.1",
-						"prepend-http": "^1.0.0",
-						"query-string": "^4.1.0",
-						"sort-keys": "^1.0.0"
-					}
-				},
-				"object-assign": {
-					"version": "4.1.1",
-					"resolved": "http://localhost:4873/object-assign/-/object-assign-4.1.1.tgz",
-					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-					"optional": true
-				},
-				"once": {
-					"version": "1.4.0",
-					"resolved": "http://localhost:4873/once/-/once-1.4.0.tgz",
-					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-					"optional": true,
-					"requires": {
-						"wrappy": "1"
-					}
-				},
-				"path-is-absolute": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-					"optional": true
-				},
-				"pify": {
-					"version": "2.3.0",
-					"resolved": "http://localhost:4873/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"optional": true
-				},
-				"pinkie": {
-					"version": "2.0.4",
-					"resolved": "http://localhost:4873/pinkie/-/pinkie-2.0.4.tgz",
-					"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-					"optional": true
-				},
-				"pinkie-promise": {
-					"version": "2.0.1",
-					"resolved": "http://localhost:4873/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-					"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-					"optional": true,
-					"requires": {
-						"pinkie": "^2.0.0"
-					}
-				},
-				"prepend-http": {
-					"version": "1.0.4",
-					"resolved": "http://localhost:4873/prepend-http/-/prepend-http-1.0.4.tgz",
-					"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-					"optional": true
-				},
-				"query-string": {
-					"version": "4.3.4",
-					"resolved": "http://localhost:4873/query-string/-/query-string-4.3.4.tgz",
-					"integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
-					"optional": true,
-					"requires": {
-						"object-assign": "^4.1.0",
-						"strict-uri-encode": "^1.0.0"
-					}
-				},
-				"rimraf": {
-					"version": "2.6.3",
-					"resolved": "http://localhost:4873/rimraf/-/rimraf-2.6.3.tgz",
-					"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-					"optional": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				},
-				"sort-keys": {
-					"version": "1.1.2",
-					"resolved": "http://localhost:4873/sort-keys/-/sort-keys-1.1.2.tgz",
-					"integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
-					"optional": true,
-					"requires": {
-						"is-plain-obj": "^1.0.0"
-					}
-				},
-				"strict-uri-encode": {
-					"version": "1.1.0",
-					"resolved": "http://localhost:4873/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-					"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-					"optional": true
-				},
-				"strip-outer": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/strip-outer/-/strip-outer-1.0.1.tgz",
-					"integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
-					"optional": true,
-					"requires": {
-						"escape-string-regexp": "^1.0.2"
-					}
-				},
-				"strip-url-auth": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/strip-url-auth/-/strip-url-auth-1.0.1.tgz",
-					"integrity": "sha1-IrD6OkE4WzO+PzMVUbu4N/oM164=",
-					"optional": true
-				},
-				"trim-repeated": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/trim-repeated/-/trim-repeated-1.0.0.tgz",
-					"integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
-					"optional": true,
-					"requires": {
-						"escape-string-regexp": "^1.0.2"
-					}
-				},
-				"universalify": {
-					"version": "0.1.2",
-					"resolved": "http://localhost:4873/universalify/-/universalify-0.1.2.tgz",
-					"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-					"optional": true
-				},
-				"wrappy": {
-					"version": "1.0.2",
-					"resolved": "http://localhost:4873/wrappy/-/wrappy-1.0.2.tgz",
-					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-					"optional": true
-				}
-			}
-		},
-		"gulp": {
-			"version": "4.0.2",
-			"resolved": "http://localhost:4873/gulp/-/gulp-4.0.2.tgz",
-			"integrity": "sha512-dvEs27SCZt2ibF29xYgmnwwCYZxdxhQ/+LFWlbAW8y7jt68L/65402Lz3+CKy0Ov4rOs+NERmDq7YlZaDqUIfA==",
-			"dev": true,
-			"requires": {
-				"glob-watcher": "^5.0.3",
-				"gulp-cli": "^2.2.0",
-				"undertaker": "^1.2.1",
-				"vinyl-fs": "^3.0.0"
-			},
-			"dependencies": {
-				"ansi-colors": {
-					"version": "1.1.0",
-					"resolved": "http://localhost:4873/ansi-colors/-/ansi-colors-1.1.0.tgz",
-					"integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
-					"dev": true,
-					"requires": {
-						"ansi-wrap": "^0.1.0"
-					}
-				},
-				"ansi-gray": {
-					"version": "0.1.1",
-					"resolved": "http://localhost:4873/ansi-gray/-/ansi-gray-0.1.1.tgz",
-					"integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
-					"dev": true,
-					"requires": {
-						"ansi-wrap": "0.1.0"
-					}
-				},
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "http://localhost:4873/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
-				},
-				"ansi-wrap": {
-					"version": "0.1.0",
-					"resolved": "http://localhost:4873/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
-					"integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
-					"dev": true
-				},
-				"anymatch": {
-					"version": "2.0.0",
-					"resolved": "http://localhost:4873/anymatch/-/anymatch-2.0.0.tgz",
-					"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
-					"dev": true,
-					"requires": {
-						"micromatch": "^3.1.4",
-						"normalize-path": "^2.1.1"
-					}
-				},
-				"append-buffer": {
-					"version": "1.0.2",
-					"resolved": "http://localhost:4873/append-buffer/-/append-buffer-1.0.2.tgz",
-					"integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
-					"dev": true,
-					"requires": {
-						"buffer-equal": "^1.0.0"
-					}
-				},
-				"archy": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/archy/-/archy-1.0.0.tgz",
-					"integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
-					"dev": true
-				},
-				"arr-diff": {
-					"version": "4.0.0",
-					"resolved": "http://localhost:4873/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-					"dev": true
-				},
-				"arr-filter": {
-					"version": "1.1.2",
-					"resolved": "http://localhost:4873/arr-filter/-/arr-filter-1.1.2.tgz",
-					"integrity": "sha1-Q/3d0JHo7xGqTEXZzcGOLf8XEe4=",
-					"dev": true,
-					"requires": {
-						"make-iterator": "^1.0.0"
-					}
-				},
-				"arr-flatten": {
-					"version": "1.1.0",
-					"resolved": "http://localhost:4873/arr-flatten/-/arr-flatten-1.1.0.tgz",
-					"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-					"dev": true
-				},
-				"arr-map": {
-					"version": "2.0.2",
-					"resolved": "http://localhost:4873/arr-map/-/arr-map-2.0.2.tgz",
-					"integrity": "sha1-Onc0X/wc814qkYJWAfnljy4kysQ=",
-					"dev": true,
-					"requires": {
-						"make-iterator": "^1.0.0"
-					}
-				},
-				"arr-union": {
-					"version": "3.1.0",
-					"resolved": "http://localhost:4873/arr-union/-/arr-union-3.1.0.tgz",
-					"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
-					"dev": true
-				},
-				"array-each": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/array-each/-/array-each-1.0.1.tgz",
-					"integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8=",
-					"dev": true
-				},
-				"array-initial": {
-					"version": "1.1.0",
-					"resolved": "http://localhost:4873/array-initial/-/array-initial-1.1.0.tgz",
-					"integrity": "sha1-L6dLJnOTccOUe9enrcc74zSz15U=",
-					"dev": true,
-					"requires": {
-						"array-slice": "^1.0.0",
-						"is-number": "^4.0.0"
-					},
-					"dependencies": {
-						"is-number": {
-							"version": "4.0.0",
-							"resolved": "http://localhost:4873/is-number/-/is-number-4.0.0.tgz",
-							"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-							"dev": true
-						}
-					}
-				},
-				"array-last": {
-					"version": "1.3.0",
-					"resolved": "http://localhost:4873/array-last/-/array-last-1.3.0.tgz",
-					"integrity": "sha512-eOCut5rXlI6aCOS7Z7kCplKRKyiFQ6dHFBem4PwlwKeNFk2/XxTrhRh5T9PyaEWGy/NHTZWbY+nsZlNFJu9rYg==",
-					"dev": true,
-					"requires": {
-						"is-number": "^4.0.0"
-					},
-					"dependencies": {
-						"is-number": {
-							"version": "4.0.0",
-							"resolved": "http://localhost:4873/is-number/-/is-number-4.0.0.tgz",
-							"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-							"dev": true
-						}
-					}
-				},
-				"array-slice": {
-					"version": "1.1.0",
-					"resolved": "http://localhost:4873/array-slice/-/array-slice-1.1.0.tgz",
-					"integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w==",
-					"dev": true
-				},
-				"array-sort": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/array-sort/-/array-sort-1.0.0.tgz",
-					"integrity": "sha512-ihLeJkonmdiAsD7vpgN3CRcx2J2S0TiYW+IS/5zHBI7mKUq3ySvBdzzBfD236ubDBQFiiyG3SWCPc+msQ9KoYg==",
-					"dev": true,
-					"requires": {
-						"default-compare": "^1.0.0",
-						"get-value": "^2.0.6",
-						"kind-of": "^5.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "5.1.0",
-							"resolved": "http://localhost:4873/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-							"dev": true
-						}
-					}
-				},
-				"array-unique": {
-					"version": "0.3.2",
-					"resolved": "http://localhost:4873/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-					"dev": true
-				},
-				"assign-symbols": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/assign-symbols/-/assign-symbols-1.0.0.tgz",
-					"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
-					"dev": true
-				},
-				"async-done": {
-					"version": "1.3.2",
-					"resolved": "http://localhost:4873/async-done/-/async-done-1.3.2.tgz",
-					"integrity": "sha512-uYkTP8dw2og1tu1nmza1n1CMW0qb8gWWlwqMmLb7MhBVs4BXrFziT6HXUd+/RlRA/i4H9AkofYloUbs1fwMqlw==",
-					"dev": true,
-					"requires": {
-						"end-of-stream": "^1.1.0",
-						"once": "^1.3.2",
-						"process-nextick-args": "^2.0.0",
-						"stream-exhaust": "^1.0.1"
-					}
-				},
-				"async-each": {
-					"version": "1.0.3",
-					"resolved": "http://localhost:4873/async-each/-/async-each-1.0.3.tgz",
-					"integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
-					"dev": true
-				},
-				"async-settle": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/async-settle/-/async-settle-1.0.0.tgz",
-					"integrity": "sha1-HQqRS7Aldb7IqPOnTlCA9yssDGs=",
-					"dev": true,
-					"requires": {
-						"async-done": "^1.2.2"
-					}
-				},
-				"atob": {
-					"version": "2.1.2",
-					"resolved": "http://localhost:4873/atob/-/atob-2.1.2.tgz",
-					"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-					"dev": true
-				},
-				"bach": {
-					"version": "1.2.0",
-					"resolved": "http://localhost:4873/bach/-/bach-1.2.0.tgz",
-					"integrity": "sha1-Szzpa/JxNPeaG0FKUcFONMO9mIA=",
-					"dev": true,
-					"requires": {
-						"arr-filter": "^1.1.1",
-						"arr-flatten": "^1.0.1",
-						"arr-map": "^2.0.0",
-						"array-each": "^1.0.0",
-						"array-initial": "^1.0.0",
-						"array-last": "^1.1.1",
-						"async-done": "^1.2.2",
-						"async-settle": "^1.0.0",
-						"now-and-later": "^2.0.0"
-					}
-				},
-				"balanced-match": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/balanced-match/-/balanced-match-1.0.0.tgz",
-					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-					"dev": true
-				},
-				"base": {
-					"version": "0.11.2",
-					"resolved": "http://localhost:4873/base/-/base-0.11.2.tgz",
-					"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
-					"dev": true,
-					"requires": {
-						"cache-base": "^1.0.1",
-						"class-utils": "^0.3.5",
-						"component-emitter": "^1.2.1",
-						"define-property": "^1.0.0",
-						"isobject": "^3.0.1",
-						"mixin-deep": "^1.2.0",
-						"pascalcase": "^0.1.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "1.0.0",
-							"resolved": "http://localhost:4873/define-property/-/define-property-1.0.0.tgz",
-							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-							"dev": true,
-							"requires": {
-								"is-descriptor": "^1.0.0"
-							}
-						},
-						"is-accessor-descriptor": {
-							"version": "1.0.0",
-							"resolved": "http://localhost:4873/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-							"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-							"dev": true,
-							"requires": {
-								"kind-of": "^6.0.0"
-							}
-						},
-						"is-data-descriptor": {
-							"version": "1.0.0",
-							"resolved": "http://localhost:4873/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-							"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-							"dev": true,
-							"requires": {
-								"kind-of": "^6.0.0"
-							}
-						},
-						"is-descriptor": {
-							"version": "1.0.2",
-							"resolved": "http://localhost:4873/is-descriptor/-/is-descriptor-1.0.2.tgz",
-							"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-							"dev": true,
-							"requires": {
-								"is-accessor-descriptor": "^1.0.0",
-								"is-data-descriptor": "^1.0.0",
-								"kind-of": "^6.0.2"
-							}
-						}
-					}
-				},
-				"binary-extensions": {
-					"version": "1.13.1",
-					"resolved": "http://localhost:4873/binary-extensions/-/binary-extensions-1.13.1.tgz",
-					"integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
-					"dev": true
-				},
-				"brace-expansion": {
-					"version": "1.1.11",
-					"resolved": "http://localhost:4873/brace-expansion/-/brace-expansion-1.1.11.tgz",
-					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-					"dev": true,
-					"requires": {
-						"balanced-match": "^1.0.0",
-						"concat-map": "0.0.1"
-					}
-				},
-				"braces": {
-					"version": "2.3.2",
-					"resolved": "http://localhost:4873/braces/-/braces-2.3.2.tgz",
-					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-					"dev": true,
-					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "http://localhost:4873/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"buffer-equal": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/buffer-equal/-/buffer-equal-1.0.0.tgz",
-					"integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74=",
-					"dev": true
-				},
-				"buffer-from": {
-					"version": "1.1.1",
-					"resolved": "http://localhost:4873/buffer-from/-/buffer-from-1.1.1.tgz",
-					"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-					"dev": true
-				},
-				"cache-base": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/cache-base/-/cache-base-1.0.1.tgz",
-					"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
-					"dev": true,
-					"requires": {
-						"collection-visit": "^1.0.0",
-						"component-emitter": "^1.2.1",
-						"get-value": "^2.0.6",
-						"has-value": "^1.0.0",
-						"isobject": "^3.0.1",
-						"set-value": "^2.0.0",
-						"to-object-path": "^0.3.0",
-						"union-value": "^1.0.0",
-						"unset-value": "^1.0.0"
-					}
-				},
-				"camelcase": {
-					"version": "3.0.0",
-					"resolved": "http://localhost:4873/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-					"dev": true
-				},
-				"chokidar": {
-					"version": "2.1.6",
-					"resolved": "http://localhost:4873/chokidar/-/chokidar-2.1.6.tgz",
-					"integrity": "sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==",
-					"dev": true,
-					"requires": {
-						"anymatch": "^2.0.0",
-						"async-each": "^1.0.1",
-						"braces": "^2.3.2",
-						"fsevents": "^1.2.7",
-						"glob-parent": "^3.1.0",
-						"inherits": "^2.0.3",
-						"is-binary-path": "^1.0.0",
-						"is-glob": "^4.0.0",
-						"normalize-path": "^3.0.0",
-						"path-is-absolute": "^1.0.0",
-						"readdirp": "^2.2.1",
-						"upath": "^1.1.1"
-					},
-					"dependencies": {
-						"normalize-path": {
-							"version": "3.0.0",
-							"resolved": "http://localhost:4873/normalize-path/-/normalize-path-3.0.0.tgz",
-							"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-							"dev": true
-						}
-					}
-				},
-				"class-utils": {
-					"version": "0.3.6",
-					"resolved": "http://localhost:4873/class-utils/-/class-utils-0.3.6.tgz",
-					"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
-					"dev": true,
-					"requires": {
-						"arr-union": "^3.1.0",
-						"define-property": "^0.2.5",
-						"isobject": "^3.0.0",
-						"static-extend": "^0.1.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "0.2.5",
-							"resolved": "http://localhost:4873/define-property/-/define-property-0.2.5.tgz",
-							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-							"dev": true,
-							"requires": {
-								"is-descriptor": "^0.1.0"
-							}
-						}
-					}
-				},
-				"cliui": {
-					"version": "3.2.0",
-					"resolved": "http://localhost:4873/cliui/-/cliui-3.2.0.tgz",
-					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-					"dev": true,
-					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wrap-ansi": "^2.0.0"
-					}
-				},
-				"clone": {
-					"version": "2.1.2",
-					"resolved": "http://localhost:4873/clone/-/clone-2.1.2.tgz",
-					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
-					"dev": true
-				},
-				"clone-buffer": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/clone-buffer/-/clone-buffer-1.0.0.tgz",
-					"integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
-					"dev": true
-				},
-				"clone-stats": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/clone-stats/-/clone-stats-1.0.0.tgz",
-					"integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
-					"dev": true
-				},
-				"cloneable-readable": {
-					"version": "1.1.3",
-					"resolved": "http://localhost:4873/cloneable-readable/-/cloneable-readable-1.1.3.tgz",
-					"integrity": "sha512-2EF8zTQOxYq70Y4XKtorQupqF0m49MBz2/yf5Bj+MHjvpG3Hy7sImifnqD6UA+TKYxeSV+u6qqQPawN5UvnpKQ==",
-					"dev": true,
-					"requires": {
-						"inherits": "^2.0.1",
-						"process-nextick-args": "^2.0.0",
-						"readable-stream": "^2.3.5"
-					}
-				},
-				"code-point-at": {
-					"version": "1.1.0",
-					"resolved": "http://localhost:4873/code-point-at/-/code-point-at-1.1.0.tgz",
-					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-					"dev": true
-				},
-				"collection-map": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/collection-map/-/collection-map-1.0.0.tgz",
-					"integrity": "sha1-rqDwb40mx4DCt1SUOFVEsiVa8Yw=",
-					"dev": true,
-					"requires": {
-						"arr-map": "^2.0.2",
-						"for-own": "^1.0.0",
-						"make-iterator": "^1.0.0"
-					}
-				},
-				"collection-visit": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/collection-visit/-/collection-visit-1.0.0.tgz",
-					"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
-					"dev": true,
-					"requires": {
-						"map-visit": "^1.0.0",
-						"object-visit": "^1.0.0"
-					}
-				},
-				"color-support": {
-					"version": "1.1.3",
-					"resolved": "http://localhost:4873/color-support/-/color-support-1.1.3.tgz",
-					"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-					"dev": true
-				},
-				"component-emitter": {
-					"version": "1.3.0",
-					"resolved": "http://localhost:4873/component-emitter/-/component-emitter-1.3.0.tgz",
-					"integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
-					"dev": true
-				},
-				"concat-map": {
-					"version": "0.0.1",
-					"resolved": "http://localhost:4873/concat-map/-/concat-map-0.0.1.tgz",
-					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-					"dev": true
-				},
-				"concat-stream": {
-					"version": "1.6.2",
-					"resolved": "http://localhost:4873/concat-stream/-/concat-stream-1.6.2.tgz",
-					"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-					"dev": true,
-					"requires": {
-						"buffer-from": "^1.0.0",
-						"inherits": "^2.0.3",
-						"readable-stream": "^2.2.2",
-						"typedarray": "^0.0.6"
-					}
-				},
-				"convert-source-map": {
-					"version": "1.6.0",
-					"resolved": "http://localhost:4873/convert-source-map/-/convert-source-map-1.6.0.tgz",
-					"integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.1"
-					}
-				},
-				"copy-descriptor": {
-					"version": "0.1.1",
-					"resolved": "http://localhost:4873/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-					"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
-					"dev": true
-				},
-				"copy-props": {
-					"version": "2.0.4",
-					"resolved": "http://localhost:4873/copy-props/-/copy-props-2.0.4.tgz",
-					"integrity": "sha512-7cjuUME+p+S3HZlbllgsn2CDwS+5eCCX16qBgNC4jgSTf49qR1VKy/Zhl400m0IQXl/bPGEVqncgUUMjrr4s8A==",
-					"dev": true,
-					"requires": {
-						"each-props": "^1.3.0",
-						"is-plain-object": "^2.0.1"
-					}
-				},
-				"core-util-is": {
-					"version": "1.0.2",
-					"resolved": "http://localhost:4873/core-util-is/-/core-util-is-1.0.2.tgz",
-					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-					"dev": true
-				},
-				"d": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/d/-/d-1.0.1.tgz",
-					"integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-					"dev": true,
-					"requires": {
-						"es5-ext": "^0.10.50",
-						"type": "^1.0.1"
-					}
-				},
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "http://localhost:4873/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"decamelize": {
-					"version": "1.2.0",
-					"resolved": "http://localhost:4873/decamelize/-/decamelize-1.2.0.tgz",
-					"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-					"dev": true
-				},
-				"decode-uri-component": {
-					"version": "0.2.0",
-					"resolved": "http://localhost:4873/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-					"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-					"dev": true
-				},
-				"default-compare": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/default-compare/-/default-compare-1.0.0.tgz",
-					"integrity": "sha512-QWfXlM0EkAbqOCbD/6HjdwT19j7WCkMyiRhWilc4H9/5h/RzTF9gv5LYh1+CmDV5d1rki6KAWLtQale0xt20eQ==",
-					"dev": true,
-					"requires": {
-						"kind-of": "^5.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "5.1.0",
-							"resolved": "http://localhost:4873/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-							"dev": true
-						}
-					}
-				},
-				"default-resolution": {
-					"version": "2.0.0",
-					"resolved": "http://localhost:4873/default-resolution/-/default-resolution-2.0.0.tgz",
-					"integrity": "sha1-vLgrqnKtebQmp2cy8aga1t8m1oQ=",
-					"dev": true
-				},
-				"define-properties": {
-					"version": "1.1.3",
-					"resolved": "http://localhost:4873/define-properties/-/define-properties-1.1.3.tgz",
-					"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-					"dev": true,
-					"requires": {
-						"object-keys": "^1.0.12"
-					}
-				},
-				"define-property": {
-					"version": "2.0.2",
-					"resolved": "http://localhost:4873/define-property/-/define-property-2.0.2.tgz",
-					"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
-					"dev": true,
-					"requires": {
-						"is-descriptor": "^1.0.2",
-						"isobject": "^3.0.1"
-					},
-					"dependencies": {
-						"is-accessor-descriptor": {
-							"version": "1.0.0",
-							"resolved": "http://localhost:4873/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-							"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-							"dev": true,
-							"requires": {
-								"kind-of": "^6.0.0"
-							}
-						},
-						"is-data-descriptor": {
-							"version": "1.0.0",
-							"resolved": "http://localhost:4873/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-							"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-							"dev": true,
-							"requires": {
-								"kind-of": "^6.0.0"
-							}
-						},
-						"is-descriptor": {
-							"version": "1.0.2",
-							"resolved": "http://localhost:4873/is-descriptor/-/is-descriptor-1.0.2.tgz",
-							"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-							"dev": true,
-							"requires": {
-								"is-accessor-descriptor": "^1.0.0",
-								"is-data-descriptor": "^1.0.0",
-								"kind-of": "^6.0.2"
-							}
-						}
-					}
-				},
-				"detect-file": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/detect-file/-/detect-file-1.0.0.tgz",
-					"integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
-					"dev": true
-				},
-				"duplexify": {
-					"version": "3.7.1",
-					"resolved": "http://localhost:4873/duplexify/-/duplexify-3.7.1.tgz",
-					"integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
-					"dev": true,
-					"requires": {
-						"end-of-stream": "^1.0.0",
-						"inherits": "^2.0.1",
-						"readable-stream": "^2.0.0",
-						"stream-shift": "^1.0.0"
-					}
-				},
-				"each-props": {
-					"version": "1.3.2",
-					"resolved": "http://localhost:4873/each-props/-/each-props-1.3.2.tgz",
-					"integrity": "sha512-vV0Hem3zAGkJAyU7JSjixeU66rwdynTAa1vofCrSA5fEln+m67Az9CcnkVD776/fsN/UjIWmBDoNRS6t6G9RfA==",
-					"dev": true,
-					"requires": {
-						"is-plain-object": "^2.0.1",
-						"object.defaults": "^1.1.0"
-					}
-				},
-				"end-of-stream": {
-					"version": "1.4.1",
-					"resolved": "http://localhost:4873/end-of-stream/-/end-of-stream-1.4.1.tgz",
-					"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-					"dev": true,
-					"requires": {
-						"once": "^1.4.0"
-					}
-				},
-				"error-ex": {
-					"version": "1.3.2",
-					"resolved": "http://localhost:4873/error-ex/-/error-ex-1.3.2.tgz",
-					"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-					"dev": true,
-					"requires": {
-						"is-arrayish": "^0.2.1"
-					}
-				},
-				"es5-ext": {
-					"version": "0.10.50",
-					"resolved": "http://localhost:4873/es5-ext/-/es5-ext-0.10.50.tgz",
-					"integrity": "sha512-KMzZTPBkeQV/JcSQhI5/z6d9VWJ3EnQ194USTUwIYZ2ZbpN8+SGXQKt1h68EX44+qt+Fzr8DO17vnxrw7c3agw==",
-					"dev": true,
-					"requires": {
-						"es6-iterator": "~2.0.3",
-						"es6-symbol": "~3.1.1",
-						"next-tick": "^1.0.0"
-					}
-				},
-				"es6-iterator": {
-					"version": "2.0.3",
-					"resolved": "http://localhost:4873/es6-iterator/-/es6-iterator-2.0.3.tgz",
-					"integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-					"dev": true,
-					"requires": {
-						"d": "1",
-						"es5-ext": "^0.10.35",
-						"es6-symbol": "^3.1.1"
-					}
-				},
-				"es6-symbol": {
-					"version": "3.1.1",
-					"resolved": "http://localhost:4873/es6-symbol/-/es6-symbol-3.1.1.tgz",
-					"integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-					"dev": true,
-					"requires": {
-						"d": "1",
-						"es5-ext": "~0.10.14"
-					}
-				},
-				"es6-weak-map": {
-					"version": "2.0.3",
-					"resolved": "http://localhost:4873/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
-					"integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
-					"dev": true,
-					"requires": {
-						"d": "1",
-						"es5-ext": "^0.10.46",
-						"es6-iterator": "^2.0.3",
-						"es6-symbol": "^3.1.1"
-					}
-				},
-				"expand-brackets": {
-					"version": "2.1.4",
-					"resolved": "http://localhost:4873/expand-brackets/-/expand-brackets-2.1.4.tgz",
-					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-					"dev": true,
-					"requires": {
-						"debug": "^2.3.3",
-						"define-property": "^0.2.5",
-						"extend-shallow": "^2.0.1",
-						"posix-character-classes": "^0.1.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "0.2.5",
-							"resolved": "http://localhost:4873/define-property/-/define-property-0.2.5.tgz",
-							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-							"dev": true,
-							"requires": {
-								"is-descriptor": "^0.1.0"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "http://localhost:4873/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"expand-tilde": {
-					"version": "2.0.2",
-					"resolved": "http://localhost:4873/expand-tilde/-/expand-tilde-2.0.2.tgz",
-					"integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
-					"dev": true,
-					"requires": {
-						"homedir-polyfill": "^1.0.1"
-					}
-				},
-				"extend": {
-					"version": "3.0.2",
-					"resolved": "http://localhost:4873/extend/-/extend-3.0.2.tgz",
-					"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-					"dev": true
-				},
-				"extend-shallow": {
-					"version": "3.0.2",
-					"resolved": "http://localhost:4873/extend-shallow/-/extend-shallow-3.0.2.tgz",
-					"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-					"dev": true,
-					"requires": {
-						"assign-symbols": "^1.0.0",
-						"is-extendable": "^1.0.1"
-					},
-					"dependencies": {
-						"is-extendable": {
-							"version": "1.0.1",
-							"resolved": "http://localhost:4873/is-extendable/-/is-extendable-1.0.1.tgz",
-							"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-							"dev": true,
-							"requires": {
-								"is-plain-object": "^2.0.4"
-							}
-						}
-					}
-				},
-				"extglob": {
-					"version": "2.0.4",
-					"resolved": "http://localhost:4873/extglob/-/extglob-2.0.4.tgz",
-					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-					"dev": true,
-					"requires": {
-						"array-unique": "^0.3.2",
-						"define-property": "^1.0.0",
-						"expand-brackets": "^2.1.4",
-						"extend-shallow": "^2.0.1",
-						"fragment-cache": "^0.2.1",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "1.0.0",
-							"resolved": "http://localhost:4873/define-property/-/define-property-1.0.0.tgz",
-							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-							"dev": true,
-							"requires": {
-								"is-descriptor": "^1.0.0"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "http://localhost:4873/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						},
-						"is-accessor-descriptor": {
-							"version": "1.0.0",
-							"resolved": "http://localhost:4873/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-							"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-							"dev": true,
-							"requires": {
-								"kind-of": "^6.0.0"
-							}
-						},
-						"is-data-descriptor": {
-							"version": "1.0.0",
-							"resolved": "http://localhost:4873/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-							"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-							"dev": true,
-							"requires": {
-								"kind-of": "^6.0.0"
-							}
-						},
-						"is-descriptor": {
-							"version": "1.0.2",
-							"resolved": "http://localhost:4873/is-descriptor/-/is-descriptor-1.0.2.tgz",
-							"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-							"dev": true,
-							"requires": {
-								"is-accessor-descriptor": "^1.0.0",
-								"is-data-descriptor": "^1.0.0",
-								"kind-of": "^6.0.2"
-							}
-						}
-					}
-				},
-				"fancy-log": {
-					"version": "1.3.3",
-					"resolved": "http://localhost:4873/fancy-log/-/fancy-log-1.3.3.tgz",
-					"integrity": "sha512-k9oEhlyc0FrVh25qYuSELjr8oxsCoc4/LEZfg2iJJrfEk/tZL9bCoJE47gqAvI2m/AUjluCS4+3I0eTx8n3AEw==",
-					"dev": true,
-					"requires": {
-						"ansi-gray": "^0.1.1",
-						"color-support": "^1.1.3",
-						"parse-node-version": "^1.0.0",
-						"time-stamp": "^1.0.0"
-					}
-				},
-				"fill-range": {
-					"version": "4.0.0",
-					"resolved": "http://localhost:4873/fill-range/-/fill-range-4.0.0.tgz",
-					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-					"dev": true,
-					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "http://localhost:4873/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"find-up": {
-					"version": "1.1.2",
-					"resolved": "http://localhost:4873/find-up/-/find-up-1.1.2.tgz",
-					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-					"dev": true,
-					"requires": {
-						"path-exists": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"findup-sync": {
-					"version": "3.0.0",
-					"resolved": "http://localhost:4873/findup-sync/-/findup-sync-3.0.0.tgz",
-					"integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
-					"dev": true,
-					"requires": {
-						"detect-file": "^1.0.0",
-						"is-glob": "^4.0.0",
-						"micromatch": "^3.0.4",
-						"resolve-dir": "^1.0.1"
-					}
-				},
-				"fined": {
-					"version": "1.2.0",
-					"resolved": "http://localhost:4873/fined/-/fined-1.2.0.tgz",
-					"integrity": "sha512-ZYDqPLGxDkDhDZBjZBb+oD1+j0rA4E0pXY50eplAAOPg2N/gUBSSk5IM1/QhPfyVo19lJ+CvXpqfvk+b2p/8Ng==",
-					"dev": true,
-					"requires": {
-						"expand-tilde": "^2.0.2",
-						"is-plain-object": "^2.0.3",
-						"object.defaults": "^1.1.0",
-						"object.pick": "^1.2.0",
-						"parse-filepath": "^1.0.1"
-					}
-				},
-				"flagged-respawn": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
-					"integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q==",
-					"dev": true
-				},
-				"flush-write-stream": {
-					"version": "1.1.1",
-					"resolved": "http://localhost:4873/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
-					"integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
-					"dev": true,
-					"requires": {
-						"inherits": "^2.0.3",
-						"readable-stream": "^2.3.6"
-					}
-				},
-				"for-in": {
-					"version": "1.0.2",
-					"resolved": "http://localhost:4873/for-in/-/for-in-1.0.2.tgz",
-					"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-					"dev": true
-				},
-				"for-own": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/for-own/-/for-own-1.0.0.tgz",
-					"integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
-					"dev": true,
-					"requires": {
-						"for-in": "^1.0.1"
-					}
-				},
-				"fragment-cache": {
-					"version": "0.2.1",
-					"resolved": "http://localhost:4873/fragment-cache/-/fragment-cache-0.2.1.tgz",
-					"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
-					"dev": true,
-					"requires": {
-						"map-cache": "^0.2.2"
-					}
-				},
-				"fs-mkdirp-stream": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz",
-					"integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.11",
-						"through2": "^2.0.3"
-					}
-				},
-				"fs.realpath": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/fs.realpath/-/fs.realpath-1.0.0.tgz",
-					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-					"dev": true
-				},
-				"fsevents": {
-					"version": "1.2.9",
-					"resolved": "http://localhost:4873/fsevents/-/fsevents-1.2.9.tgz",
-					"integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"nan": "^2.12.1",
-						"node-pre-gyp": "^0.12.0"
-					},
-					"dependencies": {
-						"abbrev": {
-							"version": "1.1.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"ansi-regex": {
-							"version": "2.1.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"aproba": {
-							"version": "1.2.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"are-we-there-yet": {
-							"version": "1.1.5",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"delegates": "^1.0.0",
-								"readable-stream": "^2.0.6"
-							}
-						},
-						"balanced-match": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"brace-expansion": {
-							"version": "1.1.11",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"balanced-match": "^1.0.0",
-								"concat-map": "0.0.1"
-							}
-						},
-						"chownr": {
-							"version": "1.1.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"code-point-at": {
-							"version": "1.1.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"concat-map": {
-							"version": "0.0.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"console-control-strings": {
-							"version": "1.1.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"core-util-is": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"debug": {
-							"version": "4.1.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"ms": "^2.1.1"
-							}
-						},
-						"deep-extend": {
-							"version": "0.6.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"delegates": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"detect-libc": {
-							"version": "1.0.3",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"fs-minipass": {
-							"version": "1.2.5",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"minipass": "^2.2.1"
-							}
-						},
-						"fs.realpath": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"gauge": {
-							"version": "2.7.4",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"aproba": "^1.0.3",
-								"console-control-strings": "^1.0.0",
-								"has-unicode": "^2.0.0",
-								"object-assign": "^4.1.0",
-								"signal-exit": "^3.0.0",
-								"string-width": "^1.0.1",
-								"strip-ansi": "^3.0.1",
-								"wide-align": "^1.1.0"
-							}
-						},
-						"glob": {
-							"version": "7.1.3",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"fs.realpath": "^1.0.0",
-								"inflight": "^1.0.4",
-								"inherits": "2",
-								"minimatch": "^3.0.4",
-								"once": "^1.3.0",
-								"path-is-absolute": "^1.0.0"
-							}
-						},
-						"has-unicode": {
-							"version": "2.0.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"iconv-lite": {
-							"version": "0.4.24",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"safer-buffer": ">= 2.1.2 < 3"
-							}
-						},
-						"ignore-walk": {
-							"version": "3.0.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"minimatch": "^3.0.4"
-							}
-						},
-						"inflight": {
-							"version": "1.0.6",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"once": "^1.3.0",
-								"wrappy": "1"
-							}
-						},
-						"inherits": {
-							"version": "2.0.3",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"ini": {
-							"version": "1.3.5",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"is-fullwidth-code-point": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"number-is-nan": "^1.0.0"
-							}
-						},
-						"isarray": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"minimatch": {
-							"version": "3.0.4",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"brace-expansion": "^1.1.7"
-							}
-						},
-						"minimist": {
-							"version": "0.0.8",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"minipass": {
-							"version": "2.3.5",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"safe-buffer": "^5.1.2",
-								"yallist": "^3.0.0"
-							}
-						},
-						"minizlib": {
-							"version": "1.2.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"minipass": "^2.2.1"
-							}
-						},
-						"mkdirp": {
-							"version": "0.5.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"minimist": "0.0.8"
-							}
-						},
-						"ms": {
-							"version": "2.1.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"needle": {
-							"version": "2.3.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"debug": "^4.1.0",
-								"iconv-lite": "^0.4.4",
-								"sax": "^1.2.4"
-							}
-						},
-						"node-pre-gyp": {
-							"version": "0.12.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"detect-libc": "^1.0.2",
-								"mkdirp": "^0.5.1",
-								"needle": "^2.2.1",
-								"nopt": "^4.0.1",
-								"npm-packlist": "^1.1.6",
-								"npmlog": "^4.0.2",
-								"rc": "^1.2.7",
-								"rimraf": "^2.6.1",
-								"semver": "^5.3.0",
-								"tar": "^4"
-							}
-						},
-						"nopt": {
-							"version": "4.0.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"abbrev": "1",
-								"osenv": "^0.1.4"
-							}
-						},
-						"npm-bundled": {
-							"version": "1.0.6",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"npm-packlist": {
-							"version": "1.4.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"ignore-walk": "^3.0.1",
-								"npm-bundled": "^1.0.1"
-							}
-						},
-						"npmlog": {
-							"version": "4.1.2",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"are-we-there-yet": "~1.1.2",
-								"console-control-strings": "~1.1.0",
-								"gauge": "~2.7.3",
-								"set-blocking": "~2.0.0"
-							}
-						},
-						"number-is-nan": {
-							"version": "1.0.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"object-assign": {
-							"version": "4.1.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"once": {
-							"version": "1.4.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"wrappy": "1"
-							}
-						},
-						"os-homedir": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"os-tmpdir": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"osenv": {
-							"version": "0.1.5",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"os-homedir": "^1.0.0",
-								"os-tmpdir": "^1.0.0"
-							}
-						},
-						"path-is-absolute": {
-							"version": "1.0.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"process-nextick-args": {
-							"version": "2.0.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"rc": {
-							"version": "1.2.8",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"deep-extend": "^0.6.0",
-								"ini": "~1.3.0",
-								"minimist": "^1.2.0",
-								"strip-json-comments": "~2.0.1"
-							},
-							"dependencies": {
-								"minimist": {
-									"version": "1.2.0",
-									"bundled": true,
-									"dev": true,
-									"optional": true
-								}
-							}
-						},
-						"readable-stream": {
-							"version": "2.3.6",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"core-util-is": "~1.0.0",
-								"inherits": "~2.0.3",
-								"isarray": "~1.0.0",
-								"process-nextick-args": "~2.0.0",
-								"safe-buffer": "~5.1.1",
-								"string_decoder": "~1.1.1",
-								"util-deprecate": "~1.0.1"
-							}
-						},
-						"rimraf": {
-							"version": "2.6.3",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"glob": "^7.1.3"
-							}
-						},
-						"safe-buffer": {
-							"version": "5.1.2",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"safer-buffer": {
-							"version": "2.1.2",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"sax": {
-							"version": "1.2.4",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"semver": {
-							"version": "5.7.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"set-blocking": {
-							"version": "2.0.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"signal-exit": {
-							"version": "3.0.2",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"string-width": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"code-point-at": "^1.0.0",
-								"is-fullwidth-code-point": "^1.0.0",
-								"strip-ansi": "^3.0.0"
-							}
-						},
-						"string_decoder": {
-							"version": "1.1.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"safe-buffer": "~5.1.0"
-							}
-						},
-						"strip-ansi": {
-							"version": "3.0.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"ansi-regex": "^2.0.0"
-							}
-						},
-						"strip-json-comments": {
-							"version": "2.0.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"tar": {
-							"version": "4.4.8",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"chownr": "^1.1.1",
-								"fs-minipass": "^1.2.5",
-								"minipass": "^2.3.4",
-								"minizlib": "^1.1.1",
-								"mkdirp": "^0.5.0",
-								"safe-buffer": "^5.1.2",
-								"yallist": "^3.0.2"
-							}
-						},
-						"util-deprecate": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"wide-align": {
-							"version": "1.1.3",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"string-width": "^1.0.2 || 2"
-							}
-						},
-						"wrappy": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"yallist": {
-							"version": "3.0.3",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						}
-					}
-				},
-				"function-bind": {
-					"version": "1.1.1",
-					"resolved": "http://localhost:4873/function-bind/-/function-bind-1.1.1.tgz",
-					"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-					"dev": true
-				},
-				"get-caller-file": {
-					"version": "1.0.3",
-					"resolved": "http://localhost:4873/get-caller-file/-/get-caller-file-1.0.3.tgz",
-					"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
-					"dev": true
-				},
-				"get-value": {
-					"version": "2.0.6",
-					"resolved": "http://localhost:4873/get-value/-/get-value-2.0.6.tgz",
-					"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
-					"dev": true
-				},
-				"glob": {
-					"version": "7.1.4",
-					"resolved": "http://localhost:4873/glob/-/glob-7.1.4.tgz",
-					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-					"dev": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"glob-parent": {
-					"version": "3.1.0",
-					"resolved": "http://localhost:4873/glob-parent/-/glob-parent-3.1.0.tgz",
-					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-					"dev": true,
-					"requires": {
-						"is-glob": "^3.1.0",
-						"path-dirname": "^1.0.0"
-					},
-					"dependencies": {
-						"is-glob": {
-							"version": "3.1.0",
-							"resolved": "http://localhost:4873/is-glob/-/is-glob-3.1.0.tgz",
-							"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-							"dev": true,
-							"requires": {
-								"is-extglob": "^2.1.0"
-							}
-						}
-					}
-				},
-				"glob-stream": {
-					"version": "6.1.0",
-					"resolved": "http://localhost:4873/glob-stream/-/glob-stream-6.1.0.tgz",
-					"integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
-					"dev": true,
-					"requires": {
-						"extend": "^3.0.0",
-						"glob": "^7.1.1",
-						"glob-parent": "^3.1.0",
-						"is-negated-glob": "^1.0.0",
-						"ordered-read-streams": "^1.0.0",
-						"pumpify": "^1.3.5",
-						"readable-stream": "^2.1.5",
-						"remove-trailing-separator": "^1.0.1",
-						"to-absolute-glob": "^2.0.0",
-						"unique-stream": "^2.0.2"
-					}
-				},
-				"glob-watcher": {
-					"version": "5.0.3",
-					"resolved": "http://localhost:4873/glob-watcher/-/glob-watcher-5.0.3.tgz",
-					"integrity": "sha512-8tWsULNEPHKQ2MR4zXuzSmqbdyV5PtwwCaWSGQ1WwHsJ07ilNeN1JB8ntxhckbnpSHaf9dXFUHzIWvm1I13dsg==",
-					"dev": true,
-					"requires": {
-						"anymatch": "^2.0.0",
-						"async-done": "^1.2.0",
-						"chokidar": "^2.0.0",
-						"is-negated-glob": "^1.0.0",
-						"just-debounce": "^1.0.0",
-						"object.defaults": "^1.1.0"
-					}
-				},
-				"global-modules": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/global-modules/-/global-modules-1.0.0.tgz",
-					"integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
-					"dev": true,
-					"requires": {
-						"global-prefix": "^1.0.1",
-						"is-windows": "^1.0.1",
-						"resolve-dir": "^1.0.0"
-					}
-				},
-				"global-prefix": {
-					"version": "1.0.2",
-					"resolved": "http://localhost:4873/global-prefix/-/global-prefix-1.0.2.tgz",
-					"integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
-					"dev": true,
-					"requires": {
-						"expand-tilde": "^2.0.2",
-						"homedir-polyfill": "^1.0.1",
-						"ini": "^1.3.4",
-						"is-windows": "^1.0.1",
-						"which": "^1.2.14"
-					}
-				},
-				"glogg": {
-					"version": "1.0.2",
-					"resolved": "http://localhost:4873/glogg/-/glogg-1.0.2.tgz",
-					"integrity": "sha512-5mwUoSuBk44Y4EshyiqcH95ZntbDdTQqA3QYSrxmzj28Ai0vXBGMH1ApSANH14j2sIRtqCEyg6PfsuP7ElOEDA==",
-					"dev": true,
-					"requires": {
-						"sparkles": "^1.0.0"
-					}
-				},
-				"graceful-fs": {
-					"version": "4.2.0",
-					"resolved": "http://localhost:4873/graceful-fs/-/graceful-fs-4.2.0.tgz",
-					"integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
-					"dev": true
-				},
-				"gulp-cli": {
-					"version": "2.2.0",
-					"resolved": "http://localhost:4873/gulp-cli/-/gulp-cli-2.2.0.tgz",
-					"integrity": "sha512-rGs3bVYHdyJpLqR0TUBnlcZ1O5O++Zs4bA0ajm+zr3WFCfiSLjGwoCBqFs18wzN+ZxahT9DkOK5nDf26iDsWjA==",
-					"dev": true,
-					"requires": {
-						"ansi-colors": "^1.0.1",
-						"archy": "^1.0.0",
-						"array-sort": "^1.0.0",
-						"color-support": "^1.1.3",
-						"concat-stream": "^1.6.0",
-						"copy-props": "^2.0.1",
-						"fancy-log": "^1.3.2",
-						"gulplog": "^1.0.0",
-						"interpret": "^1.1.0",
-						"isobject": "^3.0.1",
-						"liftoff": "^3.1.0",
-						"matchdep": "^2.0.0",
-						"mute-stdout": "^1.0.0",
-						"pretty-hrtime": "^1.0.0",
-						"replace-homedir": "^1.0.0",
-						"semver-greatest-satisfied-range": "^1.1.0",
-						"v8flags": "^3.0.1",
-						"yargs": "^7.1.0"
-					}
-				},
-				"gulplog": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/gulplog/-/gulplog-1.0.0.tgz",
-					"integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
-					"dev": true,
-					"requires": {
-						"glogg": "^1.0.0"
-					}
-				},
-				"has-symbols": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/has-symbols/-/has-symbols-1.0.0.tgz",
-					"integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
-					"dev": true
-				},
-				"has-value": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/has-value/-/has-value-1.0.0.tgz",
-					"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
-					"dev": true,
-					"requires": {
-						"get-value": "^2.0.6",
-						"has-values": "^1.0.0",
-						"isobject": "^3.0.0"
-					}
-				},
-				"has-values": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/has-values/-/has-values-1.0.0.tgz",
-					"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
-					"dev": true,
-					"requires": {
-						"is-number": "^3.0.0",
-						"kind-of": "^4.0.0"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "4.0.0",
-							"resolved": "http://localhost:4873/kind-of/-/kind-of-4.0.0.tgz",
-							"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-							"dev": true,
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
-				},
-				"homedir-polyfill": {
-					"version": "1.0.3",
-					"resolved": "http://localhost:4873/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
-					"integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
-					"dev": true,
-					"requires": {
-						"parse-passwd": "^1.0.0"
-					}
-				},
-				"hosted-git-info": {
-					"version": "2.7.1",
-					"resolved": "http://localhost:4873/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-					"integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
-					"dev": true
-				},
-				"inflight": {
-					"version": "1.0.6",
-					"resolved": "http://localhost:4873/inflight/-/inflight-1.0.6.tgz",
-					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-					"dev": true,
-					"requires": {
-						"once": "^1.3.0",
-						"wrappy": "1"
-					}
-				},
-				"inherits": {
-					"version": "2.0.4",
-					"resolved": "http://localhost:4873/inherits/-/inherits-2.0.4.tgz",
-					"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-					"dev": true
-				},
-				"ini": {
-					"version": "1.3.5",
-					"resolved": "http://localhost:4873/ini/-/ini-1.3.5.tgz",
-					"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-					"dev": true
-				},
-				"interpret": {
-					"version": "1.2.0",
-					"resolved": "http://localhost:4873/interpret/-/interpret-1.2.0.tgz",
-					"integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
-					"dev": true
-				},
-				"invert-kv": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/invert-kv/-/invert-kv-1.0.0.tgz",
-					"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-					"dev": true
-				},
-				"is-absolute": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/is-absolute/-/is-absolute-1.0.0.tgz",
-					"integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
-					"dev": true,
-					"requires": {
-						"is-relative": "^1.0.0",
-						"is-windows": "^1.0.1"
-					}
-				},
-				"is-accessor-descriptor": {
-					"version": "0.1.6",
-					"resolved": "http://localhost:4873/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-					"dev": true,
-					"requires": {
-						"kind-of": "^3.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "http://localhost:4873/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
-				},
-				"is-arrayish": {
-					"version": "0.2.1",
-					"resolved": "http://localhost:4873/is-arrayish/-/is-arrayish-0.2.1.tgz",
-					"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-					"dev": true
-				},
-				"is-binary-path": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/is-binary-path/-/is-binary-path-1.0.1.tgz",
-					"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-					"dev": true,
-					"requires": {
-						"binary-extensions": "^1.0.0"
-					}
-				},
-				"is-buffer": {
-					"version": "1.1.6",
-					"resolved": "http://localhost:4873/is-buffer/-/is-buffer-1.1.6.tgz",
-					"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-					"dev": true
-				},
-				"is-data-descriptor": {
-					"version": "0.1.4",
-					"resolved": "http://localhost:4873/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-					"dev": true,
-					"requires": {
-						"kind-of": "^3.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "http://localhost:4873/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
-				},
-				"is-descriptor": {
-					"version": "0.1.6",
-					"resolved": "http://localhost:4873/is-descriptor/-/is-descriptor-0.1.6.tgz",
-					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-					"dev": true,
-					"requires": {
-						"is-accessor-descriptor": "^0.1.6",
-						"is-data-descriptor": "^0.1.4",
-						"kind-of": "^5.0.0"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "5.1.0",
-							"resolved": "http://localhost:4873/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-							"dev": true
-						}
-					}
-				},
-				"is-extendable": {
-					"version": "0.1.1",
-					"resolved": "http://localhost:4873/is-extendable/-/is-extendable-0.1.1.tgz",
-					"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-					"dev": true
-				},
-				"is-extglob": {
-					"version": "2.1.1",
-					"resolved": "http://localhost:4873/is-extglob/-/is-extglob-2.1.1.tgz",
-					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-					"dev": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"is-glob": {
-					"version": "4.0.1",
-					"resolved": "http://localhost:4873/is-glob/-/is-glob-4.0.1.tgz",
-					"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-					"dev": true,
-					"requires": {
-						"is-extglob": "^2.1.1"
-					}
-				},
-				"is-negated-glob": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
-					"integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=",
-					"dev": true
-				},
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "http://localhost:4873/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"dev": true,
-					"requires": {
-						"kind-of": "^3.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "http://localhost:4873/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
-				},
-				"is-plain-object": {
-					"version": "2.0.4",
-					"resolved": "http://localhost:4873/is-plain-object/-/is-plain-object-2.0.4.tgz",
-					"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-					"dev": true,
-					"requires": {
-						"isobject": "^3.0.1"
-					}
-				},
-				"is-relative": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/is-relative/-/is-relative-1.0.0.tgz",
-					"integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
-					"dev": true,
-					"requires": {
-						"is-unc-path": "^1.0.0"
-					}
-				},
-				"is-unc-path": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/is-unc-path/-/is-unc-path-1.0.0.tgz",
-					"integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
-					"dev": true,
-					"requires": {
-						"unc-path-regex": "^0.1.2"
-					}
-				},
-				"is-utf8": {
-					"version": "0.2.1",
-					"resolved": "http://localhost:4873/is-utf8/-/is-utf8-0.2.1.tgz",
-					"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-					"dev": true
-				},
-				"is-valid-glob": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
-					"integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao=",
-					"dev": true
-				},
-				"is-windows": {
-					"version": "1.0.2",
-					"resolved": "http://localhost:4873/is-windows/-/is-windows-1.0.2.tgz",
-					"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-					"dev": true
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-					"dev": true
-				},
-				"isexe": {
-					"version": "2.0.0",
-					"resolved": "http://localhost:4873/isexe/-/isexe-2.0.0.tgz",
-					"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-					"dev": true
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "http://localhost:4873/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
-				},
-				"json-stable-stringify-without-jsonify": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-					"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
-					"dev": true
-				},
-				"just-debounce": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/just-debounce/-/just-debounce-1.0.0.tgz",
-					"integrity": "sha1-h/zPrv/AtozRnVX2cilD+SnqNeo=",
-					"dev": true
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "http://localhost:4873/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
-				},
-				"last-run": {
-					"version": "1.1.1",
-					"resolved": "http://localhost:4873/last-run/-/last-run-1.1.1.tgz",
-					"integrity": "sha1-RblpQsF7HHnHchmCWbqUO+v4yls=",
-					"dev": true,
-					"requires": {
-						"default-resolution": "^2.0.0",
-						"es6-weak-map": "^2.0.1"
-					}
-				},
-				"lazystream": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/lazystream/-/lazystream-1.0.0.tgz",
-					"integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
-					"dev": true,
-					"requires": {
-						"readable-stream": "^2.0.5"
-					}
-				},
-				"lcid": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/lcid/-/lcid-1.0.0.tgz",
-					"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-					"dev": true,
-					"requires": {
-						"invert-kv": "^1.0.0"
-					}
-				},
-				"lead": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/lead/-/lead-1.0.0.tgz",
-					"integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
-					"dev": true,
-					"requires": {
-						"flush-write-stream": "^1.0.2"
-					}
-				},
-				"liftoff": {
-					"version": "3.1.0",
-					"resolved": "http://localhost:4873/liftoff/-/liftoff-3.1.0.tgz",
-					"integrity": "sha512-DlIPlJUkCV0Ips2zf2pJP0unEoT1kwYhiiPUGF3s/jtxTCjziNLoiVVh+jqWOWeFi6mmwQ5fNxvAUyPad4Dfog==",
-					"dev": true,
-					"requires": {
-						"extend": "^3.0.0",
-						"findup-sync": "^3.0.0",
-						"fined": "^1.0.1",
-						"flagged-respawn": "^1.0.0",
-						"is-plain-object": "^2.0.4",
-						"object.map": "^1.0.0",
-						"rechoir": "^0.6.2",
-						"resolve": "^1.1.7"
-					}
-				},
-				"load-json-file": {
-					"version": "1.1.0",
-					"resolved": "http://localhost:4873/load-json-file/-/load-json-file-1.1.0.tgz",
-					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^2.2.0",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0",
-						"strip-bom": "^2.0.0"
-					}
-				},
-				"make-iterator": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/make-iterator/-/make-iterator-1.0.1.tgz",
-					"integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
-					"dev": true,
-					"requires": {
-						"kind-of": "^6.0.2"
-					}
-				},
-				"map-cache": {
-					"version": "0.2.2",
-					"resolved": "http://localhost:4873/map-cache/-/map-cache-0.2.2.tgz",
-					"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
-					"dev": true
-				},
-				"map-visit": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/map-visit/-/map-visit-1.0.0.tgz",
-					"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
-					"dev": true,
-					"requires": {
-						"object-visit": "^1.0.0"
-					}
-				},
-				"matchdep": {
-					"version": "2.0.0",
-					"resolved": "http://localhost:4873/matchdep/-/matchdep-2.0.0.tgz",
-					"integrity": "sha1-xvNINKDY28OzfCfui7yyfHd1WC4=",
-					"dev": true,
-					"requires": {
-						"findup-sync": "^2.0.0",
-						"micromatch": "^3.0.4",
-						"resolve": "^1.4.0",
-						"stack-trace": "0.0.10"
-					},
-					"dependencies": {
-						"findup-sync": {
-							"version": "2.0.0",
-							"resolved": "http://localhost:4873/findup-sync/-/findup-sync-2.0.0.tgz",
-							"integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
-							"dev": true,
-							"requires": {
-								"detect-file": "^1.0.0",
-								"is-glob": "^3.1.0",
-								"micromatch": "^3.0.4",
-								"resolve-dir": "^1.0.1"
-							}
-						},
-						"is-glob": {
-							"version": "3.1.0",
-							"resolved": "http://localhost:4873/is-glob/-/is-glob-3.1.0.tgz",
-							"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-							"dev": true,
-							"requires": {
-								"is-extglob": "^2.1.0"
-							}
-						}
-					}
-				},
-				"micromatch": {
-					"version": "3.1.10",
-					"resolved": "http://localhost:4873/micromatch/-/micromatch-3.1.10.tgz",
-					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-					"dev": true,
-					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
-					}
-				},
-				"minimatch": {
-					"version": "3.0.4",
-					"resolved": "http://localhost:4873/minimatch/-/minimatch-3.0.4.tgz",
-					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-					"dev": true,
-					"requires": {
-						"brace-expansion": "^1.1.7"
-					}
-				},
-				"mixin-deep": {
-					"version": "1.3.2",
-					"resolved": "http://localhost:4873/mixin-deep/-/mixin-deep-1.3.2.tgz",
-					"integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
-					"dev": true,
-					"requires": {
-						"for-in": "^1.0.2",
-						"is-extendable": "^1.0.1"
-					},
-					"dependencies": {
-						"is-extendable": {
-							"version": "1.0.1",
-							"resolved": "http://localhost:4873/is-extendable/-/is-extendable-1.0.1.tgz",
-							"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-							"dev": true,
-							"requires": {
-								"is-plain-object": "^2.0.4"
-							}
-						}
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "http://localhost:4873/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
-				},
-				"mute-stdout": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/mute-stdout/-/mute-stdout-1.0.1.tgz",
-					"integrity": "sha512-kDcwXR4PS7caBpuRYYBUz9iVixUk3anO3f5OYFiIPwK/20vCzKCHyKoulbiDY1S53zD2bxUpxN/IJ+TnXjfvxg==",
-					"dev": true
-				},
-				"nan": {
-					"version": "2.14.0",
-					"resolved": "http://localhost:4873/nan/-/nan-2.14.0.tgz",
-					"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-					"dev": true,
-					"optional": true
-				},
-				"nanomatch": {
-					"version": "1.2.13",
-					"resolved": "http://localhost:4873/nanomatch/-/nanomatch-1.2.13.tgz",
-					"integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
-					"dev": true,
-					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"fragment-cache": "^0.2.1",
-						"is-windows": "^1.0.2",
-						"kind-of": "^6.0.2",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
-					}
-				},
-				"next-tick": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/next-tick/-/next-tick-1.0.0.tgz",
-					"integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
-					"dev": true
-				},
-				"normalize-package-data": {
-					"version": "2.5.0",
-					"resolved": "http://localhost:4873/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-					"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-					"dev": true,
-					"requires": {
-						"hosted-git-info": "^2.1.4",
-						"resolve": "^1.10.0",
-						"semver": "2 || 3 || 4 || 5",
-						"validate-npm-package-license": "^3.0.1"
-					}
-				},
-				"normalize-path": {
-					"version": "2.1.1",
-					"resolved": "http://localhost:4873/normalize-path/-/normalize-path-2.1.1.tgz",
-					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-					"dev": true,
-					"requires": {
-						"remove-trailing-separator": "^1.0.1"
-					}
-				},
-				"now-and-later": {
-					"version": "2.0.1",
-					"resolved": "http://localhost:4873/now-and-later/-/now-and-later-2.0.1.tgz",
-					"integrity": "sha512-KGvQ0cB70AQfg107Xvs/Fbu+dGmZoTRJp2TaPwcwQm3/7PteUyN2BCgk8KBMPGBUXZdVwyWS8fDCGFygBm19UQ==",
-					"dev": true,
-					"requires": {
-						"once": "^1.3.2"
-					}
-				},
-				"number-is-nan": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/number-is-nan/-/number-is-nan-1.0.1.tgz",
-					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-					"dev": true
-				},
-				"object-copy": {
-					"version": "0.1.0",
-					"resolved": "http://localhost:4873/object-copy/-/object-copy-0.1.0.tgz",
-					"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
-					"dev": true,
-					"requires": {
-						"copy-descriptor": "^0.1.0",
-						"define-property": "^0.2.5",
-						"kind-of": "^3.0.3"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "0.2.5",
-							"resolved": "http://localhost:4873/define-property/-/define-property-0.2.5.tgz",
-							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-							"dev": true,
-							"requires": {
-								"is-descriptor": "^0.1.0"
-							}
-						},
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "http://localhost:4873/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
-				},
-				"object-keys": {
-					"version": "1.1.1",
-					"resolved": "http://localhost:4873/object-keys/-/object-keys-1.1.1.tgz",
-					"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-					"dev": true
-				},
-				"object-visit": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/object-visit/-/object-visit-1.0.1.tgz",
-					"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
-					"dev": true,
-					"requires": {
-						"isobject": "^3.0.0"
-					}
-				},
-				"object.assign": {
-					"version": "4.1.0",
-					"resolved": "http://localhost:4873/object.assign/-/object.assign-4.1.0.tgz",
-					"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
-					"dev": true,
-					"requires": {
-						"define-properties": "^1.1.2",
-						"function-bind": "^1.1.1",
-						"has-symbols": "^1.0.0",
-						"object-keys": "^1.0.11"
-					}
-				},
-				"object.defaults": {
-					"version": "1.1.0",
-					"resolved": "http://localhost:4873/object.defaults/-/object.defaults-1.1.0.tgz",
-					"integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
-					"dev": true,
-					"requires": {
-						"array-each": "^1.0.1",
-						"array-slice": "^1.0.0",
-						"for-own": "^1.0.0",
-						"isobject": "^3.0.0"
-					}
-				},
-				"object.map": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/object.map/-/object.map-1.0.1.tgz",
-					"integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
-					"dev": true,
-					"requires": {
-						"for-own": "^1.0.0",
-						"make-iterator": "^1.0.0"
-					}
-				},
-				"object.pick": {
-					"version": "1.3.0",
-					"resolved": "http://localhost:4873/object.pick/-/object.pick-1.3.0.tgz",
-					"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
-					"dev": true,
-					"requires": {
-						"isobject": "^3.0.1"
-					}
-				},
-				"object.reduce": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/object.reduce/-/object.reduce-1.0.1.tgz",
-					"integrity": "sha1-b+NI8qx/oPlcpiEiZZkJaCW7A60=",
-					"dev": true,
-					"requires": {
-						"for-own": "^1.0.0",
-						"make-iterator": "^1.0.0"
-					}
-				},
-				"once": {
-					"version": "1.4.0",
-					"resolved": "http://localhost:4873/once/-/once-1.4.0.tgz",
-					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-					"dev": true,
-					"requires": {
-						"wrappy": "1"
-					}
-				},
-				"ordered-read-streams": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz",
-					"integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
-					"dev": true,
-					"requires": {
-						"readable-stream": "^2.0.1"
-					}
-				},
-				"os-locale": {
-					"version": "1.4.0",
-					"resolved": "http://localhost:4873/os-locale/-/os-locale-1.4.0.tgz",
-					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-					"dev": true,
-					"requires": {
-						"lcid": "^1.0.0"
-					}
-				},
-				"parse-filepath": {
-					"version": "1.0.2",
-					"resolved": "http://localhost:4873/parse-filepath/-/parse-filepath-1.0.2.tgz",
-					"integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
-					"dev": true,
-					"requires": {
-						"is-absolute": "^1.0.0",
-						"map-cache": "^0.2.0",
-						"path-root": "^0.1.1"
-					}
-				},
-				"parse-json": {
-					"version": "2.2.0",
-					"resolved": "http://localhost:4873/parse-json/-/parse-json-2.2.0.tgz",
-					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-					"dev": true,
-					"requires": {
-						"error-ex": "^1.2.0"
-					}
-				},
-				"parse-node-version": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/parse-node-version/-/parse-node-version-1.0.1.tgz",
-					"integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==",
-					"dev": true
-				},
-				"parse-passwd": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/parse-passwd/-/parse-passwd-1.0.0.tgz",
-					"integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
-					"dev": true
-				},
-				"pascalcase": {
-					"version": "0.1.1",
-					"resolved": "http://localhost:4873/pascalcase/-/pascalcase-0.1.1.tgz",
-					"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
-					"dev": true
-				},
-				"path-dirname": {
-					"version": "1.0.2",
-					"resolved": "http://localhost:4873/path-dirname/-/path-dirname-1.0.2.tgz",
-					"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
-					"dev": true
-				},
-				"path-exists": {
-					"version": "2.1.0",
-					"resolved": "http://localhost:4873/path-exists/-/path-exists-2.1.0.tgz",
-					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-					"dev": true,
-					"requires": {
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"path-is-absolute": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-					"dev": true
-				},
-				"path-parse": {
-					"version": "1.0.6",
-					"resolved": "http://localhost:4873/path-parse/-/path-parse-1.0.6.tgz",
-					"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-					"dev": true
-				},
-				"path-root": {
-					"version": "0.1.1",
-					"resolved": "http://localhost:4873/path-root/-/path-root-0.1.1.tgz",
-					"integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
-					"dev": true,
-					"requires": {
-						"path-root-regex": "^0.1.0"
-					}
-				},
-				"path-root-regex": {
-					"version": "0.1.2",
-					"resolved": "http://localhost:4873/path-root-regex/-/path-root-regex-0.1.2.tgz",
-					"integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
-					"dev": true
-				},
-				"path-type": {
-					"version": "1.1.0",
-					"resolved": "http://localhost:4873/path-type/-/path-type-1.1.0.tgz",
-					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"pify": {
-					"version": "2.3.0",
-					"resolved": "http://localhost:4873/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
-				},
-				"pinkie": {
-					"version": "2.0.4",
-					"resolved": "http://localhost:4873/pinkie/-/pinkie-2.0.4.tgz",
-					"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-					"dev": true
-				},
-				"pinkie-promise": {
-					"version": "2.0.1",
-					"resolved": "http://localhost:4873/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-					"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-					"dev": true,
-					"requires": {
-						"pinkie": "^2.0.0"
-					}
-				},
-				"posix-character-classes": {
-					"version": "0.1.1",
-					"resolved": "http://localhost:4873/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-					"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
-					"dev": true
-				},
-				"pretty-hrtime": {
-					"version": "1.0.3",
-					"resolved": "http://localhost:4873/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
-					"integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
-					"dev": true
-				},
-				"process-nextick-args": {
-					"version": "2.0.1",
-					"resolved": "http://localhost:4873/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-					"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-					"dev": true
-				},
-				"pump": {
-					"version": "2.0.1",
-					"resolved": "http://localhost:4873/pump/-/pump-2.0.1.tgz",
-					"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-					"dev": true,
-					"requires": {
-						"end-of-stream": "^1.1.0",
-						"once": "^1.3.1"
-					}
-				},
-				"pumpify": {
-					"version": "1.5.1",
-					"resolved": "http://localhost:4873/pumpify/-/pumpify-1.5.1.tgz",
-					"integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
-					"dev": true,
-					"requires": {
-						"duplexify": "^3.6.0",
-						"inherits": "^2.0.3",
-						"pump": "^2.0.0"
-					}
-				},
-				"read-pkg": {
-					"version": "1.1.0",
-					"resolved": "http://localhost:4873/read-pkg/-/read-pkg-1.1.0.tgz",
-					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-					"dev": true,
-					"requires": {
-						"load-json-file": "^1.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^1.0.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-					"dev": true,
-					"requires": {
-						"find-up": "^1.0.0",
-						"read-pkg": "^1.0.0"
-					}
-				},
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "http://localhost:4873/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"readdirp": {
-					"version": "2.2.1",
-					"resolved": "http://localhost:4873/readdirp/-/readdirp-2.2.1.tgz",
-					"integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.11",
-						"micromatch": "^3.1.10",
-						"readable-stream": "^2.0.2"
-					}
-				},
-				"rechoir": {
-					"version": "0.6.2",
-					"resolved": "http://localhost:4873/rechoir/-/rechoir-0.6.2.tgz",
-					"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-					"dev": true,
-					"requires": {
-						"resolve": "^1.1.6"
-					}
-				},
-				"regex-not": {
-					"version": "1.0.2",
-					"resolved": "http://localhost:4873/regex-not/-/regex-not-1.0.2.tgz",
-					"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
-					"dev": true,
-					"requires": {
-						"extend-shallow": "^3.0.2",
-						"safe-regex": "^1.1.0"
-					}
-				},
-				"remove-bom-buffer": {
-					"version": "3.0.0",
-					"resolved": "http://localhost:4873/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz",
-					"integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
-					"dev": true,
-					"requires": {
-						"is-buffer": "^1.1.5",
-						"is-utf8": "^0.2.1"
-					}
-				},
-				"remove-bom-stream": {
-					"version": "1.2.0",
-					"resolved": "http://localhost:4873/remove-bom-stream/-/remove-bom-stream-1.2.0.tgz",
-					"integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
-					"dev": true,
-					"requires": {
-						"remove-bom-buffer": "^3.0.0",
-						"safe-buffer": "^5.1.0",
-						"through2": "^2.0.3"
-					}
-				},
-				"remove-trailing-separator": {
-					"version": "1.1.0",
-					"resolved": "http://localhost:4873/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-					"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-					"dev": true
-				},
-				"repeat-element": {
-					"version": "1.1.3",
-					"resolved": "http://localhost:4873/repeat-element/-/repeat-element-1.1.3.tgz",
-					"integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
-					"dev": true
-				},
-				"repeat-string": {
-					"version": "1.6.1",
-					"resolved": "http://localhost:4873/repeat-string/-/repeat-string-1.6.1.tgz",
-					"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-					"dev": true
-				},
-				"replace-ext": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/replace-ext/-/replace-ext-1.0.0.tgz",
-					"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
-					"dev": true
-				},
-				"replace-homedir": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/replace-homedir/-/replace-homedir-1.0.0.tgz",
-					"integrity": "sha1-6H9tUTuSjd6AgmDBK+f+xv9ueYw=",
-					"dev": true,
-					"requires": {
-						"homedir-polyfill": "^1.0.1",
-						"is-absolute": "^1.0.0",
-						"remove-trailing-separator": "^1.1.0"
-					}
-				},
-				"require-directory": {
-					"version": "2.1.1",
-					"resolved": "http://localhost:4873/require-directory/-/require-directory-2.1.1.tgz",
-					"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-					"dev": true
-				},
-				"require-main-filename": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/require-main-filename/-/require-main-filename-1.0.1.tgz",
-					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-					"dev": true
-				},
-				"resolve": {
-					"version": "1.12.0",
-					"resolved": "http://localhost:4873/resolve/-/resolve-1.12.0.tgz",
-					"integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
-					"dev": true,
-					"requires": {
-						"path-parse": "^1.0.6"
-					}
-				},
-				"resolve-dir": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/resolve-dir/-/resolve-dir-1.0.1.tgz",
-					"integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
-					"dev": true,
-					"requires": {
-						"expand-tilde": "^2.0.0",
-						"global-modules": "^1.0.0"
-					}
-				},
-				"resolve-options": {
-					"version": "1.1.0",
-					"resolved": "http://localhost:4873/resolve-options/-/resolve-options-1.1.0.tgz",
-					"integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
-					"dev": true,
-					"requires": {
-						"value-or-function": "^3.0.0"
-					}
-				},
-				"resolve-url": {
-					"version": "0.2.1",
-					"resolved": "http://localhost:4873/resolve-url/-/resolve-url-0.2.1.tgz",
-					"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
-					"dev": true
-				},
-				"ret": {
-					"version": "0.1.15",
-					"resolved": "http://localhost:4873/ret/-/ret-0.1.15.tgz",
-					"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
-					"dev": true
-				},
-				"safe-buffer": {
-					"version": "5.1.2",
-					"resolved": "http://localhost:4873/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-					"dev": true
-				},
-				"safe-regex": {
-					"version": "1.1.0",
-					"resolved": "http://localhost:4873/safe-regex/-/safe-regex-1.1.0.tgz",
-					"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
-					"dev": true,
-					"requires": {
-						"ret": "~0.1.10"
-					}
-				},
-				"semver": {
-					"version": "5.7.0",
-					"resolved": "http://localhost:4873/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-					"dev": true
-				},
-				"semver-greatest-satisfied-range": {
-					"version": "1.1.0",
-					"resolved": "http://localhost:4873/semver-greatest-satisfied-range/-/semver-greatest-satisfied-range-1.1.0.tgz",
-					"integrity": "sha1-E+jCZYq5aRywzXEJMkAoDTb3els=",
-					"dev": true,
-					"requires": {
-						"sver-compat": "^1.5.0"
-					}
-				},
-				"set-blocking": {
-					"version": "2.0.0",
-					"resolved": "http://localhost:4873/set-blocking/-/set-blocking-2.0.0.tgz",
-					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-					"dev": true
-				},
-				"set-value": {
-					"version": "2.0.1",
-					"resolved": "http://localhost:4873/set-value/-/set-value-2.0.1.tgz",
-					"integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
-					"dev": true,
-					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-extendable": "^0.1.1",
-						"is-plain-object": "^2.0.3",
-						"split-string": "^3.0.1"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "http://localhost:4873/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"snapdragon": {
-					"version": "0.8.2",
-					"resolved": "http://localhost:4873/snapdragon/-/snapdragon-0.8.2.tgz",
-					"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
-					"dev": true,
-					"requires": {
-						"base": "^0.11.1",
-						"debug": "^2.2.0",
-						"define-property": "^0.2.5",
-						"extend-shallow": "^2.0.1",
-						"map-cache": "^0.2.2",
-						"source-map": "^0.5.6",
-						"source-map-resolve": "^0.5.0",
-						"use": "^3.1.0"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "0.2.5",
-							"resolved": "http://localhost:4873/define-property/-/define-property-0.2.5.tgz",
-							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-							"dev": true,
-							"requires": {
-								"is-descriptor": "^0.1.0"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "http://localhost:4873/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"snapdragon-node": {
-					"version": "2.1.1",
-					"resolved": "http://localhost:4873/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
-					"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
-					"dev": true,
-					"requires": {
-						"define-property": "^1.0.0",
-						"isobject": "^3.0.0",
-						"snapdragon-util": "^3.0.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "1.0.0",
-							"resolved": "http://localhost:4873/define-property/-/define-property-1.0.0.tgz",
-							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-							"dev": true,
-							"requires": {
-								"is-descriptor": "^1.0.0"
-							}
-						},
-						"is-accessor-descriptor": {
-							"version": "1.0.0",
-							"resolved": "http://localhost:4873/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-							"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-							"dev": true,
-							"requires": {
-								"kind-of": "^6.0.0"
-							}
-						},
-						"is-data-descriptor": {
-							"version": "1.0.0",
-							"resolved": "http://localhost:4873/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-							"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-							"dev": true,
-							"requires": {
-								"kind-of": "^6.0.0"
-							}
-						},
-						"is-descriptor": {
-							"version": "1.0.2",
-							"resolved": "http://localhost:4873/is-descriptor/-/is-descriptor-1.0.2.tgz",
-							"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-							"dev": true,
-							"requires": {
-								"is-accessor-descriptor": "^1.0.0",
-								"is-data-descriptor": "^1.0.0",
-								"kind-of": "^6.0.2"
-							}
-						}
-					}
-				},
-				"snapdragon-util": {
-					"version": "3.0.1",
-					"resolved": "http://localhost:4873/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
-					"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
-					"dev": true,
-					"requires": {
-						"kind-of": "^3.2.0"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "http://localhost:4873/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "http://localhost:4873/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-					"dev": true
-				},
-				"source-map-resolve": {
-					"version": "0.5.2",
-					"resolved": "http://localhost:4873/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
-					"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
-					"dev": true,
-					"requires": {
-						"atob": "^2.1.1",
-						"decode-uri-component": "^0.2.0",
-						"resolve-url": "^0.2.1",
-						"source-map-url": "^0.4.0",
-						"urix": "^0.1.0"
-					}
-				},
-				"source-map-url": {
-					"version": "0.4.0",
-					"resolved": "http://localhost:4873/source-map-url/-/source-map-url-0.4.0.tgz",
-					"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
-					"dev": true
-				},
-				"sparkles": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/sparkles/-/sparkles-1.0.1.tgz",
-					"integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw==",
-					"dev": true
-				},
-				"spdx-correct": {
-					"version": "3.1.0",
-					"resolved": "http://localhost:4873/spdx-correct/-/spdx-correct-3.1.0.tgz",
-					"integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
-					"dev": true,
-					"requires": {
-						"spdx-expression-parse": "^3.0.0",
-						"spdx-license-ids": "^3.0.0"
-					}
-				},
-				"spdx-exceptions": {
-					"version": "2.2.0",
-					"resolved": "http://localhost:4873/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-					"integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
-					"dev": true
-				},
-				"spdx-expression-parse": {
-					"version": "3.0.0",
-					"resolved": "http://localhost:4873/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-					"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
-					"dev": true,
-					"requires": {
-						"spdx-exceptions": "^2.1.0",
-						"spdx-license-ids": "^3.0.0"
-					}
-				},
-				"spdx-license-ids": {
-					"version": "3.0.5",
-					"resolved": "http://localhost:4873/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-					"integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
-					"dev": true
-				},
-				"split-string": {
-					"version": "3.1.0",
-					"resolved": "http://localhost:4873/split-string/-/split-string-3.1.0.tgz",
-					"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
-					"dev": true,
-					"requires": {
-						"extend-shallow": "^3.0.0"
-					}
-				},
-				"stack-trace": {
-					"version": "0.0.10",
-					"resolved": "http://localhost:4873/stack-trace/-/stack-trace-0.0.10.tgz",
-					"integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
-					"dev": true
-				},
-				"static-extend": {
-					"version": "0.1.2",
-					"resolved": "http://localhost:4873/static-extend/-/static-extend-0.1.2.tgz",
-					"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
-					"dev": true,
-					"requires": {
-						"define-property": "^0.2.5",
-						"object-copy": "^0.1.0"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "0.2.5",
-							"resolved": "http://localhost:4873/define-property/-/define-property-0.2.5.tgz",
-							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-							"dev": true,
-							"requires": {
-								"is-descriptor": "^0.1.0"
-							}
-						}
-					}
-				},
-				"stream-exhaust": {
-					"version": "1.0.2",
-					"resolved": "http://localhost:4873/stream-exhaust/-/stream-exhaust-1.0.2.tgz",
-					"integrity": "sha512-b/qaq/GlBK5xaq1yrK9/zFcyRSTNxmcZwFLGSTG0mXgZl/4Z6GgiyYOXOvY7N3eEvFRAG1bkDRz5EPGSvPYQlw==",
-					"dev": true
-				},
-				"stream-shift": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/stream-shift/-/stream-shift-1.0.0.tgz",
-					"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
-					"dev": true
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "http://localhost:4873/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true,
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "http://localhost:4873/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "http://localhost:4873/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"strip-bom": {
-					"version": "2.0.0",
-					"resolved": "http://localhost:4873/strip-bom/-/strip-bom-2.0.0.tgz",
-					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"dev": true,
-					"requires": {
-						"is-utf8": "^0.2.0"
-					}
-				},
-				"sver-compat": {
-					"version": "1.5.0",
-					"resolved": "http://localhost:4873/sver-compat/-/sver-compat-1.5.0.tgz",
-					"integrity": "sha1-PPh9/rTQe0o/FIJ7wYaz/QxkXNg=",
-					"dev": true,
-					"requires": {
-						"es6-iterator": "^2.0.1",
-						"es6-symbol": "^3.1.1"
-					}
-				},
-				"through2": {
-					"version": "2.0.5",
-					"resolved": "http://localhost:4873/through2/-/through2-2.0.5.tgz",
-					"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-					"dev": true,
-					"requires": {
-						"readable-stream": "~2.3.6",
-						"xtend": "~4.0.1"
-					}
-				},
-				"through2-filter": {
-					"version": "3.0.0",
-					"resolved": "http://localhost:4873/through2-filter/-/through2-filter-3.0.0.tgz",
-					"integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
-					"dev": true,
-					"requires": {
-						"through2": "~2.0.0",
-						"xtend": "~4.0.0"
-					}
-				},
-				"time-stamp": {
-					"version": "1.1.0",
-					"resolved": "http://localhost:4873/time-stamp/-/time-stamp-1.1.0.tgz",
-					"integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
-					"dev": true
-				},
-				"to-absolute-glob": {
-					"version": "2.0.2",
-					"resolved": "http://localhost:4873/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
-					"integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
-					"dev": true,
-					"requires": {
-						"is-absolute": "^1.0.0",
-						"is-negated-glob": "^1.0.0"
-					}
-				},
-				"to-object-path": {
-					"version": "0.3.0",
-					"resolved": "http://localhost:4873/to-object-path/-/to-object-path-0.3.0.tgz",
-					"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
-					"dev": true,
-					"requires": {
-						"kind-of": "^3.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "http://localhost:4873/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
-				},
-				"to-regex": {
-					"version": "3.0.2",
-					"resolved": "http://localhost:4873/to-regex/-/to-regex-3.0.2.tgz",
-					"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
-					"dev": true,
-					"requires": {
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"regex-not": "^1.0.2",
-						"safe-regex": "^1.1.0"
-					}
-				},
-				"to-regex-range": {
-					"version": "2.1.1",
-					"resolved": "http://localhost:4873/to-regex-range/-/to-regex-range-2.1.1.tgz",
-					"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-					"dev": true,
-					"requires": {
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1"
-					}
-				},
-				"to-through": {
-					"version": "2.0.0",
-					"resolved": "http://localhost:4873/to-through/-/to-through-2.0.0.tgz",
-					"integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
-					"dev": true,
-					"requires": {
-						"through2": "^2.0.3"
-					}
-				},
-				"type": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/type/-/type-1.0.1.tgz",
-					"integrity": "sha512-MAM5dBMJCJNKs9E7JXo4CXRAansRfG0nlJxW7Wf6GZzSOvH31zClSaHdIMWLehe/EGMBkqeC55rrkaOr5Oo7Nw==",
-					"dev": true
-				},
-				"typedarray": {
-					"version": "0.0.6",
-					"resolved": "http://localhost:4873/typedarray/-/typedarray-0.0.6.tgz",
-					"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-					"dev": true
-				},
-				"unc-path-regex": {
-					"version": "0.1.2",
-					"resolved": "http://localhost:4873/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
-					"integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
-					"dev": true
-				},
-				"undertaker": {
-					"version": "1.2.1",
-					"resolved": "http://localhost:4873/undertaker/-/undertaker-1.2.1.tgz",
-					"integrity": "sha512-71WxIzDkgYk9ZS+spIB8iZXchFhAdEo2YU8xYqBYJ39DIUIqziK78ftm26eecoIY49X0J2MLhG4hr18Yp6/CMA==",
-					"dev": true,
-					"requires": {
-						"arr-flatten": "^1.0.1",
-						"arr-map": "^2.0.0",
-						"bach": "^1.0.0",
-						"collection-map": "^1.0.0",
-						"es6-weak-map": "^2.0.1",
-						"last-run": "^1.1.0",
-						"object.defaults": "^1.0.0",
-						"object.reduce": "^1.0.0",
-						"undertaker-registry": "^1.0.0"
-					}
-				},
-				"undertaker-registry": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/undertaker-registry/-/undertaker-registry-1.0.1.tgz",
-					"integrity": "sha1-XkvaMI5KiirlhPm5pDWaSZglzFA=",
-					"dev": true
-				},
-				"union-value": {
-					"version": "1.0.1",
-					"resolved": "http://localhost:4873/union-value/-/union-value-1.0.1.tgz",
-					"integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
-					"dev": true,
-					"requires": {
-						"arr-union": "^3.1.0",
-						"get-value": "^2.0.6",
-						"is-extendable": "^0.1.1",
-						"set-value": "^2.0.1"
-					}
-				},
-				"unique-stream": {
-					"version": "2.3.1",
-					"resolved": "http://localhost:4873/unique-stream/-/unique-stream-2.3.1.tgz",
-					"integrity": "sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==",
-					"dev": true,
-					"requires": {
-						"json-stable-stringify-without-jsonify": "^1.0.1",
-						"through2-filter": "^3.0.0"
-					}
-				},
-				"unset-value": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/unset-value/-/unset-value-1.0.0.tgz",
-					"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
-					"dev": true,
-					"requires": {
-						"has-value": "^0.3.1",
-						"isobject": "^3.0.0"
-					},
-					"dependencies": {
-						"has-value": {
-							"version": "0.3.1",
-							"resolved": "http://localhost:4873/has-value/-/has-value-0.3.1.tgz",
-							"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
-							"dev": true,
-							"requires": {
-								"get-value": "^2.0.3",
-								"has-values": "^0.1.4",
-								"isobject": "^2.0.0"
-							},
-							"dependencies": {
-								"isobject": {
-									"version": "2.1.0",
-									"resolved": "http://localhost:4873/isobject/-/isobject-2.1.0.tgz",
-									"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-									"dev": true,
-									"requires": {
-										"isarray": "1.0.0"
-									}
-								}
-							}
-						},
-						"has-values": {
-							"version": "0.1.4",
-							"resolved": "http://localhost:4873/has-values/-/has-values-0.1.4.tgz",
-							"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
-							"dev": true
-						}
-					}
-				},
-				"upath": {
-					"version": "1.1.2",
-					"resolved": "http://localhost:4873/upath/-/upath-1.1.2.tgz",
-					"integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==",
-					"dev": true
-				},
-				"urix": {
-					"version": "0.1.0",
-					"resolved": "http://localhost:4873/urix/-/urix-0.1.0.tgz",
-					"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
-					"dev": true
-				},
-				"use": {
-					"version": "3.1.1",
-					"resolved": "http://localhost:4873/use/-/use-3.1.1.tgz",
-					"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
-					"dev": true
-				},
-				"util-deprecate": {
-					"version": "1.0.2",
-					"resolved": "http://localhost:4873/util-deprecate/-/util-deprecate-1.0.2.tgz",
-					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-					"dev": true
-				},
-				"v8flags": {
-					"version": "3.1.3",
-					"resolved": "http://localhost:4873/v8flags/-/v8flags-3.1.3.tgz",
-					"integrity": "sha512-amh9CCg3ZxkzQ48Mhcb8iX7xpAfYJgePHxWMQCBWECpOSqJUXgY26ncA61UTV0BkPqfhcy6mzwCIoP4ygxpW8w==",
-					"dev": true,
-					"requires": {
-						"homedir-polyfill": "^1.0.1"
-					}
-				},
-				"validate-npm-package-license": {
-					"version": "3.0.4",
-					"resolved": "http://localhost:4873/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-					"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-					"dev": true,
-					"requires": {
-						"spdx-correct": "^3.0.0",
-						"spdx-expression-parse": "^3.0.0"
-					}
-				},
-				"value-or-function": {
-					"version": "3.0.0",
-					"resolved": "http://localhost:4873/value-or-function/-/value-or-function-3.0.0.tgz",
-					"integrity": "sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM=",
-					"dev": true
-				},
-				"vinyl": {
-					"version": "2.2.0",
-					"resolved": "http://localhost:4873/vinyl/-/vinyl-2.2.0.tgz",
-					"integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
-					"dev": true,
-					"requires": {
-						"clone": "^2.1.1",
-						"clone-buffer": "^1.0.0",
-						"clone-stats": "^1.0.0",
-						"cloneable-readable": "^1.0.0",
-						"remove-trailing-separator": "^1.0.1",
-						"replace-ext": "^1.0.0"
-					}
-				},
-				"vinyl-fs": {
-					"version": "3.0.3",
-					"resolved": "http://localhost:4873/vinyl-fs/-/vinyl-fs-3.0.3.tgz",
-					"integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
-					"dev": true,
-					"requires": {
-						"fs-mkdirp-stream": "^1.0.0",
-						"glob-stream": "^6.1.0",
-						"graceful-fs": "^4.0.0",
-						"is-valid-glob": "^1.0.0",
-						"lazystream": "^1.0.0",
-						"lead": "^1.0.0",
-						"object.assign": "^4.0.4",
-						"pumpify": "^1.3.5",
-						"readable-stream": "^2.3.3",
-						"remove-bom-buffer": "^3.0.0",
-						"remove-bom-stream": "^1.2.0",
-						"resolve-options": "^1.1.0",
-						"through2": "^2.0.0",
-						"to-through": "^2.0.0",
-						"value-or-function": "^3.0.0",
-						"vinyl": "^2.0.0",
-						"vinyl-sourcemap": "^1.1.0"
-					}
-				},
-				"vinyl-sourcemap": {
-					"version": "1.1.0",
-					"resolved": "http://localhost:4873/vinyl-sourcemap/-/vinyl-sourcemap-1.1.0.tgz",
-					"integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
-					"dev": true,
-					"requires": {
-						"append-buffer": "^1.0.2",
-						"convert-source-map": "^1.5.0",
-						"graceful-fs": "^4.1.6",
-						"normalize-path": "^2.1.1",
-						"now-and-later": "^2.0.0",
-						"remove-bom-buffer": "^3.0.0",
-						"vinyl": "^2.0.0"
-					}
-				},
-				"which": {
-					"version": "1.3.1",
-					"resolved": "http://localhost:4873/which/-/which-1.3.1.tgz",
-					"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-					"dev": true,
-					"requires": {
-						"isexe": "^2.0.0"
-					}
-				},
-				"which-module": {
-					"version": "1.0.0",
-					"resolved": "http://localhost:4873/which-module/-/which-module-1.0.0.tgz",
-					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
-					"dev": true
-				},
-				"wrap-ansi": {
-					"version": "2.1.0",
-					"resolved": "http://localhost:4873/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-					"dev": true,
-					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1"
-					}
-				},
-				"wrappy": {
-					"version": "1.0.2",
-					"resolved": "http://localhost:4873/wrappy/-/wrappy-1.0.2.tgz",
-					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-					"dev": true
-				},
-				"xtend": {
-					"version": "4.0.2",
-					"resolved": "http://localhost:4873/xtend/-/xtend-4.0.2.tgz",
-					"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-					"dev": true
-				},
-				"y18n": {
-					"version": "3.2.1",
-					"resolved": "http://localhost:4873/y18n/-/y18n-3.2.1.tgz",
-					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-					"dev": true
-				},
-				"yargs": {
-					"version": "7.1.0",
-					"resolved": "http://localhost:4873/yargs/-/yargs-7.1.0.tgz",
-					"integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
-					"dev": true,
-					"requires": {
-						"camelcase": "^3.0.0",
-						"cliui": "^3.2.0",
-						"decamelize": "^1.1.1",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^1.4.0",
-						"read-pkg-up": "^1.0.1",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^1.0.2",
-						"which-module": "^1.0.0",
-						"y18n": "^3.2.1",
-						"yargs-parser": "^5.0.0"
-					}
-				},
-				"yargs-parser": {
-					"version": "5.0.0",
-					"resolved": "http://localhost:4873/yargs-parser/-/yargs-parser-5.0.0.tgz",
-					"integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
-					"dev": true,
-					"requires": {
-						"camelcase": "^3.0.0"
-					}
-				}
-			}
-		}
-	}
+  "name": "@spectrum-css/spectrum-css",
+  "version": "3.0.0-alpha.5",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@a4u/a4u-collection-react-spectrum-open-source-color-icons-release": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-a4u-release/@a4u/a4u-collection-react-spectrum-open-source-color-icons-release/-/@a4u/a4u-collection-react-spectrum-open-source-color-icons-release-2.0.0.tgz",
+      "integrity": "sha1-kv4I7ZfYfM7FqxXKIdqOjqqlifo=",
+      "dev": true,
+      "optional": true
+    },
+    "@a4u/a4u-collection-react-spectrum-open-source-release": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-a4u-release/@a4u/a4u-collection-react-spectrum-open-source-release/-/@a4u/a4u-collection-react-spectrum-open-source-release-2.1.0.tgz",
+      "integrity": "sha1-M3k3IC237cLOc6YW+x4sbTXMK8I=",
+      "dev": true,
+      "optional": true
+    },
+    "@a4u/a4u-collection-spectrum-css-release": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-a4u-release/@a4u/a4u-collection-spectrum-css-release/-/@a4u/a4u-collection-spectrum-css-release-2.1.0.tgz",
+      "integrity": "sha1-v1pzFqmZ1ndiBecyF3WIKH8nr+E=",
+      "dev": true,
+      "optional": true
+    },
+    "@adobe/spectrum-css-workflow-icons": {
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@adobe/spectrum-css-workflow-icons/-/spectrum-css-workflow-icons-1.0.0-beta.3.tgz",
+      "integrity": "sha512-ZyYV6meUzdZ5vJFt4YBXCg3o5s65MTKZmKGXHjUMYLUNVxecwYeZSjWP3DPW1bW/NjzIjRz1GoTgjMoIelQFRQ==",
+      "dev": true,
+      "requires": {
+        "@a4u/a4u-collection-react-spectrum-open-source-color-icons-release": "^2.0.0",
+        "@a4u/a4u-collection-react-spectrum-open-source-release": "^2.1.0",
+        "@a4u/a4u-collection-spectrum-css-release": "^2.1.0"
+      }
+    },
+    "@spectrum-css/accordion": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {
+                "@spectrum-css/bundle-builder": {}
+              }
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/actionbar": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/button": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {
+                "@spectrum-css/bundle-builder": {}
+              }
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {
+                "@spectrum-css/component-builder": {
+                  "dependencies": {}
+                },
+                "@spectrum-css/vars": {}
+              }
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/checkbox": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {
+                "@spectrum-css/bundle-builder": {}
+              }
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {
+                "@spectrum-css/component-builder": {
+                  "dependencies": {}
+                },
+                "@spectrum-css/vars": {}
+              }
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/popover": {
+          "dependencies": {
+            "@spectrum-css/button": {
+              "dependencies": {
+                "@spectrum-css/component-builder": {
+                  "dependencies": {}
+                },
+                "@spectrum-css/icons": {
+                  "dependencies": {}
+                },
+                "@spectrum-css/vars": {}
+              }
+            },
+            "@spectrum-css/component-builder": {
+              "dependencies": {
+                "@spectrum-css/bundle-builder": {}
+              }
+            },
+            "@spectrum-css/dialog": {
+              "dependencies": {
+                "@spectrum-css/button": {
+                  "dependencies": {
+                    "@spectrum-css/component-builder": {
+                      "dependencies": {}
+                    },
+                    "@spectrum-css/icons": {
+                      "dependencies": {}
+                    },
+                    "@spectrum-css/vars": {}
+                  }
+                },
+                "@spectrum-css/component-builder": {
+                  "dependencies": {
+                    "@spectrum-css/bundle-builder": {}
+                  }
+                },
+                "@spectrum-css/icons": {
+                  "dependencies": {
+                    "@spectrum-css/component-builder": {
+                      "dependencies": {}
+                    },
+                    "@spectrum-css/vars": {}
+                  }
+                },
+                "@spectrum-css/underlay": {
+                  "dependencies": {
+                    "@spectrum-css/component-builder": {
+                      "dependencies": {
+                        "@spectrum-css/bundle-builder": {}
+                      }
+                    },
+                    "@spectrum-css/vars": {}
+                  }
+                },
+                "@spectrum-css/vars": {}
+              }
+            },
+            "@spectrum-css/menu": {
+              "dependencies": {
+                "@spectrum-css/component-builder": {
+                  "dependencies": {
+                    "@spectrum-css/bundle-builder": {}
+                  }
+                },
+                "@spectrum-css/icons": {
+                  "dependencies": {
+                    "@spectrum-css/component-builder": {
+                      "dependencies": {}
+                    },
+                    "@spectrum-css/vars": {}
+                  }
+                },
+                "@spectrum-css/vars": {}
+              }
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/table": {
+          "dependencies": {
+            "@spectrum-css/checkbox": {
+              "dependencies": {
+                "@spectrum-css/component-builder": {
+                  "dependencies": {}
+                },
+                "@spectrum-css/icons": {
+                  "dependencies": {}
+                },
+                "@spectrum-css/vars": {}
+              }
+            },
+            "@spectrum-css/component-builder": {
+              "dependencies": {
+                "@spectrum-css/bundle-builder": {}
+              }
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {
+                "@spectrum-css/component-builder": {
+                  "dependencies": {}
+                },
+                "@spectrum-css/vars": {}
+              }
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/actionmenu": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/button": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/menu": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/popover": {
+          "dependencies": {
+            "@spectrum-css/button": {
+              "dependencies": {}
+            },
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/dialog": {
+              "dependencies": {}
+            },
+            "@spectrum-css/menu": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/alert": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/button": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/asset": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/assetlist": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/checkbox": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/avatar": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/banner": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/barloader": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/breadcrumb": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/button": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/bundle-builder": {
+      "version": "1.0.0-alpha.2",
+      "dev": true
+    },
+    "@spectrum-css/button": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {}
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {}
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/buttongroup": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/button": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/calendar": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/button": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/card": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/asset": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/button": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/checkbox": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/quickaction": {
+          "dependencies": {
+            "@spectrum-css/button": {
+              "dependencies": {
+                "@spectrum-css/component-builder": {
+                  "dependencies": {}
+                },
+                "@spectrum-css/icons": {
+                  "dependencies": {}
+                },
+                "@spectrum-css/vars": {}
+              }
+            },
+            "@spectrum-css/checkbox": {
+              "dependencies": {
+                "@spectrum-css/component-builder": {
+                  "dependencies": {}
+                },
+                "@spectrum-css/icons": {
+                  "dependencies": {}
+                },
+                "@spectrum-css/vars": {}
+              }
+            },
+            "@spectrum-css/component-builder": {
+              "dependencies": {
+                "@spectrum-css/bundle-builder": {}
+              }
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/checkbox": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {}
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {}
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/circleloader": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/coachmark": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/button": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/cyclebutton": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/button": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/decoratedtextfield": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/fieldlabel": {
+          "dependencies": {
+            "@spectrum-css/checkbox": {
+              "dependencies": {
+                "@spectrum-css/component-builder": {
+                  "dependencies": {}
+                },
+                "@spectrum-css/icons": {
+                  "dependencies": {}
+                },
+                "@spectrum-css/vars": {}
+              }
+            },
+            "@spectrum-css/component-builder": {
+              "dependencies": {
+                "@spectrum-css/bundle-builder": {}
+              }
+            },
+            "@spectrum-css/dropdown": {
+              "dependencies": {
+                "@spectrum-css/button": {
+                  "dependencies": {
+                    "@spectrum-css/component-builder": {
+                      "dependencies": {}
+                    },
+                    "@spectrum-css/icons": {
+                      "dependencies": {}
+                    },
+                    "@spectrum-css/vars": {}
+                  }
+                },
+                "@spectrum-css/component-builder": {
+                  "dependencies": {
+                    "@spectrum-css/bundle-builder": {}
+                  }
+                },
+                "@spectrum-css/icons": {
+                  "dependencies": {
+                    "@spectrum-css/component-builder": {
+                      "dependencies": {}
+                    },
+                    "@spectrum-css/vars": {}
+                  }
+                },
+                "@spectrum-css/menu": {
+                  "dependencies": {
+                    "@spectrum-css/component-builder": {
+                      "dependencies": {}
+                    },
+                    "@spectrum-css/icons": {
+                      "dependencies": {}
+                    },
+                    "@spectrum-css/vars": {}
+                  }
+                },
+                "@spectrum-css/popover": {
+                  "dependencies": {
+                    "@spectrum-css/button": {
+                      "dependencies": {}
+                    },
+                    "@spectrum-css/component-builder": {
+                      "dependencies": {}
+                    },
+                    "@spectrum-css/dialog": {
+                      "dependencies": {}
+                    },
+                    "@spectrum-css/menu": {
+                      "dependencies": {}
+                    },
+                    "@spectrum-css/vars": {}
+                  }
+                },
+                "@spectrum-css/vars": {}
+              }
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {
+                "@spectrum-css/component-builder": {
+                  "dependencies": {}
+                },
+                "@spectrum-css/vars": {}
+              }
+            },
+            "@spectrum-css/radio": {
+              "dependencies": {
+                "@spectrum-css/component-builder": {
+                  "dependencies": {
+                    "@spectrum-css/bundle-builder": {}
+                  }
+                },
+                "@spectrum-css/icons": {
+                  "dependencies": {
+                    "@spectrum-css/component-builder": {
+                      "dependencies": {}
+                    },
+                    "@spectrum-css/vars": {}
+                  }
+                },
+                "@spectrum-css/vars": {}
+              }
+            },
+            "@spectrum-css/stepper": {
+              "dependencies": {
+                "@spectrum-css/button": {
+                  "dependencies": {
+                    "@spectrum-css/component-builder": {
+                      "dependencies": {}
+                    },
+                    "@spectrum-css/icons": {
+                      "dependencies": {}
+                    },
+                    "@spectrum-css/vars": {}
+                  }
+                },
+                "@spectrum-css/component-builder": {
+                  "dependencies": {
+                    "@spectrum-css/bundle-builder": {}
+                  }
+                },
+                "@spectrum-css/icons": {
+                  "dependencies": {
+                    "@spectrum-css/component-builder": {
+                      "dependencies": {}
+                    },
+                    "@spectrum-css/vars": {}
+                  }
+                },
+                "@spectrum-css/textfield": {
+                  "dependencies": {
+                    "@spectrum-css/component-builder": {
+                      "dependencies": {
+                        "@spectrum-css/bundle-builder": {}
+                      }
+                    },
+                    "@spectrum-css/vars": {}
+                  }
+                },
+                "@spectrum-css/vars": {}
+              }
+            },
+            "@spectrum-css/textfield": {
+              "dependencies": {
+                "@spectrum-css/component-builder": {
+                  "dependencies": {}
+                },
+                "@spectrum-css/vars": {}
+              }
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/textfield": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/dialog": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/button": {
+          "dependencies": {}
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {}
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {}
+        },
+        "@spectrum-css/underlay": {
+          "dependencies": {}
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/dropdown": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/button": {
+          "dependencies": {}
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {}
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {}
+        },
+        "@spectrum-css/menu": {
+          "dependencies": {}
+        },
+        "@spectrum-css/popover": {
+          "dependencies": {}
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/dropindicator": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/dropzone": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/illustratedmessage": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {
+                "@spectrum-css/bundle-builder": {}
+              }
+            },
+            "@spectrum-css/typography": {
+              "dependencies": {
+                "@spectrum-css/component-builder": {
+                  "dependencies": {
+                    "@spectrum-css/bundle-builder": {}
+                  }
+                },
+                "@spectrum-css/vars": {}
+              }
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/link": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {
+                "@spectrum-css/bundle-builder": {}
+              }
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/fieldgroup": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/checkbox": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/radio": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/fieldlabel": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/checkbox": {
+          "dependencies": {}
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {}
+        },
+        "@spectrum-css/dropdown": {
+          "dependencies": {}
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {}
+        },
+        "@spectrum-css/radio": {
+          "dependencies": {}
+        },
+        "@spectrum-css/stepper": {
+          "dependencies": {}
+        },
+        "@spectrum-css/textfield": {
+          "dependencies": {}
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/icons": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {}
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/illustratedmessage": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {}
+        },
+        "@spectrum-css/typography": {
+          "dependencies": {}
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/inputgroup": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/button": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/menu": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/popover": {
+          "dependencies": {
+            "@spectrum-css/button": {
+              "dependencies": {}
+            },
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/dialog": {
+              "dependencies": {}
+            },
+            "@spectrum-css/menu": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/textfield": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/label": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/link": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {}
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/menu": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {}
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {}
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/miller": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/assetlist": {
+          "dependencies": {
+            "@spectrum-css/checkbox": {
+              "dependencies": {}
+            },
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/checkbox": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/page": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "requires": {
+        "@spectrum-css/vars": "^2.0.0-alpha.2"
+      },
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/vars": {
+          "version": "2.0.0-alpha.2",
+          "dev": true
+        }
+      }
+    },
+    "@spectrum-css/pagination": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/button": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/splitbutton": {
+          "dependencies": {
+            "@spectrum-css/button": {
+              "dependencies": {
+                "@spectrum-css/component-builder": {
+                  "dependencies": {}
+                },
+                "@spectrum-css/icons": {
+                  "dependencies": {}
+                },
+                "@spectrum-css/vars": {}
+              }
+            },
+            "@spectrum-css/component-builder": {
+              "dependencies": {
+                "@spectrum-css/bundle-builder": {}
+              }
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {
+                "@spectrum-css/component-builder": {
+                  "dependencies": {}
+                },
+                "@spectrum-css/vars": {}
+              }
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/textfield": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/popover": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/button": {
+          "dependencies": {}
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {}
+        },
+        "@spectrum-css/dialog": {
+          "dependencies": {}
+        },
+        "@spectrum-css/menu": {
+          "dependencies": {}
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/quickaction": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/button": {
+          "dependencies": {}
+        },
+        "@spectrum-css/checkbox": {
+          "dependencies": {}
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {}
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/radio": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {}
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {}
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/rating": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/rule": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "requires": {
+        "@spectrum-css/vars": "^2.0.0-alpha.2"
+      },
+      "dependencies": {
+        "@spectrum-css/button": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/vars": {
+          "version": "2.0.0-alpha.2",
+          "dev": true
+        }
+      }
+    },
+    "@spectrum-css/search": {
+      "version": "2.0.0-alpha.5",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/button": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/textfield": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/searchwithin": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "requires": {
+        "@spectrum-css/button": "^2.0.0-alpha.4",
+        "@spectrum-css/dropdown": "^2.0.0-alpha.4",
+        "@spectrum-css/icons": "^2.0.0-alpha.4",
+        "@spectrum-css/textfield": "^2.0.0-alpha.4",
+        "@spectrum-css/vars": "^2.0.0-alpha.2"
+      },
+      "dependencies": {
+        "@spectrum-css/button": {
+          "version": "2.0.0-alpha.4",
+          "dev": true,
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/dropdown": {
+          "version": "2.0.0-alpha.4",
+          "dev": true,
+          "dependencies": {
+            "@spectrum-css/button": {
+              "dependencies": {}
+            },
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/menu": {
+              "dependencies": {}
+            },
+            "@spectrum-css/popover": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "version": "2.0.0-alpha.4",
+          "dev": true,
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/textfield": {
+          "version": "2.0.0-alpha.4",
+          "dev": true,
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {
+          "version": "2.0.0-alpha.2",
+          "dev": true
+        }
+      }
+    },
+    "@spectrum-css/sidenav": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/slider": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/splitbutton": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/button": {
+          "dependencies": {}
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {}
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {}
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/splitview": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/statuslight": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/steplist": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/tooltip": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {
+                "@spectrum-css/bundle-builder": {}
+              }
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {
+                "@spectrum-css/component-builder": {
+                  "dependencies": {}
+                },
+                "@spectrum-css/vars": {}
+              }
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/stepper": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/button": {
+          "dependencies": {}
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {}
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {}
+        },
+        "@spectrum-css/textfield": {
+          "dependencies": {}
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/table": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/checkbox": {
+          "dependencies": {}
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {}
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {}
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/tabs": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/dropdown": {
+          "dependencies": {
+            "@spectrum-css/button": {
+              "dependencies": {}
+            },
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/menu": {
+              "dependencies": {}
+            },
+            "@spectrum-css/popover": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/menu": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/tags": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/avatar": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/button": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/textfield": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {}
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/toast": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/button": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/icons": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/toggle": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/tooltip": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {}
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {}
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/treeview": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/icons": {
+          "dependencies": {
+            "@spectrum-css/component-builder": {
+              "dependencies": {}
+            },
+            "@spectrum-css/vars": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/typography": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {}
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/underlay": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {}
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "@spectrum-css/vars": {
+      "version": "2.0.0-alpha.2",
+      "dev": true
+    },
+    "@spectrum-css/well": {
+      "version": "2.0.0-alpha.4",
+      "dev": true,
+      "dependencies": {
+        "@spectrum-css/component-builder": {
+          "dependencies": {
+            "@spectrum-css/bundle-builder": {}
+          }
+        },
+        "@spectrum-css/vars": {}
+      }
+    },
+    "ansi-colors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+      "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
+      "dev": true,
+      "requires": {
+        "ansi-wrap": "^0.1.0"
+      }
+    },
+    "ansi-gray": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+      "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+      "dev": true,
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
+    },
+    "ansi-wrap": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+      "dev": true
+    },
+    "anymatch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+      "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+      "dev": true,
+      "requires": {
+        "micromatch": "^3.1.4",
+        "normalize-path": "^2.1.1"
+      }
+    },
+    "append-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/append-buffer/-/append-buffer-1.0.2.tgz",
+      "integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
+      "dev": true,
+      "requires": {
+        "buffer-equal": "^1.0.0"
+      }
+    },
+    "archy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+      "dev": true
+    },
+    "arr-diff": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "dev": true
+    },
+    "arr-filter": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/arr-filter/-/arr-filter-1.1.2.tgz",
+      "integrity": "sha1-Q/3d0JHo7xGqTEXZzcGOLf8XEe4=",
+      "dev": true,
+      "requires": {
+        "make-iterator": "^1.0.0"
+      }
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true
+    },
+    "arr-map": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/arr-map/-/arr-map-2.0.2.tgz",
+      "integrity": "sha1-Onc0X/wc814qkYJWAfnljy4kysQ=",
+      "dev": true,
+      "requires": {
+        "make-iterator": "^1.0.0"
+      }
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true
+    },
+    "array-each": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
+      "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8=",
+      "dev": true
+    },
+    "array-initial": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/array-initial/-/array-initial-1.1.0.tgz",
+      "integrity": "sha1-L6dLJnOTccOUe9enrcc74zSz15U=",
+      "dev": true,
+      "requires": {
+        "array-slice": "^1.0.0",
+        "is-number": "^4.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
+        }
+      }
+    },
+    "array-last": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/array-last/-/array-last-1.3.0.tgz",
+      "integrity": "sha512-eOCut5rXlI6aCOS7Z7kCplKRKyiFQ6dHFBem4PwlwKeNFk2/XxTrhRh5T9PyaEWGy/NHTZWbY+nsZlNFJu9rYg==",
+      "dev": true,
+      "requires": {
+        "is-number": "^4.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
+        }
+      }
+    },
+    "array-slice": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
+      "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w==",
+      "dev": true
+    },
+    "array-sort": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-sort/-/array-sort-1.0.0.tgz",
+      "integrity": "sha512-ihLeJkonmdiAsD7vpgN3CRcx2J2S0TiYW+IS/5zHBI7mKUq3ySvBdzzBfD236ubDBQFiiyG3SWCPc+msQ9KoYg==",
+      "dev": true,
+      "requires": {
+        "default-compare": "^1.0.0",
+        "get-value": "^2.0.6",
+        "kind-of": "^5.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "array-unique": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "dev": true
+    },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
+    },
+    "async-done": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/async-done/-/async-done-1.3.2.tgz",
+      "integrity": "sha512-uYkTP8dw2og1tu1nmza1n1CMW0qb8gWWlwqMmLb7MhBVs4BXrFziT6HXUd+/RlRA/i4H9AkofYloUbs1fwMqlw==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.2",
+        "process-nextick-args": "^2.0.0",
+        "stream-exhaust": "^1.0.1"
+      }
+    },
+    "async-each": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+      "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
+      "dev": true
+    },
+    "async-settle": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-settle/-/async-settle-1.0.0.tgz",
+      "integrity": "sha1-HQqRS7Aldb7IqPOnTlCA9yssDGs=",
+      "dev": true,
+      "requires": {
+        "async-done": "^1.2.2"
+      }
+    },
+    "atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "dev": true
+    },
+    "bach": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/bach/-/bach-1.2.0.tgz",
+      "integrity": "sha1-Szzpa/JxNPeaG0FKUcFONMO9mIA=",
+      "dev": true,
+      "requires": {
+        "arr-filter": "^1.1.1",
+        "arr-flatten": "^1.0.1",
+        "arr-map": "^2.0.0",
+        "array-each": "^1.0.0",
+        "array-initial": "^1.0.0",
+        "array-last": "^1.1.1",
+        "async-done": "^1.2.2",
+        "async-settle": "^1.0.0",
+        "now-and-later": "^2.0.0"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "base": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "dev": true,
+      "requires": {
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "binary-extensions": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+      "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+      "dev": true,
+      "requires": {
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "buffer-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
+      "integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74=",
+      "dev": true
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "dev": true,
+      "requires": {
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
+      }
+    },
+    "chokidar": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+      "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+      "dev": true,
+      "requires": {
+        "anymatch": "^2.0.0",
+        "async-each": "^1.0.1",
+        "braces": "^2.3.2",
+        "fsevents": "^1.2.7",
+        "glob-parent": "^3.1.0",
+        "inherits": "^2.0.3",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^4.0.0",
+        "normalize-path": "^3.0.0",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.2.1",
+        "upath": "^1.1.1"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+          "dev": true
+        }
+      }
+    },
+    "class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
+    "cliui": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wrap-ansi": "^2.0.0"
+      }
+    },
+    "clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+      "dev": true
+    },
+    "clone-buffer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+      "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
+      "dev": true
+    },
+    "clone-stats": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+      "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+      "dev": true
+    },
+    "cloneable-readable": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.3.tgz",
+      "integrity": "sha512-2EF8zTQOxYq70Y4XKtorQupqF0m49MBz2/yf5Bj+MHjvpG3Hy7sImifnqD6UA+TKYxeSV+u6qqQPawN5UvnpKQ==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "process-nextick-args": "^2.0.0",
+        "readable-stream": "^2.3.5"
+      }
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
+    "collection-map": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-map/-/collection-map-1.0.0.tgz",
+      "integrity": "sha1-rqDwb40mx4DCt1SUOFVEsiVa8Yw=",
+      "dev": true,
+      "requires": {
+        "arr-map": "^2.0.2",
+        "for-own": "^1.0.0",
+        "make-iterator": "^1.0.0"
+      }
+    },
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "dev": true,
+      "requires": {
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
+      }
+    },
+    "color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true
+    },
+    "component-emitter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "convert-source-map": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+      "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
+    },
+    "copy-props": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/copy-props/-/copy-props-2.0.4.tgz",
+      "integrity": "sha512-7cjuUME+p+S3HZlbllgsn2CDwS+5eCCX16qBgNC4jgSTf49qR1VKy/Zhl400m0IQXl/bPGEVqncgUUMjrr4s8A==",
+      "dev": true,
+      "requires": {
+        "each-props": "^1.3.0",
+        "is-plain-object": "^2.0.1"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "dev": true,
+      "requires": {
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
+      }
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
+    },
+    "default-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/default-compare/-/default-compare-1.0.0.tgz",
+      "integrity": "sha512-QWfXlM0EkAbqOCbD/6HjdwT19j7WCkMyiRhWilc4H9/5h/RzTF9gv5LYh1+CmDV5d1rki6KAWLtQale0xt20eQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "^5.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "default-resolution": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/default-resolution/-/default-resolution-2.0.0.tgz",
+      "integrity": "sha1-vLgrqnKtebQmp2cy8aga1t8m1oQ=",
+      "dev": true
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
+    "define-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "dev": true,
+      "requires": {
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "detect-file": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
+      "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
+      "dev": true
+    },
+    "duplexify": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      }
+    },
+    "each-props": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/each-props/-/each-props-1.3.2.tgz",
+      "integrity": "sha512-vV0Hem3zAGkJAyU7JSjixeU66rwdynTAa1vofCrSA5fEln+m67Az9CcnkVD776/fsN/UjIWmBDoNRS6t6G9RfA==",
+      "dev": true,
+      "requires": {
+        "is-plain-object": "^2.0.1",
+        "object.defaults": "^1.1.0"
+      }
+    },
+    "end-of-stream": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "dev": true,
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "es5-ext": {
+      "version": "0.10.50",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.50.tgz",
+      "integrity": "sha512-KMzZTPBkeQV/JcSQhI5/z6d9VWJ3EnQ194USTUwIYZ2ZbpN8+SGXQKt1h68EX44+qt+Fzr8DO17vnxrw7c3agw==",
+      "dev": true,
+      "requires": {
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.1",
+        "next-tick": "^1.0.0"
+      }
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "es6-symbol": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
+    },
+    "es6-weak-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "expand-brackets": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+      "dev": true,
+      "requires": {
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "expand-tilde": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+      "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+      "dev": true,
+      "requires": {
+        "homedir-polyfill": "^1.0.1"
+      }
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
+    },
+    "extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "dev": true,
+      "requires": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "extglob": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+      "dev": true,
+      "requires": {
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "fancy-log": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.3.tgz",
+      "integrity": "sha512-k9oEhlyc0FrVh25qYuSELjr8oxsCoc4/LEZfg2iJJrfEk/tZL9bCoJE47gqAvI2m/AUjluCS4+3I0eTx8n3AEw==",
+      "dev": true,
+      "requires": {
+        "ansi-gray": "^0.1.1",
+        "color-support": "^1.1.3",
+        "parse-node-version": "^1.0.0",
+        "time-stamp": "^1.0.0"
+      }
+    },
+    "fill-range": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "findup-sync": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-3.0.0.tgz",
+      "integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
+      "dev": true,
+      "requires": {
+        "detect-file": "^1.0.0",
+        "is-glob": "^4.0.0",
+        "micromatch": "^3.0.4",
+        "resolve-dir": "^1.0.1"
+      }
+    },
+    "fined": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fined/-/fined-1.2.0.tgz",
+      "integrity": "sha512-ZYDqPLGxDkDhDZBjZBb+oD1+j0rA4E0pXY50eplAAOPg2N/gUBSSk5IM1/QhPfyVo19lJ+CvXpqfvk+b2p/8Ng==",
+      "dev": true,
+      "requires": {
+        "expand-tilde": "^2.0.2",
+        "is-plain-object": "^2.0.3",
+        "object.defaults": "^1.1.0",
+        "object.pick": "^1.2.0",
+        "parse-filepath": "^1.0.1"
+      }
+    },
+    "flagged-respawn": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
+      "integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q==",
+      "dev": true
+    },
+    "flush-write-stream": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
+      "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.3.6"
+      }
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
+    },
+    "for-own": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+      "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+      "dev": true,
+      "requires": {
+        "for-in": "^1.0.1"
+      }
+    },
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "dev": true,
+      "requires": {
+        "map-cache": "^0.2.2"
+      }
+    },
+    "fs-mkdirp-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz",
+      "integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.11",
+        "through2": "^2.0.3"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "fsevents": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+      "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "^2.12.1",
+        "node-pre-gyp": "^0.12.0"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "debug": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "deep-extend": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minimatch": "^3.0.4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "minipass": {
+          "version": "2.3.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "needle": {
+          "version": "2.3.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "^4.1.0",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.12.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.1",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.2.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "npm-packlist": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "^0.6.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "semver": {
+          "version": "5.7.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "4.4.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "wide-align": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "^1.0.2 || 2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "get-caller-file": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+      "dev": true
+    },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+      "dev": true,
+      "requires": {
+        "is-glob": "^3.1.0",
+        "path-dirname": "^1.0.0"
+      },
+      "dependencies": {
+        "is-glob": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.0"
+          }
+        }
+      }
+    },
+    "glob-stream": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-6.1.0.tgz",
+      "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
+      "dev": true,
+      "requires": {
+        "extend": "^3.0.0",
+        "glob": "^7.1.1",
+        "glob-parent": "^3.1.0",
+        "is-negated-glob": "^1.0.0",
+        "ordered-read-streams": "^1.0.0",
+        "pumpify": "^1.3.5",
+        "readable-stream": "^2.1.5",
+        "remove-trailing-separator": "^1.0.1",
+        "to-absolute-glob": "^2.0.0",
+        "unique-stream": "^2.0.2"
+      }
+    },
+    "glob-watcher": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-5.0.3.tgz",
+      "integrity": "sha512-8tWsULNEPHKQ2MR4zXuzSmqbdyV5PtwwCaWSGQ1WwHsJ07ilNeN1JB8ntxhckbnpSHaf9dXFUHzIWvm1I13dsg==",
+      "dev": true,
+      "requires": {
+        "anymatch": "^2.0.0",
+        "async-done": "^1.2.0",
+        "chokidar": "^2.0.0",
+        "is-negated-glob": "^1.0.0",
+        "just-debounce": "^1.0.0",
+        "object.defaults": "^1.1.0"
+      }
+    },
+    "global-modules": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+      "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+      "dev": true,
+      "requires": {
+        "global-prefix": "^1.0.1",
+        "is-windows": "^1.0.1",
+        "resolve-dir": "^1.0.0"
+      }
+    },
+    "global-prefix": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+      "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+      "dev": true,
+      "requires": {
+        "expand-tilde": "^2.0.2",
+        "homedir-polyfill": "^1.0.1",
+        "ini": "^1.3.4",
+        "is-windows": "^1.0.1",
+        "which": "^1.2.14"
+      }
+    },
+    "glogg": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.2.tgz",
+      "integrity": "sha512-5mwUoSuBk44Y4EshyiqcH95ZntbDdTQqA3QYSrxmzj28Ai0vXBGMH1ApSANH14j2sIRtqCEyg6PfsuP7ElOEDA==",
+      "dev": true,
+      "requires": {
+        "sparkles": "^1.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+      "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
+      "dev": true
+    },
+    "gulp": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/gulp/-/gulp-4.0.2.tgz",
+      "integrity": "sha512-dvEs27SCZt2ibF29xYgmnwwCYZxdxhQ/+LFWlbAW8y7jt68L/65402Lz3+CKy0Ov4rOs+NERmDq7YlZaDqUIfA==",
+      "dev": true,
+      "requires": {
+        "glob-watcher": "^5.0.3",
+        "gulp-cli": "^2.2.0",
+        "undertaker": "^1.2.1",
+        "vinyl-fs": "^3.0.0"
+      },
+      "dependencies": {
+        "gulp-cli": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.2.0.tgz",
+          "integrity": "sha512-rGs3bVYHdyJpLqR0TUBnlcZ1O5O++Zs4bA0ajm+zr3WFCfiSLjGwoCBqFs18wzN+ZxahT9DkOK5nDf26iDsWjA==",
+          "dev": true,
+          "requires": {
+            "ansi-colors": "^1.0.1",
+            "archy": "^1.0.0",
+            "array-sort": "^1.0.0",
+            "color-support": "^1.1.3",
+            "concat-stream": "^1.6.0",
+            "copy-props": "^2.0.1",
+            "fancy-log": "^1.3.2",
+            "gulplog": "^1.0.0",
+            "interpret": "^1.1.0",
+            "isobject": "^3.0.1",
+            "liftoff": "^3.1.0",
+            "matchdep": "^2.0.0",
+            "mute-stdout": "^1.0.0",
+            "pretty-hrtime": "^1.0.0",
+            "replace-homedir": "^1.0.0",
+            "semver-greatest-satisfied-range": "^1.1.0",
+            "v8flags": "^3.0.1",
+            "yargs": "^7.1.0"
+          }
+        }
+      }
+    },
+    "gulplog": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+      "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
+      "dev": true,
+      "requires": {
+        "glogg": "^1.0.0"
+      }
+    },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true
+    },
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "dev": true,
+      "requires": {
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "dev": true,
+      "requires": {
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "homedir-polyfill": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+      "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+      "dev": true,
+      "requires": {
+        "parse-passwd": "^1.0.0"
+      }
+    },
+    "hosted-git-info": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
+      "integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "dev": true
+    },
+    "interpret": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
+      "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
+      "dev": true
+    },
+    "invert-kv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "dev": true
+    },
+    "is-absolute": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
+      "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
+      "dev": true,
+      "requires": {
+        "is-relative": "^1.0.0",
+        "is-windows": "^1.0.1"
+      }
+    },
+    "is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-binary-path": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^1.0.0"
+      }
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
+    },
+    "is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "dev": true,
+      "requires": {
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "^1.0.0"
+      }
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-negated-glob": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
+      "integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=",
+      "dev": true
+    },
+    "is-number": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
+    "is-relative": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
+      "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
+      "dev": true,
+      "requires": {
+        "is-unc-path": "^1.0.0"
+      }
+    },
+    "is-unc-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
+      "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
+      "dev": true,
+      "requires": {
+        "unc-path-regex": "^0.1.2"
+      }
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
+    },
+    "is-valid-glob": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
+      "integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao=",
+      "dev": true
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "just-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/just-debounce/-/just-debounce-1.0.0.tgz",
+      "integrity": "sha1-h/zPrv/AtozRnVX2cilD+SnqNeo=",
+      "dev": true
+    },
+    "kind-of": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+      "dev": true
+    },
+    "last-run": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/last-run/-/last-run-1.1.1.tgz",
+      "integrity": "sha1-RblpQsF7HHnHchmCWbqUO+v4yls=",
+      "dev": true,
+      "requires": {
+        "default-resolution": "^2.0.0",
+        "es6-weak-map": "^2.0.1"
+      }
+    },
+    "lazystream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+      "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.0.5"
+      }
+    },
+    "lcid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "dev": true,
+      "requires": {
+        "invert-kv": "^1.0.0"
+      }
+    },
+    "lead": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lead/-/lead-1.0.0.tgz",
+      "integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
+      "dev": true,
+      "requires": {
+        "flush-write-stream": "^1.0.2"
+      }
+    },
+    "liftoff": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-3.1.0.tgz",
+      "integrity": "sha512-DlIPlJUkCV0Ips2zf2pJP0unEoT1kwYhiiPUGF3s/jtxTCjziNLoiVVh+jqWOWeFi6mmwQ5fNxvAUyPad4Dfog==",
+      "dev": true,
+      "requires": {
+        "extend": "^3.0.0",
+        "findup-sync": "^3.0.0",
+        "fined": "^1.0.1",
+        "flagged-respawn": "^1.0.0",
+        "is-plain-object": "^2.0.4",
+        "object.map": "^1.0.0",
+        "rechoir": "^0.6.2",
+        "resolve": "^1.1.7"
+      }
+    },
+    "make-iterator": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
+      "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
+      "dev": true,
+      "requires": {
+        "kind-of": "^6.0.2"
+      }
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true
+    },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "dev": true,
+      "requires": {
+        "object-visit": "^1.0.0"
+      }
+    },
+    "matchdep": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/matchdep/-/matchdep-2.0.0.tgz",
+      "integrity": "sha1-xvNINKDY28OzfCfui7yyfHd1WC4=",
+      "dev": true,
+      "requires": {
+        "findup-sync": "^2.0.0",
+        "micromatch": "^3.0.4",
+        "resolve": "^1.4.0",
+        "stack-trace": "0.0.10"
+      },
+      "dependencies": {
+        "findup-sync": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
+          "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+          "dev": true,
+          "requires": {
+            "detect-file": "^1.0.0",
+            "is-glob": "^3.1.0",
+            "micromatch": "^3.0.4",
+            "resolve-dir": "^1.0.1"
+          }
+        },
+        "is-glob": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.0"
+          }
+        }
+      }
+    },
+    "micromatch": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "mixin-deep": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+      "dev": true,
+      "requires": {
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "mute-stdout": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mute-stdout/-/mute-stdout-1.0.1.tgz",
+      "integrity": "sha512-kDcwXR4PS7caBpuRYYBUz9iVixUk3anO3f5OYFiIPwK/20vCzKCHyKoulbiDY1S53zD2bxUpxN/IJ+TnXjfvxg==",
+      "dev": true
+    },
+    "nan": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+      "dev": true,
+      "optional": true
+    },
+    "nanomatch": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      }
+    },
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+      "dev": true
+    },
+    "normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "dev": true,
+      "requires": {
+        "remove-trailing-separator": "^1.0.1"
+      }
+    },
+    "now-and-later": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/now-and-later/-/now-and-later-2.0.1.tgz",
+      "integrity": "sha512-KGvQ0cB70AQfg107Xvs/Fbu+dGmZoTRJp2TaPwcwQm3/7PteUyN2BCgk8KBMPGBUXZdVwyWS8fDCGFygBm19UQ==",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.2"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "dev": true,
+      "requires": {
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
+    },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.0"
+      }
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
+    },
+    "object.defaults": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
+      "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
+      "dev": true,
+      "requires": {
+        "array-each": "^1.0.1",
+        "array-slice": "^1.0.0",
+        "for-own": "^1.0.0",
+        "isobject": "^3.0.0"
+      }
+    },
+    "object.map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object.map/-/object.map-1.0.1.tgz",
+      "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
+      "dev": true,
+      "requires": {
+        "for-own": "^1.0.0",
+        "make-iterator": "^1.0.0"
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
+    "object.reduce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object.reduce/-/object.reduce-1.0.1.tgz",
+      "integrity": "sha1-b+NI8qx/oPlcpiEiZZkJaCW7A60=",
+      "dev": true,
+      "requires": {
+        "for-own": "^1.0.0",
+        "make-iterator": "^1.0.0"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "ordered-read-streams": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz",
+      "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.0.1"
+      }
+    },
+    "os-locale": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "dev": true,
+      "requires": {
+        "lcid": "^1.0.0"
+      }
+    },
+    "parse-filepath": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
+      "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
+      "dev": true,
+      "requires": {
+        "is-absolute": "^1.0.0",
+        "map-cache": "^0.2.0",
+        "path-root": "^0.1.1"
+      }
+    },
+    "parse-node-version": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.1.tgz",
+      "integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==",
+      "dev": true
+    },
+    "parse-passwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+      "dev": true
+    },
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "dev": true
+    },
+    "path-dirname": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "path-root": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
+      "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
+      "dev": true,
+      "requires": {
+        "path-root-regex": "^0.1.0"
+      }
+    },
+    "path-root-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
+      "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
+    },
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true
+    },
+    "pretty-hrtime": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+      "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
+    "pump": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+      "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "pumpify": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+      "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+      "dev": true,
+      "requires": {
+        "duplexify": "^3.6.0",
+        "inherits": "^2.0.3",
+        "pump": "^2.0.0"
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "readdirp": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+      "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.11",
+        "micromatch": "^3.1.10",
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
+    "regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "remove-bom-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz",
+      "integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
+      "dev": true,
+      "requires": {
+        "is-buffer": "^1.1.5",
+        "is-utf8": "^0.2.1"
+      }
+    },
+    "remove-bom-stream": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/remove-bom-stream/-/remove-bom-stream-1.2.0.tgz",
+      "integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
+      "dev": true,
+      "requires": {
+        "remove-bom-buffer": "^3.0.0",
+        "safe-buffer": "^5.1.0",
+        "through2": "^2.0.3"
+      }
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
+    },
+    "repeat-element": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+      "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+      "dev": true
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
+    "replace-ext": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+      "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+      "dev": true
+    },
+    "replace-homedir": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/replace-homedir/-/replace-homedir-1.0.0.tgz",
+      "integrity": "sha1-6H9tUTuSjd6AgmDBK+f+xv9ueYw=",
+      "dev": true,
+      "requires": {
+        "homedir-polyfill": "^1.0.1",
+        "is-absolute": "^1.0.0",
+        "remove-trailing-separator": "^1.1.0"
+      }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+      "dev": true
+    },
+    "resolve": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+      "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
+    },
+    "resolve-dir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+      "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+      "dev": true,
+      "requires": {
+        "expand-tilde": "^2.0.0",
+        "global-modules": "^1.0.0"
+      }
+    },
+    "resolve-options": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-options/-/resolve-options-1.1.0.tgz",
+      "integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
+      "dev": true,
+      "requires": {
+        "value-or-function": "^3.0.0"
+      }
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "dev": true
+    },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "dev": true,
+      "requires": {
+        "ret": "~0.1.10"
+      }
+    },
+    "semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true
+    },
+    "semver-greatest-satisfied-range": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/semver-greatest-satisfied-range/-/semver-greatest-satisfied-range-1.1.0.tgz",
+      "integrity": "sha1-E+jCZYq5aRywzXEJMkAoDTb3els=",
+      "dev": true,
+      "requires": {
+        "sver-compat": "^1.5.0"
+      }
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
+    "set-value": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "snapdragon": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "dev": true,
+      "requires": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "dev": true,
+      "requires": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.2.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
+    },
+    "source-map-resolve": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+      "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+      "dev": true,
+      "requires": {
+        "atob": "^2.1.1",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
+      }
+    },
+    "source-map-url": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "dev": true
+    },
+    "sparkles": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
+      "integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw==",
+      "dev": true
+    },
+    "spdx-correct": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+      "dev": true
+    },
+    "split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.0"
+      }
+    },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+      "dev": true
+    },
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "dev": true,
+      "requires": {
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
+    "stream-exhaust": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stream-exhaust/-/stream-exhaust-1.0.2.tgz",
+      "integrity": "sha512-b/qaq/GlBK5xaq1yrK9/zFcyRSTNxmcZwFLGSTG0mXgZl/4Z6GgiyYOXOvY7N3eEvFRAG1bkDRz5EPGSvPYQlw==",
+      "dev": true
+    },
+    "stream-shift": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
+      "dev": true
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
+      "requires": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "sver-compat": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/sver-compat/-/sver-compat-1.5.0.tgz",
+      "integrity": "sha1-PPh9/rTQe0o/FIJ7wYaz/QxkXNg=",
+      "dev": true,
+      "requires": {
+        "es6-iterator": "^2.0.1",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "dev": true,
+      "requires": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "through2-filter": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-3.0.0.tgz",
+      "integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
+      "dev": true,
+      "requires": {
+        "through2": "~2.0.0",
+        "xtend": "~4.0.0"
+      }
+    },
+    "time-stamp": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
+      "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
+      "dev": true
+    },
+    "to-absolute-glob": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
+      "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
+      "dev": true,
+      "requires": {
+        "is-absolute": "^1.0.0",
+        "is-negated-glob": "^1.0.0"
+      }
+    },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "dev": true,
+      "requires": {
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "dev": true,
+      "requires": {
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
+      }
+    },
+    "to-through": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-through/-/to-through-2.0.0.tgz",
+      "integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
+      "dev": true,
+      "requires": {
+        "through2": "^2.0.3"
+      }
+    },
+    "type": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.0.3.tgz",
+      "integrity": "sha512-51IMtNfVcee8+9GJvj0spSuFcZHe9vSib6Xtgsny1Km9ugyz2mbS08I3rsUIRYgJohFRFU1160sgRodYz378Hg==",
+      "dev": true
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "unc-path-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+      "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
+      "dev": true
+    },
+    "undertaker": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/undertaker/-/undertaker-1.2.1.tgz",
+      "integrity": "sha512-71WxIzDkgYk9ZS+spIB8iZXchFhAdEo2YU8xYqBYJ39DIUIqziK78ftm26eecoIY49X0J2MLhG4hr18Yp6/CMA==",
+      "dev": true,
+      "requires": {
+        "arr-flatten": "^1.0.1",
+        "arr-map": "^2.0.0",
+        "bach": "^1.0.0",
+        "collection-map": "^1.0.0",
+        "es6-weak-map": "^2.0.1",
+        "last-run": "^1.1.0",
+        "object.defaults": "^1.0.0",
+        "object.reduce": "^1.0.0",
+        "undertaker-registry": "^1.0.0"
+      }
+    },
+    "undertaker-registry": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/undertaker-registry/-/undertaker-registry-1.0.1.tgz",
+      "integrity": "sha1-XkvaMI5KiirlhPm5pDWaSZglzFA=",
+      "dev": true
+    },
+    "union-value": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^2.0.1"
+      }
+    },
+    "unique-stream": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.3.1.tgz",
+      "integrity": "sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==",
+      "dev": true,
+      "requires": {
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "through2-filter": "^3.0.0"
+      }
+    },
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "dev": true,
+      "requires": {
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "dev": true,
+          "requires": {
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "dev": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "dev": true
+        }
+      }
+    },
+    "upath": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.2.tgz",
+      "integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==",
+      "dev": true
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "dev": true
+    },
+    "use": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "v8flags": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.3.tgz",
+      "integrity": "sha512-amh9CCg3ZxkzQ48Mhcb8iX7xpAfYJgePHxWMQCBWECpOSqJUXgY26ncA61UTV0BkPqfhcy6mzwCIoP4ygxpW8w==",
+      "dev": true,
+      "requires": {
+        "homedir-polyfill": "^1.0.1"
+      }
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "value-or-function": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/value-or-function/-/value-or-function-3.0.0.tgz",
+      "integrity": "sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM=",
+      "dev": true
+    },
+    "vinyl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+      "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
+      "dev": true,
+      "requires": {
+        "clone": "^2.1.1",
+        "clone-buffer": "^1.0.0",
+        "clone-stats": "^1.0.0",
+        "cloneable-readable": "^1.0.0",
+        "remove-trailing-separator": "^1.0.1",
+        "replace-ext": "^1.0.0"
+      }
+    },
+    "vinyl-fs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-3.0.3.tgz",
+      "integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
+      "dev": true,
+      "requires": {
+        "fs-mkdirp-stream": "^1.0.0",
+        "glob-stream": "^6.1.0",
+        "graceful-fs": "^4.0.0",
+        "is-valid-glob": "^1.0.0",
+        "lazystream": "^1.0.0",
+        "lead": "^1.0.0",
+        "object.assign": "^4.0.4",
+        "pumpify": "^1.3.5",
+        "readable-stream": "^2.3.3",
+        "remove-bom-buffer": "^3.0.0",
+        "remove-bom-stream": "^1.2.0",
+        "resolve-options": "^1.1.0",
+        "through2": "^2.0.0",
+        "to-through": "^2.0.0",
+        "value-or-function": "^3.0.0",
+        "vinyl": "^2.0.0",
+        "vinyl-sourcemap": "^1.1.0"
+      }
+    },
+    "vinyl-sourcemap": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/vinyl-sourcemap/-/vinyl-sourcemap-1.1.0.tgz",
+      "integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
+      "dev": true,
+      "requires": {
+        "append-buffer": "^1.0.2",
+        "convert-source-map": "^1.5.0",
+        "graceful-fs": "^4.1.6",
+        "normalize-path": "^2.1.1",
+        "now-and-later": "^2.0.0",
+        "remove-bom-buffer": "^3.0.0",
+        "vinyl": "^2.0.0"
+      }
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "which-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+      "dev": true
+    },
+    "wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true
+    },
+    "y18n": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+      "dev": true
+    },
+    "yargs": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+      "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+      "dev": true,
+      "requires": {
+        "camelcase": "^3.0.0",
+        "cliui": "^3.2.0",
+        "decamelize": "^1.1.1",
+        "get-caller-file": "^1.0.1",
+        "os-locale": "^1.4.0",
+        "read-pkg-up": "^1.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^1.0.1",
+        "set-blocking": "^2.0.0",
+        "string-width": "^1.0.2",
+        "which-module": "^1.0.0",
+        "y18n": "^3.2.1",
+        "yargs-parser": "^5.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "dev": true
+        },
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
+          "requires": {
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "dev": true,
+          "requires": {
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "^0.2.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+          "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^3.0.0"
+          }
+        }
+      }
+    }
+  }
 }

--- a/bundles/spectrum-css/package.json
+++ b/bundles/spectrum-css/package.json
@@ -20,10 +20,8 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
-  "optionalDependencies": {
-    "@spectrum/spectrum-icons": "^2.3.0"
-  },
   "devDependencies": {
+    "@adobe/spectrum-css-workflow-icons": "^1.0.0-beta.3",
     "@spectrum-css/accordion": "^2.0.0-alpha.4",
     "@spectrum-css/actionbar": "^2.0.0-alpha.4",
     "@spectrum-css/actionmenu": "^2.0.0-alpha.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,12 +59,6 @@
 					"resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
 					"integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
 					"dev": true
-				},
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
 				}
 			}
 		},
@@ -124,12 +118,6 @@
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
 					"integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
-					"dev": true
-				},
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
 					"dev": true
 				}
 			}
@@ -1434,40 +1422,17 @@
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
 			"integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
+			"dev": true,
 			"requires": {
 				"call-me-maybe": "^1.0.1",
 				"glob-to-regexp": "^0.3.0"
 			}
 		},
-		"@nodelib/fs.scandir": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.1.tgz",
-			"integrity": "sha512-NT/skIZjgotDSiXs0WqYhgcuBKhUMgfekCmCGtkUAiLqZdOnrdjmZr9wRl3ll64J9NF79uZ4fk16Dx0yMc/Xbg==",
-			"requires": {
-				"@nodelib/fs.stat": "2.0.1",
-				"run-parallel": "^1.1.9"
-			},
-			"dependencies": {
-				"@nodelib/fs.stat": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.1.tgz",
-					"integrity": "sha512-+RqhBlLn6YRBGOIoVYthsG0J9dfpO79eJyN7BYBkZJtfqrBwf2KK+rD/M/yjZR6WBmIhAgOV7S60eCgaSWtbFw=="
-				}
-			}
-		},
 		"@nodelib/fs.stat": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
-			"integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
-		},
-		"@nodelib/fs.walk": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.2.tgz",
-			"integrity": "sha512-J/DR3+W12uCzAJkw7niXDcqcKBg6+5G5Q/ZpThpGNzAUz70eOR6RV4XnnSN01qHZiVl0eavoxJsBypQoKsV2QQ==",
-			"requires": {
-				"@nodelib/fs.scandir": "2.1.1",
-				"fastq": "^1.6.0"
-			}
+			"integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
+			"dev": true
 		},
 		"@octokit/endpoint": {
 			"version": "5.3.2",
@@ -1621,37 +1586,17 @@
 				}
 			}
 		},
-		"@spectrum/spectrum-icons": {
-			"version": "2.3.0",
-			"resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-spectrum-release/@spectrum/spectrum-icons/-/@spectrum/spectrum-icons-2.3.0.tgz",
-			"integrity": "sha1-IlbN3PcBo3HJgtJX5bmIaDUktD4=",
-			"optional": true,
-			"requires": {
-				"gh-pages": "^2.0.1"
-			}
-		},
-		"@types/babel-types": {
-			"version": "7.0.7",
-			"resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.7.tgz",
-			"integrity": "sha512-dBtBbrc+qTHy1WdfHYjBwRln4+LWqASWakLHsWHR2NWHIFkv4W3O070IGoGLEBrJBvct3r0L1BUPuvURi7kYUQ=="
-		},
-		"@types/babylon": {
-			"version": "6.16.5",
-			"resolved": "https://registry.npmjs.org/@types/babylon/-/babylon-6.16.5.tgz",
-			"integrity": "sha512-xH2e58elpj1X4ynnKp9qSnWlsRTIs6n3tgLGNfwAGHwePw0mulHQllV34n0T25uYSu1k0hRKkWXF890B1yS47w==",
-			"requires": {
-				"@types/babel-types": "*"
-			}
-		},
 		"@types/events": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-			"integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
+			"integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+			"dev": true
 		},
 		"@types/glob": {
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
 			"integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+			"dev": true,
 			"requires": {
 				"@types/events": "*",
 				"@types/minimatch": "*",
@@ -1661,22 +1606,14 @@
 		"@types/minimatch": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
+			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+			"dev": true
 		},
 		"@types/node": {
 			"version": "12.7.2",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.2.tgz",
-			"integrity": "sha512-dyYO+f6ihZEtNPDcWNR1fkoTDf3zAK3lAABDze3mz6POyIercH0lEUawUFXlG8xaQZmm1yEBON/4TsYv/laDYg=="
-		},
-		"@types/pug": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/@types/pug/-/pug-2.0.4.tgz",
-			"integrity": "sha1-h3L80EGOPNLMFxVV1zAHQVBR9LI="
-		},
-		"@types/q": {
-			"version": "1.5.2",
-			"resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
-			"integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw=="
+			"integrity": "sha512-dyYO+f6ihZEtNPDcWNR1fkoTDf3zAK3lAABDze3mz6POyIercH0lEUawUFXlG8xaQZmm1yEBON/4TsYv/laDYg==",
+			"dev": true
 		},
 		"@zkochan/cmd-shim": {
 			"version": "3.1.0",
@@ -1704,40 +1641,6 @@
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
 			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
 			"dev": true
-		},
-		"accepts": {
-			"version": "1.3.7",
-			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
-			"integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
-			"requires": {
-				"mime-types": "~2.1.24",
-				"negotiator": "0.6.2"
-			}
-		},
-		"acorn": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-			"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
-		},
-		"acorn-globals": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
-			"integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
-			"requires": {
-				"acorn": "^4.0.4"
-			},
-			"dependencies": {
-				"acorn": {
-					"version": "4.0.13",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-					"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
-				}
-			}
-		},
-		"after": {
-			"version": "0.8.2",
-			"resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
-			"integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
 		},
 		"agent-base": {
 			"version": "4.3.0",
@@ -1769,69 +1672,26 @@
 				"uri-js": "^4.2.2"
 			}
 		},
-		"align-text": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-			"requires": {
-				"kind-of": "^3.0.2",
-				"longest": "^1.0.1",
-				"repeat-string": "^1.5.2"
-			},
-			"dependencies": {
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"requires": {
-						"is-buffer": "^1.1.5"
-					}
-				}
-			}
-		},
 		"ansi-colors": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
 			"integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
+			"dev": true,
 			"requires": {
 				"ansi-wrap": "^0.1.0"
 			}
 		},
-		"ansi-cyan": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
-			"integrity": "sha1-U4rlKK+JgvKK4w2G8vF0VtJgmHM=",
-			"requires": {
-				"ansi-wrap": "0.1.0"
-			}
-		},
 		"ansi-escapes": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.2.1.tgz",
-			"integrity": "sha512-Cg3ymMAdN10wOk/VYfLV7KCQyv7EDirJ64500sU7n9UlmioEtDuU5Gd+hj73hXSU/ex7tHJSssmyftDdkMLO8Q==",
-			"requires": {
-				"type-fest": "^0.5.2"
-			},
-			"dependencies": {
-				"type-fest": {
-					"version": "0.5.2",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.5.2.tgz",
-					"integrity": "sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw=="
-				}
-			}
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+			"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+			"dev": true
 		},
 		"ansi-gray": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
 			"integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
-			"requires": {
-				"ansi-wrap": "0.1.0"
-			}
-		},
-		"ansi-red": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
-			"integrity": "sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=",
+			"dev": true,
 			"requires": {
 				"ansi-wrap": "0.1.0"
 			}
@@ -1849,7 +1709,8 @@
 		"ansi-wrap": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
-			"integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
+			"integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+			"dev": true
 		},
 		"any-promise": {
 			"version": "1.3.0",
@@ -1860,6 +1721,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
 			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+			"dev": true,
 			"requires": {
 				"micromatch": "^3.1.4",
 				"normalize-path": "^2.1.1"
@@ -1900,6 +1762,7 @@
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
 			"requires": {
 				"sprintf-js": "~1.0.2"
 			}
@@ -1907,7 +1770,8 @@
 		"arr-diff": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+			"dev": true
 		},
 		"arr-filter": {
 			"version": "1.1.2",
@@ -1921,7 +1785,8 @@
 		"arr-flatten": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+			"dev": true
 		},
 		"arr-map": {
 			"version": "2.0.2",
@@ -1935,7 +1800,8 @@
 		"arr-union": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+			"dev": true
 		},
 		"array-differ": {
 			"version": "2.1.0",
@@ -2036,12 +1902,8 @@
 		"array-unique": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
-		},
-		"arraybuffer.slice": {
-			"version": "0.0.7",
-			"resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
-			"integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog=="
+			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+			"dev": true
 		},
 		"arrify": {
 			"version": "1.0.1",
@@ -2051,7 +1913,8 @@
 		"asap": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+			"dev": true
 		},
 		"asn1": {
 			"version": "0.2.4",
@@ -2071,16 +1934,8 @@
 		"assign-symbols": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
-		},
-		"async": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-			"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-			"optional": true,
-			"requires": {
-				"lodash": "^4.17.14"
-			}
+			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+			"dev": true
 		},
 		"async-done": {
 			"version": "1.3.2",
@@ -2097,17 +1952,8 @@
 		"async-each": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
-			"integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ=="
-		},
-		"async-each-series": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/async-each-series/-/async-each-series-0.1.1.tgz",
-			"integrity": "sha1-dhfBkXQB/Yykooqtzj266Yr+tDI="
-		},
-		"async-limiter": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-			"integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
+			"integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
+			"dev": true
 		},
 		"async-settle": {
 			"version": "1.0.0",
@@ -2127,7 +1973,8 @@
 		"atob": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
+			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+			"dev": true
 		},
 		"atob-lite": {
 			"version": "2.0.0",
@@ -2157,19 +2004,6 @@
 				}
 			}
 		},
-		"autoprefixer": {
-			"version": "6.7.7",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
-			"integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
-			"requires": {
-				"browserslist": "^1.7.6",
-				"caniuse-db": "^1.0.30000634",
-				"normalize-range": "^0.1.2",
-				"num2fraction": "^1.2.2",
-				"postcss": "^5.2.16",
-				"postcss-value-parser": "^3.2.3"
-			}
-		},
 		"aws-sign2": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -2181,22 +2015,6 @@
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
 			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
 			"dev": true
-		},
-		"axios": {
-			"version": "0.19.0",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
-			"integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
-			"requires": {
-				"follow-redirects": "1.5.10",
-				"is-buffer": "^2.0.2"
-			},
-			"dependencies": {
-				"is-buffer": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
-					"integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
-				}
-			}
 		},
 		"babel-code-frame": {
 			"version": "6.26.0",
@@ -2377,11 +2195,6 @@
 				"now-and-later": "^2.0.0"
 			}
 		},
-		"backo2": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
-			"integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
-		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -2391,6 +2204,7 @@
 			"version": "0.11.2",
 			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
 			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+			"dev": true,
 			"requires": {
 				"cache-base": "^1.0.1",
 				"class-utils": "^0.3.5",
@@ -2405,6 +2219,7 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"dev": true,
 					"requires": {
 						"is-descriptor": "^1.0.0"
 					}
@@ -2413,6 +2228,7 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -2421,6 +2237,7 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -2429,6 +2246,7 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
 						"is-data-descriptor": "^1.0.0",
@@ -2436,21 +2254,6 @@
 					}
 				}
 			}
-		},
-		"base64-arraybuffer": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
-			"integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
-		},
-		"base64id": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
-			"integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY="
-		},
-		"batch": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
-			"integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY="
 		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.2",
@@ -2467,38 +2270,16 @@
 			"integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==",
 			"dev": true
 		},
-		"better-assert": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
-			"integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
-			"requires": {
-				"callsite": "1.0.0"
-			}
-		},
 		"binary-extensions": {
 			"version": "1.13.1",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
-			"integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
-		},
-		"binaryextensions": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.1.2.tgz",
-			"integrity": "sha512-xVNN69YGDghOqCCtA6FI7avYrr02mTJjOgB0/f1VPD3pJC8QEvjTKWc4epDx8AqxxA75NI0QpVM2gPJXUbE4Tg=="
-		},
-		"blob": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
-			"integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig=="
+			"integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+			"dev": true
 		},
 		"bluebird": {
 			"version": "3.5.5",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
 			"integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w=="
-		},
-		"boolbase": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
@@ -2513,6 +2294,7 @@
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
 			"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+			"dev": true,
 			"requires": {
 				"arr-flatten": "^1.1.0",
 				"array-unique": "^0.3.2",
@@ -2530,298 +2312,12 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
 				}
 			}
-		},
-		"browser-sync": {
-			"version": "2.26.7",
-			"resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.26.7.tgz",
-			"integrity": "sha512-lY3emme0OyvA2ujEMpRmyRy9LY6gHLuTr2/ABxhIm3lADOiRXzP4dgekvnDrQqZ/Ec2Fz19lEjm6kglSG5766w==",
-			"requires": {
-				"browser-sync-client": "^2.26.6",
-				"browser-sync-ui": "^2.26.4",
-				"bs-recipes": "1.3.4",
-				"bs-snippet-injector": "^2.0.1",
-				"chokidar": "^2.0.4",
-				"connect": "3.6.6",
-				"connect-history-api-fallback": "^1",
-				"dev-ip": "^1.0.1",
-				"easy-extender": "^2.3.4",
-				"eazy-logger": "^3",
-				"etag": "^1.8.1",
-				"fresh": "^0.5.2",
-				"fs-extra": "3.0.1",
-				"http-proxy": "1.15.2",
-				"immutable": "^3",
-				"localtunnel": "1.9.2",
-				"micromatch": "^3.1.10",
-				"opn": "5.3.0",
-				"portscanner": "2.1.1",
-				"qs": "6.2.3",
-				"raw-body": "^2.3.2",
-				"resp-modifier": "6.0.2",
-				"rx": "4.1.0",
-				"send": "0.16.2",
-				"serve-index": "1.9.1",
-				"serve-static": "1.13.2",
-				"server-destroy": "1.0.1",
-				"socket.io": "2.1.1",
-				"ua-parser-js": "0.7.17",
-				"yargs": "6.4.0"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
-				},
-				"cliui": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wrap-ansi": "^2.0.0"
-					}
-				},
-				"find-up": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-					"requires": {
-						"path-exists": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"fs-extra": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
-					"integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"jsonfile": "^3.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"invert-kv": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-					"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"jsonfile": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
-					"integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
-					"requires": {
-						"graceful-fs": "^4.1.6"
-					}
-				},
-				"lcid": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-					"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-					"requires": {
-						"invert-kv": "^1.0.0"
-					}
-				},
-				"load-json-file": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^2.2.0",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0",
-						"strip-bom": "^2.0.0"
-					}
-				},
-				"os-locale": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-					"requires": {
-						"lcid": "^1.0.0"
-					}
-				},
-				"parse-json": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-					"requires": {
-						"error-ex": "^1.2.0"
-					}
-				},
-				"path-exists": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-					"requires": {
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"path-type": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"pify": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-				},
-				"qs": {
-					"version": "6.2.3",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.2.3.tgz",
-					"integrity": "sha1-HPyyXBCpsrSDBT/zn138kjOQjP4="
-				},
-				"read-pkg": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-					"requires": {
-						"load-json-file": "^1.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^1.0.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-					"requires": {
-						"find-up": "^1.0.0",
-						"read-pkg": "^1.0.0"
-					}
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"strip-bom": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"requires": {
-						"is-utf8": "^0.2.0"
-					}
-				},
-				"which-module": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
-				},
-				"y18n": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
-				},
-				"yargs": {
-					"version": "6.4.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-6.4.0.tgz",
-					"integrity": "sha1-gW4ahm1VmMzzTlWW3c4i2S2kkNQ=",
-					"requires": {
-						"camelcase": "^3.0.0",
-						"cliui": "^3.2.0",
-						"decamelize": "^1.1.1",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^1.4.0",
-						"read-pkg-up": "^1.0.1",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^1.0.2",
-						"which-module": "^1.0.0",
-						"window-size": "^0.2.0",
-						"y18n": "^3.2.1",
-						"yargs-parser": "^4.1.0"
-					}
-				},
-				"yargs-parser": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
-					"integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
-					"requires": {
-						"camelcase": "^3.0.0"
-					}
-				}
-			}
-		},
-		"browser-sync-client": {
-			"version": "2.26.6",
-			"resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.26.6.tgz",
-			"integrity": "sha512-mGrkZdNzttKdf/16I+y+2dTQxoMCIpKbVIMJ/uP8ZpnKu9f9qa/2CYVtLtbjZG8nsM14EwiCrjuFTGBEnT3Gjw==",
-			"requires": {
-				"etag": "1.8.1",
-				"fresh": "0.5.2",
-				"mitt": "^1.1.3",
-				"rxjs": "^5.5.6"
-			},
-			"dependencies": {
-				"rxjs": {
-					"version": "5.5.12",
-					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
-					"integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
-					"requires": {
-						"symbol-observable": "1.0.1"
-					}
-				}
-			}
-		},
-		"browser-sync-ui": {
-			"version": "2.26.4",
-			"resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-2.26.4.tgz",
-			"integrity": "sha512-u20P3EsZoM8Pt+puoi3BU3KlbQAH1lAcV+/O4saF26qokrBqIDotmGonfWwoRbUmdxZkM9MBmA0K39ZTG1h4sA==",
-			"requires": {
-				"async-each-series": "0.1.1",
-				"connect-history-api-fallback": "^1",
-				"immutable": "^3",
-				"server-destroy": "1.0.1",
-				"socket.io-client": "^2.0.4",
-				"stream-throttle": "^0.1.3"
-			}
-		},
-		"browserslist": {
-			"version": "1.7.7",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
-			"integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
-			"requires": {
-				"caniuse-db": "^1.0.30000639",
-				"electron-to-chromium": "^1.2.7"
-			}
-		},
-		"bs-recipes": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/bs-recipes/-/bs-recipes-1.3.4.tgz",
-			"integrity": "sha1-DS1NSKcYyMBEdp/cT4lZLci2lYU="
-		},
-		"bs-snippet-injector": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/bs-snippet-injector/-/bs-snippet-injector-2.0.1.tgz",
-			"integrity": "sha1-YbU5PxH1JVntEgaTEANDtu2wTdU="
 		},
 		"btoa-lite": {
 			"version": "1.0.0",
@@ -2859,11 +2355,6 @@
 			"integrity": "sha512-/XuKeqWocKsYa/cBY1YbSJSWWqTi4cFgr9S6OyM7PBaPbr9zvNGwWP33vt0uqGhwDdN+y3yhbXVILEUpnwEWGw==",
 			"dev": true
 		},
-		"bytes": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
-			"integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
-		},
 		"cacache": {
 			"version": "12.0.3",
 			"resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.3.tgz",
@@ -2891,6 +2382,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
 			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+			"dev": true,
 			"requires": {
 				"collection-visit": "^1.0.0",
 				"component-emitter": "^1.2.1",
@@ -2906,7 +2398,8 @@
 		"call-me-maybe": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
-			"integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
+			"integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+			"dev": true
 		},
 		"caller-callsite": {
 			"version": "2.0.0",
@@ -2926,11 +2419,6 @@
 				"caller-callsite": "^2.0.0"
 			}
 		},
-		"callsite": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-			"integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
-		},
 		"callsites": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
@@ -2942,11 +2430,6 @@
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
 			"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 		},
-		"camelcase-css": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
-			"integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA=="
-		},
 		"camelcase-keys": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
@@ -2957,25 +2440,11 @@
 				"quick-lru": "^1.0.0"
 			}
 		},
-		"caniuse-db": {
-			"version": "1.0.30000989",
-			"resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000989.tgz",
-			"integrity": "sha512-5pkU/t9nueoBgELZOCpK+wN4wK6MkIz1Q9lGZSgLwg4xR8EhLY9r0qj6T2bUI8Cq9pGbioEar+Zqgosk5fpbjg=="
-		},
 		"caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
 			"dev": true
-		},
-		"center-align": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-			"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-			"requires": {
-				"align-text": "^0.1.3",
-				"lazy-cache": "^1.0.3"
-			}
 		},
 		"chalk": {
 			"version": "1.1.3",
@@ -3033,36 +2502,17 @@
 				}
 			}
 		},
-		"character-parser": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
-			"integrity": "sha1-x84o821LzZdE5f/CxfzeHHMmH8A=",
-			"requires": {
-				"is-regex": "^1.0.3"
-			}
-		},
 		"chardet": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
-		},
-		"cheerio": {
-			"version": "1.0.0-rc.3",
-			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz",
-			"integrity": "sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==",
-			"requires": {
-				"css-select": "~1.2.0",
-				"dom-serializer": "~0.1.1",
-				"entities": "~1.1.1",
-				"htmlparser2": "^3.9.1",
-				"lodash": "^4.15.0",
-				"parse5": "^3.0.1"
-			}
+			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+			"dev": true
 		},
 		"chokidar": {
 			"version": "2.1.8",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
 			"integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+			"dev": true,
 			"requires": {
 				"anymatch": "^2.0.0",
 				"async-each": "^1.0.1",
@@ -3081,7 +2531,8 @@
 				"normalize-path": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+					"dev": true
 				}
 			}
 		},
@@ -3101,6 +2552,7 @@
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
 			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+			"dev": true,
 			"requires": {
 				"arr-union": "^3.1.0",
 				"define-property": "^0.2.5",
@@ -3112,39 +2564,27 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
 				}
 			}
 		},
-		"clean-css": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",
-			"integrity": "sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==",
-			"requires": {
-				"source-map": "~0.6.0"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				}
-			}
-		},
 		"cli-cursor": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-			"integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+			"dev": true,
 			"requires": {
-				"restore-cursor": "^3.1.0"
+				"restore-cursor": "^2.0.0"
 			}
 		},
 		"cli-width": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
+			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+			"dev": true
 		},
 		"clipboard": {
 			"version": "2.0.4",
@@ -3189,70 +2629,37 @@
 		"clone": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-			"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+			"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+			"dev": true
 		},
 		"clone-buffer": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
-			"integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg="
+			"integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
+			"dev": true
 		},
 		"clone-stats": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-			"integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
+			"integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+			"dev": true
 		},
 		"cloneable-readable": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.3.tgz",
 			"integrity": "sha512-2EF8zTQOxYq70Y4XKtorQupqF0m49MBz2/yf5Bj+MHjvpG3Hy7sImifnqD6UA+TKYxeSV+u6qqQPawN5UvnpKQ==",
+			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"process-nextick-args": "^2.0.0",
 				"readable-stream": "^2.3.5"
 			}
 		},
-		"coa": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/coa/-/coa-2.0.2.tgz",
-			"integrity": "sha512-q5/jG+YQnSy4nRTV4F7lPepBJZ8qBNJJDBuJdoejDyLXgmL7IEo+Le2JDZudFTFt7mrCqIRaSjws4ygRCTCAXA==",
-			"requires": {
-				"@types/q": "^1.5.1",
-				"chalk": "^2.4.1",
-				"q": "^1.1.2"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
-			}
-		},
 		"code-point-at": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+			"dev": true
 		},
 		"collection-map": {
 			"version": "1.0.0",
@@ -3269,6 +2676,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
 			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+			"dev": true,
 			"requires": {
 				"map-visit": "^1.0.0",
 				"object-visit": "^1.0.0"
@@ -3310,12 +2718,8 @@
 		"color-support": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
-		},
-		"colors": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
-			"integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg=="
+			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+			"dev": true
 		},
 		"columnify": {
 			"version": "1.5.4",
@@ -3339,7 +2743,9 @@
 		"commander": {
 			"version": "2.20.0",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-			"integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
+			"integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+			"dev": true,
+			"optional": true
 		},
 		"compare-func": {
 			"version": "1.3.2",
@@ -3351,20 +2757,11 @@
 				"dot-prop": "^3.0.0"
 			}
 		},
-		"component-bind": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
-			"integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E="
-		},
 		"component-emitter": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-			"integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
-		},
-		"component-inherit": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
-			"integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM="
+			"integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+			"dev": true
 		},
 		"concat-map": {
 			"version": "0.0.1",
@@ -3383,21 +2780,6 @@
 				"typedarray": "^0.0.6"
 			}
 		},
-		"concat-with-sourcemaps": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.1.0.tgz",
-			"integrity": "sha512-4gEjHJFT9e+2W/77h/DS5SGUgwDaOwprX8L/gl5+3ixnzkVJJsZWDSelmN3Oilw3LNDZjZV0yqH1hLG3k6nghg==",
-			"requires": {
-				"source-map": "^0.6.1"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				}
-			}
-		},
 		"config-chain": {
 			"version": "1.1.12",
 			"resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
@@ -3408,38 +2790,11 @@
 				"proto-list": "~1.2.1"
 			}
 		},
-		"connect": {
-			"version": "3.6.6",
-			"resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
-			"integrity": "sha1-Ce/2xVr3I24TcTWnJXSFi2eG9SQ=",
-			"requires": {
-				"debug": "2.6.9",
-				"finalhandler": "1.1.0",
-				"parseurl": "~1.3.2",
-				"utils-merge": "1.0.1"
-			}
-		},
-		"connect-history-api-fallback": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
-			"integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg=="
-		},
 		"console-control-strings": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
 			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
 			"dev": true
-		},
-		"constantinople": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/constantinople/-/constantinople-3.1.2.tgz",
-			"integrity": "sha512-yePcBqEFhLOqSBtwYOGGS1exHo/s1xjekXiinh4itpNQGCu4KA1euPh1fg07N2wMITZXQkBz75Ntdt1ctGZouw==",
-			"requires": {
-				"@types/babel-types": "^7.0.0",
-				"@types/babylon": "^6.16.2",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0"
-			}
 		},
 		"conventional-changelog-angular": {
 			"version": "5.0.3",
@@ -3660,11 +3015,6 @@
 				"safe-buffer": "~5.1.1"
 			}
 		},
-		"cookie": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-			"integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
-		},
 		"copy-concurrently": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
@@ -3682,7 +3032,8 @@
 		"copy-descriptor": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+			"dev": true
 		},
 		"copy-props": {
 			"version": "2.0.4",
@@ -3702,7 +3053,8 @@
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"dev": true
 		},
 		"cosmiconfig": {
 			"version": "5.2.1",
@@ -3727,73 +3079,6 @@
 				"semver": "^5.5.0",
 				"shebang-command": "^1.2.0",
 				"which": "^1.2.9"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
-				}
-			}
-		},
-		"css-select": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
-			"integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
-			"requires": {
-				"boolbase": "~1.0.0",
-				"css-what": "2.1",
-				"domutils": "1.5.1",
-				"nth-check": "~1.0.1"
-			}
-		},
-		"css-select-base-adapter": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
-			"integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w=="
-		},
-		"css-tree": {
-			"version": "1.0.0-alpha.33",
-			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.33.tgz",
-			"integrity": "sha512-SPt57bh5nQnpsTBsx/IXbO14sRc9xXu5MtMAVuo0BaQQmyf0NupNPPSoMaqiAF5tDFafYsTkfeH4Q/HCKXkg4w==",
-			"requires": {
-				"mdn-data": "2.0.4",
-				"source-map": "^0.5.3"
-			}
-		},
-		"css-unit-converter": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.1.tgz",
-			"integrity": "sha1-2bkoGtz9jO2TW9urqDeGiX9k6ZY="
-		},
-		"css-what": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
-			"integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg=="
-		},
-		"csso": {
-			"version": "3.5.1",
-			"resolved": "https://registry.npmjs.org/csso/-/csso-3.5.1.tgz",
-			"integrity": "sha512-vrqULLffYU1Q2tLdJvaCYbONStnfkfimRxXNaGjxMldI0C7JPBC4rB1RyjhfdZ4m1frm8pM9uRPKH3d2knZ8gg==",
-			"requires": {
-				"css-tree": "1.0.0-alpha.29"
-			},
-			"dependencies": {
-				"css-tree": {
-					"version": "1.0.0-alpha.29",
-					"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.29.tgz",
-					"integrity": "sha512-sRNb1XydwkW9IOci6iB2xmy8IGCj6r/fr+JWitvJ2JxQRPzN3T4AGGVWCMlVmVwM1gtgALJRmGIlWv5ppnGGkg==",
-					"requires": {
-						"mdn-data": "~1.1.0",
-						"source-map": "^0.5.3"
-					}
-				},
-				"mdn-data": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
-					"integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA=="
-				}
 			}
 		},
 		"currently-unhandled": {
@@ -3882,7 +3167,8 @@
 		"decode-uri-component": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+			"dev": true
 		},
 		"dedent": {
 			"version": "0.7.0",
@@ -3946,6 +3232,7 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
 			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+			"dev": true,
 			"requires": {
 				"object-keys": "^1.0.12"
 			}
@@ -3954,6 +3241,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
 			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+			"dev": true,
 			"requires": {
 				"is-descriptor": "^1.0.2",
 				"isobject": "^3.0.1"
@@ -3963,6 +3251,7 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -3971,6 +3260,7 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -3979,6 +3269,7 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
 						"is-data-descriptor": "^1.0.0",
@@ -3992,127 +3283,6 @@
 			"resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
 			"integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
 			"optional": true
-		},
-		"del": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/del/-/del-5.0.0.tgz",
-			"integrity": "sha512-TfU3nUY0WDIhN18eq+pgpbLY9AfL5RfiE9czKaTSolc6aK7qASXfDErvYgjV1UqCR4sNXDoxO0/idPmhDUt2Sg==",
-			"requires": {
-				"globby": "^10.0.0",
-				"is-path-cwd": "^2.0.0",
-				"is-path-in-cwd": "^2.0.0",
-				"p-map": "^2.0.0",
-				"rimraf": "^2.6.3"
-			},
-			"dependencies": {
-				"@nodelib/fs.stat": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.1.tgz",
-					"integrity": "sha512-+RqhBlLn6YRBGOIoVYthsG0J9dfpO79eJyN7BYBkZJtfqrBwf2KK+rD/M/yjZR6WBmIhAgOV7S60eCgaSWtbFw=="
-				},
-				"array-union": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-					"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
-				},
-				"braces": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-					"requires": {
-						"fill-range": "^7.0.1"
-					}
-				},
-				"dir-glob": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-					"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-					"requires": {
-						"path-type": "^4.0.0"
-					}
-				},
-				"fast-glob": {
-					"version": "3.0.4",
-					"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.0.4.tgz",
-					"integrity": "sha512-wkIbV6qg37xTJwqSsdnIphL1e+LaGz4AIQqr00mIubMaEhv1/HEmJ0uuCGZRNRUkZZmOB5mJKO0ZUTVq+SxMQg==",
-					"requires": {
-						"@nodelib/fs.stat": "^2.0.1",
-						"@nodelib/fs.walk": "^1.2.1",
-						"glob-parent": "^5.0.0",
-						"is-glob": "^4.0.1",
-						"merge2": "^1.2.3",
-						"micromatch": "^4.0.2"
-					}
-				},
-				"fill-range": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-					"requires": {
-						"to-regex-range": "^5.0.1"
-					}
-				},
-				"glob-parent": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.0.0.tgz",
-					"integrity": "sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==",
-					"requires": {
-						"is-glob": "^4.0.1"
-					}
-				},
-				"globby": {
-					"version": "10.0.1",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-10.0.1.tgz",
-					"integrity": "sha512-sSs4inE1FB2YQiymcmTv6NWENryABjUNPeWhOvmn4SjtKybglsyPZxFB3U1/+L1bYi0rNZDqCLlHyLYDl1Pq5A==",
-					"requires": {
-						"@types/glob": "^7.1.1",
-						"array-union": "^2.1.0",
-						"dir-glob": "^3.0.1",
-						"fast-glob": "^3.0.3",
-						"glob": "^7.1.3",
-						"ignore": "^5.1.1",
-						"merge2": "^1.2.3",
-						"slash": "^3.0.0"
-					}
-				},
-				"ignore": {
-					"version": "5.1.4",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
-					"integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A=="
-				},
-				"is-number": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
-				},
-				"micromatch": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-					"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
-					"requires": {
-						"braces": "^3.0.1",
-						"picomatch": "^2.0.5"
-					}
-				},
-				"path-type": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
-				},
-				"slash": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
-				},
-				"to-regex-range": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-					"requires": {
-						"is-number": "^7.0.0"
-					}
-				}
-			}
 		},
 		"delayed-stream": {
 			"version": "1.0.0",
@@ -4133,26 +3303,11 @@
 			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
 			"dev": true
 		},
-		"depd": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
-		},
-		"dependency-solver": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/dependency-solver/-/dependency-solver-1.0.6.tgz",
-			"integrity": "sha1-dMQQXNt+caDimANu33ooGKTCbLM="
-		},
 		"deprecation": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
 			"integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
 			"dev": true
-		},
-		"destroy": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
 		},
 		"detect-file": {
 			"version": "1.0.0",
@@ -4167,11 +3322,6 @@
 			"requires": {
 				"repeating": "^2.0.0"
 			}
-		},
-		"dev-ip": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/dev-ip/-/dev-ip-1.0.1.tgz",
-			"integrity": "sha1-p2o+0YVb56ASu4rBbLgPPADcKPA="
 		},
 		"dezalgo": {
 			"version": "1.0.3",
@@ -4190,42 +3340,6 @@
 			"dev": true,
 			"requires": {
 				"path-type": "^3.0.0"
-			}
-		},
-		"doctypes": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
-			"integrity": "sha1-6oCxBqh1OHdOijpKWv4pPeSJ4Kk="
-		},
-		"dom-serializer": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
-			"integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
-			"requires": {
-				"domelementtype": "^1.3.0",
-				"entities": "^1.1.1"
-			}
-		},
-		"domelementtype": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-			"integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
-		},
-		"domhandler": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
-			"integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
-			"requires": {
-				"domelementtype": "1"
-			}
-		},
-		"domutils": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-			"integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-			"requires": {
-				"dom-serializer": "0",
-				"domelementtype": "1"
 			}
 		},
 		"dot-prop": {
@@ -4264,22 +3378,6 @@
 				"object.defaults": "^1.1.0"
 			}
 		},
-		"easy-extender": {
-			"version": "2.3.4",
-			"resolved": "https://registry.npmjs.org/easy-extender/-/easy-extender-2.3.4.tgz",
-			"integrity": "sha512-8cAwm6md1YTiPpOvDULYJL4ZS6WfM5/cTeVVh4JsvyYZAoqlRVUpHL9Gr5Fy7HA6xcSZicUia3DeAgO3Us8E+Q==",
-			"requires": {
-				"lodash": "^4.17.10"
-			}
-		},
-		"eazy-logger": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-3.0.2.tgz",
-			"integrity": "sha1-oyWqXlPROiIliJsqxBE7K5Y29Pw=",
-			"requires": {
-				"tfunk": "^3.0.1"
-			}
-		},
 		"ecc-jsbn": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -4289,37 +3387,6 @@
 				"jsbn": "~0.1.0",
 				"safer-buffer": "^2.1.0"
 			}
-		},
-		"editions": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
-			"integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg=="
-		},
-		"ee-first": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
-		},
-		"electron-to-chromium": {
-			"version": "1.3.237",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.237.tgz",
-			"integrity": "sha512-SPAFjDr/7iiVK2kgTluwxela6eaWjjFkS9rO/iYpB/KGXgccUom5YC7OIf19c8m8GGptWxLU0Em8xM64A/N7Fg=="
-		},
-		"email-addresses": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-3.0.3.tgz",
-			"integrity": "sha512-kUlSC06PVvvjlMRpNIl3kR1NRXLEe86VQ7N0bQeaCZb2g+InShCeHQp/JvyYNTugMnRN2NvJhHlc3q12MWbbpg==",
-			"optional": true
-		},
-		"emoji-regex": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-		},
-		"encodeurl": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
 		},
 		"encoding": {
 			"version": "0.1.12",
@@ -4338,89 +3405,6 @@
 			"requires": {
 				"once": "^1.4.0"
 			}
-		},
-		"engine.io": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.2.1.tgz",
-			"integrity": "sha512-+VlKzHzMhaU+GsCIg4AoXF1UdDFjHHwMmMKqMJNDNLlUlejz58FCy4LBqB2YVJskHGYl06BatYWKP2TVdVXE5w==",
-			"requires": {
-				"accepts": "~1.3.4",
-				"base64id": "1.0.0",
-				"cookie": "0.3.1",
-				"debug": "~3.1.0",
-				"engine.io-parser": "~2.1.0",
-				"ws": "~3.3.1"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ws": {
-					"version": "3.3.3",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-					"integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
-					"requires": {
-						"async-limiter": "~1.0.0",
-						"safe-buffer": "~5.1.0",
-						"ultron": "~1.1.0"
-					}
-				}
-			}
-		},
-		"engine.io-client": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.3.2.tgz",
-			"integrity": "sha512-y0CPINnhMvPuwtqXfsGuWE8BB66+B6wTtCofQDRecMQPYX3MYUZXFNKDhdrSe3EVjgOu4V3rxdeqN/Tr91IgbQ==",
-			"requires": {
-				"component-emitter": "1.2.1",
-				"component-inherit": "0.0.3",
-				"debug": "~3.1.0",
-				"engine.io-parser": "~2.1.1",
-				"has-cors": "1.1.0",
-				"indexof": "0.0.1",
-				"parseqs": "0.0.5",
-				"parseuri": "0.0.5",
-				"ws": "~6.1.0",
-				"xmlhttprequest-ssl": "~1.5.4",
-				"yeast": "0.1.2"
-			},
-			"dependencies": {
-				"component-emitter": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-					"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
-				},
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				}
-			}
-		},
-		"engine.io-parser": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.3.tgz",
-			"integrity": "sha512-6HXPre2O4Houl7c4g7Ic/XzPnHBvaEmN90vtRO9uLmwtRqQmTOw0QMevL1TOfL2Cpu1VzsaTmMotQgMdkzGkVA==",
-			"requires": {
-				"after": "0.8.2",
-				"arraybuffer.slice": "~0.0.7",
-				"base64-arraybuffer": "0.1.5",
-				"blob": "0.0.5",
-				"has-binary2": "~1.0.2"
-			}
-		},
-		"entities": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-			"integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
 		},
 		"env-paths": {
 			"version": "1.0.0",
@@ -4446,6 +3430,7 @@
 			"version": "1.13.0",
 			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
 			"integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+			"dev": true,
 			"requires": {
 				"es-to-primitive": "^1.2.0",
 				"function-bind": "^1.1.1",
@@ -4459,6 +3444,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
 			"integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+			"dev": true,
 			"requires": {
 				"is-callable": "^1.1.4",
 				"is-date-object": "^1.0.1",
@@ -4524,11 +3510,6 @@
 				"es6-symbol": "^3.1.1"
 			}
 		},
-		"escape-html": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
-		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -4537,17 +3518,13 @@
 		"esprima": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"dev": true
 		},
 		"esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
-		},
-		"etag": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
 		},
 		"event-stream": {
 			"version": "4.0.1",
@@ -4589,6 +3566,7 @@
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
 			"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+			"dev": true,
 			"requires": {
 				"debug": "^2.3.3",
 				"define-property": "^0.2.5",
@@ -4603,6 +3581,7 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
@@ -4611,6 +3590,7 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -4636,6 +3616,7 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
 			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+			"dev": true,
 			"requires": {
 				"assign-symbols": "^1.0.0",
 				"is-extendable": "^1.0.1"
@@ -4645,6 +3626,7 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"dev": true,
 					"requires": {
 						"is-plain-object": "^2.0.4"
 					}
@@ -4655,6 +3637,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
 			"integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+			"dev": true,
 			"requires": {
 				"chardet": "^0.7.0",
 				"iconv-lite": "^0.4.24",
@@ -4665,6 +3648,7 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
 			"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+			"dev": true,
 			"requires": {
 				"array-unique": "^0.3.2",
 				"define-property": "^1.0.0",
@@ -4680,6 +3664,7 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"dev": true,
 					"requires": {
 						"is-descriptor": "^1.0.0"
 					}
@@ -4688,6 +3673,7 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -4696,6 +3682,7 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -4704,6 +3691,7 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -4712,6 +3700,7 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
 						"is-data-descriptor": "^1.0.0",
@@ -4730,6 +3719,7 @@
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.3.tgz",
 			"integrity": "sha512-k9oEhlyc0FrVh25qYuSELjr8oxsCoc4/LEZfg2iJJrfEk/tZL9bCoJE47gqAvI2m/AUjluCS4+3I0eTx8n3AEw==",
+			"dev": true,
 			"requires": {
 				"ansi-gray": "^0.1.1",
 				"color-support": "^1.1.3",
@@ -4747,6 +3737,7 @@
 			"version": "2.2.7",
 			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.7.tgz",
 			"integrity": "sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==",
+			"dev": true,
 			"requires": {
 				"@mrmlnc/readdir-enhanced": "^2.2.1",
 				"@nodelib/fs.stat": "^1.1.2",
@@ -4762,14 +3753,6 @@
 			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
 			"dev": true
 		},
-		"fastq": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.6.0.tgz",
-			"integrity": "sha512-jmxqQ3Z/nXoeyDmWAzF9kH1aGZSis6e/SbfPmJpUnyZ0ogr6iscHQaml4wsEepEWSdtmpy+eVXmCRIMpxaXqOA==",
-			"requires": {
-				"reusify": "^1.0.0"
-			}
-		},
 		"figgy-pudding": {
 			"version": "3.5.1",
 			"resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
@@ -4777,44 +3760,19 @@
 			"dev": true
 		},
 		"figures": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/figures/-/figures-3.0.0.tgz",
-			"integrity": "sha512-HKri+WoWoUgr83pehn/SIgLOMZ9nAWC6dcGj26RY2R4F50u4+RTUz0RCrUlOV3nKRAICW1UGzyb+kcX2qK1S/g==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^1.0.5"
-			}
-		},
-		"filename-reserved-regex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz",
-			"integrity": "sha1-5hz4BfDeHJhFZ9A4bcXfUO5a9+Q=",
-			"optional": true
-		},
-		"filenamify": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/filenamify/-/filenamify-1.2.1.tgz",
-			"integrity": "sha1-qfL/0RxQO+0wABUCknI3jx8TZaU=",
-			"optional": true,
-			"requires": {
-				"filename-reserved-regex": "^1.0.0",
-				"strip-outer": "^1.0.0",
-				"trim-repeated": "^1.0.0"
-			}
-		},
-		"filenamify-url": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/filenamify-url/-/filenamify-url-1.0.0.tgz",
-			"integrity": "sha1-syvYExnvWGO3MHi+1Q9GpPeXX1A=",
-			"optional": true,
-			"requires": {
-				"filenamify": "^1.0.0",
-				"humanize-url": "^1.0.0"
 			}
 		},
 		"fill-range": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
 			"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+			"dev": true,
 			"requires": {
 				"extend-shallow": "^2.0.1",
 				"is-number": "^3.0.0",
@@ -4826,24 +3784,11 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
 				}
-			}
-		},
-		"finalhandler": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
-			"integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
-			"requires": {
-				"debug": "2.6.9",
-				"encodeurl": "~1.0.1",
-				"escape-html": "~1.0.3",
-				"on-finished": "~2.3.0",
-				"parseurl": "~1.3.2",
-				"statuses": "~1.3.1",
-				"unpipe": "~1.0.0"
 			}
 		},
 		"find-up": {
@@ -4885,11 +3830,6 @@
 			"integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q==",
 			"dev": true
 		},
-		"flatten": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
-			"integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I="
-		},
 		"flush-write-stream": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
@@ -4900,28 +3840,11 @@
 				"readable-stream": "^2.3.6"
 			}
 		},
-		"follow-redirects": {
-			"version": "1.5.10",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-			"integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-			"requires": {
-				"debug": "=3.1.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				}
-			}
-		},
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+			"dev": true
 		},
 		"for-own": {
 			"version": "1.0.0",
@@ -4953,14 +3876,10 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
 			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+			"dev": true,
 			"requires": {
 				"map-cache": "^0.2.2"
 			}
-		},
-		"fresh": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
 		},
 		"from": {
 			"version": "0.1.7",
@@ -5006,18 +3925,6 @@
 			"requires": {
 				"graceful-fs": "^4.1.11",
 				"through2": "^2.0.3"
-			},
-			"dependencies": {
-				"through2": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-					"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-					"dev": true,
-					"requires": {
-						"readable-stream": "~2.3.6",
-						"xtend": "~4.0.1"
-					}
-				}
 			}
 		},
 		"fs-write-stream-atomic": {
@@ -5041,6 +3948,7 @@
 			"version": "1.2.9",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
 			"integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"nan": "^2.12.1",
@@ -5050,21 +3958,25 @@
 				"abbrev": {
 					"version": "1.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"are-we-there-yet": {
 					"version": "1.1.5",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"delegates": "^1.0.0",
@@ -5074,11 +3986,13 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
@@ -5088,31 +4002,37 @@
 				"chownr": {
 					"version": "1.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"debug": {
 					"version": "4.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"ms": "^2.1.1"
@@ -5121,21 +4041,25 @@
 				"deep-extend": {
 					"version": "0.6.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"delegates": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"detect-libc": {
 					"version": "1.0.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"fs-minipass": {
 					"version": "1.2.5",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"minipass": "^2.2.1"
@@ -5144,11 +4068,13 @@
 				"fs.realpath": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"gauge": {
 					"version": "2.7.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"aproba": "^1.0.3",
@@ -5164,6 +4090,7 @@
 				"glob": {
 					"version": "7.1.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"fs.realpath": "^1.0.0",
@@ -5177,11 +4104,13 @@
 				"has-unicode": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"iconv-lite": {
 					"version": "0.4.24",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"safer-buffer": ">= 2.1.2 < 3"
@@ -5190,6 +4119,7 @@
 				"ignore-walk": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"minimatch": "^3.0.4"
@@ -5198,6 +4128,7 @@
 				"inflight": {
 					"version": "1.0.6",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"once": "^1.3.0",
@@ -5207,16 +4138,19 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
@@ -5225,11 +4159,13 @@
 				"isarray": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
@@ -5238,11 +4174,13 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"minipass": {
 					"version": "2.3.5",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
@@ -5252,6 +4190,7 @@
 				"minizlib": {
 					"version": "1.2.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"minipass": "^2.2.1"
@@ -5260,6 +4199,7 @@
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
@@ -5268,11 +4208,13 @@
 				"ms": {
 					"version": "2.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"needle": {
 					"version": "2.3.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"debug": "^4.1.0",
@@ -5283,6 +4225,7 @@
 				"node-pre-gyp": {
 					"version": "0.12.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"detect-libc": "^1.0.2",
@@ -5300,6 +4243,7 @@
 				"nopt": {
 					"version": "4.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"abbrev": "1",
@@ -5309,11 +4253,13 @@
 				"npm-bundled": {
 					"version": "1.0.6",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"npm-packlist": {
 					"version": "1.4.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"ignore-walk": "^3.0.1",
@@ -5323,6 +4269,7 @@
 				"npmlog": {
 					"version": "4.1.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"are-we-there-yet": "~1.1.2",
@@ -5334,16 +4281,19 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"wrappy": "1"
@@ -5352,16 +4302,19 @@
 				"os-homedir": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"osenv": {
 					"version": "0.1.5",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"os-homedir": "^1.0.0",
@@ -5371,16 +4324,19 @@
 				"path-is-absolute": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"process-nextick-args": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"rc": {
 					"version": "1.2.8",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"deep-extend": "^0.6.0",
@@ -5392,6 +4348,7 @@
 						"minimist": {
 							"version": "1.2.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
@@ -5399,6 +4356,7 @@
 				"readable-stream": {
 					"version": "2.3.6",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
@@ -5413,6 +4371,7 @@
 				"rimraf": {
 					"version": "2.6.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"glob": "^7.1.3"
@@ -5421,36 +4380,43 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"sax": {
 					"version": "1.2.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"semver": {
 					"version": "5.7.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
@@ -5461,6 +4427,7 @@
 				"string_decoder": {
 					"version": "1.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"safe-buffer": "~5.1.0"
@@ -5469,6 +4436,7 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
@@ -5477,11 +4445,13 @@
 				"strip-json-comments": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"tar": {
 					"version": "4.4.8",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"chownr": "^1.1.1",
@@ -5496,11 +4466,13 @@
 				"util-deprecate": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"wide-align": {
 					"version": "1.1.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"string-width": "^1.0.2 || 2"
@@ -5509,11 +4481,13 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				}
 			}
@@ -5521,7 +4495,8 @@
 		"function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"dev": true
 		},
 		"gauge": {
 			"version": "2.7.4",
@@ -5570,7 +4545,8 @@
 		"get-caller-file": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-			"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
+			"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+			"dev": true
 		},
 		"get-pkg-repo": {
 			"version": "1.4.0",
@@ -5747,16 +4723,6 @@
 						"get-stdin": "^4.0.1"
 					}
 				},
-				"through2": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-					"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-					"dev": true,
-					"requires": {
-						"readable-stream": "~2.3.6",
-						"xtend": "~4.0.1"
-					}
-				},
 				"trim-newlines": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
@@ -5789,7 +4755,8 @@
 		"get-value": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+			"dev": true
 		},
 		"getpass": {
 			"version": "0.1.7",
@@ -5798,35 +4765,6 @@
 			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
-			}
-		},
-		"gh-pages": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-2.1.1.tgz",
-			"integrity": "sha512-yNW2SFp9xGRP/8Sk2WXuLI/Gn92oOL4HBgudn6PsqAnuWT90Y1tozJoTfX1WdrDSW5Rb90kLVOf5mm9KJ/2fDw==",
-			"optional": true,
-			"requires": {
-				"async": "^2.6.1",
-				"commander": "^2.18.0",
-				"email-addresses": "^3.0.1",
-				"filenamify-url": "^1.0.0",
-				"fs-extra": "^7.0.0",
-				"globby": "^6.1.0",
-				"graceful-fs": "^4.1.11",
-				"rimraf": "^2.6.2"
-			},
-			"dependencies": {
-				"fs-extra": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-					"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-					"optional": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				}
 			}
 		},
 		"git-raw-commits": {
@@ -5857,16 +4795,6 @@
 						"read-pkg-up": "^3.0.0",
 						"redent": "^2.0.0",
 						"trim-newlines": "^2.0.0"
-					}
-				},
-				"through2": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-					"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-					"dev": true,
-					"requires": {
-						"readable-stream": "~2.3.6",
-						"xtend": "~4.0.1"
 					}
 				}
 			}
@@ -5969,6 +4897,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
 			"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+			"dev": true,
 			"requires": {
 				"is-glob": "^3.1.0",
 				"path-dirname": "^1.0.0"
@@ -5978,6 +4907,7 @@
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
 					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+					"dev": true,
 					"requires": {
 						"is-extglob": "^2.1.0"
 					}
@@ -6005,7 +4935,8 @@
 		"glob-to-regexp": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
-			"integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs="
+			"integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
+			"dev": true
 		},
 		"glob-watcher": {
 			"version": "5.0.3",
@@ -6326,308 +5257,6 @@
 				}
 			}
 		},
-		"gulp-concat": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/gulp-concat/-/gulp-concat-2.6.1.tgz",
-			"integrity": "sha1-Yz0WyV2IUEYorQJmVmPO5aR5M1M=",
-			"requires": {
-				"concat-with-sourcemaps": "^1.0.0",
-				"through2": "^2.0.0",
-				"vinyl": "^2.0.0"
-			},
-			"dependencies": {
-				"through2": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-					"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-					"requires": {
-						"readable-stream": "~2.3.6",
-						"xtend": "~4.0.1"
-					}
-				}
-			}
-		},
-		"gulp-data": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/gulp-data/-/gulp-data-1.3.1.tgz",
-			"integrity": "sha512-fvpQJvgVyhkwRcFP3Y9QUS9sWvIFsAlJDinQjhLuknmHZz52jH0gHmTujYBFjr9aTlTHlrAayY5m1d0tA1HzGQ==",
-			"requires": {
-				"plugin-error": "^0.1.2",
-				"through2": "^2.0.0",
-				"util-extend": "^1.0.1"
-			},
-			"dependencies": {
-				"through2": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-					"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-					"requires": {
-						"readable-stream": "~2.3.6",
-						"xtend": "~4.0.1"
-					}
-				}
-			}
-		},
-		"gulp-exec": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/gulp-exec/-/gulp-exec-3.0.2.tgz",
-			"integrity": "sha512-74sde0n+pQo/Jbe5qsk0sPC4afjnB7VHDUZd4BrRTLt6lsNU451N+kSvCOoSn6q0iqS9ztT1uy8ZE/FRqmXKeQ==",
-			"requires": {
-				"lodash.template": "^4.4.0",
-				"plugin-error": "^0.1.2",
-				"through2": "^2.0.3"
-			},
-			"dependencies": {
-				"through2": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-					"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-					"requires": {
-						"readable-stream": "~2.3.6",
-						"xtend": "~4.0.1"
-					}
-				}
-			}
-		},
-		"gulp-insert": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/gulp-insert/-/gulp-insert-0.5.0.tgz",
-			"integrity": "sha1-MjE/E+SiPPWsylzl8MCAkjx3hgI=",
-			"requires": {
-				"readable-stream": "^1.0.26-4",
-				"streamqueue": "0.0.6"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-				},
-				"readable-stream": {
-					"version": "1.1.14",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.1",
-						"isarray": "0.0.1",
-						"string_decoder": "~0.10.x"
-					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-				}
-			}
-		},
-		"gulp-postcss": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/gulp-postcss/-/gulp-postcss-7.0.1.tgz",
-			"integrity": "sha1-Pxw22xGXFAw5nCUt3/M5EpY445U=",
-			"requires": {
-				"fancy-log": "^1.3.2",
-				"plugin-error": "^0.1.2",
-				"postcss": "^6.0.0",
-				"postcss-load-config": "^1.2.0",
-				"vinyl-sourcemaps-apply": "^0.2.1"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"postcss": {
-					"version": "6.0.23",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
-			}
-		},
-		"gulp-pug": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/gulp-pug/-/gulp-pug-4.0.1.tgz",
-			"integrity": "sha512-RsayLPwJtKKMub9bbO4VYlMPVnImUPdK8+BjvkiulkorrjWnahTbI3a3Li/7YkD0xs7ap7ePciNiPwweoVEPMQ==",
-			"requires": {
-				"@types/pug": "^2.0.4",
-				"fancy-log": "^1.3.2",
-				"plugin-error": "^1.0.1",
-				"pug": "^2.0.3",
-				"replace-ext": "^1.0.0",
-				"through2": "^2.0.3"
-			},
-			"dependencies": {
-				"plugin-error": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
-					"integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
-					"requires": {
-						"ansi-colors": "^1.0.1",
-						"arr-diff": "^4.0.0",
-						"arr-union": "^3.1.0",
-						"extend-shallow": "^3.0.2"
-					}
-				},
-				"through2": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-					"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-					"requires": {
-						"readable-stream": "~2.3.6",
-						"xtend": "~4.0.1"
-					}
-				}
-			}
-		},
-		"gulp-rename": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.4.0.tgz",
-			"integrity": "sha512-swzbIGb/arEoFK89tPY58vg3Ok1bw+d35PfUNwWqdo7KM4jkmuGA78JiDNqR+JeZFaeeHnRg9N7aihX3YPmsyg=="
-		},
-		"gulp-replace": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/gulp-replace/-/gulp-replace-1.0.0.tgz",
-			"integrity": "sha512-lgdmrFSI1SdhNMXZQbrC75MOl1UjYWlOWNbNRnz+F/KHmgxt3l6XstBoAYIdadwETFyG/6i+vWUSCawdC3pqOw==",
-			"requires": {
-				"istextorbinary": "2.2.1",
-				"readable-stream": "^2.0.1",
-				"replacestream": "^4.0.0"
-			}
-		},
-		"gulp-sort": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/gulp-sort/-/gulp-sort-2.0.0.tgz",
-			"integrity": "sha1-xnYqLx8N4KP8WVohWZ0/rI26Gso=",
-			"requires": {
-				"through2": "^2.0.1"
-			},
-			"dependencies": {
-				"through2": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-					"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-					"requires": {
-						"readable-stream": "~2.3.6",
-						"xtend": "~4.0.1"
-					}
-				}
-			}
-		},
-		"gulp-svgcombiner": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/gulp-svgcombiner/-/gulp-svgcombiner-1.0.2.tgz",
-			"integrity": "sha512-uMSqypfxV9oQT4K8PIOCVVMOD7WOzmZeljOOvouy08+aBv/DTN/YLMtSak1om8HapsAE2BHvgcoQvCpPnMoyrg==",
-			"requires": {
-				"plugin-error": "^1.0.1",
-				"svgcombiner": "^1.0.0",
-				"through2": "^3.0.0",
-				"vinyl": "^2.2.0",
-				"xtend": "^4.0.1"
-			},
-			"dependencies": {
-				"plugin-error": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
-					"integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
-					"requires": {
-						"ansi-colors": "^1.0.1",
-						"arr-diff": "^4.0.0",
-						"arr-union": "^3.1.0",
-						"extend-shallow": "^3.0.2"
-					}
-				}
-			}
-		},
-		"gulp-svgmin": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/gulp-svgmin/-/gulp-svgmin-2.2.0.tgz",
-			"integrity": "sha512-MjfZ7DNlomplrhACwmdowPnAV3firF+3432chp1XQyy6OxbZmM7AyMwsITfglS6bGaE3msKiNeqIb0Sn3LHlyg==",
-			"requires": {
-				"plugin-error": "^1.0.1",
-				"svgo": "^1.2.1"
-			},
-			"dependencies": {
-				"plugin-error": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
-					"integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
-					"requires": {
-						"ansi-colors": "^1.0.1",
-						"arr-diff": "^4.0.0",
-						"arr-union": "^3.1.0",
-						"extend-shallow": "^3.0.2"
-					}
-				}
-			}
-		},
-		"gulp-svgstore": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/gulp-svgstore/-/gulp-svgstore-7.0.1.tgz",
-			"integrity": "sha512-oiAXvkRnBBt6ZML+lit7W15ryClB45k0V9eCVW/i73EymunoQlzZal0Luj3NDrbPLbPIllL8/ltCXFa9Jv03Pg==",
-			"requires": {
-				"cheerio": "0.*",
-				"fancy-log": "^1.3.2",
-				"plugin-error": "^0.1.2",
-				"vinyl": "^2.1.0"
-			},
-			"dependencies": {
-				"cheerio": {
-					"version": "0.22.0",
-					"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
-					"integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
-					"requires": {
-						"css-select": "~1.2.0",
-						"dom-serializer": "~0.1.0",
-						"entities": "~1.1.1",
-						"htmlparser2": "^3.9.1",
-						"lodash.assignin": "^4.0.9",
-						"lodash.bind": "^4.1.4",
-						"lodash.defaults": "^4.0.1",
-						"lodash.filter": "^4.4.0",
-						"lodash.flatten": "^4.2.0",
-						"lodash.foreach": "^4.3.0",
-						"lodash.map": "^4.4.0",
-						"lodash.merge": "^4.4.0",
-						"lodash.pick": "^4.2.1",
-						"lodash.reduce": "^4.4.0",
-						"lodash.reject": "^4.4.0",
-						"lodash.some": "^4.4.0"
-					}
-				}
-			}
-		},
 		"gulplog": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
@@ -6677,6 +5306,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
 			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.1"
 			}
@@ -6689,26 +5319,6 @@
 				"ansi-regex": "^2.0.0"
 			}
 		},
-		"has-binary2": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
-			"integrity": "sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==",
-			"requires": {
-				"isarray": "2.0.1"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-					"integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
-				}
-			}
-		},
-		"has-cors": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
-			"integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk="
-		},
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -6717,7 +5327,8 @@
 		"has-symbols": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-			"integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
+			"integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+			"dev": true
 		},
 		"has-unicode": {
 			"version": "2.0.1",
@@ -6729,6 +5340,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
 			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+			"dev": true,
 			"requires": {
 				"get-value": "^2.0.6",
 				"has-values": "^1.0.0",
@@ -6739,6 +5351,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
 			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+			"dev": true,
 			"requires": {
 				"is-number": "^3.0.0",
 				"kind-of": "^4.0.0"
@@ -6748,6 +5361,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -6777,71 +5391,11 @@
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
 			"integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ=="
 		},
-		"htmlparser2": {
-			"version": "3.10.1",
-			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
-			"integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
-			"requires": {
-				"domelementtype": "^1.3.1",
-				"domhandler": "^2.3.0",
-				"domutils": "^1.5.1",
-				"entities": "^1.1.1",
-				"inherits": "^2.0.1",
-				"readable-stream": "^3.1.1"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
-					"requires": {
-						"inherits": "^2.0.3",
-						"string_decoder": "^1.1.1",
-						"util-deprecate": "^1.0.1"
-					}
-				}
-			}
-		},
 		"http-cache-semantics": {
 			"version": "3.8.1",
 			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
 			"integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
 			"dev": true
-		},
-		"http-errors": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
-			"integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
-			"requires": {
-				"depd": "~1.1.2",
-				"inherits": "2.0.4",
-				"setprototypeof": "1.1.1",
-				"statuses": ">= 1.5.0 < 2",
-				"toidentifier": "1.0.0"
-			},
-			"dependencies": {
-				"statuses": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-					"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
-				}
-			}
-		},
-		"http-proxy": {
-			"version": "1.15.2",
-			"resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.15.2.tgz",
-			"integrity": "sha1-ZC/cr/5S00SNK9o7AHnpQJBk2jE=",
-			"requires": {
-				"eventemitter3": "1.x.x",
-				"requires-port": "1.x.x"
-			},
-			"dependencies": {
-				"eventemitter3": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
-					"integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg="
-				}
-			}
 		},
 		"http-proxy-agent": {
 			"version": "2.1.0",
@@ -6911,20 +5465,11 @@
 				"ms": "^2.0.0"
 			}
 		},
-		"humanize-url": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/humanize-url/-/humanize-url-1.0.1.tgz",
-			"integrity": "sha1-9KuZ4NKIF0yk4eUEB8VfuuRk7/8=",
-			"optional": true,
-			"requires": {
-				"normalize-url": "^1.0.0",
-				"strip-url-auth": "^1.0.0"
-			}
-		},
 		"iconv-lite": {
 			"version": "0.4.24",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
 			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"dev": true,
 			"requires": {
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
@@ -6949,11 +5494,6 @@
 			"requires": {
 				"minimatch": "^3.0.4"
 			}
-		},
-		"immutable": {
-			"version": "3.8.2",
-			"resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
-			"integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM="
 		},
 		"import-fresh": {
 			"version": "2.0.0",
@@ -6993,16 +5533,6 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
 			"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
-		},
-		"indexes-of": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
-			"integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc="
-		},
-		"indexof": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-			"integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
 		},
 		"infer-owner": {
 			"version": "1.0.4",
@@ -7044,32 +5574,25 @@
 				"semver": "2.x || 3.x || 4 || 5",
 				"validate-npm-package-license": "^3.0.1",
 				"validate-npm-package-name": "^3.0.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
-				}
 			}
 		},
 		"inquirer": {
-			"version": "6.5.1",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.1.tgz",
-			"integrity": "sha512-uxNHBeQhRXIoHWTSNYUFhQVrHYFThIt6IVo2fFmSe8aBwdR3/w6b58hJpiL/fMukFkvGzjg+hSxFtwvVmKZmXw==",
+			"version": "6.5.2",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
+			"integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
+			"dev": true,
 			"requires": {
-				"ansi-escapes": "^4.2.1",
+				"ansi-escapes": "^3.2.0",
 				"chalk": "^2.4.2",
-				"cli-cursor": "^3.1.0",
+				"cli-cursor": "^2.1.0",
 				"cli-width": "^2.0.0",
 				"external-editor": "^3.0.3",
-				"figures": "^3.0.0",
-				"lodash": "^4.17.15",
-				"mute-stream": "0.0.8",
+				"figures": "^2.0.0",
+				"lodash": "^4.17.12",
+				"mute-stream": "0.0.7",
 				"run-async": "^2.2.0",
 				"rxjs": "^6.4.0",
-				"string-width": "^4.1.0",
+				"string-width": "^2.1.0",
 				"strip-ansi": "^5.1.0",
 				"through": "^2.3.6"
 			},
@@ -7077,12 +5600,14 @@
 				"ansi-regex": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+					"dev": true
 				},
 				"ansi-styles": {
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -7091,31 +5616,18 @@
 					"version": "2.4.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
 						"supports-color": "^5.3.0"
 					}
 				},
-				"is-fullwidth-code-point": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-				},
-				"string-width": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.1.0.tgz",
-					"integrity": "sha512-NrX+1dVVh+6Y9dnQ19pR0pP4FiEIlUvdTGn8pw6CKTNq5sgib2nIhmUNT5TAmhWmvKr3WcxBcP3E8nWezuipuQ==",
-					"requires": {
-						"emoji-regex": "^8.0.0",
-						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^5.2.0"
-					}
-				},
 				"strip-ansi": {
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
 					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "^4.1.0"
 					}
@@ -7124,6 +5636,7 @@
 					"version": "5.5.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -7170,6 +5683,7 @@
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+			"dev": true,
 			"requires": {
 				"kind-of": "^3.0.2"
 			},
@@ -7178,6 +5692,7 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -7193,6 +5708,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
 			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+			"dev": true,
 			"requires": {
 				"binary-extensions": "^1.0.0"
 			}
@@ -7200,12 +5716,14 @@
 		"is-buffer": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+			"dev": true
 		},
 		"is-callable": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-			"integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
+			"integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+			"dev": true
 		},
 		"is-ci": {
 			"version": "2.0.0",
@@ -7220,6 +5738,7 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+			"dev": true,
 			"requires": {
 				"kind-of": "^3.0.2"
 			},
@@ -7228,6 +5747,7 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -7237,12 +5757,14 @@
 		"is-date-object": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+			"dev": true
 		},
 		"is-descriptor": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+			"dev": true,
 			"requires": {
 				"is-accessor-descriptor": "^0.1.6",
 				"is-data-descriptor": "^0.1.4",
@@ -7252,40 +5774,28 @@
 				"kind-of": {
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+					"dev": true
 				}
 			}
 		},
 		"is-directory": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
-			"integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE="
-		},
-		"is-expression": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-expression/-/is-expression-3.0.0.tgz",
-			"integrity": "sha1-Oayqa+f9HzRx3ELHQW5hwkMXrJ8=",
-			"requires": {
-				"acorn": "~4.0.2",
-				"object-assign": "^4.0.1"
-			},
-			"dependencies": {
-				"acorn": {
-					"version": "4.0.13",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-					"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
-				}
-			}
+			"integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+			"dev": true
 		},
 		"is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"dev": true
 		},
 		"is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+			"dev": true
 		},
 		"is-finite": {
 			"version": "1.0.2",
@@ -7305,6 +5815,7 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
 			"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+			"dev": true,
 			"requires": {
 				"is-extglob": "^2.1.1"
 			}
@@ -7319,6 +5830,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 			"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+			"dev": true,
 			"requires": {
 				"kind-of": "^3.0.2"
 			},
@@ -7327,45 +5839,17 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
 				}
 			}
 		},
-		"is-number-like": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/is-number-like/-/is-number-like-1.0.8.tgz",
-			"integrity": "sha512-6rZi3ezCyFcn5L71ywzz2bS5b2Igl1En3eTlZlvKjpz1n3IZLAYMbKYAIQgFmEu0GENg92ziU/faEOA/aixjbA==",
-			"requires": {
-				"lodash.isfinite": "^3.3.2"
-			}
-		},
 		"is-obj": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
 			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
-		},
-		"is-path-cwd": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
-			"integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ=="
-		},
-		"is-path-in-cwd": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz",
-			"integrity": "sha512-rNocXHgipO+rvnP6dk3zI20RpOtrAM/kzbB258Uw5BWr3TpXi861yzjo16Dn4hUox07iw5AyeMLHWsujkjzvRQ==",
-			"requires": {
-				"is-path-inside": "^2.1.0"
-			}
-		},
-		"is-path-inside": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-2.1.0.tgz",
-			"integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
-			"requires": {
-				"path-is-inside": "^1.0.2"
-			}
 		},
 		"is-plain-obj": {
 			"version": "1.1.0",
@@ -7376,6 +5860,7 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
 			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"dev": true,
 			"requires": {
 				"isobject": "^3.0.1"
 			}
@@ -7383,12 +5868,14 @@
 		"is-promise": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+			"dev": true
 		},
 		"is-regex": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
 			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+			"dev": true,
 			"requires": {
 				"has": "^1.0.1"
 			}
@@ -7421,6 +5908,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
 			"integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+			"dev": true,
 			"requires": {
 				"has-symbols": "^1.0.0"
 			}
@@ -7452,7 +5940,8 @@
 		"is-utf8": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+			"dev": true
 		},
 		"is-valid-glob": {
 			"version": "1.0.0",
@@ -7463,17 +5952,14 @@
 		"is-windows": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
-		},
-		"is-wsl": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-			"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
+			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+			"dev": true
 		},
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"dev": true
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -7484,33 +5970,14 @@
 		"isobject": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+			"dev": true
 		},
 		"isstream": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
 			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
 			"dev": true
-		},
-		"istextorbinary": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.2.1.tgz",
-			"integrity": "sha512-TS+hoFl8Z5FAFMK38nhBkdLt44CclNRgDHWeMgsV8ko3nDlr/9UI2Sf839sW7enijf8oKsZYXRvM8g0it9Zmcw==",
-			"requires": {
-				"binaryextensions": "2",
-				"editions": "^1.3.3",
-				"textextensions": "2"
-			}
-		},
-		"js-base64": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
-			"integrity": "sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw=="
-		},
-		"js-stringify": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/js-stringify/-/js-stringify-1.0.2.tgz",
-			"integrity": "sha1-Fzb939lyTyijaCrcYjCufk6Weds="
 		},
 		"js-tokens": {
 			"version": "3.0.2",
@@ -7521,6 +5988,7 @@
 			"version": "3.13.1",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
 			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
@@ -7597,15 +6065,6 @@
 				"verror": "1.10.0"
 			}
 		},
-		"jstransformer": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/jstransformer/-/jstransformer-1.0.0.tgz",
-			"integrity": "sha1-7Yvwkh4vPx7U1cGkT2hwntJHIsM=",
-			"requires": {
-				"is-promise": "^2.0.0",
-				"promise": "^7.0.1"
-			}
-		},
 		"just-debounce": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/just-debounce/-/just-debounce-1.0.0.tgz",
@@ -7615,7 +6074,8 @@
 		"kind-of": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-			"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+			"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+			"dev": true
 		},
 		"last-run": {
 			"version": "1.1.1",
@@ -7626,11 +6086,6 @@
 				"default-resolution": "^2.0.0",
 				"es6-weak-map": "^2.0.1"
 			}
-		},
-		"lazy-cache": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
 		},
 		"lazystream": {
 			"version": "1.0.0",
@@ -7700,11 +6155,6 @@
 				"resolve": "^1.1.7"
 			}
 		},
-		"limiter": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.4.tgz",
-			"integrity": "sha512-XCpr5bElgDI65vVgstP8TWjv6/QKWm9GU5UG0Pr5sLQ3QLo8NVKsioe+Jed5/3vFOe3IQuqE7DKwTvKQkjTHvg=="
-		},
 		"load-json-file": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -7721,203 +6171,6 @@
 			"resolved": "https://registry.npmjs.org/loadicons/-/loadicons-1.0.0.tgz",
 			"integrity": "sha512-KSywiudfuOK5sTdhNMM8hwRpMxZ5TbQlU4ZijMxUFwRW7jpxUmb9YJoLIzDn7+xuxeLzCZWBmLJS2JDjDWCpsw==",
 			"dev": true
-		},
-		"localtunnel": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/localtunnel/-/localtunnel-1.9.2.tgz",
-			"integrity": "sha512-NEKF7bDJE9U3xzJu3kbayF0WTvng6Pww7tzqNb/XtEARYwqw7CKEX7BvOMg98FtE9es2CRizl61gkV3hS8dqYg==",
-			"requires": {
-				"axios": "0.19.0",
-				"debug": "4.1.1",
-				"openurl": "1.1.1",
-				"yargs": "6.6.0"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
-				},
-				"cliui": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wrap-ansi": "^2.0.0"
-					}
-				},
-				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"find-up": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-					"requires": {
-						"path-exists": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"invert-kv": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-					"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"lcid": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-					"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-					"requires": {
-						"invert-kv": "^1.0.0"
-					}
-				},
-				"load-json-file": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^2.2.0",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0",
-						"strip-bom": "^2.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-				},
-				"os-locale": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-					"requires": {
-						"lcid": "^1.0.0"
-					}
-				},
-				"parse-json": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-					"requires": {
-						"error-ex": "^1.2.0"
-					}
-				},
-				"path-exists": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-					"requires": {
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"path-type": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"pify": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-				},
-				"read-pkg": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-					"requires": {
-						"load-json-file": "^1.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^1.0.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-					"requires": {
-						"find-up": "^1.0.0",
-						"read-pkg": "^1.0.0"
-					}
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"strip-bom": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"requires": {
-						"is-utf8": "^0.2.0"
-					}
-				},
-				"which-module": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
-				},
-				"y18n": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
-				},
-				"yargs": {
-					"version": "6.6.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
-					"integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
-					"requires": {
-						"camelcase": "^3.0.0",
-						"cliui": "^3.2.0",
-						"decamelize": "^1.1.1",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^1.4.0",
-						"read-pkg-up": "^1.0.1",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^1.0.2",
-						"which-module": "^1.0.0",
-						"y18n": "^3.2.1",
-						"yargs-parser": "^4.2.0"
-					}
-				},
-				"yargs-parser": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
-					"integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
-					"requires": {
-						"camelcase": "^3.0.0"
-					}
-				}
-			}
 		},
 		"locate-path": {
 			"version": "2.0.0",
@@ -7936,17 +6189,8 @@
 		"lodash._reinterpolate": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
-		},
-		"lodash.assignin": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
-			"integrity": "sha1-uo31+4QesKPoBEIysOJjqNxqKKI="
-		},
-		"lodash.bind": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
-			"integrity": "sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU="
+			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+			"dev": true
 		},
 		"lodash.clonedeep": {
 			"version": "4.5.0",
@@ -7954,36 +6198,11 @@
 			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
 			"dev": true
 		},
-		"lodash.defaults": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-			"integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
-		},
-		"lodash.filter": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
-			"integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4="
-		},
-		"lodash.flatten": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-			"integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
-		},
-		"lodash.foreach": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
-			"integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
-		},
 		"lodash.get": {
 			"version": "4.4.2",
 			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
 			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
 			"dev": true
-		},
-		"lodash.isfinite": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
-			"integrity": "sha1-+4m2WpqAKBgz8LdHizpRBPiY67M="
 		},
 		"lodash.ismatch": {
 			"version": "4.4.0",
@@ -7991,41 +6210,11 @@
 			"integrity": "sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=",
 			"dev": true
 		},
-		"lodash.map": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
-			"integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM="
-		},
-		"lodash.merge": {
-			"version": "4.6.2",
-			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
-		},
-		"lodash.pick": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-			"integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
-		},
-		"lodash.reduce": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
-			"integrity": "sha1-8atrg5KZrUj3hKu/R2WW8DuRTTs="
-		},
-		"lodash.reject": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz",
-			"integrity": "sha1-gNZJLcFHCGS79YNTO2UfQqn1JBU="
-		},
 		"lodash.set": {
 			"version": "4.3.2",
 			"resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
 			"integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
 			"dev": true
-		},
-		"lodash.some": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
-			"integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0="
 		},
 		"lodash.sortby": {
 			"version": "4.7.0",
@@ -8037,6 +6226,7 @@
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
 			"integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
+			"dev": true,
 			"requires": {
 				"lodash._reinterpolate": "^3.0.0",
 				"lodash.templatesettings": "^4.0.0"
@@ -8046,6 +6236,7 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
 			"integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
+			"dev": true,
 			"requires": {
 				"lodash._reinterpolate": "^3.0.0"
 			}
@@ -8055,11 +6246,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
 			"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
 			"dev": true
-		},
-		"longest": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
 		},
 		"loose-envify": {
 			"version": "1.4.0",
@@ -8148,7 +6334,8 @@
 		"map-cache": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+			"dev": true
 		},
 		"map-obj": {
 			"version": "2.0.0",
@@ -8165,6 +6352,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
 			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+			"dev": true,
 			"requires": {
 				"object-visit": "^1.0.0"
 			}
@@ -8224,11 +6412,6 @@
 				}
 			}
 		},
-		"mdn-data": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
-			"integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA=="
-		},
 		"mem": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
@@ -8257,20 +6440,17 @@
 				"yargs-parser": "^10.0.0"
 			}
 		},
-		"merge-stream": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
-		},
 		"merge2": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.4.tgz",
-			"integrity": "sha512-FYE8xI+6pjFOhokZu0We3S5NKCirLbCzSh2Usf3qEyr4X8U+0jNg9P8RZ4qz+V2UoECLVwSyzU3LxXBaLGtD3A=="
+			"integrity": "sha512-FYE8xI+6pjFOhokZu0We3S5NKCirLbCzSh2Usf3qEyr4X8U+0jNg9P8RZ4qz+V2UoECLVwSyzU3LxXBaLGtD3A==",
+			"dev": true
 		},
 		"micromatch": {
 			"version": "3.1.10",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
 			"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+			"dev": true,
 			"requires": {
 				"arr-diff": "^4.0.0",
 				"array-unique": "^0.3.2",
@@ -8287,20 +6467,17 @@
 				"to-regex": "^3.0.2"
 			}
 		},
-		"mime": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-			"integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
-		},
 		"mime-db": {
 			"version": "1.40.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-			"integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
+			"integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
+			"dev": true
 		},
 		"mime-types": {
 			"version": "2.1.24",
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
 			"integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+			"dev": true,
 			"requires": {
 				"mime-db": "1.40.0"
 			}
@@ -8308,7 +6485,8 @@
 		"mimic-fn": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+			"dev": true
 		},
 		"minimatch": {
 			"version": "3.0.4",
@@ -8333,9 +6511,9 @@
 			}
 		},
 		"minipass": {
-			"version": "2.3.5",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
-			"integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.4.0.tgz",
+			"integrity": "sha512-6PmOuSP4NnZXzs2z6rbwzLJu/c5gdzYg1mRI/WIYdx45iiX7T+a4esOzavD6V/KmBzAaopFSTZPZcUx73bqKWA==",
 			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.1.2",
@@ -8367,29 +6545,13 @@
 				"pumpify": "^1.3.3",
 				"stream-each": "^1.1.0",
 				"through2": "^2.0.0"
-			},
-			"dependencies": {
-				"through2": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-					"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-					"dev": true,
-					"requires": {
-						"readable-stream": "~2.3.6",
-						"xtend": "~4.0.1"
-					}
-				}
 			}
-		},
-		"mitt": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/mitt/-/mitt-1.1.3.tgz",
-			"integrity": "sha512-mUDCnVNsAi+eD6qA0HkRkwYczbLHJ49z17BGe2PYRhZL4wpZUFZGJHU7/5tmvohoma+Hdn0Vh/oJTiPEmgSruA=="
 		},
 		"mixin-deep": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
 			"integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+			"dev": true,
 			"requires": {
 				"for-in": "^1.0.2",
 				"is-extendable": "^1.0.1"
@@ -8399,6 +6561,7 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"dev": true,
 					"requires": {
 						"is-plain-object": "^2.0.4"
 					}
@@ -8473,9 +6636,10 @@
 			"dev": true
 		},
 		"mute-stream": {
-			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+			"dev": true
 		},
 		"mz": {
 			"version": "2.7.0",
@@ -8492,12 +6656,14 @@
 			"version": "2.14.0",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
 			"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+			"dev": true,
 			"optional": true
 		},
 		"nanomatch": {
 			"version": "1.2.13",
 			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
 			"integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+			"dev": true,
 			"requires": {
 				"arr-diff": "^4.0.0",
 				"array-unique": "^0.3.2",
@@ -8511,11 +6677,6 @@
 				"snapdragon": "^0.8.1",
 				"to-regex": "^3.0.1"
 			}
-		},
-		"negotiator": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
-			"integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
 		},
 		"neo-async": {
 			"version": "2.6.1",
@@ -8608,39 +6769,22 @@
 				"resolve": "^1.10.0",
 				"semver": "2 || 3 || 4 || 5",
 				"validate-npm-package-license": "^3.0.1"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-				}
 			}
 		},
 		"normalize-path": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+			"dev": true,
 			"requires": {
 				"remove-trailing-separator": "^1.0.1"
 			}
 		},
-		"normalize-range": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-			"integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
-		},
 		"normalize-url": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
-			"integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
-			"optional": true,
-			"requires": {
-				"object-assign": "^4.0.1",
-				"prepend-http": "^1.0.0",
-				"query-string": "^4.1.0",
-				"sort-keys": "^1.0.0"
-			}
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
+			"integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
+			"dev": true
 		},
 		"now-and-later": {
 			"version": "2.0.1",
@@ -8683,14 +6827,6 @@
 				"osenv": "^0.1.5",
 				"semver": "^5.6.0",
 				"validate-npm-package-name": "^3.0.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
-				}
 			}
 		},
 		"npm-packlist": {
@@ -8712,14 +6848,6 @@
 				"figgy-pudding": "^3.5.1",
 				"npm-package-arg": "^6.0.0",
 				"semver": "^5.4.1"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
-				}
 			}
 		},
 		"npm-run-path": {
@@ -8743,19 +6871,6 @@
 				"set-blocking": "~2.0.0"
 			}
 		},
-		"nth-check": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
-			"integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
-			"requires": {
-				"boolbase": "~1.0.0"
-			}
-		},
-		"num2fraction": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
-			"integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4="
-		},
 		"number-is-nan": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
@@ -8772,15 +6887,11 @@
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
-		"object-component": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
-			"integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE="
-		},
 		"object-copy": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
 			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+			"dev": true,
 			"requires": {
 				"copy-descriptor": "^0.1.0",
 				"define-property": "^0.2.5",
@@ -8791,6 +6902,7 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
@@ -8799,6 +6911,7 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -8808,17 +6921,14 @@
 		"object-keys": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
-		},
-		"object-path": {
-			"version": "0.9.2",
-			"resolved": "https://registry.npmjs.org/object-path/-/object-path-0.9.2.tgz",
-			"integrity": "sha1-D9mnT8X60a45aLWGvaXGMr1sBaU="
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+			"dev": true
 		},
 		"object-visit": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
 			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+			"dev": true,
 			"requires": {
 				"isobject": "^3.0.0"
 			}
@@ -8851,6 +6961,7 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
 			"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
 				"es-abstract": "^1.5.1"
@@ -8870,6 +6981,7 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
 			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+			"dev": true,
 			"requires": {
 				"isobject": "^3.0.1"
 			}
@@ -8884,30 +6996,11 @@
 				"make-iterator": "^1.0.0"
 			}
 		},
-		"object.values": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
-			"integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
-			"requires": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.12.0",
-				"function-bind": "^1.1.1",
-				"has": "^1.0.3"
-			}
-		},
 		"octokit-pagination-methods": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz",
 			"integrity": "sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==",
 			"dev": true
-		},
-		"on-finished": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-			"integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-			"requires": {
-				"ee-first": "1.1.1"
-			}
 		},
 		"once": {
 			"version": "1.4.0",
@@ -8918,24 +7011,20 @@
 			}
 		},
 		"onetime": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
-			"integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+			"dev": true,
 			"requires": {
-				"mimic-fn": "^2.1.0"
-			}
-		},
-		"openurl": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/openurl/-/openurl-1.1.1.tgz",
-			"integrity": "sha1-OHW0sO96UsFW8NtB1GCduw+Us4c="
-		},
-		"opn": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
-			"integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
-			"requires": {
-				"is-wsl": "^1.1.0"
+				"mimic-fn": "^1.0.0"
+			},
+			"dependencies": {
+				"mimic-fn": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+					"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+					"dev": true
+				}
 			}
 		},
 		"optimist": {
@@ -9043,7 +7132,8 @@
 		"p-map": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-			"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
+			"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+			"dev": true
 		},
 		"p-map-series": {
 			"version": "1.0.0",
@@ -9129,7 +7219,8 @@
 		"parse-node-version": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.1.tgz",
-			"integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA=="
+			"integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==",
+			"dev": true
 		},
 		"parse-passwd": {
 			"version": "1.0.0",
@@ -9157,54 +7248,19 @@
 				"normalize-url": "^3.3.0",
 				"parse-path": "^4.0.0",
 				"protocols": "^1.4.0"
-			},
-			"dependencies": {
-				"normalize-url": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
-					"integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
-					"dev": true
-				}
 			}
-		},
-		"parse5": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
-			"integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
-			"requires": {
-				"@types/node": "*"
-			}
-		},
-		"parseqs": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
-			"integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
-			"requires": {
-				"better-assert": "~1.0.0"
-			}
-		},
-		"parseuri": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
-			"integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
-			"requires": {
-				"better-assert": "~1.0.0"
-			}
-		},
-		"parseurl": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
 		},
 		"pascalcase": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+			"dev": true
 		},
 		"path-dirname": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
+			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+			"dev": true
 		},
 		"path-exists": {
 			"version": "3.0.0",
@@ -9215,11 +7271,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-		},
-		"path-is-inside": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
 		},
 		"path-key": {
 			"version": "2.0.1",
@@ -9269,11 +7320,6 @@
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
 			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
 			"dev": true
-		},
-		"picomatch": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.0.7.tgz",
-			"integrity": "sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA=="
 		},
 		"pify": {
 			"version": "3.0.0",
@@ -9347,1035 +7393,11 @@
 				}
 			}
 		},
-		"plugin-error": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
-			"integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
-			"requires": {
-				"ansi-cyan": "^0.1.1",
-				"ansi-red": "^0.1.1",
-				"arr-diff": "^1.0.1",
-				"arr-union": "^2.0.1",
-				"extend-shallow": "^1.1.2"
-			},
-			"dependencies": {
-				"arr-diff": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
-					"integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
-					"requires": {
-						"arr-flatten": "^1.0.1",
-						"array-slice": "^0.2.3"
-					}
-				},
-				"arr-union": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
-					"integrity": "sha1-IPnqtexw9cfSFbEHexw5Fh0pLH0="
-				},
-				"array-slice": {
-					"version": "0.2.3",
-					"resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
-					"integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU="
-				},
-				"extend-shallow": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
-					"integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
-					"requires": {
-						"kind-of": "^1.1.0"
-					}
-				},
-				"kind-of": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
-					"integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ="
-				}
-			}
-		},
-		"portscanner": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/portscanner/-/portscanner-2.1.1.tgz",
-			"integrity": "sha1-6rtAnk3iSVD1oqUW01rnaTQ/u5Y=",
-			"requires": {
-				"async": "1.5.2",
-				"is-number-like": "^1.0.3"
-			},
-			"dependencies": {
-				"async": {
-					"version": "1.5.2",
-					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-				}
-			}
-		},
 		"posix-character-classes": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
-		},
-		"postcss": {
-			"version": "5.2.18",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-			"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-			"requires": {
-				"chalk": "^1.1.3",
-				"js-base64": "^2.1.9",
-				"source-map": "^0.5.6",
-				"supports-color": "^3.2.3"
-			},
-			"dependencies": {
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "^1.0.0"
-					}
-				}
-			}
-		},
-		"postcss-calc": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-6.0.2.tgz",
-			"integrity": "sha512-fiznXjEN5T42Qm7qqMCVJXS3roaj9r4xsSi+meaBVe7CJBl8t/QLOXu02Z2E6oWAMWIvCuF6JrvzFekmVEbOKA==",
-			"requires": {
-				"css-unit-converter": "^1.1.1",
-				"postcss": "^7.0.2",
-				"postcss-selector-parser": "^2.2.2",
-				"reduce-css-calc": "^2.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "5.5.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-							"requires": {
-								"has-flag": "^3.0.0"
-							}
-						}
-					}
-				},
-				"postcss": {
-					"version": "7.0.17",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.17.tgz",
-					"integrity": "sha512-546ZowA+KZ3OasvQZHsbuEpysvwTZNGJv9EfyCQdsIDltPSWHAeTQ5fQy/Npi2ZDtLI3zs7Ps/p6wThErhm9fQ==",
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
-			}
-		},
-		"postcss-custom-properties": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-6.3.1.tgz",
-			"integrity": "sha512-zoiwn4sCiUFbr4KcgcNZLFkR6gVQom647L+z1p/KBVHZ1OYwT87apnS42atJtx6XlX2yI7N5fjXbFixShQO2QQ==",
-			"requires": {
-				"balanced-match": "^1.0.0",
-				"postcss": "^6.0.18"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"postcss": {
-					"version": "6.0.23",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
-			}
-		},
-		"postcss-discard-empty": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-4.0.1.tgz",
-			"integrity": "sha512-B9miTzbznhDjTfjvipfHoqbWKwd0Mj+/fL5s1QOz06wufguil+Xheo4XpOnc4NqKYBCNqqEzgPv2aPBIJLox0w==",
-			"requires": {
-				"postcss": "^7.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "5.5.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-							"requires": {
-								"has-flag": "^3.0.0"
-							}
-						}
-					}
-				},
-				"postcss": {
-					"version": "7.0.17",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.17.tgz",
-					"integrity": "sha512-546ZowA+KZ3OasvQZHsbuEpysvwTZNGJv9EfyCQdsIDltPSWHAeTQ5fQy/Npi2ZDtLI3zs7Ps/p6wThErhm9fQ==",
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
-			}
-		},
-		"postcss-focus-ring": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-focus-ring/-/postcss-focus-ring-1.0.0.tgz",
-			"integrity": "sha1-31M7H6LG0tG91y6PBGLj+fegg5A=",
-			"requires": {
-				"postcss": "^6.0.1",
-				"postcss-selector-parser": "^2.2.3"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"postcss": {
-					"version": "6.0.23",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
-			}
-		},
-		"postcss-functions": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-functions/-/postcss-functions-3.0.0.tgz",
-			"integrity": "sha1-DpTQFERwCkgd4g3k1V+yZAVkJQ4=",
-			"requires": {
-				"glob": "^7.1.2",
-				"object-assign": "^4.1.1",
-				"postcss": "^6.0.9",
-				"postcss-value-parser": "^3.3.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"postcss": {
-					"version": "6.0.23",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
-			}
-		},
-		"postcss-import": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-10.0.0.tgz",
-			"integrity": "sha1-TIXJewmRNsxeoCQNwd/b/eTi674=",
-			"requires": {
-				"object-assign": "^4.0.1",
-				"postcss": "^6.0.1",
-				"postcss-value-parser": "^3.2.3",
-				"read-cache": "^1.0.0",
-				"resolve": "^1.1.7"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"postcss": {
-					"version": "6.0.23",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
-			}
-		},
-		"postcss-inherit": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-inherit/-/postcss-inherit-4.1.0.tgz",
-			"integrity": "sha512-BI3Dme4twf9uk4LInRtG3NKo3eTmfywXmazVqFvQdVHUb5qlnGItXzUTEj0ihqxpoo1u4bA1lEro3C6+UQxdvg==",
-			"requires": {
-				"debug": "^3.1.0",
-				"postcss": "^6.0.22",
-				"postcss-inherit-parser": "^0.2.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-				},
-				"postcss": {
-					"version": "6.0.23",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
-			}
-		},
-		"postcss-inherit-parser": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/postcss-inherit-parser/-/postcss-inherit-parser-0.2.0.tgz",
-			"integrity": "sha512-XL3QoYrPh+PQqIc4N3x1y0AEcXjG4gjAF+6kvD/vXNmIQRQ1Ck25Z6dyYY7clx6jrG5nlg3v+max6mzoH+K26g==",
-			"requires": {
-				"postcss": "^6.0.22"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"postcss": {
-					"version": "6.0.23",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
-			}
-		},
-		"postcss-js": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-2.0.2.tgz",
-			"integrity": "sha512-HxXLw1lrczsbVXxyC+t/VIfje9ZeZhkkXE8KpFa3MEKfp2FyHDv29JShYY9eLhYrhLyWWHNIuwkktTfLXu2otw==",
-			"requires": {
-				"camelcase-css": "^2.0.1",
-				"postcss": "^7.0.17"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "5.5.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-							"requires": {
-								"has-flag": "^3.0.0"
-							}
-						}
-					}
-				},
-				"postcss": {
-					"version": "7.0.17",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.17.tgz",
-					"integrity": "sha512-546ZowA+KZ3OasvQZHsbuEpysvwTZNGJv9EfyCQdsIDltPSWHAeTQ5fQy/Npi2ZDtLI3zs7Ps/p6wThErhm9fQ==",
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
-			}
-		},
-		"postcss-load-config": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-1.2.0.tgz",
-			"integrity": "sha1-U56a/J3chiASHr+djDZz4M5Q0oo=",
-			"requires": {
-				"cosmiconfig": "^2.1.0",
-				"object-assign": "^4.1.0",
-				"postcss-load-options": "^1.2.0",
-				"postcss-load-plugins": "^2.3.0"
-			},
-			"dependencies": {
-				"cosmiconfig": {
-					"version": "2.2.2",
-					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
-					"integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
-					"requires": {
-						"is-directory": "^0.3.1",
-						"js-yaml": "^3.4.3",
-						"minimist": "^1.2.0",
-						"object-assign": "^4.1.0",
-						"os-homedir": "^1.0.1",
-						"parse-json": "^2.2.0",
-						"require-from-string": "^1.1.0"
-					}
-				},
-				"parse-json": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-					"requires": {
-						"error-ex": "^1.2.0"
-					}
-				}
-			}
-		},
-		"postcss-load-options": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/postcss-load-options/-/postcss-load-options-1.2.0.tgz",
-			"integrity": "sha1-sJixVZ3awt8EvAuzdfmaXP4rbYw=",
-			"requires": {
-				"cosmiconfig": "^2.1.0",
-				"object-assign": "^4.1.0"
-			},
-			"dependencies": {
-				"cosmiconfig": {
-					"version": "2.2.2",
-					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
-					"integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
-					"requires": {
-						"is-directory": "^0.3.1",
-						"js-yaml": "^3.4.3",
-						"minimist": "^1.2.0",
-						"object-assign": "^4.1.0",
-						"os-homedir": "^1.0.1",
-						"parse-json": "^2.2.0",
-						"require-from-string": "^1.1.0"
-					}
-				},
-				"parse-json": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-					"requires": {
-						"error-ex": "^1.2.0"
-					}
-				}
-			}
-		},
-		"postcss-load-plugins": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/postcss-load-plugins/-/postcss-load-plugins-2.3.0.tgz",
-			"integrity": "sha1-dFdoEWWZrKLwCfrUJrABdQSdjZI=",
-			"requires": {
-				"cosmiconfig": "^2.1.1",
-				"object-assign": "^4.1.0"
-			},
-			"dependencies": {
-				"cosmiconfig": {
-					"version": "2.2.2",
-					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
-					"integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
-					"requires": {
-						"is-directory": "^0.3.1",
-						"js-yaml": "^3.4.3",
-						"minimist": "^1.2.0",
-						"object-assign": "^4.1.0",
-						"os-homedir": "^1.0.1",
-						"parse-json": "^2.2.0",
-						"require-from-string": "^1.1.0"
-					}
-				},
-				"parse-json": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-					"requires": {
-						"error-ex": "^1.2.0"
-					}
-				}
-			}
-		},
-		"postcss-mixins": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/postcss-mixins/-/postcss-mixins-6.2.2.tgz",
-			"integrity": "sha512-QqEZamiAMguYR6d2h73XXEHZgkxs03PlbU0PqgqtdCnbRlMLFNQgsfL/Td0rjIe2SwpLXOQyB9uoiLWa4GR7tg==",
-			"requires": {
-				"globby": "^8.0.1",
-				"postcss": "^7.0.17",
-				"postcss-js": "^2.0.2",
-				"postcss-simple-vars": "^5.0.2",
-				"sugarss": "^2.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "5.5.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-							"requires": {
-								"has-flag": "^3.0.0"
-							}
-						}
-					}
-				},
-				"dir-glob": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
-					"integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
-					"requires": {
-						"arrify": "^1.0.1",
-						"path-type": "^3.0.0"
-					}
-				},
-				"globby": {
-					"version": "8.0.2",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-8.0.2.tgz",
-					"integrity": "sha512-yTzMmKygLp8RUpG1Ymu2VXPSJQZjNAZPD4ywgYEaG7e4tBJeUQBO8OpXrf1RCNcEs5alsoJYPAMiIHP0cmeC7w==",
-					"requires": {
-						"array-union": "^1.0.1",
-						"dir-glob": "2.0.0",
-						"fast-glob": "^2.0.2",
-						"glob": "^7.1.2",
-						"ignore": "^3.3.5",
-						"pify": "^3.0.0",
-						"slash": "^1.0.0"
-					}
-				},
-				"ignore": {
-					"version": "3.3.10",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-					"integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug=="
-				},
-				"postcss": {
-					"version": "7.0.17",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.17.tgz",
-					"integrity": "sha512-546ZowA+KZ3OasvQZHsbuEpysvwTZNGJv9EfyCQdsIDltPSWHAeTQ5fQy/Npi2ZDtLI3zs7Ps/p6wThErhm9fQ==",
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
-			}
-		},
-		"postcss-nested": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-3.0.0.tgz",
-			"integrity": "sha512-1xxmLHSfubuUi6xZZ0zLsNoiKfk3BWQj6fkNMaBJC529wKKLcdeCxXt6KJmDLva+trNyQNwEaE/ZWMA7cve1fA==",
-			"requires": {
-				"postcss": "^6.0.14",
-				"postcss-selector-parser": "^3.1.1"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"dot-prop": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
-					"integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
-					"requires": {
-						"is-obj": "^1.0.0"
-					}
-				},
-				"postcss": {
-					"version": "6.0.23",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
-					}
-				},
-				"postcss-selector-parser": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
-					"integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
-					"requires": {
-						"dot-prop": "^4.1.1",
-						"indexes-of": "^1.0.1",
-						"uniq": "^1.0.1"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
-			}
-		},
-		"postcss-selector-parser": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
-			"integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
-			"requires": {
-				"flatten": "^1.0.2",
-				"indexes-of": "^1.0.1",
-				"uniq": "^1.0.1"
-			}
-		},
-		"postcss-simple-vars": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-simple-vars/-/postcss-simple-vars-5.0.2.tgz",
-			"integrity": "sha512-xWIufxBoINJv6JiLb7jl5oElgp+6puJwvT5zZHliUSydoLz4DADRB3NDDsYgfKVwojn4TDLiseoC65MuS8oGGg==",
-			"requires": {
-				"postcss": "^7.0.14"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "5.5.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-							"requires": {
-								"has-flag": "^3.0.0"
-							}
-						}
-					}
-				},
-				"postcss": {
-					"version": "7.0.17",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.17.tgz",
-					"integrity": "sha512-546ZowA+KZ3OasvQZHsbuEpysvwTZNGJv9EfyCQdsIDltPSWHAeTQ5fQy/Npi2ZDtLI3zs7Ps/p6wThErhm9fQ==",
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
-			}
-		},
-		"postcss-svg": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-svg/-/postcss-svg-3.0.0.tgz",
-			"integrity": "sha512-kvwD3PJ66gXHgL/6t30W8/zT0qvuZ+TGwq76JlQFHyZb6Oal4tAvp6IARRwYwoy/FxQ8XAyLoYf34kk80yg8WQ==",
-			"requires": {
-				"postcss": "^7.0.6",
-				"postcss-values-parser": "^2.0.0",
-				"svgo": "^1.1.1",
-				"xmldoc": "^1.1.2"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "5.5.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-							"requires": {
-								"has-flag": "^3.0.0"
-							}
-						}
-					}
-				},
-				"postcss": {
-					"version": "7.0.17",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.17.tgz",
-					"integrity": "sha512-546ZowA+KZ3OasvQZHsbuEpysvwTZNGJv9EfyCQdsIDltPSWHAeTQ5fQy/Npi2ZDtLI3zs7Ps/p6wThErhm9fQ==",
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
-			}
-		},
-		"postcss-value-parser": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-			"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
-		},
-		"postcss-values-parser": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-2.0.1.tgz",
-			"integrity": "sha512-2tLuBsA6P4rYTNKCXYG/71C7j1pU6pK503suYOmn4xYrQIzW+opD+7FAFNuGSdZC/3Qfy334QbeMu7MEb8gOxg==",
-			"requires": {
-				"flatten": "^1.0.2",
-				"indexes-of": "^1.0.1",
-				"uniq": "^1.0.1"
-			}
-		},
-		"prepend-http": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-			"optional": true
+			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+			"dev": true
 		},
 		"pretty-hrtime": {
 			"version": "1.0.3",
@@ -10400,15 +7422,8 @@
 		"process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-		},
-		"promise": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-			"requires": {
-				"asap": "~2.0.3"
-			}
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+			"dev": true
 		},
 		"promise-inflight": {
 			"version": "1.0.1",
@@ -10462,168 +7477,6 @@
 			"integrity": "sha512-avHdspHO+9rQTLbv1RO+MPYeP/SzsCoxofjVnHanETfQhTJrmB0HlDoW+EiN/R+C0BZ+gERab9NY0lPN2TxNag==",
 			"dev": true
 		},
-		"pug": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/pug/-/pug-2.0.4.tgz",
-			"integrity": "sha512-XhoaDlvi6NIzL49nu094R2NA6P37ijtgMDuWE+ofekDChvfKnzFal60bhSdiy8y2PBO6fmz3oMEIcfpBVRUdvw==",
-			"requires": {
-				"pug-code-gen": "^2.0.2",
-				"pug-filters": "^3.1.1",
-				"pug-lexer": "^4.1.0",
-				"pug-linker": "^3.0.6",
-				"pug-load": "^2.0.12",
-				"pug-parser": "^5.0.1",
-				"pug-runtime": "^2.0.5",
-				"pug-strip-comments": "^1.0.4"
-			}
-		},
-		"pug-attrs": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/pug-attrs/-/pug-attrs-2.0.4.tgz",
-			"integrity": "sha512-TaZ4Z2TWUPDJcV3wjU3RtUXMrd3kM4Wzjbe3EWnSsZPsJ3LDI0F3yCnf2/W7PPFF+edUFQ0HgDL1IoxSz5K8EQ==",
-			"requires": {
-				"constantinople": "^3.0.1",
-				"js-stringify": "^1.0.1",
-				"pug-runtime": "^2.0.5"
-			}
-		},
-		"pug-code-gen": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-2.0.2.tgz",
-			"integrity": "sha512-kROFWv/AHx/9CRgoGJeRSm+4mLWchbgpRzTEn8XCiwwOy6Vh0gAClS8Vh5TEJ9DBjaP8wCjS3J6HKsEsYdvaCw==",
-			"requires": {
-				"constantinople": "^3.1.2",
-				"doctypes": "^1.1.0",
-				"js-stringify": "^1.0.1",
-				"pug-attrs": "^2.0.4",
-				"pug-error": "^1.3.3",
-				"pug-runtime": "^2.0.5",
-				"void-elements": "^2.0.1",
-				"with": "^5.0.0"
-			}
-		},
-		"pug-error": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/pug-error/-/pug-error-1.3.3.tgz",
-			"integrity": "sha512-qE3YhESP2mRAWMFJgKdtT5D7ckThRScXRwkfo+Erqga7dyJdY3ZquspprMCj/9sJ2ijm5hXFWQE/A3l4poMWiQ=="
-		},
-		"pug-filters": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/pug-filters/-/pug-filters-3.1.1.tgz",
-			"integrity": "sha512-lFfjNyGEyVWC4BwX0WyvkoWLapI5xHSM3xZJFUhx4JM4XyyRdO8Aucc6pCygnqV2uSgJFaJWW3Ft1wCWSoQkQg==",
-			"requires": {
-				"clean-css": "^4.1.11",
-				"constantinople": "^3.0.1",
-				"jstransformer": "1.0.0",
-				"pug-error": "^1.3.3",
-				"pug-walk": "^1.1.8",
-				"resolve": "^1.1.6",
-				"uglify-js": "^2.6.1"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-					"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
-				},
-				"cliui": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-					"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-					"requires": {
-						"center-align": "^0.1.1",
-						"right-align": "^0.1.1",
-						"wordwrap": "0.0.2"
-					}
-				},
-				"uglify-js": {
-					"version": "2.8.29",
-					"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-					"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-					"requires": {
-						"source-map": "~0.5.1",
-						"uglify-to-browserify": "~1.0.0",
-						"yargs": "~3.10.0"
-					}
-				},
-				"window-size": {
-					"version": "0.1.0",
-					"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-					"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
-				},
-				"wordwrap": {
-					"version": "0.0.2",
-					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-					"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
-				},
-				"yargs": {
-					"version": "3.10.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-					"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-					"requires": {
-						"camelcase": "^1.0.2",
-						"cliui": "^2.1.0",
-						"decamelize": "^1.0.0",
-						"window-size": "0.1.0"
-					}
-				}
-			}
-		},
-		"pug-lexer": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/pug-lexer/-/pug-lexer-4.1.0.tgz",
-			"integrity": "sha512-i55yzEBtjm0mlplW4LoANq7k3S8gDdfC6+LThGEvsK4FuobcKfDAwt6V4jKPH9RtiE3a2Akfg5UpafZ1OksaPA==",
-			"requires": {
-				"character-parser": "^2.1.1",
-				"is-expression": "^3.0.0",
-				"pug-error": "^1.3.3"
-			}
-		},
-		"pug-linker": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/pug-linker/-/pug-linker-3.0.6.tgz",
-			"integrity": "sha512-bagfuHttfQOpANGy1Y6NJ+0mNb7dD2MswFG2ZKj22s8g0wVsojpRlqveEQHmgXXcfROB2RT6oqbPYr9EN2ZWzg==",
-			"requires": {
-				"pug-error": "^1.3.3",
-				"pug-walk": "^1.1.8"
-			}
-		},
-		"pug-load": {
-			"version": "2.0.12",
-			"resolved": "https://registry.npmjs.org/pug-load/-/pug-load-2.0.12.tgz",
-			"integrity": "sha512-UqpgGpyyXRYgJs/X60sE6SIf8UBsmcHYKNaOccyVLEuT6OPBIMo6xMPhoJnqtB3Q3BbO4Z3Bjz5qDsUWh4rXsg==",
-			"requires": {
-				"object-assign": "^4.1.0",
-				"pug-walk": "^1.1.8"
-			}
-		},
-		"pug-parser": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/pug-parser/-/pug-parser-5.0.1.tgz",
-			"integrity": "sha512-nGHqK+w07p5/PsPIyzkTQfzlYfuqoiGjaoqHv1LjOv2ZLXmGX1O+4Vcvps+P4LhxZ3drYSljjq4b+Naid126wA==",
-			"requires": {
-				"pug-error": "^1.3.3",
-				"token-stream": "0.0.1"
-			}
-		},
-		"pug-runtime": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/pug-runtime/-/pug-runtime-2.0.5.tgz",
-			"integrity": "sha512-P+rXKn9un4fQY77wtpcuFyvFaBww7/91f3jHa154qU26qFAnOe6SW1CbIDcxiG5lLK9HazYrMCCuDvNgDQNptw=="
-		},
-		"pug-strip-comments": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-1.0.4.tgz",
-			"integrity": "sha512-i5j/9CS4yFhSxHp5iKPHwigaig/VV9g+FgReLJWWHEHbvKsbqL0oP/K5ubuLco6Wu3Kan5p7u7qk8A4oLLh6vw==",
-			"requires": {
-				"pug-error": "^1.3.3"
-			}
-		},
-		"pug-walk": {
-			"version": "1.1.8",
-			"resolved": "https://registry.npmjs.org/pug-walk/-/pug-walk-1.1.8.tgz",
-			"integrity": "sha512-GMu3M5nUL3fju4/egXwZO0XLi6fW/K3T3VTgFQ14GxNi8btlxgT5qZL//JwZFm/2Fa64J/PNS8AZeys3wiMkVA=="
-		},
 		"pump": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -10666,7 +7519,8 @@
 		"q": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+			"dev": true
 		},
 		"qs": {
 			"version": "6.5.2",
@@ -10674,36 +7528,10 @@
 			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
 			"dev": true
 		},
-		"query-string": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
-			"integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
-			"optional": true,
-			"requires": {
-				"object-assign": "^4.1.0",
-				"strict-uri-encode": "^1.0.0"
-			}
-		},
 		"quick-lru": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
 			"integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g="
-		},
-		"range-parser": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
-		},
-		"raw-body": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.1.tgz",
-			"integrity": "sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==",
-			"requires": {
-				"bytes": "3.1.0",
-				"http-errors": "1.7.3",
-				"iconv-lite": "0.4.24",
-				"unpipe": "1.0.0"
-			}
 		},
 		"read": {
 			"version": "1.0.7",
@@ -10712,21 +7540,6 @@
 			"dev": true,
 			"requires": {
 				"mute-stream": "~0.0.4"
-			}
-		},
-		"read-cache": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
-			"integrity": "sha1-5mTvMRYRZsl1HNvo28+GtftY93Q=",
-			"requires": {
-				"pify": "^2.3.0"
-			},
-			"dependencies": {
-				"pify": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-				}
 			}
 		},
 		"read-cmd-shim": {
@@ -10785,6 +7598,7 @@
 			"version": "2.3.6",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+			"dev": true,
 			"requires": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.3",
@@ -10811,6 +7625,7 @@
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
 			"integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.11",
 				"micromatch": "^3.1.10",
@@ -10841,15 +7656,6 @@
 				"strip-indent": "^2.0.0"
 			}
 		},
-		"reduce-css-calc": {
-			"version": "2.1.6",
-			"resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-2.1.6.tgz",
-			"integrity": "sha512-+l5/qlQmdsbM9h6JerJ/y5vR5Ci0k93aszLNpCmbadC3nBcbRGmIBm0s9Nj59i22LvCjTGftWzdQRwdknayxhw==",
-			"requires": {
-				"css-unit-converter": "^1.1.1",
-				"postcss-value-parser": "^3.3.0"
-			}
-		},
 		"regenerator-runtime": {
 			"version": "0.11.1",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
@@ -10859,6 +7665,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
 			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+			"dev": true,
 			"requires": {
 				"extend-shallow": "^3.0.2",
 				"safe-regex": "^1.1.0"
@@ -10883,34 +7690,25 @@
 				"remove-bom-buffer": "^3.0.0",
 				"safe-buffer": "^5.1.0",
 				"through2": "^2.0.3"
-			},
-			"dependencies": {
-				"through2": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-					"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-					"dev": true,
-					"requires": {
-						"readable-stream": "~2.3.6",
-						"xtend": "~4.0.1"
-					}
-				}
 			}
 		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+			"dev": true
 		},
 		"repeat-element": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
-			"integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g=="
+			"integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+			"dev": true
 		},
 		"repeat-string": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+			"dev": true
 		},
 		"repeating": {
 			"version": "2.0.1",
@@ -10923,7 +7721,8 @@
 		"replace-ext": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-			"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
+			"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+			"dev": true
 		},
 		"replace-homedir": {
 			"version": "1.0.0",
@@ -10934,16 +7733,6 @@
 				"homedir-polyfill": "^1.0.1",
 				"is-absolute": "^1.0.0",
 				"remove-trailing-separator": "^1.1.0"
-			}
-		},
-		"replacestream": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/replacestream/-/replacestream-4.0.3.tgz",
-			"integrity": "sha512-AC0FiLS352pBBiZhd4VXB1Ab/lh0lEgpP+GGvZqbQh8a5cmXVoTe5EX/YeTFArnp4SRGTHh1qCHu9lGs1qG8sA==",
-			"requires": {
-				"escape-string-regexp": "^1.0.3",
-				"object-assign": "^4.0.1",
-				"readable-stream": "^2.0.2"
 			}
 		},
 		"request": {
@@ -10977,22 +7766,14 @@
 		"require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
-		},
-		"require-from-string": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
-			"integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg="
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+			"dev": true
 		},
 		"require-main-filename": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
-		},
-		"requires-port": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+			"dev": true
 		},
 		"resolve": {
 			"version": "1.12.0",
@@ -11047,30 +7828,24 @@
 		"resolve-url": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
-		},
-		"resp-modifier": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/resp-modifier/-/resp-modifier-6.0.2.tgz",
-			"integrity": "sha1-sSTeXE+6/LpUH0j/pzlw9KpFa08=",
-			"requires": {
-				"debug": "^2.2.0",
-				"minimatch": "^3.0.2"
-			}
+			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+			"dev": true
 		},
 		"restore-cursor": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-			"integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+			"dev": true,
 			"requires": {
-				"onetime": "^5.1.0",
+				"onetime": "^2.0.0",
 				"signal-exit": "^3.0.2"
 			}
 		},
 		"ret": {
 			"version": "0.1.15",
 			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+			"dev": true
 		},
 		"retry": {
 			"version": "0.10.1",
@@ -11078,23 +7853,11 @@
 			"integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
 			"dev": true
 		},
-		"reusify": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
-		},
-		"right-align": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-			"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-			"requires": {
-				"align-text": "^0.1.1"
-			}
-		},
 		"rimraf": {
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
 			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+			"dev": true,
 			"requires": {
 				"glob": "^7.1.3"
 			}
@@ -11103,14 +7866,10 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
 			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+			"dev": true,
 			"requires": {
 				"is-promise": "^2.1.0"
 			}
-		},
-		"run-parallel": {
-			"version": "1.1.9",
-			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
-			"integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q=="
 		},
 		"run-queue": {
 			"version": "1.0.3",
@@ -11121,15 +7880,11 @@
 				"aproba": "^1.1.1"
 			}
 		},
-		"rx": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
-			"integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
-		},
 		"rxjs": {
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
 			"integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
+			"dev": true,
 			"requires": {
 				"tslib": "^1.9.0"
 			}
@@ -11143,6 +7898,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+			"dev": true,
 			"requires": {
 				"ret": "~0.1.10"
 			}
@@ -11150,12 +7906,8 @@
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-		},
-		"sax": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true
 		},
 		"select": {
 			"version": "1.1.2",
@@ -11165,9 +7917,9 @@
 			"optional": true
 		},
 		"semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
 		},
 		"semver-greatest-satisfied-range": {
 			"version": "1.1.0",
@@ -11178,121 +7930,17 @@
 				"sver-compat": "^1.5.0"
 			}
 		},
-		"send": {
-			"version": "0.16.2",
-			"resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
-			"integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
-			"requires": {
-				"debug": "2.6.9",
-				"depd": "~1.1.2",
-				"destroy": "~1.0.4",
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"etag": "~1.8.1",
-				"fresh": "0.5.2",
-				"http-errors": "~1.6.2",
-				"mime": "1.4.1",
-				"ms": "2.0.0",
-				"on-finished": "~2.3.0",
-				"range-parser": "~1.2.0",
-				"statuses": "~1.4.0"
-			},
-			"dependencies": {
-				"http-errors": {
-					"version": "1.6.3",
-					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-					"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-					"requires": {
-						"depd": "~1.1.2",
-						"inherits": "2.0.3",
-						"setprototypeof": "1.1.0",
-						"statuses": ">= 1.4.0 < 2"
-					}
-				},
-				"inherits": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-				},
-				"setprototypeof": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-					"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
-				},
-				"statuses": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-					"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
-				}
-			}
-		},
-		"serve-index": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
-			"integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
-			"requires": {
-				"accepts": "~1.3.4",
-				"batch": "0.6.1",
-				"debug": "2.6.9",
-				"escape-html": "~1.0.3",
-				"http-errors": "~1.6.2",
-				"mime-types": "~2.1.17",
-				"parseurl": "~1.3.2"
-			},
-			"dependencies": {
-				"http-errors": {
-					"version": "1.6.3",
-					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-					"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-					"requires": {
-						"depd": "~1.1.2",
-						"inherits": "2.0.3",
-						"setprototypeof": "1.1.0",
-						"statuses": ">= 1.4.0 < 2"
-					}
-				},
-				"inherits": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-				},
-				"setprototypeof": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-					"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
-				},
-				"statuses": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-					"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
-				}
-			}
-		},
-		"serve-static": {
-			"version": "1.13.2",
-			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
-			"integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
-			"requires": {
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"parseurl": "~1.3.2",
-				"send": "0.16.2"
-			}
-		},
-		"server-destroy": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
-			"integrity": "sha1-8Tv5KOQrnD55OD5hzDmYtdFObN0="
-		},
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+			"dev": true
 		},
 		"set-value": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
 			"integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+			"dev": true,
 			"requires": {
 				"extend-shallow": "^2.0.1",
 				"is-extendable": "^0.1.1",
@@ -11304,16 +7952,12 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
 				}
 			}
-		},
-		"setprototypeof": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
-			"integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
 		},
 		"shebang-command": {
 			"version": "1.2.0",
@@ -11356,6 +8000,7 @@
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
 			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+			"dev": true,
 			"requires": {
 				"base": "^0.11.1",
 				"debug": "^2.2.0",
@@ -11371,6 +8016,7 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
@@ -11379,6 +8025,7 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -11389,6 +8036,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
 			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+			"dev": true,
 			"requires": {
 				"define-property": "^1.0.0",
 				"isobject": "^3.0.0",
@@ -11399,6 +8047,7 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"dev": true,
 					"requires": {
 						"is-descriptor": "^1.0.0"
 					}
@@ -11407,6 +8056,7 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -11415,6 +8065,7 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -11423,6 +8074,7 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
 						"is-data-descriptor": "^1.0.0",
@@ -11435,6 +8087,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
 			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+			"dev": true,
 			"requires": {
 				"kind-of": "^3.2.0"
 			},
@@ -11443,172 +8096,10 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
-				}
-			}
-		},
-		"socket.io": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.1.1.tgz",
-			"integrity": "sha512-rORqq9c+7W0DAK3cleWNSyfv/qKXV99hV4tZe+gGLfBECw3XEhBy7x85F3wypA9688LKjtwO9pX9L33/xQI8yA==",
-			"requires": {
-				"debug": "~3.1.0",
-				"engine.io": "~3.2.0",
-				"has-binary2": "~1.0.2",
-				"socket.io-adapter": "~1.1.0",
-				"socket.io-client": "2.1.1",
-				"socket.io-parser": "~3.2.0"
-			},
-			"dependencies": {
-				"component-emitter": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-					"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
-				},
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"engine.io-client": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
-					"integrity": "sha512-y5AbkytWeM4jQr7m/koQLc5AxpRKC1hEVUb/s1FUAWEJq5AzJJ4NLvzuKPuxtDi5Mq755WuDvZ6Iv2rXj4PTzw==",
-					"requires": {
-						"component-emitter": "1.2.1",
-						"component-inherit": "0.0.3",
-						"debug": "~3.1.0",
-						"engine.io-parser": "~2.1.1",
-						"has-cors": "1.1.0",
-						"indexof": "0.0.1",
-						"parseqs": "0.0.5",
-						"parseuri": "0.0.5",
-						"ws": "~3.3.1",
-						"xmlhttprequest-ssl": "~1.5.4",
-						"yeast": "0.1.2"
-					}
-				},
-				"isarray": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-					"integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
-				},
-				"socket.io-client": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.1.1.tgz",
-					"integrity": "sha512-jxnFyhAuFxYfjqIgduQlhzqTcOEQSn+OHKVfAxWaNWa7ecP7xSNk2Dx/3UEsDcY7NcFafxvNvKPmmO7HTwTxGQ==",
-					"requires": {
-						"backo2": "1.0.2",
-						"base64-arraybuffer": "0.1.5",
-						"component-bind": "1.0.0",
-						"component-emitter": "1.2.1",
-						"debug": "~3.1.0",
-						"engine.io-client": "~3.2.0",
-						"has-binary2": "~1.0.2",
-						"has-cors": "1.1.0",
-						"indexof": "0.0.1",
-						"object-component": "0.0.3",
-						"parseqs": "0.0.5",
-						"parseuri": "0.0.5",
-						"socket.io-parser": "~3.2.0",
-						"to-array": "0.1.4"
-					}
-				},
-				"socket.io-parser": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
-					"integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
-					"requires": {
-						"component-emitter": "1.2.1",
-						"debug": "~3.1.0",
-						"isarray": "2.0.1"
-					}
-				},
-				"ws": {
-					"version": "3.3.3",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-					"integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
-					"requires": {
-						"async-limiter": "~1.0.0",
-						"safe-buffer": "~5.1.0",
-						"ultron": "~1.1.0"
-					}
-				}
-			}
-		},
-		"socket.io-adapter": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-1.1.1.tgz",
-			"integrity": "sha1-KoBeihTWNyEk3ZFZrUUC+MsH8Gs="
-		},
-		"socket.io-client": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.2.0.tgz",
-			"integrity": "sha512-56ZrkTDbdTLmBIyfFYesgOxsjcLnwAKoN4CiPyTVkMQj3zTUh0QAx3GbvIvLpFEOvQWu92yyWICxB0u7wkVbYA==",
-			"requires": {
-				"backo2": "1.0.2",
-				"base64-arraybuffer": "0.1.5",
-				"component-bind": "1.0.0",
-				"component-emitter": "1.2.1",
-				"debug": "~3.1.0",
-				"engine.io-client": "~3.3.1",
-				"has-binary2": "~1.0.2",
-				"has-cors": "1.1.0",
-				"indexof": "0.0.1",
-				"object-component": "0.0.3",
-				"parseqs": "0.0.5",
-				"parseuri": "0.0.5",
-				"socket.io-parser": "~3.3.0",
-				"to-array": "0.1.4"
-			},
-			"dependencies": {
-				"component-emitter": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-					"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
-				},
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				}
-			}
-		},
-		"socket.io-parser": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
-			"integrity": "sha512-hczmV6bDgdaEbVqhAeVMM/jfUfzuEZHsQg6eOmLgJht6G3mPKMxYm75w2+qhAQZ+4X+1+ATZ+QFKeOZD5riHng==",
-			"requires": {
-				"component-emitter": "1.2.1",
-				"debug": "~3.1.0",
-				"isarray": "2.0.1"
-			},
-			"dependencies": {
-				"component-emitter": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-					"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
-				},
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"isarray": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-					"integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
 				}
 			}
 		},
@@ -11644,10 +8135,10 @@
 			}
 		},
 		"sort-keys": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
-			"integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
-			"optional": true,
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
+			"integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
+			"dev": true,
 			"requires": {
 				"is-plain-obj": "^1.0.0"
 			}
@@ -11661,6 +8152,7 @@
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
 			"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+			"dev": true,
 			"requires": {
 				"atob": "^2.1.1",
 				"decode-uri-component": "^0.2.0",
@@ -11680,7 +8172,8 @@
 		"source-map-url": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+			"dev": true
 		},
 		"sparkles": {
 			"version": "1.0.1",
@@ -11729,6 +8222,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
 			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+			"dev": true,
 			"requires": {
 				"extend-shallow": "^3.0.0"
 			}
@@ -11740,24 +8234,13 @@
 			"dev": true,
 			"requires": {
 				"through2": "^2.0.2"
-			},
-			"dependencies": {
-				"through2": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-					"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-					"dev": true,
-					"requires": {
-						"readable-stream": "~2.3.6",
-						"xtend": "~4.0.1"
-					}
-				}
 			}
 		},
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
 		},
 		"sshpk": {
 			"version": "1.16.1",
@@ -11785,11 +8268,6 @@
 				"figgy-pudding": "^3.5.1"
 			}
 		},
-		"stable": {
-			"version": "0.1.8",
-			"resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
-			"integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
-		},
 		"stack-trace": {
 			"version": "0.0.10",
 			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
@@ -11800,6 +8278,7 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
 			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+			"dev": true,
 			"requires": {
 				"define-property": "^0.2.5",
 				"object-copy": "^0.1.0"
@@ -11809,16 +8288,12 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
 				}
 			}
-		},
-		"statuses": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-			"integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
 		},
 		"stream-combiner": {
 			"version": "0.2.2",
@@ -11852,52 +8327,6 @@
 			"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
 			"dev": true
 		},
-		"stream-throttle": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/stream-throttle/-/stream-throttle-0.1.3.tgz",
-			"integrity": "sha1-rdV8jXzHOoFjDTHNVdOWHPr7qcM=",
-			"requires": {
-				"commander": "^2.2.0",
-				"limiter": "^1.0.5"
-			}
-		},
-		"streamqueue": {
-			"version": "0.0.6",
-			"resolved": "https://registry.npmjs.org/streamqueue/-/streamqueue-0.0.6.tgz",
-			"integrity": "sha1-ZvX17JTpuK8knkrsLdH3Qb/pTeM=",
-			"requires": {
-				"readable-stream": "^1.0.26-2"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-				},
-				"readable-stream": {
-					"version": "1.1.14",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.1",
-						"isarray": "0.0.1",
-						"string_decoder": "~0.10.x"
-					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-				}
-			}
-		},
-		"strict-uri-encode": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-			"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-			"optional": true
-		},
 		"string-width": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -11929,6 +8358,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.0"
 			}
@@ -11957,21 +8387,6 @@
 			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
 			"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
 		},
-		"strip-outer": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
-			"integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
-			"optional": true,
-			"requires": {
-				"escape-string-regexp": "^1.0.2"
-			}
-		},
-		"strip-url-auth": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/strip-url-auth/-/strip-url-auth-1.0.1.tgz",
-			"integrity": "sha1-IrD6OkE4WzO+PzMVUbu4N/oM164=",
-			"optional": true
-		},
 		"strong-log-transformer": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/strong-log-transformer/-/strong-log-transformer-2.1.0.tgz",
@@ -11981,67 +8396,6 @@
 				"duplexer": "^0.1.1",
 				"minimist": "^1.2.0",
 				"through": "^2.3.4"
-			}
-		},
-		"sugarss": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/sugarss/-/sugarss-2.0.0.tgz",
-			"integrity": "sha512-WfxjozUk0UVA4jm+U1d736AUpzSrNsQcIbyOkoE364GrtWmIrFdk5lksEupgWMD4VaT/0kVx1dobpiDumSgmJQ==",
-			"requires": {
-				"postcss": "^7.0.2"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "5.5.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-							"requires": {
-								"has-flag": "^3.0.0"
-							}
-						}
-					}
-				},
-				"postcss": {
-					"version": "7.0.17",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.17.tgz",
-					"integrity": "sha512-546ZowA+KZ3OasvQZHsbuEpysvwTZNGJv9EfyCQdsIDltPSWHAeTQ5fQy/Npi2ZDtLI3zs7Ps/p6wThErhm9fQ==",
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"supports-color": {
@@ -12058,87 +8412,6 @@
 				"es6-iterator": "^2.0.1",
 				"es6-symbol": "^3.1.1"
 			}
-		},
-		"svgcombiner": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/svgcombiner/-/svgcombiner-1.0.1.tgz",
-			"integrity": "sha512-rnKRVkcHlERoDrZ+dNlcm2qkuptKLH8WxMmJz/PrKbydRNlh2jK803I6esA+a7ec5d/8qHFVuOZKKYUs8Rc7aA==",
-			"requires": {
-				"cheerio": "^1.0.0-rc.2"
-			}
-		},
-		"svgo": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.0.tgz",
-			"integrity": "sha512-MLfUA6O+qauLDbym+mMZgtXCGRfIxyQoeH6IKVcFslyODEe/ElJNwr0FohQ3xG4C6HK6bk3KYPPXwHVJk3V5NQ==",
-			"requires": {
-				"chalk": "^2.4.1",
-				"coa": "^2.0.2",
-				"css-select": "^2.0.0",
-				"css-select-base-adapter": "^0.1.1",
-				"css-tree": "1.0.0-alpha.33",
-				"csso": "^3.5.1",
-				"js-yaml": "^3.13.1",
-				"mkdirp": "~0.5.1",
-				"object.values": "^1.1.0",
-				"sax": "~1.2.4",
-				"stable": "^0.1.8",
-				"unquote": "~1.1.1",
-				"util.promisify": "~1.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"css-select": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/css-select/-/css-select-2.0.2.tgz",
-					"integrity": "sha512-dSpYaDVoWaELjvZ3mS6IKZM/y2PMPa/XYoEfYNZePL4U/XgyxZNroHEHReDx/d+VgXh9VbCTtFqLkFbmeqeaRQ==",
-					"requires": {
-						"boolbase": "^1.0.0",
-						"css-what": "^2.1.2",
-						"domutils": "^1.7.0",
-						"nth-check": "^1.0.2"
-					}
-				},
-				"domutils": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
-					"integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
-					"requires": {
-						"dom-serializer": "0",
-						"domelementtype": "1"
-					}
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
-			}
-		},
-		"symbol-observable": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
-			"integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
 		},
 		"tar": {
 			"version": "4.4.10",
@@ -12181,20 +8454,6 @@
 			"integrity": "sha512-F91ZqLgvi1E0PdvmxMgp+gcf6q8fMH7mhdwWfzXnl1k+GbpQDmi8l7DzLC5JTASKbwpY3TfxajAUzAXcv2NmsQ==",
 			"dev": true
 		},
-		"textextensions": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.5.0.tgz",
-			"integrity": "sha512-1IkVr355eHcomgK7fgj1Xsokturx6L5S2JRT5WcRdA6v5shk9sxWuO/w/VbpQexwkXJMQIa/j1dBi3oo7+HhcA=="
-		},
-		"tfunk": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/tfunk/-/tfunk-3.1.0.tgz",
-			"integrity": "sha1-OORBT8ZJd9h6/apy+sttKfgve1s=",
-			"requires": {
-				"chalk": "^1.1.1",
-				"object-path": "^0.9.0"
-			}
-		},
 		"thenify": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
@@ -12216,14 +8475,17 @@
 		"through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+			"dev": true
 		},
 		"through2": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
-			"integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+			"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+			"dev": true,
 			"requires": {
-				"readable-stream": "2 || 3"
+				"readable-stream": "~2.3.6",
+				"xtend": "~4.0.1"
 			}
 		},
 		"through2-filter": {
@@ -12234,24 +8496,13 @@
 			"requires": {
 				"through2": "~2.0.0",
 				"xtend": "~4.0.0"
-			},
-			"dependencies": {
-				"through2": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-					"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-					"dev": true,
-					"requires": {
-						"readable-stream": "~2.3.6",
-						"xtend": "~4.0.1"
-					}
-				}
 			}
 		},
 		"time-stamp": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
-			"integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM="
+			"integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
+			"dev": true
 		},
 		"tiny-emitter": {
 			"version": "2.1.0",
@@ -12264,6 +8515,7 @@
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
 			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+			"dev": true,
 			"requires": {
 				"os-tmpdir": "~1.0.2"
 			}
@@ -12278,11 +8530,6 @@
 				"is-negated-glob": "^1.0.0"
 			}
 		},
-		"to-array": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
-			"integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA="
-		},
 		"to-fast-properties": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
@@ -12292,6 +8539,7 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
 			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+			"dev": true,
 			"requires": {
 				"kind-of": "^3.0.2"
 			},
@@ -12300,6 +8548,7 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -12310,6 +8559,7 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
 			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+			"dev": true,
 			"requires": {
 				"define-property": "^2.0.2",
 				"extend-shallow": "^3.0.2",
@@ -12321,6 +8571,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
 			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+			"dev": true,
 			"requires": {
 				"is-number": "^3.0.0",
 				"repeat-string": "^1.6.1"
@@ -12333,29 +8584,7 @@
 			"dev": true,
 			"requires": {
 				"through2": "^2.0.3"
-			},
-			"dependencies": {
-				"through2": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-					"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-					"dev": true,
-					"requires": {
-						"readable-stream": "~2.3.6",
-						"xtend": "~4.0.1"
-					}
-				}
 			}
-		},
-		"toidentifier": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
-			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
-		},
-		"token-stream": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/token-stream/-/token-stream-0.0.1.tgz",
-			"integrity": "sha1-zu78cXp2xDFvEm0LnbqlXX598Bo="
 		},
 		"tough-cookie": {
 			"version": "2.4.3",
@@ -12395,15 +8624,6 @@
 			"integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
 			"dev": true
 		},
-		"trim-repeated": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
-			"integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
-			"optional": true,
-			"requires": {
-				"escape-string-regexp": "^1.0.2"
-			}
-		},
 		"trim-right": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
@@ -12412,7 +8632,8 @@
 		"tslib": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+			"dev": true
 		},
 		"tunnel-agent": {
 			"version": "0.6.0",
@@ -12447,11 +8668,6 @@
 			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
 			"dev": true
 		},
-		"ua-parser-js": {
-			"version": "0.7.17",
-			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
-			"integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
-		},
 		"uglify-js": {
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
@@ -12472,22 +8688,11 @@
 				}
 			}
 		},
-		"uglify-to-browserify": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-			"integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-			"optional": true
-		},
 		"uid-number": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
 			"integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
 			"dev": true
-		},
-		"ultron": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-			"integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
 		},
 		"umask": {
 			"version": "1.1.0",
@@ -12528,17 +8733,13 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
 			"integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+			"dev": true,
 			"requires": {
 				"arr-union": "^3.1.0",
 				"get-value": "^2.0.6",
 				"is-extendable": "^0.1.1",
 				"set-value": "^2.0.1"
 			}
-		},
-		"uniq": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
-			"integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
 		},
 		"unique-filename": {
 			"version": "1.1.1",
@@ -12582,20 +8783,11 @@
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
 			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
 		},
-		"unpipe": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
-		},
-		"unquote": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
-			"integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ="
-		},
 		"unset-value": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
 			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+			"dev": true,
 			"requires": {
 				"has-value": "^0.3.1",
 				"isobject": "^3.0.0"
@@ -12605,6 +8797,7 @@
 					"version": "0.3.1",
 					"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
 					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+					"dev": true,
 					"requires": {
 						"get-value": "^2.0.3",
 						"has-values": "^0.1.4",
@@ -12615,6 +8808,7 @@
 							"version": "2.1.0",
 							"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
 							"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+							"dev": true,
 							"requires": {
 								"isarray": "1.0.0"
 							}
@@ -12624,14 +8818,16 @@
 				"has-values": {
 					"version": "0.1.4",
 					"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+					"dev": true
 				}
 			}
 		},
 		"upath": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/upath/-/upath-1.1.2.tgz",
-			"integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q=="
+			"integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==",
+			"dev": true
 		},
 		"uri-js": {
 			"version": "4.2.2",
@@ -12645,7 +8841,8 @@
 		"urix": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+			"dev": true
 		},
 		"url-template": {
 			"version": "2.0.8",
@@ -12656,17 +8853,14 @@
 		"use": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
-			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
+			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+			"dev": true
 		},
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-		},
-		"util-extend": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
-			"integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8="
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"dev": true
 		},
 		"util-promisify": {
 			"version": "2.1.0",
@@ -12676,20 +8870,6 @@
 			"requires": {
 				"object.getownpropertydescriptors": "^2.0.3"
 			}
-		},
-		"util.promisify": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
-			"integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
-			"requires": {
-				"define-properties": "^1.1.2",
-				"object.getownpropertydescriptors": "^2.0.3"
-			}
-		},
-		"utils-merge": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
 		},
 		"uuid": {
 			"version": "3.3.3",
@@ -12745,6 +8925,7 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
 			"integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
+			"dev": true,
 			"requires": {
 				"clone": "^2.1.1",
 				"clone-buffer": "^1.0.0",
@@ -12777,18 +8958,6 @@
 				"value-or-function": "^3.0.0",
 				"vinyl": "^2.0.0",
 				"vinyl-sourcemap": "^1.1.0"
-			},
-			"dependencies": {
-				"through2": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-					"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-					"dev": true,
-					"requires": {
-						"readable-stream": "~2.3.6",
-						"xtend": "~4.0.1"
-					}
-				}
 			}
 		},
 		"vinyl-sourcemap": {
@@ -12805,19 +8974,6 @@
 				"remove-bom-buffer": "^3.0.0",
 				"vinyl": "^2.0.0"
 			}
-		},
-		"vinyl-sourcemaps-apply": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
-			"integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
-			"requires": {
-				"source-map": "^0.5.1"
-			}
-		},
-		"void-elements": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
-			"integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w="
 		},
 		"wcwidth": {
 			"version": "1.0.1",
@@ -12869,11 +9025,6 @@
 				"string-width": "^1.0.2 || 2"
 			}
 		},
-		"window-size": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-			"integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
-		},
 		"windows-release": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.2.0.tgz",
@@ -12881,15 +9032,6 @@
 			"dev": true,
 			"requires": {
 				"execa": "^1.0.0"
-			}
-		},
-		"with": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/with/-/with-5.1.1.tgz",
-			"integrity": "sha1-+k2qktrzLE6pTtRTyB8EaGtXXf4=",
-			"requires": {
-				"acorn": "^3.1.0",
-				"acorn-globals": "^3.0.0"
 			}
 		},
 		"wordwrap": {
@@ -12902,6 +9044,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+			"dev": true,
 			"requires": {
 				"string-width": "^1.0.1",
 				"strip-ansi": "^3.0.1"
@@ -12911,6 +9054,7 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -12919,6 +9063,7 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"dev": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -12971,14 +9116,6 @@
 					"requires": {
 						"pify": "^4.0.1",
 						"semver": "^5.6.0"
-					},
-					"dependencies": {
-						"semver": {
-							"version": "5.7.1",
-							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-							"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-							"dev": true
-						}
 					}
 				},
 				"pify": {
@@ -12986,15 +9123,6 @@
 					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
 					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
 					"dev": true
-				},
-				"sort-keys": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
-					"integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
-					"dev": true,
-					"requires": {
-						"is-plain-obj": "^1.0.0"
-					}
 				}
 			}
 		},
@@ -13014,15 +9142,6 @@
 					"integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
 					"dev": true
 				},
-				"sort-keys": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
-					"integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
-					"dev": true,
-					"requires": {
-						"is-plain-obj": "^1.0.0"
-					}
-				},
 				"write-json-file": {
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/write-json-file/-/write-json-file-2.3.0.tgz",
@@ -13038,27 +9157,6 @@
 					}
 				}
 			}
-		},
-		"ws": {
-			"version": "6.1.4",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-6.1.4.tgz",
-			"integrity": "sha512-eqZfL+NE/YQc1/ZynhojeV8q+H050oR8AZ2uIev7RU10svA9ZnJUddHcOUZTJLinZ9yEfdA2kSATS2qZK5fhJA==",
-			"requires": {
-				"async-limiter": "~1.0.0"
-			}
-		},
-		"xmldoc": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/xmldoc/-/xmldoc-1.1.2.tgz",
-			"integrity": "sha512-ruPC/fyPNck2BD1dpz0AZZyrEwMOrWTO5lDdIXS91rs3wtm4j+T8Rp2o+zoOYkkAxJTZRPOSnOGei1egoRmKMQ==",
-			"requires": {
-				"sax": "^1.2.1"
-			}
-		},
-		"xmlhttprequest-ssl": {
-			"version": "1.5.5",
-			"resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
-			"integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4="
 		},
 		"xtend": {
 			"version": "4.0.2",
@@ -13166,11 +9264,6 @@
 			"requires": {
 				"camelcase": "^4.1.0"
 			}
-		},
-		"yeast": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
-			"integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk="
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
   "optionalDependencies": {
     "@a4u/a4u-collection-essential-ui-icons-release": "^4.1.0",
     "@spectrum/balthazar": "^3.0.1",
-    "@spectrum/spectrum-dna": "^5.15.0",
-    "@spectrum/spectrum-icons": "^2.3.0"
+    "@spectrum/spectrum-dna": "^5.15.0"
   }
 }

--- a/tools/bundle-builder/index.js
+++ b/tools/bundle-builder/index.js
@@ -112,8 +112,10 @@ function copyIcons() {
   // lerna bug: require.resolve() won't find spectrum-icons within spectrum-css-compat, so we have to assume it's at the top level
   // note: maybe it needs a package.main?
   return gulp.src([
-    `${dirs.topLevel}/node_modules/@spectrum/spectrum-icons/dist/svg/**`,
-    `${dirs.topLevel}/node_modules/@spectrum/spectrum-icons/dist/lib/**`
+    `${dirs.topLevel}/node_modules/@adobe/spectrum-css-workflow-icons/dist/**`,
+    `!${dirs.topLevel}/node_modules/@adobe/spectrum-css-workflow-icons/dist/18/**`,
+    `!${dirs.topLevel}/node_modules/@adobe/spectrum-css-workflow-icons/dist/24/**`,
+    `!${dirs.topLevel}/node_modules/@adobe/spectrum-css-workflow-icons/dist/color/**`
   ])
     .pipe(gulp.dest('dist/icons/'));
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Switch from private @spectrum/spectrum-icons package to open sourced @adobe/spectrum-css-workflow-icons package.

## Related Issue
#60 

## Motivation and Context

1. Help contributor to get all the Adobe open sourced workflow icons on their local box.
2. Fully enable visual regression testing.

## How Has This Been Tested?
Safari, Firefox and Chrome on latest MacOS

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
