### PR TITLE
fix: vertical rule doesn't render

### DIFF
--- a/components/buttongroup/index.css
+++ b/components/buttongroup/index.css
@@ -23,6 +23,11 @@ governing permissions and limitations under the License.
     flex-shrink: 0;
   }
 
+  > .spectrum-Rule--vertical {
+    height: auto;
+    align-self: stretch;
+  }
+
   .spectrum-Button + .spectrum-Button {
     margin-left: var(--spectrum-buttongroup-button-gap-x);
   }

--- a/components/rule/index.css
+++ b/components/rule/index.css
@@ -13,7 +13,10 @@ governing permissions and limitations under the License.
 @import '../commons/index.css';
 
 :root {
-  --spectrum-rule-vertical-height: 100%;
+  --spectrum-divider-vertical-height: 100%;
+
+  /* Work around DNA misspelling */
+  --spectrum-divider-small-vertical-width: var(--spectrum-divider-small-vertical-width, var(--spectrum-divider-small-veritcal-width));
 }
 
 .spectrum-Rule {
@@ -23,40 +26,40 @@ governing permissions and limitations under the License.
   overflow: visible;
 
   border: none;
-  border-width: var(--spectrum-rule-medium-height);
-  border-radius: var(--spectrum-rule-medium-height);
+  border-width: var(--spectrum-divider-medium-height);
+  border-radius: var(--spectrum-divider-medium-height);
 }
 
 .spectrum-Rule--large {
-  height: var(--spectrum-rule-large-height);
+  height: var(--spectrum-divider-large-height);
 
-  border-radius: var(--spectrum-rule-large-border-radius);
+  border-radius: var(--spectrum-divider-large-border-radius);
 }
 
 .spectrum-Rule--medium {
-  height: var(--spectrum-rule-medium-height);
+  height: var(--spectrum-divider-medium-height);
 
-  border-radius: var(--spectrum-rule-medium-border-radius);
+  border-radius: var(--spectrum-divider-medium-border-radius);
 }
 
 .spectrum-Rule--small {
-  height: var(--spectrum-rule-small-height);
+  height: var(--spectrum-divider-small-height);
 
-  border-radius: var(--spectrum-rule-small-border-radius);
+  border-radius: var(--spectrum-divider-small-border-radius);
 }
 
 .spectrum-Rule--vertical {
-  height: var(--spectrum-rule-vertical-height);
+  height: var(--spectrum-divider-vertical-height);
 
   &.spectrum-Rule--large {
-    width: var(--spectrum-rule-large-height);
+    width: var(--spectrum-divider-large-vertical-width);
   }
 
   &.spectrum-Rule--medium {
-    width: var(--spectrum-rule-medium-height);
+    width: var(--spectrum-divider-medium-vertical-width);
   }
 
   &.spectrum-Rule--small {
-    width: var(--spectrum-rule-small-height);
+    width: var(--spectrum-divider-small-vertical-width);
   }
 }

--- a/components/rule/index.css
+++ b/components/rule/index.css
@@ -12,6 +12,10 @@ governing permissions and limitations under the License.
 
 @import '../commons/index.css';
 
