### PR TITLE
fix: preprocess percentage values and convert them to floats, fixes #340

### DIFF
--- a/components/avatar/skin.css
+++ b/components/avatar/skin.css
@@ -11,9 +11,9 @@ governing permissions and limitations under the License.
 */
 
 .spectrum-Avatar {
-  opacity: percent(var(--spectrum-avatar-small-opacity));
+  opacity: var(--spectrum-avatar-small-opacity);
 
   &.is-disabled {
-    opacity: percent(var(--spectrum-avatar-small-opacity-disabled));
+    opacity: var(--spectrum-avatar-small-opacity-disabled);
   }
 }

--- a/components/tags/skin.css
+++ b/components/tags/skin.css
@@ -75,7 +75,7 @@ governing permissions and limitations under the License.
 
     .spectrum-Avatar {
       /* Duplicated so state is on the tag */
-      opacity: percent(var(--spectrum-avatar-small-opacity-disabled));
+      opacity: var(--spectrum-avatar-small-opacity-disabled);
     }
   }
 }

--- a/components/vars/css/components/spectrum-avatar.css
+++ b/components/vars/css/components/spectrum-avatar.css
@@ -1,7 +1,7 @@
 :root {
-  --spectrum-avatar-small-opacity: 100%;
-  --spectrum-avatar-small-opacity-disabled: 30%;
-  --spectrum-avatar-small-border-radius: 50%;
+  --spectrum-avatar-small-opacity: 1;
+  --spectrum-avatar-small-opacity-disabled: 0.3;
+  --spectrum-avatar-small-border-radius: 0.5;
   --spectrum-avatar-small-width: var(--spectrum-global-dimension-size-200);
   --spectrum-avatar-small-height: var(--spectrum-global-dimension-size-200);
 }

--- a/components/vars/css/components/spectrum-dialog.css
+++ b/components/vars/css/components/spectrum-dialog.css
@@ -4,7 +4,7 @@
   --spectrum-dialog-confirm-icon-color: var(--spectrum-global-color-gray-900);
   --spectrum-dialog-confirm-title-text-color: var(--spectrum-global-color-gray-900);
   --spectrum-dialog-confirm-description-text-color: var(--spectrum-global-color-gray-800);
-  --spectrum-dialog-confirm-width: 90%;
+  --spectrum-dialog-confirm-width: 0.9;
   --spectrum-dialog-confirm-min-width: var(--spectrum-global-dimension-static-size-3600);
   --spectrum-dialog-confirm-icon-margin-left: var(--spectrum-global-dimension-static-size-300);
   --spectrum-dialog-confirm-divider-margin-top: var(--spectrum-global-dimension-static-size-150);
@@ -43,7 +43,7 @@
   --spectrum-dialog-rule-color: var(--spectrum-global-color-gray-300);
   --spectrum-dialog-title-text-color: var(--spectrum-global-color-gray-900);
   --spectrum-dialog-content-text-color: var(--spectrum-global-color-gray-800);
-  --spectrum-dialog-width: 90%;
+  --spectrum-dialog-width: 0.9;
   --spectrum-dialog-min-width: var(--spectrum-global-dimension-static-size-3600);
   --spectrum-dialog-icon-margin-left: var(--spectrum-global-dimension-static-size-300);
   --spectrum-dialog-rule-height: var(--spectrum-global-dimension-static-size-25);
@@ -86,7 +86,7 @@
   --spectrum-dialog-destructive-icon-color: var(--spectrum-global-color-gray-900);
   --spectrum-dialog-destructive-title-text-color: var(--spectrum-global-color-gray-900);
   --spectrum-dialog-destructive-description-text-color: var(--spectrum-global-color-gray-800);
-  --spectrum-dialog-destructive-width: 90%;
+  --spectrum-dialog-destructive-width: 0.9;
   --spectrum-dialog-destructive-min-width: var(--spectrum-global-dimension-static-size-3600);
   --spectrum-dialog-destructive-icon-margin-left: var(--spectrum-global-dimension-static-size-300);
   --spectrum-dialog-destructive-divider-margin-top: var(--spectrum-global-dimension-static-size-150);
