### PR TITLE
feat: adding Spectrum Website slug for components (SDS-2623)

### DIFF
--- a/components/barloader/metadata/barloader.yml
+++ b/components/barloader/metadata/barloader.yml
@@ -1,4 +1,5 @@
 name: Bar Loader
+SpectrumSiteSlug: https://spectrum.adobe.com/page/bar-loader/
 examples:
   - id: barloader-small
     name: Standard

--- a/components/barloader/metadata/meter.yml
+++ b/components/barloader/metadata/meter.yml
@@ -1,5 +1,6 @@
 name: Meter
 description: Meter is implemented using the BarLoader component.
+SpectrumSiteSlug: https://spectrum.adobe.com/page/meter/
 examples:
   - id: meter-small
     name: Standard

--- a/components/button/metadata/actionbutton.yml
+++ b/components/button/metadata/actionbutton.yml
@@ -1,5 +1,6 @@
 name: Action Button
 status: Verified
+SpectrumSiteSlug: https://spectrum.adobe.com/page/button/
 examples:
   - id: actionbutton
     name: Standard

--- a/components/button/metadata/button-cta.yml
+++ b/components/button/metadata/button-cta.yml
@@ -1,6 +1,7 @@
 name: Button - CTA
 status: Verified
 description: The call to action button communicates strong emphasis and is reserved for encouraging critical actions.
+SpectrumSiteSlug: https://spectrum.adobe.com/page/button/
 examples:
   - id: button-cta
     name: Standard

--- a/components/button/metadata/button-over-background.yml
+++ b/components/button/metadata/button-over-background.yml
@@ -1,6 +1,7 @@
 name: Button - Over Background
 status: Verified
 description: 'When a button needs to be placed on top of a colored background or a visual, use the over background button. In order to implement this button, you must set the CSS color property of a parent element to the same value as the background the button is placed against.'
+SpectrumSiteSlug: https://spectrum.adobe.com/page/button/#Over-background
 examples:
   - id: button-over-background
     name: Over background

--- a/components/button/metadata/button-primary.yml
+++ b/components/button/metadata/button-primary.yml
@@ -1,6 +1,7 @@
 name: Button - Primary
 status: Verified
 description: The primary button is used for medium emphasis.
+SpectrumSiteSlug: https://spectrum.adobe.com/page/button/#Primary
 examples:
   - id: button-primary
     name: Primary

--- a/components/button/metadata/button-secondary.yml
+++ b/components/button/metadata/button-secondary.yml
@@ -1,6 +1,7 @@
 name: Button - Secondary
 status: Verified
 description: The secondary button is for low emphasis.
+SpectrumSiteSlug: https://spectrum.adobe.com/page/button/#Secondary
 examples:
   - id: button-secondary
     name: Secondary

--- a/components/button/metadata/button-warning.yml
+++ b/components/button/metadata/button-warning.yml
@@ -1,6 +1,7 @@
 name: Button - Warning
 status: Verified
 description: The negative button is for high emphasis of negative or destructive actions.
+SpectrumSiteSlug: https://spectrum.adobe.com/page/button/#Negative
 examples:
   - id: button-warning
     name: Warning

--- a/components/button/metadata/tool.yml
+++ b/components/button/metadata/tool.yml
@@ -1,6 +1,7 @@
 name: Tool
 status: Verified
 description: The tool button.
+SpectrumSiteSlug: https://spectrum.adobe.com/page/tool/
 examples:
   - name: Standard
     markup: |

--- a/components/buttongroup/metadata/buttongroup.yml
+++ b/components/buttongroup/metadata/buttongroup.yml
@@ -1,4 +1,5 @@
 name: Button Group
+SpectrumSiteSlug: https://spectrum.corp.adobe.com/page/button/
 examples:
   - id: buttongroup
     name: Horizontal

--- a/components/checkbox/metadata/checkbox.yml
+++ b/components/checkbox/metadata/checkbox.yml
@@ -1,6 +1,7 @@
 name: Checkbox
 status: Verified
 description: 'Checkboxes allow users to select multiple items from a list of individual items, or mark one individual item as selected.'
+SpectrumSiteSlug: https://spectrum.adobe.com/page/checkbox/
 examples:
   - id: checkbox-default
     name: Standard

--- a/components/circleloader/metadata/circleloader.yml
+++ b/components/circleloader/metadata/circleloader.yml
@@ -1,5 +1,6 @@
 name: Circle Loader
 status: Verified
+SpectrumSiteSlug: https://spectrum.adobe.com/page/circle-loader/
 examples:
   - id: circleloader-small
     name: Standard

--- a/components/coachmark/metadata/coachmark.yml
+++ b/components/coachmark/metadata/coachmark.yml
@@ -1,4 +1,5 @@
 name: Coach Mark
