### PR TITLE
docs: restore wrapping/truncation studies

### DIFF
--- a/site/truncation.pug
+++ b/site/truncation.pug
@@ -1,0 +1,153 @@
+doctype html
+html(lang='en-US').spectrum.spectrum--light.spectrum--medium
+  head
+    title Truncation - Spectrum CSS
+
+    include includes/dependencies.pug
+
+    -
+      var exampleDependencies = [
+        'button',
+        'quickaction',
+        'tags',
+        'tabs',
+        'inputgroup',
+        'dropdown',
+        'textfield'
+      ];
+
+    each dep in exampleDependencies.filter(dep => dependencyOrder.indexOf(dep) === -1)
+      link(rel='stylesheet', type='text/css', href='../components/' + dep + '/index-vars.css', data-dependency=dep)
+
+  body
+
+    .spectrum-Site
+
+      include includes/header.pug
+
+      .spectrum-Site-content
+
+        include includes/sidebar.pug
+
+        .spectrum-Site-mainContainer
+          .spectrum-Site-page.spectrum-Typography
+
+            h1.spectrum-Heading1 A study of truncation across a number of components
+
+            article.spectrum-CSSExample
+              h5.spectrum-CSSExample-heading.spectrum-Heading4 Action Button (truncated)
+              section.spectrum-CSSExample-container
+                .spectrum-CSSExample-example
+                  <button class="spectrum-ActionButton" style="width: 128px">
+                    <span class="spectrum-ActionButton-label">Präferenzen Verwalten</span>
+                  </button>
+
+            article.spectrum-CSSExample
+              h5.spectrum-CSSExample-heading.spectrum-Heading4 Action Button with Icon (truncated)
+              section.spectrum-CSSExample-container
+                .spectrum-CSSExample-example
+                  <button class="spectrum-ActionButton" style="width: 128px">
+                    <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Settings">
+                      <use xlink:href="#spectrum-icon-18-Settings" />
+                    </svg>
+                    <span class="spectrum-ActionButton-label">Präferenzen Verwalten</span>
+                  </button>
+
+            article.spectrum-CSSExample
+              h5.spectrum-CSSExample-heading.spectrum-Heading4 Action Button (truncated)
+              section.spectrum-CSSExample-container
+                .spectrum-CSSExample-example
+                  <button class="spectrum-ActionButton spectrum-ActionButton--quiet" style="width: 128px">
+                    <span class="spectrum-ActionButton-label">Präferenzen Verwalten</span>
+                  </button>
+
+            article.spectrum-CSSExample
+              h5.spectrum-CSSExample-heading.spectrum-Heading4 Action Button with Icon (truncated)
+              section.spectrum-CSSExample-container
+                .spectrum-CSSExample-example
+                  <button class="spectrum-ActionButton spectrum-ActionButton--quiet" style="width: 128px">
+                    <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Settings">
+                      <use xlink:href="#spectrum-icon-18-Settings" />
+                    </svg>
+                    <span class="spectrum-ActionButton-label">Präferenzen Verwalten</span>
+                  </button>
+
+            article.spectrum-CSSExample
+              h5.spectrum-CSSExample-heading.spectrum-Heading4 Quick Actions (truncated)
+              section.spectrum-CSSExample-container
+                .spectrum-CSSExample-example
+                  <div class="spectrum-QuickActions-overlay" style="padding: 40px;">
+                    <div class="spectrum-QuickActions is-open" style="width: 150px;">
+                      <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
+                        <span class="spectrum-ActionButton-label">Bearbeitenslkdasjhkdfadsfa</span>
+                      </button>
+                      <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
+                        <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="More">
+                          <use xlink:href="#spectrum-icon-18-More" />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+
+            article.spectrum-CSSExample
+              h5.spectrum-CSSExample-heading.spectrum-Heading4 Tag (truncated)
+              section.spectrum-CSSExample-container
+                .spectrum-CSSExample-example
+                  <div class="spectrum-Tags-item" role="listitem" tabindex="0" style="width: 168px;">
+                    <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="GraphPie">
+                      <use xlink:href="#spectrum-icon-18-GraphPie"></use>
+                    </svg>
+                    <span class="spectrum-Tags-itemLabel">Apathorn Rungratsamentagfslkjd</span>
+                  </div>
+
+            article.spectrum-CSSExample
+              h5.spectrum-CSSExample-heading.spectrum-Heading4 Tabs (truncated)
+              section.spectrum-CSSExample-container
+                .spectrum-CSSExample-example
+                  <div class="spectrum-Tabs spectrum-Tabs--horizontal" style="width: 212px">
+                    <div class="spectrum-Dropdown spectrum-Dropdown--quiet">
+                      <button class="spectrum-FieldButton spectrum-FieldButton--quiet spectrum-Dropdown-trigger is-selected" aria-haspopup="true">
+                        <span class="spectrum-Dropdown-label">A comparative study of artificial intelligence as applied to choosing outfits for small dogs</span>
+                        <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
+                          <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />
+                        </svg>
+                      </button>
+                    </div>
+                    <div class="spectrum-Tabs-selectionIndicator" style="left: 8px; right: 8px;"></div>
+                  </div>
+
+            article.spectrum-CSSExample
+              h5.spectrum-CSSExample-heading.spectrum-Heading4 Combobox (truncated)
+              section.spectrum-CSSExample-container
+                .spectrum-CSSExample-example
+                  <div class="spectrum-InputGroup">
+                    <input type="text" placeholder="Type here" name="field" value="Lorem ipsum dolor sit amet, consectetur adipiscing elit" class="spectrum-Textfield spectrum-InputGroup-field">
+                    <button class="spectrum-FieldButton spectrum-InputGroup-button" aria-haspopup="true">
+                      <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-InputGroup-icon" focusable="false" aria-hidden="true">
+                        <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />
+                      </svg>
+                    </button>
+                  </div>
+
+            article.spectrum-CSSExample
+              h5.spectrum-CSSExample-heading.spectrum-Heading4 Dropdown (truncated)
+              section.spectrum-CSSExample-container
+                .spectrum-CSSExample-example
+                  <div class="spectrum-Dropdown" style="width: 240px;">
+                    <button class="spectrum-FieldButton spectrum-Dropdown-trigger" aria-haspopup="true">
+                      <span class="spectrum-Dropdown-label is-placeholder">Lorem ipsum dolor sit amet, consectetur adipiscing elit</span>
+                      <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
+                        <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />
+                      </svg>
+                    </button>
+                  </div>
+
+            article.spectrum-CSSExample
+              h5.spectrum-CSSExample-heading.spectrum-Heading4 Textfield (truncated)
+              section.spectrum-CSSExample-container
+                .spectrum-CSSExample-example
+                  <input type="text" placeholder="Enter your name" name="field" value="Lorem ipsum dolor sit amet, consectetur adipiscing elit" class="spectrum-Textfield">
+
+            include includes/footer.pug
+
+    include includes/pageBottom.pug

