### PR TITLE
Typography migration guide

### DIFF
--- a/components/site/index.css
+++ b/components/site/index.css
@@ -442,8 +442,6 @@ governing permissions and limitations under the License.
 
   border-radius: 0 0 var(--spectrum-cssexample-border-radius) var(--spectrum-cssexample-border-radius);
 
-  font-size: var(--spectrum-global-dimension-font-size-25);
-
   overflow: hidden;
 }
 

--- a/components/site/index.css
+++ b/components/site/index.css
@@ -362,16 +362,6 @@ governing permissions and limitations under the License.
   margin-bottom: var(--spectrum-global-dimension-size-300);
 }
 
-.spectrum-CSSComponent-resource--adobe {
-  color: rgb(255, 2, 1) !important;
-  background-color: var(--spectrum-global-color-gray-100) !important;
-}
-
-.spectrum-CSSComponent-resource--github {
-  background-color: rgba(0, 0, 0, 0.1) !important;
-  color: black;
-}
-
 .spectrum--dark,
 .spectrum--darkest {
   .spectrum-CSSComponent-resource--github {

--- a/components/site/skin.css
+++ b/components/site/skin.css
@@ -99,3 +99,7 @@ governing permissions and limitations under the License.
   background: rgba(0,0,0,0.4);
   color: rgba(0,0,0,0.4);
 }
+
+.spectrum-CSSExample-oldAPI {
+  color: var(--spectrum-semantic-negative-color-text-small);
+}

--- a/components/site/skin.css
+++ b/components/site/skin.css
@@ -50,6 +50,16 @@ governing permissions and limitations under the License.
   background: var(--spectrum-site-overlay-underlay-background-color);
 }
 
