### PR TITLE
fix: point footer and adobe launch to production while next export

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -115,8 +115,7 @@ console.log(process.env.NODE_ENV);
 console.log(process.env.BUILD);
 module.exports = withCSS({
   env: {
-    build: process.env.BUILD,
-    adobeLaunchEnv: process.env.ADOBE_LAUNCH_ENV
+    build: process.env.BUILD
   },
   exportTrailingSlash: true,
   pageExtensions: ['js', 'jsx'],

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -28,7 +28,7 @@ class MyDocument extends Document {
               adobe: {
                 launch: {
                   property: 'global',
-                  environment: '${process.env.adobeLaunchEnv || 'stage'}'
+                  environment: 'production'
                 },
                 target: false,
                 audienceManager: false
@@ -86,7 +86,7 @@ class MyDocument extends Document {
           }}>
         </script>
         {
-          process.env.environment === 'production' ?
+          process.env.NODE_ENV === 'production' ?
             <script
               src="//wwwimages2.adobe.com/etc/beagle/public/globalnav/adobe-globalnav/latest/adobe-globalnav.min.js">
             </script>


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
# Always point to Adobe Launch Production env
# Use the correct env variable to point adobe footer to correspond env.

## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
