### PR TITLE
fix: SDS-2298 add correct placeholder opacity for textfields, closes #275

### DIFF
--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -70,6 +70,9 @@ governing permissions and limitations under the License.
     Removes the native spin buttons in Firefox; -moz-appearance: none results in spinners.
     This has to come after -webkit-appearance or it gets overridden (#214)
     Details: http://stackoverflow.com/questions/23372903/hide-spinner-in-input-number-firefox-29
+
+    Sets the opacity to 1 as normalize.css sets an opacity to placeholders
+    Details: https://github.com/csstools/normalize.css/blob/master/normalize.css#L297
   */
   -moz-appearance: textfield;
 
@@ -77,6 +80,7 @@ governing permissions and limitations under the License.
     font-weight: var(--spectrum-textfield-placeholder-text-font-weight);
     font-style: var(--spectrum-textfield-placeholder-text-font-style);
     transition: color var(--spectrum-global-animation-duration-100) ease-in-out;
+    opacity: 1;
   }
 
   /* added to work with Edge, note, it needs double ::
@@ -86,6 +90,7 @@ governing permissions and limitations under the License.
     font-weight: var(--spectrum-textfield-placeholder-text-font-weight);
     font-style: var(--spectrum-textfield-placeholder-text-font-style);
     transition: color var(--spectrum-global-animation-duration-100) ease-in-out;
+    opacity: 1;
   }
 
   &:lang(ja), &:lang(zh), &:lang(ko) {


### PR DESCRIPTION
 update @spectrum-css/textfield from 2.0.0-alpha.5 to 2.0.0-alpha.6

 Jira: https://jira.corp.adobe.com/browse/SDS-2298
 Github: https://github.com/adobe/spectrum-css/issues/275

<!--- Provide a general summary of your changes in the Title above -->
Fixes opacity on placeholder text in combination with a CSS resetter. 

## Description
<!--- Describe your changes in detail -->
Fixed a visual bug where textfields receive an opacity setting for placeholders when a CSS resetter is used. 

Example CSS Resetter is https://github.com/csstools/normalize.css/blob/master/normalize.css#L297

Also bumps up textfield's version in package.js 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

 Jira: https://jira.corp.adobe.com/browse/SDS-2298
 Github: https://github.com/adobe/spectrum-css/issues/275

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Allows Spectrum CSS textfields to remain a consistent look in combination with a CSS resetter.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Added an import of https://github.com/csstools/normalize.css/blob/master/normalize.css
in index.css

2. Checked the output of the compiled files via:
`gulp buildStandalone`
3. Navigated to `dist/standalone/spectrum-light.css`

4. Ensured the added opacity was present:

```CSS
  /*
    Removes the native spin buttons in Firefox; -moz-appearance: none results in spinners.
    This has to come after -webkit-appearance or it gets overridden (#214)
    Details: http://stackoverflow.com/questions/23372903/hide-spinner-in-input-number-firefox-29

    Sets the opacity to 1 as normalize.css sets an opacity to placeholders
    Details: https://github.com/csstools/normalize.css/blob/master/normalize.css#L297
  */
  -moz-appearance: textfield;

  &::placeholder {
    font-weight: var(--spectrum-textfield-placeholder-text-font-weight);
    font-style: var(--spectrum-textfield-placeholder-text-font-style);
    transition: color var(--spectrum-global-animation-duration-100) ease-in-out;
    opacity: 1;
  }

  /* added to work with Edge, note, it needs double ::
   * not single : which is what autoprefixer will add
   */
  &::-ms-input-placeholder {
    font-weight: var(--spectrum-textfield-placeholder-text-font-weight);
    font-style: var(--spectrum-textfield-placeholder-text-font-style);
    transition: color var(--spectrum-global-animation-duration-100) ease-in-out;
    opacity: 1;
  }
```
## Screenshots (if appropriate):

Before:

![before](https://user-images.githubusercontent.com/52184321/64826672-4743e580-d576-11e9-958d-aad24438bc86.png)
After:
![after](https://user-images.githubusercontent.com/52184321/64826671-4743e580-d576-11e9-88b9-9474559ae5b6.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