+.spectrum-CSSComponent-resource--github {
+  background-color: rgba(0, 0, 0, 0.1) !important;
+  color: black;
+}
+
+.spectrum-CSSComponent-resource--adobe {
+  color: rgb(255, 2, 1) !important;
+  background-color: var(--spectrum-global-color-gray-100) !important;
+}
+
 /* Scrollable */
 .u-scrollable::-webkit-scrollbar-track,
 .u-scrollable::-webkit-scrollbar-track-piece {

--- a/components/typography/metadata/typography.yml
+++ b/components/typography/metadata/typography.yml
@@ -43,3 +43,69 @@ examples:
       [View the Code typography component](typography-code.html)
     markup: |
       <code class="spectrum-Code spectrum-Code--S">alert("Hello world");</code>
+  - id: migrating-typography
+    status: Verified
+    name: Migrating from deprecated Typography
+    description: |
+      See the table below to reference what will need to change when migrating to the new Typography API. Cells with a dash indicate the typography style did not exist in the previous API.
+
+      Note that all instances of typography now require the component class in addition to the modifier class. For example, to get a large Heading, you will need the `.spectrum-Heading--L` modifier class as well as the `.spectrum-Heading` component class.
+
+      #### Heading
+
+      | Deprecated Classname                                    | New Classname                                                      |
+      | ------------------------------------------------------- | ------------------------------------------------------------------ |
+      | `~.spectrum-Heading1--display`                           | `.spectrum-Heading.spectrum-Heading--XXXL`                         |
+      | `~.spectrum-Heading1--display.spectrum-Heading1--quiet`  | `.spectrum-Heading.spectrum-Heading--XXXL.spectrum-Heading--light` |
+      | `~.spectrum-Heading1--display.spectrum-Heading1--strong` | `.spectrum-Heading.spectrum-Heading--XXXL.spectrum-Heading--heavy` |
+      | `~.spectrum-Heading2--display`                           | `.spectrum-Heading.spectrum-Heading-XXL`                           |
+      | `~.spectrum-Heading2--display.spectrum-Heading2--quiet`  | `.spectrum-Heading.spectrum-Heading--XXL.spectrum-Heading--light`  |
+      | `~.spectrum-Heading2--display.spectrum-Heading2--strong` | `.spectrum-Heading.spectrum-Heading--XXL.spectrum-Heading--heavy`  |
+      | `~.spectrum-Heading1`                                    | `.spectrum-Heading.spectrum-Heading-XL`                            |
+      | `~.spectrum-Heading1--quiet`                             | `.spectrum-Heading.spectrum-Heading--XL.spectrum-Heading--light`   |
+      | `~.spectrum-Heading1--strong`                            | `.spectrum-Heading.spectrum-Heading--XL.spectrum-Heading--heavy`   |
+      | `~.spectrum-Heading2`                                    | `.spectrum-Heading.spectrum-Heading-L`                             |
+      | `~.spectrum-Heading1--quiet`                             | `.spectrum-Heading.spectrum-Heading--L.spectrum-Heading--light`    |
+      | `~.spectrum-Heading2--strong`                            | `.spectrum-Heading.spectrum-Heading--L.spectrum-Heading--heavy`    |
+      | `~.spectrum-Heading3`                                    | `.spectrum-Heading.spectrum-Heading--M`                            |
+      | `~.spectrum-Heading4`                                    | `.spectrum-Heading.spectrum-Heading--S`                            |
+      | `~.spectrum-Heading5`                                    | `.spectrum-Heading.spectrum-Heading--XS`                           |
+      | `~.spectrum-Heading6`                                    | `.spectrum-Heading.spectrum-Heading--XXS`                          |
+
+
+      #### Body
+
+      | Deprecated Classname | New Classname                        |
+      | -------------------- | ------------------------------------ |
+      | -                    | `.spectrum-Body.spectrum-Body--XXXL` |
+      | -                    | `.spectrum-Body.spectrum-Body--XXL`  |
+      | `~.spectrum-Body1`    | `.spectrum-Body.spectrum-Body--XL`   |
+      | `~.spectrum-Body2`    | `.spectrum-Body.spectrum-Body--L`    |
+      | `~.spectrum-Body3`    | `.spectrum-Body.spectrum-Body--M`    |
+      | `~.spectrum-Body4`    | `.spectrum-Body.spectrum-Body--S`    |
+      | `~.spectrum-Body5`    | `.spectrum-Body.spectrum-Body--XS`   |
+
+
+      #### Detail
+
+      | Deprecated Classname   | New Classname                                 |
+      | ---------------------- | --------------------------------------------- |
+      | -                      | `.spectrum-Detail--XL`                        |
+      | -                      | `.spectrum-Detail--XL.spectrum-Detail--light` |
+      | -                      | `.spectrum-Detail--L`                         |
+      | -                      | `.spectrum-Detail--L.spectrum-Detail--light`  |
+      | -                      | `.spectrum-Detail--M`                         |
+      | -                      | `.spectrum-Detail--M.spectrum-Detail--light`  |
+      | `~.spectrum-Subheading` | `.spectrum-Detail--S`                         |
+      | `~.spectrum-Detail`     | `.spectrum-Detail--S.spectrum-Detail--light`  |
+
+
+      #### Code
+
+      | Deprecated Classname | New Classname       |
+      | -------------------- | ------------------- |
+      | `~.spectrum-Code-1`   | `.spectrum-Code--XL`|
+      | `~.spectrum-Code-2`   | `.spectrum-Code--L` |
+      | `~.spectrum-Code-3`   | `.spectrum-Code--M` |
+      | `~.spectrum-Code-4`   | `.spectrum-Code--S` |
+      | `~.spectrum-Code-5`   | `.spectrum-Code--XS`|

--- a/components/typography/metadata/typography.yml
+++ b/components/typography/metadata/typography.yml
@@ -43,15 +43,23 @@ examples:
       [View the Code typography component](typography-code.html)
     markup: |
       <code class="spectrum-Code spectrum-Code--S">alert("Hello world");</code>
-  - id: migrating-typography
-    status: Verified
-    name: Migrating from deprecated Typography
+sections:
+  - name: Applying margins
+    description: |
+      By default, Typography components do not include outer margins. If you would like to add margins, simply add the `.spectrum-Typography` class to your container, and every typography component inside of your container will have the correct margins.
+    markup: |
+      <div class="spectrum-Typography">
+        <h1 class="spectrum-Heading spectrum-Heading--XL">Aliquet Mauris Eu</h1>
+        <p class="spectrum-Body spectrum-Body--XL">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit. Sed finibus dapibus diam et sollicitudin. Phasellus in ipsum nec ante elementum congue eget in leo. Morbi eleifend justo non rutrum venenatis. Fusce cursus et lectus eu facilisis. Ut laoreet felis in magna dignissim feugiat.</p>
+      </div>
+
+  - name: Migrating from deprecated Typography
     description: |
       See the table below to reference what will need to change when migrating to the new Typography API. Cells with a dash indicate the typography style did not exist in the previous API.
 
       Note that all instances of typography now require the component class in addition to the modifier class. For example, to get a large Heading, you will need the `.spectrum-Heading--L` modifier class as well as the `.spectrum-Heading` component class.
 
-      #### Heading
+      ### Heading
 
       | Deprecated Classname                                    | New Classname                                                      |
       | ------------------------------------------------------- | ------------------------------------------------------------------ |
@@ -73,7 +81,7 @@ examples:
       | `~.spectrum-Heading6`                                    | `.spectrum-Heading.spectrum-Heading--XXS`                          |
 
 
-      #### Body
+      ### Body
 
       | Deprecated Classname | New Classname                        |
       | -------------------- | ------------------------------------ |
@@ -86,7 +94,7 @@ examples:
       | `~.spectrum-Body5`    | `.spectrum-Body.spectrum-Body--XS`   |
 
 
-      #### Detail
+      ### Detail
 
       | Deprecated Classname   | New Classname                                 |
       | ---------------------- | --------------------------------------------- |
@@ -100,7 +108,7 @@ examples:
       | `~.spectrum-Detail`     | `.spectrum-Detail--S.spectrum-Detail--light`  |
 
 
-      #### Code
+      ### Code
 
       | Deprecated Classname | New Classname       |
       | -------------------- | ------------------- |

--- a/components/typography/metadata/typography.yml
+++ b/components/typography/metadata/typography.yml
@@ -61,59 +61,59 @@ sections:
 
       ### Heading
 
-      | Deprecated Classname                                    | New Classname                                                      |
-      | ------------------------------------------------------- | ------------------------------------------------------------------ |
-      | `~.spectrum-Heading1--display`                           | `.spectrum-Heading.spectrum-Heading--XXXL`                         |
-      | `~.spectrum-Heading1--display.spectrum-Heading1--quiet`  | `.spectrum-Heading.spectrum-Heading--XXXL.spectrum-Heading--light` |
-      | `~.spectrum-Heading1--display.spectrum-Heading1--strong` | `.spectrum-Heading.spectrum-Heading--XXXL.spectrum-Heading--heavy` |
-      | `~.spectrum-Heading2--display`                           | `.spectrum-Heading.spectrum-Heading-XXL`                           |
-      | `~.spectrum-Heading2--display.spectrum-Heading2--quiet`  | `.spectrum-Heading.spectrum-Heading--XXL.spectrum-Heading--light`  |
-      | `~.spectrum-Heading2--display.spectrum-Heading2--strong` | `.spectrum-Heading.spectrum-Heading--XXL.spectrum-Heading--heavy`  |
-      | `~.spectrum-Heading1`                                    | `.spectrum-Heading.spectrum-Heading-XL`                            |
-      | `~.spectrum-Heading1--quiet`                             | `.spectrum-Heading.spectrum-Heading--XL.spectrum-Heading--light`   |
-      | `~.spectrum-Heading1--strong`                            | `.spectrum-Heading.spectrum-Heading--XL.spectrum-Heading--heavy`   |
-      | `~.spectrum-Heading2`                                    | `.spectrum-Heading.spectrum-Heading-L`                             |
-      | `~.spectrum-Heading1--quiet`                             | `.spectrum-Heading.spectrum-Heading--L.spectrum-Heading--light`    |
-      | `~.spectrum-Heading2--strong`                            | `.spectrum-Heading.spectrum-Heading--L.spectrum-Heading--heavy`    |
-      | `~.spectrum-Heading3`                                    | `.spectrum-Heading.spectrum-Heading--M`                            |
-      | `~.spectrum-Heading4`                                    | `.spectrum-Heading.spectrum-Heading--S`                            |
-      | `~.spectrum-Heading5`                                    | `.spectrum-Heading.spectrum-Heading--XS`                           |
-      | `~.spectrum-Heading6`                                    | `.spectrum-Heading.spectrum-Heading--XXS`                          |
+      | Deprecated Classname                                      | New Classname                                                      |
+      | --------------------------------------------------------- | ------------------------------------------------------------------ |
+      | `~.spectrum-Heading1--display~`                           | `.spectrum-Heading.spectrum-Heading--XXXL`                         |
+      | `~.spectrum-Heading1--display.spectrum-Heading1--quiet~`  | `.spectrum-Heading.spectrum-Heading--XXXL.spectrum-Heading--light` |
+      | `~.spectrum-Heading1--display.spectrum-Heading1--strong~` | `.spectrum-Heading.spectrum-Heading--XXXL.spectrum-Heading--heavy` |
+      | `~.spectrum-Heading2--display~`                           | `.spectrum-Heading.spectrum-Heading-XXL`                           |
+      | `~.spectrum-Heading2--display.spectrum-Heading2--quiet~`  | `.spectrum-Heading.spectrum-Heading--XXL.spectrum-Heading--light`  |
+      | `~.spectrum-Heading2--display.spectrum-Heading2--strong~` | `.spectrum-Heading.spectrum-Heading--XXL.spectrum-Heading--heavy`  |
+      | `~.spectrum-Heading1~`                                    | `.spectrum-Heading.spectrum-Heading-XL`                            |
+      | `~.spectrum-Heading1--quiet~`                             | `.spectrum-Heading.spectrum-Heading--XL.spectrum-Heading--light`   |
+      | `~.spectrum-Heading1--strong~`                            | `.spectrum-Heading.spectrum-Heading--XL.spectrum-Heading--heavy`   |
+      | `~.spectrum-Heading2~`                                    | `.spectrum-Heading.spectrum-Heading-L`                             |
+      | `~.spectrum-Heading1--quiet~`                             | `.spectrum-Heading.spectrum-Heading--L.spectrum-Heading--light`    |
+      | `~.spectrum-Heading2--strong~`                            | `.spectrum-Heading.spectrum-Heading--L.spectrum-Heading--heavy`    |
+      | `~.spectrum-Heading3~`                                    | `.spectrum-Heading.spectrum-Heading--M`                            |
+      | `~.spectrum-Heading4~`                                    | `.spectrum-Heading.spectrum-Heading--S`                            |
+      | `~.spectrum-Heading5~`                                    | `.spectrum-Heading.spectrum-Heading--XS`                           |
+      | `~.spectrum-Heading6~`                                    | `.spectrum-Heading.spectrum-Heading--XXS`                          |
 
 
       ### Body
 
-      | Deprecated Classname | New Classname                        |
-      | -------------------- | ------------------------------------ |
-      | -                    | `.spectrum-Body.spectrum-Body--XXXL` |
-      | -                    | `.spectrum-Body.spectrum-Body--XXL`  |
-      | `~.spectrum-Body1`    | `.spectrum-Body.spectrum-Body--XL`   |
-      | `~.spectrum-Body2`    | `.spectrum-Body.spectrum-Body--L`    |
-      | `~.spectrum-Body3`    | `.spectrum-Body.spectrum-Body--M`    |
-      | `~.spectrum-Body4`    | `.spectrum-Body.spectrum-Body--S`    |
-      | `~.spectrum-Body5`    | `.spectrum-Body.spectrum-Body--XS`   |
+      | Deprecated Classname   | New Classname                        |
+      | ---------------------- | ------------------------------------ |
+      | -                      | `.spectrum-Body.spectrum-Body--XXXL` |
+      | -                      | `.spectrum-Body.spectrum-Body--XXL`  |
+      | `~.spectrum-Body1~`    | `.spectrum-Body.spectrum-Body--XL`   |
+      | `~.spectrum-Body2~`    | `.spectrum-Body.spectrum-Body--L`    |
+      | `~.spectrum-Body3~`    | `.spectrum-Body.spectrum-Body--M`    |
+      | `~.spectrum-Body4~`    | `.spectrum-Body.spectrum-Body--S`    |
+      | `~.spectrum-Body5~`    | `.spectrum-Body.spectrum-Body--XS`   |
 
 
       ### Detail
 
-      | Deprecated Classname   | New Classname                                 |
-      | ---------------------- | --------------------------------------------- |
-      | -                      | `.spectrum-Detail--XL`                        |
-      | -                      | `.spectrum-Detail--XL.spectrum-Detail--light` |
-      | -                      | `.spectrum-Detail--L`                         |
-      | -                      | `.spectrum-Detail--L.spectrum-Detail--light`  |
-      | -                      | `.spectrum-Detail--M`                         |
-      | -                      | `.spectrum-Detail--M.spectrum-Detail--light`  |
-      | `~.spectrum-Subheading` | `.spectrum-Detail--S`                         |
-      | `~.spectrum-Detail`     | `.spectrum-Detail--S.spectrum-Detail--light`  |
+      | Deprecated Classname     | New Classname                                 |
+      | ------------------------ | --------------------------------------------- |
+      | -                        | `.spectrum-Detail--XL`                        |
+      | -                        | `.spectrum-Detail--XL.spectrum-Detail--light` |
+      | -                        | `.spectrum-Detail--L`                         |
+      | -                        | `.spectrum-Detail--L.spectrum-Detail--light`  |
+      | -                        | `.spectrum-Detail--M`                         |
+      | -                        | `.spectrum-Detail--M.spectrum-Detail--light`  |
+      | `~.spectrum-Subheading~` | `.spectrum-Detail--S`                         |
+      | `~.spectrum-Detail~`     | `.spectrum-Detail--S.spectrum-Detail--light`  |
 
 
       ### Code
 
       | Deprecated Classname | New Classname       |
       | -------------------- | ------------------- |
-      | `~.spectrum-Code-1`   | `.spectrum-Code--XL`|
-      | `~.spectrum-Code-2`   | `.spectrum-Code--L` |
-      | `~.spectrum-Code-3`   | `.spectrum-Code--M` |
-      | `~.spectrum-Code-4`   | `.spectrum-Code--S` |
-      | `~.spectrum-Code-5`   | `.spectrum-Code--XS`|
+      | `~.spectrum-Code-1~` | `.spectrum-Code--XL`|
+      | `~.spectrum-Code-2~` | `.spectrum-Code--L` |
+      | `~.spectrum-Code-3~` | `.spectrum-Code--M` |
+      | `~.spectrum-Code-4~` | `.spectrum-Code--S` |
+      | `~.spectrum-Code-5~` | `.spectrum-Code--XS`|

--- a/components/typography/metadata/typography.yml
+++ b/components/typography/metadata/typography.yml
@@ -35,7 +35,7 @@ examples:
     markup: |
       <p class="spectrum-Detail spectrum-Detail--XL">Our recommendations</p>
   - id: code-m
-    name: Typography - Code
+    name: Code
     status: Verified
     description: |
       Code is used for text that represents code.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -175,6 +175,8 @@ exports.devHeavy = gulp.series(
   exports.devHeavy
 );
 
+exports.buildDocs = builder.buildDocs;
+
 exports.releaseBundles = releaseBundles;
 
 exports.prepare = site.copySiteResources;

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "lerna": "^3.16.4",
     "loadicons": "^1.0.0",
     "lunr": "^2.3.6",
-    "markdown": "^0.5.0",
     "prismjs": "^1.17.1",
     "semver": "^6.3.0",
     "through2": "^3.0.1"
@@ -72,5 +71,8 @@
     "hooks": {
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
     }
+  },
+  "dependencies": {
+    "markdown-it": "^10.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "lerna": "^3.16.4",
     "loadicons": "^1.0.0",
     "lunr": "^2.3.6",
+    "markdown-it": "^10.0.0",
     "prismjs": "^1.17.1",
     "semver": "^6.3.0",
     "through2": "^3.0.1"
@@ -71,8 +72,5 @@
     "hooks": {
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
     }
-  },
-  "dependencies": {
-    "markdown-it": "^10.0.0"
   }
 }

