### PR TITLE
fix: fix button width in InputGroup, fix DatePicker example, fixes #399

### DIFF
--- a/components/inputgroup/index.css
+++ b/components/inputgroup/index.css
@@ -22,6 +22,8 @@ governing permissions and limitations under the License.
   --spectrum-datepicker-range-dash-margin-left: calc(-0.5 * var(--spectrum-global-dimension-static-font-size-100));
   --spectrum-datepicker-range-dash-padding-top: 0;
   --spectrum-datepicker-range-dash-line-height: calc(var(--spectrum-textfield-height) - var(--spectrum-global-dimension-size-100));
+
+  --spectrum-combobox-button-width: calc(var(--spectrum-global-dimension-size-400) + var(--spectrum-global-dimension-size-25));
 }
 
 .spectrum-InputGroup {
@@ -33,7 +35,8 @@ governing permissions and limitations under the License.
   border-radius: var(--spectrum-border-radius);
 
   .spectrum-FieldButton {
-    padding: 0 var(--spectrum-dropdown-padding-x);
+    padding: 0;
+    width: var(--spectrum-combobox-button-width);
     border-top-left-radius: var(--spectrum-combobox-fieldbutton-border-top-left-radius);
     border-bottom-left-radius: var(--spectrum-combobox-fieldbutton-border-bottom-left-radius);
   }
@@ -48,12 +51,16 @@ governing permissions and limitations under the License.
 
 .spectrum-InputGroup--quiet {
   border-radius: var(--spectrum-combobox-quiet-fieldbutton-border-radius);
-  .spectrum-FieldButton {
-    border-radius: var(--spectrum-combobox-quiet-fieldbutton-border-radius);
 
+  .spectrum-FieldButton {
+    width: auto;
     position: relative;
+
+    padding-left: var(--spectrum-dropdown-padding-x);
     padding-right: var(--spectrum-combobox-quiet-fieldbutton-padding-right);
+
     border-bottom: var(--spectrum-textfield-quiet-affixed-border-size) solid;
+    border-radius: var(--spectrum-combobox-quiet-fieldbutton-border-radius);
 
     /* More hitarea */
     &:after {

--- a/components/inputgroup/metadata/datepicker.yml
+++ b/components/inputgroup/metadata/datepicker.yml
@@ -95,7 +95,7 @@ examples:
       <div class="spectrum-InputGroup spectrum-InputGroup--quiet spectrum-Datepicker spectrum-Datepicker--range" role="combobox" aria-expanded="false" aria-haspopup="dialog">
         <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field spectrum-Datepicker-startField" placeholder="mm/dd/yyyy" name="start" value="2018-10-01">
         <div class="spectrum-Datepicker--rangeDash"></div>
-        <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field spectrum-Datepicker-startField" placeholder="mm/dd/yyyy" name="end" value="2018-10-30">
+        <input type="text" class="spectrum-Textfield spectrum-Textfield--quiet spectrum-InputGroup-field spectrum-Datepicker-endField" placeholder="mm/dd/yyyy" name="end" value="2018-10-30">
         <button type="button" class="spectrum-FieldButton spectrum-FieldButton--quiet" tabindex="-1" aria-label="Calendar">
           <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
             <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->
Corrects the width of InputGroup buttons, fixes #399 

Also fixes #394 (documentation markup was wrong).

## How and where has this been tested?
 - **How this was tested:** Open Date picker examples, use eyes
 - **Browser(s) and OS(s) this was tested with:** Chrome on macOS

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->

![image](https://user-images.githubusercontent.com/201344/70481324-0e44df80-1a97-11ea-95d0-dac19414396c.png)

## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
