### PR TITLE
fix: vertical alignment of Status Light text, fixes #426

### DIFF
--- a/components/statuslight/index.css
+++ b/components/statuslight/index.css
@@ -14,8 +14,13 @@ governing permissions and limitations under the License.
 
 :root {
   --spectrum-statuslight-padding-y: var(--spectrum-global-dimension-size-75);
+
   /* Override line-height to fix Firefox */
   --spectrum-statuslight-text-line-height: 1.44;
+
+  /* Override padding to fix alignment of the first line of text (needs to be moved down 1px) */
+  --spectrum-statuslight-padding-top: calc(var(--spectrum-statuslight-padding-y) - 1px);
+  --spectrum-statuslight-padding-bottom: calc(var(--spectrum-statuslight-padding-y) + 1px);
 }
 
 .spectrum-StatusLight {
@@ -24,7 +29,7 @@ governing permissions and limitations under the License.
   flex-direction: row;
   align-items: flex-start;
 
-  padding: calc(var(--spectrum-statuslight-padding-y) - 1px) 0 calc(var(--spectrum-statuslight-padding-y) + 1px) 0;
+  padding: var(--spectrum-statuslight-padding-top) 0 var(--spectrum-statuslight-padding-bottom) 0;
   box-sizing: border-box;
 
   font-size: var(--spectrum-statuslight-text-size);
@@ -39,7 +44,9 @@ governing permissions and limitations under the License.
     width: var(--spectrum-statuslight-dot-size);
     height: var(--spectrum-statuslight-dot-size);
     border-radius: 50%;
-    margin: calc(var(--spectrum-statuslight-padding-y) + 1px) var(--spectrum-statuslight-text-gap) calc(var(--spectrum-statuslight-padding-y) - 1px) var(--spectrum-statuslight-text-gap);
+
+    /* margin on the dog is the opposite of the padding in order to align the dot as if the padding hack was not present */
+    margin: var(--spectrum-statuslight-padding-bottom) var(--spectrum-statuslight-text-gap) var(--spectrum-statuslight-padding-top) var(--spectrum-statuslight-text-gap);
   }
 }
 

--- a/components/statuslight/index.css
+++ b/components/statuslight/index.css
@@ -14,6 +14,8 @@ governing permissions and limitations under the License.
 
 :root {
   --spectrum-statuslight-padding-y: var(--spectrum-global-dimension-size-75);
+  /* Override line-height to fix Firefox */
+  --spectrum-statuslight-text-line-height: 1.44;
 }
 
 .spectrum-StatusLight {
@@ -22,11 +24,12 @@ governing permissions and limitations under the License.
   flex-direction: row;
   align-items: flex-start;
 
-  padding: var(--spectrum-statuslight-padding-y) 0px;
+  padding: calc(var(--spectrum-statuslight-padding-y) - 1px) 0 calc(var(--spectrum-statuslight-padding-y) + 1px) 0;
   box-sizing: border-box;
 
   font-size: var(--spectrum-statuslight-text-size);
   font-weight: var(--spectrum-statuslight-text-font-weight);
+  line-height: var(--spectrum-statuslight-text-line-height);
 
   &::before {
     content: '';
@@ -36,7 +39,7 @@ governing permissions and limitations under the License.
     width: var(--spectrum-statuslight-dot-size);
     height: var(--spectrum-statuslight-dot-size);
     border-radius: 50%;
-    margin: var(--spectrum-statuslight-padding-y) var(--spectrum-statuslight-text-gap);
+    margin: calc(var(--spectrum-statuslight-padding-y) + 1px) var(--spectrum-statuslight-text-gap) calc(var(--spectrum-statuslight-padding-y) - 1px) var(--spectrum-statuslight-text-gap);
   }
 }
 


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->
This PR fixes the vertical alignment of text in Status Light by reducing the top padding to move the text upward.

## How and where has this been tested?
 - **How this was tested:** eyeballs
 - **Browser(s) and OS(s) this was tested with:** all the many


## Screenshots
<!-- If applicable, add screenshots to show what you changed -->

✅Chrome 78.0.3904.108
![image](https://user-images.githubusercontent.com/201344/70569235-67bc1580-1b4e-11ea-856b-e0e969e2b3a6.png)
✅Safari 13.0.3
![image](https://user-images.githubusercontent.com/201344/70569185-4eb36480-1b4e-11ea-82d6-9dd0f503b1b5.png)
✅Safari 11.1.2
![image](https://user-images.githubusercontent.com/201344/70569143-37747700-1b4e-11ea-8c33-490728253615.png)
✅Firefox 70.0.1 (off by a half pixel)
![image](https://user-images.githubusercontent.com/201344/70569481-d4cfab00-1b4e-11ea-8dd1-3b5d59244a4d.png)
✅IE11 (the font doesn't render the right height, but it looks visually correct next to the dot)
![image](https://user-images.githubusercontent.com/201344/70569071-0d22b980-1b4e-11ea-9db7-27fe0eb22980.png)
✅Edge 42.17134.1.0 (off by a half pixel)
![image](https://user-images.githubusercontent.com/201344/70569626-2841f900-1b4f-11ea-89cf-6da8aab80221.png)



## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
