### PR TITLE
fix: revert Checkbox/Radio/Switch color change, fixes #355

### DIFF
--- a/components/checkbox/skin.css
+++ b/components/checkbox/skin.css
@@ -11,24 +11,24 @@ governing permissions and limitations under the License.
 */
 
 .spectrum-Checkbox-label {
-  color: var(--spectrum-checkbox-text-color);
+  color: var(--spectrum-checkbox-emphasized-text-color);
 }
 
 .spectrum-Checkbox-box {
-  border-color: var(--spectrum-checkbox-box-border-color);
-  background-color: var(--spectrum-checkbox-box-background-color);
+  border-color: var(--spectrum-checkbox-emphasized-box-border-color);
+  background-color: var(--spectrum-checkbox-emphasized-box-background-color);
 }
 
 /* Indetermiate is basically a checked state, so handle colors for checked state here */
 .spectrum-Checkbox.is-indeterminate .spectrum-Checkbox-box,
 .spectrum-Checkbox-input:checked + .spectrum-Checkbox-box {
-  border-color: var(--spectrum-checkbox-box-border-color-selected);
+  border-color: var(--spectrum-checkbox-emphasized-box-border-color-selected);
 }
 
 .spectrum-Checkbox:hover {
   &.is-indeterminate .spectrum-Checkbox-box,
   .spectrum-Checkbox-input:checked + .spectrum-Checkbox-box {
-    border-color: var(--spectrum-checkbox-box-border-color-selected-hover);
+    border-color: var(--spectrum-checkbox-emphasized-box-border-color-selected-hover);
 
   }
 }
@@ -36,51 +36,51 @@ governing permissions and limitations under the License.
 .spectrum-Checkbox:active {
   &.is-indeterminate .spectrum-Checkbox-box,
   .spectrum-Checkbox-input:checked + .spectrum-Checkbox-box {
-    border-color: var(--spectrum-checkbox-box-border-color-selected-down);
+    border-color: var(--spectrum-checkbox-emphasized-box-border-color-selected-down);
 
   }
 }
 
 .spectrum-Checkbox {
-  border-color: var(--spectrum-checkbox-box-border-color);
+  border-color: var(--spectrum-checkbox-emphasized-box-border-color);
 
   &:hover {
     .spectrum-Checkbox-box {
-      border-color: var(--spectrum-checkbox-box-border-color-hover);
+      border-color: var(--spectrum-checkbox-emphasized-box-border-color-hover);
 
       box-shadow: none;
     }
     .spectrum-Checkbox-label {
-      color: var(--spectrum-checkbox-text-color-hover);
+      color: var(--spectrum-checkbox-emphasized-text-color-hover);
     }
   }
 
   &:active {
     .spectrum-Checkbox-box {
-      border-color: var(--spectrum-checkbox-box-border-color-down);
+      border-color: var(--spectrum-checkbox-emphasized-box-border-color-down);
 
     }
     .spectrum-Checkbox-label {
-      color: var(--spectrum-checkbox-text-color-down);
+      color: var(--spectrum-checkbox-emphasized-text-color-down);
     }
   }
 
   .spectrum-Checkbox-checkmark,
   .spectrum-Checkbox-partialCheckmark {
-    color: var(--spectrum-checkbox-checkmark-color);
+    color: var(--spectrum-checkbox-emphasized-checkmark-color);
   }
 }
 
 .spectrum-Checkbox-input {
   &:disabled + .spectrum-Checkbox-box {
     /* Use important to override hover states */
-    border-color: var(--spectrum-checkbox-box-border-color-disabled) !important;
+    border-color: var(--spectrum-checkbox-emphasized-box-border-color-disabled) !important;
 
-    background-color: var(--spectrum-checkbox-box-background-color-disabled);
+    background-color: var(--spectrum-checkbox-emphasized-box-background-color-disabled);
   }
 
   &:disabled ~ .spectrum-Checkbox-label {
-    color: var(--spectrum-checkbox-text-color-disabled);
+    color: var(--spectrum-checkbox-emphasized-text-color-disabled);
   }
 }
 
