### PR TITLE
Rating - Adds container around icons for visible keyboard focus

### DIFF
--- a/components/rating/index.css
+++ b/components/rating/index.css
@@ -39,7 +39,23 @@ governing permissions and limitations under the License.
 
   width: calc(var(--spectrum-rating-icon-width) * var(--spectrum-rating-icon-count));
 
+  background: transparent;
+  
+  border: 0;
   border-radius: var(--spectrum-rating-border-radius);
+  outline: 0;
+
+  margin: 0;
+  padding: 0;
+
+  /* Remove the inheritance of text transform on button in Edge, Firefox, and IE. */
+  text-transform: none;
+  -webkit-font-smoothing: antialiased;
+  /* Font smoothing for Firefox */
+  -moz-osx-font-smoothing: grayscale;
+
+  /* Correct the inability to style clickable types in iOS and Safari. */
+  -webkit-appearance: button;
 
   cursor: pointer;
 

--- a/components/rating/index.css
+++ b/components/rating/index.css
@@ -33,30 +33,6 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Rating {
-  position: relative;
-  display: inline-flex;
-  flex: 0 0 auto;
-
-  width: calc(var(--spectrum-rating-icon-width) * var(--spectrum-rating-icon-count));
-
-  background: transparent;
-  
-  border: 0;
-  border-radius: var(--spectrum-rating-border-radius);
-  outline: 0;
-
-  margin: 0;
-  padding: 0;
-
-  /* Remove the inheritance of text transform on button in Edge, Firefox, and IE. */
-  text-transform: none;
-  -webkit-font-smoothing: antialiased;
-  /* Font smoothing for Firefox */
-  -moz-osx-font-smoothing: grayscale;
-
-  /* Correct the inability to style clickable types in iOS and Safari. */
-  -webkit-appearance: button;
-
   cursor: pointer;
 
   &.is-disabled,
@@ -71,6 +47,16 @@ governing permissions and limitations under the License.
       @extend %spectrum-Rating-filledStar;
     }
   }
+}
+
+.spectrum-Rating-containter {
+  position: relative;
+  display: inline-flex;
+  flex: 0 0 auto;
+
+  width: calc(var(--spectrum-rating-icon-width) * var(--spectrum-rating-icon-count));
+
+  border-radius: var(--spectrum-rating-border-radius);
 }
 
 .spectrum-Rating-input {

--- a/components/rating/index.css
+++ b/components/rating/index.css
@@ -33,7 +33,13 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Rating {
+  display: inline-block;
+
+  line-height: 0;
+
   cursor: pointer;
+
+  width: calc(var(--spectrum-rating-icon-width) * var(--spectrum-rating-icon-count));
 
   &.is-disabled,
   &.is-readOnly {
@@ -53,8 +59,6 @@ governing permissions and limitations under the License.
   position: relative;
   display: inline-flex;
   flex: 0 0 auto;
-
-  width: calc(var(--spectrum-rating-icon-width) * var(--spectrum-rating-icon-count));
 
   border-radius: var(--spectrum-rating-border-radius);
 }

--- a/components/rating/index.css
+++ b/components/rating/index.css
@@ -49,7 +49,7 @@ governing permissions and limitations under the License.
   }
 }
 
