### PR TITLE
docs: fix dialog presentation on docs page

### DIFF
--- a/components/css/componentPage.scss
+++ b/components/css/componentPage.scss
@@ -28,6 +28,7 @@
 }
 
 :local(.example) {
+  position: relative;
   background-color: var(--spectrum-global-color-gray-100);
   border-radius: var(--spectrum-global-dimension-size-50) var(--spectrum-global-dimension-size-50) 0 0;
   flex: 1 0 auto;
@@ -68,4 +69,16 @@
   padding: 0 0 var(--spectrum-global-dimension-size-160) var(--spectrum-global-dimension-size-85);
   text-align: left;
   display: inline-block;
+}
+
+:global(.spectrum-CSSExample-example--overlay) {
+  background: rgba(0,0,0,0.4);
+  color: rgba(0,0,0,0.4);
+}
+
+:global(.spectrum-CSSExample-overlayShowButton) {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
 }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -162,6 +162,7 @@ class MyApp extends App {
               <Component {...pageProps} />
             </Layout>
           </div>
+          <div class="spectrum-Underlay" id="spectrum-underlay"></div>
         </Provider>
       </div>
     )

--- a/pages/components/id.js
+++ b/pages/components/id.js
@@ -52,7 +52,7 @@ class Markup extends React.Component {
 
 class Variant extends React.Component {
   render() {
-    this.props.example.markup = this.props.example.markup.replace('src="img/', `src="${process.env.BACKEND_URL}/static/images/`)
+    this.props.example.markup = this.props.example.markup.replace('src="img/', `src="${process.env.BACKEND_URL}/static/images/`).replace('url(img/', `url(${process.env.BACKEND_URL}/static/images/`)
     return (
       <article>
         <SubHeader title={this.props.example.name}>
@@ -66,7 +66,7 @@ class Variant extends React.Component {
         ) : undefined }
         { this.props.example.markup ? (
           <section className={compStyles.exampleContainer}>
-            <div className={compStyles.example} dangerouslySetInnerHTML={{
+            <div className={classNames(compStyles.example, this.props.example.demoClassName)} dangerouslySetInnerHTML={{
               __html: this.props.example.markup
             }}/>
           <Markup>{this.props.example.markup}</Markup>


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->
Fix Dialog page on next.js documentation

## How and where has this been tested?
 - **How this was tested:** open Dialog and check it out
 - **Browser(s) and OS(s) this was tested with:** Chrome macOS

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->
![image](https://user-images.githubusercontent.com/201344/67431138-895e3f00-f598-11e9-8d7a-dbdb18739912.png)


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