--- a/site/getting-started.pug
+++ b/site/getting-started.pug
@@ -17,8 +17,8 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
 
         .spectrum-Site-mainContainer
           .spectrum-Site-page
-            h1.spectrum-Heading1 Getting Started
-              p.spectrum-Body2 Please see the #[a(href="https://github.com/adobe/spectrum-css/blob/master/.github/CONTRIBUTING.md" target="_blank") contributing document] and #[a(href="https://github.com/adobe/spectrum-css" target="_blank") project documentation] for information on how to get started with Spectrum CSS.
+            h1.spectrum-Heading.spectrum-Heading--XL Getting Started
+              p.spectrum-Body.spectrum-Body--L Please see the #[a(href="https://github.com/adobe/spectrum-css/blob/master/.github/CONTRIBUTING.md" target="_blank") contributing document] and #[a(href="https://github.com/adobe/spectrum-css" target="_blank") project documentation] for information on how to get started with Spectrum CSS.
 
             include includes/footer.pug
 

--- a/site/includes/example.pug
+++ b/site/includes/example.pug
@@ -4,19 +4,4 @@ article.spectrum-CSSExample
       =example.name
     div(class=`spectrum-StatusLight spectrum-CSSExample-status spectrum-StatusLight--${util.getStatusLightVariant(example.status)}`)= example.status
 
-  if example.description
-    .spectrum-Typography
-      section.spectrum-CSSExample-description.spectrum-Body.spectrum-Body--M!= util.markdown.render(example.description)
-
-  if example.details
-    .spectrum-Typography
-      .section.spectrum-CSSExample-description.spectrum-Body.spectrum-Body--M!= util.markdown.render(example.details)
-
-  if example.markup
-    section.spectrum-CSSExample-container
-      .spectrum-CSSExample-example(class=example.demoClassName ? `${example.demoClassName}` : '')!= example.markup
-      .spectrum-CSSExample-markup.spectrum-Code.spectrum-Code--XS
-        if example.markup.split('\n').length > 2
-          a.js-markup-toggle.spectrum-CSSExample-markupToggle.spectrum-Link(href="#") Show markup
-        pre
-          code.language-markup!= util.Prism.highlight(example.markup, util.Prism.languages.markup, 'markup')
+  include exampleContent.pug

--- a/site/includes/example.pug
+++ b/site/includes/example.pug
@@ -1,14 +1,16 @@
-article.spectrum-CSSExample.spectrum-Typography
+article.spectrum-CSSExample
   h3.spectrum-CSSExample-heading.spectrum-Heading.spectrum-Heading--S(id=example.slug)
     a(href=`#${example.slug}`).spectrum-CSSComponent-link
       =example.name
     div(class=`spectrum-StatusLight spectrum-CSSExample-status spectrum-StatusLight--${util.getStatusLightVariant(example.status)}`)= example.status
 
   if example.description
-    section.spectrum-CSSExample-description.spectrum-Body.spectrum-Body--M!= util.markdown.render(example.description)
+    .spectrum-Typography
+      section.spectrum-CSSExample-description.spectrum-Body.spectrum-Body--M!= util.markdown.render(example.description)
 
   if example.details
-    .section.spectrum-CSSExample-description.spectrum-Body.spectrum-Body--M!= util.markdown.render(example.details)
+    .spectrum-Typography
+      .section.spectrum-CSSExample-description.spectrum-Body.spectrum-Body--M!= util.markdown.render(example.details)
 
   if example.markup
     section.spectrum-CSSExample-container