@@ -88,13 +88,13 @@ governing permissions and limitations under the License.
 .spectrum-Checkbox-input {
   &:focus-ring + .spectrum-Checkbox-box {
     /* Since the specificity of .focus-ring is less than :hover, we need important */
-    border-color: var(--spectrum-checkbox-box-border-color-key-focus) !important;
+    border-color: var(--spectrum-checkbox-emphasized-box-border-color-key-focus) !important;
 
-    box-shadow: 0 0 0 1px var(--spectrum-checkbox-box-border-color-key-focus) !important;
+    box-shadow: 0 0 0 1px var(--spectrum-checkbox-emphasized-box-border-color-key-focus) !important;
   }
 
   &:focus-ring ~ .spectrum-Checkbox-label {
-    color: var(--spectrum-checkbox-text-color-key-focus) !important;
+    color: var(--spectrum-checkbox-emphasized-text-color-key-focus) !important;
   }
 }
 

--- a/components/radio/skin.css
+++ b/components/radio/skin.css
@@ -12,49 +12,49 @@ governing permissions and limitations under the License.
 
 .spectrum-Radio .spectrum-Radio-input {
   &:checked + .spectrum-Radio-button {
-    border-color: var(--spectrum-radio-circle-border-color-selected);
+    border-color: var(--spectrum-radio-emphasized-circle-border-color-selected);
   }
 }
 
 .spectrum-Radio-label {
-  color: var(--spectrum-radio-text-color);
+  color: var(--spectrum-radio-emphasized-text-color);
 }
 
 .spectrum-Radio-button {
-  background-color: var(--spectrum-radio-circle-background-color);
-  border-color: var(--spectrum-radio-circle-border-color);
+  background-color: var(--spectrum-radio-emphasized-circle-background-color);
+  border-color: var(--spectrum-radio-emphasized-circle-border-color);
 }
 
 .spectrum-Radio {
   &:hover {
     .spectrum-Radio-button {
-      border-color: var(--spectrum-radio-circle-border-color-hover);
+      border-color: var(--spectrum-radio-emphasized-circle-border-color-hover);
       box-shadow: none;
     }
 
     .spectrum-Radio-input:checked + .spectrum-Radio-button {
-      border-color: var(--spectrum-radio-circle-border-color-selected-hover);
+      border-color: var(--spectrum-radio-emphasized-circle-border-color-selected-hover);
 
     }
 
     .spectrum-Radio-label {
-      color: var(--spectrum-radio-text-color-hover);
+      color: var(--spectrum-radio-emphasized-text-color-hover);
     }
 
   }
 
   &:active {
     .spectrum-Radio-button {
-      border-color: var(--spectrum-radio-circle-border-color-down);
+      border-color: var(--spectrum-radio-emphasized-circle-border-color-down);
     }
 
     .spectrum-Radio-input:checked + .spectrum-Radio-button {
-      border-color: var(--spectrum-radio-circle-border-color-selected-down);
+      border-color: var(--spectrum-radio-emphasized-circle-border-color-selected-down);
 
     }
 
     .spectrum-Radio-label {
-      color: var(--spectrum-radio-text-color-down);
+      color: var(--spectrum-radio-emphasized-text-color-down);
     }
   }
 }
@@ -79,37 +79,37 @@ governing permissions and limitations under the License.
 .spectrum-Radio, .spectrum-Radio--quiet {
   &.is-invalid:hover {
     .spectrum-Radio-input + .spectrum-Radio-button {
-      border-color: var(--spectrum-radio-circle-border-color-error-hover);
+      border-color: var(--spectrum-radio-emphasized-circle-border-color-error-hover);
     }
     .spectrum-Radio-label {
-      color: var(--spectrum-radio-circle-border-color-error-hover);
+      color: var(--spectrum-radio-emphasized-circle-border-color-error-hover);
     }
   }
   &.is-invalid:active {
     .spectrum-Radio-input + .spectrum-Radio-button {
-      border-color: var(--spectrum-radio-circle-border-color-error-down);
+      border-color: var(--spectrum-radio-emphasized-circle-border-color-error-down);
     }
     .spectrum-Radio-label {
-      color: var(--spectrum-radio-circle-border-color-error-down);
+      color: var(--spectrum-radio-emphasized-circle-border-color-error-down);
     }
   }
   &.is-invalid {
     .spectrum-Radio-button, .spectrum-Radio-input:checked + .spectrum-Radio-button {
-      border-color: var(--spectrum-radio-circle-border-color-error);
+      border-color: var(--spectrum-radio-emphasized-circle-border-color-error);
     }
     .spectrum-Radio-label {
-      color: var(--spectrum-radio-circle-border-color-error);
+      color: var(--spectrum-radio-emphasized-circle-border-color-error);
     }
   }
 }
 
 .spectrum-Radio-input {
   &:disabled + .spectrum-Radio-button {
-    border-color: var(--spectrum-radio-circle-border-color-disabled) !important;
+    border-color: var(--spectrum-radio-emphasized-circle-border-color-disabled) !important;
   }
 
   &:disabled ~ .spectrum-Radio-label {
-    color: var(--spectrum-radio-text-color-disabled) !important;
+    color: var(--spectrum-radio-emphasized-text-color-disabled) !important;
   }
 }
 
