### PR TITLE
Actionbar popover width fixed

### DIFF
--- a/components/actionbar/index.css
+++ b/components/actionbar/index.css
@@ -73,7 +73,7 @@ governing permissions and limitations under the License.
   position: relative;
 
   box-sizing: border-box;
-  width: var(--spectrum-actionbar-width);
+  width: var(--spectrum-actionbar-width, 100%);
   margin: auto;
   height: var(--spectrum-actionbar-height);
   min-width: var(--spectrum-actionbar-min-width);

--- a/components/actionbar/index.css
+++ b/components/actionbar/index.css
@@ -64,6 +64,12 @@ governing permissions and limitations under the License.
   position: sticky;
 }
 
+.spectrum-ActionBar--flexible {
+  .spectrum-ActionBar-popover {
+    width: auto;
+  }
+}
+
 .spectrum-ActionBar--fixed {
    position: fixed;
 }
@@ -73,7 +79,7 @@ governing permissions and limitations under the License.
   position: relative;
 
   box-sizing: border-box;
-  width: var(--spectrum-actionbar-width, 100%);
+  width: 100%;
   margin: auto;
   height: var(--spectrum-actionbar-height);
   min-width: var(--spectrum-actionbar-min-width);

--- a/components/actionbar/index.css
+++ b/components/actionbar/index.css
@@ -73,7 +73,7 @@ governing permissions and limitations under the License.
   position: relative;
 
   box-sizing: border-box;
-  width: 100%;
+  width: var(--spectrum-actionbar-width);
   margin: auto;
   height: var(--spectrum-actionbar-height);
   min-width: var(--spectrum-actionbar-min-width);

--- a/components/actionbar/metadata/actionbar.yml
+++ b/components/actionbar/metadata/actionbar.yml
@@ -3,139 +3,135 @@ description: Floating action bar that appears in selection mode.
 examples:
   - id: actionbar
     name: Standard
+    description: Standard Action Bars fill the width of their container.
     markup: |
-      <div style="position: relative;">
-        <div class="spectrum-ActionBar is-open">
-          <div class="spectrum-Popover spectrum-ActionBar-popover is-open">
-            <label class="spectrum-Checkbox is-indeterminate">
-              <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-0">
-              <span class="spectrum-Checkbox-box">
-                <svg class="spectrum-Icon spectrum-UIIcon-CheckmarkSmall spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-                  <use xlink:href="#spectrum-css-icon-CheckmarkSmall" />
-                </svg>
-                <svg class="spectrum-Icon spectrum-UIIcon-DashSmall spectrum-Checkbox-partialCheckmark" focusable="false" aria-hidden="true">
-                  <use xlink:href="#spectrum-css-icon-DashSmall" />
-                </svg>
-              </span>
-              <span class="spectrum-Checkbox-label">2 Selected</span>
-            </label>
-            <div class="spectrum-ButtonGroup">
-              <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
-                <span class="spectrum-ActionButton-label">Edit</span>
-              </button>
-              <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
-                <span class="spectrum-ActionButton-label">Copy</span>
-              </button>
-              <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
-                <span class="spectrum-ActionButton-label">Delete</span>
-              </button>
-            </div>
+      <div class="spectrum-ActionBar is-open">
+        <div class="spectrum-Popover spectrum-ActionBar-popover is-open">
+          <label class="spectrum-Checkbox is-indeterminate">
+            <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-0">
+            <span class="spectrum-Checkbox-box">
+              <svg class="spectrum-Icon spectrum-UIIcon-CheckmarkSmall spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-CheckmarkSmall" />
+              </svg>
+              <svg class="spectrum-Icon spectrum-UIIcon-DashSmall spectrum-Checkbox-partialCheckmark" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-DashSmall" />
+              </svg>
+            </span>
+            <span class="spectrum-Checkbox-label">2 Selected</span>
+          </label>
+          <div class="spectrum-ButtonGroup">
+            <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
+              <span class="spectrum-ActionButton-label">Edit</span>
+            </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
+              <span class="spectrum-ActionButton-label">Copy</span>
+            </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
+              <span class="spectrum-ActionButton-label">Delete</span>
+            </button>
           </div>
         </div>
       </div>
 