--- a/site/wrapping.pug
+++ b/site/wrapping.pug
@@ -1,0 +1,399 @@
+doctype html
+html(lang='en-US').spectrum.spectrum--light.spectrum--medium
+  head
+    title Wrapping - Spectrum CSS
+
+    include includes/dependencies.pug
+
+    -
+      var exampleDependencies = [
+        'link',
+        'toast',
+        'tooltip',
+        'coachmark',
+        'dialog',
+        'button',
+        'sidenav',
+        'menu',
+        'barloader',
+        'inputgroup',
+        'dropdown',
+        'slider',
+        'toggle',
+        'checkbox',
+        'radio'
+      ];
+
+    each dep in exampleDependencies.filter(dep => dependencyOrder.indexOf(dep) === -1)
+      link(rel='stylesheet', type='text/css', href='../components/' + dep + '/index-vars.css', data-dependency=dep)
+
+  body
+
+    .spectrum-Site
+
+      include includes/header.pug
+
+      .spectrum-Site-content
+
+        include includes/sidebar.pug
+
+        .spectrum-Site-mainContainer
+          .spectrum-Site-page.spectrum-Typography
+
+            h1.spectrum-Heading1 A study of wrapping across a number of components
+
+            article.spectrum-CSSExample
+              h5.spectrum-CSSExample-heading.spectrum-Heading4 Link (wrapping)
+              section.spectrum-CSSExample-container
+                .spectrum-CSSExample-example
+                  <div style="width: 146px">See our <a href="#" class="spectrum-Link">Privacy Policy</a> for more details or <a href="#" class="spectrum-Link">opt-out at any time</a>.</div>
+
+            article.spectrum-CSSExample
+              h5.spectrum-CSSExample-heading.spectrum-Heading4 Toast (wrapping)
+              section.spectrum-CSSExample-container
+                .spectrum-CSSExample-example
+                  <div class="spectrum-Toast" style="width: 280px;">
+                    <div class="spectrum-Toast-body">
+                      <div class="spectrum-Toast-content">All documents in this folder have been archived</div>
+                    </div>
+                    <div class="spectrum-Toast-buttons">
+                      <button class="spectrum-ClearButton spectrum-ClearButton--medium spectrum-ClearButton--overBackground">
+                        <svg class="spectrum-Icon spectrum-UIIcon-CrossMedium focusable="false" aria-hidden="true">
+                          <use xlink:href="#spectrum-css-icon-CrossMedium" />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+
+            article.spectrum-CSSExample
+              h5.spectrum-CSSExample-heading.spectrum-Heading4 Toast with Icon and Button (wrapping)
+              section.spectrum-CSSExample-container
+                .spectrum-CSSExample-example
+                  <div class="spectrum-Toast spectrum-Toast--info" style="width: 318px;">
+                    <svg class="spectrum-Icon spectrum-UIIcon-InfoMedium spectrum-Toast-typeIcon" focusable="false" aria-hidden="true">
+                      <use xlink:href="#spectrum-css-icon-InfoMedium" />
+                    </svg>
+                    <div class="spectrum-Toast-body">
+                      <div class="spectrum-Toast-content">A new version of Lightroom Classic is now available</div>
+                      <button class="spectrum-Button spectrum-Button--overBackground spectrum-Button--quiet">
+                        <span class="spectrum-Button-label">Update</span>
+                      </button>
+                    </div>
+                    <div class="spectrum-Toast-buttons">
+                      <button class="spectrum-ClearButton spectrum-ClearButton--medium spectrum-ClearButton--overBackground">
+                        <svg class="spectrum-Icon spectrum-UIIcon-CrossMedium focusable="false" aria-hidden="true">
+                          <use xlink:href="#spectrum-css-icon-CrossMedium" />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+
+            article.spectrum-CSSExample
+              h5.spectrum-CSSExample-heading.spectrum-Heading4 Tooltip (wrapping)
+              section.spectrum-CSSExample-container
+                .spectrum-CSSExample-example
+                  <span class="spectrum-Tooltip spectrum-Tooltip--top is-open">
+                    <span class="spectrum-Tooltip-label">Lorem ipsum dolor sit amet, consectetur adipiscing elit</span>
+                    <span class="spectrum-Tooltip-tip"></span>
+                  </span>
+
+            article.spectrum-CSSExample
+              h5.spectrum-CSSExample-heading.spectrum-Heading4 Tooltip with Icon (wrapping)
+              section.spectrum-CSSExample-container
+                .spectrum-CSSExample-example
+                  <span class="spectrum-Tooltip spectrum-Tooltip--top spectrum-Tooltip--info is-open">
+                    <svg class="spectrum-Icon spectrum-UIIcon-SuccessSmall spectrum-Tooltip-typeIcon" focusable="false" aria-hidden="true">
+                      <use xlink:href="#spectrum-css-icon-SuccessSmall" />
+                    </svg>
+                    <span class="spectrum-Tooltip-label">Lorem ipsum dolor sit amet, consectetur adipiscing elit</span>
+                    <span class="spectrum-Tooltip-tip"></span>
+                  </span>
+
+            article.spectrum-CSSExample
+              h5.spectrum-CSSExample-heading.spectrum-Heading4 Coach Mark (wrapping)
+              section.spectrum-CSSExample-container
+                .spectrum-CSSExample-example
+                  <div class="spectrum-CoachMarkPopover" style="width: 226px">
+                    <img src="img/example-ava.jpg" class="spectrum-CoachMarkPopover-image" />
+
+                    <div class="spectrum-CoachMarkPopover-header">
+                      <div class="spectrum-CoachMarkPopover-title">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</div>
+                      <div class="spectrum-CoachMarkPopover-step">3 of 100</div>
+                    </div>
+                    <div class="spectrum-CoachMarkPopover-content">
+                      Smart filters are nondestructive and will preserve your original images.
+                    </div>
+                    <div class="spectrum-CoachMarkPopover-footer">
+                      <button class="spectrum-Button spectrum-Button--secondary spectrum-Button--quiet">
+                        <span class="spectrum-Button-label">Skip Tour</span>
+                      </button>
+                      <button class="spectrum-Button spectrum-Button--primary">
+                        <span class="spectrum-Button-label">Next</span>
+                      </button>
+                    </div>
+                  </div>
+
+            article.spectrum-CSSExample
+              h5.spectrum-CSSExample-heading.spectrum-Heading4 Dialog (wrapping)
+              section.spectrum-CSSExample-container
+                .spectrum-CSSExample-example.spectrum-CSSExample-example--overlay
+                  <button class="spectrum-Button spectrum-Button--overBackground spectrum-CSSExample-overlayShowButton" onclick="openDialog(this.nextElementSibling)">Open Dialog</button>
+
+                  <!-- spectrum-CSSExample-dialog class is included for demo purposes only -->
+                  <div class="spectrum-Dialog spectrum-Dialog--alert is-open spectrum-CSSExample-dialog" style="width: 300px">
+                    <div class="spectrum-Dialog-header">
+                      <h2 class="spectrum-Dialog-title">Lorem ipsum dolor sit amet, consectetur adipiscing elit</h2>
+                    </div>
+                    <div class="spectrum-Dialog-content">
+                      Smart filters are nondestructive and will preserve your original images.
+                    </div>
+                    <div class="spectrum-Dialog-footer">
+                      <button class="spectrum-Button spectrum-Button--secondary" onclick="closeDialog(this.closest('.spectrum-Dialog'))">Cancel</button>
+                      <button class="spectrum-Button spectrum-Button--cta" onclick="closeDialog(this.closest('.spectrum-Dialog'))">Enable</button>
+                    </div>
+                  </div>
+
+            article.spectrum-CSSExample
+              h5.spectrum-CSSExample-heading.spectrum-Heading4 Button (wrapping)
+              section.spectrum-CSSExample-container
+                .spectrum-CSSExample-example
+                  <div style="max-width: 168px; margin: 0 0 10px 0">
+                    <button class="spectrum-Button spectrum-Button--cta">
+                      <span class="spectrum-Button-label">Informationen über Creative Cloud</span>
+                    </button>
+                  </div>
+                  <div style="max-width: 168px; margin: 0 0 10px 0">
+                    <button class="spectrum-Button spectrum-Button--primary">
+                      <span class="spectrum-Button-label">Informationen über Creative Cloud</span>
+                    </button>
+                  </div>
+                  <div style="max-width: 168px; margin: 0 0 10px 0">
+                    <button class="spectrum-Button spectrum-Button--secondary">
+                      <span class="spectrum-Button-label">Informationen über Creative Cloud</span>
+                    </button>
+                  </div>
+
+            article.spectrum-CSSExample
+              h5.spectrum-CSSExample-heading.spectrum-Heading4 Menu (wrapping)
+              section.spectrum-CSSExample-container
+                .spectrum-CSSExample-example
+                  <div class="spectrum-Popover is-open" style="position: relative; width: 176px">
+                    <ul class="spectrum-Menu" role="menu">
+                      <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
+                        <span class="spectrum-Menu-itemLabel">Canada</span>
+                      </li>
+                      <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
+                        <span class="spectrum-Menu-itemLabel">Congo, Democratic Republic of the</span>
+                      </li>
+                      <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
+                        <span class="spectrum-Menu-itemLabel">Mexico</span>
+                      </li>
+                      <li class="spectrum-Menu-item is-selected" role="menuitem" tabindex="0">
+                        <span class="spectrum-Menu-itemLabel">United States</span>
+                      </li>
+                    </ul>
+                  </div>
+
+            article.spectrum-CSSExample
+              h5.spectrum-CSSExample-heading.spectrum-Heading4 Menu with Icons (wrapping)
+              section.spectrum-CSSExample-container
+                .spectrum-CSSExample-example
+                  <div class="spectrum-Popover is-open" style="position: relative; width: 176px">
+                    <ul class="spectrum-Menu" role="menu">
+                      <li role="presentation">
+                        <span class="spectrum-Menu-sectionHeading" id="menu-heading-category-2"  aria-hidden="true">Section Heading</span>
+                        <ul class="spectrum-Menu" role="group" aria-labelledby="menu-heading-category-1" aria-disabled="true">
+                          <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
+                            <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-Menu-itemIcon" focusable="false" aria-hidden="true" aria-label="SaveFloppy">
+                              <use xlink:href="#spectrum-icon-18-SaveFloppy"></use>
+                            </svg>
+                            <span class="spectrum-Menu-itemLabel">Save to the magnetic disk of the past</span>
+                          </li>
+                          <li class="spectrum-Menu-item" role="menuitem">
+                            <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-Menu-itemIcon" focusable="false" aria-hidden="true" aria-label="DataDownload">
+                              <use xlink:href="#spectrum-icon-18-DataDownload"></use>
+                            </svg>
+                            <span class="spectrum-Menu-itemLabel">Download to the magnetic drive of the past</span>
+                          </li>
+                        </ul>
+                      </li>
+                    </ul>
+                  </div>
+
+            article.spectrum-CSSExample
+              h5.spectrum-CSSExample-heading.spectrum-Heading4 Side Navigation (wrapping)
+              section.spectrum-CSSExample-container
+                .spectrum-CSSExample-example
+                  <nav style="width: 170px;">
+                    <ul class="spectrum-SideNav">
+                      <li class="spectrum-SideNav-item">
+                        <a href="#" class="spectrum-SideNav-itemLink">Privatsphäre</a>
+                      </li>
+                      <li class="spectrum-SideNav-item is-selected">
+                        <a href="#" class="spectrum-SideNav-itemLink">Benutzerprofileinstellungen</a>
+                      </li>
+                      <li class="spectrum-SideNav-item">
+                        <a href="#" class="spectrum-SideNav-itemLink">Hilfe & Unterstützung</a>
+                      </li>
+                    </ul>
+                  </nav>
+
+            article.spectrum-CSSExample
+              h5.spectrum-CSSExample-heading.spectrum-Heading4 Checkbox (wrapping)
+              section.spectrum-CSSExample-container
+                .spectrum-CSSExample-example
+                  <label class="spectrum-Checkbox">
+                    <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-0" checked>
+                    <span class="spectrum-Checkbox-box">
+                      <svg class="spectrum-Icon spectrum-UIIcon-CheckmarkSmall spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                        <use xlink:href="#spectrum-css-icon-CheckmarkSmall" />
+                      </svg>
+                      <svg class="spectrum-Icon spectrum-UIIcon-DashSmall spectrum-Checkbox-partialCheckmark" focusable="false" aria-hidden="true">
+                        <use xlink:href="#spectrum-css-icon-DashSmall" />
+                      </svg>
+                    </span>
+                    <span class="spectrum-Checkbox-label">Add Adobe Stock. Get one month free.*</span>
+                  </label>
+                  <br>
+                  <label class="spectrum-Checkbox" style="width: 149px">
+                    <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-0" checked>
+                    <span class="spectrum-Checkbox-box">
+                      <svg class="spectrum-Icon spectrum-UIIcon-CheckmarkSmall spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                        <use xlink:href="#spectrum-css-icon-CheckmarkSmall" />
+                      </svg>
+                      <svg class="spectrum-Icon spectrum-UIIcon-DashSmall spectrum-Checkbox-partialCheckmark" focusable="false" aria-hidden="true">
+                        <use xlink:href="#spectrum-css-icon-DashSmall" />
+                      </svg>
+                    </span>
+                    <span class="spectrum-Checkbox-label">Add Adobe Stock. Get one month free.*</span>
+                  </label>
+
+            article.spectrum-CSSExample
+              h5.spectrum-CSSExample-heading.spectrum-Heading4 Radio (wrapping)
+              section.spectrum-CSSExample-container
+                .spectrum-CSSExample-example
+                  <div class="spectrum-Radio">
+                    <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-0">
+                    <span class="spectrum-Radio-button"></span>
+                    <label class="spectrum-Radio-label" for="radio-0">Add Adobe Stock. Get one month free.*</label>
+                  </div>
+                  <br>
+                  <div class="spectrum-Radio" style="width: 149px">
+                    <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-0" checked>
+                    <span class="spectrum-Radio-button"></span>
+                    <label class="spectrum-Radio-label" for="radio-0">Add Adobe Stock. Get one month free.*</label>
+                  </div>
+
+            article.spectrum-CSSExample
+              h5.spectrum-CSSExample-heading.spectrum-Heading4 Switch (wrapping)
+              section.spectrum-CSSExample-container
+                .spectrum-CSSExample-example
+                  <div class="spectrum-ToggleSwitch">
+                    <input type="checkbox" class="spectrum-ToggleSwitch-input" id="toggle-onoff-0">
+                    <span class="spectrum-ToggleSwitch-switch"></span>
+                    <label class="spectrum-ToggleSwitch-label" for="toggle-onoff-0">Add Adobe Stock. Get one month free.*</label>
+                  </div>
+                  <br>
+                  <div class="spectrum-ToggleSwitch" style="width: 170px">
+                    <input type="checkbox" class="spectrum-ToggleSwitch-input" id="toggle-onoff-0">
+                    <span class="spectrum-ToggleSwitch-switch"></span>
+                    <label class="spectrum-ToggleSwitch-label" for="toggle-onoff-0">Add Adobe Stock. Get one month free.*</label>
+                  </div>
+
+            article.spectrum-CSSExample
+              h5.spectrum-CSSExample-heading.spectrum-Heading4 Barloader (wrapping)
+              section.spectrum-CSSExample-container
+                .spectrum-CSSExample-example
+                  <div style="margin: 20px 0; width: 168px">
+                    <div class="spectrum-BarLoader" value="26" role="progressbar" aria-valuenow="26" aria-valuemin="0" aria-valuemax="100">
+                      <div class="spectrum-BarLoader-label">Laden ihrer Creative Cloud dateien</div>
+                      <div class="spectrum-BarLoader-percentage">26%</div>
+                      <div class="spectrum-BarLoader-track">
+                        <div class="spectrum-BarLoader-fill" style="width: 26%;"></div>
+                      </div>
+                    </div>
+                  </div>
+
+            article.spectrum-CSSExample
+              h5.spectrum-CSSExample-heading.spectrum-Heading4 Meter (wrapping)
+              section.spectrum-CSSExample-container
+                .spectrum-CSSExample-example
+                  <div style="margin: 20px 0;">
+                    <div class="spectrum-BarLoader is-positive" value="26" role="progressbar" aria-valuenow="26" aria-valuemin="0" aria-valuemax="100">
+                      <div class="spectrum-BarLoader-label">Creative Cloud datennutzung insgesamt</div>
+                      <div class="spectrum-BarLoader-percentage">26%</div>
+                      <div class="spectrum-BarLoader-track">
+                        <div class="spectrum-BarLoader-fill" style="width: 26%;"></div>
+                      </div>
+                    </div>
+                  </div>
+
+            article.spectrum-CSSExample
+              h5.spectrum-CSSExample-heading.spectrum-Heading4 Combobox (wrapping label)
+              section.spectrum-CSSExample-container
+                .spectrum-CSSExample-example
+                  <div style="width: 160px">
+                    <label class="spectrum-Form-itemLabel" for="spectrum-combobox-instance">Vorhergesagtes jährliches wachstum</label>
+                    <div class="spectrum-InputGroup">
+                      <input type="text" placeholder="Type here" name="field" value="" id="spectrum-combobox-instance" class="spectrum-Textfield spectrum-InputGroup-field">
+                      <button class="spectrum-FieldButton spectrum-InputGroup-button" aria-haspopup="true">
+                        <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-InputGroup-icon" focusable="false" aria-hidden="true">
+                          <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+
+            article.spectrum-CSSExample
+              h5.spectrum-CSSExample-heading.spectrum-Heading4 Dropdown (wrapping label)
+              section.spectrum-CSSExample-container
+                .spectrum-CSSExample-example
+                  <div style="width: 160px">
+                    <label class="spectrum-Form-itemLabel" for="spectrum-combobox-instance">Vorhergesagtes jährliches wachstum</label>
+                    <div class="spectrum-Dropdown" style="width: 195px;">
+                      <button class="spectrum-FieldButton spectrum-Dropdown-trigger" aria-haspopup="true">
+                        <span class="spectrum-Dropdown-label is-placeholder">Select an option</span>
+                        <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
+                          <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+
+            article.spectrum-CSSExample
+              h5.spectrum-CSSExample-heading.spectrum-Heading4 Textfield (wrapping label)
+              section.spectrum-CSSExample-container
+                .spectrum-CSSExample-example
+                  <div style="width: 160px">
+                    <label class="spectrum-Form-itemLabel" for="spectrum-combobox-instance">Vorhergesagtes jährliches wachstum</label>
+                  <input type="text" placeholder="Enter your name" name="field" value="" class="spectrum-Textfield">
+                  </div>
+
+            article.spectrum-CSSExample
+              h5.spectrum-CSSExample-heading.spectrum-Heading4 Slider (wrapping)
+              section.spectrum-CSSExample-container
+                .spectrum-CSSExample-example
+                  <div class="spectrum-Slider spectrum-Slider--filled" style="width: 208px">
+                    <div class="spectrum-Slider-labelContainer">
+                      <label class="spectrum-Slider-label" id="spectrum-Slider-label-8" for="spectrum-Slider-input-8">Lorem ipsum dolor sit amet, consectetur adipiscing elit</label>
+                      <div class="spectrum-Slider-value" role="textbox" aria-readonly="true" aria-labelledby="spectrum-Slider-label-8">14</div>
+                    </div>
+                    <div class="spectrum-Slider-controls">
+                      <div class="spectrum-Slider-track"></div>
+                      <div class="spectrum-Slider-handle" style="left: 40%;">
+                        <input type="range" class="spectrum-Slider-input" value="14" step="2" min="10" max="20" id="spectrum-Slider-input-8">
+                      </div>
+                      <div class="spectrum-Slider-track"></div>
+                    </div>
+                  </div>
+
+            article.spectrum-CSSExample
+              h5.spectrum-CSSExample-heading.spectrum-Heading4 Status Light (wrapping)
+              section.spectrum-CSSExample-container
+                .spectrum-CSSExample-example
+                  <div class="spectrum-StatusLight spectrum-StatusLight--positive">Lorem ipsum dolor sit amet, consectetur adipiscing elit</div>
+                  <div class="spectrum-StatusLight spectrum-StatusLight--positive" style="width: 157px">Lorem ipsum dolor sit amet, consectetur adipiscing elit</div>
+
+            include includes/footer.pug
+
+    include includes/pageBottom.pug


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->
In testing #415, I realized the Wrapping and Truncation studies from #176  did not make it when we moved to individually versioned components and the new dev site. This PR adds them back.

## How and where has this been tested?
 - **How this was tested:** `gulp dev; open http://localhost:3000/docs/truncation.html; open http://localhost:3000/docs/wrapping.html`
 - **Browser(s) and OS(s) this was tested with:** Chrome on macOS

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->
![image](https://user-images.githubusercontent.com/201344/69999622-ee993e80-150d-11ea-801e-627043b94a24.png)
![image](https://user-images.githubusercontent.com/201344/69999628-f0fb9880-150d-11ea-9e98-f97b5ba3d32a.png)


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
