### PR TITLE
test(backstopjs): support configurable bitmaps reference path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,10 @@ node_js:
 services:
   - docker
 before_install:
+  # Enforce upgrading to the latest yarn to avoid random version of yarn assigned by travis virtual environment.
   - npm install -g yarn
 install:
   - yarn
-before_script:
-  - yarn global add gulp-cli
 script:
   # This script should be the first that runs to reduce the risk of
   # executing a script from a compromised NPM package.

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ script:
   # This script should be the first that runs to reduce the risk of
   # executing a script from a compromised NPM package.
   - audit-ci --moderate
-  - gulp build
-  - gulp dev &
+  - yarn run build
+  - yarn run watch &
   - sleep 5
   - yarn run backstop:ci:test themes=light scales=medium

--- a/backstop_data/backstop_test.js
+++ b/backstop_data/backstop_test.js
@@ -24,8 +24,9 @@ const LOCALHOST_LINUX = '127.0.0.1';
 let isDocker = false;
 let env = 'local';
 let host = LOCALHOST_MAC;
-let report = 'ci';
+let report = 'CI';
 let captureLimit = 1;
+let bitmapsRef = 'node_modules/@spectrum-css/spectrum-css-vr-test-asset/bitmaps_reference';
 
 // Shared scenario configuration
 const baseScenarioConfig = {
@@ -62,6 +63,9 @@ rest.forEach(argv => {
   else if (argv.startsWith('scales=')) {
     scales.clear();
     argv.slice('scales='.length).split(',').forEach(s => scales.add(s));
+  }
+  else if (argv.startsWith('reference=')) {
+    bitmapsRef = argv.slice('reference='.length);
   }
   else if (!argv.startsWith('--')) {
     packageNameSet.add(`@spectrum-css/${argv}`);
@@ -125,7 +129,7 @@ module.exports = {
   onReadyScript: 'puppet/onReady.js',
   scenarios,
   paths: {
-    bitmaps_reference: 'node_modules/@spectrum-css/spectrum-css-vr-test-asset/bitmaps_reference',
+    bitmaps_reference: bitmapsRef,
     bitmaps_test: 'backstop_data/bitmaps_test',
     engine_scripts: 'backstop_data/engine_scripts',
     html_report: 'backstop_data/html_report',

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "kill-zombies": "pkill -f \"(chrome)?(--headless)\"",
     "prepublishOnly": "backstop test --docker --config=backstop_data/backstop_test.js --env=local themes=lightest,light,dark,darkest scales=medium,large",
     "postpublish": "npx lerna run publishpages --concurrency=1",
-    "prepare": "gulp prepare"
+    "prepare": "gulp prepare",
+    "watch": "gulp watch"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->
1. Enhance backstopjs testing script to support configurable bitmaps reference path. It can make update bitmaps reference easier.
2. Add `npm run watch`.
3. Update travis ci script to use `watch` instead of `dev` to avoid unnecessary rebuild.


## How and where has this been tested?
Test with latest mac and travis-ci passed

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaning tasks here -->
- [x] This pull request is ready to merge.