-      <div style="position: relative;">
-        <div class="spectrum-ActionBar is-open">
-          <div class="spectrum-Popover spectrum-ActionBar-popover is-open">
-            <label class="spectrum-Checkbox is-indeterminate">
-              <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-1">
-              <span class="spectrum-Checkbox-box">
-                <svg class="spectrum-Icon spectrum-UIIcon-CheckmarkSmall spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-                  <use xlink:href="#spectrum-css-icon-CheckmarkSmall" />
-                </svg>
-                <svg class="spectrum-Icon spectrum-UIIcon-DashSmall spectrum-Checkbox-partialCheckmark" focusable="false" aria-hidden="true">
-                  <use xlink:href="#spectrum-css-icon-DashSmall" />
-                </svg>
-              </span>
-              <span class="spectrum-Checkbox-label">4 Selected</span>
-            </label>
-            <div class="spectrum-ButtonGroup">
-              <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
-                <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Edit">
-                  <use xlink:href="#spectrum-icon-18-Edit"></use>
-                </svg>
-                <span class="spectrum-ActionButton-label">Edit</span>
-              </button>
-              <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
-                <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Copy">
-                  <use xlink:href="#spectrum-icon-18-Copy"></use>
-                </svg>
-                <span class="spectrum-ActionButton-label">Copy</span>
-              </button>
-              <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
-                <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Delete">
-                  <use xlink:href="#spectrum-icon-18-Delete"></use>
-                </svg>
-                <span class="spectrum-ActionButton-label">Delete</span>
-              </button>
-            </div>
+      <div class="spectrum-ActionBar is-open">
+        <div class="spectrum-Popover spectrum-ActionBar-popover is-open">
+          <label class="spectrum-Checkbox is-indeterminate">
+            <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-1">
+            <span class="spectrum-Checkbox-box">
+              <svg class="spectrum-Icon spectrum-UIIcon-CheckmarkSmall spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-CheckmarkSmall" />
+              </svg>
+              <svg class="spectrum-Icon spectrum-UIIcon-DashSmall spectrum-Checkbox-partialCheckmark" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-DashSmall" />
+              </svg>
+            </span>
+            <span class="spectrum-Checkbox-label">4 Selected</span>
+          </label>
+          <div class="spectrum-ButtonGroup">
+            <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
+              <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit"></use>
+              </svg>
+              <span class="spectrum-ActionButton-label">Edit</span>
+            </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
+              <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Copy">
+                <use xlink:href="#spectrum-icon-18-Copy"></use>
+              </svg>
+              <span class="spectrum-ActionButton-label">Copy</span>
+            </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
+              <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Delete">
+                <use xlink:href="#spectrum-icon-18-Delete"></use>
+              </svg>
+              <span class="spectrum-ActionButton-label">Delete</span>
+            </button>
           </div>
         </div>
       </div>
 