@@ -117,17 +117,17 @@ governing permissions and limitations under the License.
 .spectrum-Radio, .spectrum-Radio--quiet {
   & .spectrum-Radio-input:focus-ring, &:hover .spectrum-Radio-input:focus-ring {
     & + .spectrum-Radio-button {
-      border-color: var(--spectrum-radio-circle-border-color-key-focus);
-      box-shadow: 0 0 0 1px var(--spectrum-radio-circle-border-color-key-focus);
+      border-color: var(--spectrum-radio-emphasized-circle-border-color-key-focus);
+      box-shadow: 0 0 0 1px var(--spectrum-radio-emphasized-circle-border-color-key-focus);
     }
     & ~ .spectrum-Radio-label {
-      color: var(--spectrum-radio-text-color-key-focus);
+      color: var(--spectrum-radio-emphasized-text-color-key-focus);
     }
   }
   &.is-invalid {
     .spectrum-Radio-input:checked:focus-ring + .spectrum-Radio-button {
-      border-color: var(--spectrum-radio-circle-border-color-key-focus);
-      box-shadow: 0 0 0 1px var(--spectrum-radio-circle-border-color-key-focus);
+      border-color: var(--spectrum-radio-emphasized-circle-border-color-key-focus);
+      box-shadow: 0 0 0 1px var(--spectrum-radio-emphasized-circle-border-color-key-focus);
     }
   }
 }

--- a/components/toggle/skin.css
+++ b/components/toggle/skin.css
@@ -14,25 +14,25 @@ governing permissions and limitations under the License.
 .spectrum-ToggleSwitch-switch {
   /* :before is used for the track of the switch */
   &::before {
-    background-color: var(--spectrum-switch-track-color);
+    background-color: var(--spectrum-switch-emphasized-track-color);
   }
   /* :after is used for the handle of the switch */
   &::after {
-    background-color: var(--spectrum-switch-handle-background-color);
-    border-color: var(--spectrum-switch-handle-border-color);
+    background-color: var(--spectrum-switch-emphasized-handle-background-color);
+    border-color: var(--spectrum-switch-emphasized-handle-border-color);
   }
 }
 .spectrum-ToggleSwitch-input ~ .spectrum-ToggleSwitch-label {
-  color: var(--spectrum-switch-text-color);
+  color: var(--spectrum-switch-emphasized-text-color);
 }
 /* Selected */
 .spectrum-ToggleSwitch-input {
   &:checked + .spectrum-ToggleSwitch-switch {
     &::before {
-      background-color: var(--spectrum-switch-track-color-selected);
+      background-color: var(--spectrum-switch-emphasized-track-color-selected);
     }
     &::after {
-      border-color: var(--spectrum-switch-handle-border-color-selected);
+      border-color: var(--spectrum-switch-emphasized-handle-border-color-selected);
     }
   }
 }
@@ -41,20 +41,20 @@ governing permissions and limitations under the License.
   .spectrum-ToggleSwitch-input {
     & + .spectrum-ToggleSwitch-switch {
       &::after {
-        border-color: var(--spectrum-switch-handle-border-color-hover);
+        border-color: var(--spectrum-switch-emphasized-handle-border-color-hover);
         box-shadow: none;
       }
     }
     & ~ .spectrum-ToggleSwitch-label {
-      color: var(--spectrum-switch-text-color-hover);
+      color: var(--spectrum-switch-emphasized-text-color-hover);
     }
     /* Selected Hover */
     &:checked:enabled + .spectrum-ToggleSwitch-switch {
       &::before {
-        background-color: var(--spectrum-switch-track-color-selected-hover);
+        background-color: var(--spectrum-switch-emphasized-track-color-selected-hover);
       }
       &::after {
-        border-color: var(--spectrum-switch-handle-border-color-selected-hover);
+        border-color: var(--spectrum-switch-emphasized-handle-border-color-selected-hover);
       }
     }
   }
