### PR TITLE
fix: text wrapping in Meter/BarLoader, fixes #420

### DIFF
--- a/components/barloader/index.css
+++ b/components/barloader/index.css
@@ -48,7 +48,7 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-BarLoader-label {
-  flex: 1 0 auto;
+  flex: 1 1 0%;
 }
 
 .spectrum-BarLoader-percentage {


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->
This PR fixes the wrapping of BarLoader/Meter labels. This was a regression caused by changing the `flex: 1` to `flex: 1 0 auto` for IE 11 support, when it should have been `flex: 1 1 0%`.

## How and where has this been tested?
 - **How this was tested:** open link, use eyes
 - **Browser(s) and OS(s) this was tested with:** Chrome on macOS, IE 11ing

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->
✅Chrome 78
![image](https://user-images.githubusercontent.com/201344/70572062-e23b6400-1b53-11ea-9400-a2485340ef88.png)

✅IE 11
![image](https://user-images.githubusercontent.com/201344/70572020-ce8ffd80-1b53-11ea-8fad-14906f00945f.png)


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
