### PR TITLE
fix: adding overflow-wrap to dropdown #451

### DIFF
--- a/components/dropdown/metadata/dropdown.yml
+++ b/components/dropdown/metadata/dropdown.yml
@@ -38,7 +38,7 @@ examples:
               </svg>
             </li>
             <li class="spectrum-Menu-item" role="option" tabindex="0">
-              <span class="spectrum-Menu-itemLabel">Very long text with hyphens-between-words.</span>
+              <span class="spectrum-Menu-itemLabel">Very long text with hyphens-between-words</span>
               <svg class="spectrum-Icon spectrum-UIIcon-CheckmarkMedium spectrum-Menu-checkmark spectrum-Menu-itemIcon" focusable="false" aria-hidden="true">
                 <use xlink:href="#spectrum-css-icon-CheckmarkMedium" />
               </svg>
@@ -62,7 +62,7 @@ examples:
           <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Image">
             <use xlink:href="#spectrum-icon-18-Image" />
           </svg>
-          <span class="spectrum-Dropdown-label">Ballard</span>
+          <span class="spectrum-Dropdown-label">Donaudampfschifffahrtsgesellschaftskapitän</span>
           <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
             <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />
           </svg>
@@ -73,7 +73,7 @@ examples:
               <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-Menu-itemIcon" focusable="false" aria-hidden="true" aria-label="Image">
                 <use xlink:href="#spectrum-icon-18-Image" />
               </svg>
-              <span class="spectrum-Menu-itemLabel">Ballard</span>
+              <span class="spectrum-Menu-itemLabel">Donaudampfschifffahrtsgesellschaftskapitän</span>
               <svg class="spectrum-Icon spectrum-UIIcon-CheckmarkMedium spectrum-Menu-checkmark spectrum-Menu-itemIcon" focusable="false" aria-hidden="true">
                 <use xlink:href="#spectrum-css-icon-CheckmarkMedium" />
               </svg>
@@ -82,7 +82,7 @@ examples:
               <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-Menu-itemIcon" focusable="false" aria-hidden="true" aria-label="Image">
                 <use xlink:href="#spectrum-icon-18-Image" />
               </svg>
-              <span class="spectrum-Menu-itemLabel">Fremont</span>
+              <span class="spectrum-Menu-itemLabel">Some long value that should be cut off</span>
               <svg class="spectrum-Icon spectrum-UIIcon-CheckmarkMedium spectrum-Menu-checkmark spectrum-Menu-itemIcon" focusable="false" aria-hidden="true">
                 <use xlink:href="#spectrum-css-icon-CheckmarkMedium" />
               </svg>
@@ -91,7 +91,7 @@ examples:
               <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-Menu-itemIcon" focusable="false" aria-hidden="true" aria-label="Image">
                 <use xlink:href="#spectrum-icon-18-Image" />
               </svg>
-              <span class="spectrum-Menu-itemLabel">Greenwood</span>
+              <span class="spectrum-Menu-itemLabel">Very long text with hyphens-between-words</span>
               <svg class="spectrum-Icon spectrum-UIIcon-CheckmarkMedium spectrum-Menu-checkmark spectrum-Menu-itemIcon" focusable="false" aria-hidden="true">
                 <use xlink:href="#spectrum-css-icon-CheckmarkMedium" />
               </svg>

--- a/components/dropdown/metadata/dropdown.yml
+++ b/components/dropdown/metadata/dropdown.yml
@@ -38,7 +38,7 @@ examples:
               </svg>
             </li>
             <li class="spectrum-Menu-item" role="option" tabindex="0">
-              <span class="spectrum-Menu-itemLabel">A very long text that has spaces and hyphens-between-words.</span>
+              <span class="spectrum-Menu-itemLabel">A very long text with spaces and hyphen-words.</span>
               <svg class="spectrum-Icon spectrum-UIIcon-CheckmarkMedium spectrum-Menu-checkmark spectrum-Menu-itemIcon" focusable="false" aria-hidden="true">
                 <use xlink:href="#spectrum-css-icon-CheckmarkMedium" />
               </svg>

--- a/components/dropdown/metadata/dropdown.yml
+++ b/components/dropdown/metadata/dropdown.yml
@@ -18,7 +18,7 @@ examples:
       <h4>Open</h4>
       <div class="spectrum-Dropdown is-open" style="width: 240px;">
         <button class="spectrum-FieldButton spectrum-Dropdown-trigger is-selected" aria-haspopup="listbox">
-          <span class="spectrum-Dropdown-label">Ballard</span>
+          <span class="spectrum-Dropdown-label">Donaudampfschifffahrtsgesellschaftskapitän</span>
           <svg class="spectrum-Icon spectrum-UIIcon-ChevronDownMedium spectrum-Dropdown-icon" focusable="false" aria-hidden="true">
             <use xlink:href="#spectrum-css-icon-ChevronDownMedium" />
           </svg>
@@ -26,19 +26,19 @@ examples:
         <div class="spectrum-Popover spectrum-Popover--bottom spectrum-Dropdown-popover is-open" style="width: 100%">
           <ul class="spectrum-Menu" role="listbox">
             <li class="spectrum-Menu-item is-selected" role="option" aria-selected="true" tabindex="0">
-              <span class="spectrum-Menu-itemLabel">Ballard</span>
+              <span class="spectrum-Menu-itemLabel">Donaudampfschifffahrtsgesellschaftskapitän</span>
               <svg class="spectrum-Icon spectrum-UIIcon-CheckmarkMedium spectrum-Menu-checkmark spectrum-Menu-itemIcon" focusable="false" aria-hidden="true">
                 <use xlink:href="#spectrum-css-icon-CheckmarkMedium" />
               </svg>
             </li>
             <li class="spectrum-Menu-item" role="option" tabindex="0">
