### PR TITLE
chore: update package.json/README.md for all tools/components, add linters

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ The following tasks are available:
 - `gulp buildCombined` - Builds the combined output files (`dist/spectrum-*.css`)
 - `gulp buildStandalone` - Builds the standalone output files (`dist/standalone/spectrum-*.css`)
 - `gulp release` - Performs a release of the top-level package
+- `gulp packageLint` - Lint the `package.json` file for each component in the monorepo
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ The following tasks are available:
 - `gulp buildStandalone` - Builds the standalone output files (`dist/standalone/spectrum-*.css`)
 - `gulp release` - Performs a release of the top-level package
 - `gulp packageLint` - Lint the `package.json` file for each component in the monorepo
+- `gulp readmeLint` - Generate a generic `README.md` file for each component in the monorepo
 
 ## Testing
 

--- a/components/accordion/README.md
+++ b/components/accordion/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/accordion
+> The Spectrum CSS accordion component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/accordion/package.json
+++ b/components/accordion/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/accordion",
   "version": "2.0.0-alpha.6",
   "description": "The Spectrum CSS accordion component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/accordion"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -24,5 +24,9 @@
     "@spectrum-css/icon": "^2.0.0-alpha.6",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/actionbar/README.md
+++ b/components/actionbar/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/actionbar
+> The Spectrum CSS actionbar component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/actionbar/package.json
+++ b/components/actionbar/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/actionbar",
   "version": "2.0.0-alpha.6",
   "description": "The Spectrum CSS actionbar component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/actionbar"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -31,5 +31,9 @@
     "@spectrum-css/table": "^2.0.0-alpha.6",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/actionmenu/README.md
+++ b/components/actionmenu/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/actionmenu
+> The Spectrum CSS actionmenu component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/actionmenu/package.json
+++ b/components/actionmenu/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/actionmenu",
   "version": "2.0.0-alpha.6",
   "description": "The Spectrum CSS actionmenu component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/actionmenu"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -30,5 +30,9 @@
     "@spectrum-css/popover": "^2.0.0-alpha.6",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/alert/README.md
+++ b/components/alert/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/alert
+> The Spectrum CSS alert component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/alert/package.json
+++ b/components/alert/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/alert",
   "version": "2.0.0-alpha.6",
   "description": "The Spectrum CSS alert component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/alert"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -25,5 +25,9 @@
     "@spectrum-css/icon": "^2.0.0-alpha.6",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/asset/README.md
+++ b/components/asset/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/asset
+> The Spectrum CSS asset component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/asset/package.json
+++ b/components/asset/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/asset",
   "version": "2.0.0-alpha.5",
   "description": "The Spectrum CSS asset component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/asset"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -22,5 +22,9 @@
     "@spectrum-css/component-builder": "^1.0.0-alpha.5",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/assetlist/README.md
+++ b/components/assetlist/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/assetlist
+> The Spectrum CSS assetlist component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/assetlist/package.json
+++ b/components/assetlist/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/assetlist",
   "version": "2.0.0-alpha.6",
   "description": "The Spectrum CSS assetlist component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/assetlist"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -26,5 +26,9 @@
     "@spectrum-css/icon": "^2.0.0-alpha.6",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/avatar/README.md
+++ b/components/avatar/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/avatar
+> The Spectrum CSS avatar component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/avatar/package.json
+++ b/components/avatar/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/avatar",
   "version": "2.0.0-alpha.5",
   "description": "The Spectrum CSS avatar component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/avatar"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -22,5 +22,9 @@
     "@spectrum-css/component-builder": "^1.0.0-alpha.5",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/banner/README.md
+++ b/components/banner/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/banner
+> The Spectrum CSS banner component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/banner/package.json
+++ b/components/banner/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/banner",
   "version": "2.0.0-alpha.5",
   "description": "The Spectrum CSS banner component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/banner"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -22,5 +22,9 @@
     "@spectrum-css/component-builder": "^1.0.0-alpha.5",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/barloader/README.md
