### PR TITLE
docs: make issue report template fields for environment bold

### DIFF
--- a/.github/ISSUE_TEMPLATE/--bug-report.md
+++ b/.github/ISSUE_TEMPLATE/--bug-report.md
@@ -27,8 +27,8 @@ assignees: ''
 
 
 ## Environment
- - Spectrum CSS version: <!-- 2.13.0 -->
- - Browser(s) and OS(s): <!-- Chrome 75.0.3770.142 on Win 10 -->
+ - **Spectrum CSS version:** <!-- 2.13.0 -->
+ - **Browser(s) and OS(s):** <!-- Chrome 75.0.3770.142 on Win 10 -->
 
 ## Additional context
 <!-- Provide any additional information that might help us debug the issue -->

--- a/.github/ISSUE_TEMPLATE/--support-request.md
+++ b/.github/ISSUE_TEMPLATE/--support-request.md
@@ -16,8 +16,8 @@ assignees: ''
 
 
 ## Environment
- - Spectrum CSS version: <!-- 2.13.0 -->
- - Browser and OS: <!-- Chrome 75.0.3770.142 on Win 10 -->
+ - **Spectrum CSS version:** <!-- 2.13.0 -->
+ - **Browser(s) and OS(s):** <!-- Chrome 75.0.3770.142 on Win 10 -->
 
 ## Additional context
 <!-- Provide any additional information that might help us understand your request -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,9 +10,8 @@
 
 
 ## How and where has this been tested?
-
- - How this was tested: <!-- Using steps in issue #000 -->
- - Browser(s) and OS(s) this was tested with: <!-- Chrome 75.0.3770.142 on Win 10 -->
+ - **How this was tested:** <!-- Using steps in issue #000 -->
+ - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->
 
 ## Screenshots
 <!-- If applicable, add screenshots to show what you changed -->


### PR DESCRIPTION


## How and where has this been tested?

 - **How this was tested:** On this actual PR!
 - **Browser(s) and OS(s) this was tested with:** n/a

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->
INCEPTION
![image](https://user-images.githubusercontent.com/201344/65537305-d5df2d80-deb9-11e9-8761-6894e6579e14.png)

## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaning tasks here -->
- [x] This pull request is ready to merge.
