### PR TITLE
fix(vulnerabilities): https-proxy-agent@2.2.2 => https-proxy-agent@^3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "@spectrum/spectrum-icons": "^2.3.0"
   },
   "resolutions": {
-    "handlebars": "^4.3.0"
+    "handlebars": "^4.3.0",
+    "https-proxy-agent": "^3.0.0"
   },
   "workspaces": [
     "components/*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4844,10 +4844,10 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-https-proxy-agent@^2.2.1:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz#271ea8e90f836ac9f119daccd39c19ff7dfb0793"
-  integrity sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==
+https-proxy-agent@^2.2.1, https-proxy-agent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-3.0.0.tgz#0106efa5d63d6d6f3ab87c999fa4877a3fd1ff97"
+  integrity sha512-y4jAxNEihqvBI5F3SaO2rtsjIOnnNA8sEbuiP+UhJZJHeM2NRm6c09ax2tgqme+SgUUvjao2fJXF4h3D6Cb2HQ==
   dependencies:
     agent-base "^4.3.0"
     debug "^3.1.0"


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
backstopjs => puppeteer@1.2.0 => https-proxy-agent@2.2.2

We need to upgrade https-proxy-agent to 3.0.0 to fix security vulnerabilities.


## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaning tasks here -->
- [ ] This pull request is ready to merge.
