### PR TITLE
test(ci): fix application of classes to docs for theme/scale

### DIFF
--- a/backstop_data/engine_scripts/puppet/injectSpectrumThemeAndScale.js
+++ b/backstop_data/engine_scripts/puppet/injectSpectrumThemeAndScale.js
@@ -16,7 +16,7 @@ module.exports = function (page, scenario) {
   page.evaluate(() => {
     const SCALES = ['medium', 'large'];
     const THEMES = ['lightest', 'light', 'dark', 'darkest'];
-    const bodyElm = document.body;
+    const bodyElm = document.documentElement;
     if (window._spectrumScale && !bodyElm.classList.contains(window._spectrumScale)) {
       // Remove all the theme class
       SCALES.forEach(t => {


### PR DESCRIPTION

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->

It seems that VR testing was applying the `.spectrum` classname in the wrong place, resulting in incorrect output.

## How and where has this been tested?
 - **How this was tested:** Local backstop testing
 - **Browser(s) and OS(s) this was tested with:** n/a


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaning tasks here -->
- [x] This pull request is ready to merge.
