### PR TITLE
Temporary site design update for 2.14 release

### DIFF
--- a/components/card/index.css
+++ b/components/card/index.css
@@ -24,6 +24,8 @@ governing permissions and limitations under the License.
   border: var(--spectrum-card-border-size) solid transparent;
   border-radius: var(--spectrum-card-border-radius);
 
+  text-decoration: none;
+
   &:focus {
     outline: none;
   }
@@ -223,6 +225,40 @@ governing permissions and limitations under the License.
 
   .spectrum-Card-title {
     font-size: var(--spectrum-card-quiet-small-title-text-size);
+  }
+}
+
+.spectrum-Card--horizontal {
+  flex-direction: row;
+
+  .spectrum-Card-preview {
+    min-height: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    border-radius: var(--spectrum-card-quiet-border-radius) 0 0 var(--spectrum-card-quiet-border-radius);
+    border-right: var(--spectrum-card-border-size) solid transparent;
+
+    padding: var(--spectrum-global-dimension-size-175);
+  }
+
+  .spectrum-Card-header,
+  .spectrum-Card-content {
+    margin-top: 0;
+    height: auto;
+  }
+
+  .spectrum-Card-title {
+    padding-right: 0;
+  }
+
+  .spectrum-Card-body {
+    display: flex;
+    justify-content: center;
+    flex-direction: column;
+
+    padding: 0 var(--spectrum-global-dimension-size-200);
   }
 }
 

--- a/components/card/index.css
+++ b/components/card/index.css
@@ -232,6 +232,7 @@ governing permissions and limitations under the License.
   flex-direction: row;
 
   .spectrum-Card-preview {
+    flex-shrink: 0;
     min-height: 0;
     display: flex;
     align-items: center;
@@ -254,6 +255,7 @@ governing permissions and limitations under the License.
   }
 
   .spectrum-Card-body {
+    flex-shrink: 0;
     display: flex;
     justify-content: center;
     flex-direction: column;

--- a/components/card/metadata/card.yml
+++ b/components/card/metadata/card.yml
@@ -233,6 +233,27 @@ examples:
           </div>
         </div>
       </div>
+  - id: card-small
+    name: Small (horizontal)
+    description: A small, horizontal card. Small cards should not be used without `--quiet`.
+    markup: |
+      <div style="width: 208px;">
+        <div class="spectrum-Card spectrum-Card--small spectrum-Card--horizontal" tabindex="0" role="figure">
+          <div class="spectrum-Card-preview">
+            <svg class="spectrum-Icon spectrum-Icon--sizeL" focusable="false" aria-hidden="true" aria-label="FileTxt">
+              <use xlink:href="#spectrum-icon-18-FileTxt"></use>
+            </svg>
+          </div>
+          <div class="spectrum-Card-body">
+            <div class="spectrum-Card-header">
+              <div class="spectrum-Card-title">Card Title</div>
+            </div>
+            <div class="spectrum-Card-content">
+              <div class="spectrum-Card-subtitle">jpg</div>
+            </div>
+          </div>
+        </div>
+      </div>
   - id: card-quiet-small
     name: Small (quiet)
     description: 'A small, quiet card.'

--- a/components/card/skin.css
+++ b/components/card/skin.css
@@ -29,6 +29,14 @@ governing permissions and limitations under the License.
     box-shadow: 0 0 0 1px var(--spectrum-card-border-color-key-focus);
     background-color: var(--spectrum-alias-highlight-selected);
   }
+
+  .spectrum-Card-title {
+    color: var(--spectrum-alias-text-color);
+  }
+
+  .spectrum-Card-subtitle {
+    color: var(--spectrum-card-description-text-color);
+  }
 }
 
 .spectrum-Card-description {
@@ -105,5 +113,19 @@ governing permissions and limitations under the License.
 
   .spectrum-Card-subtitle {
     color: var(--spectrum-card-quiet-subtitle-text-color);
+  }
+}
+
+.spectrum-Card--horizontal {
+  &:hover {
+    .spectrum-Card-preview {
+      border-color: var(--spectrum-card-border-color-hover);
+    }
+  }
+
+  .spectrum-Card-preview {
+    background-color: var(--spectrum-card-quiet-preview-background-color);
+
+    border-color: var(--spectrum-card-border-color);
   }
 }

--- a/components/dropdown/metadata/dropdown.yml
+++ b/components/dropdown/metadata/dropdown.yml
@@ -6,7 +6,7 @@ examples:
     markup: |
       <h4>Closed</h4>
       <div class="spectrum-Dropdown" style="width: 240px;">
-        <button class="spectrum-FieldButton spectrum-Dropdown-trigger" aria-haspopup="true">
+        <button class="spectrum-FieldButton spectrum-Dropdown-trigger" aria-haspopup="listbox">
           <span class="spectrum-Dropdown-label is-placeholder">Select a Country with a very long label, too long in fact</span>
           <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
             <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />
@@ -16,7 +16,7 @@ examples:
 
       <h4>Open</h4>
       <div class="spectrum-Dropdown is-open" style="width: 240px;">
-        <button class="spectrum-FieldButton spectrum-Dropdown-trigger is-selected" aria-haspopup="true">
+        <button class="spectrum-FieldButton spectrum-Dropdown-trigger is-selected" aria-haspopup="listbox">
           <span class="spectrum-Dropdown-label">Ballard</span>
           <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
             <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />
@@ -32,13 +32,22 @@ examples:
             </li>
             <li class="spectrum-Menu-item" role="option" tabindex="0">
               <span class="spectrum-Menu-itemLabel">Fremont</span>
+              <svg class="spectrum-Icon spectrum-UIIcon-CheckmarkMedium spectrum-Menu-checkmark" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-CheckmarkMedium" />
+              </svg>
             </li>
             <li class="spectrum-Menu-item" role="option" tabindex="0">
               <span class="spectrum-Menu-itemLabel">Greenwood</span>
+              <svg class="spectrum-Icon spectrum-UIIcon-CheckmarkMedium spectrum-Menu-checkmark" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-CheckmarkMedium" />
+              </svg>
             </li>
             <li class="spectrum-Menu-divider" role="separator"></li>
             <li class="spectrum-Menu-item is-disabled" role="option" aria-disabled="true">
               <span class="spectrum-Menu-itemLabel">United States of America</span>
+              <svg class="spectrum-Icon spectrum-UIIcon-CheckmarkMedium spectrum-Menu-checkmark" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-CheckmarkMedium" />
+              </svg>
             </li>
           </ul>
         </div>
@@ -48,7 +57,7 @@ examples:
 
       <h4>With Thumbnails</h4>
       <div class="spectrum-Dropdown is-open" style="width: 240px;">
-        <button class="spectrum-FieldButton spectrum-Dropdown-trigger is-selected" aria-haspopup="true">
+        <button class="spectrum-FieldButton spectrum-Dropdown-trigger is-selected" aria-haspopup="listbox">
           <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Image">
             <use xlink:href="#spectrum-icon-18-Image" />
           </svg>
@@ -73,12 +82,18 @@ examples:
                 <use xlink:href="#spectrum-icon-18-Image" />
               </svg>
               <span class="spectrum-Menu-itemLabel">Fremont</span>
+              <svg class="spectrum-Icon spectrum-UIIcon-CheckmarkMedium spectrum-Menu-checkmark" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-CheckmarkMedium" />
+              </svg>
             </li>
             <li class="spectrum-Menu-item" role="option" tabindex="0">
               <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Image">
                 <use xlink:href="#spectrum-icon-18-Image" />
               </svg>
               <span class="spectrum-Menu-itemLabel">Greenwood</span>
+              <svg class="spectrum-Icon spectrum-UIIcon-CheckmarkMedium spectrum-Menu-checkmark" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-CheckmarkMedium" />
+              </svg>
             </li>
             <li class="spectrum-Menu-divider" role="separator"></li>
             <li class="spectrum-Menu-item is-disabled" role="option" aria-disabled="true">
@@ -86,6 +101,9 @@ examples:
                 <use xlink:href="#spectrum-icon-18-Image" />
               </svg>
               <span class="spectrum-Menu-itemLabel">United States of America</span>
+              <svg class="spectrum-Icon spectrum-UIIcon-CheckmarkMedium spectrum-Menu-checkmark" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-CheckmarkMedium" />
+              </svg>
             </li>
           </ul>
         </div>
@@ -95,7 +113,7 @@ examples:
 
       <h4>Disabled</h4>
       <div class="spectrum-Dropdown is-disabled" style="width: 240px;">
-        <button class="spectrum-FieldButton spectrum-Dropdown-trigger" disabled aria-haspopup="true">
+        <button class="spectrum-FieldButton spectrum-Dropdown-trigger" disabled aria-haspopup="listbox">
           <span class="spectrum-Dropdown-label is-placeholder">Select a Country</span>
           <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
             <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />
@@ -105,7 +123,7 @@ examples:
 
       <h4>Closed</h4>
       <div class="spectrum-Dropdown is-invalid" style="width: 240px;">
-        <button class="spectrum-FieldButton spectrum-Dropdown-trigger is-invalid" aria-haspopup="true">
+        <button class="spectrum-FieldButton spectrum-Dropdown-trigger is-invalid" aria-haspopup="listbox">
           <span class="spectrum-Dropdown-label is-placeholder">Select a Country</span>
           <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Folder">
             <use xlink:href="#spectrum-icon-18-Alert" />
@@ -118,7 +136,7 @@ examples:
 
       <h4>Open</h4>
       <div class="spectrum-Dropdown is-open is-invalid" style="width: 240px;">
-        <button class="spectrum-FieldButton spectrum-Dropdown-trigger is-invalid is-selected" aria-haspopup="true">
+        <button class="spectrum-FieldButton spectrum-Dropdown-trigger is-invalid is-selected" aria-haspopup="listbox">
           <span class="spectrum-Dropdown-label">Ballard</span>
           <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Folder">
             <use xlink:href="#spectrum-icon-18-Alert" />
@@ -137,13 +155,22 @@ examples:
             </li>
             <li class="spectrum-Menu-item" role="option" tabindex="0">
               <span class="spectrum-Menu-itemLabel">Fremont</span>
+              <svg class="spectrum-Icon spectrum-UIIcon-CheckmarkMedium spectrum-Menu-checkmark" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-CheckmarkMedium" />
+              </svg>
             </li>
             <li class="spectrum-Menu-item" role="option" tabindex="0">
               <span class="spectrum-Menu-itemLabel">Greenwood</span>
+              <svg class="spectrum-Icon spectrum-UIIcon-CheckmarkMedium spectrum-Menu-checkmark" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-CheckmarkMedium" />
+              </svg>
             </li>
             <li class="spectrum-Menu-divider" role="separator"></li>
             <li class="spectrum-Menu-item is-disabled" role="option" aria-disabled="true">
               <span class="spectrum-Menu-itemLabel">United States of America</span>
+              <svg class="spectrum-Icon spectrum-UIIcon-CheckmarkMedium spectrum-Menu-checkmark" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-CheckmarkMedium" />
+              </svg>
             </li>
           </ul>
         </div>
@@ -153,7 +180,7 @@ examples:
 
       <h4>Disabled</h4>
       <div class="spectrum-Dropdown is-invalid is-disabled" style="width: 240px;">
-        <button class="spectrum-FieldButton spectrum-Dropdown-trigger is-invalid" disabled aria-haspopup="true">
+        <button class="spectrum-FieldButton spectrum-Dropdown-trigger is-invalid" disabled aria-haspopup="listbox">
           <span class="spectrum-Dropdown-label is-placeholder">Select a Country</span>
           <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Folder">
             <use xlink:href="#spectrum-icon-18-Alert" />
@@ -169,7 +196,7 @@ examples:
     markup: |
       <h4>Closed</h4>
       <div class="spectrum-Dropdown spectrum-Dropdown--quiet">
-        <button class="spectrum-FieldButton spectrum-FieldButton--quiet spectrum-Dropdown-trigger" aria-haspopup="true">
+        <button class="spectrum-FieldButton spectrum-FieldButton--quiet spectrum-Dropdown-trigger" aria-haspopup="listbox">
           <span class="spectrum-Dropdown-label is-placeholder">Select a Country</span>
           <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
             <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />
@@ -179,7 +206,7 @@ examples:
 
       <h4>Open</h4>
       <div class="spectrum-Dropdown spectrum-Dropdown--quiet is-open">
-        <button class="spectrum-FieldButton spectrum-FieldButton--quiet spectrum-Dropdown-trigger is-selected" aria-haspopup="true">
+        <button class="spectrum-FieldButton spectrum-FieldButton--quiet spectrum-Dropdown-trigger is-selected" aria-haspopup="listbox">
           <span class="spectrum-Dropdown-label">Ballard</span>
           <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
             <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />
@@ -196,13 +223,22 @@ examples:
           </li>
           <li class="spectrum-Menu-item" role="option" tabindex="0">
             <span class="spectrum-Menu-itemLabel">Fremont</span>
