### PR TITLE
Fix yarn optional-dependency issue.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
   - "node"
 install:
-  - yarn --ignore-optional
+  - yarn
 before_script:
   - npm install -g gulp-cli
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
 install:
   - yarn
 before_script:
-  - npm install -g gulp-cli
+  - yarn global add gulp-cli
 script:
   # This script should be the first that runs to reduce the risk of
   # executing a script from a compromised NPM package.

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,2 @@
+workspaces-experimental true
+ignore-optional true

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,2 +1,1 @@
-workspaces-experimental true
 ignore-optional true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Using `.yarnrc` file to enforce `workspaces` and `ignore-optional` always true for spectrum-css.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
