### PR TITLE
fix: fix Calendar title wrapping/alignment, related to #269

### DIFF
--- a/components/calendar/index.css
+++ b/components/calendar/index.css
@@ -17,9 +17,11 @@ governing permissions and limitations under the License.
   --spectrum-calendar-border-width-reset: 0;
   --spectrum-calendar-margin-y: 24px;
   --spectrum-calendar-margin-x: 32px;
+  --spectrum-calendar-width: calc((var(--spectrum-calendar-day-width) + var(--spectrum-calendar-day-padding) * 2) * 7);
 }
 
 .spectrum-Calendar {
+  width: var(--spectrum-calendar-width);
   display: inline-block;
 }
 
@@ -29,9 +31,8 @@ governing permissions and limitations under the License.
 
 .spectrum-Calendar-header {
   display: flex;
-  box-sizing: border-box;
   width: 100%;
-  height: var(--spectrum-calendar-title-height);
+  align-items: center;
 }
 
 .spectrum-Calendar-title {
@@ -40,7 +41,6 @@ governing permissions and limitations under the License.
 
   line-height: var(--spectrum-calendar-title-height);
   margin: 0;
-  padding: 0 var(--spectrum-calendar-title-height);
   order: 1;
   flex-grow: 1;
 

--- a/components/calendar/index.css
+++ b/components/calendar/index.css
@@ -18,6 +18,7 @@ governing permissions and limitations under the License.
   --spectrum-calendar-margin-y: 24px;
   --spectrum-calendar-margin-x: 32px;
   --spectrum-calendar-width: calc((var(--spectrum-calendar-day-width) + var(--spectrum-calendar-day-padding) * 2) * 7);
+  --spectrum-calendar-button-gap: var(--spectrum-global-dimension-size-40);
 }
 
 .spectrum-Calendar {
@@ -44,6 +45,8 @@ governing permissions and limitations under the License.
   order: 1;
   flex-grow: 1;
 
+  padding: 0 var(--spectrum-calendar-button-gap);
+
   text-align: center;
   overflow: hidden;
   white-space: nowrap;
@@ -51,12 +54,12 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Calendar-prevMonth {
-  margin-left: 3px;
+  margin: 0 !important; /* override adjacent sibling selector from ActionButton */
   order: 0;
 }
 
 .spectrum-Calendar-nextMonth {
-  margin-right: 3px;
+  margin: 0 !important; /* override adjacent sibling selector from ActionButton */
   order: 2;
 }
 

--- a/components/calendar/index.css
+++ b/components/calendar/index.css
@@ -45,7 +45,6 @@ governing permissions and limitations under the License.
   order: 1;
   flex-grow: 1;
 
-  padding: 0 var(--spectrum-calendar-button-gap);
 
   text-align: center;
   overflow: hidden;
@@ -53,13 +52,16 @@ governing permissions and limitations under the License.
   text-overflow: ellipsis;
 }
 
+.spectrum-Calendar-prevMonth,
+.spectrum-Calendar-nextMonth {
+  margin: 0 var(--spectrum-calendar-button-gap) !important; /* override adjacent sibling selector from ActionButton */
+}
+
 .spectrum-Calendar-prevMonth {
-  margin: 0 !important; /* override adjacent sibling selector from ActionButton */
   order: 0;
 }
 
 .spectrum-Calendar-nextMonth {
-  margin: 0 !important; /* override adjacent sibling selector from ActionButton */
   order: 2;
 }
 

--- a/components/calendar/index.css
+++ b/components/calendar/index.css
@@ -52,9 +52,11 @@ governing permissions and limitations under the License.
   text-overflow: ellipsis;
 }
 
-.spectrum-Calendar-prevMonth,
-.spectrum-Calendar-nextMonth {
-  margin: 0 var(--spectrum-calendar-button-gap) !important; /* override adjacent sibling selector from ActionButton */
+.spectrum-Calendar {
+  .spectrum-Calendar-prevMonth,
+  .spectrum-Calendar-nextMonth {
+    margin: 0 var(--spectrum-calendar-button-gap);
+  }
 }
 
 .spectrum-Calendar-prevMonth {


### PR DESCRIPTION
## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->

While testing for the 2.14 release, I discovered some extra padding on the calendar heading, and when removed, I found that calendar headings no longer truncate correctly or align vertically in the large scale. Also, the horizontal alignment of the text was wrong due to an Action Button margin applied to adjacent siblings. This fixes all that. 

This relates to work done in #269 

## How and where has this been tested?
 - **How this was tested:** Load up docs, give a calendar a large heading like `August of the good year 2017`, it should truncate, switch to large scale, it should line up vertically
 - **Browser(s) and OS(s) this was tested with:** Chrome 77 on macOS

## Screenshots

![image](https://user-images.githubusercontent.com/201344/66340776-c8cf2f00-e8fa-11e9-8b5f-45484733b7f5.png)
![image](https://user-images.githubusercontent.com/201344/66340789-ce2c7980-e8fa-11e9-9ec2-1276504e6d04.png)

![image](https://user-images.githubusercontent.com/201344/66340757-bce36d00-e8fa-11e9-86c9-6092f6bf92fd.png)


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaning tasks here -->
- [x] This pull request is ready to merge.