+++ b/components/barloader/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/barloader
+> The Spectrum CSS barloader component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/barloader/package.json
+++ b/components/barloader/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/barloader",
   "version": "2.0.0-alpha.5",
   "description": "The Spectrum CSS barloader component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/barloader"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -22,5 +22,9 @@
     "@spectrum-css/component-builder": "^1.0.0-alpha.5",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/breadcrumb/README.md
+++ b/components/breadcrumb/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/breadcrumb
+> The Spectrum CSS breadcrumb component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/breadcrumb/package.json
+++ b/components/breadcrumb/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/breadcrumb",
   "version": "2.0.0-alpha.6",
   "description": "The Spectrum CSS breadcrumb component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/breadcrumb"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -26,5 +26,9 @@
     "@spectrum-css/icon": "^2.0.0-alpha.6",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/button/README.md
+++ b/components/button/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/button
+> The Spectrum CSS button component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/button/package.json
+++ b/components/button/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/button",
   "version": "2.0.0-alpha.6",
   "description": "The Spectrum CSS button component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/button"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -23,5 +23,9 @@
     "@spectrum-css/icon": "^2.0.0-alpha.6",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/buttongroup/README.md
+++ b/components/buttongroup/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/buttongroup
+> The Spectrum CSS buttongroup component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/buttongroup/package.json
+++ b/components/buttongroup/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/buttongroup",
   "version": "2.0.0-alpha.6",
   "description": "The Spectrum CSS buttongroup component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/buttongroup"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -25,5 +25,9 @@
     "@spectrum-css/icon": "^2.0.0-alpha.6",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/calendar/README.md
+++ b/components/calendar/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/calendar
+> The Spectrum CSS calendar component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/calendar/package.json
+++ b/components/calendar/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/calendar",
   "version": "2.0.0-alpha.6",
   "description": "The Spectrum CSS calendar component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/calendar"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -26,5 +26,9 @@
     "@spectrum-css/icon": "^2.0.0-alpha.6",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/card/README.md
+++ b/components/card/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/card
+> The Spectrum CSS card component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/card/package.json
+++ b/components/card/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/card",
   "version": "2.0.0-alpha.6",
   "description": "The Spectrum CSS card component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/card"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -32,5 +32,9 @@
     "@spectrum-css/quickaction": "^2.0.0-alpha.6",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/checkbox/README.md
+++ b/components/checkbox/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/checkbox
+> The Spectrum CSS checkbox component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/checkbox/package.json
+++ b/components/checkbox/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/checkbox",
   "version": "2.0.0-alpha.6",
   "description": "The Spectrum CSS checkbox component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/checkbox"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -24,5 +24,9 @@
     "@spectrum-css/icon": "^2.0.0-alpha.6",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/circleloader/README.md
+++ b/components/circleloader/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/circleloader
+> The Spectrum CSS circleloader component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/circleloader/package.json
+++ b/components/circleloader/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/circleloader",
   "version": "2.0.0-alpha.5",
   "description": "The Spectrum CSS circleloader component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/circleloader"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -22,5 +22,9 @@
     "@spectrum-css/component-builder": "^1.0.0-alpha.5",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/coachmark/README.md
+++ b/components/coachmark/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/coachmark
+> The Spectrum CSS coachmark component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/coachmark/package.json
+++ b/components/coachmark/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/coachmark",
   "version": "2.0.0-alpha.6",
   "description": "The Spectrum CSS coachmark component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/coachmark"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -24,5 +24,9 @@
     "@spectrum-css/component-builder": "^1.0.0-alpha.5",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/commons/README.md