@@ -124,7 +124,7 @@
   --spectrum-dialog-error-background-color: var(--spectrum-alias-background-color-default);
   --spectrum-dialog-error-overlay-background-color: var(--spectrum-alias-background-color-modal-overlay);
   --spectrum-dialog-error-description-text-color: var(--spectrum-global-color-gray-800);
-  --spectrum-dialog-error-width: 90%;
+  --spectrum-dialog-error-width: 0.9;
   --spectrum-dialog-error-min-width: var(--spectrum-global-dimension-static-size-3600);
   --spectrum-dialog-error-icon-margin-left: var(--spectrum-global-dimension-static-size-300);
   --spectrum-dialog-error-divider-margin-top: var(--spectrum-global-dimension-static-size-150);
@@ -162,7 +162,7 @@
   --spectrum-dialog-info-icon-color: var(--spectrum-global-color-gray-900);
   --spectrum-dialog-info-title-text-color: var(--spectrum-global-color-gray-900);
   --spectrum-dialog-info-description-text-color: var(--spectrum-global-color-gray-800);
-  --spectrum-dialog-info-width: 90%;
+  --spectrum-dialog-info-width: 0.9;
   --spectrum-dialog-info-min-width: var(--spectrum-global-dimension-static-size-3600);
   --spectrum-dialog-info-icon-margin-left: var(--spectrum-global-dimension-static-size-300);
   --spectrum-dialog-info-divider-margin-top: var(--spectrum-global-dimension-static-size-150);

--- a/components/vars/css/components/spectrum-selectlist.css
+++ b/components/vars/css/components/spectrum-selectlist.css
@@ -52,7 +52,7 @@
   --spectrum-selectlist-thumbnail-option-text-color: var(--spectrum-alias-text-color);
   --spectrum-selectlist-thumbnail-option-icon-color: var(--spectrum-alias-icon-color-selected);
   --spectrum-selectlist-thumbnail-divider-color: var(--spectrum-alias-border-color-extralight);
-  --spectrum-selectlist-thumbnail-image-opacity: 100%;
+  --spectrum-selectlist-thumbnail-image-opacity: 1;
   --spectrum-selectlist-thumbnail-option-icon-color-hover: var(--spectrum-alias-icon-color-selected);
   --spectrum-selectlist-thumbnail-option-background-color-hover: var(--spectrum-alias-background-color-hover-overlay);
   --spectrum-selectlist-thumbnail-option-text-color-hover: var(--spectrum-alias-text-color);
@@ -74,7 +74,7 @@
   --spectrum-selectlist-thumbnail-option-background-color-disabled: var(--spectrum-alias-background-color-transparent);
   --spectrum-selectlist-thumbnail-option-text-color-disabled: var(--spectrum-alias-text-color-disabled);
   --spectrum-selectlist-thumbnail-option-icon-color-disabled: var(--spectrum-alias-icon-color-disabled);
-  --spectrum-selectlist-thumbnail-image-opacity-disabled: 30%;
+  --spectrum-selectlist-thumbnail-image-opacity-disabled: 0.3;
   --spectrum-selectlist-thumbnail-image-border-color: var(--spectrum-alias-border-color-translucent-dark);
   --spectrum-selectlist-thumbnail-option-focus-indicator-color: var(--spectrum-alias-border-color-focus);
   --spectrum-selectlist-thumbnail-background-color: var(--spectrum-alias-background-color-transparent);
@@ -102,7 +102,7 @@
   --spectrum-selectlist-thumbnail-small-option-text-color: var(--spectrum-alias-text-color);
   --spectrum-selectlist-thumbnail-small-option-icon-color: var(--spectrum-alias-icon-color-selected);
   --spectrum-selectlist-thumbnail-small-divider-color: var(--spectrum-alias-border-color-extralight);