--- a/site/includes/example.pug
+++ b/site/includes/example.pug
@@ -1,14 +1,14 @@
-article.spectrum-CSSExample
+article.spectrum-CSSExample.spectrum-Typography
   h3.spectrum-CSSExample-heading.spectrum-Heading.spectrum-Heading--S(id=example.slug)
     a(href=`#${example.slug}`).spectrum-CSSComponent-link
       =example.name
     div(class=`spectrum-StatusLight spectrum-CSSExample-status spectrum-StatusLight--${util.getStatusLightVariant(example.status)}`)= example.status
 
   if example.description
-    section.spectrum-CSSExample-description.spectrum-Body.spectrum-Body--M!= util.markdown.toHTML(example.description)
+    section.spectrum-CSSExample-description.spectrum-Body.spectrum-Body--M!= util.markdown.render(example.description)
 
   if example.details
-    .section.spectrum-CSSExample-description.spectrum-Body.spectrum-Body--M!= util.markdown.toHTML(example.details)
+    .section.spectrum-CSSExample-description.spectrum-Body.spectrum-Body--M!= util.markdown.render(example.details)
 
   if example.markup
     section.spectrum-CSSExample-container

--- a/site/includes/example.pug
+++ b/site/includes/example.pug
@@ -13,7 +13,7 @@ article.spectrum-CSSExample.spectrum-Typography
   if example.markup
     section.spectrum-CSSExample-container
       .spectrum-CSSExample-example(class=example.demoClassName ? `${example.demoClassName}` : '')!= example.markup
-      .spectrum-CSSExample-markup
+      .spectrum-CSSExample-markup.spectrum-Code.spectrum-Code--XS
         if example.markup.split('\n').length > 2
           a.js-markup-toggle.spectrum-CSSExample-markupToggle.spectrum-Link(href="#") Show markup
         pre

--- a/site/includes/example.pug
+++ b/site/includes/example.pug
@@ -1,14 +1,14 @@
 article.spectrum-CSSExample
-  h5.spectrum-CSSExample-heading.spectrum-Heading4(id=example.slug)
+  h3.spectrum-CSSExample-heading.spectrum-Heading.spectrum-Heading--S(id=example.slug)
     a(href=`#${example.slug}`).spectrum-CSSComponent-link
       =example.name
     div(class=`spectrum-StatusLight spectrum-CSSExample-status spectrum-StatusLight--${util.getStatusLightVariant(example.status)}`)= example.status
 
   if example.description
-    section.spectrum-CSSExample-description.spectrum-Body3!= util.markdown.toHTML(example.description)
+    section.spectrum-CSSExample-description.spectrum-Body.spectrum-Body--M!= util.markdown.toHTML(example.description)
 
   if example.details
-    .section.spectrum-CSSExample-description.spectrum-Body3!= util.markdown.toHTML(example.details)
+    .section.spectrum-CSSExample-description.spectrum-Body.spectrum-Body--M!= util.markdown.toHTML(example.details)
 
   if example.markup
     section.spectrum-CSSExample-container

--- a/site/includes/exampleContent.pug
+++ b/site/includes/exampleContent.pug
@@ -1,0 +1,16 @@
+if example.description
+  .spectrum-Typography
+    section.spectrum-CSSExample-description.spectrum-Body.spectrum-Body--M!= util.markdown.render(example.description)
+
+if example.details
+  .spectrum-Typography
+    .section.spectrum-CSSExample-description.spectrum-Body.spectrum-Body--M!= util.markdown.render(example.details)
+
+if example.markup
+  section.spectrum-CSSExample-container
+    .spectrum-CSSExample-example(class=example.demoClassName ? `${example.demoClassName}` : '')!= example.markup
+    .spectrum-CSSExample-markup.spectrum-Code.spectrum-Code--XS
+      if example.markup.split('\n').length > 2
+        a.js-markup-toggle.spectrum-CSSExample-markupToggle.spectrum-Link(href="#") Show markup
+      pre
+        code.language-markup!= util.Prism.highlight(example.markup, util.Prism.languages.markup, 'markup')

--- a/site/includes/section.pug
+++ b/site/includes/section.pug
@@ -1,0 +1,8 @@
+header.spectrum-CSSComponent-sectionHeading(id=`${util.getSlug(section.name)}`)
+  h2.spectrum-Heading.spectrum-Heading--M
+    a(href=`#${util.getSlug(section.name)}`).spectrum-BigSubtleLink=`${section.name}`
+  hr.spectrum-Rule.spectrum-Rule--large
+
+  -
+    let example = section;
+  include exampleContent.pug

--- a/site/includes/sidebar.pug
+++ b/site/includes/sidebar.pug
@@ -4,7 +4,7 @@
       polygon(points="19,0 30,0 30,26")
       polygon(points="11.1,0 0,0 0,26")
       polygon(points="15,9.6 22.1,26 17.5,26 15.4,20.8 10.2,20.8")
-    h2.spectrum-Site-title.spectrum-Heading3 Spectrum CSS
+    h2.spectrum-Site-title.spectrum-Heading.spectrum-Heading--M Spectrum CSS
 
   div#site-search
 

--- a/site/index.pug
+++ b/site/index.pug
@@ -18,9 +18,9 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
         .spectrum-Site-mainContainer
           .spectrum-Site-page
             .spectrum-Site-hero
-              .spectrum-Article.spectrum-Site-heroHeading
-                h1.spectrum-Heading1--display Meet Spectrum CSS
-              p.spectrum-Body1 The CSS implementation of Adobe’s design system.
+              .spectrum-Site-heroHeading
+                h1.spectrum-Heading.spectrum-Heading--XXXL.spectrum-Heading--serif Meet Spectrum CSS
+              p.spectrum-Body.spectrum-Body--XL The CSS implementation of Adobe’s design system.
               img.spectrum-Site-heroImage(src='img/spectrum_illustration_2x.png', alt='Spectrum Illustration')
 
             include includes/footer.pug

--- a/site/templates/individualComponent.pug
+++ b/site/templates/individualComponent.pug
@@ -85,7 +85,7 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
         p.spectrum-CSSComponent-version.spectrum-Body.spectrum-Body--S Version #{pkg.version}
 
       if component.description
-        section.spectrum-CSSComponent-description.spectrum-Body.spectrum-Body--L!= util.markdown.toHTML(component.description)
+        section.spectrum-CSSComponent-description.spectrum-Body.spectrum-Body--L!= util.markdown.render(component.description)
 
       each example in examples
         article.spectrum-CSSExample
@@ -94,7 +94,7 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
               h3.spectrum-CSSExample-heading.spectrum-Heading.spectrum-Heading--S #{example.name}
 
             if example.description
-              section.spectrum-CSSExample-description.spectrum-Body.spectrum-Body--L!= util.markdown.toHTML(example.description)
+              section.spectrum-CSSExample-description.spectrum-Body.spectrum-Body--L!= util.markdown.render(example.description)
 
           if example.markup
 

--- a/site/templates/individualComponent.pug
+++ b/site/templates/individualComponent.pug
@@ -80,21 +80,21 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
     article.spectrum-CSSComponent
 
       header(id=component.slug).spectrum-CSSComponent-heading
-        a(href=`#${component.slug}`).spectrum-BigSubtleLink.spectrum-CSSComponent-title.spectrum-Article
-          h2.spectrum-Heading1--display #{component.name}
-        .spectrum-CSSComponent-version.spectrum-Body Version #{pkg.version}
+        h1.spectrum-CSSComponent-title.spectrum-Heading.spectrum-Heading--XXXL.spectrum-Heading--serif
+          a(href=`#${component.slug}`).spectrum-BigSubtleLink #{component.name}
+        p.spectrum-CSSComponent-version.spectrum-Body.spectrum-Body--S Version #{pkg.version}
 
       if component.description
-        section.spectrum-CSSComponent-description.spectrum-Body2!= util.markdown.toHTML(component.description)
+        section.spectrum-CSSComponent-description.spectrum-Body.spectrum-Body--L!= util.markdown.toHTML(component.description)
 
       each example in examples
         article.spectrum-CSSExample
           if example != component
             header(id=example.slug)
-              h4.spectrum-Heading--subtitle3 #{example.name}
+              h3.spectrum-CSSExample-heading.spectrum-Heading.spectrum-Heading--S #{example.name}
 
             if example.description
