### PR TITLE
fix: don't try to add fallbacks inside of url(), related to #223

### DIFF
--- a/tools/component-builder/css/plugins/postcss-custom-properties-mapping.js
+++ b/tools/component-builder/css/plugins/postcss-custom-properties-mapping.js
@@ -49,6 +49,12 @@ module.exports = postcss.plugin('postcss-custom-properties-mapping', function() 
         if (customPropertiesRegExp.test(decl.value)) {
           let value = valueParser(decl.value);
 
+          if (value.nodes && value.nodes[0] && value.nodes[0].value === 'url') {
+            // Don't process custom properties within URLs, it does nothing and breaks parcel
+            // see https://github.com/parcel-bundler/parcel/issues/3881
+            return;
+          }
+
           value.walk((node, index, nodes) => {
             if (node.type === 'function' && node.value === 'var') {
               let v = node.nodes[0].value;


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->
This is a workaround for https://github.com/parcel-bundler/parcel/issues/3881

Effectively, this tells the algorithm that adds fallback CSS custom properties to ignore them when they appear inside of a `url()`. The variables within the `url()` are already doing nothing (see #223), this just removes the fallback that was causing Parcel bundling to fail in Leonardo.

## How and where has this been tested?
 - **How this was tested:** `cd packages/textfield; gulp build`
 - **Browser(s) and OS(s) this was tested with:** n/a


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
