### PR TITLE
docs: fix quickstart docs to reference yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ Check out the [contributing guidelines](.github/CONTRIBUTING.md) for quick start
 Run the following commands:
 
 ```
-npm install -g gulp-cli
-npm install
+yarn global add gulp-cli
+yarn install
 gulp dev
 ```
 


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->

The README still references `npm` for package installations, this PR fixes that. This was discovered during work on #269 

## How and where has this been tested?
 - **How this was tested:** commands ran on terminal
 - **Browser(s) and OS(s) this was tested with:** n/a


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaning tasks here -->
- [x] This pull request is ready to merge.
