### PR TITLE
Fix button height in flex container

### DIFF
--- a/components/button/index.css
+++ b/components/button/index.css
@@ -99,7 +99,7 @@ governing permissions and limitations under the License.
   border-radius: var(--spectrum-button-primary-border-radius);
 
   min-height: var(--spectrum-button-primary-height);
-  height: auto;
+  height: 0%;
   min-width: var(--spectrum-button-primary-min-width);
 
   padding: var(--spectrum-button-padding-y) calc(var(--spectrum-button-primary-padding-x) - var(--spectrum-button-primary-border-size));

--- a/site/wrapping.pug
+++ b/site/wrapping.pug
@@ -174,6 +174,22 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
                   </div>
 
             article.spectrum-CSSExample
+              h5.spectrum-CSSExample-heading.spectrum-Heading4 Button (within flexbox)
+              section.spectrum-CSSExample-container
+                .spectrum-CSSExample-example
+
+
+                  <div style="margin: 0 0 10px 0; display: flex; flex-direction: row;">
+                    <div style="width: 32px; height: 96px; background-color: pink; margin: 0 10px;"></div>
+                    <button class="spectrum-Button spectrum-Button--cta" style="width: 186px">
+                      <span class="spectrum-Button-label">Informationen über Creative Cloud</span>
+                    </button>
+                    <button class="spectrum-Button spectrum-Button--primary">
+                      <span class="spectrum-Button-label">Informationen</span>
+                    </button>
+                  </div>
+
+            article.spectrum-CSSExample
               h5.spectrum-CSSExample-heading.spectrum-Heading4 Menu (wrapping)
               section.spectrum-CSSExample-container
                 .spectrum-CSSExample-example


### PR DESCRIPTION
When a button is inside a flex container and some of the items are taller than it, currently the button will expand to match the height of the other items. This causes it to look strange and not rounded correctly. This is due to a `min-height` but no `height` setting. Setting a height of 0% fixes the problem, and still allows it to grow when the button is multi-line. CSS is weird man. See https://stackoverflow.com/questions/27575779/prevent-a-flex-items-height-from-expanding-to-match-other-flex-items.

Before:

![image](https://user-images.githubusercontent.com/19409/69449006-ad837c00-0d0e-11ea-8629-4af4f9f537b7.png)

After:

![image](https://user-images.githubusercontent.com/19409/69449021-b411f380-0d0e-11ea-821c-4a77286e0733.png)
