### PR TITLE
docs: fix FOUT if Typekit times out

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -14,7 +14,8 @@ body {
   // transition: opacity var(--spectrum-global-animation-duration-200) ease-out 0ms;
 }
 
-:global(.wf-active) {
+:global(.wf-active),
+:global(.wf-inactive) {
   opacity: 1;
 }
 


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->
If Typekit times out, we get `.wf-inactive` instead of `.wf-active`. This PR makes things still display.

## How and where has this been tested?
 - **How this was tested:** load site with WiFi off
 - **Browser(s) and OS(s) this was tested with:** Chrome macOS


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaning tasks here -->
- [x] This pull request is ready to merge.
