### PR TITLE
fix: disable resize functionality when disabled, fixes #443

### DIFF
--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -109,6 +109,9 @@ governing permissions and limitations under the License.
   }
 
   &:disabled {
+    /* Disable the resize functionality when disabled */
+    resize: none;
+
     /* The opacity must be set to 1 */
     opacity: 1;
     &::placeholder {


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->
Remove resize functionality completely when textfield are disabled.

## How and where has this been tested?
 - **How this was tested:** Open textarea example, try in vain to resize the disabled textarea
 - **Browser(s) and OS(s) this was tested with:** Chrome on macOS

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->
![image](https://user-images.githubusercontent.com/201344/70737528-96a9c700-1cc7-11ea-9ed6-2c7a68aa8a63.png)


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
