### PR TITLE
fix: order of psuedo selectors search 

### DIFF
--- a/components/search/skin.css
+++ b/components/search/skin.css
@@ -15,12 +15,6 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Search-input {
-  &:disabled {
-    & ~ .spectrum-Search-icon {
-      color: var(--spectrum-textfield-text-color-disabled);
-    }
-  }
-
   /* The value of color is identical for hover/active/focus-ring, but we repeat it here in case one is changed in the future */
   &:hover {
     & ~ .spectrum-Search-icon {
@@ -37,6 +31,12 @@ governing permissions and limitations under the License.
   &:focus-ring {
     & ~ .spectrum-Search-icon {
       color: var(--spectrum-search-icon-color-key-focus);
+    }
+  }
+
+  &:disabled {
+    & ~ .spectrum-Search-icon {
+      color: var(--spectrum-textfield-text-color-disabled);
     }
   }
 }


### PR DESCRIPTION
I'm not sure why it works on spectrum-css but not in react-spectrum, but the order matters because it's the same specificity, maybe there's some other way so it's not order dependent?

<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->


## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 --> Chrome  79.0.3945.117 (Official Build) (64-bit)

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->
This is what it looks like for us without this change.

<img width="216" alt="Screen Shot 2020-01-17 at 3 21 24 PM" src="https://user-images.githubusercontent.com/698229/72652787-0d785680-393d-11ea-9f58-cbb3db174904.png">



## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