-              <span class="spectrum-Menu-itemLabel">Fremont</span>
+              <span class="spectrum-Menu-itemLabel">Some long value that should be cut off</span>
               <svg class="spectrum-Icon spectrum-UIIcon-CheckmarkMedium spectrum-Menu-checkmark spectrum-Menu-itemIcon" focusable="false" aria-hidden="true">
                 <use xlink:href="#spectrum-css-icon-CheckmarkMedium" />
               </svg>
             </li>
             <li class="spectrum-Menu-item" role="option" tabindex="0">
-              <span class="spectrum-Menu-itemLabel">Greenwood</span>
+              <span class="spectrum-Menu-itemLabel">A very long text that has spaces and hyphens-between-words.</span>
               <svg class="spectrum-Icon spectrum-UIIcon-CheckmarkMedium spectrum-Menu-checkmark spectrum-Menu-itemIcon" focusable="false" aria-hidden="true">
                 <use xlink:href="#spectrum-css-icon-CheckmarkMedium" />
               </svg>

--- a/components/dropdown/metadata/dropdown.yml
+++ b/components/dropdown/metadata/dropdown.yml
@@ -38,7 +38,7 @@ examples:
               </svg>
             </li>
             <li class="spectrum-Menu-item" role="option" tabindex="0">
-              <span class="spectrum-Menu-itemLabel">A very long text with spaces and hyphen-words.</span>
+              <span class="spectrum-Menu-itemLabel">Very long text with hyphens-between-words.</span>
               <svg class="spectrum-Icon spectrum-UIIcon-CheckmarkMedium spectrum-Menu-checkmark spectrum-Menu-itemIcon" focusable="false" aria-hidden="true">
                 <use xlink:href="#spectrum-css-icon-CheckmarkMedium" />
               </svg>

--- a/components/menu/index.css
+++ b/components/menu/index.css
@@ -109,6 +109,14 @@ governing permissions and limitations under the License.
   .spectrum-Icon + .spectrum-Menu-itemLabel,
   .spectrum-Menu-itemIcon  + .spectrum-Menu-itemLabel {
     margin-left: var(--spectrum-selectlist-thumbnail-image-padding-x);
+
+    width: calc(
+      100%
+      - var(--spectrum-icon-checkmark-medium-width)
+      - var(--spectrum-selectlist-option-icon-padding-x)
+      - var(--spectrum-selectlist-thumbnail-image-padding-x)
+      - var(--spectrum-alias-workflow-icon-size)
+    );
   }
 }
 
@@ -117,7 +125,11 @@ governing permissions and limitations under the License.
   line-height: var(--spectrum-selectlist-option-label-line-height);
   hyphens: auto;
   overflow-wrap: break-word;
-  width: calc(100% - (var(--spectrum-icon-checkmark-medium-width) + var(--spectrum-selectlist-option-icon-padding-x))); 
+  width: calc(
+    100%
+    - var(--spectrum-icon-checkmark-medium-width)
+    - var(--spectrum-selectlist-option-icon-padding-x)
+  );
 }
 
 .spectrum-Menu-itemLabel--wrapping {

--- a/components/menu/index.css
+++ b/components/menu/index.css
@@ -115,7 +115,9 @@ governing permissions and limitations under the License.
 .spectrum-Menu-itemLabel {
   flex: 1 1 auto;
   line-height: var(--spectrum-selectlist-option-label-line-height);
-  word-break: break-all;
+  hyphens: auto;
+  overflow-wrap: break-word;
+  width: 80%;
 }
 
 .spectrum-Menu-itemLabel--wrapping {

--- a/components/menu/index.css
+++ b/components/menu/index.css
@@ -117,7 +117,7 @@ governing permissions and limitations under the License.
   line-height: var(--spectrum-selectlist-option-label-line-height);
   hyphens: auto;
   overflow-wrap: break-word;
-  width: 80%;
+  width: calc(100% - (var(--spectrum-icon-checkmark-medium-width) + var(--spectrum-selectlist-option-icon-padding-x))); 
 }
 
 .spectrum-Menu-itemLabel--wrapping {


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

Adding overflow-wrap and hyphen option to dropdown label and limiting the width to `80%` to force wrapping. 


## Description
In order to break "unbreakable words" like German connected nouns or urls / paths we need to allow overflow-wrap for words.

Fixes #451 ([SDS-4649](https://jira.corp.adobe.com/browse/SDS-4649)).
Previous fix was not sufficient int #452
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->


## How and where has this been tested?


 - **How this was tested:** 

Swap out the following text in the `components/dropdown/metadata/dropdown.yml`
 go to`http://localhost:3000/docs/dropdown.html` and inspect the dropdown label

 - **Browser(s) and OS(s) this was tested with:** 

Browsers left to right:
On macOs Mojave 10.14.5 (18F203): 
Chrome Version 81.0.4027.0 (Official Build) canary (64-bit)
Safari Version 12.1.1 (14607.2.6.1.1)
FireFox 72.0.1 (64-bit)
Edge Version 80.0.361.32 (Official build) Beta (64-bit)

On Windows 10:
Microsoft Edge 42.17134.1098.0

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->
![Screen Shot 2020-01-17 at 14 26 24](https://user-images.githubusercontent.com/52184321/72651010-f7679780-3936-11ea-8cbc-87186c4690db.png)

![Screen Shot 2020-01-17 at 14 30 31](https://user-images.githubusercontent.com/52184321/72651029-00586900-3937-11ea-873e-c2b914533dee.png)




## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
