### PR TITLE
fix: top margin for switch, checkbox & radio button

### DIFF
--- a/components/checkbox/index.css
+++ b/components/checkbox/index.css
@@ -17,6 +17,10 @@ governing permissions and limitations under the License.
   Will be a DNA token in https://jira.corp.adobe.com/browse/SDS-4466
   */
   --spectrum-checkbox-label-margin-top: var(--spectrum-global-dimension-size-85);
+
+  /* Fix for inconsistent line-height between browsers that would push the label 1px below the intended baseline */
+  /* more info: https://stackoverflow.com/questions/47700568/css-fonts-render-differently-in-firefox-and-chrome */
+  --spectrum-checkbox-label-line-height: 1.49;
 }
 
 .spectrum-Checkbox {
@@ -97,15 +101,11 @@ governing permissions and limitations under the License.
 
 .spectrum-Checkbox-label {
   margin-left: var(--spectrum-checkbox-text-gap);
+  margin-top: var(--spectrum-checkbox-label-margin-top);
   font-size: var(--spectrum-checkbox-text-size);
   font-weight: var(--spectrum-checkbox-text-font-weight);
+  line-height: var(--spectrum-checkbox-label-line-height);
   transition: color var(--spectrum-global-animation-duration-100) ease-in-out;
-
-  /* Fix for inconsistent line-height between browsers that would push the label 1px below the intended baseline */
-  /* more info: https://stackoverflow.com/questions/47700568/css-fonts-render-differently-in-firefox-and-chrome */
-  line-height: 1.49;
-  
-  margin-top: var(--spectrum-checkbox-label-margin-top);
 }
 
 .spectrum-Checkbox-box {

--- a/components/checkbox/index.css
+++ b/components/checkbox/index.css
@@ -14,7 +14,7 @@ governing permissions and limitations under the License.
 
 :root {
   /* Hardcoded for wrapping study */
-  --spectrum-checkbox-label-margin-top: var(--spectrum-global-dimension-size-75);
+  --spectrum-checkbox-label-margin-top: var(--spectrum-global-dimension-size-85);
 }
 
 .spectrum-Checkbox {

--- a/components/checkbox/index.css
+++ b/components/checkbox/index.css
@@ -55,7 +55,7 @@ governing permissions and limitations under the License.
   position: absolute;
   top: 0;
   left: calc(var(--spectrum-checkbox-cursor-hit-x) * -1);
-  width: calc(100% + var(--spectrum-checkbox-cursor-hit-x) * 2);;
+  width: calc(100% + var(--spectrum-checkbox-cursor-hit-x) * 2);
   height: 100%;
 
   opacity: .0001;
@@ -101,6 +101,10 @@ governing permissions and limitations under the License.
   font-weight: var(--spectrum-checkbox-text-font-weight);
   transition: color var(--spectrum-global-animation-duration-100) ease-in-out;
 
+  /* Fix for inconsistent line-height between browsers that would push the label 1px below the intended baseline */
+  /* more info: https://stackoverflow.com/questions/47700568/css-fonts-render-differently-in-firefox-and-chrome */
+  line-height: 1.49;
+  
   margin-top: var(--spectrum-checkbox-label-margin-top);
 }
 

--- a/components/checkbox/index.css
+++ b/components/checkbox/index.css
@@ -13,7 +13,9 @@ governing permissions and limitations under the License.
 @import '../commons/index.css';
 
 :root {
-  /* Hardcoded for wrapping study */
+  /* Hardcoded for wrapping study.
+  Will be a DNA token in https://jira.corp.adobe.com/browse/SDS-4466
+  */
   --spectrum-checkbox-label-margin-top: var(--spectrum-global-dimension-size-85);
 }
 

--- a/components/radio/index.css
+++ b/components/radio/index.css
@@ -81,8 +81,11 @@ governing permissions and limitations under the License.
 .spectrum-Radio-label {
   margin-left: var(--spectrum-radio-text-gap);
   font-size: var(--spectrum-radio-text-size);
-
   transition: color var(--spectrum-global-animation-duration-100) ease-in-out;
+
+  /* Fix for inconsistent line-height between browsers that would push the label 1px below the intended baseline */
+  /* more info: https://stackoverflow.com/questions/47700568/css-fonts-render-differently-in-firefox-and-chrome */
+  line-height: 1.49;
 
   /* Hardcoded as no good way to calculate this */
   margin-top: var(--spectrum-radio-label-margin-top);

--- a/components/radio/index.css
+++ b/components/radio/index.css
@@ -20,7 +20,7 @@ governing permissions and limitations under the License.
   --spectrum-radio-labelbelow-height: auto;
 
   /* Hardcoded for wrapping study */
-  --spectrum-radio-label-margin-top: var(--spectrum-global-dimension-size-75);
+  --spectrum-radio-label-margin-top: var(--spectrum-global-dimension-size-85);
 }
 
 .spectrum-Radio {

--- a/components/radio/index.css
+++ b/components/radio/index.css
@@ -19,7 +19,9 @@ governing permissions and limitations under the License.
   --spectrum-radio-labelbelow-label-margin: var(--spectrum-global-dimension-size-40) 0 0 0;
   --spectrum-radio-labelbelow-height: auto;
 
-  /* Hardcoded for wrapping study */
+  /* Hardcoded for wrapping study.
+  Will be a DNA token in https://jira.corp.adobe.com/browse/SDS-4466
+  */
   --spectrum-radio-label-margin-top: var(--spectrum-global-dimension-size-85);
 }
 

--- a/components/radio/index.css
+++ b/components/radio/index.css
@@ -23,6 +23,10 @@ governing permissions and limitations under the License.
   Will be a DNA token in https://jira.corp.adobe.com/browse/SDS-4466
   */
   --spectrum-radio-label-margin-top: var(--spectrum-global-dimension-size-85);
+
+  /* Fix for inconsistent line-height between browsers that would push the label 1px below the intended baseline */
+  /* more info: https://stackoverflow.com/questions/47700568/css-fonts-render-differently-in-firefox-and-chrome */
+  --spectrum-radio-label-line-height: 1.49;
 }
 
 .spectrum-Radio {
@@ -80,15 +84,11 @@ governing permissions and limitations under the License.
 
 .spectrum-Radio-label {
   margin-left: var(--spectrum-radio-text-gap);
-  font-size: var(--spectrum-radio-text-size);
-  transition: color var(--spectrum-global-animation-duration-100) ease-in-out;
-
-  /* Fix for inconsistent line-height between browsers that would push the label 1px below the intended baseline */
-  /* more info: https://stackoverflow.com/questions/47700568/css-fonts-render-differently-in-firefox-and-chrome */
-  line-height: 1.49;
-
   /* Hardcoded as no good way to calculate this */
   margin-top: var(--spectrum-radio-label-margin-top);
+  font-size: var(--spectrum-radio-text-size);
+  line-height: var(--spectrum-radio-label-line-height);
+  transition: color var(--spectrum-global-animation-duration-100) ease-in-out;
 }
 
 .spectrum-Radio-button {

--- a/components/toggle/index.css
+++ b/components/toggle/index.css
@@ -13,7 +13,9 @@ governing permissions and limitations under the License.
 @import '../commons/index.css';
 
 :root {
-  /* Hardcoded for wrapping study */
+  /* Hardcoded for wrapping study.
+  Will be a DNA token in https://jira.corp.adobe.com/browse/SDS-4466
+  */
   --spectrum-switch-label-margin-top: var(--spectrum-global-dimension-size-85);
 }
 

--- a/components/toggle/index.css
+++ b/components/toggle/index.css
@@ -70,6 +70,10 @@ governing permissions and limitations under the License.
   font-size: var(--spectrum-switch-text-size);
   transition: color var(--spectrum-global-animation-duration-200) ease-in-out;
 
+  /* Fix for inconsistent line-height between browsers that would push the label 1px below the intended baseline */
+  /* more info: https://stackoverflow.com/questions/47700568/css-fonts-render-differently-in-firefox-and-chrome */
+  line-height: 1.49;  
+
   margin-top: var(--spectrum-switch-label-margin-top);
 }
 

--- a/components/toggle/index.css
+++ b/components/toggle/index.css
@@ -14,7 +14,7 @@ governing permissions and limitations under the License.
 
 :root {
   /* Hardcoded for wrapping study */
-  --spectrum-switch-label-margin-top: var(--spectrum-global-dimension-size-75);
+  --spectrum-switch-label-margin-top: var(--spectrum-global-dimension-size-85);
 }
 
 .spectrum-ToggleSwitch {

--- a/components/toggle/index.css
+++ b/components/toggle/index.css
@@ -17,6 +17,9 @@ governing permissions and limitations under the License.
   Will be a DNA token in https://jira.corp.adobe.com/browse/SDS-4466
   */
   --spectrum-switch-label-margin-top: var(--spectrum-global-dimension-size-85);
+  /* Fix for inconsistent line-height between browsers that would push the label 1px below the intended baseline */
+  /* more info: https://stackoverflow.com/questions/47700568/css-fonts-render-differently-in-firefox-and-chrome */
+  --spectrum-switch-label-line-height: 1.49;
 }
 
 .spectrum-ToggleSwitch {
@@ -67,14 +70,10 @@ governing permissions and limitations under the License.
 
 .spectrum-ToggleSwitch-label {
   margin: 0 var(--spectrum-switch-text-gap);
-  font-size: var(--spectrum-switch-text-size);
-  transition: color var(--spectrum-global-animation-duration-200) ease-in-out;
-
-  /* Fix for inconsistent line-height between browsers that would push the label 1px below the intended baseline */
-  /* more info: https://stackoverflow.com/questions/47700568/css-fonts-render-differently-in-firefox-and-chrome */
-  line-height: 1.49;  
-
   margin-top: var(--spectrum-switch-label-margin-top);
+  font-size: var(--spectrum-switch-text-size);
+  line-height: var(--spectrum-switch-label-line-height);  
+  transition: color var(--spectrum-global-animation-duration-200) ease-in-out;
 }
 
 .spectrum-ToggleSwitch-switch {


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->
Correcting the top margin for checkboxes & radio buttons. 
https://jira.corp.adobe.com/browse/SDS-4420 closes #406, 
https://jira.corp.adobe.com/browse/SDS-4418 closes #402,
https://jira.corp.adobe.com/browse/SDS-4403 closes #403 


## Description
Adding the correct margin. There seems to be a "wrapping study" in #176 that hard-coded the value `--spectrum-global-dimension-size-75`. The correct value should be `--spectrum-global-dimension-size-85`.
@lazd  Maybe we should remove the hard-coded value instead if the wrapping study is complete.  

## How and where has this been tested?
Go to the following pages and inspect the label for the checkbox or radio button
http://localhost:3000/docs/radio.html
http://localhost:3000/docs/checkbox.html
http://localhost:3000/docs/toggle.html

Browser(s) and OS(s): macOS Mojave 10.14.5 (18F203)
Google Chrome Version 80.0.3968.0 (Official Build) canary (64-bit)


## Screenshots
**The orange background is for reference only to show the span of the margin applied to the switch, textbox and radio button label**

Before:

<img width="859" alt="Screen Shot 2019-11-21 at 16 18 39" src="https://user-images.githubusercontent.com/52184321/69317104-90eb3380-0c7d-11ea-8161-3ddeadaae5ea.png">
<img width="398" alt="Screen Shot 2019-11-21 at 16 14 21" src="https://user-images.githubusercontent.com/52184321/69317106-90eb3380-0c7d-11ea-8d6b-a4b379145a9d.png">
<img width="837" alt="Screen Shot 2019-11-22 at 11 05 29" src="https://user-images.githubusercontent.com/52184321/69393006-4fa96100-0d1b-11ea-9938-18493c93cb2e.png">


After:
<img width="851" alt="Screen Shot 2019-11-21 at 16 18 50" src="https://user-images.githubusercontent.com/52184321/69317111-93e62400-0c7d-11ea-8ee7-61e9ae35cb19.png">
<img width="360" alt="Screen Shot 2019-11-21 at 16 14 29" src="https://user-images.githubusercontent.com/52184321/69317112-947eba80-0c7d-11ea-87c2-b318a590c9e6.png">
<img width="850" alt="Screen Shot 2019-11-22 at 11 05 42" src="https://user-images.githubusercontent.com/52184321/69393011-52a45180-0d1b-11ea-9df1-ca9fc73363c0.png">


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