+SpectrumSiteSlug: https://spectrum.adobe.com/page/coach-mark/
 examples:
   - id: coachmark
     name: Standard

--- a/components/decoratedtextfield/metadata/decoratedtextfield.yml
+++ b/components/decoratedtextfield/metadata/decoratedtextfield.yml
@@ -1,5 +1,6 @@
 name: Text Field - Decorated
 description: A Spectrum text field with an additional icon. The icon must be the Small size (18px) in order for it to be positioned correctly.
+SpectrumSiteSlug: https://spectrum.adobe.com/page/text-field/#Validation-icon
 examples:
   - id: textfield
     name: Standard

--- a/components/dialog/metadata/dialog.yml
+++ b/components/dialog/metadata/dialog.yml
@@ -1,5 +1,6 @@
 name: Dialog
 description: 'In order to avoid blurry Dialogs, wrap them in `<div class="spectrum-Dialog-wrapper">` and apply `.is-open` to both the Wrapper and the Dialog at the same time. See [this example](dialogAlert.html) for a working demonstration.'
+SpectrumSiteSlug: https://spectrum.adobe.com/page/dialog/
 examples:
   - id: dialog
     name: Dialog - Small

--- a/components/dropdown/metadata/dropdown.yml
+++ b/components/dropdown/metadata/dropdown.yml
@@ -1,5 +1,6 @@
 name: Dropdown
 status: Verified
+SpectrumSiteSlug: https://spectrum.adobe.com/page/dropdown/
 examples:
   - id: dropdown
     name: Standard

--- a/components/fieldlabel/metadata/fieldlabel.yml
+++ b/components/fieldlabel/metadata/fieldlabel.yml
@@ -1,5 +1,6 @@
 name: Field Label
 description: Field label for use with form inputs.
+SpectrumSiteSlug: https://spectrum.adobe.com/page/text-field/#Include-a-label
 examples:
   - id: fieldlabel
     name: Standard

--- a/components/illustratedmessage/metadata/illustratedmessage.yml
+++ b/components/illustratedmessage/metadata/illustratedmessage.yml
@@ -1,4 +1,5 @@
 name: Illustrated Message
+SpectrumSiteSlug: https://spectrum.adobe.com/page/informational-illustrations/
 examples:
   - id: illustratedmessage-default
     name: Standard

--- a/components/inputgroup/metadata/combobox.yml
+++ b/components/inputgroup/metadata/combobox.yml
@@ -1,4 +1,5 @@
 name: Combobox
+SpectrumSiteSlug: https://spectrum.adobe.com/page/combo-box/
 examples:
   - id: combobox
     name: Standard

--- a/components/label/metadata/label.yml
+++ b/components/label/metadata/label.yml
@@ -1,4 +1,5 @@
 name: Label
+SpectrumSiteSlug: https://spectrum.adobe.com/page/tag/#Label
 examples:
   - id: label-colored
     name: Standard

--- a/components/link/metadata/link.yml
+++ b/components/link/metadata/link.yml
@@ -1,4 +1,5 @@
 name: Link
+SpectrumSiteSlug: https://spectrum.adobe.com/page/link/
 examples:
   - id: link
     name: Standard

--- a/components/menu/metadata/menu.yml
+++ b/components/menu/metadata/menu.yml
@@ -1,4 +1,5 @@
 name: Menu
+SpectrumSiteSlug: https://spectrum.adobe.com/page/side-navigation/
 examples:
   - id: selectlist
     name: Standard

--- a/components/popover/metadata/popover.yml
+++ b/components/popover/metadata/popover.yml
@@ -1,4 +1,5 @@
 name: Popover
+SpectrumSiteSlug: https://spectrum.adobe.com/page/popovers/
 examples:
   - id: popover
     name: Standard

--- a/components/quickaction/metadata/quickaction.yml
+++ b/components/quickaction/metadata/quickaction.yml
@@ -2,6 +2,7 @@ id: quickactions
 name: Quick Actions
 status: Verified
 description: 'Note that the `.spectrum-QuickActions-overlay` class should be placed on the container where the Quick Actions are displayed, and the `.spectrum-QuickActions--textOnly` class should be applied when the buttons have text only.'
+SpectrumSiteSlug: https://spectrum.adobe.com/page/quick-actions/
 examples:
   - id: quickactions
     name: Standard

--- a/components/radio/metadata/radio.yml
+++ b/components/radio/metadata/radio.yml
@@ -1,5 +1,6 @@
 name: Radio
 status: Verified
+SpectrumSiteSlug: https://spectrum.adobe.com/page/radio-button/
 examples:
   - id: radio
     name: Standard