+            <svg class="spectrum-Icon spectrum-UIIcon-CheckmarkMedium spectrum-Menu-checkmark" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-CheckmarkMedium" />
+            </svg>
           </li>
           <li class="spectrum-Menu-item" role="option" tabindex="0">
             <span class="spectrum-Menu-itemLabel">Greenwood</span>
+            <svg class="spectrum-Icon spectrum-UIIcon-CheckmarkMedium spectrum-Menu-checkmark" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-CheckmarkMedium" />
+            </svg>
           </li>
           <li class="spectrum-Menu-divider" role="separator"></li>
           <li class="spectrum-Menu-item is-disabled" role="option" aria-disabled="true">
             <span class="spectrum-Menu-itemLabel">United States of America</span>
+            <svg class="spectrum-Icon spectrum-UIIcon-CheckmarkMedium spectrum-Menu-checkmark" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-CheckmarkMedium" />
+            </svg>
           </li>
         </ul>
       </div>
@@ -211,7 +247,7 @@ examples:
 
       <h4>With Thumbnails</h4>
       <div class="spectrum-Dropdown spectrum-Dropdown--quiet is-open">
-        <button class="spectrum-FieldButton spectrum-FieldButton--quiet spectrum-Dropdown-trigger is-selected" aria-haspopup="true">
+        <button class="spectrum-FieldButton spectrum-FieldButton--quiet spectrum-Dropdown-trigger is-selected" aria-haspopup="listbox">
           <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Image">
             <use xlink:href="#spectrum-icon-18-Image" />
           </svg>
@@ -237,12 +273,18 @@ examples:
               <use xlink:href="#spectrum-icon-18-Image" />
             </svg>
             <span class="spectrum-Menu-itemLabel">Fremont</span>
+            <svg class="spectrum-Icon spectrum-UIIcon-CheckmarkMedium spectrum-Menu-checkmark" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-CheckmarkMedium" />
+            </svg>
           </li>
           <li class="spectrum-Menu-item" role="option" tabindex="0">
             <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Image">
               <use xlink:href="#spectrum-icon-18-Image" />
             </svg>
             <span class="spectrum-Menu-itemLabel">Greenwood</span>
+            <svg class="spectrum-Icon spectrum-UIIcon-CheckmarkMedium spectrum-Menu-checkmark" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-CheckmarkMedium" />
+            </svg>
           </li>
           <li class="spectrum-Menu-divider" role="separator"></li>
           <li class="spectrum-Menu-item is-disabled" role="option" aria-disabled="true">
@@ -250,6 +292,9 @@ examples:
               <use xlink:href="#spectrum-icon-18-Image" />
             </svg>
             <span class="spectrum-Menu-itemLabel">United States of America</span>
+            <svg class="spectrum-Icon spectrum-UIIcon-CheckmarkMedium spectrum-Menu-checkmark" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-CheckmarkMedium" />
+            </svg>
           </li>
         </ul>
       </div>
@@ -258,7 +303,7 @@ examples:
 
       <h4>Disabled</h4>
       <div class="spectrum-Dropdown spectrum-Dropdown--quiet is-disabled">
-        <button class="spectrum-FieldButton spectrum-FieldButton--quiet spectrum-Dropdown-trigger" disabled aria-haspopup="true">
+        <button class="spectrum-FieldButton spectrum-FieldButton--quiet spectrum-Dropdown-trigger" disabled aria-haspopup="listbox">
           <span class="spectrum-Dropdown-label is-placeholder">Select a Country</span>
           <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
             <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />
@@ -268,7 +313,7 @@ examples:
 
       <h4>Closed</h4>
       <div class="spectrum-Dropdown spectrum-Dropdown--quiet is-invalid">
-        <button class="spectrum-FieldButton spectrum-FieldButton--quiet is-invalid spectrum-Dropdown-trigger" aria-haspopup="true">
+        <button class="spectrum-FieldButton spectrum-FieldButton--quiet is-invalid spectrum-Dropdown-trigger" aria-haspopup="listbox">
           <span class="spectrum-Dropdown-label is-placeholder">Select a Country</span>
           <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Folder">
             <use xlink:href="#spectrum-icon-18-Alert" />
@@ -281,7 +326,7 @@ examples:
 
       <h4>Open</h4>
       <div class="spectrum-Dropdown spectrum-Dropdown--quiet is-open is-invalid">
-        <button class="spectrum-FieldButton spectrum-FieldButton--quiet is-invalid spectrum-Dropdown-trigger" aria-haspopup="true">
+        <button class="spectrum-FieldButton spectrum-FieldButton--quiet is-invalid spectrum-Dropdown-trigger" aria-haspopup="listbox">
           <span class="spectrum-Dropdown-label">Ballard</span>
           <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Folder">
             <use xlink:href="#spectrum-icon-18-Alert" />
@@ -301,13 +346,22 @@ examples:
           </li>
           <li class="spectrum-Menu-item" role="option" tabindex="0">
             <span class="spectrum-Menu-itemLabel">Fremont</span>
+            <svg class="spectrum-Icon spectrum-UIIcon-CheckmarkMedium spectrum-Menu-checkmark" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-CheckmarkMedium" />
+            </svg>
           </li>
           <li class="spectrum-Menu-item" role="option" tabindex="0">
             <span class="spectrum-Menu-itemLabel">Greenwood</span>
+            <svg class="spectrum-Icon spectrum-UIIcon-CheckmarkMedium spectrum-Menu-checkmark" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-CheckmarkMedium" />
+            </svg>
           </li>
           <li class="spectrum-Menu-divider" role="separator"></li>
           <li class="spectrum-Menu-item is-disabled" role="option" aria-disabled="true">
             <span class="spectrum-Menu-itemLabel">United States of America</span>
+            <svg class="spectrum-Icon spectrum-UIIcon-CheckmarkMedium spectrum-Menu-checkmark" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-CheckmarkMedium" />
+            </svg>
           </li>
         </ul>
       </div>
@@ -316,7 +370,7 @@ examples:
 
       <h4>Disabled</h4>
       <div class="spectrum-Dropdown spectrum-Dropdown--quiet is-invalid is-disabled">
-        <button class="spectrum-FieldButton spectrum-FieldButton--quiet is-invalid spectrum-Dropdown-trigger" disabled aria-haspopup="true">
+        <button class="spectrum-FieldButton spectrum-FieldButton--quiet is-invalid spectrum-Dropdown-trigger" disabled aria-haspopup="listbox">
           <span class="spectrum-Dropdown-label is-placeholder">Select a Country</span>
           <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Folder">
             <use xlink:href="#spectrum-icon-18-Alert" />

--- a/components/site/index.css
+++ b/components/site/index.css
@@ -27,18 +27,23 @@ governing permissions and limitations under the License.
   --spectrum-csscomponent-margin: var(--spectrum-global-dimension-size-500);
   --spectrum-csscomponent-padding: var(--spectrum-global-dimension-size-700);
   --spectrum-csscomponent-max-width: 1080px;
-  --spectrum-csscomponent-heading-margin-bottom: var(--spectrum-global-dimension-size-200);
+  --spectrum-csscomponent-sectionheading-margin-top: var(--spectrum-global-dimension-size-700);
+  --spectrum-csscomponent-sectionheading-margin-bottom: var(--spectrum-global-dimension-size-400);
+  --spectrum-csscomponent-heading-margin-bottom: var(--spectrum-global-dimension-size-500);
 
   --spectrum-csscomponent-description-margin-bottom: var(--spectrum-global-dimension-size-800);
 
   --spectrum-csscomponent-statuscontainer-margin-x: var(--spectrum-global-dimension-size-200);
   --spectrum-csscomponent-status-margin-x: var(--spectrum-global-dimension-size-100);
+  --spectrum-csscomponent-detailstable-padding-x: var(--spectrum-global-dimension-size-300);
+  --spectrum-csscomponent-detailstable-margin-top: var(--spectrum-global-dimension-size-500);
+  --spectrum-csscomponent-detailstable-margin-bottom: var(--spectrum-global-dimension-size-700);
 
   /* .spectrum-CSSExample */
   --spectrum-cssexample-border-radius: var(--spectrum-global-dimension-size-75);
   --spectrum-cssexample-margin-bottom: var(--spectrum-global-dimension-size-500);
 
-  --spectrum-cssexample-header-margin-bottom: var(--spectrum-global-dimension-size-500);
+  --spectrum-cssexample-heading-margin-bottom: var(--spectrum-global-dimension-size-100);
 
   --spectrum-cssexample-markup-height: var(--spectrum-global-dimension-size-900);
   --spectrum-cssexample-markup-padding-x: var(--spectrum-global-dimension-size-225);
@@ -255,6 +260,17 @@ governing permissions and limitations under the License.
   align-items: start;
 }
 
+.spectrum-CSSComponent-link {
+  display: flex;
+  align-items: center;
+  color: inherit;
+  text-decoration: none;
+}
+
+.spectrum-CSSComponent-link:hover {
+  text-decoration: underline;
+}
+
 .spectrum-CSSComponent-statusContainer {
   align-self: center;
   flex-grow: 1;
@@ -262,8 +278,35 @@ governing permissions and limitations under the License.
   margin: 0 var(--spectrum-csscomponent-statuscontainer-margin-x);
 }
 
+.spectrum-CSSComponent-detailsTable th {
+  text-align: left;
+  height: var(--spectrum-global-dimension-size-350);
+  font-weight: var(--spectrum-global-font-weight-regular);
+  padding-right: var(--spectrum-csscomponent-detailstable-padding-x);
+}
+
+.spectrum-CSSComponent-detailsTable {
+  margin-top: var(--spectrum-csscomponent-detailstable-margin-top);
+  margin-bottom: var(--spectrum-csscomponent-detailstable-margin-bottom);
+}
+
+.spectrum-CSSComponent-sectionHeading {
+  margin-top: var(--spectrum-csscomponent-sectionheading-margin-top);
+  margin-bottom: var(--spectrum-csscomponent-sectionheading-margin-bottom);
+}
+
+.spectrum-CSSExample-status,
 .spectrum-CSSComponent-status {
-  margin: 0 var(--spectrum-csscomponent-status-margin-x);
+  padding: 0 !important;
+  min-height: 0 !important;
+}
+
+.spectrum-CSSComponent-status::before {
+  margin-left: 0 !important;
+}
+
+.spectrum-CSSExample-status {
+  margin-left: var(--spectrum-global-dimension-size-200);
 }
 
 .spectrum-CSSComponent-version {
@@ -273,6 +316,34 @@ governing permissions and limitations under the License.
 
 .spectrum-CSSComponent-description {
   margin-bottom: var(--spectrum-csscomponent-description-margin-bottom);
+}
+
+/* cards */
+.spectrum-CSSComponent-resources {
+  display: flex;
+  flex-direction: row;
+  margin-bottom: var(--spectrum-global-dimension-size-700);
+}
+
+.spectrum-CSSComponent-resources .spectrum-Card + .spectrum-Card {
+  margin-left: var(--spectrum-global-dimension-size-300);
+}
+
+.spectrum-CSSComponent-resource--adobe {
+  color: rgb(255, 2, 1) !important;
+}
+
+.spectrum-CSSComponent-resource--github {
+  background-color: rgb(234, 234, 234) !important;
+  color: black;
+}
+
+.spectrum-CSSComponent-resource--npm {
+  background-color: rgb(253, 233, 234) !important;
+}
+
+.spectrum-CSSComponent-cardImage {
+  text-decoration: none;
 }
 
 /* CSS Example */
@@ -289,17 +360,11 @@ governing permissions and limitations under the License.
   border-radius: var(--spectrum-cssexample-border-radius);
 }
 