@@ -64,19 +64,19 @@ governing permissions and limitations under the License.
   .spectrum-ToggleSwitch-input {
     & + .spectrum-ToggleSwitch-switch {
       &::after {
-        border-color: var(--spectrum-switch-handle-border-color-down);
+        border-color: var(--spectrum-switch-emphasized-handle-border-color-down);
       }
     }
     & ~ .spectrum-ToggleSwitch-label {
-      color: var(--spectrum-switch-text-color-down);
+      color: var(--spectrum-switch-emphasized-text-color-down);
     }
     /* Selected Down */
     &:checked:enabled + .spectrum-ToggleSwitch-switch {
       &::before {
-        background-color: var(--spectrum-switch-track-color-selected-down);
+        background-color: var(--spectrum-switch-emphasized-track-color-selected-down);
       }
       &::after {
-        border-color: var(--spectrum-switch-handle-border-color-selected-down);
+        border-color: var(--spectrum-switch-emphasized-handle-border-color-selected-down);
       }
     }
   }
@@ -85,28 +85,28 @@ governing permissions and limitations under the License.
 .spectrum-ToggleSwitch .spectrum-ToggleSwitch-input:disabled {
   & + .spectrum-ToggleSwitch-switch {
     &::before {
-      background-color: var(--spectrum-switch-track-color-disabled);
+      background-color: var(--spectrum-switch-emphasized-track-color-disabled);
     }
 
     &::after {
-      border-color: var(--spectrum-switch-handle-border-color-disabled);
+      border-color: var(--spectrum-switch-emphasized-handle-border-color-disabled);
     }
   }
   & ~ .spectrum-ToggleSwitch-label {
-    color: var(--spectrum-switch-text-color-disabled);
+    color: var(--spectrum-switch-emphasized-text-color-disabled);
   }
   /* Selected Disabled */
   &:checked {
     & + .spectrum-ToggleSwitch-switch {
       &::before {
-        background-color: var(--spectrum-switch-track-color-selected-disabled);
+        background-color: var(--spectrum-switch-emphasized-track-color-selected-disabled);
       }
       &::after {
-        border-color: var(--spectrum-switch-handle-border-color-selected-disabled);
+        border-color: var(--spectrum-switch-emphasized-handle-border-color-selected-disabled);
       }
     }
     & ~ .spectrum-ToggleSwitch-label {
-      color: var(--spectrum-switch-text-color-selected-disabled);
+      color: var(--spectrum-switch-emphasized-text-color-selected-disabled);
     }
   }
 }
@@ -149,26 +149,26 @@ governing permissions and limitations under the License.
   .spectrum-ToggleSwitch-input:focus-ring {
     & + .spectrum-ToggleSwitch-switch {
       &::after {
-        border-color: var(--spectrum-switch-handle-border-color-key-focus);
-        box-shadow: 0 0 0 1px var(--spectrum-switch-handle-border-color-key-focus);
+        border-color: var(--spectrum-switch-emphasized-handle-border-color-key-focus);
+        box-shadow: 0 0 0 1px var(--spectrum-switch-emphasized-handle-border-color-key-focus);
       }
     }
     & ~ .spectrum-ToggleSwitch-label {
-      color: var(--spectrum-switch-text-color-key-focus);
+      color: var(--spectrum-switch-emphasized-text-color-key-focus);
     }
     /* Selected Key Focus */
     &:checked {
       & + .spectrum-ToggleSwitch-switch {
         &::before {
-          background-color: var(--spectrum-switch-track-color-selected-key-focus);
+          background-color: var(--spectrum-switch-emphasized-track-color-selected-key-focus);
         }
         &::after {
-          border-color: var(--spectrum-switch-handle-border-color-selected-key-focus);
-          box-shadow: 0 0 0 1px var(--spectrum-switch-handle-border-color-selected-key-focus);
+          border-color: var(--spectrum-switch-emphasized-handle-border-color-selected-key-focus);
+          box-shadow: 0 0 0 1px var(--spectrum-switch-emphasized-handle-border-color-selected-key-focus);
         }
       }
       & ~ .spectrum-ToggleSwitch-label {
-        color: var(--spectrum-switch-text-color-selected-key-focus);
+        color: var(--spectrum-switch-emphasized-text-color-selected-key-focus);
       }
     }
   }