--- a/components/rating/metadata/rating.yml
+++ b/components/rating/metadata/rating.yml
@@ -1,5 +1,6 @@
 name: Rating
 status: Verified
+SpectrumSiteSlug: https://spectrum.adobe.com/page/rating/
 examples:
   - id: rating
     name: Standard

--- a/components/rule/metadata/rule.yml
+++ b/components/rule/metadata/rule.yml
@@ -1,5 +1,6 @@
 name: Rule
 status: Verified
+SpectrumSiteSlug: https://spectrum.adobe.com/page/divider/
 examples:
   - id: rule-large
     name: 'Large'

--- a/components/sidenav/metadata/sidenav.yml
+++ b/components/sidenav/metadata/sidenav.yml
@@ -1,5 +1,6 @@
 name: Side Navigation
 status: Verified
+SpectrumSiteSlug: https://spectrum.adobe.com/page/side-navigation/
 examples:
   - id: sidenav
     name: Standard

--- a/components/slider/metadata/slider.yml
+++ b/components/slider/metadata/slider.yml
@@ -1,4 +1,5 @@
 name: Slider
+SpectrumSiteSlug: https://spectrum.adobe.com/page/slider/
 examples:
   - id: slider
     name: Standard

--- a/components/statuslight/metadata/statuslight.yml
+++ b/components/statuslight/metadata/statuslight.yml
@@ -1,4 +1,5 @@
 name: Status Light
+SpectrumSiteSlug: https://spectrum.adobe.com/page/status-light/
 examples:
   - id: statuslight
     name: Colors

--- a/components/table/metadata/table.yml
+++ b/components/table/metadata/table.yml
@@ -1,4 +1,5 @@
 name: Table
+SpectrumSiteSlug: https://spectrum.adobe.com/page/table/
 examples:
   - id: table
     name: Standard

--- a/components/tabs/metadata/tabs.yml
+++ b/components/tabs/metadata/tabs.yml
@@ -1,4 +1,5 @@
 name: Tabs
+SpectrumSiteSlug: https://spectrum.adobe.com/page/tabs/
 examples:
   - id: tabs
     name: Basic tabs

--- a/components/tags/metadata/tags.yml
+++ b/components/tags/metadata/tags.yml
@@ -1,6 +1,7 @@
 name: Tags
 status: Verified
 description: A list of tags.
+SpectrumSiteSlug: https://spectrum.adobe.com/page/tag/
 examples:
   - id: taggroup
     name: Standard

--- a/components/textfield/metadata/textfield.yml
+++ b/components/textfield/metadata/textfield.yml
@@ -1,6 +1,7 @@
 name: Text Field
 status: Verified
 description: A Spectrum text field
+SpectrumSiteSlug: https://spectrum.adobe.com/page/text-field/
 examples:
   - id: textfield
     name: Standard

--- a/components/toast/metadata/toast.yml
+++ b/components/toast/metadata/toast.yml
@@ -1,4 +1,5 @@
 name: Toast
+SpectrumSiteSlug: https://spectrum.adobe.com/page/toast/
 examples:
   - id: toast
     name: Default

--- a/components/toggle/metadata/toggle.yml
+++ b/components/toggle/metadata/toggle.yml
@@ -1,4 +1,5 @@
 name: Switch
+SpectrumSiteSlug: https://spectrum.adobe.com/page/switch/
 examples:
   - id: switch
     name: Standard

--- a/components/tooltip/metadata/tooltip.yml
+++ b/components/tooltip/metadata/tooltip.yml
@@ -1,4 +1,5 @@
 name: Tooltip
+SpectrumSiteSlug: https://spectrum.adobe.com/page/tooltip/
 examples:
   - id: tooltip
     name: Neutral

--- a/components/typography/metadata/typography.yml
+++ b/components/typography/metadata/typography.yml
@@ -1,5 +1,6 @@
 name: Typography
 description: 'English typography examples. See the [typography example page](typography.html) for Japanese, Han, and Arabic examples.'
+SpectrumSiteSlug: https://spectrum.adobe.com/page/typography/
 examples:
   - id: heading-1
     name: Standard


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->
[SDS-2623](https://jira.corp.adobe.com/browse/SDS-2623)
Adding Spectrum Documentation Website Slug

## Description
Adding the Slug for the Documentation Website.
Summary: https://paper.dropbox.com/doc/Matching-components-from-Spectrum-CSS-to-Spectrum-Documentation-October-2019--AmoFLfMEb5JDCzut~MgPcpx1Ag-HqLp71eyfJ24cqB2TTS3H

## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
Manual matching of the components. 

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaning tasks here -->
- [ ] This pull request is ready to merge.