-.spectrum-CSSExample-header {
-  margin-bottom: var(--spectrum-cssexample-header-margin-bottom);
-}
-
-.spectrum-CSSExample-link {
-  color: inherit;
-  text-decoration: none;
-}
-
-.spectrum-CSSExample-link:hover {
-  text-decoration: underline;
+.spectrum-CSSExample-heading {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  margin-bottom: var(--spectrum-cssexample-heading-margin-bottom) !important;
 }
 
 .spectrum-CSSExample-example,
@@ -333,6 +398,8 @@ governing permissions and limitations under the License.
 
 .spectrum-CSSExample-markup.is-open {
   max-height: 100%;
+
+  padding-bottom: var(--spectrum-global-dimension-size-300);
 }
 
 .spectrum-CSSExample-markup.is-open .spectrum-CSSExample-markupToggle::before {
@@ -379,9 +446,8 @@ governing permissions and limitations under the License.
   box-sizing: border-box;
   padding: 0.5rem 0;
 
-
   font-size: var(--spectrum-global-dimension-font-size-100);
-  text-align: center;
+  text-align: left
 }
 
 .spectrum-CSSExample-markupToggle::before {
@@ -416,7 +482,7 @@ governing permissions and limitations under the License.
     padding: var(--spectrum-global-dimension-size-200) var(--spectrum-global-dimension-size-200);
   }
 
-  .spectrum-CSSExample-header {
+  .spectrum-CSSComponent-header {
     margin-bottom: var(--spectrum-global-dimension-size-150);
   }
 

--- a/components/site/index.css
+++ b/components/site/index.css
@@ -416,9 +416,12 @@ governing permissions and limitations under the License.
 .spectrum-CSSExample-example {
   flex: 1 0 auto;
 
+  /*
+  // this breaks layout for some examples, we'll need to fix later
   display: flex;
   align-items: center;
   justify-content: center;
+  */
 
   min-height: var(--spectrum-cssexample-min-height);
 

--- a/components/site/index.css
+++ b/components/site/index.css
@@ -169,6 +169,7 @@ governing permissions and limitations under the License.
 
 .spectrum-Site-heroImage {
   margin-top: 40px;
+  margin-bottom: 80px;
   max-width: 100%;
 }
 

--- a/components/site/index.css
+++ b/components/site/index.css
@@ -304,6 +304,7 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-CSSComponent-detailsTable {
+  border-spacing: 0;
   margin-top: var(--spectrum-csscomponent-detailstable-margin-top);
   margin-bottom: var(--spectrum-csscomponent-detailstable-margin-bottom);
 }

--- a/components/site/index.css
+++ b/components/site/index.css
@@ -370,6 +370,9 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-CSSComponent-switcher {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
 }
 
 .spectrum-CSS-switcherContainer {

--- a/components/site/index.css
+++ b/components/site/index.css
@@ -28,27 +28,30 @@ governing permissions and limitations under the License.
   --spectrum-csscomponent-padding: var(--spectrum-global-dimension-size-700);
   --spectrum-csscomponent-max-width: 1080px;
   --spectrum-csscomponent-sectionheading-margin-top: var(--spectrum-global-dimension-size-700);
-  --spectrum-csscomponent-sectionheading-margin-bottom: var(--spectrum-global-dimension-size-400);
+  --spectrum-csscomponent-sectionheading-margin-bottom: var(--spectrum-global-dimension-size-500);
   --spectrum-csscomponent-heading-margin-bottom: var(--spectrum-global-dimension-size-500);
 
-  --spectrum-csscomponent-description-margin-bottom: var(--spectrum-global-dimension-size-800);
+  --spectrum-csscomponent-description-margin-bottom: var(--spectrum-global-dimension-size-900);
+  --spectrum-csscomponent-description-margin-top: var(--spectrum-global-dimension-size-300);
 
   --spectrum-csscomponent-statuscontainer-margin-x: var(--spectrum-global-dimension-size-200);
   --spectrum-csscomponent-status-margin-x: var(--spectrum-global-dimension-size-100);
   --spectrum-csscomponent-detailstable-padding-x: var(--spectrum-global-dimension-size-300);
   --spectrum-csscomponent-detailstable-margin-top: var(--spectrum-global-dimension-size-500);
-  --spectrum-csscomponent-detailstable-margin-bottom: var(--spectrum-global-dimension-size-700);
+  --spectrum-csscomponent-detailstable-margin-bottom: var(--spectrum-global-dimension-size-450);
 
   /* .spectrum-CSSExample */
-  --spectrum-cssexample-border-radius: var(--spectrum-global-dimension-size-75);
-  --spectrum-cssexample-margin-bottom: var(--spectrum-global-dimension-size-500);
+  --spectrum-cssexample-border-radius: var(--spectrum-global-dimension-size-50);
+  --spectrum-cssexample-margin-bottom: var(--spectrum-global-dimension-size-800);
+  --spectrum-cssexample-min-height: --spectrum-global-dimension-size-2400;
 
   --spectrum-cssexample-heading-margin-bottom: var(--spectrum-global-dimension-size-100);
 
-  --spectrum-cssexample-markup-height: var(--spectrum-global-dimension-size-900);
+  --spectrum-cssexample-markup-height: var(--spectrum-global-dimension-size-2400);
   --spectrum-cssexample-markup-padding-x: var(--spectrum-global-dimension-size-225);
   --spectrum-cssexample-markup-padding-y: var(--spectrum-global-dimension-size-125);
-  --spectrum-cssexample-markup-toggle-height: var(--spectrum-global-dimension-size-400);
+  --spectrum-cssexample-markup-toggle-padding-x: var(--spectrum-global-dimension-size-300);
+  --spectrum-cssexample-markup-toggle-padding-y: var(--spectrum-global-dimension-size-300);
 
   --spectrum-cssexample-padding-x: var(--spectrum-global-dimension-size-500);
   --spectrum-cssexample-padding-y: var(--spectrum-global-dimension-size-400);
@@ -243,8 +246,8 @@ governing permissions and limitations under the License.
   }
 
   .spectrum-Site-page {
-    padding-left: var(--spectrum-global-dimension-size-200);
-    padding-right: var(--spectrum-global-dimension-size-200);
+    padding-left: var(--spectrum-global-dimension-size-300);
+    padding-right: var(--spectrum-global-dimension-size-300);
   }
 
   .spectrum-Site-hero {
@@ -329,6 +332,7 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-CSSComponent-description {
+  margin-top: var(--spectrum-csscomponent-description-margin-top);
   margin-bottom: var(--spectrum-csscomponent-description-margin-bottom);
 }
 
@@ -375,6 +379,7 @@ governing permissions and limitations under the License.
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 .spectrum-CSS-switcherContainer {
@@ -411,7 +416,11 @@ governing permissions and limitations under the License.
 .spectrum-CSSExample-example {
   flex: 1 0 auto;
 
-  min-height: var(--spectrum-global-dimension-size-800);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  min-height: var(--spectrum-cssexample-min-height);
 
   padding: var(--spectrum-cssexample-padding-y) var(--spectrum-cssexample-padding-x);
 
@@ -435,7 +444,7 @@ governing permissions and limitations under the License.
 .spectrum-CSSExample-markup.is-open {
   max-height: 100%;
 
-  padding-bottom: var(--spectrum-global-dimension-size-300);
+  padding-bottom: var(--spectrum-global-dimension-size-700);
 }
 
 .spectrum-CSSExample-markup.is-open .spectrum-CSSExample-markupToggle::before {
@@ -480,28 +489,15 @@ governing permissions and limitations under the License.
   right: 0;
 
   box-sizing: border-box;
-  padding: 0.5rem 0;
+  padding: var(--spectrum-cssexample-markup-toggle-padding-y) var(--spectrum-cssexample-markup-toggle-padding-x);
 
-  font-size: var(--spectrum-global-dimension-font-size-100);
+  font-size: var(--spectrum-global-dimension-font-size-150);
   text-align: left
-}
-
-.spectrum-CSSExample-markupToggle::before {
-  content: '';
-
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 100%;
-
-  width: 100%;
-  height: var(--spectrum-cssexample-markup-toggle-height);
-
 }
 
 @media screen and (max-width: 960px) {
   .spectrum-CSSComponent {
-    padding: 0 var(--spectrum-global-dimension-size-150);
+    padding: 0 var(--spectrum-global-dimension-size-250);
     margin: var(--spectrum-global-dimension-size-100) auto;
   }
 

--- a/components/site/index.css
+++ b/components/site/index.css
@@ -277,8 +277,10 @@ governing permissions and limitations under the License.
   align-items: center;
   color: inherit;
   text-decoration: none;
+  outline: none;
 }
 
+.spectrum-CSSComponent-link:focus-ring,
 .spectrum-CSSComponent-link:hover {
   text-decoration: underline;
 }

--- a/components/site/index.css
+++ b/components/site/index.css
@@ -243,8 +243,8 @@ governing permissions and limitations under the License.
   }
 
   .spectrum-Site-page {
-    padding-left: 0;
-    padding-right: 0;
+    padding-left: var(--spectrum-global-dimension-size-200);
+    padding-right: var(--spectrum-global-dimension-size-200);
   }
 
   .spectrum-Site-hero {

--- a/components/site/index.css
+++ b/components/site/index.css
@@ -343,15 +343,24 @@ governing permissions and limitations under the License.
 
 .spectrum-CSSComponent-resource--adobe {
   color: rgb(255, 2, 1) !important;
+  background-color: rgba(255, 2, 1, 0.1) !important;
 }
 
 .spectrum-CSSComponent-resource--github {
-  background-color: rgb(234, 234, 234) !important;
+  background-color: rgba(0, 0, 0, 0.1) !important;
   color: black;
 }
 
+.spectrum--dark,
+.spectrum--darkest {
+  .spectrum-CSSComponent-resource--github {
+    background-color: rgba(245, 245, 245, 0.1) !important;
+    color: rgb(245, 245, 245);
+  }
+}
+
 .spectrum-CSSComponent-resource--npm {
-  background-color: rgb(253, 233, 234) !important;
+  background-color: rgba(203, 56, 55, 0.1) !important;
 }
 
 .spectrum-CSSComponent-cardImage {

--- a/components/site/index.css
+++ b/components/site/index.css
@@ -168,6 +168,16 @@ governing permissions and limitations under the License.
   max-width: 100%;
 }
 
+.spectrum-Site-footer {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}
+.spectrum-Site-footerContent {
+}
+.spectrum-Site-footerCopyright {
+}
+
 /* Kill the overlay without animating when the page is resized */
 .spectrum-Site-overlay {
   display: none;

--- a/components/site/index.css
+++ b/components/site/index.css
@@ -127,8 +127,9 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Site-logo {
-  margin-right: var(--spectrum-global-dimension-size-250);
-  width: var(--spectrum-global-dimension-size-500);
+  margin-right: var(--spectrum-global-dimension-size-175);
+  width: var(--spectrum-global-dimension-size-400);
+  color: rgb(255, 2, 1) !important;
 }
 
 .spectrum-Site-nav {

--- a/components/site/index.css
+++ b/components/site/index.css
@@ -333,12 +333,14 @@ governing permissions and limitations under the License.
 /* cards */
 .spectrum-CSSComponent-resources {
   display: flex;
+  flex-wrap: wrap;
   flex-direction: row;
   margin-bottom: var(--spectrum-global-dimension-size-700);
 }
 
-.spectrum-CSSComponent-resources .spectrum-Card + .spectrum-Card {
-  margin-left: var(--spectrum-global-dimension-size-300);
+.spectrum-CSSComponent-resources .spectrum-Card {
+  margin-right: var(--spectrum-global-dimension-size-300);
+  margin-bottom: var(--spectrum-global-dimension-size-300);
 }
 
 .spectrum-CSSComponent-resource--adobe {
@@ -370,10 +372,10 @@ governing permissions and limitations under the License.
 .spectrum-CSSComponent-switcher {
 }
 
-.spectrum-CSSComponent-switcher .spectrum-FieldLabel {
+.spectrum-CSS-switcherContainer {
   margin-left: var(--spectrum-global-dimension-size-400);
+  white-space: nowrap;
 }
-
 
 /* CSS Example */
 .spectrum-CSSExample {

--- a/components/site/index.css
+++ b/components/site/index.css
@@ -268,7 +268,8 @@ governing permissions and limitations under the License.
 
   display: flex;
   flex-direction: row;
-  align-items: start;
+  align-items: center;
+  justify-content: space-between;
 }
 
 .spectrum-CSSComponent-link {
@@ -356,6 +357,14 @@ governing permissions and limitations under the License.
 .spectrum-CSSComponent-cardImage {
   text-decoration: none;
 }
+
+.spectrum-CSSComponent-switcher {
+}
+
+.spectrum-CSSComponent-switcher .spectrum-FieldLabel {
+  margin-left: var(--spectrum-global-dimension-size-400);
+}
+
 
 /* CSS Example */
 .spectrum-CSSExample {

--- a/components/site/skin.css
+++ b/components/site/skin.css
@@ -25,7 +25,7 @@ governing permissions and limitations under the License.
 
   /* .spectrum-CSSExample */
   --spectrum-cssexample-markup-background-color: var(--spectrum-global-color-gray-75);
-  --spectrum-cssexample-border-color: var(--spectrum-global-color-gray-200);
+  --spectrum-cssexample-border-color: var(--spectrum-global-color-gray-100);
 }
 
 /* Site */
@@ -78,7 +78,7 @@ governing permissions and limitations under the License.
 .spectrum-CSSExample-markupToggle {
   z-index: 1;
 
-  background: white;
+  background: var(--spectrum-cssexample-markup-background-color);
 }
 
 .spectrum-CSSExample-markup.is-open .spectrum-CSSExample-markupToggle {
@@ -88,18 +88,4 @@ governing permissions and limitations under the License.
 .spectrum-CSSExample-example--overlay {
   background: rgba(0,0,0,0.4);
   color: rgba(0,0,0,0.4);
-}
-
-.spectrum-CSSExample-markupToggle::before {
-  background: linear-gradient(to bottom, rgba(255,255,255,0) 10%,rgba(255,255,255,1) 100%);
-}
-
-.spectrum--dark .spectrum-CSSExample-markupToggle,
-.spectrum--darkest .spectrum-CSSExample-markupToggle {
-  background: rgb(40, 40, 40);
-}
-
-.spectrum--dark .spectrum-CSSExample-markupToggle::before,
-.spectrum--darkest .spectrum-CSSExample-markupToggle::before {
-  background: linear-gradient(to bottom, rgba(40,40,40,0) 10%, rgba(40,40,40,1) 100%);
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -71,6 +71,11 @@ exports.dev = gulp.series(
   exports.dev
 );
 
+exports.devHeavy = gulp.series(
+  exports.copySiteResources,
+  exports.devHeavy
+);
+
 exports.releaseBundles = releaseBundles;
 
 exports.prepare = site.copySiteResources;

--- a/package.json
+++ b/package.json
@@ -58,6 +58,9 @@
     "@spectrum/spectrum-dna": "^5.15.0",
     "@spectrum/spectrum-icons": "^2.3.0"
   },
+  "resolutions": {
+    "handlebars": "^4.3.0"
+  },
   "workspaces": [
     "components/*",
     "tools/*"

--- a/site/getting-started.pug
+++ b/site/getting-started.pug
@@ -18,8 +18,7 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
         .spectrum-Site-mainContainer
           .spectrum-Site-page
             h1.spectrum-Heading1 Getting Started
-              p.spectrum-Body1 Content goes here!
-              p.spectrum-Body2 And moar content!
+              p.spectrum-Body2 Please see the #[a(href="https://github.com/adobe/spectrum-css/blob/master/.github/CONTRIBUTING.md" target="_blank") contributing document] and #[a(href="https://github.com/adobe/spectrum-css" target="_blank") project documentation] for information on how to get started with Spectrum CSS.
 
             include includes/footer.pug
 

--- a/site/getting-started.pug
+++ b/site/getting-started.pug
@@ -21,4 +21,6 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
               p.spectrum-Body1 Content goes here!
               p.spectrum-Body2 And moar content!
 
-    include includes/footer.pug
+            include includes/footer.pug
+
+    include includes/pageBottom.pug

--- a/site/includes/example.pug
+++ b/site/includes/example.pug
@@ -1,0 +1,20 @@
+article.spectrum-CSSExample
+  h5.spectrum-CSSExample-heading.spectrum-Heading4(id=example.slug)
+    a(href=`#${example.slug}`).spectrum-CSSComponent-link
+      =example.name
+    div(class=`spectrum-StatusLight spectrum-CSSExample-status spectrum-StatusLight--${util.getStatusLightVariant(example.status)}`)= example.status
+
+  if example.description
+    section.spectrum-CSSExample-description.spectrum-Body3!= util.markdown.toHTML(example.description)
+
+  if example.details
+    .section.spectrum-CSSExample-description.spectrum-Body3!= util.markdown.toHTML(example.details)
+
+  if example.markup
+    section.spectrum-CSSExample-container
+      .spectrum-CSSExample-example(class=example.demoClassName ? `${example.demoClassName}` : '')!= example.markup
+      .spectrum-CSSExample-markup
+        if example.markup.split('\n').length > 2
+          a.js-markup-toggle.spectrum-CSSExample-markupToggle.spectrum-Link(href="#") Show Markup
+        pre
+          code.language-markup!= util.Prism.highlight(example.markup, util.Prism.languages.markup, 'markup')

--- a/site/includes/example.pug
+++ b/site/includes/example.pug
@@ -15,6 +15,6 @@ article.spectrum-CSSExample
       .spectrum-CSSExample-example(class=example.demoClassName ? `${example.demoClassName}` : '')!= example.markup
       .spectrum-CSSExample-markup
         if example.markup.split('\n').length > 2
-          a.js-markup-toggle.spectrum-CSSExample-markupToggle.spectrum-Link(href="#") Show Markup
+          a.js-markup-toggle.spectrum-CSSExample-markupToggle.spectrum-Link(href="#") Show markup
         pre
           code.language-markup!= util.Prism.highlight(example.markup, util.Prism.languages.markup, 'markup')

--- a/site/includes/footer.pug
+++ b/site/includes/footer.pug
@@ -1,6 +1,6 @@
 hr.spectrum-Rule.spectrum-Rule--medium
 .spectrum-Site-footer
-  //- .spectrum-Site-footerContent.
+  .spectrum-Site-footerContent.
   //-   For any questions or feedback, please contact us.
   .spectrum-Site-footerCopyright.
     © Adobe. All rights reserved.

--- a/site/includes/footer.pug
+++ b/site/includes/footer.pug
@@ -1,6 +1,6 @@
 hr.spectrum-Rule.spectrum-Rule--medium
 .spectrum-Site-footer
-  .spectrum-Site-footerContent.
-    For any questions or feedback, please contact us.
+  //- .spectrum-Site-footerContent.
+  //-   For any questions or feedback, please contact us.
   .spectrum-Site-footerCopyright.
     © Adobe. All rights reserved.

--- a/site/includes/footer.pug
+++ b/site/includes/footer.pug
@@ -1,1 +1,6 @@
-div.spectrum-Underlay#spectrum-underlay
+hr.spectrum-Rule.spectrum-Rule--medium
+.spectrum-Site-footer
+  .spectrum-Site-footerContent.
+    For any questions or feedback, please contact us.
+  .spectrum-Site-footerCopyright.
+    © Adobe. All rights reserved.

--- a/site/includes/nav.pug
+++ b/site/includes/nav.pug
@@ -1,8 +1,8 @@
 .u-scrollable.spectrum-Site-nav
   nav
     ul.spectrum-SideNav.spectrum-SideNav--multiLevel
-      li.spectrum-SideNav-item(class=pageURL === 'getting-started.html' ? 'is-selected' : '')
-        a.spectrum-SideNav-itemLink.js-fastLoad(href='getting-started.html') Getting Started
+      //- li.spectrum-SideNav-item(class=pageURL === 'getting-started.html' ? 'is-selected' : '')
+      //-   a.spectrum-SideNav-itemLink.js-fastLoad(href='getting-started.html') Getting Started
       li.spectrum-SideNav-item
         a.spectrum-SideNav-itemLink(href='https://github.com/adobe/spectrum-css', target='_blank', rel='noopener') Github
       li.spectrum-SideNav-item
@@ -12,7 +12,7 @@
             li.spectrum-SideNav-item(class=pageURL === component.href ? 'is-selected' : '')
               a.spectrum-SideNav-itemLink.js-fastLoad(href=component.href)= component.name
 
-  nav.spectrum-Site-bottomNav
-    ul.spectrum-SideNav
-      li.spectrum-SideNav-item
-        a.spectrum-SideNav-itemLink(href='http://opensource.adobe.com/spectrum', target='_blank', rel='noopener') Spectrum
+  //- nav.spectrum-Site-bottomNav
+  //-   ul.spectrum-SideNav
+  //-     li.spectrum-SideNav-item
+  //-       a.spectrum-SideNav-itemLink(href='http://opensource.adobe.com/spectrum', target='_blank', rel='noopener') Spectrum

--- a/site/includes/pageBottom.pug
+++ b/site/includes/pageBottom.pug
@@ -1,0 +1,1 @@
+div.spectrum-Underlay#spectrum-underlay

--- a/site/includes/sidebar.pug
+++ b/site/includes/sidebar.pug
@@ -1,6 +1,7 @@
 .spectrum-Site-sideBar#site-sidebar
   a.spectrum-Site-sideBarHeader.js-fastLoad(href='index.html')
-    img.spectrum-Site-logo(src='img/spectrum_logo_light.svg', alt='Spectrum Logo')
+    svg.spectrum-Site-logo.spectrum-Icon.spectrum-Icon--sizeL(viewBox="0 0 36 36" focusable="false" aria-hidden="true" aria-label="Adobe logo")
+      path(d="M22.175 4H34v28L22.175 4zm-8.336 0H2v28L13.839 4zm4.165 10.317l7.538 17.682h-4.939l-2.258-5.632h-5.517l5.176-12.05z")
     h2.spectrum-Site-title.spectrum-Heading3 Spectrum CSS
 
   div#site-search

--- a/site/index.pug
+++ b/site/index.pug
@@ -19,8 +19,8 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
           .spectrum-Site-page
             .spectrum-Site-hero
               .spectrum-Article.spectrum-Site-heroHeading
-                h1.spectrum-Heading1--display Meet Spectrum CSS, Adobe's design system in CSS
-              p.spectrum-Body1 That's right, there's CSS for all those pretty components.
+                h1.spectrum-Heading1--display Meet Spectrum CSS
+              p.spectrum-Body1 The CSS implementation of Adobe’s design system.
               img.spectrum-Site-heroImage(src='img/spectrum_illustration_2x.png', alt='Spectrum Illustration')
 
             include includes/footer.pug

--- a/site/index.pug
+++ b/site/index.pug
@@ -23,4 +23,6 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
               p.spectrum-Body1 That's right, there's CSS for all those pretty components.
               img.spectrum-Site-heroImage(src='img/spectrum_illustration_2x.png', alt='Spectrum Illustration')
 
-    include includes/footer.pug
+            include includes/footer.pug
+
+    include includes/pageBottom.pug

--- a/site/resources/css/docs.css
+++ b/site/resources/css/docs.css
@@ -26,6 +26,7 @@ code[class*="language-"], pre[class*="language-"] {
   vertical-align: middle;
 }
 
+.spectrum-BigSubtleLink.focus-ring,
 .spectrum-BigSubtleLink:hover {
   text-decoration: underline;
 }

--- a/site/resources/js/Search.js
+++ b/site/resources/js/Search.js
@@ -192,6 +192,9 @@ Search.prototype.handlePopoverNavigation = function(e) {
     else if (e.key === 'Escape') {
       this.input.focus();
     }
+    else if (e.key === 'Enter') {
+      currentItem.click();
+    }
     if (newItemIndex !== -1) {
       items[newItemIndex].focus();
 
@@ -275,7 +278,6 @@ Search.prototype.search = function(val) {
     this.searchResults.hidden = false;
 
     let markup = `
-<ul class="spectrum-Menu" id="search-results-listbox" role="listbox" aria-label="Search">
   ${
     Search.Categories.map(function(category) {
       return results[category].length ?
@@ -297,7 +299,6 @@ Search.prototype.search = function(val) {
         ` : ''
     }).join('\n')
   }
-</ul>
 `;
     this.searchResults.innerHTML = markup;
 

--- a/site/resources/js/Search.js
+++ b/site/resources/js/Search.js
@@ -17,7 +17,7 @@ function Search(el) {
   this.el.innerHTML = `
 <div class="spectrum-Site-search" role="search">
   <form class="spectrum-Search js-form" role="combobox" aria-expanded="false" aria-owns="search-results-listbox" aria-haspopup="listbox">
-    <input type="search" placeholder="Search" name="search" autocomplete="off" class="spectrum-Textfield spectrum-Search-input js-input" aria-autocomplete="list" aria-owns="search-results-listbox" aria-label="Search">
+    <input type="search" placeholder="Search for components" name="search" autocomplete="off" class="spectrum-Textfield spectrum-Search-input js-input" aria-autocomplete="list" aria-owns="search-results-listbox" aria-label="Search">
     <svg class="spectrum-Icon spectrum-UIIcon-Magnifier spectrum-Search-icon" focusable="false" aria-hidden="true">
       <use xlink:href="#spectrum-css-icon-Magnifier" />
     </svg>

--- a/site/resources/js/Search.js
+++ b/site/resources/js/Search.js
@@ -78,7 +78,7 @@ function Search(el) {
   }.bind(this));
 
   document.addEventListener('keydown', function(e) {
-    if ((e.ctrlKey || e.metaKey) && e.key === 'f') {
+    if (e.key === '/' && document.activeElement === document.body) {
       this.input.classList.add('focus-ring');
       this.input.setSelectionRange(0, this.input.value.length);
       setTimeout(this.input.focus.bind(this.input), 100);

--- a/site/resources/js/docs.js
+++ b/site/resources/js/docs.js
@@ -23,7 +23,7 @@ function toggleMarkupVisibility(event) {
   var exampleMarkup = event.target.closest('.spectrum-CSSExample-markup');
   var style = window.getComputedStyle(exampleMarkup);
   var isOpen = exampleMarkup.classList.contains('is-open');
-  event.target.innerHTML = isOpen ? 'Show Markup' : 'Hide Markup';
+  event.target.innerHTML = isOpen ? 'Show markup' : 'Hide markup';
   exampleMarkup.classList.toggle('is-open');
 }
 

--- a/site/resources/js/enhancement.js
+++ b/site/resources/js/enhancement.js
@@ -68,7 +68,7 @@ governing permissions and limitations under the License.
           closeAndFocusDropdown(dropdown);
         }
         else if (event.key === 'Enter') {
-          handleMenuChange(menu, menuItem, items[menuItemIndex].getAttribute('value'));
+          handleMenuChange(menu, menuItem);
 
           var dropdown = event.target.closest('.spectrum-Dropdown');
           closeAndFocusDropdown(dropdown);
@@ -100,34 +100,49 @@ governing permissions and limitations under the License.
   });
 
   function setDropdownValue(dropdown, value, label) {
-    var fieldButton = dropdown.querySelector('.spectrum-Dropdown-trigger');
-    dropdown.setAttribute('value', value);
-    var event = new CustomEvent('change', {
-      detail: {
-        label: label,
-        value: value
-      }
-    });
-    dropdown.dispatchEvent(event);
+    var menu = dropdown.querySelector('.spectrum-Menu');
+    var menuItem = dropdown.querySelector('.spectrum-Menu-item[value="'+value+'"]');
 
+    if (menuItem) {
+      var selectedMenuItem = menu.querySelector('.spectrum-Menu-item.is-selected');
+      if (selectedMenuItem) {
+        selectedMenuItem.classList.remove('is-selected');
+        selectedMenuItem.removeAttribute('aria-selected');
+      }
+
+      menuItem.classList.add('is-selected');
+      menuItem.setAttribute('aria-selected', 'true');
+
+      if (!label) {
+        var menuLabel = menuItem.querySelector('.spectrum-Menu-itemLabel');
+        if (menuLabel) {
+          label = menuLabel.innerHTML;
+        }
+      }
+    }
+
+    dropdown.setAttribute('value', value);
+    var fieldButton = dropdown.querySelector('.spectrum-Dropdown-trigger');
     if (fieldButton && label) {
       var dropdownLabel = fieldButton.querySelector('.spectrum-Dropdown-label');
       if (dropdownLabel) {
         dropdownLabel.innerHTML = label;
       }
     }
+
+    var event = new CustomEvent('change', {
+      bubbles: true,
+      detail: {
+        label: label,
+        value: value
+      }
+    });
+
+    dropdown.dispatchEvent(event);
   }
 
-  function handleMenuChange(menu, menuItem, value) {
-    var selectedMenuItem = menu.querySelector('.spectrum-Menu-item.is-selected');
-    if (selectedMenuItem) {
-      selectedMenuItem.classList.remove('is-selected');
-      selectedMenuItem.removeAttribute('aria-selected');
-    }
-
-    menuItem.classList.add('is-selected');
-    menuItem.setAttribute('aria-selected', 'true');
-
+  function handleMenuChange(menu, menuItem) {
+    var value = menuItem.getAttribute('value');
     var menuLabel = menuItem.querySelector('.spectrum-Menu-itemLabel');
     var label = menuLabel.innerHTML;
 
@@ -154,7 +169,7 @@ governing permissions and limitations under the License.
             dropdownLabel.innerHTML = menuLabel.innerHTML;
 
             event.stopPropagation();
-            handleMenuChange(menuItem.parentElement, menuItem, menuItem.getAttribute('value'));
+            handleMenuChange(menuItem.parentElement, menuItem);
           }
         }
       }
@@ -165,6 +180,8 @@ governing permissions and limitations under the License.
       }
     }
   });
+
+  window.setDropdownValue = setDropdownValue;
 }());
 
 // Treeview

--- a/site/resources/js/enhancement.js
+++ b/site/resources/js/enhancement.js
@@ -195,6 +195,19 @@ window.addEventListener('click', function(event) {
   }
 });
 
+// Accordion
+window.addEventListener('click', function(event) {
+  let heading = event.target.closest('.spectrum-Accordion-itemHeading');
+  if (heading) {
+    let item = event.target.closest('.spectrum-Accordion-item');
+    let isDisabled = item.classList.contains('is-disabled');
+    if (!isDisabled) {
+      item.classList.toggle('is-open');
+      event.preventDefault();
+    }
+  }
+});
+
 // Cyclebutton
 window.addEventListener('click', function(event) {
   var button = event.target.closest('.spectrum-CycleButton');
@@ -209,7 +222,7 @@ window.addEventListener('click', function(event) {
       icons[newIndex].classList.add('is-selected');
     }
   }
-})
+});
 
 // Display InputGroup focus style
 function toggleInputGroupFocus(event) {

--- a/site/resources/js/site.js
+++ b/site/resources/js/site.js
@@ -191,19 +191,25 @@ window.addEventListener('DOMContentLoaded', function() {
   }
   scaleMQL.addListener(handleScaleMQLChange);
 
-  var scaleSwitcher = document.querySelector('#switcher-scale');
-  if (scaleSwitcher) {
-    scaleSwitcher.addEventListener('change', function(event) {
+  document.body.addEventListener('change', function(event) {
+    if (event.target.id === 'switcher-scale') {
       switcher.scale = event.detail.value;
-    });
-  }
-
-  var themeSwitcher = document.querySelector('#switcher-theme');
-  if (themeSwitcher) {
-    themeSwitcher.addEventListener('change', function(event) {
+    }
+    else if (event.target.id === 'switcher-theme') {
       switcher.theme = event.detail.value;
-    });
-  }
+    }
+  });
+
+  window.addEventListener('PageFastLoaded', function updateScaleDropdowns() {
+    let scaleDropdown = document.querySelector('#switcher-scale');
+    let themeDropdown = document.querySelector('#switcher-theme');
+    if (scaleDropdown) {
+      setDropdownValue(scaleDropdown, switcher.scale);
+    }
+    if (themeDropdown) {
+      setDropdownValue(themeDropdown, switcher.theme);
+    }
+  });
 
   var sidebarMQL = window.matchMedia('(max-width: 960px)');
   function handleSidebarMQLChange() {

--- a/site/resources/js/site.js
+++ b/site/resources/js/site.js
@@ -180,7 +180,7 @@ window.addEventListener('DOMContentLoaded', function() {
   // Sidebar
   var sideBar = document.querySelector('#site-sidebar');
   var overlay = document.querySelector('#site-overlay');
-  let scaleMQL = window.matchMedia('(max-width: 768px)');
+  var scaleMQL = window.matchMedia('(max-width: 768px)');
   function handleScaleMQLChange() {
     if (scaleMQL.matches) {
       switcher.scale = 'large';
@@ -191,7 +191,21 @@ window.addEventListener('DOMContentLoaded', function() {
   }
   scaleMQL.addListener(handleScaleMQLChange);
 
-  let sidebarMQL = window.matchMedia('(max-width: 960px)');
+  var scaleSwitcher = document.querySelector('#switcher-scale');
+  if (scaleSwitcher) {
+    scaleSwitcher.addEventListener('change', function(event) {
+      switcher.scale = event.detail.value;
+    });
+  }
+
+  var themeSwitcher = document.querySelector('#switcher-theme');
+  if (themeSwitcher) {
+    themeSwitcher.addEventListener('change', function(event) {
+      switcher.theme = event.detail.value;
+    });
+  }
+
+  var sidebarMQL = window.matchMedia('(max-width: 960px)');
   function handleSidebarMQLChange() {
     if (!sidebarMQL.matches) {
       // Get rid of the overlay if we resize while the sidebar is open

--- a/site/templates/siteComponent.pug
+++ b/site/templates/siteComponent.pug
@@ -63,9 +63,54 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
         .spectrum-Site-mainContainer
 
           article.spectrum-CSSComponent
+
             header(id=component.slug).spectrum-CSSComponent-heading
               h2.spectrum-CSSComponent-title.spectrum-Article.spectrum-Heading1--display
                 a(href=`#${component.slug}`).spectrum-BigSubtleLink #{component.name}
+              .spectrum-CSSComponent-switcher
+                label.spectrum-FieldLabel.spectrum-FieldLabel--left(for='switcher-theme') Theme
+
+                .spectrum-Dropdown.spectrum-Dropdown--quiet(id="switcher-theme")
+                  button.spectrum-FieldButton.spectrum-FieldButton--quiet.spectrum-Dropdown-trigger(aria-haspopup="true")
+                    span.spectrum-Dropdown-label Light
+                    svg.spectrum-Icon.spectrum-UIIcon-ChevronDownMedium.spectrum-Dropdown-icon(focusable="false" aria-hidden="true")
+                      use(xlink:href="#spectrum-css-icon-ChevronDownMedium")
+                  .spectrum-Popover.spectrum-Popover--bottom.spectrum-Dropdown-popover.spectrum-Dropdown-popover--quiet
+                    ul.spectrum-Menu(role='listbox')
+                      li.spectrum-Menu-item(role='option' aria-selected='true' tabindex='0' value="lightest")
+                        span.spectrum-Menu-itemLabel Lightest
+                        svg.spectrum-Icon.spectrum-UIIcon-CheckmarkMedium.spectrum-Menu-checkmark(focusable='false' aria-hidden='true')
+                          use(xlink:href='#spectrum-css-icon-CheckmarkMedium')
+                      li.spectrum-Menu-item.is-selected(role='option' tabindex='0' value="light")
+                        span.spectrum-Menu-itemLabel Light
+                        svg.spectrum-Icon.spectrum-UIIcon-CheckmarkMedium.spectrum-Menu-checkmark(focusable='false' aria-hidden='true')
+                          use(xlink:href='#spectrum-css-icon-CheckmarkMedium')
+                      li.spectrum-Menu-item(role='option' tabindex='0' value="dark")
+                        span.spectrum-Menu-itemLabel Dark
+                        svg.spectrum-Icon.spectrum-UIIcon-CheckmarkMedium.spectrum-Menu-checkmark(focusable='false' aria-hidden='true')
+                          use(xlink:href='#spectrum-css-icon-CheckmarkMedium')
+                      li.spectrum-Menu-item(role='option' tabindex='0' value="darkest")
+                        span.spectrum-Menu-itemLabel Darkest
+                        svg.spectrum-Icon.spectrum-UIIcon-CheckmarkMedium.spectrum-Menu-checkmark(focusable='false' aria-hidden='true')
+                          use(xlink:href='#spectrum-css-icon-CheckmarkMedium')
+
+                label.spectrum-FieldLabel.spectrum-FieldLabel--left(for='switcher-scale') Scale
+
+                .spectrum-Dropdown.spectrum-Dropdown--quiet(id="switcher-scale")
+                  button.spectrum-FieldButton.spectrum-FieldButton--quiet.spectrum-Dropdown-trigger(aria-haspopup="true")
+                    span.spectrum-Dropdown-label Medium
+                    svg.spectrum-Icon.spectrum-UIIcon-ChevronDownMedium.spectrum-Dropdown-icon(focusable="false" aria-hidden="true")
+                      use(xlink:href="#spectrum-css-icon-ChevronDownMedium")
+                  .spectrum-Popover.spectrum-Popover--bottom.spectrum-Dropdown-popover.spectrum-Dropdown-popover--quiet
+                    ul.spectrum-Menu(role='listbox')
+                      li.spectrum-Menu-item.is-selected(role='option' aria-selected='true' tabindex='0' value="medium")
+                        span.spectrum-Menu-itemLabel Medium
+                        svg.spectrum-Icon.spectrum-UIIcon-CheckmarkMedium.spectrum-Menu-checkmark(focusable='false' aria-hidden='true')
+                          use(xlink:href='#spectrum-css-icon-CheckmarkMedium')
+                      li.spectrum-Menu-item(role='option' tabindex='0' value="large")
+                        span.spectrum-Menu-itemLabel Large
+                        svg.spectrum-Icon.spectrum-UIIcon-CheckmarkMedium.spectrum-Menu-checkmark(focusable='false' aria-hidden='true')
+                          use(xlink:href='#spectrum-css-icon-CheckmarkMedium')
 
             table.spectrum-CSSComponent-detailsTable
               tr

--- a/site/templates/siteComponent.pug
+++ b/site/templates/siteComponent.pug
@@ -14,6 +14,35 @@
     examples = component.examples;
   }
 
+  if (!Array.isArray(examples)) {
+    examples = Object.values(examples);
+  }
+
+  examples.forEach(example => {
+    if (example.dnaStatus === 'Deprecated' || example.cssStatus === 'Deprecated') {
+      example.status = 'Deprecated';
+    }
+    else if (example.cssStatus === 'Verified' || example.dnaStatus === 'Canon') {
+      example.status = 'Verified';
+    }
+    else {
+      example.status = 'Contribution';
+    }
+  });
+
+  let dnaStatusTranslation = {
+    'Canon': 'Verified',
+    'Precursor': 'Contribution'
+  };
+
+  let exampleOrder = {
+    'Verified': 1,
+    'Contribution': 2,
+    'Deprecated': 3
+  };
+
+  let status = dnaStatusTranslation[component.dnaStatus] || component.dnaStatus;
+
 doctype html
 html(lang='en-US').spectrum.spectrum--light.spectrum--medium
   head
@@ -38,55 +67,73 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
               h2.spectrum-CSSComponent-title.spectrum-Article.spectrum-Heading1--display
                 a(href=`#${component.slug}`).spectrum-BigSubtleLink #{component.name}
 
-              if !component.examples
-                if component.cssStatus != 'n/a'
-                  .spectrum-CSSComponent-statusContainer.u-tooltip-showOnHover
-                    div(class=`spectrum-CSSComponent-status spectrum-Label spectrum-Label--${util.getLabelColor(component.dnaStatus)}`).
-                      #{component.dnaStatus}
-                    if component.dnaStatus != 'Deprecated'
-                      div(class=`spectrum-CSSComponent-status spectrum-Label spectrum-Label--${util.getLabelColor(component.cssStatus)}`).
-                        #{component.cssStatus}
-                    if component.details
-                      .spectrum-Tooltip.spectrum-Tooltip--right
-                        .spectrum-Tooltip-label!= util.markdown.toHTML(component.details)
-                        .spectrum-Tooltip-tip
+            table.spectrum-CSSComponent-detailsTable
+              tr
+                th.spectrum-Body--secondary Component status
+                td
+                  div(class=`spectrum-StatusLight spectrum-CSSComponent-status spectrum-StatusLight--${util.getStatusLightVariant(component.dnaStatus)}`)= status
+              tr
+                th.spectrum-Body--secondary Last released
+                td= releaseDate
+              tr
+                th.spectrum-Body--secondary Current version
+                td #{pkg.name}@#{pkg.version}
+            if component.details
+              tr
+                th Details
+                tr!= util.markdown.toHTML(component.details)
 
-              .spectrum-CSSComponent-version.spectrum-Body #{pkg.name}@#{pkg.version}
+            div.spectrum-CSSComponent-resources
+              a.spectrum-Card.spectrum-Card--small.spectrum-Card--horizontal(href=`${spectrumURL || 'https://spectrum.corp.adobe.com/'+pkg.name.split('/').pop()}`)
+                .spectrum-Card-preview.spectrum-CSSComponent-resource--adobe
+                  svg(class="spectrum-Icon spectrum-Icon--sizeL" viewBox="0 0 36 36" focusable="false" aria-hidden="true" aria-label="AdobeLogo")
+                    path(d="M22.175 4H34v28L22.175 4zm-8.336 0H2v28L13.839 4zm4.165 10.317l7.538 17.682h-4.939l-2.258-5.632h-5.517l5.176-12.05z")
+                .spectrum-Card-body
+                  .spectrum-Card-header
+                    .spectrum-Card-title.
+                      View guidelines
+                  .spectrum-Card-content
+                    .spectrum-Card-description.
+                      Spectrum website
+              a.spectrum-Card.spectrum-Card--small.spectrum-Card--horizontal(href=`https://github.com/adobe/spectrum-css/tree/master/components/${pkg.name.split('/').pop()}`)
+                .spectrum-Card-preview.spectrum-CSSComponent-resource--github
+                  svg(class="spectrum-Icon spectrum-Icon--sizeL" focusable="false" aria-hidden="true" aria-label="GitHub" viewBox="0 0 36 36")
+                    path(d="M17.988 2a16.291 16.291 0 0 0-5.147 31.747c.814.149 1.111-.354 1.111-.786 0-.386-.014-1.411-.022-2.77-4.531.984-5.487-2.184-5.487-2.184a4.32 4.32 0 0 0-1.809-2.383c-1.479-1.01.112-.99.112-.99a3.42 3.42 0 0 1 2.495 1.679 3.468 3.468 0 0 0 4.741 1.353 3.482 3.482 0 0 1 1.034-2.177C11.4 25.078 7.6 23.68 7.6 17.438a6.3 6.3 0 0 1 1.677-4.371 5.863 5.863 0 0 1 .16-4.311s1.368-.438 4.479 1.67a15.451 15.451 0 0 1 8.157 0c3.109-2.108 4.475-1.67 4.475-1.67a5.857 5.857 0 0 1 .162 4.311 6.286 6.286 0 0 1 1.674 4.371c0 6.258-3.808 7.635-7.437 8.038a3.888 3.888 0 0 1 1.106 3.017c0 2.177-.02 3.934-.02 4.468 0 .436.293.943 1.12.784A16.292 16.292 0 0 0 17.988 2z")
+                .spectrum-Card-body
+                  .spectrum-Card-header
+                    .spectrum-Card-title.
+                      View repository
+                  .spectrum-Card-content
+                    .spectrum-Card-description.
+                      Github
+              a.spectrum-Card.spectrum-Card--small.spectrum-Card--horizontal(href=`https://www.npmjs.com/package/${pkg.name}`)
+                .spectrum-Card-preview.spectrum-CSSComponent-resource--npm
+                  svg(class="spectrum-Icon spectrum-Icon--sizeL" viewBox="0 0 18 7" focusable="false" aria-hidden="true" aria-label="npm")
+                    path(fill="#CB3837" d="M0,0h18v6H9v1H5V6H0V0z M1,5h2V2h1v3h1V1H1V5z M6,1v5h2V5h2V1H6z M8,2h1v2H8V2z M11,1v4h2V2h1v3h1V2h1v3h1V1H11z")
+                    polygon(fill="#FFFFFF" points="1,5 3,5 3,2 4,2 4,5 5,5 5,1 1,1 ")
+                    path(fill="#FFFFFF" d="M6,1v5h2V5h2V1H6z M9,4H8V2h1V4z")
+                    polygon(fill="#FFFFFF" points="11,1 11,5 13,5 13,2 14,2 14,5 15,5 15,2 16,2 16,5 17,5 17,1 ")
+                .spectrum-Card-body
+                  .spectrum-Card-header
+                    .spectrum-Card-title.
+                      View package
+                  .spectrum-Card-content
+                    .spectrum-Card-description.
+                      npm
 
             if component.description
-              section.spectrum-CSSComponent-description.spectrum-Body2!= util.markdown.toHTML(component.description)
+              header.spectrum-CSSComponent-sectionHeading(id=usage)
+                h4.spectrum-Heading3.
+                  Usage notes
+                hr.spectrum-Rule.spectrum-Rule--large
+                section.spectrum-CSSComponent-description.spectrum-Body3!= util.markdown.toHTML(component.description)
 
-            each example in examples
-              article.spectrum-CSSExample
-                if example != component
-                  header.spectrum-CSSExample-header(id=example.slug)
-                    h4.spectrum-Heading3
-                      a(href=`#${example.slug}`).spectrum-CSSExample-link #{example.name}
-                      if example.cssStatus != 'n/a'
-                        .spectrum-CSSComponent-statusContainer.u-tooltip-showOnHover
-                          div(class=`spectrum-CSSComponent-status spectrum-Label spectrum-Label--${util.getLabelColor(example.dnaStatus)}`).
-                            #{example.dnaStatus}
-                          if example.dnaStatus != 'Deprecated'
-                            div(class=`spectrum-CSSComponent-status spectrum-Label spectrum-Label--${util.getLabelColor(example.cssStatus)}`).
-                              #{example.cssStatus}
-                          if example.details
-                            .spectrum-Tooltip.spectrum-Tooltip--right
-                              .spectrum-Tooltip-label!= util.markdown.toHTML(example.details)
-                              .spectrum-Tooltip-tip
-
-                        hr.spectrum-Rule.spectrum-Rule--large
-
-                  if example.description
-                    section.spectrum-CSSExample-description.spectrum-Body2!= util.markdown.toHTML(example.description)
-
-                if example.markup
-
-                  section.spectrum-CSSExample-container
-                    .spectrum-CSSExample-example(class=example.demoClassName ? `${example.demoClassName}` : '')!= example.markup
-                    .spectrum-CSSExample-markup
-                      if example.markup.split('\n').length > 2
-                        a.js-markup-toggle.spectrum-CSSExample-markupToggle.spectrum-Link(href="#") Show Markup
-                      pre
-                        code.language-markup!= util.Prism.highlight(example.markup, util.Prism.languages.markup, 'markup')
+            if examples.length
+              header.spectrum-CSSComponent-sectionHeading(id=varia ts)
+                h4.spectrum-Heading3.
+                  Variants
+                hr.spectrum-Rule.spectrum-Rule--large
+              each example in examples
+                include ../includes/example.pug
 
     include ../includes/footer.pug

--- a/site/templates/siteComponent.pug
+++ b/site/templates/siteComponent.pug
@@ -131,7 +131,7 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
                 tr!= util.markdown.toHTML(component.details)
 
             div.spectrum-CSSComponent-resources
-              a.spectrum-Card.spectrum-Card--small.spectrum-Card--horizontal(href=`${spectrumURL || 'https://spectrum.corp.adobe.com/'+pkg.name.split('/').pop()}`)
+              a.spectrum-Card.spectrum-Card--small.spectrum-Card--horizontal(href=`${spectrumURL || 'https://spectrum.corp.adobe.com/'+pkg.name.split('/').pop()}` target="_blank")
                 .spectrum-Card-preview.spectrum-CSSComponent-resource--adobe
                   svg(class="spectrum-Icon spectrum-Icon--sizeL" viewBox="0 0 36 36" focusable="false" aria-hidden="true" aria-label="AdobeLogo")
                     path(d="M22.175 4H34v28L22.175 4zm-8.336 0H2v28L13.839 4zm4.165 10.317l7.538 17.682h-4.939l-2.258-5.632h-5.517l5.176-12.05z")
@@ -142,7 +142,7 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
                   .spectrum-Card-content
                     .spectrum-Card-description.
                       Spectrum website
-              a.spectrum-Card.spectrum-Card--small.spectrum-Card--horizontal(href=`https://github.com/adobe/spectrum-css/tree/master/components/${pkg.name.split('/').pop()}`)
+              a.spectrum-Card.spectrum-Card--small.spectrum-Card--horizontal(href=`https://github.com/adobe/spectrum-css/tree/master/components/${pkg.name.split('/').pop()}` target="_blank")
                 .spectrum-Card-preview.spectrum-CSSComponent-resource--github
                   svg(class="spectrum-Icon spectrum-Icon--sizeL" focusable="false" aria-hidden="true" aria-label="GitHub" viewBox="0 0 36 36")
                     path(d="M17.988 2a16.291 16.291 0 0 0-5.147 31.747c.814.149 1.111-.354 1.111-.786 0-.386-.014-1.411-.022-2.77-4.531.984-5.487-2.184-5.487-2.184a4.32 4.32 0 0 0-1.809-2.383c-1.479-1.01.112-.99.112-.99a3.42 3.42 0 0 1 2.495 1.679 3.468 3.468 0 0 0 4.741 1.353 3.482 3.482 0 0 1 1.034-2.177C11.4 25.078 7.6 23.68 7.6 17.438a6.3 6.3 0 0 1 1.677-4.371 5.863 5.863 0 0 1 .16-4.311s1.368-.438 4.479 1.67a15.451 15.451 0 0 1 8.157 0c3.109-2.108 4.475-1.67 4.475-1.67a5.857 5.857 0 0 1 .162 4.311 6.286 6.286 0 0 1 1.674 4.371c0 6.258-3.808 7.635-7.437 8.038a3.888 3.888 0 0 1 1.106 3.017c0 2.177-.02 3.934-.02 4.468 0 .436.293.943 1.12.784A16.292 16.292 0 0 0 17.988 2z")
@@ -153,7 +153,7 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
                   .spectrum-Card-content
                     .spectrum-Card-description.
                       Github
-              a.spectrum-Card.spectrum-Card--small.spectrum-Card--horizontal(href=`https://www.npmjs.com/package/${pkg.name}`)
+              a.spectrum-Card.spectrum-Card--small.spectrum-Card--horizontal(href=`https://www.npmjs.com/package/${pkg.name}` target="_blank")
                 .spectrum-Card-preview.spectrum-CSSComponent-resource--npm
                   svg(class="spectrum-Icon spectrum-Icon--sizeL" viewBox="0 0 18 7" focusable="false" aria-hidden="true" aria-label="npm")
                     path(fill="#CB3837" d="M0,0h18v6H9v1H5V6H0V0z M1,5h2V2h1v3h1V1H1V5z M6,1v5h2V5h2V1H6z M8,2h1v2H8V2z M11,1v4h2V2h1v3h1V2h1v3h1V1H11z")

--- a/site/templates/siteComponent.pug
+++ b/site/templates/siteComponent.pug
@@ -136,4 +136,6 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
               each example in examples
                 include ../includes/example.pug
 
+            include ../includes/footer.pug
+
     include ../includes/footer.pug

--- a/site/templates/siteComponent.pug
+++ b/site/templates/siteComponent.pug
@@ -172,14 +172,14 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
             if component.description
               header.spectrum-CSSComponent-sectionHeading(id="usage")
                 h4.spectrum-Heading3
-                  a(href="usage").spectrum-BigSubtleLink Usage notes
+                  a(href="#usage").spectrum-BigSubtleLink Usage notes
                 hr.spectrum-Rule.spectrum-Rule--large
                 section.spectrum-CSSComponent-description.spectrum-Body3!= util.markdown.toHTML(component.description)
 
             if examples.length
               header.spectrum-CSSComponent-sectionHeading(id="variants")
                 h4.spectrum-Heading3
-                  a(href="variants").spectrum-BigSubtleLink Variants
+                  a(href="#variants").spectrum-BigSubtleLink Variants
                 hr.spectrum-Rule.spectrum-Rule--large
               each example in examples
                 include ../includes/example.pug

--- a/site/templates/siteComponent.pug
+++ b/site/templates/siteComponent.pug
@@ -131,17 +131,18 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
                 tr!= util.markdown.toHTML(component.details)
 
             div.spectrum-CSSComponent-resources
-              a.spectrum-Card.spectrum-Card--small.spectrum-Card--horizontal(href=`${spectrumURL || 'https://spectrum.corp.adobe.com/'+pkg.name.split('/').pop()}` target="_blank")
-                .spectrum-Card-preview.spectrum-CSSComponent-resource--adobe
-                  svg(class="spectrum-Icon spectrum-Icon--sizeL" viewBox="0 0 36 36" focusable="false" aria-hidden="true" aria-label="AdobeLogo")
-                    path(d="M22.175 4H34v28L22.175 4zm-8.336 0H2v28L13.839 4zm4.165 10.317l7.538 17.682h-4.939l-2.258-5.632h-5.517l5.176-12.05z")
-                .spectrum-Card-body
-                  .spectrum-Card-header
-                    .spectrum-Card-title.
-                      View guidelines
-                  .spectrum-Card-content
-                    .spectrum-Card-description.
-                      Spectrum website
+              //-
+                a.spectrum-Card.spectrum-Card--small.spectrum-Card--horizontal(href=`${spectrumURL || 'https://spectrum.corp.adobe.com/'+pkg.name.split('/').pop()}` target="_blank")
+                  .spectrum-Card-preview.spectrum-CSSComponent-resource--adobe
+                    svg(class="spectrum-Icon spectrum-Icon--sizeL" viewBox="0 0 36 36" focusable="false" aria-hidden="true" aria-label="AdobeLogo")
+                      path(d="M22.175 4H34v28L22.175 4zm-8.336 0H2v28L13.839 4zm4.165 10.317l7.538 17.682h-4.939l-2.258-5.632h-5.517l5.176-12.05z")
+                  .spectrum-Card-body
+                    .spectrum-Card-header
+                      .spectrum-Card-title.
+                        View guidelines
+                    .spectrum-Card-content
+                      .spectrum-Card-description.
+                        Spectrum website
               a.spectrum-Card.spectrum-Card--small.spectrum-Card--horizontal(href=`https://github.com/adobe/spectrum-css/tree/master/components/${pkg.name.split('/').pop()}` target="_blank")
                 .spectrum-Card-preview.spectrum-CSSComponent-resource--github
                   svg(class="spectrum-Icon spectrum-Icon--sizeL" focusable="false" aria-hidden="true" aria-label="GitHub" viewBox="0 0 36 36")

--- a/site/templates/siteComponent.pug
+++ b/site/templates/siteComponent.pug
@@ -68,49 +68,51 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
               h2.spectrum-CSSComponent-title.spectrum-Article.spectrum-Heading1--display
                 a(href=`#${component.slug}`).spectrum-BigSubtleLink #{component.name}
               .spectrum-CSSComponent-switcher
-                label.spectrum-FieldLabel.spectrum-FieldLabel--left(for='switcher-theme') Theme
 
-                .spectrum-Dropdown.spectrum-Dropdown--quiet(id="switcher-theme")
-                  button.spectrum-FieldButton.spectrum-FieldButton--quiet.spectrum-Dropdown-trigger(aria-haspopup="true")
-                    span.spectrum-Dropdown-label Light
-                    svg.spectrum-Icon.spectrum-UIIcon-ChevronDownMedium.spectrum-Dropdown-icon(focusable="false" aria-hidden="true")
-                      use(xlink:href="#spectrum-css-icon-ChevronDownMedium")
-                  .spectrum-Popover.spectrum-Popover--bottom.spectrum-Dropdown-popover.spectrum-Dropdown-popover--quiet
-                    ul.spectrum-Menu(role='listbox')
-                      li.spectrum-Menu-item(role='option' aria-selected='true' tabindex='0' value="lightest")
-                        span.spectrum-Menu-itemLabel Lightest
-                        svg.spectrum-Icon.spectrum-UIIcon-CheckmarkMedium.spectrum-Menu-checkmark(focusable='false' aria-hidden='true')
-                          use(xlink:href='#spectrum-css-icon-CheckmarkMedium')
-                      li.spectrum-Menu-item.is-selected(role='option' tabindex='0' value="light")
-                        span.spectrum-Menu-itemLabel Light
-                        svg.spectrum-Icon.spectrum-UIIcon-CheckmarkMedium.spectrum-Menu-checkmark(focusable='false' aria-hidden='true')
-                          use(xlink:href='#spectrum-css-icon-CheckmarkMedium')
-                      li.spectrum-Menu-item(role='option' tabindex='0' value="dark")
-                        span.spectrum-Menu-itemLabel Dark
-                        svg.spectrum-Icon.spectrum-UIIcon-CheckmarkMedium.spectrum-Menu-checkmark(focusable='false' aria-hidden='true')
-                          use(xlink:href='#spectrum-css-icon-CheckmarkMedium')
-                      li.spectrum-Menu-item(role='option' tabindex='0' value="darkest")
-                        span.spectrum-Menu-itemLabel Darkest
-                        svg.spectrum-Icon.spectrum-UIIcon-CheckmarkMedium.spectrum-Menu-checkmark(focusable='false' aria-hidden='true')
-                          use(xlink:href='#spectrum-css-icon-CheckmarkMedium')
+                div.spectrum-CSS-switcherContainer
+                  label.spectrum-FieldLabel.spectrum-FieldLabel--left(for='switcher-theme') Theme
 
-                label.spectrum-FieldLabel.spectrum-FieldLabel--left(for='switcher-scale') Scale
+                  .spectrum-Dropdown.spectrum-Dropdown--quiet(id="switcher-theme")
+                    button.spectrum-FieldButton.spectrum-FieldButton--quiet.spectrum-Dropdown-trigger(aria-haspopup="true")
+                      span.spectrum-Dropdown-label Light
+                      svg.spectrum-Icon.spectrum-UIIcon-ChevronDownMedium.spectrum-Dropdown-icon(focusable="false" aria-hidden="true")
+                        use(xlink:href="#spectrum-css-icon-ChevronDownMedium")
+                    .spectrum-Popover.spectrum-Popover--bottom.spectrum-Dropdown-popover.spectrum-Dropdown-popover--quiet
+                      ul.spectrum-Menu(role='listbox')
+                        li.spectrum-Menu-item(role='option' aria-selected='true' tabindex='0' value="lightest")
+                          span.spectrum-Menu-itemLabel Lightest
+                          svg.spectrum-Icon.spectrum-UIIcon-CheckmarkMedium.spectrum-Menu-checkmark(focusable='false' aria-hidden='true')
+                            use(xlink:href='#spectrum-css-icon-CheckmarkMedium')
+                        li.spectrum-Menu-item.is-selected(role='option' tabindex='0' value="light")
+                          span.spectrum-Menu-itemLabel Light
+                          svg.spectrum-Icon.spectrum-UIIcon-CheckmarkMedium.spectrum-Menu-checkmark(focusable='false' aria-hidden='true')
+                            use(xlink:href='#spectrum-css-icon-CheckmarkMedium')
+                        li.spectrum-Menu-item(role='option' tabindex='0' value="dark")
+                          span.spectrum-Menu-itemLabel Dark
+                          svg.spectrum-Icon.spectrum-UIIcon-CheckmarkMedium.spectrum-Menu-checkmark(focusable='false' aria-hidden='true')
+                            use(xlink:href='#spectrum-css-icon-CheckmarkMedium')
+                        li.spectrum-Menu-item(role='option' tabindex='0' value="darkest")
+                          span.spectrum-Menu-itemLabel Darkest
+                          svg.spectrum-Icon.spectrum-UIIcon-CheckmarkMedium.spectrum-Menu-checkmark(focusable='false' aria-hidden='true')
+                            use(xlink:href='#spectrum-css-icon-CheckmarkMedium')
+                div.spectrum-CSS-switcherContainer
+                  label.spectrum-FieldLabel.spectrum-FieldLabel--left(for='switcher-scale') Scale
 
-                .spectrum-Dropdown.spectrum-Dropdown--quiet(id="switcher-scale")
-                  button.spectrum-FieldButton.spectrum-FieldButton--quiet.spectrum-Dropdown-trigger(aria-haspopup="true")
-                    span.spectrum-Dropdown-label Medium
-                    svg.spectrum-Icon.spectrum-UIIcon-ChevronDownMedium.spectrum-Dropdown-icon(focusable="false" aria-hidden="true")
-                      use(xlink:href="#spectrum-css-icon-ChevronDownMedium")
-                  .spectrum-Popover.spectrum-Popover--bottom.spectrum-Dropdown-popover.spectrum-Dropdown-popover--quiet
-                    ul.spectrum-Menu(role='listbox')
-                      li.spectrum-Menu-item.is-selected(role='option' aria-selected='true' tabindex='0' value="medium")
-                        span.spectrum-Menu-itemLabel Medium
-                        svg.spectrum-Icon.spectrum-UIIcon-CheckmarkMedium.spectrum-Menu-checkmark(focusable='false' aria-hidden='true')
-                          use(xlink:href='#spectrum-css-icon-CheckmarkMedium')
-                      li.spectrum-Menu-item(role='option' tabindex='0' value="large")
-                        span.spectrum-Menu-itemLabel Large
-                        svg.spectrum-Icon.spectrum-UIIcon-CheckmarkMedium.spectrum-Menu-checkmark(focusable='false' aria-hidden='true')
-                          use(xlink:href='#spectrum-css-icon-CheckmarkMedium')
+                  .spectrum-Dropdown.spectrum-Dropdown--quiet(id="switcher-scale")
+                    button.spectrum-FieldButton.spectrum-FieldButton--quiet.spectrum-Dropdown-trigger(aria-haspopup="true")
+                      span.spectrum-Dropdown-label Medium
+                      svg.spectrum-Icon.spectrum-UIIcon-ChevronDownMedium.spectrum-Dropdown-icon(focusable="false" aria-hidden="true")
+                        use(xlink:href="#spectrum-css-icon-ChevronDownMedium")
+                    .spectrum-Popover.spectrum-Popover--bottom.spectrum-Dropdown-popover.spectrum-Dropdown-popover--quiet
+                      ul.spectrum-Menu(role='listbox')
+                        li.spectrum-Menu-item.is-selected(role='option' aria-selected='true' tabindex='0' value="medium")
+                          span.spectrum-Menu-itemLabel Medium
+                          svg.spectrum-Icon.spectrum-UIIcon-CheckmarkMedium.spectrum-Menu-checkmark(focusable='false' aria-hidden='true')
+                            use(xlink:href='#spectrum-css-icon-CheckmarkMedium')
+                        li.spectrum-Menu-item(role='option' tabindex='0' value="large")
+                          span.spectrum-Menu-itemLabel Large
+                          svg.spectrum-Icon.spectrum-UIIcon-CheckmarkMedium.spectrum-Menu-checkmark(focusable='false' aria-hidden='true')
+                            use(xlink:href='#spectrum-css-icon-CheckmarkMedium')
 
             table.spectrum-CSSComponent-detailsTable
               tr

--- a/site/templates/siteComponent.pug
+++ b/site/templates/siteComponent.pug
@@ -64,55 +64,55 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
 
           article.spectrum-CSSComponent
 
+            .spectrum-CSSComponent-switcher
+              div.spectrum-CSS-switcherContainer
+                label.spectrum-FieldLabel.spectrum-FieldLabel--left(for='switcher-theme') Theme
+
+                .spectrum-Dropdown.spectrum-Dropdown--quiet(id="switcher-theme")
+                  button.spectrum-FieldButton.spectrum-FieldButton--quiet.spectrum-Dropdown-trigger(aria-haspopup="true")
+                    span.spectrum-Dropdown-label Light
+                    svg.spectrum-Icon.spectrum-UIIcon-ChevronDownMedium.spectrum-Dropdown-icon(focusable="false" aria-hidden="true")
+                      use(xlink:href="#spectrum-css-icon-ChevronDownMedium")
+                  .spectrum-Popover.spectrum-Popover--bottom.spectrum-Dropdown-popover.spectrum-Dropdown-popover--quiet
+                    ul.spectrum-Menu(role='listbox')
+                      li.spectrum-Menu-item(role='option' aria-selected='true' tabindex='0' value="lightest")
+                        span.spectrum-Menu-itemLabel Lightest
+                        svg.spectrum-Icon.spectrum-UIIcon-CheckmarkMedium.spectrum-Menu-checkmark(focusable='false' aria-hidden='true')
+                          use(xlink:href='#spectrum-css-icon-CheckmarkMedium')
+                      li.spectrum-Menu-item.is-selected(role='option' tabindex='0' value="light")
+                        span.spectrum-Menu-itemLabel Light
+                        svg.spectrum-Icon.spectrum-UIIcon-CheckmarkMedium.spectrum-Menu-checkmark(focusable='false' aria-hidden='true')
+                          use(xlink:href='#spectrum-css-icon-CheckmarkMedium')
+                      li.spectrum-Menu-item(role='option' tabindex='0' value="dark")
+                        span.spectrum-Menu-itemLabel Dark
+                        svg.spectrum-Icon.spectrum-UIIcon-CheckmarkMedium.spectrum-Menu-checkmark(focusable='false' aria-hidden='true')
+                          use(xlink:href='#spectrum-css-icon-CheckmarkMedium')
+                      li.spectrum-Menu-item(role='option' tabindex='0' value="darkest")
+                        span.spectrum-Menu-itemLabel Darkest
+                        svg.spectrum-Icon.spectrum-UIIcon-CheckmarkMedium.spectrum-Menu-checkmark(focusable='false' aria-hidden='true')
+                          use(xlink:href='#spectrum-css-icon-CheckmarkMedium')
+              div.spectrum-CSS-switcherContainer
+                label.spectrum-FieldLabel.spectrum-FieldLabel--left(for='switcher-scale') Scale
+
+                .spectrum-Dropdown.spectrum-Dropdown--quiet(id="switcher-scale")
+                  button.spectrum-FieldButton.spectrum-FieldButton--quiet.spectrum-Dropdown-trigger(aria-haspopup="true")
+                    span.spectrum-Dropdown-label Medium
+                    svg.spectrum-Icon.spectrum-UIIcon-ChevronDownMedium.spectrum-Dropdown-icon(focusable="false" aria-hidden="true")
+                      use(xlink:href="#spectrum-css-icon-ChevronDownMedium")
+                  .spectrum-Popover.spectrum-Popover--bottom.spectrum-Dropdown-popover.spectrum-Dropdown-popover--quiet
+                    ul.spectrum-Menu(role='listbox')
+                      li.spectrum-Menu-item.is-selected(role='option' aria-selected='true' tabindex='0' value="medium")
+                        span.spectrum-Menu-itemLabel Medium
+                        svg.spectrum-Icon.spectrum-UIIcon-CheckmarkMedium.spectrum-Menu-checkmark(focusable='false' aria-hidden='true')
+                          use(xlink:href='#spectrum-css-icon-CheckmarkMedium')
+                      li.spectrum-Menu-item(role='option' tabindex='0' value="large")
+                        span.spectrum-Menu-itemLabel Large
+                        svg.spectrum-Icon.spectrum-UIIcon-CheckmarkMedium.spectrum-Menu-checkmark(focusable='false' aria-hidden='true')
+                          use(xlink:href='#spectrum-css-icon-CheckmarkMedium')
+
             header(id=component.slug).spectrum-CSSComponent-heading
               h2.spectrum-CSSComponent-title.spectrum-Article.spectrum-Heading1--display
                 a(href=`#${component.slug}`).spectrum-BigSubtleLink #{component.name}
-              .spectrum-CSSComponent-switcher
-
-                div.spectrum-CSS-switcherContainer
-                  label.spectrum-FieldLabel.spectrum-FieldLabel--left(for='switcher-theme') Theme
-
-                  .spectrum-Dropdown.spectrum-Dropdown--quiet(id="switcher-theme")
-                    button.spectrum-FieldButton.spectrum-FieldButton--quiet.spectrum-Dropdown-trigger(aria-haspopup="true")
-                      span.spectrum-Dropdown-label Light
-                      svg.spectrum-Icon.spectrum-UIIcon-ChevronDownMedium.spectrum-Dropdown-icon(focusable="false" aria-hidden="true")
-                        use(xlink:href="#spectrum-css-icon-ChevronDownMedium")
-                    .spectrum-Popover.spectrum-Popover--bottom.spectrum-Dropdown-popover.spectrum-Dropdown-popover--quiet
-                      ul.spectrum-Menu(role='listbox')
-                        li.spectrum-Menu-item(role='option' aria-selected='true' tabindex='0' value="lightest")
-                          span.spectrum-Menu-itemLabel Lightest
-                          svg.spectrum-Icon.spectrum-UIIcon-CheckmarkMedium.spectrum-Menu-checkmark(focusable='false' aria-hidden='true')
-                            use(xlink:href='#spectrum-css-icon-CheckmarkMedium')
-                        li.spectrum-Menu-item.is-selected(role='option' tabindex='0' value="light")
-                          span.spectrum-Menu-itemLabel Light
-                          svg.spectrum-Icon.spectrum-UIIcon-CheckmarkMedium.spectrum-Menu-checkmark(focusable='false' aria-hidden='true')
-                            use(xlink:href='#spectrum-css-icon-CheckmarkMedium')
-                        li.spectrum-Menu-item(role='option' tabindex='0' value="dark")
-                          span.spectrum-Menu-itemLabel Dark
-                          svg.spectrum-Icon.spectrum-UIIcon-CheckmarkMedium.spectrum-Menu-checkmark(focusable='false' aria-hidden='true')
-                            use(xlink:href='#spectrum-css-icon-CheckmarkMedium')
-                        li.spectrum-Menu-item(role='option' tabindex='0' value="darkest")
-                          span.spectrum-Menu-itemLabel Darkest
-                          svg.spectrum-Icon.spectrum-UIIcon-CheckmarkMedium.spectrum-Menu-checkmark(focusable='false' aria-hidden='true')
-                            use(xlink:href='#spectrum-css-icon-CheckmarkMedium')
-                div.spectrum-CSS-switcherContainer
-                  label.spectrum-FieldLabel.spectrum-FieldLabel--left(for='switcher-scale') Scale
-
-                  .spectrum-Dropdown.spectrum-Dropdown--quiet(id="switcher-scale")
-                    button.spectrum-FieldButton.spectrum-FieldButton--quiet.spectrum-Dropdown-trigger(aria-haspopup="true")
-                      span.spectrum-Dropdown-label Medium
-                      svg.spectrum-Icon.spectrum-UIIcon-ChevronDownMedium.spectrum-Dropdown-icon(focusable="false" aria-hidden="true")
-                        use(xlink:href="#spectrum-css-icon-ChevronDownMedium")
-                    .spectrum-Popover.spectrum-Popover--bottom.spectrum-Dropdown-popover.spectrum-Dropdown-popover--quiet
-                      ul.spectrum-Menu(role='listbox')
-                        li.spectrum-Menu-item.is-selected(role='option' aria-selected='true' tabindex='0' value="medium")
-                          span.spectrum-Menu-itemLabel Medium
-                          svg.spectrum-Icon.spectrum-UIIcon-CheckmarkMedium.spectrum-Menu-checkmark(focusable='false' aria-hidden='true')
-                            use(xlink:href='#spectrum-css-icon-CheckmarkMedium')
-                        li.spectrum-Menu-item(role='option' tabindex='0' value="large")
-                          span.spectrum-Menu-itemLabel Large
-                          svg.spectrum-Icon.spectrum-UIIcon-CheckmarkMedium.spectrum-Menu-checkmark(focusable='false' aria-hidden='true')
-                            use(xlink:href='#spectrum-css-icon-CheckmarkMedium')
 
             table.spectrum-CSSComponent-detailsTable
               tr
@@ -174,7 +174,8 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
                 h4.spectrum-Heading3
                   a(href="#usage").spectrum-BigSubtleLink Usage notes
                 hr.spectrum-Rule.spectrum-Rule--large
-                section.spectrum-CSSComponent-description.spectrum-Body3!= util.markdown.toHTML(component.description)
+              section.spectrum-CSSComponent-description
+                div.spectrum-Body3!= util.markdown.toHTML(component.description)
 
             if examples.length
               header.spectrum-CSSComponent-sectionHeading(id="variants")

--- a/site/templates/siteComponent.pug
+++ b/site/templates/siteComponent.pug
@@ -169,16 +169,16 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
                       npm
 
             if component.description
-              header.spectrum-CSSComponent-sectionHeading(id=usage)
-                h4.spectrum-Heading3.
-                  Usage notes
+              header.spectrum-CSSComponent-sectionHeading(id="usage")
+                h4.spectrum-Heading3
+                  a(href="usage").spectrum-BigSubtleLink Usage notes
                 hr.spectrum-Rule.spectrum-Rule--large
                 section.spectrum-CSSComponent-description.spectrum-Body3!= util.markdown.toHTML(component.description)
 
             if examples.length
-              header.spectrum-CSSComponent-sectionHeading(id=varia ts)
-                h4.spectrum-Heading3.
-                  Variants
+              header.spectrum-CSSComponent-sectionHeading(id="variants")
+                h4.spectrum-Heading3
+                  a(href="variants").spectrum-BigSubtleLink Variants
                 hr.spectrum-Rule.spectrum-Rule--large
               each example in examples
                 include ../includes/example.pug

--- a/site/util.js
+++ b/site/util.js
@@ -15,16 +15,16 @@ const logger = require('gulplog');
 exports.markdown = require('markdown').markdown;
 exports.Prism = require('prismjs');
 
-const labelColors = {
-  'Deprecated': 'red',
+const statusLightVariants = {
+  'Deprecated': 'negative',
 
-  'Beta Contribution': 'orange',
+  'Beta Contribution': 'notice',
 
-  'Contribution': 'yellow',
-  'CSS Unverified': 'yellow',
+  'Contribution': 'notice',
+  'Unverified': 'notice',
 
-  'Canon': 'green',
-  'CSS Verified': 'green'
+  'Canon': 'positive',
+  'Verified': 'positive'
 };
 
 const dnaStatusTranslation = {
@@ -34,13 +34,13 @@ const dnaStatusTranslation = {
 };
 
 const cssStatusTranslation = {
-  'Beta': 'CSS Unverified',
-  'Unverified': 'CSS Unverified',
-  'Verified': 'CSS Verified'
+  'Contribution': 'Unverified',
+  'Unverified': 'Unverified',
+  'Verified': 'Verified'
 };
 
-exports.getLabelColor = function(status) {
-  return labelColors[status] || 'grey';
+exports.getStatusLightVariant = function(status) {
+  return statusLightVariants[status] || 'neutral';
 };
 
 exports.getDNAStatus = function(dnaComponentId, dnaStatus, cssStatus) {
@@ -48,7 +48,7 @@ exports.getDNAStatus = function(dnaComponentId, dnaStatus, cssStatus) {
     dnaStatus = 'Deprecated';
   }
 
-  if (cssStatus === 'CSS Verified') {
+  if (cssStatus === 'Verified') {
     if (dnaStatusTranslation[dnaStatus] !== 'Canon') {
       logger.debug(`${dnaComponentId} is ${cssStatus} in CSS, but ${dnaStatus} in DNA`);
     }
@@ -56,7 +56,7 @@ exports.getDNAStatus = function(dnaComponentId, dnaStatus, cssStatus) {
 
   if (!dnaStatus) {
     logger.debug(`${dnaComponentId} has no DNA status`);
-    dnaStatus = 'Beta Contribution';
+    dnaStatus = 'Contribution';
   }
 
   return dnaStatusTranslation[dnaStatus] || dnaStatus;
@@ -64,7 +64,7 @@ exports.getDNAStatus = function(dnaComponentId, dnaStatus, cssStatus) {
 
 exports.getCSSStatus = function(dnaComponentId, cssStatus) {
   if (!cssStatus) {
-    cssStatus = 'Beta';
+    cssStatus = 'Contribution';
   }
   return cssStatusTranslation[cssStatus] || cssStatus;
 };

--- a/tools/bundle-builder/docs/index.js
+++ b/tools/bundle-builder/docs/index.js
@@ -42,6 +42,7 @@ let minimumDeps = [
   'menu',
   'popover',
   'underlay',
+  'card',
   'rule',
   'illustratedmessage'
 ];

--- a/tools/bundle-builder/docs/index.js
+++ b/tools/bundle-builder/docs/index.js
@@ -40,6 +40,8 @@ let minimumDeps = [
   'textfield',
   'search',
   'menu',
+  'fieldlabel',
+  'dropdown',
   'popover',
   'underlay',
   'card',

--- a/tools/bundle-builder/lib/exec.js
+++ b/tools/bundle-builder/lib/exec.js
@@ -24,12 +24,12 @@ function task(taskName, command) {
 
 function promise(command, options) {
   return new Promise((resolve, reject) => {
-    runCommand(command, (err) => {
+    runCommand(command, (err, stdout, stderr) => {
       if (err) {
         reject(err);
       }
       else {
-        resolve();
+        resolve(stdout);
       }
     }, options);
   });


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description

This PR implements the fancy new site design.

Also added is the Small Horizontal card, required for the site design.

## How and where has this been tested?

 - How this was tested: A little scrolly scroll on the deployed (internal) test site https://git.corp.adobe.com/pages/lawdavis/spectrum-css-new-design/docs/
 - Browser(s) and OS(s) this was tested with: Chrome 75 on macOS

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->

![image](https://user-images.githubusercontent.com/201344/65618754-adb40500-df73-11e9-80e2-8f1dba9891e0.png)

![image](https://user-images.githubusercontent.com/201344/65624976-c5918600-df7f-11e9-838e-73a6c623434f.png)





## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaning tasks here -->
- [x] Theme/scale switcher
- [x] This pull request is ready to merge.

Not implemented:
- Bundle version switcher
- Spectrum website card links
- Footer contact us link
- Getting started