-  --spectrum-selectlist-thumbnail-small-image-opacity: 100%;
+  --spectrum-selectlist-thumbnail-small-image-opacity: 1;
   --spectrum-selectlist-thumbnail-small-option-icon-color-hover: var(--spectrum-alias-icon-color-selected);
   --spectrum-selectlist-thumbnail-small-option-background-color-hover: var(--spectrum-alias-background-color-hover-overlay);
   --spectrum-selectlist-thumbnail-small-option-text-color-hover: var(--spectrum-alias-text-color);
@@ -124,7 +124,7 @@
   --spectrum-selectlist-thumbnail-small-option-background-color-disabled: var(--spectrum-alias-background-color-transparent);
   --spectrum-selectlist-thumbnail-small-option-text-color-disabled: var(--spectrum-alias-text-color-disabled);
   --spectrum-selectlist-thumbnail-small-option-icon-color-disabled: var(--spectrum-alias-icon-color-disabled);
-  --spectrum-selectlist-thumbnail-small-image-opacity-disabled: 30%;
+  --spectrum-selectlist-thumbnail-small-image-opacity-disabled: 0.3;
   --spectrum-selectlist-thumbnail-small-image-border-color: var(--spectrum-alias-border-color-translucent-dark);
   --spectrum-selectlist-thumbnail-small-option-focus-indicator-color: var(--spectrum-alias-border-color-focus);
   --spectrum-selectlist-thumbnail-small-background-color: var(--spectrum-alias-background-color-transparent);

--- a/components/vars/css/components/spectrum-tray.css
+++ b/components/vars/css/components/spectrum-tray.css
@@ -3,7 +3,7 @@
   --spectrum-tray-underlay-background-color: var(--spectrum-alias-background-color-modal-overlay);
   --spectrum-tray-padding-x: var(--spectrum-global-dimension-static-size-100);
   --spectrum-tray-padding-y: 0;
-  --spectrum-tray-width: 100%;
+  --spectrum-tray-width: 1;
   --spectrum-tray-max-width: 375px;
   --spectrum-tray-min-height: var(--spectrum-global-dimension-static-size-800);
   --spectrum-tray-border-radius: 0px;

--- a/components/vars/css/globals/spectrum-dimensionGlobals.css
+++ b/components/vars/css/globals/spectrum-dimensionGlobals.css
@@ -45,14 +45,14 @@
   --spectrum-global-dimension-static-font-size-800: 32px;
   --spectrum-global-dimension-static-font-size-900: 36px;
   --spectrum-global-dimension-static-font-size-1000: 40px;
-  --spectrum-global-dimension-static-percent-50: 50%;
-  --spectrum-global-dimension-static-percent-100: 100%;
+  --spectrum-global-dimension-static-percent-50: 0.5;
+  --spectrum-global-dimension-static-percent-100: 1;
   --spectrum-global-dimension-static-breakpoint-xsmall: 304px;
   --spectrum-global-dimension-static-breakpoint-small: 768px;
   --spectrum-global-dimension-static-breakpoint-medium: 1280px;
   --spectrum-global-dimension-static-breakpoint-large: 1768px;
   --spectrum-global-dimension-static-breakpoint-xlarge: 2160px;
   --spectrum-global-dimension-static-grid-columns: 12;
-  --spectrum-global-dimension-static-grid-fluid-width: 100%;
+  --spectrum-global-dimension-static-grid-fluid-width: 1;
   --spectrum-global-dimension-static-grid-fixed-max-width: 1280px;
 }

--- a/components/vars/tasks/updateDNA.js
+++ b/components/vars/tasks/updateDNA.js
@@ -115,6 +115,9 @@ function processValue(name, value) {
     }
     return value;
   }
+  if (typeof(value) === 'string' && value.substr(-1) === '%') {
+    return parseInt(value, 10) / 100;
+  }
   return value;
 }
 


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->
Instead of attempting to convert percentage values to floats at the CSS implementation level, we instead convert them at the variable import level. This means you can directly use opacity variables and they'll already be real CSS values.

## How and where has this been tested?
 - **How this was tested:**
```
cd components/vars
gulp update
git diff
```
 - **Browser(s) and OS(s) this was tested with:** n/a


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaning tasks here -->
- [x] This pull request is ready to merge.
