### PR TITLE
fix: vertical rule doesn't render

### DIFF
--- a/components/rule/index.css
+++ b/components/rule/index.css
@@ -13,8 +13,6 @@ governing permissions and limitations under the License.
 @import '../commons/index.css';
 
 .spectrum-Rule {
-  width: 100%;
-
   /* Show the overflow for hr in Edge and IE. */
   overflow: visible;
 
@@ -24,26 +22,35 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Rule--large {
-  height: var(--spectrum-rule-large-height);
-
   border-radius: var(--spectrum-rule-large-border-radius);
 }
 
 .spectrum-Rule--medium {
-  height: var(--spectrum-rule-medium-height);
-
   border-radius: var(--spectrum-rule-medium-border-radius);
 }
 
 .spectrum-Rule--small {
-  height: var(--spectrum-rule-small-height);
-
   border-radius: var(--spectrum-rule-small-border-radius);
 }
 
-.spectrum-Rule--vertical {
-  height: 100%;
+.spectrum-Rule--horizontal {
+  &.spectrum-Rule--large {
+    height: var(--spectrum-rule-large-height);
+  }
 
+  &.spectrum-Rule--medium {
+    height: var(--spectrum-rule-medium-height);
+  }
+
+  &.spectrum-Rule--small {
+    height: var(--spectrum-rule-small-height);
+  }
+}
+
+.spectrum-Rule--vertical {
+  /* expected usage, people need to set height 100% if they aren't using flex on the container
+   * if they *ARE* using flex, then they need to either have align-items stretch OR align-self stretch
+   */
   &.spectrum-Rule--large {
     width: var(--spectrum-rule-large-height);
   }

--- a/components/rule/metadata/rule.yml
+++ b/components/rule/metadata/rule.yml
@@ -6,24 +6,24 @@ examples:
     name: 'Large'
     markup: |
       <h2 class="spectrum-Heading--subtitle1">Large</h2>
-      <hr class="spectrum-Rule spectrum-Rule--large">
+      <hr class="spectrum-Rule spectrum-Rule--horizontal spectrum-Rule--large">
       <p class="spectrum-Body">Page or Section Titles.</p>
   - id: rule-medium
     name: 'Medium'
     markup: |
       <h3 class="spectrum-Heading--subtitle2">Medium</h3>
-      <hr class="spectrum-Rule spectrum-Rule--medium">
+      <hr class="spectrum-Rule spectrum-Rule--horizontal spectrum-Rule--medium">
       <p class="spectrum-Body">Divide subsections, or divide different groups of elements (between panels, rails, etc.)</p>
   - id: rule-small
     name: 'Small'
     markup: |
       <h4 class="spectrum-Heading--subtitle3">Small</h4>
-      <hr class="spectrum-Rule spectrum-Rule--small">
+      <hr class="spectrum-Rule spectrum-Rule--horizontal spectrum-Rule--small">
       <p class="spectrum-Body">Divide like-elements (tables, tool groups, elements within a panel, etc.)</p>
   - id: rule-vertical-small
     name: 'Vertical, Small'
     markup: |
-      <div style="display: flex; flex-direction: row; height: 32px">
+      <div style="display: flex">
         <div class="spectrum-ButtonGroup">
           <button class="spectrum-Tool">
             <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Properties">
@@ -43,7 +43,7 @@ examples:
   - id: rule-vertical-medium
     name: 'Vertical, Medium'
     markup: |
-      <div style="display: flex; flex-direction: row; height: 32px">
+      <div style="display: flex">
         <div class="spectrum-ButtonGroup">
           <button class="spectrum-Tool">
             <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Properties">


### PR DESCRIPTION
Split css into two classes so that they don't need to override each others settings
keep shared styles in a shared area
get rid of height 100% because that's meaningless in a container without an explicit height and will actually cause it to collapse, which is what's happening now

this would probably be considered breaking because there is no longer a default, horizontal must be specified

<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->
https://github.com/adobe/spectrum-css/issues/455

## How and where has this been tested?
Chrome 78 Mac 10.15.1 localhost

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