+:root {
+  --spectrum-rule-vertical-height: 100%;
+}
+
 .spectrum-Rule {
   width: 100%;
 
@@ -42,7 +46,7 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Rule--vertical {
-  height: 100%;
+  height: var(--spectrum-rule-vertical-height);
 
   &.spectrum-Rule--large {
     width: var(--spectrum-rule-large-height);

--- a/components/rule/metadata/rule.yml
+++ b/components/rule/metadata/rule.yml
@@ -27,13 +27,13 @@ examples:
       ButtonGroup automatically applies these styles to vertical Rules.
     markup: |
       <div class="spectrum-ButtonGroup">
-        <button class="spectrum-Tool">
+        <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
           <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Properties">
             <use xlink:href="#spectrum-icon-18-Properties" />
           </svg>
         </button>
         <div class="spectrum-Rule spectrum-Rule--small spectrum-Rule--vertical"></div>
-        <button class="spectrum-Tool">
+        <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
           <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Select">
             <use xlink:href="#spectrum-icon-18-Select" />
           </svg>
@@ -43,13 +43,13 @@ examples:
     name: 'Vertical, Medium'
     markup: |
       <div class="spectrum-ButtonGroup">
-        <button class="spectrum-Tool">
+        <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
           <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Properties">
             <use xlink:href="#spectrum-icon-18-Properties" />
           </svg>
         </button>
         <div class="spectrum-Rule spectrum-Rule--medium spectrum-Rule--vertical"></div>
-        <button class="spectrum-Tool">
+        <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
           <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Select">
             <use xlink:href="#spectrum-icon-18-Select" />
           </svg>

--- a/components/rule/metadata/rule.yml
+++ b/components/rule/metadata/rule.yml
@@ -22,41 +22,36 @@ examples:
       <p class="spectrum-Body">Divide like-elements (tables, tool groups, elements within a panel, etc.)</p>
   - id: rule-vertical-small
     name: 'Vertical, Small'
+    description: |
+      When a vertical Rule is used inside of a flex container, use `align-self: stretch; height: auto` on the Rule.
+      ButtonGroup automatically applies these styles to vertical Rules.
     markup: |
-      <div style="display: flex; flex-direction: row; height: 32px">
-        <div class="spectrum-ButtonGroup">
-          <button class="spectrum-Tool">
-            <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Properties">
-              <use xlink:href="#spectrum-icon-18-Properties" />
-            </svg>
-          </button>
-        </div>
+      <div class="spectrum-ButtonGroup">
+        <button class="spectrum-Tool">
+          <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Properties">
+            <use xlink:href="#spectrum-icon-18-Properties" />
+          </svg>
+        </button>
         <div class="spectrum-Rule spectrum-Rule--small spectrum-Rule--vertical"></div>
-        <div class="spectrum-ButtonGroup">
-          <button class="spectrum-Tool">
-            <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Select">
-              <use xlink:href="#spectrum-icon-18-Select" />
-            </svg>
-          </button>
-        </div>
+        <button class="spectrum-Tool">
+          <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Select">
+            <use xlink:href="#spectrum-icon-18-Select" />
+          </svg>
+        </button>
       </div>
   - id: rule-vertical-medium
     name: 'Vertical, Medium'
     markup: |
-      <div style="display: flex; flex-direction: row; height: 32px">
-        <div class="spectrum-ButtonGroup">
-          <button class="spectrum-Tool">
-            <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Properties">
-              <use xlink:href="#spectrum-icon-18-Properties" />
-            </svg>
-          </button>
-        </div>
+      <div class="spectrum-ButtonGroup">
+        <button class="spectrum-Tool">
+          <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Properties">
+            <use xlink:href="#spectrum-icon-18-Properties" />
+          </svg>
+        </button>
         <div class="spectrum-Rule spectrum-Rule--medium spectrum-Rule--vertical"></div>
-        <div class="spectrum-ButtonGroup">
-          <button class="spectrum-Tool">
-            <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Select">
-              <use xlink:href="#spectrum-icon-18-Select" />
-            </svg>
-          </button>
-        </div>
+        <button class="spectrum-Tool">
+          <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Select">
+            <use xlink:href="#spectrum-icon-18-Select" />
+          </svg>
+        </button>
       </div>

--- a/components/rule/package.json
+++ b/components/rule/package.json
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "@spectrum-css/button": "^2.0.3",
+    "@spectrum-css/buttongroup": "^2.0.3",
     "@spectrum-css/component-builder": "^1.0.2",
     "@spectrum-css/vars": "^1.0.0-alpha.0",
     "gulp": "^4.0.0"


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->
This PR does a few different things:

* Update DNA to 5.23 to catch new tokens
* Use correct DNA tokens for Rule, closes #425
* Make vertical Rule's height a variable, fixes #455
* Support vertical Rules inside of ButtonGroup, simplifying usage examples
* Add documentation on using vertical Rules inside of a flex context

## How and where has this been tested?
 - **How this was tested:** A little scrolly scroll
 - **Browser(s) and OS(s) this was tested with:**  Chrome on macOS

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->
![image](https://user-images.githubusercontent.com/201344/72303809-4e155e80-3623-11ea-8fa8-13c3ef30a30b.png)


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
