### PR TITLE
chore: refactor Calendar header to use flexbox per issue #269

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,13 @@ Check out the [contributing guidelines](.github/CONTRIBUTING.md) for quick start
 Run the following commands:
 
 ```
+# install lerna and gulp globally (only necessary the first time)
+npm install --g lerna
 npm install -g gulp-cli
-npm install
+```
+
+```
+lerna bootstrap
 gulp dev
 ```
 

--- a/README.md
+++ b/README.md
@@ -132,13 +132,8 @@ Check out the [contributing guidelines](.github/CONTRIBUTING.md) for quick start
 Run the following commands:
 
 ```
-# install lerna and gulp globally (only necessary the first time)
-npm install --g lerna
 npm install -g gulp-cli
-```
-
-```
-lerna bootstrap
+npm install
 gulp dev
 ```
 

--- a/components/calendar/index.css
+++ b/components/calendar/index.css
@@ -28,17 +28,13 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Calendar-header {
-  position: relative;
+  display: flex;
   box-sizing: border-box;
   width: 100%;
   height: var(--spectrum-calendar-title-height);
 }
 
 .spectrum-Calendar-title {
-  position: absolute;
-  left: 0;
-  top: 0;
-
   font-size: var(--spectrum-calendar-title-text-size);
   font-weight: bold;
 
@@ -47,6 +43,7 @@ governing permissions and limitations under the License.
   line-height: var(--spectrum-calendar-title-height);
   margin: 0;
   padding: 0 var(--spectrum-calendar-title-height);
+  order: 1;
 
   text-align: center;
   overflow: hidden;
@@ -54,18 +51,14 @@ governing permissions and limitations under the License.
   text-overflow: ellipsis;
 }
 
-.spectrum-Calendar-prevMonth,
-.spectrum-Calendar-nextMonth {
-  position: absolute;
-
-}
-
 .spectrum-Calendar-prevMonth {
   left: 3px;
+  order: 0;
 }
 
 .spectrum-Calendar-nextMonth {
   right: 3px;
+  order: 2;
 }
 
 .spectrum-Calendar-dayOfWeek {

--- a/components/calendar/index.css
+++ b/components/calendar/index.css
@@ -38,12 +38,11 @@ governing permissions and limitations under the License.
   font-size: var(--spectrum-calendar-title-text-size);
   font-weight: bold;
 
-  box-sizing: border-box;
-  width: 100%;
   line-height: var(--spectrum-calendar-title-height);
   margin: 0;
   padding: 0 var(--spectrum-calendar-title-height);
   order: 1;
+  flex-grow: 1;
 
   text-align: center;
   overflow: hidden;
@@ -52,12 +51,12 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Calendar-prevMonth {
-  left: 3px;
+  margin-left: 3px;
   order: 0;
 }
 
 .spectrum-Calendar-nextMonth {
-  right: 3px;
+  margin-right: 3px;
   order: 2;
 }
 


### PR DESCRIPTION
# Refactor Calendar header to use flexbox per issue #269 

## Description
Changes display styling on Calender heading away from absolute positioning to flexbox order.

## How and where has this been tested?
Tested in Chrome, Safari and FireFox

## Screenshots
<img width="1127" alt="Screen Shot 2019-10-01 at 8 21 51 AM" src="https://user-images.githubusercontent.com/3717760/65977011-09740780-e426-11e9-8d97-8569bc114d5e.png">

While setting the parent to `dir="rtl"` switches the next and previous buttons there is still a need for a modifier selector to flip the caret direction. 

<img width="1149" alt="Screen Shot 2019-10-01 at 8 23 13 AM" src="https://user-images.githubusercontent.com/3717760/65977012-09740780-e426-11e9-9e32-cc6bfb2a7c85.png">