@@ -179,7 +179,7 @@ governing permissions and limitations under the License.
     & {
       &:checked + .spectrum-ToggleSwitch-switch {
         &::before {
-          background-color: var(--spectrum-switch-track-color);
+          background-color: var(--spectrum-switch-emphasized-track-color);
         }
       }
     }
@@ -187,17 +187,17 @@ governing permissions and limitations under the License.
     &:checked + .spectrum-ToggleSwitch-switch {
       &::after {
         /* Don't be blue */
-        border-color: var(--spectrum-switch-handle-border-color);
+        border-color: var(--spectrum-switch-emphasized-handle-border-color);
       }
     }
 
     &:focus-ring {
       &:checked + .spectrum-ToggleSwitch-switch {
         &::before {
-          background-color: var(--spectrum-switch-track-color);
+          background-color: var(--spectrum-switch-emphasized-track-color);
         }
         &::after {
-          border-color: var(--spectrum-switch-handle-border-color-key-focus);
+          border-color: var(--spectrum-switch-emphasized-handle-border-color-key-focus);
         }
       }
     }
@@ -205,17 +205,17 @@ governing permissions and limitations under the License.
     &:disabled {
       &:checked + .spectrum-ToggleSwitch-switch {
         &::before {
-          background-color: var(--spectrum-switch-track-color-disabled);
+          background-color: var(--spectrum-switch-emphasized-track-color-disabled);
         }
       }
 
       & + .spectrum-ToggleSwitch-switch {
         &::before {
-          background-color: var(--spectrum-switch-track-color-disabled);
+          background-color: var(--spectrum-switch-emphasized-track-color-disabled);
         }
 
         &::after {
-          border-color: var(--spectrum-switch-handle-border-color-disabled);
+          border-color: var(--spectrum-switch-emphasized-handle-border-color-disabled);
         }
       }
     }
@@ -225,10 +225,10 @@ governing permissions and limitations under the License.
     .spectrum-ToggleSwitch-input {
       &:checked:enabled + .spectrum-ToggleSwitch-switch {
         &::before {
-          background-color: var(--spectrum-switch-track-color);
+          background-color: var(--spectrum-switch-emphasized-track-color);
         }
         &::after {
-          border-color: var(--spectrum-switch-handle-border-color-hover);
+          border-color: var(--spectrum-switch-emphasized-handle-border-color-hover);
         }
       }
     }
@@ -238,10 +238,10 @@ governing permissions and limitations under the License.
     .spectrum-ToggleSwitch-input {
       &:checked:enabled + .spectrum-ToggleSwitch-switch {
         &::before {
-          background-color: var(--spectrum-switch-track-color);
+          background-color: var(--spectrum-switch-emphasized-track-color);
         }
         &::after {
-          border-color: var(--spectrum-switch-handle-border-color-down);
+          border-color: var(--spectrum-switch-emphasized-handle-border-color-down);
         }
       }
     }


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->
This PR reverts the Checkbox/Radio/Switch color change, addressing #355 by using the emphasized variant by default.

## How and where has this been tested?
 - **How this was tested:** visit Checkbox/Radio/Switch, observe blue goodness
 - **Browser(s) and OS(s) this was tested with:** Chrome macOS

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->
![image](https://user-images.githubusercontent.com/201344/67320978-cf959e80-f4c3-11e9-9a9b-054b166db4dc.png)
![image](https://user-images.githubusercontent.com/201344/67321785-d96bd180-f4c4-11e9-8dea-3a824007deb2.png)
![image](https://user-images.githubusercontent.com/201344/67321823-eb4d7480-f4c4-11e9-9945-0d0f7a7e310f.png)


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaning tasks here -->
- [ ] This pull request is ready to merge.
