### PR TITLE
Fixed the order of a few of the globals sizes

### DIFF
--- a/components/vars/css/globals/spectrum-dimensionGlobals.css
+++ b/components/vars/css/globals/spectrum-dimensionGlobals.css
@@ -2,8 +2,8 @@
   --spectrum-global-dimension-static-size-0: 0px;
   --spectrum-global-dimension-static-size-10: 1px;
   --spectrum-global-dimension-static-size-25: 2px;
-  --spectrum-global-dimension-static-size-50: 4px;
   --spectrum-global-dimension-static-size-40: 3px;
+  --spectrum-global-dimension-static-size-50: 4px;
   --spectrum-global-dimension-static-size-65: 5px;
   --spectrum-global-dimension-static-size-100: 8px;
   --spectrum-global-dimension-static-size-115: 9px;


### PR DESCRIPTION
## Description
https://github.com/adobe/spectrum-css/issues/512

No tests or screenshot.


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x ] If my change impacts other components, I have tested to make sure they don't break.
- [x ] If my change impacts documentation, I have updated the documentation accordingly.
- [ x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x ] This pull request is ready to merge.