-              section.spectrum-CSSExample-description.spectrum-Body2!= util.markdown.toHTML(example.description)
+              section.spectrum-CSSExample-description.spectrum-Body.spectrum-Body--L!= util.markdown.toHTML(example.description)
 
           if example.markup
 

--- a/site/templates/siteComponent.pug
+++ b/site/templates/siteComponent.pug
@@ -111,7 +111,7 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
                           use(xlink:href='#spectrum-css-icon-CheckmarkMedium')
 
             header(id=component.slug).spectrum-CSSComponent-heading
-              h2.spectrum-CSSComponent-title.spectrum-Article.spectrum-Heading1--display
+              h1.spectrum-CSSComponent-title.spectrum-Heading.spectrum-Heading--XXXL.spectrum-Heading--serif
                 a(href=`#${component.slug}`).spectrum-BigSubtleLink #{component.name}
 
             table.spectrum-CSSComponent-detailsTable
@@ -171,15 +171,15 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
 
             if component.description
               header.spectrum-CSSComponent-sectionHeading(id="usage")
-                h4.spectrum-Heading3
+                h2.spectrum-Heading.spectrum-Heading--M
                   a(href="#usage").spectrum-BigSubtleLink Usage notes
                 hr.spectrum-Rule.spectrum-Rule--large
               section.spectrum-CSSComponent-description
-                div.spectrum-Body3!= util.markdown.toHTML(component.description)
+                div.spectrum-Body.spectrum-Body--M!= util.markdown.toHTML(component.description)
 
             if examples.length
               header.spectrum-CSSComponent-sectionHeading(id="variants")
-                h4.spectrum-Heading3
+                h2.spectrum-Heading.spectrum-Heading--M
                   a(href="#variants").spectrum-BigSubtleLink=`${component.examplesHeading ? component.examplesHeading : 'Variants'}`
                 hr.spectrum-Rule.spectrum-Rule--large
               each example in examples

--- a/site/templates/siteComponent.pug
+++ b/site/templates/siteComponent.pug
@@ -185,6 +185,10 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
               each example in examples
                 include ../includes/example.pug
 
+            if component.sections
+              each section in component.sections
+                include ../includes/section.pug
+
             include ../includes/footer.pug
 
     include ../includes/pageBottom.pug

--- a/site/templates/siteComponent.pug
+++ b/site/templates/siteComponent.pug
@@ -128,7 +128,7 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
             if component.details
               tr
                 th Details
-                tr!= util.markdown.toHTML(component.details)
+                tr!= util.markdown.render(component.details)
 
             div.spectrum-CSSComponent-resources
               if component.SpectrumSiteSlug
@@ -175,7 +175,7 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
                   a(href="#usage").spectrum-BigSubtleLink Usage notes
                 hr.spectrum-Rule.spectrum-Rule--large
               section.spectrum-CSSComponent-description
-                div.spectrum-Body.spectrum-Body--M!= util.markdown.toHTML(component.description)
+                div.spectrum-Body.spectrum-Body--M!= util.markdown.render(component.description)
 
             if examples.length
               header.spectrum-CSSComponent-sectionHeading(id="variants")

--- a/site/truncation.pug
+++ b/site/truncation.pug
@@ -32,10 +32,10 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
         .spectrum-Site-mainContainer
           .spectrum-Site-page.spectrum-Typography
 
-            h1.spectrum-Heading1 A study of truncation across a number of components
+            h1.spectrum-Heading.spectrum-Heading--XL A study of truncation across a number of components
 
             article.spectrum-CSSExample
-              h5.spectrum-CSSExample-heading.spectrum-Heading4 Action Button (truncated)
+              h5.spectrum-CSSExample-heading.spectrum-Heading.spectrum-Heading--S Action Button (truncated)
               section.spectrum-CSSExample-container
                 .spectrum-CSSExample-example
                   <button class="spectrum-ActionButton" style="width: 128px">
@@ -43,7 +43,7 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
                   </button>
 
             article.spectrum-CSSExample
-              h5.spectrum-CSSExample-heading.spectrum-Heading4 Action Button with Icon (truncated)
+              h5.spectrum-CSSExample-heading.spectrum-Heading.spectrum-Heading--S Action Button with Icon (truncated)
               section.spectrum-CSSExample-container
                 .spectrum-CSSExample-example
                   <button class="spectrum-ActionButton" style="width: 128px">
@@ -54,7 +54,7 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
                   </button>
 
             article.spectrum-CSSExample
-              h5.spectrum-CSSExample-heading.spectrum-Heading4 Action Button (truncated)
+              h5.spectrum-CSSExample-heading.spectrum-Heading.spectrum-Heading--S Action Button (truncated)
               section.spectrum-CSSExample-container
                 .spectrum-CSSExample-example
                   <button class="spectrum-ActionButton spectrum-ActionButton--quiet" style="width: 128px">
@@ -62,7 +62,7 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
                   </button>
 
             article.spectrum-CSSExample
-              h5.spectrum-CSSExample-heading.spectrum-Heading4 Action Button with Icon (truncated)
+              h5.spectrum-CSSExample-heading.spectrum-Heading.spectrum-Heading--S Action Button with Icon (truncated)
               section.spectrum-CSSExample-container
                 .spectrum-CSSExample-example
                   <button class="spectrum-ActionButton spectrum-ActionButton--quiet" style="width: 128px">
@@ -73,7 +73,7 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
                   </button>
 
             article.spectrum-CSSExample
-              h5.spectrum-CSSExample-heading.spectrum-Heading4 Quick Actions (truncated)
+              h5.spectrum-CSSExample-heading.spectrum-Heading.spectrum-Heading--S Quick Actions (truncated)
               section.spectrum-CSSExample-container
                 .spectrum-CSSExample-example
                   <div class="spectrum-QuickActions-overlay" style="padding: 40px;">
@@ -90,7 +90,7 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
                   </div>
 
             article.spectrum-CSSExample
-              h5.spectrum-CSSExample-heading.spectrum-Heading4 Tag (truncated)
+              h5.spectrum-CSSExample-heading.spectrum-Heading.spectrum-Heading--S Tag (truncated)
               section.spectrum-CSSExample-container
                 .spectrum-CSSExample-example
                   <div class="spectrum-Tags-item" role="listitem" tabindex="0" style="width: 168px;">
@@ -101,7 +101,7 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
                   </div>
 
             article.spectrum-CSSExample
-              h5.spectrum-CSSExample-heading.spectrum-Heading4 Tabs (truncated)
+              h5.spectrum-CSSExample-heading.spectrum-Heading.spectrum-Heading--S Tabs (truncated)
               section.spectrum-CSSExample-container
                 .spectrum-CSSExample-example
                   <div class="spectrum-Tabs spectrum-Tabs--horizontal" style="width: 212px">
@@ -117,7 +117,7 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
                   </div>
 
             article.spectrum-CSSExample
-              h5.spectrum-CSSExample-heading.spectrum-Heading4 Combobox (truncated)
+              h5.spectrum-CSSExample-heading.spectrum-Heading.spectrum-Heading--S Combobox (truncated)
               section.spectrum-CSSExample-container
                 .spectrum-CSSExample-example
                   <div class="spectrum-InputGroup">
@@ -130,7 +130,7 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
                   </div>
 
             article.spectrum-CSSExample
-              h5.spectrum-CSSExample-heading.spectrum-Heading4 Dropdown (truncated)
+              h5.spectrum-CSSExample-heading.spectrum-Heading.spectrum-Heading--S Dropdown (truncated)
               section.spectrum-CSSExample-container
                 .spectrum-CSSExample-example
                   <div class="spectrum-Dropdown" style="width: 240px;">
@@ -143,7 +143,7 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
                   </div>
 
             article.spectrum-CSSExample
-              h5.spectrum-CSSExample-heading.spectrum-Heading4 Textfield (truncated)
+              h5.spectrum-CSSExample-heading.spectrum-Heading.spectrum-Heading--S Textfield (truncated)
               section.spectrum-CSSExample-container
                 .spectrum-CSSExample-example
                   <input type="text" placeholder="Enter your name" name="field" value="Lorem ipsum dolor sit amet, consectetur adipiscing elit" class="spectrum-Textfield">

