### PR TITLE
docs: fix switcher wrapping on small screens

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -119,7 +119,9 @@ p:global(.spectrum-Body3) {
   display: flex;
   justify-content: flex-end;
   flex-wrap: wrap;
-  & > * {
-    margin-right: 37px;
-  }
+  margin-right: var(--spectrum-global-dimension-size-200);
+}
+
+:global(.scaleSelector) {
+  margin-left: var(--spectrum-global-dimension-size-400);
 }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -119,7 +119,7 @@ class MyApp extends App {
             <Sidebar {...pageProps} />
             <Layout>
               <div className="switcherContainer">
-                <FieldLabel label="Theme" labelFor="theme-selector" position="left">
+                <FieldLabel className="themeSelector" label="Theme" labelFor="theme-selector" position="left">
                   <Select
                     onChange={this.updateTheme}
                     id="theme-selector"
@@ -135,7 +135,7 @@ class MyApp extends App {
                     flexible
                   />
                 </FieldLabel>
-                <FieldLabel label="Scale" labelFor="scale-selector" position="left">
+                <FieldLabel className="scaleSelector" label="Scale" labelFor="scale-selector" position="left">
                   <Select
                     ref={this.scaleSelector}
                     id="scale-selector"


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->
This makes things wrap nicely on tiny phones.

## How and where has this been tested?
 - **How this was tested:** Use device inspector, select iPhone 5, switch to Large scale
 - **Browser(s) and OS(s) this was tested with:** iOS Simulator, Chrome

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->
![image](https://user-images.githubusercontent.com/201344/67309763-46756c00-f4b1-11e9-8184-8a620f0011b4.png)


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaning tasks here -->
- [x] This pull request is ready to merge.
