### PR TITLE
fix: fix order of processor includes when doing diff CSS, fixes #495

### DIFF
--- a/tools/component-builder/css/legacyBuild.js
+++ b/tools/component-builder/css/legacyBuild.js
@@ -132,8 +132,7 @@ function buildMultiStops() {
   Create a file that only includes statements that are affected by variables
 */
 function buildDiff() {
-  var varsProcessors = processors.getProcessors(false, false, false);
-  varsProcessors.unshift(require('./plugins/postcss-varsonly')());
+  var varsProcessors = processors.getProcessors(false, false, false, true);
 
   return gulp.src('index.css')
     // Use large variables

--- a/tools/component-builder/css/processors.js
+++ b/tools/component-builder/css/processors.js
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 
 const postcssReal = require('postcss');
 
-function getProcessors(keepVars = false, notNested = true, secondNotNested = true) {
+function getProcessors(keepVars = false, notNested = true, secondNotNested = true, diff = false) {
   return [
     require('postcss-import'),
     require('postcss-mixins')({
@@ -83,6 +83,7 @@ function getProcessors(keepVars = false, notNested = true, secondNotNested = tru
     }),
     require('postcss-nested'),
     require('postcss-inherit'),
+    diff ? require('./plugins/postcss-varsonly')() : null,
     require('postcss-custom-properties')({
       noValueNotifications: 'error',
       warnings: !keepVars


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->

When generating `index-diff.css`, we were running the `varsonly` plugin before the `import` plugin, which was working fine for most components.

Icon, however, uses imports for all of its CSS, and because `varsonly` was running before `import`, it was never seeing the actual CSS and was unable to filter out properties that only contain variables. As a result, it was wrapping ALL rules and all properties for icon in `.spectrum--large`, which resulted in a very specific selector setting the `display` property, which was overriding the rule that hides the checkbox for non-selected menu items, which was causing the checkbox to appear at all times when in Large scale, resulting in #495 .

Before, inside of `icon/dist/index-diff.css`:

```css
.spectrum--large .spectrum-Icon, .spectrum--large .spectrum-UIIcon {
    display: inline-block;
    color: inherit;
    fill: currentColor;
    pointer-events: none;
}
```

After, the above rule does not exist at all, as expected.

Fixes #495 

## How and where has this been tested?
 - **How this was tested:** `gulp devHeavy`, run `testMultistops()` on Dropdown page. More testing is required, including a diff of every `index-diff.css` output to ensure nothing weird happened.
 - **Browser(s) and OS(s) this was tested with:** Chrome on macOS

## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] Do more testing; this is a pretty core change
- [x] This pull request is ready to merge.
