### PR TITLE
fix: correct Search icon color on hover/down/focus, fixes #409

### DIFF
--- a/components/search/index.css
+++ b/components/search/index.css
@@ -72,5 +72,7 @@ governing permissions and limitations under the License.
   left: 12px;
   top: calc(calc(var(--spectrum-textfield-height) / 2) - calc(var(--spectrum-icon-magnifier-width) / 2));
 
+  transition: color var(--spectrum-global-animation-duration-100) ease-in-out;
+
   pointer-events: none;
 }

--- a/components/search/skin.css
+++ b/components/search/skin.css
@@ -14,10 +14,31 @@ governing permissions and limitations under the License.
   color: var(--spectrum-textfield-icon-color);
 }
 
+.spectrum-Search {
+}
+
 .spectrum-Search-input {
   &:disabled {
     & ~ .spectrum-Search-icon {
       color: var(--spectrum-textfield-text-color-disabled);
+    }
+  }
+
+  &:hover {
+    & ~ .spectrum-Search-icon {
+      color: var(--spectrum-search-icon-color-hover);
+    }
+  }
+
+  &:active {
+    & ~ .spectrum-Search-icon {
+      color: var(--spectrum-search-icon-color-down);
+    }
+  }
+
+  &:focus-ring {
+    & ~ .spectrum-Search-icon {
+      color: var(--spectrum-search-icon-color-key-focus);
     }
   }
 }

--- a/components/search/skin.css
+++ b/components/search/skin.css
@@ -14,9 +14,6 @@ governing permissions and limitations under the License.
   color: var(--spectrum-textfield-icon-color);
 }
 
-.spectrum-Search {
-}
-
 .spectrum-Search-input {
   &:disabled {
     & ~ .spectrum-Search-icon {
@@ -24,6 +21,7 @@ governing permissions and limitations under the License.
     }
   }
 
+  /* The value of color is identical for hover/active/focus-ring, but we repeat it here in case one is changed in the future */
   &:hover {
     & ~ .spectrum-Search-icon {
       color: var(--spectrum-search-icon-color-hover);


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->

Fixes #409 by correctly using DNA tokens. 

## How and where has this been tested?
 - **How this was tested:** Look at example, hover on it, smile
 - **Browser(s) and OS(s) this was tested with:** Chrome on macOS

## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