-      <div style="position: relative;">
-        <div class="spectrum-ActionBar is-open">
-          <div class="spectrum-Popover spectrum-ActionBar-popover is-open">
-            <label class="spectrum-Checkbox is-indeterminate">
-              <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-1">
-              <span class="spectrum-Checkbox-box">
-                <svg class="spectrum-Icon spectrum-UIIcon-CheckmarkSmall spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-                  <use xlink:href="#spectrum-css-icon-CheckmarkSmall" />
-                </svg>
-                <svg class="spectrum-Icon spectrum-UIIcon-DashSmall spectrum-Checkbox-partialCheckmark" focusable="false" aria-hidden="true">
-                  <use xlink:href="#spectrum-css-icon-DashSmall" />
-                </svg>
-              </span>
-              <span class="spectrum-Checkbox-label">6 Selected</span>
-            </label>
-            <div class="spectrum-ButtonGroup">
-              <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
-                <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Edit">
-                  <use xlink:href="#spectrum-icon-18-Edit"></use>
-                </svg>
-              </button>
-              <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
-                <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Copy">
-                  <use xlink:href="#spectrum-icon-18-Copy"></use>
-                </svg>
-              </button>
-              <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
-                <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Delete">
-                  <use xlink:href="#spectrum-icon-18-Delete"></use>
-                </svg>
-              </button>
-            </div>
+      <div class="spectrum-ActionBar is-open">
+        <div class="spectrum-Popover spectrum-ActionBar-popover is-open">
+          <label class="spectrum-Checkbox is-indeterminate">
+            <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-1">
+            <span class="spectrum-Checkbox-box">
+              <svg class="spectrum-Icon spectrum-UIIcon-CheckmarkSmall spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-CheckmarkSmall" />
+              </svg>
+              <svg class="spectrum-Icon spectrum-UIIcon-DashSmall spectrum-Checkbox-partialCheckmark" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-DashSmall" />
+              </svg>
+            </span>
+            <span class="spectrum-Checkbox-label">6 Selected</span>
+          </label>
+          <div class="spectrum-ButtonGroup">
+            <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
+              <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit"></use>
+              </svg>
+            </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
+              <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Copy">
+                <use xlink:href="#spectrum-icon-18-Copy"></use>
+              </svg>
+            </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
+              <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Delete">
+                <use xlink:href="#spectrum-icon-18-Delete"></use>
+              </svg>
+            </button>
           </div>
         </div>
       </div>
-
-      <div style="position: relative; width: 312px;">
-        <div class="spectrum-ActionBar is-open">
-          <div class="spectrum-Popover spectrum-ActionBar-popover is-open">
-            <label class="spectrum-Checkbox is-indeterminate">
-              <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-1">
-              <span class="spectrum-Checkbox-box">
-                <svg class="spectrum-Icon spectrum-UIIcon-CheckmarkSmall spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-                  <use xlink:href="#spectrum-css-icon-CheckmarkSmall" />
-                </svg>
-                <svg class="spectrum-Icon spectrum-UIIcon-DashSmall spectrum-Checkbox-partialCheckmark" focusable="false" aria-hidden="true">
-                  <use xlink:href="#spectrum-css-icon-DashSmall" />
-                </svg>
-              </span>
-              <span class="spectrum-Checkbox-label">228 Selected</span>
-            </label>
-            <div class="spectrum-ButtonGroup">
-              <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
-                <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Edit">
-                  <use xlink:href="#spectrum-icon-18-Edit"></use>
-                </svg>
-              </button>
-              <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
-                <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="More">
-                  <use xlink:href="#spectrum-icon-18-More"></use>
-                </svg>
-              </button>
-            </div>
+  - id: actionbar
+    name: Flexible
+    description: Flexible Action Bars fit the width of their content.
+    markup: |
+      <div class="spectrum-ActionBar spectrum-ActionBar--flexible is-open">
+        <div class="spectrum-Popover spectrum-ActionBar-popover is-open">
+          <label class="spectrum-Checkbox is-indeterminate">
+            <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-1">
+            <span class="spectrum-Checkbox-box">
+              <svg class="spectrum-Icon spectrum-UIIcon-CheckmarkSmall spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-CheckmarkSmall" />
+              </svg>
+              <svg class="spectrum-Icon spectrum-UIIcon-DashSmall spectrum-Checkbox-partialCheckmark" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-DashSmall" />
+              </svg>
+            </span>
+            <span class="spectrum-Checkbox-label">228 Selected</span>
+          </label>
+          <div class="spectrum-ButtonGroup">
+            <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
+              <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit"></use>
+              </svg>
+            </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
+              <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="More">
+                <use xlink:href="#spectrum-icon-18-More"></use>
+              </svg>
+            </button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->
Added the relative width in actionbar popover as mentioned in #319 


## How and where has this been tested?
 - **How this was tested:** Using steps in issue #319 
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaning tasks here -->
- [x] This pull request is ready to merge.