--- a/site/util.js
+++ b/site/util.js
@@ -54,9 +54,11 @@ md.renderer.rules.code_inline = function(tokens, idx, options, env, self) {
 
     let className = 'spectrum-CSSExample-oldAPI';
     if (aIndex < 0) {
-      tokens[idx].attrPush(['class', className]); // add new attribute
+      // add class
+      tokens[idx].attrPush(['class', className]);
     }
     else {
+      // append class
       tokens[idx].attrs[aIndex][1] = `${tokens[idx].attrs[aIndex][1]} ${className}`;
     }
 

--- a/site/util.js
+++ b/site/util.js
@@ -12,7 +12,57 @@ governing permissions and limitations under the License.
 
 const logger = require('gulplog');
 
-exports.markdown = require('markdown').markdown;
+const md = require('markdown-it')({
+  html: true,
+  linkify: false,
+  typographer: true,
+  breaks: true
+});
+
+function defaultRenderer(tokens, idx, options, env, self) {
+  return self.renderToken(tokens, idx, options, env, self);
+}
+
+let ruleClassnames = {
+  'link_open': 'spectrum-Link',
+  'table_open': 'spectrum-Table',
+  'thead_open': 'spectrum-Table-head',
+  'tr_open': 'spectrum-Table-row',
+  'tbody_open': 'spectrum-Table-body',
+  'th_open': 'spectrum-Table-headCell',
+  'td_open': 'spectrum-Table-cell',
+  'code_inline': 'spectrum-Code spectrum-Code--S',
+  'code_block': 'spectrum-Code spectrum-Code--S'
+};
+
+for (let [rule, className] of Object.entries(ruleClassnames)) {
+  md.renderer.rules[rule] = (function(className) {
+    const oldRule = md.renderer.rules[rule] || defaultRenderer;
+    return function (tokens, idx, options, env, self) {
+      tokens[idx].attrPush(['class', className]);
+      return oldRule(tokens, idx, options, env, self);
+    };
+  })(className);
+}
+
+const headingMap = {
+  'h1': 'spectrum-Heading spectrum-Heading--L',
+  'h2': 'spectrum-Heading spectrum-Heading--M',
+  'h3': 'spectrum-Heading spectrum-Heading--S',
+  'h4': 'spectrum-Heading spectrum-Heading--XS',
+  'h5': 'spectrum-Heading spectrum-Heading--XXS'
+};
+
+md.renderer.rules.heading_open = function(tokens, idx, options, env, self) {
+  let headingClass = headingMap[tokens[idx].tag];
+  if (headingClass) {
+    tokens[idx].attrPush(['class', headingClass]);
+  }
+  return defaultRenderer(tokens, idx, options, env, self);
+};
+
+exports.markdown = md;
+
 exports.Prism = require('prismjs');
 
 const statusLightVariants = {

--- a/site/util.js
+++ b/site/util.js
@@ -45,6 +45,26 @@ for (let [rule, className] of Object.entries(ruleClassnames)) {
   })(className);
 }
 
