### PR TITLE
fix: be explicit about Treeview group indicator box model

### DIFF
--- a/components/treeview/index.css
+++ b/components/treeview/index.css
@@ -84,6 +84,7 @@ governing permissions and limitations under the License.
 
 .spectrum-TreeView-indicator {
   display: block;
+  box-sizing: content-box;
 
   float: left;
   position: relative;


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->
Be explicit about Treeview group indicator box model.

Fixes #467


## How and where has this been tested?
 - **How this was tested:** Open treeview docs, add rule: `* { box-sizing: border-box; }` and make sure the indicator was still there
 - **Browser(s) and OS(s) this was tested with:** Chrome on macOS

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->
![image](https://user-images.githubusercontent.com/201344/72835492-a827ac80-3c3f-11ea-9fce-84c4e14f1530.png)


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