+++ b/components/commons/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/commons
+> Common mixins and variables for Spectrum CSS components
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/commons/package.json
+++ b/components/commons/package.json
@@ -2,17 +2,21 @@
   "name": "@spectrum-css/commons",
   "version": "2.0.0-alpha.2",
   "description": "Common mixins and variables for Spectrum CSS components",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/commons"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
   "scripts": {
     "build": "echo 'No build required'"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/cyclebutton/README.md
+++ b/components/cyclebutton/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/cyclebutton
+> The Spectrum CSS cyclebutton component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/cyclebutton/package.json
+++ b/components/cyclebutton/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/cyclebutton",
   "version": "2.0.0-alpha.6",
   "description": "The Spectrum CSS cyclebutton component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/cyclebutton"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -26,5 +26,9 @@
     "@spectrum-css/icon": "^2.0.0-alpha.6",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/decoratedtextfield/README.md
+++ b/components/decoratedtextfield/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/decoratedtextfield
+> The Spectrum CSS decoratedtextfield component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/decoratedtextfield/package.json
+++ b/components/decoratedtextfield/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/decoratedtextfield",
   "version": "2.0.0-alpha.6",
   "description": "The Spectrum CSS decoratedtextfield component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/decoratedtextfield"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -28,5 +28,9 @@
     "@spectrum-css/textfield": "^2.0.0-alpha.5",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/dialog/README.md
+++ b/components/dialog/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/dialog
+> The Spectrum CSS dialog component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/dialog/package.json
+++ b/components/dialog/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/dialog",
   "version": "2.0.0-alpha.6",
   "description": "The Spectrum CSS dialog component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/dialog"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -28,5 +28,9 @@
     "@spectrum-css/underlay": "^2.0.0-alpha.5",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/dropdown/README.md
+++ b/components/dropdown/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/dropdown
+> The Spectrum CSS dropdown component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/dropdown/package.json
+++ b/components/dropdown/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/dropdown",
   "version": "2.0.0-alpha.6",
   "description": "The Spectrum CSS dropdown component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/dropdown"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -30,5 +30,9 @@
     "@spectrum-css/popover": "^2.0.0-alpha.6",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/dropindicator/README.md
+++ b/components/dropindicator/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/dropindicator
+> The Spectrum CSS dropindicator component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/dropindicator/package.json
+++ b/components/dropindicator/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/dropindicator",
   "version": "2.0.0-alpha.6",
   "description": "The Spectrum CSS dropindicator component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/dropindicator"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -24,5 +24,9 @@
     "@spectrum-css/icon": "^2.0.0-alpha.6",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/dropzone/README.md
+++ b/components/dropzone/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/dropzone
+> The Spectrum CSS dropzone component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/dropzone/package.json
+++ b/components/dropzone/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/dropzone",
   "version": "2.0.0-alpha.5",
   "description": "The Spectrum CSS dropzone component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/dropzone"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -26,5 +26,9 @@
     "@spectrum-css/link": "^2.0.0-alpha.5",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/fieldgroup/README.md
+++ b/components/fieldgroup/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/fieldgroup
+> The Spectrum CSS fieldgroup component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/fieldgroup/package.json
+++ b/components/fieldgroup/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/fieldgroup",
   "version": "2.0.0-alpha.6",
   "description": "The Spectrum CSS fieldgroup component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/fieldgroup"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -28,5 +28,9 @@
     "@spectrum-css/radio": "^2.0.0-alpha.6",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/fieldlabel/README.md
+++ b/components/fieldlabel/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/fieldlabel
+> The Spectrum CSS fieldlabel component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/fieldlabel/package.json
+++ b/components/fieldlabel/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/fieldlabel",
   "version": "2.0.0-alpha.6",
   "description": "The Spectrum CSS fieldlabel component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/fieldlabel"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -29,5 +29,9 @@
     "@spectrum-css/textfield": "^2.0.0-alpha.5",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/icon/package.json
+++ b/components/icon/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/icon",
   "version": "2.0.0-alpha.6",
   "description": "The Spectrum CSS icon component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/icon"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -29,5 +29,9 @@
     "gulp-svgcombiner": "^1.0.1",
     "gulp-svgmin": "^2.1.0",
     "gulp-svgstore": "^7.0.1"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/illustratedmessage/README.md
+++ b/components/illustratedmessage/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/illustratedmessage
+> The Spectrum CSS illustratedmessage component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/illustratedmessage/package.json
+++ b/components/illustratedmessage/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/illustratedmessage",
   "version": "2.0.0-alpha.5",
   "description": "The Spectrum CSS illustratedmessage component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/illustratedmessage"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -24,5 +24,9 @@
     "@spectrum-css/typography": "^2.0.0-alpha.5",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/inputgroup/README.md
+++ b/components/inputgroup/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/inputgroup
+> The Spectrum CSS inputgroup component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/inputgroup/package.json
+++ b/components/inputgroup/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/inputgroup",
   "version": "2.0.0-alpha.6",
   "description": "The Spectrum CSS inputgroup component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/inputgroup"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -29,5 +29,9 @@
     "@spectrum-css/textfield": "^2.0.0-alpha.5",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/label/README.md
+++ b/components/label/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/label
+> The Spectrum CSS label component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/label/package.json
+++ b/components/label/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/label",
   "version": "2.0.0-alpha.5",
   "description": "The Spectrum CSS label component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/label"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -22,5 +22,9 @@
     "@spectrum-css/component-builder": "^1.0.0-alpha.5",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/link/README.md
+++ b/components/link/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/link
+> The Spectrum CSS link component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/link/package.json
+++ b/components/link/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/link",
   "version": "2.0.0-alpha.5",
   "description": "The Spectrum CSS link component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/link"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -22,5 +22,9 @@
     "@spectrum-css/component-builder": "^1.0.0-alpha.5",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/menu/README.md
+++ b/components/menu/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/menu
+> The Spectrum CSS menu component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/menu/package.json
+++ b/components/menu/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/menu",
   "version": "2.0.0-alpha.6",
   "description": "The Spectrum CSS menu component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/menu"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -24,5 +24,9 @@
     "@spectrum-css/icon": "^2.0.0-alpha.6",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/miller/README.md
+++ b/components/miller/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/miller
+> The Spectrum CSS miller component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/miller/package.json
+++ b/components/miller/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/miller",
   "version": "2.0.0-alpha.6",
   "description": "The Spectrum CSS miller component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/miller"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -28,5 +28,9 @@
     "@spectrum-css/icon": "^2.0.0-alpha.6",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/overlay/README.md
+++ b/components/overlay/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/overlay
+> Overlay mixin
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/overlay/package.json
+++ b/components/overlay/package.json
@@ -2,17 +2,21 @@
   "name": "@spectrum-css/overlay",
   "version": "2.0.0-alpha.1",
   "description": "Overlay mixin",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/overlay"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
   "scripts": {
     "build": "echo 'No build required'"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/page/README.md
+++ b/components/page/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/page
+> The Spectrum CSS page component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/page/package.json
+++ b/components/page/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/page",
   "version": "2.0.0-alpha.5",
   "description": "The Spectrum CSS page component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/page"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -22,5 +22,9 @@
     "@spectrum-css/component-builder": "^1.0.0-alpha.5",
     "@spectrum-css/vars": "^1.0.0-alpha.0",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/pagination/README.md
+++ b/components/pagination/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/pagination
+> The Spectrum CSS pagination component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/pagination/package.json
+++ b/components/pagination/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/pagination",
   "version": "2.0.0-alpha.6",
   "description": "The Spectrum CSS pagination component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/pagination"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -30,5 +30,9 @@
     "@spectrum-css/textfield": "^2.0.0-alpha.5",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/popover/README.md
+++ b/components/popover/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/popover
+> The Spectrum CSS popover component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/popover/package.json
+++ b/components/popover/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/popover",
   "version": "2.0.0-alpha.6",
   "description": "The Spectrum CSS popover component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/popover"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -25,5 +25,9 @@
     "@spectrum-css/menu": "^2.0.0-alpha.6",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/quickaction/README.md
+++ b/components/quickaction/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/quickaction
+> The Spectrum CSS quickaction component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/quickaction/package.json
+++ b/components/quickaction/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/quickaction",
   "version": "2.0.0-alpha.6",
   "description": "The Spectrum CSS quickaction component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/quickaction"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -25,5 +25,9 @@
     "@spectrum-css/component-builder": "^1.0.0-alpha.5",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/radio/README.md
+++ b/components/radio/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/radio
+> The Spectrum CSS radio component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/radio/package.json
+++ b/components/radio/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/radio",
   "version": "2.0.0-alpha.6",
   "description": "The Spectrum CSS radio component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/radio"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -24,5 +24,9 @@
     "@spectrum-css/icon": "^2.0.0-alpha.6",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/rating/README.md
+++ b/components/rating/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/rating
+> The Spectrum CSS rating component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/rating/package.json
+++ b/components/rating/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/rating",
   "version": "2.0.0-alpha.6",
   "description": "The Spectrum CSS rating component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/rating"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -24,5 +24,9 @@
     "@spectrum-css/icon": "^2.0.0-alpha.6",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/rule/README.md
+++ b/components/rule/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/rule
+> The Spectrum CSS rule component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/rule/package.json
+++ b/components/rule/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/rule",
   "version": "2.0.0-alpha.6",
   "description": "The Spectrum CSS rule component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/rule"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -23,5 +23,9 @@
     "@spectrum-css/component-builder": "^1.0.0-alpha.5",
     "@spectrum-css/vars": "^1.0.0-alpha.0",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/search/README.md
+++ b/components/search/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/search
+> The Spectrum CSS search component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/search/package.json
+++ b/components/search/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/search",
   "version": "2.0.0-alpha.7",
   "description": "The Spectrum CSS search component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/search"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -28,5 +28,9 @@
     "@spectrum-css/textfield": "^2.0.0-alpha.5",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/searchwithin/README.md
+++ b/components/searchwithin/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/searchwithin
+> The Spectrum CSS searchwithin component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/searchwithin/package.json
+++ b/components/searchwithin/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/searchwithin",
   "version": "2.0.0-alpha.6",
   "description": "The Spectrum CSS searchwithin component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/searchwithin"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -30,5 +30,9 @@
     "@spectrum-css/textfield": "^1.0.0-alpha.0",
     "@spectrum-css/vars": "^1.0.0-alpha.0",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/sidenav/README.md
+++ b/components/sidenav/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/sidenav
+> The Spectrum CSS sidenav component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/sidenav/package.json
+++ b/components/sidenav/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/sidenav",
   "version": "2.0.0-alpha.6",
   "description": "The Spectrum CSS sidenav component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/sidenav"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -23,5 +23,9 @@
     "@spectrum-css/icon": "^2.0.0-alpha.6",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/site/README.md
+++ b/components/site/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/site
+> The Spectrum CSS Site component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/site/package.json
+++ b/components/site/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/site",
   "version": "1.0.0-alpha.1",
   "description": "The Spectrum CSS Site component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/site"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -22,5 +22,9 @@
     "@spectrum-css/component-builder": "^1.0.0-alpha.5",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/slider/README.md
+++ b/components/slider/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/slider
+> The Spectrum CSS slider component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/slider/package.json
+++ b/components/slider/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/slider",
   "version": "2.0.0-alpha.5",
   "description": "The Spectrum CSS slider component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/slider"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -22,5 +22,9 @@
     "@spectrum-css/component-builder": "^1.0.0-alpha.5",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/splitbutton/README.md
+++ b/components/splitbutton/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/splitbutton
+> The Spectrum CSS splitbutton component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/splitbutton/package.json
+++ b/components/splitbutton/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/splitbutton",
   "version": "2.0.0-alpha.6",
   "description": "The Spectrum CSS splitbutton component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/splitbutton"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -25,5 +25,9 @@
     "@spectrum-css/icon": "^2.0.0-alpha.6",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/splitview/README.md
+++ b/components/splitview/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/splitview
+> The Spectrum CSS splitview component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/splitview/package.json
+++ b/components/splitview/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/splitview",
   "version": "2.0.0-alpha.5",
   "description": "The Spectrum CSS splitview component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/splitview"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -22,5 +22,9 @@
     "@spectrum-css/component-builder": "^1.0.0-alpha.5",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/statuslight/README.md
+++ b/components/statuslight/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/statuslight
+> The Spectrum CSS statuslight component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/statuslight/package.json
+++ b/components/statuslight/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/statuslight",
   "version": "2.0.0-alpha.5",
   "description": "The Spectrum CSS statuslight component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/statuslight"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -22,5 +22,9 @@
     "@spectrum-css/component-builder": "^1.0.0-alpha.5",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/steplist/README.md
+++ b/components/steplist/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/steplist
+> The Spectrum CSS steplist component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/steplist/package.json
+++ b/components/steplist/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/steplist",
   "version": "2.0.0-alpha.6",
   "description": "The Spectrum CSS steplist component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/steplist"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -25,5 +25,9 @@
     "@spectrum-css/tooltip": "^2.0.0-alpha.6",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/stepper/README.md
+++ b/components/stepper/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/stepper
+> The Spectrum CSS stepper component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/stepper/package.json
+++ b/components/stepper/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/stepper",
   "version": "2.0.0-alpha.6",
   "description": "The Spectrum CSS stepper component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/stepper"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -28,5 +28,9 @@
     "@spectrum-css/textfield": "^2.0.0-alpha.5",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/table/README.md
+++ b/components/table/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/table
+> The Spectrum CSS table component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/table/package.json
+++ b/components/table/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/table",
   "version": "2.0.0-alpha.6",
   "description": "The Spectrum CSS table component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/table"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -25,5 +25,9 @@
     "@spectrum-css/icon": "^2.0.0-alpha.6",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/tabs/README.md
+++ b/components/tabs/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/tabs
+> The Spectrum CSS tabs component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/tabs/package.json
+++ b/components/tabs/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/tabs",
   "version": "2.0.0-alpha.6",
   "description": "The Spectrum CSS tabs component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/tabs"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -27,5 +27,9 @@
     "@spectrum-css/menu": "^2.0.0-alpha.6",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/tags/README.md
+++ b/components/tags/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/tags
+> The Spectrum CSS tags component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/tags/package.json
+++ b/components/tags/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/tags",
   "version": "2.0.0-alpha.6",
   "description": "The Spectrum CSS tags component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/tags"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -26,5 +26,9 @@
     "@spectrum-css/icon": "^2.0.0-alpha.6",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/textfield/README.md
+++ b/components/textfield/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/textfield
+> The Spectrum CSS textfield component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/textfield/package.json
+++ b/components/textfield/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/textfield",
   "version": "2.0.0-alpha.5",
   "description": "The Spectrum CSS textfield component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/textfield"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -22,5 +22,9 @@
     "@spectrum-css/component-builder": "^1.0.0-alpha.5",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/toast/README.md
+++ b/components/toast/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/toast
+> The Spectrum CSS toast component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/toast/package.json
+++ b/components/toast/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/toast",
   "version": "2.0.0-alpha.6",
   "description": "The Spectrum CSS toast component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/toast"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -26,5 +26,9 @@
     "@spectrum-css/icon": "^2.0.0-alpha.6",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/toggle/README.md
+++ b/components/toggle/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/toggle
+> The Spectrum CSS toggle component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/toggle/package.json
+++ b/components/toggle/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/toggle",
   "version": "2.0.0-alpha.5",
   "description": "The Spectrum CSS toggle component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/toggle"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -22,5 +22,9 @@
     "@spectrum-css/component-builder": "^1.0.0-alpha.5",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/tooltip/README.md
+++ b/components/tooltip/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/tooltip
+> The Spectrum CSS tooltip component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/tooltip/package.json
+++ b/components/tooltip/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/tooltip",
   "version": "2.0.0-alpha.6",
   "description": "The Spectrum CSS tooltip component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/tooltip"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -24,5 +24,9 @@
     "@spectrum-css/icon": "^2.0.0-alpha.6",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/treeview/README.md
+++ b/components/treeview/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/treeview
+> The Spectrum CSS treeview component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/treeview/package.json
+++ b/components/treeview/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/treeview",
   "version": "2.0.0-alpha.6",
   "description": "The Spectrum CSS treeview component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/treeview"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -24,5 +24,9 @@
     "@spectrum-css/icon": "^2.0.0-alpha.6",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/typography/README.md
+++ b/components/typography/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/typography
+> The Spectrum CSS typography component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/typography/package.json
+++ b/components/typography/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/typography",
   "version": "2.0.0-alpha.5",
   "description": "The Spectrum CSS typography component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/typography"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -22,5 +22,9 @@
     "@spectrum-css/component-builder": "^1.0.0-alpha.5",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/underlay/README.md
+++ b/components/underlay/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/underlay
+> The Spectrum CSS underlay component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/underlay/package.json
+++ b/components/underlay/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/underlay",
   "version": "2.0.0-alpha.5",
   "description": "The Spectrum CSS underlay component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/underlay"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -22,5 +22,9 @@
     "@spectrum-css/component-builder": "^1.0.0-alpha.5",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/vars/package.json
+++ b/components/vars/package.json
@@ -2,7 +2,6 @@
   "name": "@spectrum-css/vars",
   "version": "2.0.0-alpha.3",
   "description": "The Spectrum CSS vars package",
-  "author": "",
   "license": "Apache-2.0",
   "main": "js/index.js",
   "scripts": {
@@ -10,7 +9,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/vars"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -23,5 +23,9 @@
     "postcss": "^5.2.18",
     "replace-ext": "^1.0.0",
     "through2": "^3.0.1"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/components/well/README.md
+++ b/components/well/README.md
@@ -1,0 +1,6 @@
+# @spectrum-css/well
+> The Spectrum CSS well component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/well/package.json
+++ b/components/well/package.json
@@ -2,12 +2,12 @@
   "name": "@spectrum-css/well",
   "version": "2.0.0-alpha.5",
   "description": "The Spectrum CSS well component",
-  "author": "",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/well"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
@@ -22,5 +22,9 @@
     "@spectrum-css/component-builder": "^1.0.0-alpha.5",
     "@spectrum-css/vars": "^2.0.0-alpha.3",
     "gulp": "^4.0.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/"
 }

--- a/package.json
+++ b/package.json
@@ -36,11 +36,11 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@adobe/spectrum-css-workflow-icons": "^1.0.0-beta.6",
     "@adobe/focus-ring-polyfill": "^0.1.5",
-    "@spectrum-css/spectrum-css-vr-test-asset": "^1.0.1",
+    "@adobe/spectrum-css-workflow-icons": "^1.0.0-beta.6",
     "@commitlint/cli": "^8.1.0",
     "@commitlint/config-conventional": "^8.1.0",
+    "@spectrum-css/spectrum-css-vr-test-asset": "^1.0.1",
     "audit-ci": "^2.0.1",
     "backstopjs": "^4.3.2",
     "gulp": "^4.0.0",
@@ -50,7 +50,8 @@
     "loadicons": "^1.0.0",
     "lunr": "^2.3.6",
     "markdown": "^0.5.0",
-    "prismjs": "^1.17.1"
+    "prismjs": "^1.17.1",
+    "through2": "^3.0.1"
   },
   "optionalDependencies": {
     "@a4u/a4u-collection-essential-ui-icons-release": "^4.1.0",

--- a/tools/bundle-builder/package.json
+++ b/tools/bundle-builder/package.json
@@ -4,7 +4,8 @@
   "description": "The Spectrum CSS top-level builder",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "tools/bundle-builder"
   },
   "author": "Larry Davis <lazdnet@gmail.com>",
   "contributors": [
@@ -14,6 +15,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "license": "Apache-2.0",
   "devDependencies": {
     "browser-sync": "^2.26.7",
     "colors": "^1.3.3",

--- a/tools/component-builder/package.json
+++ b/tools/component-builder/package.json
@@ -2,18 +2,15 @@
   "name": "@spectrum-css/component-builder",
   "version": "1.0.0-alpha.5",
   "description": "The Spectrum CSS component builder",
-  "author": "",
-  "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "tools/component-builder"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
-  "publishConfig": {
-    "directory": "./"
-  },
+  "license": "Apache-2.0",
   "dependencies": {
     "autoprefixer": "^6.5.3",
     "browser-sync": "^2.26.7",

--- a/tools/conventional-changelog-spectrum/package.json
+++ b/tools/conventional-changelog-spectrum/package.json
@@ -9,7 +9,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/conventional-changelog/conventional-changelog.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "tools/conventional-changelog-spectrum"
+  },
+  "bugs": {
+    "url": "https://github.com/adobe/spectrum-css/issues"
   },
   "keywords": [
     "conventional-changelog",

--- a/tools/test-builder/package.json
+++ b/tools/test-builder/package.json
@@ -1,19 +1,17 @@
 {
   "name": "@spectrum-css/test-builder",
   "version": "1.0.0-alpha.1",
-  "description": "The Spectrum CSS component builder",
-  "author": "",
-  "license": "Apache-2.0",
+  "private": true,
+  "description": "The Spectrum CSS text builder",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "tools/test-builder"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
-  "publishConfig": {
-    "directory": "./"
-  },
+  "license": "Apache-2.0",
   "dependencies": {
     "del": "^5.0.0",
     "gulp": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4670,10 +4670,10 @@ gulplog@^1.0.0:
   dependencies:
     glogg "^1.0.0"
 
-handlebars@^4.1.2:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.2.0.tgz#57ce8d2175b9bbb3d8b3cf3e4217b1aec8ddcb2e"
-  integrity sha512-Kb4xn5Qh1cxAKvQnzNWZ512DhABzyFNmsaJf3OAkWNa4NkaqWcNI8Tao8Tasi0/F4JD9oyG0YxuFyvyR57d+Gw==
+handlebars@^4.1.2, handlebars@^4.3.0:
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.3.3.tgz#56dd05fe33d6bd8a7d797351c39a0cdcfd576be5"
+  integrity sha512-VupOxR91xcGojfINrzMqrvlyYbBs39sXIrWa7YdaQWeBudOlvKEGvCczMfJPgnuwHE/zyH1M6J+IUP6cgDVyxg==
   dependencies:
     neo-async "^2.6.0"
     optimist "^0.6.1"


### PR DESCRIPTION
## Description

This PR addresses SDS-2444 and SDS-2445.

A new command, `gulp packageLint`, has been added to perform linting/fixing of the `package.json` files in the repo. This ensures the repository, license, and homepage fields are defined, and does not allow a blank author field.

A new command, `gulp readmeLint`, has been added to generate generic `README.md` files for each component in the repo. The generic README content was approved by content strategy.

## How and where has this been tested?
 - **How this was tested:** `gulp packageLint readmeLint; git diff`
 - **Browser(s) and OS(s) this was tested with:** n/a

## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaning tasks here -->
- [x] This pull request is ready to merge.
