### PR TITLE
docs: fix dev site Dropdown enhancements in IE 11

### DIFF
--- a/site/resources/js/enhancement.js
+++ b/site/resources/js/enhancement.js
@@ -20,12 +20,12 @@ governing permissions and limitations under the License.
     var popover = dropdown.querySelector('.spectrum-Dropdown-popover');
 
     dropdown[isOpen ? 'setAttribute' : 'removeAttribute']('aria-expanded', 'true');
-    dropdown.classList.toggle('is-open', isOpen);
-    fieldButton.classList.toggle('is-selected', isOpen);
+    dropdown.classList[isOpen ? 'add' : 'remove']('is-open');
+    fieldButton.classList[isOpen ? 'add' : 'remove']('is-selected');
 
     if (popover) {
       popover.style.zIndex = 1;
-      popover.classList.toggle('is-open', isOpen);
+      popover.classList[isOpen ? 'add' : 'remove']('is-open');
     }
 
     if (isOpen) {

--- a/site/resources/js/polyfills.js
+++ b/site/resources/js/polyfills.js
@@ -30,6 +30,19 @@ if (!Element.prototype.closest) {
   };
 }
 
+if (typeof window.CustomEvent !== 'function') {
+  function CustomEvent (event, params) {
+    params = params || { bubbles: false, cancelable: false, detail: undefined };
+    var evt = document.createEvent('CustomEvent');
+    evt.initCustomEvent(event, params.bubbles, params.cancelable, params.detail);
+    return evt;
+  }
+
+  CustomEvent.prototype = window.Event.prototype;
+
+  window.CustomEvent = CustomEvent;
+}
+
 (function() {
   // IE 11 compat
   let stops = [


### PR DESCRIPTION
##  Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->
The dev site Dropdown enhancements were broken in IE 11 as they rely on `CustomEvent`.

This PR adds a polyfill for `CustomEvent` and works around IE 11's lack of support for the second argument to [`classList.toggle()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/classList)


## How and where has this been tested?
 - **How this was tested:** 
1. Dust of IE 11 VM (blow in serial port if it doesn't start)
1. Open up dev docs site
1. Click Theme or Scale dropdown
1. Select a new Theme or Scale
1. Theme/Scale switches, dropdown closes
 - **Browser(s) and OS(s) this was tested with:** IE 11 on Windows 8.1

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->
![image](https://user-images.githubusercontent.com/201344/67712763-d4ee5f80-f981-11e9-85ed-007ae71629ab.png)


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
