### PR TITLE
docs: add Rating enhancement to show focus, closes #249

### DIFF
--- a/components/rating/metadata/rating.yml
+++ b/components/rating/metadata/rating.yml
@@ -109,7 +109,7 @@ examples:
     description: A non-interactive rating.
     markup: |
       <div class="spectrum-Rating is-readOnly">
-        <input class="spectrum-Rating-input" type="range" min="0" max="5" value="0" readOnly aria-label="Rating">
+        <input class="spectrum-Rating-input" type="range" min="0" max="5" value="3" readonly aria-label="Rating">
 
         <span class="spectrum-Rating-icon is-selected">
           <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">
@@ -262,7 +262,7 @@ examples:
     name: Quiet (read-only)
     markup: |
       <div class="spectrum-Rating spectrum-Rating--quiet is-readOnly">
-        <input class="spectrum-Rating-input" type="range" min="0" max="5" value="0" readOnly aria-label="Rating">
+        <input class="spectrum-Rating-input" type="range" min="0" max="5" value="3" readonly aria-label="Rating">
 
         <span class="spectrum-Rating-icon is-selected">
           <svg class="spectrum-Icon spectrum-UIIcon-Star spectrum-Rating-starActive" focusable="false" aria-hidden="true">

--- a/site/resources/js/enhancement.js
+++ b/site/resources/js/enhancement.js
@@ -10,6 +10,62 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+// Rating
+(function() {
+  function setFocus(rating, focused) {
+    rating.classList[focused ? 'add' : 'remove']('is-focused');
+  }
+
+  function setValue(rating, value) {
+    var input = rating.querySelector('.spectrum-Rating-input');
+    input.value = value;
+    Array.prototype.forEach.call(rating.querySelectorAll('.spectrum-Rating-icon'), function(el, index) {
+      el.classList[index <= value - 1 ? 'add' : 'remove']('is-selected');
+      el.classList[index === value - 1 ? 'add' : 'remove']('is-currentValue');
+    });
+  }
+
+  document.addEventListener('focusin', function(event) {
+    var rating = event.target.closest('.spectrum-Rating');
+
+    if (rating) {
+      setFocus(rating, true);
+    }
+  });
+
+  document.addEventListener('focusout', function(event) {
+    var rating = event.target.closest('.spectrum-Rating');
+
+    if (rating) {
+      setFocus(rating, false);
+    }
+  });
+
+  document.addEventListener('change', function(event) {
+    var input = event.target.closest('.spectrum-Rating-input');
+    if (input) {
+      if (input.hasAttribute('readonly')) {
+        event.preventDefault();
+        input.value = event.defaultValue;
+      }
+      else {
+        var value = parseInt(input.value, 10);
+        var rating = event.target.closest('.spectrum-Rating');
+        setValue(rating, value);
+      }
+    }
+  });
+
+  document.addEventListener('click', function(event) {
+    var icon = event.target.closest('.spectrum-Rating-icon');
+    if (icon) {
+      var rating = event.target.closest('.spectrum-Rating');
+      var value = Array.prototype.indexOf.call(rating.querySelectorAll('.spectrum-Rating-icon'), icon) + 1;
+      setValue(rating, value);
+    }
+  });
+}());
+
 // Dropdown
 (function() {
   var openDropdown = null;


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->
This enables focus and clicking on Ratings to show the focus and selected states.

## How and where has this been tested?
 - **How this was tested:** Tab to focus on Rating, observe focus.
 - **Browser(s) and OS(s) this was tested with:** Chrome on macOS

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->

![image](https://user-images.githubusercontent.com/201344/67902356-39e2ba80-fb26-11e9-85a9-8a38c732e75b.png)



## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
