### PR TITLE
fix: wrapping on long words indropdowns (SDS-4649) #451

### DIFF
--- a/components/menu/index.css
+++ b/components/menu/index.css
@@ -115,6 +115,7 @@ governing permissions and limitations under the License.
 .spectrum-Menu-itemLabel {
   flex: 1 1 auto;
   line-height: var(--spectrum-selectlist-option-label-line-height);
+  word-break: break-all;
 }
 
 .spectrum-Menu-itemLabel--wrapping {


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->
adding `word-break: break-all;` to dropdown label.

## Description
In order to break "unbreakable words" like German connected nouns or urls / paths we need to allow break-all for words.

<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->


## How and where has this been tested?

 - **How this was tested:** <!-- Using steps in issue #000 --> go to `http://localhost:3000/docs/dropdown.html` and inspect the dropdown label
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 --> Google Chrome Canary Version 81.0.3993.0 (Official Build) canary (64-bit) on macOS Mojave 0.14.5 (18F203)

## Screenshots
Before:

<img width="363" alt="Screen Shot 2019-12-13 at 23 15 45" src="https://user-images.githubusercontent.com/52184321/70836520-a8db5080-1e00-11ea-9e59-ba58c0c528ea.png">


After:
<img width="344" alt="Screen Shot 2019-12-13 at 23 19 48" src="https://user-images.githubusercontent.com/52184321/70836521-ab3daa80-1e00-11ea-9cfd-3078ca55a5d7.png">


<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
