### PR TITLE
Typography metadata fixes and deprecation bits

### DIFF
--- a/components/button/metadata/actionbutton.yml
+++ b/components/button/metadata/actionbutton.yml
@@ -191,6 +191,7 @@ examples:
       </button>
   - id: actionbutton-quiet
     name: Quiet
+    description: The Quiet Action Button should be used where you previously used the [deprecated Tool component](tool.html).
     markup: |
       <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
         <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Edit">

--- a/components/button/metadata/tool.yml
+++ b/components/button/metadata/tool.yml
@@ -1,7 +1,8 @@
 name: Tool
-status: Verified
+dnaStatus: Deprecated
 description: The tool button.
 SpectrumSiteSlug: https://spectrum.adobe.com/page/tool/
+hide: true
 examples:
   - name: Standard
     markup: |

--- a/components/buttongroup/metadata/buttongroup.yml
+++ b/components/buttongroup/metadata/buttongroup.yml
@@ -1,5 +1,5 @@
 name: Button Group
-SpectrumSiteSlug: https://spectrum.corp.adobe.com/page/button/
+SpectrumSiteSlug: https://spectrum.adobe.com/page/button/
 examples:
   - id: buttongroup
     name: Horizontal

--- a/components/site/index.css
+++ b/components/site/index.css
@@ -364,7 +364,7 @@ governing permissions and limitations under the License.
 
 .spectrum-CSSComponent-resource--adobe {
   color: rgb(255, 2, 1) !important;
-  background-color: rgba(255, 2, 1, 0.1) !important;
+  background-color: var(--spectrum-global-color-gray-100) !important;
 }
 
 .spectrum-CSSComponent-resource--github {

--- a/components/typography/metadata/typography-body.yml
+++ b/components/typography/metadata/typography-body.yml
@@ -1,6 +1,6 @@
 name: Typography Body
 id: body-m
-description: The Body typography component.
+description: Body is a typography component primarily used within Spectrum components and for blocks of text.
 SpectrumSiteSlug: https://spectrum.adobe.com/page/body/
 examples:
   - id: body-m

--- a/components/typography/metadata/typography-body.yml
+++ b/components/typography/metadata/typography-body.yml
@@ -1,8 +1,9 @@
 name: Typography Body
-description: "Spectrum Typography Body."
-SpectrumSiteSlug: https://spectrum.corp.adobe.com/page/body/
+id: body-m
+description: The Body typography component.
+SpectrumSiteSlug: https://spectrum.adobe.com/page/body/
 examples:
-  - id: body-1
+  - id: body-m
     name: Body
     status: Verified
     description: Default body text sizes.
@@ -27,13 +28,12 @@ examples:
         <p class="spectrum-Body spectrum-Body--XS spectrum-Body--serif">BodyXS Text Serif <em>BodyXS Emphasis Serif</em> <strong>BodyXS Strong Serif</strong>.</p>
       </div>
 
-  - id: heading-body-1
+  - id: heading-m
     name: Standard
     status: Verified
     description: Typography elements paired to display clear content hierarchies.
     markup: |
       <div class="spectrum-Typography">
-        <div style="max-width: 600px;">
         <h1 class="spectrum-Heading spectrum-Heading--XXXL">Aliquet Mauris Eu</h1>
         <p class="spectrum-Body spectrum-Body--XXXL">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit. Sed finibus dapibus diam et sollicitudin. Phasellus in ipsum nec ante elementum congue eget in leo. Morbi eleifend justo non rutrum venenatis. Fusce cursus et lectus eu facilisis. Ut laoreet felis in magna dignissim feugiat.</p>
         <p class="spectrum-Body spectrum-Body--XXXL">Ut et lectus finibus, aliquet mauris eu, tincidunt mi. Donec scelerisque orci sit amet venenatis luctus. Morbi eget lacus est. Duis iaculis magna quis aliquam lacinia. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
@@ -49,23 +49,19 @@ examples:
         <p class="spectrum-Body spectrum-Body--L">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit. Sed finibus dapibus diam et sollicitudin. Phasellus in ipsum nec ante elementum congue eget in leo. Morbi eleifend justo non rutrum venenatis. Fusce cursus et lectus eu facilisis. Ut laoreet felis in magna dignissim feugiat.</p>
         <p class="spectrum-Body spectrum-Body--L">Ut et lectus finibus, aliquet mauris eu, tincidunt mi. Donec scelerisque orci sit amet venenatis luctus. Morbi eget lacus est. Duis iaculis magna quis aliquam lacinia. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 
-        <h1 class="spectrum-Heading spectrum-Heading--L">Lorem Ipsum Dolor</h1>
-        <p class="spectrum-Body spectrum-Body--L">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit. Sed finibus dapibus diam et sollicitudin. Phasellus in ipsum nec ante elementum congue eget in leo. Morbi eleifend justo non rutrum venenatis. Fusce cursus et lectus eu facilisis. Ut laoreet felis in magna dignissim feugiat.</p>
-        <p class="spectrum-Body spectrum-Body--L">Ut et lectus finibus, aliquet mauris eu, tincidunt mi. Donec scelerisque orci sit amet venenatis luctus. Morbi eget lacus est. Duis iaculis magna quis aliquam lacinia. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-
-        <h1 class="spectrum-Heading spectrum-Heading--M">Lorem Ipsum Dolor</h1>
+        <h3 class="spectrum-Heading spectrum-Heading--M">Lorem Ipsum Dolor</h3>
         <p class="spectrum-Body spectrum-Body--M">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit. Sed finibus dapibus diam et sollicitudin. Phasellus in ipsum nec ante elementum congue eget in leo. Morbi eleifend justo non rutrum venenatis. Fusce cursus et lectus eu facilisis. Ut laoreet felis in magna dignissim feugiat.</p>
         <p class="spectrum-Body spectrum-Body--M">Ut et lectus finibus, aliquet mauris eu, tincidunt mi. Donec scelerisque orci sit amet venenatis luctus. Morbi eget lacus est. Duis iaculis magna quis aliquam lacinia. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 
-        <h1 class="spectrum-Heading spectrum-Heading--S">Lorem Ipsum Dolor</h1>
+        <h4 class="spectrum-Heading spectrum-Heading--S">Lorem Ipsum Dolor</h4>
         <p class="spectrum-Body spectrum-Body--S">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit. Sed finibus dapibus diam et sollicitudin. Phasellus in ipsum nec ante elementum congue eget in leo. Morbi eleifend justo non rutrum venenatis. Fusce cursus et lectus eu facilisis. Ut laoreet felis in magna dignissim feugiat.</p>
         <p class="spectrum-Body spectrum-Body--S">Ut et lectus finibus, aliquet mauris eu, tincidunt mi. Donec scelerisque orci sit amet venenatis luctus. Morbi eget lacus est. Duis iaculis magna quis aliquam lacinia. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 
-        <h1 class="spectrum-Heading spectrum-Heading--XS">Lorem Ipsum Dolor</h1>
+        <h5 class="spectrum-Heading spectrum-Heading--XS">Lorem Ipsum Dolor</h5>
         <p class="spectrum-Body spectrum-Body--XS">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit. Sed finibus dapibus diam et sollicitudin. Phasellus in ipsum nec ante elementum congue eget in leo. Morbi eleifend justo non rutrum venenatis. Fusce cursus et lectus eu facilisis. Ut laoreet felis in magna dignissim feugiat.</p>
         <p class="spectrum-Body spectrum-Body--XS">Ut et lectus finibus, aliquet mauris eu, tincidunt mi. Donec scelerisque orci sit amet venenatis luctus. Morbi eget lacus est. Duis iaculis magna quis aliquam lacinia. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 
-        <h1 class="spectrum-Heading spectrum-Heading--XXS">Lorem Ipsum Dolor</h1>
+        <h6 class="spectrum-Heading spectrum-Heading--XXS">Lorem Ipsum Dolor</h6>
         <p class="spectrum-Body spectrum-Body--XS">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit. Sed finibus dapibus diam et sollicitudin. Phasellus in ipsum nec ante elementum congue eget in leo. Morbi eleifend justo non rutrum venenatis. Fusce cursus et lectus eu facilisis. Ut laoreet felis in magna dignissim feugiat.</p>
         <p class="spectrum-Body spectrum-Body--XS">Ut et lectus finibus, aliquet mauris eu, tincidunt mi. Donec scelerisque orci sit amet venenatis luctus. Morbi eget lacus est. Duis iaculis magna quis aliquam lacinia. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
       </div>

--- a/components/typography/metadata/typography-code.yml
+++ b/components/typography/metadata/typography-code.yml
@@ -1,6 +1,6 @@
 name: Typography Code
 id: code-m
-description: The Code typography component.
+description: Code is a typography component used for text that represents code.
 SpectrumSiteSlug: https://spectrum.adobe.com/page/code/
 examples:
   - id: code-m

--- a/components/typography/metadata/typography-code.yml
+++ b/components/typography/metadata/typography-code.yml
@@ -1,8 +1,9 @@
 name: Typography Code
-description: "English typography examples. See the [typography example page](typography.html) for Japanese, Han, and Arabic examples."
+id: code-m
+description: The Code typography component.
 SpectrumSiteSlug: https://spectrum.adobe.com/page/code/
 examples:
-  - id: code-1
+  - id: code-m
     name: Typography - Code
     status: Verified
     description: Typographic styles for computer code.
@@ -12,7 +13,8 @@ examples:
       <code class="spectrum-Code spectrum-Code--M">CodeM Text <strong>Strong</strong> <em>Emphasis</em> </code>
       <code class="spectrum-Code spectrum-Code--S">CodeS Text <strong>Strong</strong> <em>Emphasis</em> </code>
       <code class="spectrum-Code spectrum-Code--XS">CodeXS Text <strong>Strong</strong> <em>Emphasis</em> </code>
-      <pre><code class="spectrum-Code spectrum-Code--M">CodeM Text Wrapped in:
+      <pre><code class="spectrum-Code spectrum-Code--M">CodeM text
+      wrapped in
       pre tags for
       multiline
       goodness</code></pre>

--- a/components/typography/metadata/typography-deprecated.yml
+++ b/components/typography/metadata/typography-deprecated.yml
@@ -1,19 +1,181 @@
-id: heading-display
-name: Typography (Deprecated II)
+name: Typography (Deprecated)
+description: Deprecated typography components. The [new Typography components](typography.html) should be used instead.
 status: Deprecated
-details: These styles can be replicated using new Typography classes
-description: Legacy typography elements.
+hide: true
 examples:
-  - id: heading-display
+  - id: heading-1
     name: Standard
+    description: Typography elements paired to display clear content hierarchies.
     markup: |
-      <h1 class="spectrum-Heading--display">Display (h1)</h1>
-      <h2 class="spectrum-Heading--pageTitle">Page Title (h2)</h2>
-      <h2 class="spectrum-Heading--subtitle1">Subtitle 1 (h2)</h2>
-      <h3 class="spectrum-Heading--subtitle2">Subtitle 2 (h3)</h3>
-      <h4 class="spectrum-Heading--subtitle3">Subtitle 3 (h4)</h4>
-      <p class="spectrum-Body--small">Small Body Text</p>
-      <p class="spectrum-Body">Default Body Text</p>
-      <p class="spectrum-Body--secondary">Secondary Body Text</p>
-      <p class="spectrum-Body--italic"> Body Text Italic</p>
-      <p class="spectrum-Body--large">Large Body Text</p>
+      <div class="spectrum-Typography">
+        <h1 class="spectrum-Heading1">Aliquet Mauris Eu</h1>
+        <p class="spectrum-Body1">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit. Sed finibus dapibus diam et sollicitudin. Phasellus in ipsum nec ante elementum congue eget in leo. Morbi eleifend justo non rutrum venenatis. Fusce cursus et lectus eu facilisis. Ut laoreet felis in magna dignissim feugiat.</p>
+        <p class="spectrum-Body1">Ut et lectus finibus, aliquet mauris eu, tincidunt mi. Donec scelerisque orci sit amet venenatis luctus. Morbi eget lacus est. Duis iaculis magna quis aliquam lacinia. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+
+        <h2 class="spectrum-Heading2">Aliquet Mauris Eu</h1>
+        <p class="spectrum-Body2">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit. Sed finibus dapibus diam et sollicitudin. Phasellus in ipsum nec ante elementum congue eget in leo. Morbi eleifend justo non rutrum venenatis. Fusce cursus et lectus eu facilisis. Ut laoreet felis in magna dignissim feugiat.</p>
+        <p class="spectrum-Body2">Ut et lectus finibus, aliquet mauris eu, tincidunt mi. Donec scelerisque orci sit amet venenatis luctus. Morbi eget lacus est. Duis iaculis magna quis aliquam lacinia. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+
+        <h1 class="spectrum-Heading2">Lorem Ipsum Dolor</h1>
+        <p class="spectrum-Body2">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit. Sed finibus dapibus diam et sollicitudin. Phasellus in ipsum nec ante elementum congue eget in leo. Morbi eleifend justo non rutrum venenatis. Fusce cursus et lectus eu facilisis. Ut laoreet felis in magna dignissim feugiat.</p>
+        <p class="spectrum-Body2">Ut et lectus finibus, aliquet mauris eu, tincidunt mi. Donec scelerisque orci sit amet venenatis luctus. Morbi eget lacus est. Duis iaculis magna quis aliquam lacinia. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+
+
+        <h1 class="spectrum-Heading3">Lorem Ipsum Dolor</h1>
+        <p class="spectrum-Body3">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit. Sed finibus dapibus diam et sollicitudin. Phasellus in ipsum nec ante elementum congue eget in leo. Morbi eleifend justo non rutrum venenatis. Fusce cursus et lectus eu facilisis. Ut laoreet felis in magna dignissim feugiat.</p>
+        <p class="spectrum-Body3">Ut et lectus finibus, aliquet mauris eu, tincidunt mi. Donec scelerisque orci sit amet venenatis luctus. Morbi eget lacus est. Duis iaculis magna quis aliquam lacinia. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+
+
+        <h1 class="spectrum-Heading4">Lorem Ipsum Dolor</h1>
+        <p class="spectrum-Body4">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit. Sed finibus dapibus diam et sollicitudin. Phasellus in ipsum nec ante elementum congue eget in leo. Morbi eleifend justo non rutrum venenatis. Fusce cursus et lectus eu facilisis. Ut laoreet felis in magna dignissim feugiat.</p>
+        <p class="spectrum-Body4">Ut et lectus finibus, aliquet mauris eu, tincidunt mi. Donec scelerisque orci sit amet venenatis luctus. Morbi eget lacus est. Duis iaculis magna quis aliquam lacinia. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+
+
+        <h1 class="spectrum-Heading5">Lorem Ipsum Dolor</h1>
+        <p class="spectrum-Body5">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit. Sed finibus dapibus diam et sollicitudin. Phasellus in ipsum nec ante elementum congue eget in leo. Morbi eleifend justo non rutrum venenatis. Fusce cursus et lectus eu facilisis. Ut laoreet felis in magna dignissim feugiat.</p>
+        <p class="spectrum-Body5">Ut et lectus finibus, aliquet mauris eu, tincidunt mi. Donec scelerisque orci sit amet venenatis luctus. Morbi eget lacus est. Duis iaculis magna quis aliquam lacinia. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+
+
+        <h1 class="spectrum-Heading6">Lorem Ipsum Dolor</h1>
+        <p class="spectrum-Body5">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit. Sed finibus dapibus diam et sollicitudin. Phasellus in ipsum nec ante elementum congue eget in leo. Morbi eleifend justo non rutrum venenatis. Fusce cursus et lectus eu facilisis. Ut laoreet felis in magna dignissim feugiat.</p>
+        <p class="spectrum-Body5">Ut et lectus finibus, aliquet mauris eu, tincidunt mi. Donec scelerisque orci sit amet venenatis luctus. Morbi eget lacus est. Duis iaculis magna quis aliquam lacinia. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+
+        <h1 class="spectrum-Subheading">Lorem Ipsum Dolor</h1>
+        <p class="spectrum-Body4">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit. Sed finibus dapibus diam et sollicitudin. Phasellus in ipsum nec ante elementum congue eget in leo. Morbi eleifend justo non rutrum venenatis. Fusce cursus et lectus eu facilisis. Ut laoreet felis in magna dignissim feugiat.</p>
+        <p class="spectrum-Body4">Ut et lectus finibus, aliquet mauris eu, tincidunt mi. Donec scelerisque orci sit amet venenatis luctus. Morbi eget lacus est. Duis iaculis magna quis aliquam lacinia. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+        </div>
+      </div>
+  - id: heading-1
+    name: Heading
+    description: Headings for typography.
+    markup: |
+      <div class="spectrum">
+        <p class="spectrum-Heading1">Heading1 <em>Heading1 Emphasis</em> <strong>Heading1 Strong</strong>.</p>
+        <p class="spectrum-Heading2">Heading2 <em>Heading2 Emphasis</em> <strong>Heading2 Strong</strong>.</p>
+        <p class="spectrum-Heading3">Heading3 <em>Heading3 Emphasis</em> <strong>Heading3 Strong</strong>.</p>
+        <p class="spectrum-Heading4">Heading4 <em>Heading4 Emphasis</em> <strong>Heading4 Strong</strong>.</p>
+        <p class="spectrum-Heading5">Heading5 <em>Heading5 Emphasis</em> <strong>Heading5 Strong</strong>.</p>
+        <p class="spectrum-Subheading">Subheading <em>Subheading Emphasis</em> <strong>Subheading Strong</strong>.</p>
+      </div>
+      <br/>
+      <div class="spectrum-Article">
+        <p class="spectrum-Heading1">Article Heading1 <em>Emphasis</em> <strong>Strong</strong>.</p>
+        <p class="spectrum-Heading2">Article Heading2 <em>Emphasis</em> <strong>Strong</strong>.</p>
+        <p class="spectrum-Heading3">Article Heading3 <em>Emphasis</em> <strong>Strong</strong>.</p>
+        <p class="spectrum-Heading4">Article Heading4 <em>Emphasis</em> <strong>Strong</strong>.</p>
+        <p class="spectrum-Heading5">Article Heading5 <em>Emphasis</em> <strong>Strong</strong>.</p>
+      </div>
+  - id: heading-1
+    name: Heading (Strong)
+    description: Strong headings for typography.
+    markup: |
+      <div class="spectrum">
+        <p class="spectrum-Heading1--strong">Heading1 <em>Heading1 Emphasis</em> <strong>Heading1 Strong</strong>.</p>
+        <p class="spectrum-Heading2--strong">Heading2 <em>Heading2 Emphasis</em> <strong>Heading2 Strong</strong>.</p>
+      </div>
+      <br/>
+      <div class="spectrum-Article">
+        <p class="spectrum-Heading1--strong">Article Heading1 <em>Emphasis</em> <strong>Strong</strong>.</p>
+        <p class="spectrum-Heading2--strong">Article Heading2 <em>Emphasis</em> <strong>Strong</strong>.</p>
+      </div>
+  - id: heading-1
+    name: Heading (Quiet)
+    description: Quiet headings for typography.
+    markup: |
+      <div class="spectrum">
+        <p class="spectrum-Heading1--quiet">Heading1 <em>Heading1 Emphasis</em> <strong>Heading1 Strong</strong>.</p>
+        <p class="spectrum-Heading2--quiet">Heading2 <em>Heading2 Emphasis</em> <strong>Heading2 Strong</strong>.</p>
+      </div>
+      <br/>
+      <div class="spectrum-Article">
+        <p class="spectrum-Heading1--quiet">Article Heading1 <em>Emphasis</em> <strong>Strong</strong>.</p>
+        <p class="spectrum-Heading2--quiet">Article Heading2 <em>Emphasis</em> <strong>Strong</strong>.</p>
+      </div>
+  - id: heading-1
+    name: Display
+    description: Display headings for typography.
+    markup: |
+      <div class="spectrum">
+        <p class="spectrum-Heading1--display">Heading1 <em>Emphasis</em> <strong>Strong</strong>.</p>
+        <p class="spectrum-Heading2--display">Heading2 <em>Emphasis</em> <strong>Strong</strong>.</p>
+      </div>
+      <br/>
+      <div class="spectrum-Article">
+        <p class="spectrum-Heading1--display">Article Heading1 <em>Emphasis</em> <strong>Strong</strong>.</p>
+        <p class="spectrum-Heading2--display">Article Heading2 <em>Emphasis</em> <strong>Strong</strong>.</p>
+      </div>
+  - id: heading-1
+    name: Display (Strong)
+    description: Strong display headings for typography.
+    markup: |
+      <div class="spectrum">
+        <p class="spectrum-Heading1--display spectrum-Heading1--strong">Heading1 <em>Emphasis</em> <strong>Strong</strong>.</p>
+        <p class="spectrum-Heading2--display spectrum-Heading2--strong">Heading2 <em>Emphasis</em> <strong>Strong</strong>.</p>
+      </div>
+  - id: heading-1
+    name: Display (Quiet)
+    description: Quiet display headings for typography.
+    markup: |
+      <div class="spectrum">
+        <p class="spectrum-Heading1--display spectrum-Heading1--quiet">Heading1 <em>Emphasis</em> <strong>Strong</strong>.</p>
+        <p class="spectrum-Heading2--display spectrum-Heading2--quiet">Heading2 <em>Emphasis</em> <strong>Strong</strong>.</p>
+      </div>
+      <br/>
+      <div class="spectrum-Article">
+        <p class="spectrum-Heading1--display spectrum-Heading1--quiet">Article Heading1 <em>Emphasis</em> <strong>Strong</strong>.</p>
+        <p class="spectrum-Heading2--display spectrum-Heading2--quiet">Article Heading2 <em>Emphasis</em> <strong>Strong</strong>.</p>
+      </div>
+  - id: heading-1
+    name: Body
+    description: Default body text sizes.
+    markup: |
+      <div class="spectrum">
+        <p class="spectrum-Body1">Body1 Text <em>Body1 Emphasis</em> <strong>Body1 Strong</strong>.</p>
+        <p class="spectrum-Body2">Body2 text <em>Body2 Emphasis</em> <strong>Body2 Strong</strong>.</p>
+        <p class="spectrum-Body3">Body3 Text <em>Body3 Emphasis</em> <strong>Body3 Strong</strong>.</p>
+        <p class="spectrum-Body4">Body4 Text <em>Body4 Emphasis</em> <strong>Body4 Strong</strong>.</p>
+        <p class="spectrum-Body5">Body5 Text <em>Body5 Emphasis</em> <strong>Body5 Strong</strong>.</p>
+        <p class="spectrum-Detail">Detail Text <em>Detail Emphasis</em> <strong>Detail Strong</strong>.</p>
+      </div>
+      <br/>
+      <div class="spectrum-Article">
+        <p class="spectrum-Body1">Article Body1 Text <em>Article Body1 Emphasis</em> <strong>Article Body1 Strong</strong>.</p>
+        <p class="spectrum-Body2">Article Body2 text <em>Article Body2 Emphasis</em> <strong>Article Body2 Strong</strong>.</p>
+        <p class="spectrum-Body3">Article Body3 Text <em>Article Body3 Emphasis</em> <strong>Article Body3 Strong</strong>.</p>
+        <p class="spectrum-Body4">Article Body4 Text <em>Article Body4 Emphasis</em> <strong>Article Body4 Strong</strong>.</p>
+        <p class="spectrum-Body5">Article Body5 Text <em>Article Body5 Emphasis</em> <strong>Article Body5 Strong</strong>.</p>
+        <p class="spectrum-Detail">Detail Text <em>Detail Emphasis</em> <strong>Detail Strong</strong>.</p>
+      </div>
+  - id: heading-1
+    name: Article
+    description: Typography elements paired to display clear content hierarchies in long form articles.
+    markup: |
+      <div class="spectrum-Article">
+        <h1 class="spectrum-Heading1">Heading 1</h1>
+        <p class="spectrum-Body1">Body copy that pairs with heading 1</p>
+
+        <h2 class="spectrum-Heading2">Heading 2</h1>
+        <p class="spectrum-Body2">Body copy that pairs with heading 2</p>
+
+        <h3 class="spectrum-Heading3">Heading 3</h1>
+        <p class="spectrum-Body3">Body copy that pairs with heading 3</p>
+
+        <h4 class="spectrum-Heading4">Heading 4</h4>
+        <p class="spectrum-Body4">Body copy that pairs with heading 4</p>
+
+        <h5 class="spectrum-Heading5">Heading 5</h5>
+        <p class="spectrum-Body5">Body copy that pairs with heading 5</p>
+      </div>
+  - id: heading-1
+    name: Typography - Code
+    description: Typographic styles for computer code.
+    markup: |
+      <code class="spectrum-Code1">Code1 Text <strong>Strong</strong></code>
+      <code class="spectrum-Code2">Code2 Text <strong>Strong</strong></code>
+      <code class="spectrum-Code3">Code3 Text <strong>Strong</strong></code>
+      <code class="spectrum-Code4">Code4 Text <strong>Strong</strong></code>
+      <code class="spectrum-Code5">Code5 Text <strong>Strong</strong></code>
+      <pre><code class="spectrum-Code3">Code3 Text Wrapped in:
+      pre tags for
+      multiline
+      goodness</code></pre>

--- a/components/typography/metadata/typography-detail.yml
+++ b/components/typography/metadata/typography-detail.yml
@@ -1,8 +1,9 @@
 name: Typography Detail
-description: "English typography examples. See the [typography example page](typography.html) for Japanese, Han, and Arabic examples."
+dnaStatus: Verified
+description: The Detail typography component.
 SpectrumSiteSlug: https://spectrum.adobe.com/page/detail/
 examples:
-  - id: detail-1
+  - id: detail-m
     status: Verified
     name: Detail
     description: Subheadings for typography.

--- a/components/typography/metadata/typography-detail.yml
+++ b/components/typography/metadata/typography-detail.yml
@@ -1,12 +1,11 @@
 name: Typography Detail
 dnaStatus: Verified
-description: The Detail typography component.
+description: Detail is a typography component used for disclosing extra information or smaller items in hierarchical relationships of text.
 SpectrumSiteSlug: https://spectrum.adobe.com/page/detail/
 examples:
   - id: detail-m
     status: Verified
     name: Detail
-    description: Subheadings for typography.
     markup: |
       <div class="spectrum">
         <p class="spectrum-Detail spectrum-Detail--XL">DetailXL <em>DetailXL Emphasis</em> <span class="spectrum-Detail--light">DetailXL Light</span> <strong>DetailXL Strong</strong>.</p>

--- a/components/typography/metadata/typography-heading.yml
+++ b/components/typography/metadata/typography-heading.yml
@@ -1,73 +1,73 @@
 name: Typography Heading
+id: heading-m
 description: "Spectrum Typography Headings."
-SpectrumSiteSlug: https://spectrum.corp.adobe.com/page/heading/
+SpectrumSiteSlug: https://spectrum.adobe.com/page/heading/
 examples:
-  - id: heading-1
+  - id: heading-m
     name: Heading
     status: Verified
     description: Headings for typography.
     markup: |
       <div class="spectrum">
-        <p class="spectrum-Heading spectrum-Heading--XXXL">HeadingXXXL <em>HeadingXXXL Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XXL">HeadingXXL <em>HeadingXXL Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XL">HeadingXL <em>HeadingXL Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--L">HeadingL <em>HeadingL Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--M">HeadingM <em>HeadingM Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--S">HeadingS <em>HeadingS Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XS">HeadingXS <em>HeadingXS Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XXS">HeadingXXS <em>HeadingXXS Emphasis</em> <strong>Strong</strong>.</p>
+        <h1 class="spectrum-Heading spectrum-Heading--XXXL">HeadingXXXL <em>HeadingXXXL Emphasis</em> <strong>Strong</strong>.</h1>
+        <h1 class="spectrum-Heading spectrum-Heading--XXL">HeadingXXL <em>HeadingXXL Emphasis</em> <strong>Strong</strong>.</h1>
+        <h1 class="spectrum-Heading spectrum-Heading--XL">HeadingXL <em>HeadingXL Emphasis</em> <strong>Strong</strong>.</h1>
+        <h2 class="spectrum-Heading spectrum-Heading--L">HeadingL <em>HeadingL Emphasis</em> <strong>Strong</strong>.</h2>
+        <h3 class="spectrum-Heading spectrum-Heading--M">HeadingM <em>HeadingM Emphasis</em> <strong>Strong</strong>.</h3>
+        <h4 class="spectrum-Heading spectrum-Heading--S">HeadingS <em>HeadingS Emphasis</em> <strong>Strong</strong>.</h4>
+        <h5 class="spectrum-Heading spectrum-Heading--XS">HeadingXS <em>HeadingXS Emphasis</em> <strong>Strong</strong>.</h5>
+        <h6 class="spectrum-Heading spectrum-Heading--XXS">HeadingXXS <em>HeadingXXS Emphasis</em> <strong>Strong</strong>.</h6>
         <br/>
-        <p class="spectrum-Heading spectrum-Heading--XXXL spectrum-Heading--serif">HeadingXXXL Serif <em>Serif Emphasis</em> <strong>Serif Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XXL spectrum-Heading--serif">HeadingXXL Serif <em>Serif Emphasis</em> <strong>Serif Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XL spectrum-Heading--serif">HeadingXL Serif <em>Serif Emphasis</em> <strong>Serif Strong</strong>.</p>
+        <h1 class="spectrum-Heading spectrum-Heading--XXXL spectrum-Heading--serif">HeadingXXXL Serif <em>Serif Emphasis</em> <strong>Serif Strong</strong>.</h1>
+        <h1 class="spectrum-Heading spectrum-Heading--XXL spectrum-Heading--serif">HeadingXXL Serif <em>Serif Emphasis</em> <strong>Serif Strong</strong>.</h1>
+        <h1 class="spectrum-Heading spectrum-Heading--XL spectrum-Heading--serif">HeadingXL Serif <em>Serif Emphasis</em> <strong>Serif Strong</strong>.</h1>
         <p class="spectrum-Heading spectrum-Heading--L spectrum-Heading--serif">HeadingL Serif <em>Serif Emphasis</em> <strong>Serif Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--M spectrum-Heading--serif">HeadingM Serif <em>Serif Emphasis</em> <strong>Serif Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--S spectrum-Heading--serif">HeadingS Serif <em>Serif Emphasis</em> <strong>Serif Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XS spectrum-Heading--serif">HeadingXS Serif <em>Serif Emphasis</em> <strong>Serif Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XXS spectrum-Heading--serif">HeadingXXS Serif <em>Serif Emphasis</em> <strong>Serif Strong</strong>.</p>
+        <h3 class="spectrum-Heading spectrum-Heading--M spectrum-Heading--serif">HeadingM Serif <em>Serif Emphasis</em> <strong>Serif Strong</strong>.</h3>
+        <h4 class="spectrum-Heading spectrum-Heading--S spectrum-Heading--serif">HeadingS Serif <em>Serif Emphasis</em> <strong>Serif Strong</strong>.</h4>
+        <h5 class="spectrum-Heading spectrum-Heading--XS spectrum-Heading--serif">HeadingXS Serif <em>Serif Emphasis</em> <strong>Serif Strong</strong>.</h5>
+        <h6 class="spectrum-Heading spectrum-Heading--XXS spectrum-Heading--serif">HeadingXXS Serif <em>Serif Emphasis</em> <strong>Serif Strong</strong>.</h6>
       </div>
 
-  - id: heading-1
+  - id: heading-heavy-m
     name: Heading (Heavy)
     status: Verified
     description: Strong headings for typography.
     markup: |
       <div class="spectrum">
-        <p class="spectrum-Heading spectrum-Heading--XXXL spectrum-Heading--heavy">HeadingXXXL <em>Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XXL spectrum-Heading--heavy">HeadingXXL <em>Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XL spectrum-Heading--heavy">HeadingXL <em>Emphasis</em> <strong>Strong</strong>.</p>
+        <h1 class="spectrum-Heading spectrum-Heading--XXXL spectrum-Heading--heavy">HeadingXXXL <em>Emphasis</em> <strong>Strong</strong>.</h1>
+        <h1 class="spectrum-Heading spectrum-Heading--XXL spectrum-Heading--heavy">HeadingXXL <em>Emphasis</em> <strong>Strong</strong>.</h1>
+        <h1 class="spectrum-Heading spectrum-Heading--XL spectrum-Heading--heavy">HeadingXL <em>Emphasis</em> <strong>Strong</strong>.</h1>
         <p class="spectrum-Heading spectrum-Heading--L spectrum-Heading--heavy">HeadingL <em>Emphasis</em> <strong>strong</strong>.</p>
         <br/>
-        <p class="spectrum-Heading spectrum-Heading--XXXL spectrum-Heading--heavy spectrum-Heading--serif">HeadingXXXL Serif <em>Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XXL spectrum-Heading--heavy spectrum-Heading--serif">HeadingXXL Serif <em>Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XL spectrum-Heading--heavy spectrum-Heading--serif">HeadingXL Serif <em>Emphasis</em> <strong>Strong</strong>.</p>
+        <h1 class="spectrum-Heading spectrum-Heading--XXXL spectrum-Heading--heavy spectrum-Heading--serif">HeadingXXXL Serif <em>Emphasis</em> <strong>Strong</strong>.</h1>
+        <h1 class="spectrum-Heading spectrum-Heading--XXL spectrum-Heading--heavy spectrum-Heading--serif">HeadingXXL Serif <em>Emphasis</em> <strong>Strong</strong>.</h1>
+        <h1 class="spectrum-Heading spectrum-Heading--XL spectrum-Heading--heavy spectrum-Heading--serif">HeadingXL Serif <em>Emphasis</em> <strong>Strong</strong>.</h1>
         <p class="spectrum-Heading spectrum-Heading--L spectrum-Heading--heavy spectrum-Heading--serif">HeadingL Serif <em>Emphasis</em> <strong>strong</strong>.</p>
       </div>
 
-  - id: heading-1
+  - id: heading-light-m
     name: Heading (Light)
     status: Verified
     description: Light headings for typography.
     markup: |
       <div class="spectrum">
-        <p class="spectrum-Heading spectrum-Heading--XXXL spectrum-Heading--light">HeadingXXXL <em>Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XXL spectrum-Heading--light">HeadingXXL <em>Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XL spectrum-Heading--light">HeadingXL <em>Emphasis</em> <strong>Strong</strong>.</p>
+        <h1 class="spectrum-Heading spectrum-Heading--XXXL spectrum-Heading--light">HeadingXXXL <em>Emphasis</em> <strong>Strong</strong>.</h1>
+        <h1 class="spectrum-Heading spectrum-Heading--XXL spectrum-Heading--light">HeadingXXL <em>Emphasis</em> <strong>Strong</strong>.</h1>
+        <h1 class="spectrum-Heading spectrum-Heading--XL spectrum-Heading--light">HeadingXL <em>Emphasis</em> <strong>Strong</strong>.</h1>
         <p class="spectrum-Heading spectrum-Heading--L spectrum-Heading--light">HeadingL <em>Emphasis</em> <strong>Strong</strong>.</p>
         <br/>
-        <p class="spectrum-Heading spectrum-Heading--XXXL spectrum-Heading--light spectrum-Heading--serif">HeadingXXXL Serif <em>Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XXL spectrum-Heading--light spectrum-Heading--serif">HeadingXXL Serif <em>Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XL spectrum-Heading--light spectrum-Heading--serif">HeadingXL Serif <em>Emphasis</em> <strong>Strong</strong>.</p>
+        <h1 class="spectrum-Heading spectrum-Heading--XXXL spectrum-Heading--light spectrum-Heading--serif">HeadingXXXL Serif <em>Emphasis</em> <strong>Strong</strong>.</h1>
+        <h1 class="spectrum-Heading spectrum-Heading--XXL spectrum-Heading--light spectrum-Heading--serif">HeadingXXL Serif <em>Emphasis</em> <strong>Strong</strong>.</h1>
+        <h1 class="spectrum-Heading spectrum-Heading--XL spectrum-Heading--light spectrum-Heading--serif">HeadingXL Serif <em>Emphasis</em> <strong>Strong</strong>.</h1>
         <p class="spectrum-Heading spectrum-Heading--L spectrum-Heading--light spectrum-Heading--serif">HeadingL Serif <em>Emphasis</em> <strong>Strong</strong>.</p>
       </div>
 
-  - id: heading-body-1
+  - id: heading-m
     name: Standard
     status: Verified
     description: Typography elements paired to display clear content hierarchies.
     markup: |
       <div class="spectrum-Typography">
-        <div style="max-width: 600px;">
         <h1 class="spectrum-Heading spectrum-Heading--XXXL">Aliquet Mauris Eu</h1>
         <p class="spectrum-Body spectrum-Body--XXXL">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit. Sed finibus dapibus diam et sollicitudin. Phasellus in ipsum nec ante elementum congue eget in leo. Morbi eleifend justo non rutrum venenatis. Fusce cursus et lectus eu facilisis. Ut laoreet felis in magna dignissim feugiat.</p>
         <p class="spectrum-Body spectrum-Body--XXXL">Ut et lectus finibus, aliquet mauris eu, tincidunt mi. Donec scelerisque orci sit amet venenatis luctus. Morbi eget lacus est. Duis iaculis magna quis aliquam lacinia. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
@@ -83,23 +83,19 @@ examples:
         <p class="spectrum-Body spectrum-Body--L">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit. Sed finibus dapibus diam et sollicitudin. Phasellus in ipsum nec ante elementum congue eget in leo. Morbi eleifend justo non rutrum venenatis. Fusce cursus et lectus eu facilisis. Ut laoreet felis in magna dignissim feugiat.</p>
         <p class="spectrum-Body spectrum-Body--L">Ut et lectus finibus, aliquet mauris eu, tincidunt mi. Donec scelerisque orci sit amet venenatis luctus. Morbi eget lacus est. Duis iaculis magna quis aliquam lacinia. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 
-        <h1 class="spectrum-Heading spectrum-Heading--L">Lorem Ipsum Dolor</h1>
-        <p class="spectrum-Body spectrum-Body--L">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit. Sed finibus dapibus diam et sollicitudin. Phasellus in ipsum nec ante elementum congue eget in leo. Morbi eleifend justo non rutrum venenatis. Fusce cursus et lectus eu facilisis. Ut laoreet felis in magna dignissim feugiat.</p>
-        <p class="spectrum-Body spectrum-Body--L">Ut et lectus finibus, aliquet mauris eu, tincidunt mi. Donec scelerisque orci sit amet venenatis luctus. Morbi eget lacus est. Duis iaculis magna quis aliquam lacinia. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-
-        <h1 class="spectrum-Heading spectrum-Heading--M">Lorem Ipsum Dolor</h1>
+        <h3 class="spectrum-Heading spectrum-Heading--M">Lorem Ipsum Dolor</h1>
         <p class="spectrum-Body spectrum-Body--M">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit. Sed finibus dapibus diam et sollicitudin. Phasellus in ipsum nec ante elementum congue eget in leo. Morbi eleifend justo non rutrum venenatis. Fusce cursus et lectus eu facilisis. Ut laoreet felis in magna dignissim feugiat.</p>
         <p class="spectrum-Body spectrum-Body--M">Ut et lectus finibus, aliquet mauris eu, tincidunt mi. Donec scelerisque orci sit amet venenatis luctus. Morbi eget lacus est. Duis iaculis magna quis aliquam lacinia. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 
-        <h1 class="spectrum-Heading spectrum-Heading--S">Lorem Ipsum Dolor</h1>
+        <h4 class="spectrum-Heading spectrum-Heading--S">Lorem Ipsum Dolor</h1>
         <p class="spectrum-Body spectrum-Body--S">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit. Sed finibus dapibus diam et sollicitudin. Phasellus in ipsum nec ante elementum congue eget in leo. Morbi eleifend justo non rutrum venenatis. Fusce cursus et lectus eu facilisis. Ut laoreet felis in magna dignissim feugiat.</p>
         <p class="spectrum-Body spectrum-Body--S">Ut et lectus finibus, aliquet mauris eu, tincidunt mi. Donec scelerisque orci sit amet venenatis luctus. Morbi eget lacus est. Duis iaculis magna quis aliquam lacinia. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 
-        <h1 class="spectrum-Heading spectrum-Heading--XS">Lorem Ipsum Dolor</h1>
+        <h5 class="spectrum-Heading spectrum-Heading--XS">Lorem Ipsum Dolor</h1>
         <p class="spectrum-Body spectrum-Body--XS">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit. Sed finibus dapibus diam et sollicitudin. Phasellus in ipsum nec ante elementum congue eget in leo. Morbi eleifend justo non rutrum venenatis. Fusce cursus et lectus eu facilisis. Ut laoreet felis in magna dignissim feugiat.</p>
         <p class="spectrum-Body spectrum-Body--XS">Ut et lectus finibus, aliquet mauris eu, tincidunt mi. Donec scelerisque orci sit amet venenatis luctus. Morbi eget lacus est. Duis iaculis magna quis aliquam lacinia. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 
-        <h1 class="spectrum-Heading spectrum-Heading--XXS">Lorem Ipsum Dolor</h1>
+        <h6 class="spectrum-Heading spectrum-Heading--XXS">Lorem Ipsum Dolor</h1>
         <p class="spectrum-Body spectrum-Body--XS">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit. Sed finibus dapibus diam et sollicitudin. Phasellus in ipsum nec ante elementum congue eget in leo. Morbi eleifend justo non rutrum venenatis. Fusce cursus et lectus eu facilisis. Ut laoreet felis in magna dignissim feugiat.</p>
         <p class="spectrum-Body spectrum-Body--XS">Ut et lectus finibus, aliquet mauris eu, tincidunt mi. Donec scelerisque orci sit amet venenatis luctus. Morbi eget lacus est. Duis iaculis magna quis aliquam lacinia. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
       </div>

--- a/components/typography/metadata/typography-heading.yml
+++ b/components/typography/metadata/typography-heading.yml
@@ -1,6 +1,6 @@
 name: Typography Heading
 id: heading-m
-description: "Spectrum Typography Headings."
+description: The Heading typography component.
 SpectrumSiteSlug: https://spectrum.adobe.com/page/heading/
 examples:
   - id: heading-m

--- a/components/typography/metadata/typography-heading.yml
+++ b/components/typography/metadata/typography-heading.yml
@@ -1,6 +1,6 @@
 name: Typography Heading
 id: heading-m
-description: The Heading typography component.
+description: Heading is a typography component used to create various levels of hierarchies between text.
 SpectrumSiteSlug: https://spectrum.adobe.com/page/heading/
 examples:
   - id: heading-m

--- a/components/typography/metadata/typography-international-deprecated.yml
+++ b/components/typography/metadata/typography-international-deprecated.yml
@@ -1,12 +1,12 @@
-name: Typography (Int., Deprecated I)
+name: Typography (Intenationalized, Deprecated)
 status: Deprecated
+hide: true
 examples:
   - id: heading-1
     name: Typography
     description: Typography elements paired to display clear content hierarchies.
     markup: |
       <div class="spectrum-Typography">
-        <div style="max-width: 600px;">
         <h1 class="spectrum-Heading1">Aliquet Mauris Eu</h1>
         <p class="spectrum-Body1">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit. Sed finibus dapibus diam et sollicitudin. Phasellus in ipsum nec ante elementum congue eget in leo. Morbi eleifend justo non rutrum venenatis. Fusce cursus et lectus eu facilisis. Ut laoreet felis in magna dignissim feugiat.</p>
         <p class="spectrum-Body1">Ut et lectus finibus, aliquet mauris eu, tincidunt mi. Donec scelerisque orci sit amet venenatis luctus. Morbi eget lacus est. Duis iaculis magna quis aliquam lacinia. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
@@ -42,7 +42,6 @@ examples:
         <h1 class="spectrum-Subheading">Lorem Ipsum Dolor</h1>
         <p class="spectrum-Body4">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit. Sed finibus dapibus diam et sollicitudin. Phasellus in ipsum nec ante elementum congue eget in leo. Morbi eleifend justo non rutrum venenatis. Fusce cursus et lectus eu facilisis. Ut laoreet felis in magna dignissim feugiat.</p>
         <p class="spectrum-Body4">Ut et lectus finibus, aliquet mauris eu, tincidunt mi. Donec scelerisque orci sit amet venenatis luctus. Morbi eget lacus est. Duis iaculis magna quis aliquam lacinia. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-        </div>
       </div>
   - id: heading-1
     name: Heading

--- a/components/typography/metadata/typography-international-deprecated.yml
+++ b/components/typography/metadata/typography-international-deprecated.yml
@@ -1,4 +1,4 @@
-name: Typography (Intenationalized, Deprecated)
+name: Typography (Internationalized, Deprecated)
 status: Deprecated
 hide: true
 examples:

--- a/components/typography/metadata/typography-international.yml
+++ b/components/typography/metadata/typography-international.yml
@@ -1,12 +1,16 @@
 name: Typography (Internationalized)
+fastLoad: false
+description: Internationalized typography examples. Note that, for these examples to work correctly, your Typekit needs to include the appropriate Han fonts.
+SpectrumSiteSlug: https://spectrum.adobe.com/page/typography/
+status: Verified
+id: heading-han-m
 examples:
-  - id: heading-1
+  - id: heading-m
     name: Typography
     status: Verified
     description: Typography elements paired to display clear content hierarchies.
     markup: |
       <div class="spectrum-Typography">
-        <div style="max-width: 600px;">
         <h1 class="spectrum-Heading spectrum-Heading--XXXL">Aliquet Mauris Eu</h1>
         <p class="spectrum-Body spectrum-Body--XXXL">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit. Sed finibus dapibus diam et sollicitudin. Phasellus in ipsum nec ante elementum congue eget in leo. Morbi eleifend justo non rutrum venenatis. Fusce cursus et lectus eu facilisis. Ut laoreet felis in magna dignissim feugiat.</p>
         <p class="spectrum-Body spectrum-Body--XXXL">Ut et lectus finibus, aliquet mauris eu, tincidunt mi. Donec scelerisque orci sit amet venenatis luctus. Morbi eget lacus est. Duis iaculis magna quis aliquam lacinia. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
@@ -22,152 +26,148 @@ examples:
         <p class="spectrum-Body spectrum-Body--L">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit. Sed finibus dapibus diam et sollicitudin. Phasellus in ipsum nec ante elementum congue eget in leo. Morbi eleifend justo non rutrum venenatis. Fusce cursus et lectus eu facilisis. Ut laoreet felis in magna dignissim feugiat.</p>
         <p class="spectrum-Body spectrum-Body--L">Ut et lectus finibus, aliquet mauris eu, tincidunt mi. Donec scelerisque orci sit amet venenatis luctus. Morbi eget lacus est. Duis iaculis magna quis aliquam lacinia. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 
-        <h1 class="spectrum-Heading spectrum-Heading--L">Lorem Ipsum Dolor</h1>
-        <p class="spectrum-Body spectrum-Body--L">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit. Sed finibus dapibus diam et sollicitudin. Phasellus in ipsum nec ante elementum congue eget in leo. Morbi eleifend justo non rutrum venenatis. Fusce cursus et lectus eu facilisis. Ut laoreet felis in magna dignissim feugiat.</p>
-        <p class="spectrum-Body spectrum-Body--L">Ut et lectus finibus, aliquet mauris eu, tincidunt mi. Donec scelerisque orci sit amet venenatis luctus. Morbi eget lacus est. Duis iaculis magna quis aliquam lacinia. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-
-        <h1 class="spectrum-Heading spectrum-Heading--M">Lorem Ipsum Dolor</h1>
+        <h3 class="spectrum-Heading spectrum-Heading--M">Lorem Ipsum Dolor</h1>
         <p class="spectrum-Body spectrum-Body--M">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit. Sed finibus dapibus diam et sollicitudin. Phasellus in ipsum nec ante elementum congue eget in leo. Morbi eleifend justo non rutrum venenatis. Fusce cursus et lectus eu facilisis. Ut laoreet felis in magna dignissim feugiat.</p>
         <p class="spectrum-Body spectrum-Body--M">Ut et lectus finibus, aliquet mauris eu, tincidunt mi. Donec scelerisque orci sit amet venenatis luctus. Morbi eget lacus est. Duis iaculis magna quis aliquam lacinia. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 
-        <h1 class="spectrum-Heading spectrum-Heading--S">Lorem Ipsum Dolor</h1>
+        <h4 class="spectrum-Heading spectrum-Heading--S">Lorem Ipsum Dolor</h1>
         <p class="spectrum-Body spectrum-Body--S">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit. Sed finibus dapibus diam et sollicitudin. Phasellus in ipsum nec ante elementum congue eget in leo. Morbi eleifend justo non rutrum venenatis. Fusce cursus et lectus eu facilisis. Ut laoreet felis in magna dignissim feugiat.</p>
         <p class="spectrum-Body spectrum-Body--S">Ut et lectus finibus, aliquet mauris eu, tincidunt mi. Donec scelerisque orci sit amet venenatis luctus. Morbi eget lacus est. Duis iaculis magna quis aliquam lacinia. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 
-        <h1 class="spectrum-Heading spectrum-Heading--XS">Lorem Ipsum Dolor</h1>
+        <h5 class="spectrum-Heading spectrum-Heading--XS">Lorem Ipsum Dolor</h1>
         <p class="spectrum-Body spectrum-Body--XS">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit. Sed finibus dapibus diam et sollicitudin. Phasellus in ipsum nec ante elementum congue eget in leo. Morbi eleifend justo non rutrum venenatis. Fusce cursus et lectus eu facilisis. Ut laoreet felis in magna dignissim feugiat.</p>
         <p class="spectrum-Body spectrum-Body--XS">Ut et lectus finibus, aliquet mauris eu, tincidunt mi. Donec scelerisque orci sit amet venenatis luctus. Morbi eget lacus est. Duis iaculis magna quis aliquam lacinia. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 
-        <h1 class="spectrum-Heading spectrum-Heading--XXS">Lorem Ipsum Dolor</h1>
+        <h6 class="spectrum-Heading spectrum-Heading--XXS">Lorem Ipsum Dolor</h1>
         <p class="spectrum-Body spectrum-Body--XS">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit. Sed finibus dapibus diam et sollicitudin. Phasellus in ipsum nec ante elementum congue eget in leo. Morbi eleifend justo non rutrum venenatis. Fusce cursus et lectus eu facilisis. Ut laoreet felis in magna dignissim feugiat.</p>
         <p class="spectrum-Body spectrum-Body--XS">Ut et lectus finibus, aliquet mauris eu, tincidunt mi. Donec scelerisque orci sit amet venenatis luctus. Morbi eget lacus est. Duis iaculis magna quis aliquam lacinia. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
       </div>
 
-  - id: heading-1
+  - id: heading-m
     name: Heading
     status: Verified
     description: Headings for typography.
     markup: |
       <div class="spectrum" lang="en">
-        <p class="spectrum-Heading spectrum-Heading--XXXL">HeadingXXXL <em>HeadingXXXL Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XXL">HeadingXXL <em>HeadingXXL Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XL">HeadingXL <em>HeadingXL Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--L">HeadingL <em>HeadingL Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--M">HeadingM <em>HeadingM Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--S">HeadingS <em>HeadingS Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XS">HeadingXS <em>HeadingXS Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XXS">HeadingXXS <em>HeadingXXS Emphasis</em> <strong>Strong</strong>.</p>
+        <h1 class="spectrum-Heading spectrum-Heading--XXXL">HeadingXXXL <em>HeadingXXXL Emphasis</em> <strong>Strong</strong>.</h1>
+        <h1 class="spectrum-Heading spectrum-Heading--XXL">HeadingXXL <em>HeadingXXL Emphasis</em> <strong>Strong</strong>.</h1>
+        <h1 class="spectrum-Heading spectrum-Heading--XL">HeadingXL <em>HeadingXL Emphasis</em> <strong>Strong</strong>.</h1>
+        <h2 class="spectrum-Heading spectrum-Heading--L">HeadingL <em>HeadingL Emphasis</em> <strong>Strong</strong>.</h2>
+        <h3 class="spectrum-Heading spectrum-Heading--M">HeadingM <em>HeadingM Emphasis</em> <strong>Strong</strong>.</h3>
+        <h4 class="spectrum-Heading spectrum-Heading--S">HeadingS <em>HeadingS Emphasis</em> <strong>Strong</strong>.</h4>
+        <h5 class="spectrum-Heading spectrum-Heading--XS">HeadingXS <em>HeadingXS Emphasis</em> <strong>Strong</strong>.</h5>
+        <h6 class="spectrum-Heading spectrum-Heading--XXS">HeadingXXS <em>HeadingXXS Emphasis</em> <strong>Strong</strong>.</h6>
         <br/>
-        <p class="spectrum-Heading spectrum-Heading--XXXL spectrum-Heading--serif">HeadingXXXL Serif <em>Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XXL spectrum-Heading--serif">HeadingXXL Serif <em>Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XL spectrum-Heading--serif">HeadingXL Serif <em>Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--L spectrum-Heading--serif">HeadingL Serif <em>Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--M spectrum-Heading--serif">HeadingM Serif <em>Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--S spectrum-Heading--serif">HeadingS Serif <em>Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XS spectrum-Heading--serif">HeadingXS Serif <em>Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XXS spectrum-Heading--serif">HeadingXXS Serif <em>Emphasis</em> <strong>Strong</strong>.</p>
+        <h1 class="spectrum-Heading spectrum-Heading--XXXL spectrum-Heading--serif">HeadingXXXL Serif <em>Emphasis</em> <strong>Strong</strong>.</h1>
+        <h1 class="spectrum-Heading spectrum-Heading--XXL spectrum-Heading--serif">HeadingXXL Serif <em>Emphasis</em> <strong>Strong</strong>.</h1>
+        <h1 class="spectrum-Heading spectrum-Heading--XL spectrum-Heading--serif">HeadingXL Serif <em>Emphasis</em> <strong>Strong</strong>.</h1>
+        <h2 class="spectrum-Heading spectrum-Heading--L spectrum-Heading--serif"> spectrum-Heading--serif</h2>
+        <h3 class="spectrum-Heading spectrum-Heading--M spectrum-Heading--serif">HeadingM Serif <em>Emphasis</em> <strong>Strong</strong>.</h3>
+        <h4 class="spectrum-Heading spectrum-Heading--S spectrum-Heading--serif">HeadingS Serif <em>Emphasis</em> <strong>Strong</strong>.</h4>
+        <h5 class="spectrum-Heading spectrum-Heading--XS spectrum-Heading--serif">HeadingXS Serif <em>Emphasis</em> <strong>Strong</strong>.</h5>
+        <h6 class="spectrum-Heading spectrum-Heading--XXS spectrum-Heading--serif">HeadingXXS Serif <em>Emphasis</em> <strong>Strong</strong>.</h6>
       </div>
 
       <div class="spectrum" lang="ja">
-        <p class="spectrum-Heading spectrum-Heading--XXXL">見出しXXXL <em>見出しXXXL 重点</em> <strong>見出しXXXL 強い強調</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XXL">見出しXXL <em>見出しXXL 重点</em> <strong>見出しXXL 強い強調</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XL">見出しXL <em>見出しXL 重点</em> <strong>見出しXL 強い強調</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--L">見出しL <em>見出しL 重点</em> <strong>見出しL 強い強調</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--M">見出しM <em>見出しM 重点</em> <strong>見出しM 強い強調</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--S">見出しS <em>見出しS 重点</em> <strong>見出しS 強い強調</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XS">見出しXS <em>見出しXS 重点</em> <strong>見出しXS 強い強調</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XXS">見出しXXS <em>見出しXXS 重点</em> <strong>見出しXXS 強い強調</strong>.</p>
+        <h1 class="spectrum-Heading spectrum-Heading--XXXL">見出しXXXL <em>見出しXXXL 重点</em> <strong>見出しXXXL 強い強調</strong>.</h1>
+        <h1 class="spectrum-Heading spectrum-Heading--XXL">見出しXXL <em>見出しXXL 重点</em> <strong>見出しXXL 強い強調</strong>.</h1>
+        <h1 class="spectrum-Heading spectrum-Heading--XL">見出しXL <em>見出しXL 重点</em> <strong>見出しXL 強い強調</strong>.</h1>
+        <h2 class="spectrum-Heading spectrum-Heading--L">見出しL <em>見出しL 重点</em> <strong>見出しL 強い強調</strong>.</h2>
+        <h3 class="spectrum-Heading spectrum-Heading--M">見出しM <em>見出しM 重点</em> <strong>見出しM 強い強調</strong>.</h3>
+        <h4 class="spectrum-Heading spectrum-Heading--S">見出しS <em>見出しS 重点</em> <strong>見出しS 強い強調</strong>.</h4>
+        <h5 class="spectrum-Heading spectrum-Heading--XS">見出しXS <em>見出しXS 重点</em> <strong>見出しXS 強い強調</strong>.</h5>
+        <h6 class="spectrum-Heading spectrum-Heading--XXS">見出しXXS <em>見出しXXS 重点</em> <strong>見出しXXS 強い強調</strong>.</h6>
       </div>
 
       <div class="spectrum" lang="ar">
-        <p class="spectrum-Heading spectrum-Heading--XXXL">XXXLالقسم <em>XXXLالقسم  تشديد</em> <strong>XXXLالقسم  تأكيد قو</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XXL">XXLالقسم <em>XXLالقسم  تشديد</em> <strong>XXLالقسم  تأكيد قو</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XL">XLالقسم <em>XLالقسم  تشديد</em> <strong>XLالقسم  تأكيد قو</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--L">Lالقسم <em>Lالقسم  تشديد</em> <strong>Lالقسم  تأكيد قو</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--M">Mالقسم <em>Mالقسم  تشديد</em> <strong>Mالقسم  تأكيد قو</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--S">Sالقسم <em>Sالقسم  تشديد</em> <strong>Sالقسم  تأكيد قو</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XS">XSالقسم <em>XSالقسم  تشديد</em> <strong>XSالقسم  تأكيد قو</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XXS">XSSالقسم <em>XSSالقسم  تشديد</em> <strong>XXSالقسم  تأكيد قو</strong>.</p>
+        <h1 class="spectrum-Heading spectrum-Heading--XXXL">XXXLالقسم <em>XXXLالقسم  تشديد</em> <strong>XXXLالقسم  تأكيد قو</strong>.</h1>
+        <h1 class="spectrum-Heading spectrum-Heading--XXL">XXLالقسم <em>XXLالقسم  تشديد</em> <strong>XXLالقسم  تأكيد قو</strong>.</h1>
+        <h1 class="spectrum-Heading spectrum-Heading--XL">XLالقسم <em>XLالقسم  تشديد</em> <strong>XLالقسم  تأكيد قو</strong>.</h1>
+        <h2 class="spectrum-Heading spectrum-Heading--L">Lالقسم <em>Lالقسم  تشديد</em> <strong>Lالقسم  تأكيد قو</strong>.</h2>
+        <h3 class="spectrum-Heading spectrum-Heading--M">Mالقسم <em>Mالقسم  تشديد</em> <strong>Mالقسم  تأكيد قو</strong>.</h3>
+        <h4 class="spectrum-Heading spectrum-Heading--S">Sالقسم <em>Sالقسم  تشديد</em> <strong>Sالقسم  تأكيد قو</strong>.</h4>
+        <h5 class="spectrum-Heading spectrum-Heading--XS">XSالقسم <em>XSالقسم  تشديد</em> <strong>XSالقسم  تأكيد قو</strong>.</h5>
+        <h6 class="spectrum-Heading spectrum-Heading--XXS">XSSالقسم <em>XSSالقسم  تشديد</em> <strong>XXSالقسم  تأكيد قو</strong>.</h6>
       </div>
 
       <div class="spectrum" lang="he">
-        <p class="spectrum-Heading spectrum-Heading--XXXL">XXXLדגש כותרת <em>XXXLמאמר</em> <strong>XXXLחזק</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XXL">XXLדגש כותרת <em>XXLמאמר</em> <strong>XXLחזק</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XL">XLדגש כותרת <em>XLמאמר</em> <strong>XLחזק</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--L">Lדגש כותרת <em>Lמאמר</em> <strong>Lחזק</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--M">Mדגש כותרת <em>Mמאמר</em> <strong>Mחזק</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--S">Sדגש כותרת <em>Sמאמר</em> <strong>Sחזק</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XS">XSדגש כותרת <em>XSמאמר</em> <strong>XSחזק</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XXS">XXSדגש כותרת <em>XXSמאמר</em> <strong>XXSחזק</strong>.</p>
+        <h1 class="spectrum-Heading spectrum-Heading--XXXL">XXXLדגש כותרת <em>XXXLמאמר</em> <strong>XXXLחזק</strong>.</h1>
+        <h1 class="spectrum-Heading spectrum-Heading--XXL">XXLדגש כותרת <em>XXLמאמר</em> <strong>XXLחזק</strong>.</h1>
+        <h1 class="spectrum-Heading spectrum-Heading--XL">XLדגש כותרת <em>XLמאמר</em> <strong>XLחזק</strong>.</h1>
+        <h2 class="spectrum-Heading spectrum-Heading--L">Lדגש כותרת <em>Lמאמר</em> <strong>Lחזק</strong>.</h2>
+        <h3 class="spectrum-Heading spectrum-Heading--M">Mדגש כותרת <em>Mמאמר</em> <strong>Mחזק</strong>.</h3>
+        <h4 class="spectrum-Heading spectrum-Heading--S">Sדגש כותרת <em>Sמאמר</em> <strong>Sחזק</strong>.</h4>
+        <h5 class="spectrum-Heading spectrum-Heading--XS">XSדגש כותרת <em>XSמאמר</em> <strong>XSחזק</strong>.</h5>
+        <h6 class="spectrum-Heading spectrum-Heading--XXS">XXSדגש כותרת <em>XXSמאמר</em> <strong>XXSחזק</strong>.</h6>
       </div>
 
-  - id: heading-1
+  - id: heading-heavy-m
     name: Heading (Heavy)
     status: Verified
     description: Strong headings for typography.
     markup: |
       <div class="spectrum" lang="en">
-        <p class="spectrum-Heading spectrum-Heading--XXXL spectrum-Heading--heavy">HeadingXXXL <em>Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XXL spectrum-Heading--heavy">HeadingXXL <em>Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XL spectrum-Heading--heavy">HeadingXL <em>Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--L spectrum-Heading--heavy">HeadingL <em>Emphasis</em> <strong>heavy</strong>.</p>
+        <h1 class="spectrum-Heading spectrum-Heading--XXXL spectrum-Heading--heavy">HeadingXXXL <em>Emphasis</em> <strong>Strong</strong>.</h1>
+        <h1 class="spectrum-Heading spectrum-Heading--XXL spectrum-Heading--heavy">HeadingXXL <em>Emphasis</em> <strong>Strong</strong>.</h1>
+        <h1 class="spectrum-Heading spectrum-Heading--XL spectrum-Heading--heavy">HeadingXL <em>Emphasis</em> <strong>Strong</strong>.</h1>
+        <h2 class="spectrum-Heading spectrum-Heading--L spectrum-Heading--heavy"> spectrum-Heading--heavy</h2>
         <br/>
-        <p class="spectrum-Heading spectrum-Heading--XXXL spectrum-Heading--heavy spectrum-Heading--serif">HeadingXXXL Serif <em>Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XXL spectrum-Heading--heavy spectrum-Heading--serif">HeadingXXL Serif <em>Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XL spectrum-Heading--heavy spectrum-Heading--serif">HeadingXL Serif <em>Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--L spectrum-Heading--heavy spectrum-Heading--serif">HeadingL Serif  <em>Emphasis</em> <strong>heavy</strong>.</p>
+        <h1 class="spectrum-Heading spectrum-Heading--XXXL spectrum-Heading--heavy spectrum-Heading--serif">HeadingXXXL Serif <em>Emphasis</em> <strong>Strong</strong>.</h1>
+        <h1 class="spectrum-Heading spectrum-Heading--XXL spectrum-Heading--heavy spectrum-Heading--serif">HeadingXXL Serif <em>Emphasis</em> <strong>Strong</strong>.</h1>
+        <h1 class="spectrum-Heading spectrum-Heading--XL spectrum-Heading--heavy spectrum-Heading--serif">HeadingXL Serif <em>Emphasis</em> <strong>Strong</strong>.</h1>
+        <h2 class="spectrum-Heading spectrum-Heading--L spectrum-Heading--heavy spectrum-Heading--serif"> spectrum-Heading--heavy spectrum-Heading--serif</h2>
       </div>
 
       <div class="spectrum" lang="ja">
-        <p class="spectrum-Heading spectrum-Heading--XXXL spectrum-Heading--heavy">見出しXXXL <em>見出し XXXL </em> <strong>>見出しXXXL 強い強調</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XXL spectrum-Heading--heavy">見出しXXL <em>見出し XXL 重点</em> <strong>見出しXXL 強い強調</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XL spectrum-Heading--heavy">見出しXL <em>見出しXL  重点</em> <strong>見出しXL強い強調</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--L spectrum-Heading--heavy">見出しL <em>見出しL  重点</em> <strong>見出しL強い強調</strong>.</p>
+        <h1 class="spectrum-Heading spectrum-Heading--XXXL spectrum-Heading--heavy">見出しXXXL <em>見出し XXXL </em> <strong>>見出しXXXL 強い強調</strong>.</h1>
+        <h1 class="spectrum-Heading spectrum-Heading--XXL spectrum-Heading--heavy">見出しXXL <em>見出し XXL 重点</em> <strong>見出しXXL 強い強調</strong>.</h1>
+        <h1 class="spectrum-Heading spectrum-Heading--XL spectrum-Heading--heavy">見出しXL <em>見出しXL  重点</em> <strong>見出しXL強い強調</strong>.</h1>
+        <h2 class="spectrum-Heading spectrum-Heading--L spectrum-Heading--heavy"> spectrum-Heading--heavy</h2>
       </div>
 
       <div class="spectrum" lang="ar">
-        <p class="spectrum-Heading spectrum-Heading--XXXL spectrum-Heading--heavy">القسمXXXL <em>القسم XXXL  تشديد</em> <strong>القسم 2XXXL تأكيد قو</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XXL spectrum-Heading--heavy">القسمXXL <em>القسم 1XXL  تشديد Emphasis</em> <strong>القسم XXL تأكيد قو</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XL spectrum-Heading--heavy">القسمXL<em>القسم 1XL  تشديد</em> <strong>القسم XL تأكيد قو</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--L spectrum-Heading--heavy">القسمL <em>القسم L  تشديد</em> <strong>القسم L تأكيد قو</strong>.</p>
+        <h1 class="spectrum-Heading spectrum-Heading--XXXL spectrum-Heading--heavy">القسمXXXL <em>القسم XXXL  تشديد</em> <strong>القسم 2XXXL تأكيد قو</strong>.</h1>
+        <h1 class="spectrum-Heading spectrum-Heading--XXL spectrum-Heading--heavy">القسمXXL <em>القسم 1XXL  تشديد Emphasis</em> <strong>القسم XXL تأكيد قو</strong>.</h1>
+        <h1 class="spectrum-Heading spectrum-Heading--XL spectrum-Heading--heavy">القسمXL<em>القسم 1XL  تشديد</em> <strong>القسم XL تأكيد قو</strong>.</h1>
+        <h2 class="spectrum-Heading spectrum-Heading--L spectrum-Heading--heavy"> spectrum-Heading--heavy</h2>
       </div>
 
       <div class="spectrum" lang="he">
-        <p class="spectrum-Heading spectrum-Heading--XXXL spectrum-Heading--heavy">XXXLדגש כותרת <em>XXXLמאמר</em> <strong>XXXLחזק</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XXL spectrum-Heading--heavy">XXLדגש כותרת <em>XXLמאמר</em> <strong>XXLחזק</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XL spectrum-Heading--heavy">XLדגש כותרת <em>XLמאמר</em> <strong>XLחזק</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--L spectrum-Heading--heavy">Lדגש כותרת <em>Lמאמר</em> <strong>Lחזק</strong>.</p>
+        <h1 class="spectrum-Heading spectrum-Heading--XXXL spectrum-Heading--heavy">XXXLדגש כותרת <em>XXXLמאמר</em> <strong>XXXLחזק</strong>.</h1>
+        <h1 class="spectrum-Heading spectrum-Heading--XXL spectrum-Heading--heavy">XXLדגש כותרת <em>XXLמאמר</em> <strong>XXLחזק</strong>.</h1>
+        <h1 class="spectrum-Heading spectrum-Heading--XL spectrum-Heading--heavy">XLדגש כותרת <em>XLמאמר</em> <strong>XLחזק</strong>.</h1>
+        <h2 class="spectrum-Heading spectrum-Heading--L spectrum-Heading--heavy"> spectrum-Heading--heavy</h2>
       </div>
 
-  - id: heading-1
+  - id: heading-light-m
     name: Heading (Light)
     status: Verified
     description: Light headings for typography.
     markup: |
       <div class="spectrum" lang="en">
-        <p class="spectrum-Heading spectrum-Heading--XXXL spectrum-Heading--light">HeadingXXXL <em>Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XXL spectrum-Heading--light">HeadingXXL <em>Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XL spectrum-Heading--light">HeadingXL <em>Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--L spectrum-Heading--light">HeadingL <em>Emphasis</em> <strong>Strong</strong>.</p>
+        <h1 class="spectrum-Heading spectrum-Heading--XXXL spectrum-Heading--light">HeadingXXXL <em>Emphasis</em> <strong>Strong</strong>.</h1>
+        <h1 class="spectrum-Heading spectrum-Heading--XXL spectrum-Heading--light">HeadingXXL <em>Emphasis</em> <strong>Strong</strong>.</h1>
+        <h1 class="spectrum-Heading spectrum-Heading--XL spectrum-Heading--light">HeadingXL <em>Emphasis</em> <strong>Strong</strong>.</h1>
+        <h2 class="spectrum-Heading spectrum-Heading--L spectrum-Heading--light"> spectrum-Heading--light</h2>
         <br/>
-        <p class="spectrum-Heading spectrum-Heading--XXXL spectrum-Heading--light spectrum-Heading--serif">HeadingXXXL Serif <em>Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XXL spectrum-Heading--light spectrum-Heading--serif">HeadingXXL Serif <em>Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XL spectrum-Heading--light spectrum-Heading--serif">HeadingXL Serif <em>Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--L spectrum-Heading--light spectrum-Heading--serif">HeadingL Serif <em>Emphasis</em> <strong>Strong</strong>.</p>
+        <h1 class="spectrum-Heading spectrum-Heading--XXXL spectrum-Heading--light spectrum-Heading--serif">HeadingXXXL Serif <em>Emphasis</em> <strong>Strong</strong>.</h1>
+        <h1 class="spectrum-Heading spectrum-Heading--XXL spectrum-Heading--light spectrum-Heading--serif">HeadingXXL Serif <em>Emphasis</em> <strong>Strong</strong>.</h1>
+        <h1 class="spectrum-Heading spectrum-Heading--XL spectrum-Heading--light spectrum-Heading--serif">HeadingXL Serif <em>Emphasis</em> <strong>Strong</strong>.</h1>
+        <h2 class="spectrum-Heading spectrum-Heading--L spectrum-Heading--light spectrum-Heading--serif"> spectrum-Heading--light spectrum-Heading--serif</h2>
       </div>
 
       <div class="spectrum" lang="ja">
-        <p class="spectrum-Heading spectrum-Heading--XXXL spectrum-Heading--light">見出しXXXL <em>見出しXXXL 重点</em> <strong>見出しXXXL 強い強調</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XXL spectrum-Heading--light">見出しXXL <em>見出しXXL 重点</em> <strong>見出しXXL 強い強調</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XL spectrum-Heading--light">見出しXL <em>見出しXL 重点</em> <strong>見出しXL 強い強調</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--L spectrum-Heading--light">見出しL <em>見出しL 重点</em> <strong>見出しL 強い強調</strong>.</p>
+        <h1 class="spectrum-Heading spectrum-Heading--XXXL spectrum-Heading--light">見出しXXXL <em>見出しXXXL 重点</em> <strong>見出しXXXL 強い強調</strong>.</h1>
+        <h1 class="spectrum-Heading spectrum-Heading--XXL spectrum-Heading--light">見出しXXL <em>見出しXXL 重点</em> <strong>見出しXXL 強い強調</strong>.</h1>
+        <h1 class="spectrum-Heading spectrum-Heading--XL spectrum-Heading--light">見出しXL <em>見出しXL 重点</em> <strong>見出しXL 強い強調</strong>.</h1>
+        <h2 class="spectrum-Heading spectrum-Heading--L spectrum-Heading--light"> spectrum-Heading--light</h2>
       </div>
 
       <div class="spectrum" lang="ar">
-        <p class="spectrum-Heading spectrum-Heading--XXXL spectrum-Heading--light">XXXLالقسم <em>القسم XXXL  تشديد</em> <strong>XXXLالقسم  تأكيد قو</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XXL spectrum-Heading--light">XXLالقسم <em>القسم XXL  تشديد</em> <strong>XXLالقسم  تأكيد قو</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--XL spectrum-Heading--light">XLالقسم <em>القسم XL  تشديد</em> <strong>XLالقسم  تأكيد قو</strong>.</p>
-        <p class="spectrum-Heading spectrum-Heading--L spectrum-Heading--light">Lالقسم <em>القسم L  تشديد</em> <strong>Lالقسم  تأكيد قو</strong>.</p>
+        <h1 class="spectrum-Heading spectrum-Heading--XXXL spectrum-Heading--light">XXXLالقسم <em>القسم XXXL  تشديد</em> <strong>XXXLالقسم  تأكيد قو</strong>.</h1>
+        <h1 class="spectrum-Heading spectrum-Heading--XXL spectrum-Heading--light">XXLالقسم <em>القسم XXL  تشديد</em> <strong>XXLالقسم  تأكيد قو</strong>.</h1>
+        <h1 class="spectrum-Heading spectrum-Heading--XL spectrum-Heading--light">XLالقسم <em>القسم XL  تشديد</em> <strong>XLالقسم  تأكيد قو</strong>.</h1>
+        <h2 class="spectrum-Heading spectrum-Heading--L spectrum-Heading--light"> spectrum-Heading--light</h2>
       </div>
 
       <div class="spectrum" lang="he">
@@ -177,7 +177,7 @@ examples:
         <p class="spectrum-Heading spectrum-HeadingL--light">Lדגש כותרת <em>Lמאמר</em> <strong>Lחזק</strong>.</p>
       </div>
 
-  - id: heading-1
+  - id: body-m
     name: Body
     status: Verified
     description: Default body text sizes.
@@ -230,7 +230,7 @@ examples:
         <p class="spectrum-Body spectrum-Body--XS">XSטקסט גוף הדגשות <em>XSגוף חזק</em> <strong>XSגוף חזק</strong>.</p>
       </div>
 
-  - id: detail-1
+  - id: detail-m
     status: Verified
     name: Detail
     description: Subheadings for typography.
@@ -268,7 +268,7 @@ examples:
         <p class="spectrum-Detail spectrum-Detail--S">Sالقسم טקסט גוף הדגשות <em>Sגוף חזק</em> <strong>Sגוף חזק</strong>.</p>
       </div>
 
-  - id: heading-1
+  - id: heading-han-m
     name: Han
     status: Verified
     description: Typographic pairings for Adobe Clean Han.
@@ -292,7 +292,7 @@ examples:
         <p class="spectrum-Body spectrum-Body--XS spectrum-Body--serif">見出しとよく対になる本文。</p>
       </div>
 
-  - id: code-1
+  - id: code-m
     name: Typography - Code
     status: Verified
     description: Typographic styles for computer code.

--- a/components/typography/metadata/typography-legacy.yml
+++ b/components/typography/metadata/typography-legacy.yml
@@ -1,0 +1,19 @@
+name: Typography (Legacy)
+description: Legacy typography components. The [new Typography components](typography.html) should be used instead.
+id: heading-display
+status: Deprecated
+hide: true
+examples:
+  - id: heading-display
+    name: Standard
+    markup: |
+      <h1 class="spectrum-Heading--display">Display (h1)</h1>
+      <h2 class="spectrum-Heading--pageTitle">Page Title (h2)</h2>
+      <h2 class="spectrum-Heading--subtitle1">Subtitle 1 (h2)</h2>
+      <h3 class="spectrum-Heading--subtitle2">Subtitle 2 (h3)</h3>
+      <h4 class="spectrum-Heading--subtitle3">Subtitle 3 (h4)</h4>
+      <p class="spectrum-Body--small">Small Body Text</p>
+      <p class="spectrum-Body">Default Body Text</p>
+      <p class="spectrum-Body--secondary">Secondary Body Text</p>
+      <p class="spectrum-Body--italic"> Body Text Italic</p>
+      <p class="spectrum-Body--large">Large Body Text</p>

--- a/components/typography/metadata/typography.yml
+++ b/components/typography/metadata/typography.yml
@@ -1,182 +1,45 @@
-name: Typography (Deprecated I)
-description: 'English typography examples. See the [typography example page](typography.html) for Japanese, Han, and Arabic examples.'
-status: Deprecated
+name: Typography
+dnaStatus: Verified
+description: |
+  Spectrum Typography is broken out into several separate components.
+
+  In addition, the previous deprecated Typogaphy implementations ([legacy](typography-legacy.html), [depreacted](typography-deprecated.html)) are still shipped, but their usage is discouraged.
 SpectrumSiteSlug: https://spectrum.adobe.com/page/typography/
+examplesHeading: Components
 examples:
-  - id: heading-1
-    name: Standard
-    description: Typography elements paired to display clear content hierarchies.
-    markup: |
-      <div class="spectrum-Typography">
-        <div style="max-width: 600px;">
-        <h1 class="spectrum-Heading1">Aliquet Mauris Eu</h1>
-        <p class="spectrum-Body1">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit. Sed finibus dapibus diam et sollicitudin. Phasellus in ipsum nec ante elementum congue eget in leo. Morbi eleifend justo non rutrum venenatis. Fusce cursus et lectus eu facilisis. Ut laoreet felis in magna dignissim feugiat.</p>
-        <p class="spectrum-Body1">Ut et lectus finibus, aliquet mauris eu, tincidunt mi. Donec scelerisque orci sit amet venenatis luctus. Morbi eget lacus est. Duis iaculis magna quis aliquam lacinia. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-
-        <h2 class="spectrum-Heading2">Aliquet Mauris Eu</h1>
-        <p class="spectrum-Body2">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit. Sed finibus dapibus diam et sollicitudin. Phasellus in ipsum nec ante elementum congue eget in leo. Morbi eleifend justo non rutrum venenatis. Fusce cursus et lectus eu facilisis. Ut laoreet felis in magna dignissim feugiat.</p>
-        <p class="spectrum-Body2">Ut et lectus finibus, aliquet mauris eu, tincidunt mi. Donec scelerisque orci sit amet venenatis luctus. Morbi eget lacus est. Duis iaculis magna quis aliquam lacinia. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-
-        <h1 class="spectrum-Heading2">Lorem Ipsum Dolor</h1>
-        <p class="spectrum-Body2">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit. Sed finibus dapibus diam et sollicitudin. Phasellus in ipsum nec ante elementum congue eget in leo. Morbi eleifend justo non rutrum venenatis. Fusce cursus et lectus eu facilisis. Ut laoreet felis in magna dignissim feugiat.</p>
-        <p class="spectrum-Body2">Ut et lectus finibus, aliquet mauris eu, tincidunt mi. Donec scelerisque orci sit amet venenatis luctus. Morbi eget lacus est. Duis iaculis magna quis aliquam lacinia. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-
-
-        <h1 class="spectrum-Heading3">Lorem Ipsum Dolor</h1>
-        <p class="spectrum-Body3">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit. Sed finibus dapibus diam et sollicitudin. Phasellus in ipsum nec ante elementum congue eget in leo. Morbi eleifend justo non rutrum venenatis. Fusce cursus et lectus eu facilisis. Ut laoreet felis in magna dignissim feugiat.</p>
-        <p class="spectrum-Body3">Ut et lectus finibus, aliquet mauris eu, tincidunt mi. Donec scelerisque orci sit amet venenatis luctus. Morbi eget lacus est. Duis iaculis magna quis aliquam lacinia. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-
-
-        <h1 class="spectrum-Heading4">Lorem Ipsum Dolor</h1>
-        <p class="spectrum-Body4">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit. Sed finibus dapibus diam et sollicitudin. Phasellus in ipsum nec ante elementum congue eget in leo. Morbi eleifend justo non rutrum venenatis. Fusce cursus et lectus eu facilisis. Ut laoreet felis in magna dignissim feugiat.</p>
-        <p class="spectrum-Body4">Ut et lectus finibus, aliquet mauris eu, tincidunt mi. Donec scelerisque orci sit amet venenatis luctus. Morbi eget lacus est. Duis iaculis magna quis aliquam lacinia. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-
-
-        <h1 class="spectrum-Heading5">Lorem Ipsum Dolor</h1>
-        <p class="spectrum-Body5">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit. Sed finibus dapibus diam et sollicitudin. Phasellus in ipsum nec ante elementum congue eget in leo. Morbi eleifend justo non rutrum venenatis. Fusce cursus et lectus eu facilisis. Ut laoreet felis in magna dignissim feugiat.</p>
-        <p class="spectrum-Body5">Ut et lectus finibus, aliquet mauris eu, tincidunt mi. Donec scelerisque orci sit amet venenatis luctus. Morbi eget lacus est. Duis iaculis magna quis aliquam lacinia. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-
-
-        <h1 class="spectrum-Heading6">Lorem Ipsum Dolor</h1>
-        <p class="spectrum-Body5">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit. Sed finibus dapibus diam et sollicitudin. Phasellus in ipsum nec ante elementum congue eget in leo. Morbi eleifend justo non rutrum venenatis. Fusce cursus et lectus eu facilisis. Ut laoreet felis in magna dignissim feugiat.</p>
-        <p class="spectrum-Body5">Ut et lectus finibus, aliquet mauris eu, tincidunt mi. Donec scelerisque orci sit amet venenatis luctus. Morbi eget lacus est. Duis iaculis magna quis aliquam lacinia. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-
-        <h1 class="spectrum-Subheading">Lorem Ipsum Dolor</h1>
-        <p class="spectrum-Body4">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit. Sed finibus dapibus diam et sollicitudin. Phasellus in ipsum nec ante elementum congue eget in leo. Morbi eleifend justo non rutrum venenatis. Fusce cursus et lectus eu facilisis. Ut laoreet felis in magna dignissim feugiat.</p>
-        <p class="spectrum-Body4">Ut et lectus finibus, aliquet mauris eu, tincidunt mi. Donec scelerisque orci sit amet venenatis luctus. Morbi eget lacus est. Duis iaculis magna quis aliquam lacinia. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-        </div>
-      </div>
-  - id: heading-1
+  - id: heading-m
     name: Heading
-    description: Headings for typography.
+    status: Verified
+    description: |
+      Heading is used to create various levels of typographic hierarchies.
+
+      [View the Heading typography component](typography-heading.html)
     markup: |
-      <div class="spectrum">
-        <p class="spectrum-Heading1">Heading1 <em>Heading1 Emphasis</em> <strong>Heading1 Strong</strong>.</p>
-        <p class="spectrum-Heading2">Heading2 <em>Heading2 Emphasis</em> <strong>Heading2 Strong</strong>.</p>
-        <p class="spectrum-Heading3">Heading3 <em>Heading3 Emphasis</em> <strong>Heading3 Strong</strong>.</p>
-        <p class="spectrum-Heading4">Heading4 <em>Heading4 Emphasis</em> <strong>Heading4 Strong</strong>.</p>
-        <p class="spectrum-Heading5">Heading5 <em>Heading5 Emphasis</em> <strong>Heading5 Strong</strong>.</p>
-        <p class="spectrum-Subheading">Subheading <em>Subheading Emphasis</em> <strong>Subheading Strong</strong>.</p>
-      </div>
-      <br/>
-      <div class="spectrum-Article">
-        <p class="spectrum-Heading1">Article Heading1 <em>Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading2">Article Heading2 <em>Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading3">Article Heading3 <em>Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading4">Article Heading4 <em>Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading5">Article Heading5 <em>Emphasis</em> <strong>Strong</strong>.</p>
-      </div>
-  - id: heading-1
-    name: Heading (Strong)
-    description: Strong headings for typography.
-    markup: |
-      <div class="spectrum">
-        <p class="spectrum-Heading1--strong">Heading1 <em>Heading1 Emphasis</em> <strong>Heading1 Strong</strong>.</p>
-        <p class="spectrum-Heading2--strong">Heading2 <em>Heading2 Emphasis</em> <strong>Heading2 Strong</strong>.</p>
-      </div>
-      <br/>
-      <div class="spectrum-Article">
-        <p class="spectrum-Heading1--strong">Article Heading1 <em>Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading2--strong">Article Heading2 <em>Emphasis</em> <strong>Strong</strong>.</p>
-      </div>
-  - id: heading-1
-    name: Heading (Quiet)
-    description: Quiet headings for typography.
-    markup: |
-      <div class="spectrum">
-        <p class="spectrum-Heading1--quiet">Heading1 <em>Heading1 Emphasis</em> <strong>Heading1 Strong</strong>.</p>
-        <p class="spectrum-Heading2--quiet">Heading2 <em>Heading2 Emphasis</em> <strong>Heading2 Strong</strong>.</p>
-      </div>
-      <br/>
-      <div class="spectrum-Article">
-        <p class="spectrum-Heading1--quiet">Article Heading1 <em>Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading2--quiet">Article Heading2 <em>Emphasis</em> <strong>Strong</strong>.</p>
-      </div>
-  - id: heading-1
-    name: Display
-    description: Display headings for typography.
-    markup: |
-      <div class="spectrum">
-        <p class="spectrum-Heading1--display">Heading1 <em>Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading2--display">Heading2 <em>Emphasis</em> <strong>Strong</strong>.</p>
-      </div>
-      <br/>
-      <div class="spectrum-Article">
-        <p class="spectrum-Heading1--display">Article Heading1 <em>Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading2--display">Article Heading2 <em>Emphasis</em> <strong>Strong</strong>.</p>
-      </div>
-  - id: heading-1
-    name: Display (Strong)
-    description: Strong display headings for typography.
-    markup: |
-      <div class="spectrum">
-        <p class="spectrum-Heading1--display spectrum-Heading1--strong">Heading1 <em>Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading2--display spectrum-Heading2--strong">Heading2 <em>Emphasis</em> <strong>Strong</strong>.</p>
-      </div>
-  - id: heading-1
-    name: Display (Quiet)
-    description: Quiet display headings for typography.
-    markup: |
-      <div class="spectrum">
-        <p class="spectrum-Heading1--display spectrum-Heading1--quiet">Heading1 <em>Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading2--display spectrum-Heading2--quiet">Heading2 <em>Emphasis</em> <strong>Strong</strong>.</p>
-      </div>
-      <br/>
-      <div class="spectrum-Article">
-        <p class="spectrum-Heading1--display spectrum-Heading1--quiet">Article Heading1 <em>Emphasis</em> <strong>Strong</strong>.</p>
-        <p class="spectrum-Heading2--display spectrum-Heading2--quiet">Article Heading2 <em>Emphasis</em> <strong>Strong</strong>.</p>
-      </div>
-  - id: heading-1
+      <h1 class="spectrum-Heading spectrum-Heading--XXL">Hello world.</h1>
+  - id: body-m
     name: Body
-    description: Default body text sizes.
+    status: Verified
+    description: |
+      Body is primarily used for Spectrum components and for blocks of text.
+
+      [View the Body typography component](typography-body.html)
     markup: |
-      <div class="spectrum">
-        <p class="spectrum-Body1">Body1 Text <em>Body1 Emphasis</em> <strong>Body1 Strong</strong>.</p>
-        <p class="spectrum-Body2">Body2 text <em>Body2 Emphasis</em> <strong>Body2 Strong</strong>.</p>
-        <p class="spectrum-Body3">Body3 Text <em>Body3 Emphasis</em> <strong>Body3 Strong</strong>.</p>
-        <p class="spectrum-Body4">Body4 Text <em>Body4 Emphasis</em> <strong>Body4 Strong</strong>.</p>
-        <p class="spectrum-Body5">Body5 Text <em>Body5 Emphasis</em> <strong>Body5 Strong</strong>.</p>
-        <p class="spectrum-Detail">Detail Text <em>Detail Emphasis</em> <strong>Detail Strong</strong>.</p>
-      </div>
-      <br/>
-      <div class="spectrum-Article">
-        <p class="spectrum-Body1">Article Body1 Text <em>Article Body1 Emphasis</em> <strong>Article Body1 Strong</strong>.</p>
-        <p class="spectrum-Body2">Article Body2 text <em>Article Body2 Emphasis</em> <strong>Article Body2 Strong</strong>.</p>
-        <p class="spectrum-Body3">Article Body3 Text <em>Article Body3 Emphasis</em> <strong>Article Body3 Strong</strong>.</p>
-        <p class="spectrum-Body4">Article Body4 Text <em>Article Body4 Emphasis</em> <strong>Article Body4 Strong</strong>.</p>
-        <p class="spectrum-Body5">Article Body5 Text <em>Article Body5 Emphasis</em> <strong>Article Body5 Strong</strong>.</p>
-        <p class="spectrum-Detail">Detail Text <em>Detail Emphasis</em> <strong>Detail Strong</strong>.</p>
-      </div>
-  - id: heading-1
-    name: Article
-    description: Typography elements paired to display clear content hierarchies in long form articles.
+      <p class="spectrum-Body spectrum-Body--M">Spectrum is based on real-world situations.</p>
+  - id: detail-m
+    status: Verified
+    name: Detail
+    description: |
+      Detail is used for disclosing extra information or smaller items in hierarchical relationships of text.
+
+      [View the Detail typography component](typography-detail.html)
     markup: |
-      <div class="spectrum-Article">
-        <h1 class="spectrum-Heading1">Heading 1</h1>
-        <p class="spectrum-Body1">Body copy that pairs with heading 1</p>
-
-        <h2 class="spectrum-Heading2">Heading 2</h1>
-        <p class="spectrum-Body2">Body copy that pairs with heading 2</p>
-
-        <h3 class="spectrum-Heading3">Heading 3</h1>
-        <p class="spectrum-Body3">Body copy that pairs with heading 3</p>
-
-        <h4 class="spectrum-Heading4">Heading 4</h4>
-        <p class="spectrum-Body4">Body copy that pairs with heading 4</p>
-
-        <h5 class="spectrum-Heading5">Heading 5</h5>
-        <p class="spectrum-Body5">Body copy that pairs with heading 5</p>
-      </div>
-  - id: heading-1
+      <p class="spectrum-Detail spectrum-Detail--XL">Our recommendations</p>
+  - id: code-m
     name: Typography - Code
-    description: Typographic styles for computer code.
+    status: Verified
+    description: |
+      Code is used for text that represents code.
+
+      [View the Code typography component](typography-code.html)
     markup: |
-      <code class="spectrum-Code1">Code1 Text <strong>Strong</strong></code>
-      <code class="spectrum-Code2">Code2 Text <strong>Strong</strong></code>
-      <code class="spectrum-Code3">Code3 Text <strong>Strong</strong></code>
-      <code class="spectrum-Code4">Code4 Text <strong>Strong</strong></code>
-      <code class="spectrum-Code5">Code5 Text <strong>Strong</strong></code>
-      <pre><code class="spectrum-Code3">Code3 Text Wrapped in:
-      pre tags for
-      multiline
-      goodness</code></pre>
+      <code class="spectrum-Code spectrum-Code--S">alert("Hello world");</code>

--- a/site/includes/nav.pug
+++ b/site/includes/nav.pug
@@ -9,8 +9,12 @@
         a.spectrum-SideNav-itemLink(href='#') Components
         ul.spectrum-SideNav.spectrum-SideNav--multiLevel
           each component in nav
-            li.spectrum-SideNav-item(class=pageURL === component.href ? 'is-selected' : '')
-              a.spectrum-SideNav-itemLink.js-fastLoad(href=component.href)= component.name
+            unless component.hide
+              li.spectrum-SideNav-item(class=pageURL === component.href ? 'is-selected' : '')
+                a(class={
+                  'spectrum-SideNav-itemLink': true,
+                  'js-fastLoad': component.fastLoad != false
+                }, href=component.href)= component.name
 
   //- nav.spectrum-Site-bottomNav
   //-   ul.spectrum-SideNav

--- a/site/templates/siteComponent.pug
+++ b/site/templates/siteComponent.pug
@@ -131,8 +131,8 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
                 tr!= util.markdown.toHTML(component.details)
 
             div.spectrum-CSSComponent-resources
-              //-
-                a.spectrum-Card.spectrum-Card--small.spectrum-Card--horizontal(href=`${spectrumURL || 'https://spectrum.corp.adobe.com/'+pkg.name.split('/').pop()}` target="_blank")
+              if component.SpectrumSiteSlug
+                a.spectrum-Card.spectrum-Card--small.spectrum-Card--horizontal(href=`${component.SpectrumSiteSlug}` target="_blank")
                   .spectrum-Card-preview.spectrum-CSSComponent-resource--adobe
                     svg(class="spectrum-Icon spectrum-Icon--sizeL" viewBox="0 0 36 36" focusable="false" aria-hidden="true" aria-label="AdobeLogo")
                       path(d="M22.175 4H34v28L22.175 4zm-8.336 0H2v28L13.839 4zm4.165 10.317l7.538 17.682h-4.939l-2.258-5.632h-5.517l5.176-12.05z")
@@ -180,7 +180,7 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
             if examples.length
               header.spectrum-CSSComponent-sectionHeading(id="variants")
                 h4.spectrum-Heading3
-                  a(href="#variants").spectrum-BigSubtleLink Variants
+                  a(href="#variants").spectrum-BigSubtleLink=`${component.examplesHeading ? component.examplesHeading : 'Variants'}`
                 hr.spectrum-Rule.spectrum-Rule--large
               each example in examples
                 include ../includes/example.pug

--- a/tools/bundle-builder/docs/index.js
+++ b/tools/bundle-builder/docs/index.js
@@ -249,6 +249,8 @@ function buildSite_getData() {
     nav.push({
       name: componentData.name,
       component: componentName,
+      hide: componentData.hide,
+      fastLoad: componentData.fastLoad,
       href: fileName,
       description: componentData.description
     });


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->
This PR does the following:

* Fixes Typography's metadata status
* Fixes Typography's usage of heading level elements (i.e. `<h1>`)
* Fixed Typography's description text
* Removes duplicate Typography examples
* Hides deprecated Typography components from the dev site menu
* Adds a landing page for Typography, link to deprecated components
* Adds Spectrum site badge for verifying links are correct
* Adds the ability to change the  "Variants" section title in dev site
* Fixes incorrect Spectrum site link for ButtonGroup
* Hides Tool from dev site menu, link to Tool from Quiet Action Button

## How and where has this been tested?
 - **How this was tested:** `gulp dev`, use eyes
 - **Browser(s) and OS(s) this was tested with:** n/a

Docs are deployed here for your perusal: https://git.corp.adobe.com/pages/lawdavis/spectrum-css-typography/docs/typography.html

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->
![image](https://user-images.githubusercontent.com/201344/73975465-399f4b80-48db-11ea-9d6b-a35345a4f25c.png)


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