+const code_inline = md.renderer.rules.code_inline || defaultRenderer;
+md.renderer.rules.code_inline = function(tokens, idx, options, env, self) {
+  const token = tokens[idx];
+  // ~ indicates markup that should be red
+  if (token.content[0] === '~') {
+    let aIndex = tokens[idx].attrIndex('class');
+
+    let className = 'spectrum-CSSExample-oldAPI';
+    if (aIndex < 0) {
+      tokens[idx].attrPush(['class', className]); // add new attribute
+    }
+    else {
+      tokens[idx].attrs[aIndex][1] = `${tokens[idx].attrs[aIndex][1]} ${className}`;
+    }
+
+    token.content = token.content.substr(1);
+  }
+  return code_inline(tokens, idx, options, env, self);
+};
+
 const headingMap = {
   'h1': 'spectrum-Heading spectrum-Heading--L',
   'h2': 'spectrum-Heading spectrum-Heading--M',

--- a/site/util.js
+++ b/site/util.js
@@ -49,7 +49,7 @@ const code_inline = md.renderer.rules.code_inline || defaultRenderer;
 md.renderer.rules.code_inline = function(tokens, idx, options, env, self) {
   const token = tokens[idx];
   // ~ indicates markup that should be red
-  if (token.content[0] === '~') {
+  if (token.content.substr(0, 1) === '~' && token.content.substr(-1) === '~') {
     let aIndex = tokens[idx].attrIndex('class');
 
     let className = 'spectrum-CSSExample-oldAPI';
@@ -62,7 +62,7 @@ md.renderer.rules.code_inline = function(tokens, idx, options, env, self) {
       tokens[idx].attrs[aIndex][1] = `${tokens[idx].attrs[aIndex][1]} ${className}`;
     }
 
-    token.content = token.content.substr(1);
+    token.content = token.content.slice(1, -1);
   }
   return code_inline(tokens, idx, options, env, self);
 };

--- a/site/wrapping.pug
+++ b/site/wrapping.pug
@@ -40,16 +40,16 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
         .spectrum-Site-mainContainer
           .spectrum-Site-page.spectrum-Typography
 
-            h1.spectrum-Heading1 A study of wrapping across a number of components
+            h1.spectrum-Heading.spectrum-Heading--XL A study of wrapping across a number of components
 
             article.spectrum-CSSExample
-              h5.spectrum-CSSExample-heading.spectrum-Heading4 Link (wrapping)
+              h5.spectrum-CSSExample-heading.spectrum-Heading.spectrum-Heading--S Link (wrapping)
               section.spectrum-CSSExample-container
                 .spectrum-CSSExample-example
                   <div style="width: 146px">See our <a href="#" class="spectrum-Link">Privacy Policy</a> for more details or <a href="#" class="spectrum-Link">opt-out at any time</a>.</div>
 
             article.spectrum-CSSExample
-              h5.spectrum-CSSExample-heading.spectrum-Heading4 Toast (wrapping)
+              h5.spectrum-CSSExample-heading.spectrum-Heading.spectrum-Heading--S Toast (wrapping)
               section.spectrum-CSSExample-container
                 .spectrum-CSSExample-example
                   <div class="spectrum-Toast" style="width: 280px;">
@@ -66,7 +66,7 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
                   </div>
 
             article.spectrum-CSSExample
-              h5.spectrum-CSSExample-heading.spectrum-Heading4 Toast with Icon and Button (wrapping)
+              h5.spectrum-CSSExample-heading.spectrum-Heading.spectrum-Heading--S Toast with Icon and Button (wrapping)
               section.spectrum-CSSExample-container
                 .spectrum-CSSExample-example
                   <div class="spectrum-Toast spectrum-Toast--info" style="width: 318px;">
@@ -89,7 +89,7 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
                   </div>
 
             article.spectrum-CSSExample
-              h5.spectrum-CSSExample-heading.spectrum-Heading4 Tooltip (wrapping)
+              h5.spectrum-CSSExample-heading.spectrum-Heading.spectrum-Heading--S Tooltip (wrapping)
               section.spectrum-CSSExample-container
                 .spectrum-CSSExample-example
                   <span class="spectrum-Tooltip spectrum-Tooltip--top is-open">
@@ -98,7 +98,7 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
                   </span>
 
             article.spectrum-CSSExample
-              h5.spectrum-CSSExample-heading.spectrum-Heading4 Tooltip with Icon (wrapping)
+              h5.spectrum-CSSExample-heading.spectrum-Heading.spectrum-Heading--S Tooltip with Icon (wrapping)
               section.spectrum-CSSExample-container
                 .spectrum-CSSExample-example
                   <span class="spectrum-Tooltip spectrum-Tooltip--top spectrum-Tooltip--info is-open">
@@ -110,7 +110,7 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
                   </span>
 
             article.spectrum-CSSExample
-              h5.spectrum-CSSExample-heading.spectrum-Heading4 Coach Mark (wrapping)
+              h5.spectrum-CSSExample-heading.spectrum-Heading.spectrum-Heading--S Coach Mark (wrapping)
               section.spectrum-CSSExample-container
                 .spectrum-CSSExample-example
                   <div class="spectrum-CoachMarkPopover" style="width: 226px">
@@ -134,7 +134,7 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
                   </div>
 
             article.spectrum-CSSExample
-              h5.spectrum-CSSExample-heading.spectrum-Heading4 Dialog (wrapping)
+              h5.spectrum-CSSExample-heading.spectrum-Heading.spectrum-Heading--S Dialog (wrapping)
               section.spectrum-CSSExample-container
                 .spectrum-CSSExample-example.spectrum-CSSExample-example--overlay
                   <button class="spectrum-Button spectrum-Button--overBackground spectrum-CSSExample-overlayShowButton" onclick="openDialog(this.nextElementSibling)">Open Dialog</button>
@@ -154,7 +154,7 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
                   </div>
 
             article.spectrum-CSSExample
-              h5.spectrum-CSSExample-heading.spectrum-Heading4 Button (wrapping)
+              h5.spectrum-CSSExample-heading.spectrum-Heading.spectrum-Heading--S Button (wrapping)
               section.spectrum-CSSExample-container
                 .spectrum-CSSExample-example
                   <div style="max-width: 168px; margin: 0 0 10px 0">
@@ -174,7 +174,7 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
                   </div>
 
             article.spectrum-CSSExample
-              h5.spectrum-CSSExample-heading.spectrum-Heading4 Menu (wrapping)
+              h5.spectrum-CSSExample-heading.spectrum-Heading.spectrum-Heading--S Menu (wrapping)
               section.spectrum-CSSExample-container
                 .spectrum-CSSExample-example
                   <div class="spectrum-Popover is-open" style="position: relative; width: 176px">
@@ -195,7 +195,7 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
                   </div>
 
             article.spectrum-CSSExample
-              h5.spectrum-CSSExample-heading.spectrum-Heading4 Menu with Icons (wrapping)
+              h5.spectrum-CSSExample-heading.spectrum-Heading.spectrum-Heading--S Menu with Icons (wrapping)
               section.spectrum-CSSExample-container
                 .spectrum-CSSExample-example
                   <div class="spectrum-Popover is-open" style="position: relative; width: 176px">
@@ -221,7 +221,7 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
                   </div>
 
             article.spectrum-CSSExample
-              h5.spectrum-CSSExample-heading.spectrum-Heading4 Side Navigation (wrapping)
+              h5.spectrum-CSSExample-heading.spectrum-Heading.spectrum-Heading--S Side Navigation (wrapping)
               section.spectrum-CSSExample-container
                 .spectrum-CSSExample-example
                   <nav style="width: 170px;">
@@ -239,7 +239,7 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
                   </nav>
 
             article.spectrum-CSSExample
-              h5.spectrum-CSSExample-heading.spectrum-Heading4 Checkbox (wrapping)
+              h5.spectrum-CSSExample-heading.spectrum-Heading.spectrum-Heading--S Checkbox (wrapping)
               section.spectrum-CSSExample-container
                 .spectrum-CSSExample-example
                   <label class="spectrum-Checkbox">
@@ -269,7 +269,7 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
                   </label>
 
             article.spectrum-CSSExample
-              h5.spectrum-CSSExample-heading.spectrum-Heading4 Radio (wrapping)
+              h5.spectrum-CSSExample-heading.spectrum-Heading.spectrum-Heading--S Radio (wrapping)
               section.spectrum-CSSExample-container
                 .spectrum-CSSExample-example
                   <div class="spectrum-Radio">
@@ -285,7 +285,7 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
                   </div>
 
             article.spectrum-CSSExample
-              h5.spectrum-CSSExample-heading.spectrum-Heading4 Switch (wrapping)
+              h5.spectrum-CSSExample-heading.spectrum-Heading.spectrum-Heading--S Switch (wrapping)
               section.spectrum-CSSExample-container
                 .spectrum-CSSExample-example
                   <div class="spectrum-ToggleSwitch">
@@ -301,7 +301,7 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
                   </div>
 
             article.spectrum-CSSExample
-              h5.spectrum-CSSExample-heading.spectrum-Heading4 Barloader (wrapping)
+              h5.spectrum-CSSExample-heading.spectrum-Heading.spectrum-Heading--S Barloader (wrapping)
               section.spectrum-CSSExample-container
                 .spectrum-CSSExample-example
                   <div style="margin: 20px 0; width: 168px">
@@ -315,7 +315,7 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
                   </div>
 
             article.spectrum-CSSExample
-              h5.spectrum-CSSExample-heading.spectrum-Heading4 Meter (wrapping)
+              h5.spectrum-CSSExample-heading.spectrum-Heading.spectrum-Heading--S Meter (wrapping)
               section.spectrum-CSSExample-container
                 .spectrum-CSSExample-example
                   <div style="margin: 20px 0;">
@@ -329,7 +329,7 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
                   </div>
 
             article.spectrum-CSSExample
-              h5.spectrum-CSSExample-heading.spectrum-Heading4 Combobox (wrapping label)
+              h5.spectrum-CSSExample-heading.spectrum-Heading.spectrum-Heading--S Combobox (wrapping label)
               section.spectrum-CSSExample-container
                 .spectrum-CSSExample-example
                   <div style="width: 160px">
@@ -345,7 +345,7 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
                   </div>
 
             article.spectrum-CSSExample
-              h5.spectrum-CSSExample-heading.spectrum-Heading4 Dropdown (wrapping label)
+              h5.spectrum-CSSExample-heading.spectrum-Heading.spectrum-Heading--S Dropdown (wrapping label)
               section.spectrum-CSSExample-container
                 .spectrum-CSSExample-example
                   <div style="width: 160px">
@@ -361,7 +361,7 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
                   </div>
 
             article.spectrum-CSSExample
-              h5.spectrum-CSSExample-heading.spectrum-Heading4 Textfield (wrapping label)
+              h5.spectrum-CSSExample-heading.spectrum-Heading.spectrum-Heading--S Textfield (wrapping label)
               section.spectrum-CSSExample-container
                 .spectrum-CSSExample-example
                   <div style="width: 160px">
@@ -370,7 +370,7 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
                   </div>
 
             article.spectrum-CSSExample
-              h5.spectrum-CSSExample-heading.spectrum-Heading4 Slider (wrapping)
+              h5.spectrum-CSSExample-heading.spectrum-Heading.spectrum-Heading--S Slider (wrapping)
               section.spectrum-CSSExample-container
                 .spectrum-CSSExample-example
                   <div class="spectrum-Slider spectrum-Slider--filled" style="width: 208px">
@@ -388,7 +388,7 @@ html(lang='en-US').spectrum.spectrum--light.spectrum--medium
                   </div>
 
             article.spectrum-CSSExample
-              h5.spectrum-CSSExample-heading.spectrum-Heading4 Status Light (wrapping)
+              h5.spectrum-CSSExample-heading.spectrum-Heading.spectrum-Heading--S Status Light (wrapping)
               section.spectrum-CSSExample-container
                 .spectrum-CSSExample-example
                   <div class="spectrum-StatusLight spectrum-StatusLight--positive">Lorem ipsum dolor sit amet, consectetur adipiscing elit</div>

--- a/tools/bundle-builder/docs/README.md
+++ b/tools/bundle-builder/docs/README.md
@@ -18,14 +18,14 @@ Each item in the `examples` array supports the following properties:
 
 * `id` - Provide the DNA ID here to fetch the status of this example.
 * `name` - The name of the example. If not provided, it will be loaded from DNA.
-* `description` - The example's description
+* `description` - The example's description, written in markdown. All links, headings, code blocks, and tables will automatically get Spectrum CSS classes applied to them.
 * `markup` - The markup example
 * `status` - The status of the example's design review; one of `Unverified`, `Verified`, or `Deprecated`.
 
 Each item in the `sections` array supports the following properties:
 
 * `name` - The name of the example (appears in the navigation and as the heading of the page). If not provided, it will be loaded from DNA.
-* `description` - The topmost description of the component. This will be loaded from DNA if something matches the ID of the component.
+* `description` - The content of the section, written in markdown. All links, headings, code blocks, and tables will automatically get Spectrum CSS classes applied to them.
 * `markup` - An optional markup example for the section
 
 ## Architecture

--- a/tools/bundle-builder/docs/README.md
+++ b/tools/bundle-builder/docs/README.md
@@ -7,17 +7,26 @@ Component documentation is built using [Pug templates](https://pugjs.org/api/get
 The top level of the `.yml` files can have the following properties:
 
 * `id` - If the name of the component doesn't match DNA, provide the DNA ID here.
+* `name` - The name of the component (appears in the navigation and as the heading of the page). If not provided, it will be loaded from DNA based on the id.
+* `description` - The topmost description of the component. This will be loaded from DNA if something matches the ID of the component.
+* `status` - The status of the overall component's design review; one of `Unverified`, `Verified`, or `Deprecated`. This will be pulled from DNA if not provided.
+* `examples` - An array of examples which should show each variant of the component (see properties below).
+* `examplesHeading` - The heading to use for examples. Default is "Variants"
+* `sections` - An optional array of sections to provide additional information (see properties below).
+
+Each item in the `examples` array supports the following properties:
+
+* `id` - Provide the DNA ID here to fetch the status of this example.
+* `name` - The name of the example. If not provided, it will be loaded from DNA.
+* `description` - The example's description
+* `markup` - The markup example
+* `status` - The status of the example's design review; one of `Unverified`, `Verified`, or `Deprecated`.
+
+Each item in the `sections` array supports the following properties:
+
 * `name` - The name of the example (appears in the navigation and as the heading of the page). If not provided, it will be loaded from DNA.
 * `description` - The topmost description of the component. This will be loaded from DNA if something matches the ID of the component.
-* `components` - An object keyed on component ID with properties defined below.
-* `status` - The status of the component's design review; one of `Unverified`, `Verified`, or `Deprecated`. This will be pulled from DNA if not provided.
-
-Each entry in the `components` object within the `.yml` file can have the following properties:
-
-* `id` - If the key in the `components` object doesn't match DNA, provide the DNA ID here.
-* `name` - The name of the example (appears in the navigation and as the heading of the page). If not provided, it will be loaded from DNA.
-* `description` - The topmost description of the component. This will be loaded from DNA if something matches the ID of the component.
-* `status` - The status of the component's design review; one of `Unverified`, `Verified`, or `Deprecated`.
+* `markup` - An optional markup example for the section
 
 ## Architecture
 

--- a/tools/bundle-builder/docs/index.js
+++ b/tools/bundle-builder/docs/index.js
@@ -49,7 +49,8 @@ let minimumDeps = [
   'illustratedmessage',
   'fieldlabel',
   'accordion',
-  'decoratedtextfield'
+  'decoratedtextfield',
+  'table'
 ];
 
 let templateData = {

--- a/tools/bundle-builder/index.js
+++ b/tools/bundle-builder/index.js
@@ -223,6 +223,7 @@ exports.buildComponents = subrunner.buildComponents;
 exports.buildCombined = buildCombined;
 exports.buildStandalone = buildStandalone;
 exports.buildLite = buildLite;
+exports.buildDocs = docs.buildDocs;
 exports.dev = devTask;
 exports.clean = clean;
 exports.build = build;

--- a/tools/component-builder/package.json
+++ b/tools/component-builder/package.json
@@ -28,7 +28,6 @@
     "gulp-replace": "^1.0.0",
     "gulplog": "^1.0.0",
     "js-yaml": "^3.13.1",
-    "markdown": "^0.5.0",
     "merge-stream": "^2.0.0",
     "postcss": "^5.2.18",
     "postcss-calc": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3495,7 +3495,7 @@ entities@^1.1.1, entities@~1.1.1:
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
   integrity sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==
 
-entities@^2.0.0:
+entities@^2.0.0, entities@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.0.tgz#68d6084cab1b079767540d80e56a39b423e4abf4"
   integrity sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==
@@ -5732,6 +5732,13 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
+linkify-it@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-2.2.0.tgz#e3b54697e78bf915c70a38acd78fd09e0058b1cf"
+  integrity sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==
+  dependencies:
+    uc.micro "^1.0.1"
+
 load-bmfont@^1.2.3:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/load-bmfont/-/load-bmfont-1.4.0.tgz#75f17070b14a8c785fe7f5bee2e6fd4f98093b6b"
@@ -6051,6 +6058,17 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+markdown-it@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-10.0.0.tgz#abfc64f141b1722d663402044e43927f1f50a8dc"
+  integrity sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==
+  dependencies:
+    argparse "^1.0.7"
+    entities "~2.0.0"
+    linkify-it "^2.0.0"
+    mdurl "^1.0.1"
+    uc.micro "^1.0.5"
+
 markdown@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/markdown/-/markdown-0.5.0.tgz#28205b565a8ae7592de207463d6637dc182722b2"
@@ -6082,6 +6100,11 @@ mdn-data@~1.1.0:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-1.1.4.tgz#50b5d4ffc4575276573c4eedb8780812a8419f01"
   integrity sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA==
+
+mdurl@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
+  integrity sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -9374,6 +9397,11 @@ ua-parser-js@0.7.17:
   version "0.7.17"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.17.tgz#e9ec5f9498b9ec910e7ae3ac626a805c4d09ecac"
   integrity sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g==
+
+uc.micro@^1.0.1, uc.micro@^1.0.5:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
+  integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
 
 uglify-js@^2.6.1:
   version "2.8.29"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6069,13 +6069,6 @@ markdown-it@^10.0.0:
     mdurl "^1.0.1"
     uc.micro "^1.0.5"
 
-markdown@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/markdown/-/markdown-0.5.0.tgz#28205b565a8ae7592de207463d6637dc182722b2"
-  integrity sha1-KCBbVlqK51kt4gdGPWY33BgnIrI=
-  dependencies:
-    nopt "~2.1.1"
-
 marky@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/marky/-/marky-1.2.1.tgz#a3fcf82ffd357756b8b8affec9fdbf3a30dc1b02"
@@ -6540,13 +6533,6 @@ nopt@^4.0.1:
   dependencies:
     abbrev "1"
     osenv "^0.1.4"
-
-nopt@~2.1.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-2.1.2.tgz#6cccd977b80132a07731d6e8ce58c2c8303cf9af"
-  integrity sha1-bMzZd7gBMqB3MdbozljCyDA8+a8=
-  dependencies:
-    abbrev "1"
 
 normalize-package-data@^2.0.0, normalize-package-data@^2.3.0, normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.3.5, normalize-package-data@^2.4.0, normalize-package-data@^2.5.0:
   version "2.5.0"


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->
This pull request does the following:

* Add migration guide for new Typography API
* Switch from `markdown` (deprecated) to `markdown-it`
* Implement Spectrum classes for markdown'd links, tables, and code samples
* Use new Typography components on site template for header/body text
* Use new Typography Code component for markup examples
* Fix color styles that leaked into `site/index.css` (should be in `site/skin.css`)
* Fix header for Code on Typography landing page
* Support `sections` property in metadata to define sections
* Update documentation for component metadata to document new properties and correct errors

## How and where has this been tested?
 - **How this was tested:** Load up https://git.corp.adobe.com/pages/lawdavis/spectrum-css-typography/docs/typography.html#migratingfromdeprecatedtypography, use eyes
 - **Browser(s) and OS(s) this was tested with:** Chrome on macOS

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->

### Typography migration guide

![image](https://user-images.githubusercontent.com/201344/74075789-31bdd500-49c9-11ea-864f-d1363772b352.png)

### Pretty new links and code

![image](https://user-images.githubusercontent.com/201344/74064051-a92e3d00-49a6-11ea-8491-9ba97dff4abe.png)

### Pretty sections in component pages
![image](https://user-images.githubusercontent.com/201344/74075776-1eab0500-49c9-11ea-89ac-2059a0dd3ba6.png)


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
