### PR TITLE
build: add vars as a peerDep, fixes #413

### DIFF
--- a/tools/component-builder/package.json
+++ b/tools/component-builder/package.json
@@ -11,6 +11,9 @@
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
   "license": "Apache-2.0",
+  "peerDependencies": {
+    "@spectrum-css/vars": "^2.0.2"
+  },
   "dependencies": {
     "autoprefixer": "^6.5.3",
     "browser-sync": "^2.26.7",


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->
This PR declares `@spectrum-css/vars` as a `peerDependency` in `@spectrum-css/component-builder` so uses outside of Spectrum CSS will be aware that it is required.

## How and where has this been tested?
 - **How this was tested:** n/a
 - **Browser(s) and OS(s) this was tested with:** n/a

## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
