### PR TITLE
fix: normalizing sidebar search input field for Combobox site (SDS-3248)

### DIFF
--- a/components/css/siteSearch.scss
+++ b/components/css/siteSearch.scss
@@ -1,5 +1,18 @@
 :local(.searchContainer) {
-    margin-top:24px;
+    margin-top: 24px;
+
+    // the Combobox component will over-write the search in the sidebar.
+    // Resetting the left search to gain 100% width and adding the correct padding 
+    // for the text input field.
+    & :global(.spectrum-Search) {
+        width: 100%;
+    }
+
+    & :global(.spectrum-Search-input) {
+        padding-left: var(--spectrum-global-dimension-size-450);
+        width: var(--spectrum-global-dimension-size-2400);
+    }
+
 }
 :local(.results) {
     border: 1px solid var(--spectrum-global-color-gray-400);


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->
[SDS-3248](https://jira.corp.adobe.com/browse/SDS-3248) Sidebar search input field got over-written by the Combobox component on the page. 
This re-sets the search input box in the sidebar. 

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->
There is debate if this should be fixed with a reset or with a re-ordering of the requested stylesheet rules. 


## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
Navigated to 3 pages:
/components/combobox/ (viewport mobile & desktop)
/components/search
/ (homepage)
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->
Chrome Desktop Version 80.0.3955.4 (Official Build) canary (64-bit)

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->
![Screen Shot 2019-11-01 at 12 18 30](https://user-images.githubusercontent.com/52184321/68050538-8a7f2280-fca2-11e9-98c1-984d252c37c2.png)
![Screen Shot 2019-11-01 at 12 18 38](https://user-images.githubusercontent.com/52184321/68050539-8a7f2280-fca2-11e9-8c1d-9e859334821c.png)
![Screen Shot 2019-11-01 at 12 18 45](https://user-images.githubusercontent.com/52184321/68050540-8a7f2280-fca2-11e9-888f-e580b49a05dd.png)
![Screen Shot 2019-11-01 at 12 25 25](https://user-images.githubusercontent.com/52184321/68050613-b5697680-fca2-11e9-9ba3-8f3de99c6e17.png)



## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
