### PR TITLE
fix: add missing variables to -unique files, closes #336

### DIFF
--- a/tools/component-builder/css/lib/varUtils.js
+++ b/tools/component-builder/css/lib/varUtils.js
@@ -98,11 +98,13 @@ function getClassNames(contents, pkgName) {
 }
 
 function resolveValue(value, vars) {
-  let match = value.match(/var\((.*?),?.*?\)/);
-  if (match) {
-    return vars[matches[0]];
+  if (value) {
+    let match = value.match(/var\((.+),?.*?\)/);
+    if (match) {
+      return match[1];
+    }
+    return value;
   }
-  return value;
 }
 
 const varDir = path.join(path.dirname(require.resolve('@spectrum-css/vars')), '..');


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->
Include all the variables referred to up the chain.

## How and where has this been tested?
 - **How this was tested:** 
1. Run the following:

```
git co master
gulp buildUniqueVars
cp dist/vars/spectrum-light-unique.css /tmp/spectrum-light-unique-master.css
git co uniquevars
gulp buildUniqueVars
diff /tmp/spectrum-light-unique-master.css dist/vars/spectrum-light-unique.css
```

2. Observe the output, you should see the following vars

Ensure the following vars are present:
```
--spectrum-global-color-red-400
--spectrum-global-color-green-400
--spectrum-global-color-green-600
--spectrum-global-color-orange-400
--spectrum-global-color-orange-600
--spectrum-global-color-orange-500
```

Additionally, these vars should be present in other files:
```
--spectrum-global-color-static-blue-600
--spectrum-global-font-weight-black
--spectrum-global-dimension-font-size-500
--spectrum-global-font-weight-light
--spectrum-global-dimension-font-size-1100
--spectrum-global-dimension-font-size-1000
--spectrum-global-dimension-font-size-800
--spectrum-global-dimension-font-size-600
--spectrum-global-font-family-serif
--spectrum-global-font-line-height-large
--spectrum-global-font-weight-extra-bold
--spectrum-global-font-family-code
```

 - **Browser(s) and OS(s) this was tested with:** n/a


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaning tasks here -->
- [x] This pull request is ready to merge.
