### PR TITLE
fix: alignment of icon in DecoratedTextfield and Textfield, closes #494

### DIFF
--- a/components/decoratedtextfield/index.css
+++ b/components/decoratedtextfield/index.css
@@ -12,6 +12,10 @@ governing permissions and limitations under the License.
 
 @import '../commons/index.css';
 
+:root {
+  --spectrum-textfield-padding-x-adjusted: calc(var(--spectrum-textfield-padding-x) - var(--spectrum-textfield-border-size));
+}
+
 .spectrum-DecoratedTextfield {
   display: inline-block;
   position: relative;
@@ -22,10 +26,10 @@ governing permissions and limitations under the License.
   height: var(--spectrum-textfield-icon-size);
 
   position: absolute;
-  bottom: calc(calc(var(--spectrum-textfield-icon-frame) / 2) - calc(var(--spectrum-textfield-icon-size) / 2));
-  right: calc(calc(var(--spectrum-textfield-icon-frame) / 2) - calc(var(--spectrum-textfield-icon-size) / 2));
+  top: calc(calc(var(--spectrum-textfield-height) / 2) - calc(var(--spectrum-textfield-icon-size) / 2));
+  right: var(--spectrum-textfield-padding-x);
 }
 
 .spectrum-DecoratedTextfield-field {
-  padding-right: var(--spectrum-textfield-icon-frame);
+  padding-right: calc(var(--spectrum-textfield-padding-x-adjusted) + var(--spectrum-textfield-icon-size) + var(--spectrum-textfield-icon-margin-left));
 }

--- a/components/decoratedtextfield/metadata/decoratedtextfield.yml
+++ b/components/decoratedtextfield/metadata/decoratedtextfield.yml
@@ -5,13 +5,12 @@ examples:
   - id: textfield
     name: Standard
     markup: |
+      <label for="DecoratedTextField-single" class="spectrum-FieldLabel">Search</label>
       <div class="spectrum-DecoratedTextfield is-decorated">
-        <label for="DecoratedTextField-single" class="spectrum-FieldLabel">Search</label>
-
         <input id="DecoratedTextField-single" placeholder="Enter your name" class="spectrum-Textfield spectrum-DecoratedTextfield-field" aria-invalid="false" type="text">
 
-        <svg class="spectrum-Icon spectrum-UIIcon-InfoMedium spectrum-Icon--sizeS spectrum-DecoratedTextfield-icon" focusable="false" aria-hidden="true">
-          <use xlink:href="#spectrum-css-icon-InfoMedium" />
+        <svg class="spectrum-Icon spectrum-UIIcon-AlertMedium spectrum-Icon--sizeS spectrum-DecoratedTextfield-icon" focusable="false" aria-hidden="true">
+          <use xlink:href="#spectrum-css-icon-AlertMedium" />
         </svg>
       </div>
   - id: textfield
@@ -22,7 +21,7 @@ examples:
 
         <textarea id="DecoratedTextField-multiline" placeholder="Enter your life story" name="field" value="" class="spectrum-Textfield spectrum-Textfield--multiline spectrum-DecoratedTextfield-field"></textarea>
 
-        <svg class="spectrum-Icon spectrum-UIIcon-InfoMedium spectrum-Icon--sizeS spectrum-DecoratedTextfield-icon" focusable="false" aria-hidden="true">
-          <use xlink:href="#spectrum-css-icon-InfoMedium" />
+        <svg class="spectrum-Icon spectrum-UIIcon-AlertMedium spectrum-Icon--sizeS spectrum-DecoratedTextfield-icon" focusable="false" aria-hidden="true">
+          <use xlink:href="#spectrum-css-icon-AlertMedium" />
         </svg>
       </div>

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -151,13 +151,13 @@ governing permissions and limitations under the License.
   &.is-invalid,
   &:invalid {
     background-size: var(--spectrum-icon-alert-medium-width) var(--spectrum-icon-alert-medium-width);
-    background-position: calc(100% - var(--spectrum-textfield-padding-x-adjusted)) 50%;
+    background-position: calc(100% - var(--spectrum-textfield-padding-x-adjusted)) calc(calc(var(--spectrum-textfield-height) / 2) - calc(var(--spectrum-icon-alert-medium-height) / 2) - var(--spectrum-textfield-quiet-border-size));
     padding-right: calc(var(--spectrum-textfield-padding-x-adjusted) + var(--spectrum-icon-alert-medium-width) + var(--spectrum-textfield-icon-margin-left));
   }
 
   &.is-valid {
     background-size: var(--spectrum-icon-checkmark-medium-width) var(--spectrum-icon-checkmark-medium-width);
-    background-position: calc(100% - var(--spectrum-textfield-padding-x-adjusted)) 50%;
+    background-position: calc(100% - var(--spectrum-textfield-padding-x-adjusted)) calc(calc(var(--spectrum-textfield-height) / 2) - calc(var(--spectrum-icon-checkmark-medium-height) / 2));
     padding-right: calc(var(--spectrum-textfield-padding-x-adjusted) + var(--spectrum-icon-checkmark-medium-width) + var(--spectrum-textfield-icon-margin-left));
   }
 }
@@ -169,12 +169,6 @@ governing permissions and limitations under the License.
 
   /* Remove the default vertical scrollbar for textarea in IE. */
   overflow: auto;
-
-  &.is-invalid,
-  &:invalid,
-  &.is-valid {
-    background-position: calc(100% - calc(var(--spectrum-textfield-icon-size) / 2)) calc(100% - calc(var(--spectrum-textfield-icon-size) / 2));
-  }
 }
 
 .spectrum-Textfield--quiet {


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->
This PR fixes the alignment of icons inside of DecoratedTextfield and multiline Textfields (Textareas). They now (finally) match the design guidance given here https://github.com/adobe/spectrum-css/issues/494#issuecomment-578192258

## How and where has this been tested?
 - **How this was tested:** Open up DecoratedTextfield, Textarea examples, paste them over the design screenshot, and check icon position
 - **Browser(s) and OS(s) this was tested with:** Chrome on macOS

## Screenshots
Textarea:
<!-- If applicable, add screenshots to show what you changed -->
![image](https://user-images.githubusercontent.com/201344/73111311-c5b67980-3ebe-11ea-84a5-7fcb383653eb.png)

DecoratedTextfield:
![image](https://user-images.githubusercontent.com/201344/73111327-d49d2c00-3ebe-11ea-8516-4e12a64d631d.png)


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] Confirm position of validation icon in multiline textfields @NateBaldwinDesign will provide on Monday
- [x] This pull request is ready to merge.