### PR TITLE
fix: opening View Guielines link in new window (SDS-3251)

### DIFF
--- a/components/ResourceCard.js
+++ b/components/ResourceCard.js
@@ -4,6 +4,8 @@ import styles from './css/resourceCard.scss';
 class ResourceCard extends React.Component {
   constructor(props) {
     super(props);
+    // set default target for links to "_blank" unless passed as prop.
+    this.linkTarget = (props.target) ? props.target : "_blank";
   }
   goToResource = (url) => {
     window.open(url, "_blank");
@@ -13,7 +15,7 @@ class ResourceCard extends React.Component {
     return (
 
 
-        <a href={props.url} target={(props.type === 'Spectrum') ? "_self" : "_blank"} aria-label={props.clickEvent ? `Download ${props.componentName} UI Kit`: undefined} className={styles.cardButton} tabIndex="0">
+        <a href={props.url} target={this.linkTarget} aria-label={props.clickEvent ? `Download ${props.componentName} UI Kit`: undefined} className={styles.cardButton} tabIndex="0">
         <div className={styles.card} tabIndex="-1">
           <div>
             {


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->
[SDS-3251](https://jira.corp.adobe.com/browse/SDS-3251)
Making all resources links open in a `_blank` new window unless specified as a `target` prop.


## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->
Opens by default the resource cards in a new window.

## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->
clicked on a card.

## Screenshots
![2019-10-31_14-47-54 (1)](https://user-images.githubusercontent.com/52184321/67988536-87762a80-fbed-11e9-920d-f8c738c0b67c.gif)

<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
