### PR TITLE
docs: fix detail table styling

### DIFF
--- a/components/css/componentPage.scss
+++ b/components/css/componentPage.scss
@@ -15,6 +15,18 @@
   margin-bottom: 73px;
 }
 
+:global(.spectrum--large),
+:global(.spectrum--medium) {
+  :local(.compStatus) {
+    min-height: 0;
+    padding: 0;
+
+    &:before {
+      margin-left: 0;
+    }
+  }
+}
+
 :local(div.subHeadStatusLight) {
   display: inline-flex;
 }

--- a/pages/components/id.js
+++ b/pages/components/id.js
@@ -101,16 +101,16 @@ class Page extends React.Component {
             <tr>
               <th className="spectrum-Body--secondary">Component status</th>
               <td>
-                <Status style={{position: "relative", left: "-11px"}} status={componentStatus}/>
+                <Status className={compStyles.compStatus} status={componentStatus}/>
               </td>
             </tr>
             <tr>
               <th className="spectrum-Body--secondary">Last released</th>
-              <td>October 8, 2019</td>
+              <td className="spectrum-Body4">October 8, 2019</td>
             </tr>
             <tr>
               <th className="spectrum-Body--secondary">Current version</th>
-              <td>{this.props.pageData.packageName}@{this.props.pageData.packageVersion}</td>
+              <td className="spectrum-Body4">{this.props.pageData.packageName}@{this.props.pageData.packageVersion}</td>
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->
This fixes the detail table font size on large scale as well as line height for the first entry.

## How and where has this been tested?
 - **How this was tested:** Load, use large, examine detail table
 - **Browser(s) and OS(s) this was tested with:** Chrome macOS

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->
![image](https://user-images.githubusercontent.com/201344/67248437-56417180-f419-11e9-8b2a-19e6c4c9b0f7.png)


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaning tasks here -->
- [x] This pull request is ready to merge.
