### PR TITLE
fix: large Quiet Dropdown when using multistops

### DIFF
--- a/components/dropdown/index.css
+++ b/components/dropdown/index.css
@@ -15,6 +15,9 @@ governing permissions and limitations under the License.
 :root {
   --spectrum-dropdown-popover-max-width: var(--spectrum-global-dimension-size-3000);
   --spectrum-dropdown-width: var(--spectrum-global-dimension-size-2400);
+
+  /* This needs to be a variable so it overrides when using multiStops */
+  --spectrum-dropdown-quiet-width: auto;
 }
 
 .spectrum-Dropdown {
@@ -123,7 +126,7 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Dropdown--quiet {
-  width: auto;
+  width: var(--spectrum-dropdown-quiet-width);
   min-width: var(--spectrum-dropdown-quiet-min-width);
 }
 

--- a/site/resources/js/polyfills.js
+++ b/site/resources/js/polyfills.js
@@ -102,4 +102,9 @@ if (typeof window.CustomEvent !== 'function') {
     convertVarsToMultistops(document);
     window.fastLoadDisabled = true;
   }
+
+  // Expose for manual testing
+  window.testMultistops = function() {
+    convertVarsToMultistops(document);
+  };
 }());


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->
Use a variable for the Quiet Dropdown's width, fixes #477 

Also, added `testMultistops()` function that can be ran from the console to convert everything on the page from Custom Properties to multistops. This will help testing bugs like this one.

## How and where has this been tested?
 - **How this was tested:** `gulp devHeavy`, go to Quiet Dropdown example, then `testMultistops()` in console
 - **Browser(s) and OS(s) this was tested with:** Chrome on macOS

## Why does this work?

These kinds of bugs happen because the multistop algorithm basically takes any property with a variable and re-defines it for the large scale with the resolved, large variable value.

This works great normally, but sometimes, a variant will override a property with a bare value, when the default (no variant) version of the component defines the same property with a variable value. For custom properties, that's not a problem -- the order of the variant class wins, and everything renders right. For multistops, however, that means we get a very specific selector that overrides the variant's value for that property, even if the variant is present:

```css
.spectrum-Dropdown {
    width: 192px;
}
.spectrum-Dropdown--quiet {
    width: auto;
}
.spectrum--large .spectrum-Dropdown {
    width: 240px;
}
```

So basically, the fix for almost any bug that only happens in multistops is to make whatever is broken a variable in :root, and the the multistops algorithm will add another override for it:

```css
.spectrum-Dropdown {
    width: 192px;
}
.spectrum-Dropdown--quiet {
    width: auto;
}
.spectrum--large .spectrum-Dropdown {
    width: 240px;
}
.spectrum--large .spectrum-Dropdown--quiet {
    width: auto;
}
```

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->
![image](https://user-images.githubusercontent.com/201344/72834602-05baf980-3c3e-11ea-8c01-f3d501ef3f63.png)


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