-.spectrum-Rating-containter {
+.spectrum-Rating-container {
   position: relative;
   display: inline-flex;
   flex: 0 0 auto;

--- a/components/rating/metadata/rating.yml
+++ b/components/rating/metadata/rating.yml
@@ -4,358 +4,372 @@ examples:
   - id: rating
     name: Standard
     markup: |
-      <button class="spectrum-Rating">
+      <div class="spectrum-Rating">
         <input class="spectrum-Rating-input" type="range" min="0" max="5" value="0" aria-label="Rating">
 
-        <span class="spectrum-Rating-icon">
-          <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Star"></use>
-          </svg>
-          <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-StarOutline"></use>
-          </svg>
-        </span>
+        <div class="spectrum-Rating-containter">
+          <span class="spectrum-Rating-icon">
+            <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Star"></use>
+            </svg>
+            <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-StarOutline"></use>
+            </svg>
+          </span>
 
-        <span class="spectrum-Rating-icon">
-          <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Star"></use>
-          </svg>
-          <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-StarOutline"></use>
-          </svg>
-        </span>
+          <span class="spectrum-Rating-icon">
+            <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Star"></use>
+            </svg>
+            <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-StarOutline"></use>
+            </svg>
+          </span>
 
-        <span class="spectrum-Rating-icon">
-          <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Star"></use>
-          </svg>
-          <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-StarOutline"></use>
-          </svg>
-        </span>
+          <span class="spectrum-Rating-icon">
+            <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Star"></use>
+            </svg>
+            <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-StarOutline"></use>
+            </svg>
+          </span>
 
-        <span class="spectrum-Rating-icon">
-          <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Star"></use>
-          </svg>
-          <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-StarOutline"></use>
-          </svg>
-        </span>
+          <span class="spectrum-Rating-icon">
+            <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Star"></use>
+            </svg>
+            <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-StarOutline"></use>
+            </svg>
+          </span>
 
-        <span class="spectrum-Rating-icon">
-          <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Star"></use>
-          </svg>
-          <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-StarOutline"></use>
-          </svg>
-        </span>
-      </button>
+          <span class="spectrum-Rating-icon">
+            <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Star"></use>
+            </svg>
+            <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-StarOutline"></use>
+            </svg>
+          </span>
+        </div>
+      </div>
   - id: rating
     name: Selected
     markup: |
-      <button class="spectrum-Rating">
+      <div class="spectrum-Rating">
         <input class="spectrum-Rating-input" type="range" min="0" max="5" value="0" aria-label="Rating">
 
-        <span class="spectrum-Rating-icon is-selected">
-          <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Star"></use>
-          </svg>
-          <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-StarOutline"></use>
-          </svg>
-        </span>
+        <div class="spectrum-Rating-containter">
+          <span class="spectrum-Rating-icon is-selected">
+            <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Star"></use>
+            </svg>
+            <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-StarOutline"></use>
+            </svg>
+          </span>
 
-        <span class="spectrum-Rating-icon is-selected">
-          <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Star"></use>
-          </svg>
-          <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-StarOutline"></use>
-          </svg>
-        </span>
+          <span class="spectrum-Rating-icon is-selected">
+            <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Star"></use>
+            </svg>
+            <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-StarOutline"></use>
+            </svg>
+          </span>
 
-        <span class="spectrum-Rating-icon is-selected is-currentValue">
-          <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Star"></use>
-          </svg>
-          <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-StarOutline"></use>
-          </svg>
-        </span>
+          <span class="spectrum-Rating-icon is-selected is-currentValue">
+            <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Star"></use>
+            </svg>
+            <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-StarOutline"></use>
+            </svg>
+          </span>
 
-        <span class="spectrum-Rating-icon">
-          <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Star"></use>
-          </svg>
-          <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-StarOutline"></use>
-          </svg>
-        </span>
+          <span class="spectrum-Rating-icon">
+            <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Star"></use>
+            </svg>
+            <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-StarOutline"></use>
+            </svg>
+          </span>
 
-        <span class="spectrum-Rating-icon">
-          <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Star"></use>
-          </svg>
-          <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-StarOutline"></use>
-          </svg>
-        </span>
-      </button>
+          <span class="spectrum-Rating-icon">
+            <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Star"></use>
+            </svg>
+            <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-StarOutline"></use>
+            </svg>
+          </span>
+        </div>
+      </div>
   - id: rating
     name: Read-only
     description: A non-interactive rating.
     markup: |
-      <button class="spectrum-Rating is-readOnly">
-        <input class="spectrum-Rating-input" type="range" min="0" max="5" value="0" readOnly aria-label="Rating">
+      <div class="spectrum-Rating is-readOnly">
+        <input class="spectrum-Rating-input" type="range" min="0" max="5" value="0" readOnly aria-label="Rating" readonly>
 
-        <span class="spectrum-Rating-icon is-selected">
-          <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Star"></use>
-          </svg>
-          <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-StarOutline"></use>
-          </svg>
-        </span>
+        <div class="spectrum-Rating-containter">
+          <span class="spectrum-Rating-icon is-selected">
+            <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Star"></use>
+            </svg>
+            <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-StarOutline"></use>
+            </svg>
+          </span>
 
-        <span class="spectrum-Rating-icon is-selected">
-          <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Star"></use>
-          </svg>
-          <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-StarOutline"></use>
-          </svg>
-        </span>
+          <span class="spectrum-Rating-icon is-selected">
+            <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Star"></use>
+            </svg>
+            <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-StarOutline"></use>
+            </svg>
+          </span>
 
-        <span class="spectrum-Rating-icon is-selected is-currentValue">
-          <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Star"></use>
-          </svg>
-          <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-StarOutline"></use>
-          </svg>
-        </span>
+          <span class="spectrum-Rating-icon is-selected is-currentValue">
+            <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Star"></use>
+            </svg>
+            <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-StarOutline"></use>
+            </svg>
+          </span>
 
-        <span class="spectrum-Rating-icon">
-          <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Star"></use>
-          </svg>
-          <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-StarOutline"></use>
-          </svg>
-        </span>
+          <span class="spectrum-Rating-icon">
+            <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Star"></use>
+            </svg>
+            <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-StarOutline"></use>
+            </svg>
+          </span>
 
-        <span class="spectrum-Rating-icon">
-          <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Star"></use>
-          </svg>
-          <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-StarOutline"></use>
-          </svg>
-        </span>
-      </button>
+          <span class="spectrum-Rating-icon">
+            <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Star"></use>
+            </svg>
+            <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-StarOutline"></use>
+            </svg>
+          </span>
+        </div>
+      </div>
   - id: rating-quiet
     name: Quiet
     markup: |
-      <button class="spectrum-Rating spectrum-Rating--quiet">
+      <div class="spectrum-Rating spectrum-Rating--quiet">
         <input class="spectrum-Rating-input" type="range" min="0" max="5" value="0" aria-label="Rating">
 
-        <span class="spectrum-Rating-icon">
-          <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Star"></use>
-          </svg>
-          <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-StarOutline"></use>
-          </svg>
-        </span>
+        <div class="spectrum-Rating-containter">
+          <span class="spectrum-Rating-icon">
+            <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Star"></use>
+            </svg>
+            <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-StarOutline"></use>
+            </svg>
+          </span>
 
-        <span class="spectrum-Rating-icon">
-          <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Star"></use>
-          </svg>
-          <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-StarOutline"></use>
-          </svg>
-        </span>
+          <span class="spectrum-Rating-icon">
+            <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Star"></use>
+            </svg>
+            <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-StarOutline"></use>
+            </svg>
+          </span>
 
-        <span class="spectrum-Rating-icon">
-          <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Star"></use>
-          </svg>
-          <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-StarOutline"></use>
-          </svg>
-        </span>
+          <span class="spectrum-Rating-icon">
+            <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Star"></use>
+            </svg>
+            <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-StarOutline"></use>
+            </svg>
+          </span>
 
-        <span class="spectrum-Rating-icon">
-          <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Star"></use>
-          </svg>
-          <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-StarOutline"></use>
-          </svg>
-        </span>
+          <span class="spectrum-Rating-icon">
+            <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Star"></use>
+            </svg>
+            <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-StarOutline"></use>
+            </svg>
+          </span>
 
-        <span class="spectrum-Rating-icon">
-          <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Star"></use>
-          </svg>
-          <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-StarOutline"></use>
-          </svg>
-        </span>
-      </button>
+          <span class="spectrum-Rating-icon">
+            <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Star"></use>
+            </svg>
+            <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-StarOutline"></use>
+            </svg>
+          </span>
+        </div>
+      </div>
   - id: rating-quiet
     name: Quiet (selected)
     markup: |
-      <button class="spectrum-Rating spectrum-Rating--quiet">
+      <div class="spectrum-Rating spectrum-Rating--quiet">
         <input class="spectrum-Rating-input" type="range" min="0" max="5" value="0" aria-label="Rating">
 
-        <span class="spectrum-Rating-icon is-selected">
-          <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Star"></use>
-          </svg>
-          <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-StarOutline"></use>
-          </svg>
-        </span>
+        <div class="spectrum-Rating-containter">
+          <span class="spectrum-Rating-icon is-selected">
+            <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Star"></use>
+            </svg>
+            <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-StarOutline"></use>
+            </svg>
+          </span>
 
-        <span class="spectrum-Rating-icon is-selected">
-          <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Star"></use>
-          </svg>
-          <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-StarOutline"></use>
-          </svg>
-        </span>
+          <span class="spectrum-Rating-icon is-selected">
+            <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Star"></use>
+            </svg>
+            <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-StarOutline"></use>
+            </svg>
+          </span>
 
-        <span class="spectrum-Rating-icon is-selected is-currentValue">
-          <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Star"></use>
-          </svg>
-          <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-StarOutline"></use>
-          </svg>
-        </span>
+          <span class="spectrum-Rating-icon is-selected is-currentValue">
+            <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Star"></use>
+            </svg>
+            <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-StarOutline"></use>
+            </svg>
+          </span>
 
-        <span class="spectrum-Rating-icon">
-          <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Star"></use>
-          </svg>
-          <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-StarOutline"></use>
-          </svg>
-        </span>
+          <span class="spectrum-Rating-icon">
+            <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Star"></use>
+            </svg>
+            <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-StarOutline"></use>
+            </svg>
+          </span>
 
-        <span class="spectrum-Rating-icon">
-          <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Star"></use>
-          </svg>
-          <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-StarOutline"></use>
-          </svg>
-        </span>
-      </button>
+          <span class="spectrum-Rating-icon">
+            <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Star"></use>
+            </svg>
+            <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-StarOutline"></use>
+            </svg>
+          </span>
+        </div>
+      </div>
   - id: rating-quiet
     name: Quiet (read-only)
     markup: |
-      <button class="spectrum-Rating spectrum-Rating--quiet is-readOnly">
+      <div class="spectrum-Rating spectrum-Rating--quiet is-readOnly">
         <input class="spectrum-Rating-input" type="range" min="0" max="5" value="0" readOnly aria-label="Rating">
 
-        <span class="spectrum-Rating-icon is-selected">
-          <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Star"></use>
-          </svg>
-          <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-StarOutline"></use>
-          </svg>
-        </span>
+        <div class="spectrum-Rating-containter">
+          <span class="spectrum-Rating-icon is-selected">
+            <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Star"></use>
+            </svg>
+            <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-StarOutline"></use>
+            </svg>
+          </span>
 
-        <span class="spectrum-Rating-icon is-selected">
-          <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Star"></use>
-          </svg>
-          <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-StarOutline"></use>
-          </svg>
-        </span>
+          <span class="spectrum-Rating-icon is-selected">
+            <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Star"></use>
+            </svg>
+            <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-StarOutline"></use>
+            </svg>
+          </span>
 
-        <span class="spectrum-Rating-icon is-selected is-currentValue">
-          <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Star"></use>
-          </svg>
-          <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-StarOutline"></use>
-          </svg>
-        </span>
+          <span class="spectrum-Rating-icon is-selected is-currentValue">
+            <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Star"></use>
+            </svg>
+            <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-StarOutline"></use>
+            </svg>
+          </span>
 
-        <span class="spectrum-Rating-icon">
-          <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Star"></use>
-          </svg>
-          <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-StarOutline"></use>
-          </svg>
-        </span>
+          <span class="spectrum-Rating-icon">
+            <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Star"></use>
+            </svg>
+            <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-StarOutline"></use>
+            </svg>
+          </span>
 
-        <span class="spectrum-Rating-icon">
-          <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Star"></use>
-          </svg>
-          <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-StarOutline"></use>
-          </svg>
-        </span>
-      </button>
+          <span class="spectrum-Rating-icon">
+            <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Star"></use>
+            </svg>
+            <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-StarOutline"></use>
+            </svg>
+          </span>
+        </div>
+      </div>
   - id: rating
     name: Disabled
     markup: |
-      <button class="spectrum-Rating is-disabled">
+      <div class="spectrum-Rating is-disabled">
         <input class="spectrum-Rating-input" disabled type="range" min="0" max="5" value="0" aria-label="Rating">
 
-        <span class="spectrum-Rating-icon is-selected">
-          <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Star"></use>
-          </svg>
-          <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-StarOutline"></use>
-          </svg>
-        </span>
+        <div class="spectrum-Rating-containter">
+          <span class="spectrum-Rating-icon is-selected">
+            <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Star"></use>
+            </svg>
+            <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-StarOutline"></use>
+            </svg>
+          </span>
 
-        <span class="spectrum-Rating-icon is-selected">
-          <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Star"></use>
-          </svg>
-          <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-StarOutline"></use>
-          </svg>
-        </span>
+          <span class="spectrum-Rating-icon is-selected">
+            <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Star"></use>
+            </svg>
+            <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-StarOutline"></use>
+            </svg>
+          </span>
 
-        <span class="spectrum-Rating-icon is-selected is-currentValue">
-          <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Star"></use>
-          </svg>
-          <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-StarOutline"></use>
-          </svg>
-        </span>
+          <span class="spectrum-Rating-icon is-selected is-currentValue">
+            <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Star"></use>
+            </svg>
+            <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-StarOutline"></use>
+            </svg>
+          </span>
 
-        <span class="spectrum-Rating-icon">
-          <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Star"></use>
-          </svg>
-          <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-StarOutline"></use>
-          </svg>
-        </span>
+          <span class="spectrum-Rating-icon">
+            <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Star"></use>
+            </svg>
+            <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-StarOutline"></use>
+            </svg>
+          </span>
 
-        <span class="spectrum-Rating-icon">
-          <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Star"></use>
-          </svg>
-          <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-StarOutline"></use>
-          </svg>
-        </span>
-      </button>
+          <span class="spectrum-Rating-icon">
+            <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Star"></use>
+            </svg>
+            <svg class="spectrum-Icon spectrum-UIIcon-StarOutline spectrum-Rating-starInactive" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-StarOutline"></use>
+            </svg>
+          </span>
+        </div>
+      </div>

--- a/components/rating/metadata/rating.yml
+++ b/components/rating/metadata/rating.yml
@@ -4,7 +4,7 @@ examples:
   - id: rating
     name: Standard
     markup: |
-      <div class="spectrum-Rating">
+      <button class="spectrum-Rating">
         <input class="spectrum-Rating-input" type="range" min="0" max="5" value="0" aria-label="Rating">
 
         <span class="spectrum-Rating-icon">
@@ -51,11 +51,11 @@ examples:
             <use xlink:href="#spectrum-css-icon-StarOutline"></use>
           </svg>
         </span>
-      </div>
+      </button>
   - id: rating
     name: Selected
     markup: |
-      <div class="spectrum-Rating">
+      <button class="spectrum-Rating">
         <input class="spectrum-Rating-input" type="range" min="0" max="5" value="0" aria-label="Rating">
 
         <span class="spectrum-Rating-icon is-selected">
@@ -102,12 +102,12 @@ examples:
             <use xlink:href="#spectrum-css-icon-StarOutline"></use>
           </svg>
         </span>
-      </div>
+      </button>
   - id: rating
     name: Read-only
     description: A non-interactive rating.
     markup: |
-      <div class="spectrum-Rating is-readOnly">
+      <button class="spectrum-Rating is-readOnly">
         <input class="spectrum-Rating-input" type="range" min="0" max="5" value="0" readOnly aria-label="Rating">
 
         <span class="spectrum-Rating-icon is-selected">
@@ -154,11 +154,11 @@ examples:
             <use xlink:href="#spectrum-css-icon-StarOutline"></use>
           </svg>
         </span>
-      </div>
+      </button>
   - id: rating-quiet
     name: Quiet
     markup: |
-      <div class="spectrum-Rating spectrum-Rating--quiet">
+      <button class="spectrum-Rating spectrum-Rating--quiet">
         <input class="spectrum-Rating-input" type="range" min="0" max="5" value="0" aria-label="Rating">
 
         <span class="spectrum-Rating-icon">
@@ -205,11 +205,11 @@ examples:
             <use xlink:href="#spectrum-css-icon-StarOutline"></use>
           </svg>
         </span>
-      </div>
+      </button>
   - id: rating-quiet
     name: Quiet (selected)
     markup: |
-      <div class="spectrum-Rating spectrum-Rating--quiet">
+      <button class="spectrum-Rating spectrum-Rating--quiet">
         <input class="spectrum-Rating-input" type="range" min="0" max="5" value="0" aria-label="Rating">
 
         <span class="spectrum-Rating-icon is-selected">
@@ -256,11 +256,11 @@ examples:
             <use xlink:href="#spectrum-css-icon-StarOutline"></use>
           </svg>
         </span>
-      </div>
+      </button>
   - id: rating-quiet
     name: Quiet (read-only)
     markup: |
-      <div class="spectrum-Rating spectrum-Rating--quiet is-readOnly">
+      <button class="spectrum-Rating spectrum-Rating--quiet is-readOnly">
         <input class="spectrum-Rating-input" type="range" min="0" max="5" value="0" readOnly aria-label="Rating">
 
         <span class="spectrum-Rating-icon is-selected">
@@ -307,11 +307,11 @@ examples:
             <use xlink:href="#spectrum-css-icon-StarOutline"></use>
           </svg>
         </span>
-      </div>
+      </button>
   - id: rating
     name: Disabled
     markup: |
-      <div class="spectrum-Rating is-disabled">
+      <button class="spectrum-Rating is-disabled">
         <input class="spectrum-Rating-input" disabled type="range" min="0" max="5" value="0" aria-label="Rating">
 
         <span class="spectrum-Rating-icon is-selected">
@@ -358,4 +358,4 @@ examples:
             <use xlink:href="#spectrum-css-icon-StarOutline"></use>
           </svg>
         </span>
-      </div>
+      </button>

--- a/components/rating/metadata/rating.yml
+++ b/components/rating/metadata/rating.yml
@@ -7,7 +7,7 @@ examples:
       <div class="spectrum-Rating">
         <input class="spectrum-Rating-input" type="range" min="0" max="5" value="0" aria-label="Rating">
 
-        <div class="spectrum-Rating-containter">
+        <div class="spectrum-Rating-container">
           <span class="spectrum-Rating-icon">
             <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
               <use xlink:href="#spectrum-css-icon-Star"></use>
@@ -60,7 +60,7 @@ examples:
       <div class="spectrum-Rating">
         <input class="spectrum-Rating-input" type="range" min="0" max="5" value="0" aria-label="Rating">
 
-        <div class="spectrum-Rating-containter">
+        <div class="spectrum-Rating-container">
           <span class="spectrum-Rating-icon is-selected">
             <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
               <use xlink:href="#spectrum-css-icon-Star"></use>
@@ -114,7 +114,7 @@ examples:
       <div class="spectrum-Rating is-readOnly">
         <input class="spectrum-Rating-input" type="range" min="0" max="5" value="0" readOnly aria-label="Rating" readonly>
 
-        <div class="spectrum-Rating-containter">
+        <div class="spectrum-Rating-container">
           <span class="spectrum-Rating-icon is-selected">
             <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
               <use xlink:href="#spectrum-css-icon-Star"></use>
@@ -167,7 +167,7 @@ examples:
       <div class="spectrum-Rating spectrum-Rating--quiet">
         <input class="spectrum-Rating-input" type="range" min="0" max="5" value="0" aria-label="Rating">
 
-        <div class="spectrum-Rating-containter">
+        <div class="spectrum-Rating-container">
           <span class="spectrum-Rating-icon">
             <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
               <use xlink:href="#spectrum-css-icon-Star"></use>
@@ -220,7 +220,7 @@ examples:
       <div class="spectrum-Rating spectrum-Rating--quiet">
         <input class="spectrum-Rating-input" type="range" min="0" max="5" value="0" aria-label="Rating">
 
-        <div class="spectrum-Rating-containter">
+        <div class="spectrum-Rating-container">
           <span class="spectrum-Rating-icon is-selected">
             <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
               <use xlink:href="#spectrum-css-icon-Star"></use>
@@ -273,7 +273,7 @@ examples:
       <div class="spectrum-Rating spectrum-Rating--quiet is-readOnly">
         <input class="spectrum-Rating-input" type="range" min="0" max="5" value="0" readOnly aria-label="Rating">
 
-        <div class="spectrum-Rating-containter">
+        <div class="spectrum-Rating-container">
           <span class="spectrum-Rating-icon is-selected">
             <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
               <use xlink:href="#spectrum-css-icon-Star"></use>
@@ -326,7 +326,7 @@ examples:
       <div class="spectrum-Rating is-disabled">
         <input class="spectrum-Rating-input" disabled type="range" min="0" max="5" value="0" aria-label="Rating">
 
-        <div class="spectrum-Rating-containter">
+        <div class="spectrum-Rating-container">
           <span class="spectrum-Rating-icon is-selected">
             <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
               <use xlink:href="#spectrum-css-icon-Star"></use>

--- a/components/rating/skin.css
+++ b/components/rating/skin.css
@@ -11,7 +11,7 @@ governing permissions and limitations under the License.
 */
 
 .spectrum-Rating {
-  &.is-focused {
+  &.focus-ring {
     box-shadow: 0 0 0 var(--spectrum-global-dimension-static-size-25) var(--spectrum-rating-focus-ring-color);
   }
 

--- a/components/rating/skin.css
+++ b/components/rating/skin.css
@@ -37,7 +37,7 @@ governing permissions and limitations under the License.
   }
 }
 
-.spectrum-Rating-containter {
+.spectrum-Rating-container {
   .focus-ring + & {
     box-shadow: 0 0 0 var(--spectrum-global-dimension-static-size-25) var(--spectrum-rating-focus-ring-color);
   }

--- a/components/rating/skin.css
+++ b/components/rating/skin.css
@@ -11,10 +11,6 @@ governing permissions and limitations under the License.
 */
 
 .spectrum-Rating {
-  &.focus-ring {
-    box-shadow: 0 0 0 var(--spectrum-global-dimension-static-size-25) var(--spectrum-rating-focus-ring-color);
-  }
-
   &:hover {
     .spectrum-Rating-icon {
       /* Make all stars colored when the component is hovered */
@@ -38,6 +34,12 @@ governing permissions and limitations under the License.
         }
       }
     }
+  }
+}
+
+.spectrum-Rating-containter {
+  .focus-ring + & {
+    box-shadow: 0 0 0 var(--spectrum-global-dimension-static-size-25) var(--spectrum-rating-focus-ring-color);
   }
 }
 


### PR DESCRIPTION
For Issue #249

# Adds container around `spectrum-Rating-icon` icons for visible keyboard focus

## Description
In order to preview the focus state of the Rating component this PR adds a container around `spectrum-Rating-icon` icons for visible keyboard focus using a `.focus-ring + &` sibling selector.


<img width="481" alt="Screen Shot 2019-10-11 at 3 28 24 PM" src="https://user-images.githubusercontent.com/3717760/66688522-e0c8ea80-ec3b-11e9-9788-33948f4839fc.png">
