### PR TITLE
Fix Github to GitHub

### DIFF
--- a/site/templates/siteComponent.pug
+++ b/site/templates/siteComponent.pug
@@ -153,7 +153,7 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
                       View repository
                   .spectrum-Card-content
                     .spectrum-Card-description.
-                      Github
+                      GitHub
               a.spectrum-Card.spectrum-Card--small.spectrum-Card--horizontal(href=`https://www.npmjs.com/package/${pkg.name}` target="_blank")
                 .spectrum-Card-preview.spectrum-CSSComponent-resource--npm
                   svg(class="spectrum-Icon spectrum-Icon--sizeL" viewBox="0 0 18 7" focusable="false" aria-hidden="true" aria-label="npm")


### PR DESCRIPTION
## Description
Fix `GitHub` name to be right, not `Github`.

## How and where has this been tested?
 - **How this was tested:** Rebuild doc and browse any component page.
 - **Browser(s) and OS(s) this was tested with:** Nothing special.

## Screenshots
Before:
<img width="441" alt="Screen Shot 2019-10-30 at 2 12 50 PM" src="https://user-images.githubusercontent.com/579366/67830830-8aa2e500-fb1f-11e9-9445-e4cda660de7a.png">

After:
<img width="439" alt="Screen Shot 2019-10-30 at 2 13 06 PM" src="https://user-images.githubusercontent.com/579366/67830833-8ecf0280-fb1f-11e9-826b-7007bc182aec.png">


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
