### PR TITLE
fix: make quiet Text area 1 line tall by default, fixes #442

### DIFF
--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -188,4 +188,9 @@ governing permissions and limitations under the License.
   &.is-valid {
     background-position: var(--spectrum-textfield-quiet-invalid-background-position);
   }
+
+  &.spectrum-Textfield--multiline {
+    height: var(--spectrum-textfield-height);
+    min-height: var(--spectrum-textfield-height);
+  }
 }


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->
Accomplished by setting both `height` and `min-height` to the height of a textfield. It's on implementations to change `height` as necessary on input.

## How and where has this been tested?
 - **How this was tested:** view example, rejoice
 - **Browser(s) and OS(s) this was tested with:** Chrome on macOS

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->
![image](https://user-images.githubusercontent.com/201344/70739220-33219880-1ccb-11ea-9c25-1540c749c221.png)


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
