### PR TITLE
fix: correct positioning of children of wrapped Dialogs, closes #389

### DIFF
--- a/components/dialog/index.css
+++ b/components/dialog/index.css
@@ -184,7 +184,9 @@ governing permissions and limitations under the License.
   .spectrum-Dialog:not(.spectrum-Dialog--fullscreen):not(.spectrum-Dialog--fullscreenTakeover) {
     pointer-events: auto;
 
-    position: static;
+    position: relative;
+    left: auto;
+    top: auto;
     transform: translateY(var(--spectrum-dialog-entry-animation-distance));
     margin-top: var(--spectrum-dialog-vertical-offset);
 

--- a/components/dialog/metadata/dialog.yml
+++ b/components/dialog/metadata/dialog.yml
@@ -1,5 +1,5 @@
 name: Dialog
-description: 'In order to avoid blurry Dialogs, wrap them in `<div class="spectrum-Dialog-wrapper">` and apply `.is-open` to both the Wrapper and the Dialog at the same time. See [this example](dialogAlert.html) for a working demonstration.'
+description: 'In order to avoid blurry Dialogs, wrap them in `<div class="spectrum-Dialog-wrapper">` and apply `.is-open` to both the Wrapper and the Dialog at the same time. See [this example](#dialog-wrapped) for a working demonstration.'
 SpectrumSiteSlug: https://spectrum.adobe.com/page/dialog/
 examples:
   - id: dialog
@@ -429,5 +429,29 @@ examples:
         </div>
         <div class="spectrum-Dialog-footer">
           Anything in the footer is sticky and aligned right.
+        </div>
+      </div>
+
+  - id: dialog
+    name: Dialog - Wrapped
+    status: Verified
+    description: A dialog wrapped so that its positioned in a non-blurry way
+    demoClassName: spectrum-CSSExample-example--overlay
+    markup: |
+      <button class="spectrum-Button spectrum-Button--overBackground spectrum-CSSExample-overlayShowButton" onclick="openDialog(this.nextElementSibling)">Open Wrapped Dialog</button>
+
+      <div class="spectrum-Dialog-wrapper">
+        <div class="spectrum-Dialog spectrum-Dialog--small spectrum-Dialog--dismissible">
+          <div class="spectrum-Dialog-header">
+            <h2 class="spectrum-Dialog-title">Disclaimer</h2>
+            <button class="spectrum-ActionButton spectrum-ActionButton--quiet spectrum-Dialog-closeButton" onclick="closeDialog(this.closest('.spectrum-Dialog'))">
+              <svg class="spectrum-Icon spectrum-UIIcon-CrossLarge" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-CrossLarge" />
+              </svg>
+            </button>
+          </div>
+          <div class="spectrum-Dialog-content">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Auctor augue mauris augue neque gravida. Libero volutpat sed ornare arcu. Quisque egestas diam in arcu cursus euismod quis viverra. Posuere ac ut consequat semper viverra nam libero justo laoreet. Enim ut tellus elementum sagittis vitae et leo duis ut. Neque laoreet suspendisse interdum consectetur libero id faucibus nisl. Diam volutpat commodo sed egestas egestas. Dolor magna eget est lorem ipsum dolor. Vitae suscipit tellus mauris a diam maecenas sed. Turpis in eu mi bibendum neque egestas congue. Rhoncus est pellentesque elit ullamcorper dignissim cras lobortis.
+          </div>
         </div>
       </div>

--- a/site/resources/js/enhancement.js
+++ b/site/resources/js/enhancement.js
@@ -490,11 +490,24 @@ function openDialog(dialog, withOverlay) {
   }
 
   dialog.classList.add('is-open');
+
+  // Support wrapped dialogs
+  var innerDialog = dialog.querySelector('.spectrum-Dialog');
+  if (innerDialog) {
+    innerDialog.classList.add('is-open');
+  }
 }
 
 function closeDialog(dialog) {
   document.getElementById('spectrum-underlay').classList.remove('is-open');
   dialog.classList.remove('is-open');
+
+  // Support wrapped dialogs
+  var innerDialog = dialog.querySelector('.spectrum-Dialog');
+  if (innerDialog) {
+    innerDialog.classList.remove('is-open');
+  }
+
   setTimeout(function() {
     dialog.classList.remove('spectrum-CSSExample-dialog');
   }, 10);

--- a/site/templates/siteComponent.pug
+++ b/site/templates/siteComponent.pug
@@ -187,4 +187,4 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
 
             include ../includes/footer.pug
 
-    include ../includes/footer.pug
+    include ../includes/pageBottom.pug


### PR DESCRIPTION

<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->

* fix Dialog examples if page loaded directly
* add wrapped Dialog example


## How and where has this been tested?
 - **How this was tested:** open `dialog.html`, scroll to the bottom, clicky the button
 - **Browser(s) and OS(s) this was tested with:** Chrome on macOS

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->
![image](https://user-images.githubusercontent.com/201344/68430552-1bec0a00-0165-11ea-8828-b884a698279a.png)


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
