### PR TITLE
fix: sidebar width is too small to fit "Spectrum CSS" in large scale

### DIFF
--- a/components/Sidebar.js
+++ b/components/Sidebar.js
@@ -74,6 +74,8 @@ class Sidebar extends React.Component {
   };
 
   render() {
+    let sidebarWidth = '208px';
+
     return (
       <>
         <div
@@ -107,7 +109,7 @@ class Sidebar extends React.Component {
             <div className={styles.navigation}>
               <SideNav
                 defaultValue={this.props.router.query.id}
-                style={{ width: "200px", marginBottom: 80 }}
+                style={{ width: sidebarWidth, marginBottom: 80 }}
                 variant="multiLevel"
               >
                 {menuData.menu[0].children.map((item, i) => {
@@ -117,7 +119,7 @@ class Sidebar extends React.Component {
                         value={item.url}
                         label={item.title}
                         key={i}
-                        style={{ width: "200px" }}
+                        style={{ width: sidebarWidth }}
                         ref={
                           item.url === this.props.router.query.id
                             ? this.selectedItem
@@ -146,7 +148,7 @@ class Sidebar extends React.Component {
                         label={item.title}
                         key={i}
                         defaultExpanded={item.defaultExpanded}
-                        style={{ width: "200px" }}
+                        style={{ width: sidebarWidth }}
                       >
                         {item.children &&
                           item.children.map((childItem, childI) => {
@@ -155,7 +157,7 @@ class Sidebar extends React.Component {
                                 value={childItem.url}
                                 label={childItem.title}
                                 key={childI}
-                                style={{ width: "200px" }}
+                                style={{ width: sidebarWidth }}
                                 ref={
                                   childItem.url === this.props.router.query.id
                                     ? this.selectedItem
@@ -184,12 +186,12 @@ class Sidebar extends React.Component {
                   }
                 })}
               </SideNav>
-              <SideNav style={{ width: "200px", marginBottom: "40px" }}>
+              <SideNav style={{ width: sidebarWidth, marginBottom: "40px" }}>
                 <SideNavItem
                   value="Spectrum"
                   target="_blank"
                   href="https://spectrum.adobe.com/"
-                  style={{ width: "200px" }}
+                  style={{ width: sidebarWidth }}
                 >
                   Spectrum
                 </SideNavItem>

--- a/components/css/sidebar.scss
+++ b/components/css/sidebar.scss
@@ -54,7 +54,7 @@
   left:0px;
   top:0px;
   bottom:0px;
-  width:248px;
+  width:256px;
   transition: none;
 
   @media screen and (max-width: 960px) {
@@ -84,7 +84,7 @@
 
   padding: 30px 24px 24px 24px;
 
-  width: 248px;
+  width: 256px;
 
 }
 


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->
Fix width of the sidebar.

## How and where has this been tested?
 - **How this was tested:** load site, get large, expand menu, look to make sure Spectrum CSS doesn't wrap
 - **Browser(s) and OS(s) this was tested with:** Chrome macOS


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaning tasks here -->
- [x] This pull request is ready to merge.
