### PR TITLE
feat: fix tabs markup, support anchors for labels

### DIFF
--- a/components/tabs/index.css
+++ b/components/tabs/index.css
@@ -96,6 +96,9 @@ governing permissions and limitations under the License.
   font-size: var(--spectrum-tabs-text-size);
   font-weight: var(--spectrum-tabs-text-font-weight);
 
+  /* support links */
+  text-decoration: none;
+
   &:empty {
     /* Hide the tab label if it's not being used */
     display: none;

--- a/components/tabs/metadata/tabs.yml
+++ b/components/tabs/metadata/tabs.yml
@@ -448,3 +448,22 @@ examples:
       </div>
 
       <div class="dummy-spacing"></div>
+  - id: tabs
+    name: Tabs with anchors
+    status: Verified
+    markup: |
+      <div class="spectrum-Tabs spectrum-Tabs--horizontal">
+        <div class="spectrum-Tabs-item is-selected" tabindex="0">
+          <a href="#1" class="spectrum-Tabs-itemLabel">Tab 1</a>
+        </div>
+        <div class="spectrum-Tabs-item" tabindex="0">
+          <a href="#2" class="spectrum-Tabs-itemLabel">Tab 2</a>
+        </div>
+        <div class="spectrum-Tabs-item" tabindex="0">
+          <a href="#3" class="spectrum-Tabs-itemLabel">Tab 3</a>
+        </div>
+        <div class="spectrum-Tabs-item" tabindex="0">
+        <a href="#4" class="spectrum-Tabs-itemLabel">Tab 4</a>
+        </div>
+        <div class="spectrum-Tabs-selectionIndicator" style="width: 27px; left: 0px;"></div>
+      </div>

--- a/components/tabs/metadata/tabs.yml
+++ b/components/tabs/metadata/tabs.yml
@@ -453,17 +453,17 @@ examples:
     status: Verified
     markup: |
       <div class="spectrum-Tabs spectrum-Tabs--horizontal">
-        <div class="spectrum-Tabs-item is-selected" tabindex="0">
-          <a href="#1" class="spectrum-Tabs-itemLabel">Tab 1</a>
-        </div>
-        <div class="spectrum-Tabs-item" tabindex="0">
-          <a href="#2" class="spectrum-Tabs-itemLabel">Tab 2</a>
-        </div>
-        <div class="spectrum-Tabs-item" tabindex="0">
-          <a href="#3" class="spectrum-Tabs-itemLabel">Tab 3</a>
-        </div>
-        <div class="spectrum-Tabs-item" tabindex="0">
-        <a href="#4" class="spectrum-Tabs-itemLabel">Tab 4</a>
-        </div>
+        <a href="#1" class="spectrum-Tabs-item is-selected">
+          <span class="spectrum-Tabs-itemLabel">Tab 1</span>
+        </a>
+        <a href="#2" class="spectrum-Tabs-item">
+          <span class="spectrum-Tabs-itemLabel">Tab 2</span>
+        </a>
+        <a href="#3" class="spectrum-Tabs-item">
+          <span class="spectrum-Tabs-itemLabel">Tab 3</span>
+        </a>
+        <a href="#4" class="spectrum-Tabs-item">
+          <span class="spectrum-Tabs-itemLabel">Tab 4</span>
+        </a>
         <div class="spectrum-Tabs-selectionIndicator" style="width: 27px; left: 0px;"></div>
       </div>

--- a/components/tabs/metadata/tabs.yml
+++ b/components/tabs/metadata/tabs.yml
@@ -7,16 +7,16 @@ examples:
     markup: |
       <div class="spectrum-Tabs spectrum-Tabs--horizontal">
         <div class="spectrum-Tabs-item is-selected" tabindex="0">
-          <label class="spectrum-Tabs-itemLabel">Tab 1</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 1</span>
         </div>
         <div class="spectrum-Tabs-item" tabindex="0">
-          <label class="spectrum-Tabs-itemLabel">Tab 2</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 2</span>
         </div>
         <div class="spectrum-Tabs-item" tabindex="0">
-          <label class="spectrum-Tabs-itemLabel">Tab 3</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 3</span>
         </div>
         <div class="spectrum-Tabs-item" tabindex="0">
-          <label class="spectrum-Tabs-itemLabel">Tab 4</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 4</span>
         </div>
         <div class="spectrum-Tabs-selectionIndicator" style="width: 27px; left: 0px;"></div>
       </div>
@@ -29,25 +29,25 @@ examples:
           <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Folder">
             <use xlink:href="#spectrum-icon-18-Folder" />
           </svg>
-          <label class="spectrum-Tabs-itemLabel">Tab 1</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 1</span>
         </div>
         <div class="spectrum-Tabs-item" tabindex="0">
           <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Image">
             <use xlink:href="#spectrum-icon-18-Image" />
           </svg>
-          <label class="spectrum-Tabs-itemLabel">Tab 2</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 2</span>
         </div>
         <div class="spectrum-Tabs-item" tabindex="0">
           <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Filter">
             <use xlink:href="#spectrum-icon-18-Filter" />
           </svg>
-          <label class="spectrum-Tabs-itemLabel">Tab 3</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 3</span>
         </div>
         <div class="spectrum-Tabs-item" tabindex="0">
           <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Comment">
             <use xlink:href="#spectrum-icon-18-Comment" />
           </svg>
-          <label class="spectrum-Tabs-itemLabel">Tab 4</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 4</span>
         </div>
         <div class="spectrum-Tabs-selectionIndicator" style="width: 55px; left: 0px;"></div>
       </div>
@@ -57,16 +57,16 @@ examples:
     markup: |
       <div class="spectrum-Tabs spectrum-Tabs--horizontal spectrum-Tabs--quiet">
         <div class="spectrum-Tabs-item is-selected" tabindex="0">
-          <label class="spectrum-Tabs-itemLabel">Tab 1</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 1</span>
         </div>
         <div class="spectrum-Tabs-item" tabindex="0">
-          <label class="spectrum-Tabs-itemLabel">Tab 2</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 2</span>
         </div>
         <div class="spectrum-Tabs-item" tabindex="0">
-          <label class="spectrum-Tabs-itemLabel">Tab 3</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 3</span>
         </div>
         <div class="spectrum-Tabs-item" tabindex="0">
-          <label class="spectrum-Tabs-itemLabel">Tab 4</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 4</span>
         </div>
         <div class="spectrum-Tabs-selectionIndicator" style="width: 27px; left: 0px;"></div>
       </div>
@@ -79,25 +79,25 @@ examples:
           <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Folder">
             <use xlink:href="#spectrum-icon-18-Folder" />
           </svg>
-          <label class="spectrum-Tabs-itemLabel">Tab 1</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 1</span>
         </div>
         <div class="spectrum-Tabs-item" tabindex="0">
           <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Image">
             <use xlink:href="#spectrum-icon-18-Image" />
           </svg>
-          <label class="spectrum-Tabs-itemLabel">Tab 2</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 2</span>
         </div>
         <div class="spectrum-Tabs-item" tabindex="0">
           <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Filter">
             <use xlink:href="#spectrum-icon-18-Filter" />
           </svg>
-          <label class="spectrum-Tabs-itemLabel">Tab 3</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 3</span>
         </div>
         <div class="spectrum-Tabs-item" tabindex="0">
           <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Comment">
             <use xlink:href="#spectrum-icon-18-Comment" />
           </svg>
-          <label class="spectrum-Tabs-itemLabel">Tab 4</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 4</span>
         </div>
         <div class="spectrum-Tabs-selectionIndicator" style="width: 55px; left: 0px;"></div>
       </div>
@@ -107,16 +107,16 @@ examples:
     markup: |
       <div class="spectrum-Tabs spectrum-Tabs--horizontal spectrum-Tabs--compact">
         <div class="spectrum-Tabs-item is-selected" tabindex="0">
-          <label class="spectrum-Tabs-itemLabel">Tab 1</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 1</span>
         </div>
         <div class="spectrum-Tabs-item" tabindex="0">
-          <label class="spectrum-Tabs-itemLabel">Tab 2</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 2</span>
         </div>
         <div class="spectrum-Tabs-item" tabindex="0">
-          <label class="spectrum-Tabs-itemLabel">Tab 3</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 3</span>
         </div>
         <div class="spectrum-Tabs-item" tabindex="0">
-          <label class="spectrum-Tabs-itemLabel">Tab 4</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 4</span>
         </div>
         <div class="spectrum-Tabs-selectionIndicator" style="width: 27px; left: 0px;"></div>
       </div>
@@ -128,25 +128,25 @@ examples:
           <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Folder">
             <use xlink:href="#spectrum-icon-18-Folder" />
           </svg>
-          <label class="spectrum-Tabs-itemLabel">Tab 1</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 1</span>
         </div>
         <div class="spectrum-Tabs-item" tabindex="0">
           <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Image">
             <use xlink:href="#spectrum-icon-18-Image" />
           </svg>
-          <label class="spectrum-Tabs-itemLabel">Tab 2</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 2</span>
         </div>
         <div class="spectrum-Tabs-item" tabindex="0">
           <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Filter">
             <use xlink:href="#spectrum-icon-18-Filter" />
           </svg>
-          <label class="spectrum-Tabs-itemLabel">Tab 3</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 3</span>
         </div>
         <div class="spectrum-Tabs-item" tabindex="0">
           <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Comment">
             <use xlink:href="#spectrum-icon-18-Comment" />
           </svg>
-          <label class="spectrum-Tabs-itemLabel">Tab 4</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 4</span>
         </div>
         <div class="spectrum-Tabs-selectionIndicator" style="width: 55px; left: 0px;"></div>
       </div>
@@ -182,16 +182,16 @@ examples:
     markup: |
       <div class="spectrum-Tabs spectrum-Tabs--horizontal spectrum-Tabs--compact spectrum-Tabs--quiet">
         <div class="spectrum-Tabs-item is-selected" tabindex="0">
-          <label class="spectrum-Tabs-itemLabel">Tab 1</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 1</span>
         </div>
         <div class="spectrum-Tabs-item" tabindex="0">
-          <label class="spectrum-Tabs-itemLabel">Tab 2</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 2</span>
         </div>
         <div class="spectrum-Tabs-item" tabindex="0">
-          <label class="spectrum-Tabs-itemLabel">Tab 3</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 3</span>
         </div>
         <div class="spectrum-Tabs-item" tabindex="0">
-          <label class="spectrum-Tabs-itemLabel">Tab 4</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 4</span>
         </div>
         <div class="spectrum-Tabs-selectionIndicator" style="width: 27px; left: 0px;"></div>
       </div>
@@ -203,25 +203,25 @@ examples:
           <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Folder">
             <use xlink:href="#spectrum-icon-18-Folder" />
           </svg>
-          <label class="spectrum-Tabs-itemLabel">Tab 1</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 1</span>
         </div>
         <div class="spectrum-Tabs-item" tabindex="0">
           <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Image">
             <use xlink:href="#spectrum-icon-18-Image" />
           </svg>
-          <label class="spectrum-Tabs-itemLabel">Tab 2</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 2</span>
         </div>
         <div class="spectrum-Tabs-item" tabindex="0">
           <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Filter">
             <use xlink:href="#spectrum-icon-18-Filter" />
           </svg>
-          <label class="spectrum-Tabs-itemLabel">Tab 3</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 3</span>
         </div>
         <div class="spectrum-Tabs-item" tabindex="0">
           <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Comment">
             <use xlink:href="#spectrum-icon-18-Comment" />
           </svg>
-          <label class="spectrum-Tabs-itemLabel">Tab 4</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 4</span>
         </div>
         <div class="spectrum-Tabs-selectionIndicator" style="width: 55px; left: 0px;"></div>
       </div>
@@ -256,16 +256,16 @@ examples:
     markup: |
       <div class="spectrum-Tabs spectrum-Tabs--vertical">
         <div class="spectrum-Tabs-item is-selected" tabindex="0">
-          <label class="spectrum-Tabs-itemLabel">Tab 1</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 1</span>
         </div>
         <div class="spectrum-Tabs-item" tabindex="0">
-          <label class="spectrum-Tabs-itemLabel">Tab 2</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 2</span>
         </div>
         <div class="spectrum-Tabs-item" tabindex="0">
-          <label class="spectrum-Tabs-itemLabel">Tab 3</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 3</span>
         </div>
         <div class="spectrum-Tabs-item" tabindex="0">
-          <label class="spectrum-Tabs-itemLabel">Tab 4</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 4</span>
         </div>
         <div class="spectrum-Tabs-selectionIndicator" style="height: 46px; top: 0px;"></div>
       </div>
@@ -277,25 +277,25 @@ examples:
           <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Folder">
             <use xlink:href="#spectrum-icon-18-Folder" />
           </svg>
-          <label class="spectrum-Tabs-itemLabel">Tab 1</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 1</span>
         </div>
         <div class="spectrum-Tabs-item" tabindex="0">
           <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Image">
             <use xlink:href="#spectrum-icon-18-Image" />
           </svg>
-          <label class="spectrum-Tabs-itemLabel">Tab 2</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 2</span>
         </div>
         <div class="spectrum-Tabs-item" tabindex="0">
           <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Filter">
             <use xlink:href="#spectrum-icon-18-Filter" />
           </svg>
-          <label class="spectrum-Tabs-itemLabel">Tab 3</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 3</span>
         </div>
         <div class="spectrum-Tabs-item" tabindex="0">
           <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Comment">
             <use xlink:href="#spectrum-icon-18-Comment" />
           </svg>
-          <label class="spectrum-Tabs-itemLabel">Tab 4</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 4</span>
         </div>
         <div class="spectrum-Tabs-selectionIndicator" style="height: 46px; top: 0px;"></div>
       </div>
@@ -304,16 +304,16 @@ examples:
     markup: |
       <div class="spectrum-Tabs spectrum-Tabs--vertical spectrum-Tabs--compact">
         <div class="spectrum-Tabs-item is-selected" tabindex="0">
-          <label class="spectrum-Tabs-itemLabel">Tab 1</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 1</span>
         </div>
         <div class="spectrum-Tabs-item" tabindex="0">
-          <label class="spectrum-Tabs-itemLabel">Tab 2</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 2</span>
         </div>
         <div class="spectrum-Tabs-item" tabindex="0">
-          <label class="spectrum-Tabs-itemLabel">Tab 3</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 3</span>
         </div>
         <div class="spectrum-Tabs-item" tabindex="0">
-          <label class="spectrum-Tabs-itemLabel">Tab 4</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 4</span>
         </div>
         <div class="spectrum-Tabs-selectionIndicator" style="height: 32px; top: 0px;"></div>
       </div>
@@ -325,25 +325,25 @@ examples:
           <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Folder">
             <use xlink:href="#spectrum-icon-18-Folder" />
           </svg>
-          <label class="spectrum-Tabs-itemLabel">Tab 1</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 1</span>
         </div>
         <div class="spectrum-Tabs-item" tabindex="0">
           <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Image">
             <use xlink:href="#spectrum-icon-18-Image" />
           </svg>
-          <label class="spectrum-Tabs-itemLabel">Tab 2</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 2</span>
         </div>
         <div class="spectrum-Tabs-item" tabindex="0">
           <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Filter">
             <use xlink:href="#spectrum-icon-18-Filter" />
           </svg>
-          <label class="spectrum-Tabs-itemLabel">Tab 3</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 3</span>
         </div>
         <div class="spectrum-Tabs-item" tabindex="0">
           <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Comment">
             <use xlink:href="#spectrum-icon-18-Comment" />
           </svg>
-          <label class="spectrum-Tabs-itemLabel">Tab 4</label>
+          <span class="spectrum-Tabs-itemLabel">Tab 4</span>
         </div>
         <div class="spectrum-Tabs-selectionIndicator" style="height: 32px; top: 0px;"></div>
       </div>

--- a/components/tabs/skin.css
+++ b/components/tabs/skin.css
@@ -23,18 +23,14 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Tabs-item {
-  .spectrum-Tabs-itemLabel {
-    color: var(--spectrum-tabs-text-color);
-  }
+  color: var(--spectrum-tabs-text-color);
 
   .spectrum-Icon {
     color: var(--spectrum-tabs-icon-color)
   }
 
   &:hover {
-    .spectrum-Tabs-itemLabel {
-      color: var(--spectrum-tabs-text-color-hover);
-    }
+    color: var(--spectrum-tabs-text-color-hover);
 
     .spectrum-Icon {
       color: var(--spectrum-tabs-icon-color-hover)
@@ -42,9 +38,7 @@ governing permissions and limitations under the License.
   }
 
   &.is-selected {
-    .spectrum-Tabs-itemLabel {
-      color: var(--spectrum-tabs-text-color-selected);
-    }
+    color: var(--spectrum-tabs-text-color-selected);
 
     .spectrum-Icon {
       color: var(--spectrum-tabs-icon-color-selected)
@@ -52,9 +46,7 @@ governing permissions and limitations under the License.
   }
 
   &:focus-ring {
-    .spectrum-Tabs-itemLabel {
-      color: var(--spectrum-tabs-text-color-key-focus);
-    }
+    color: var(--spectrum-tabs-text-color-key-focus);
 
     &::before {
       border-color: var(--spectrum-tabs-focus-ring-color);
@@ -66,9 +58,7 @@ governing permissions and limitations under the License.
   }
 
   &.is-disabled {
-    .spectrum-Tabs-itemLabel {
-      color: var(--spectrum-tabs-text-color-disabled);
-    }
+    color: var(--spectrum-tabs-text-color-disabled);
 
     .spectrum-Icon {
       color: var(--spectrum-tabs-icon-color-disabled)

--- a/components/tabs/skin.css
+++ b/components/tabs/skin.css
@@ -23,14 +23,18 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Tabs-item {
-  color: var(--spectrum-tabs-text-color);
+  .spectrum-Tabs-itemLabel {
+    color: var(--spectrum-tabs-text-color);
+  }
 
   .spectrum-Icon {
     color: var(--spectrum-tabs-icon-color)
   }
 
   &:hover {
-    color: var(--spectrum-tabs-text-color-hover);
+    .spectrum-Tabs-itemLabel {
+      color: var(--spectrum-tabs-text-color-hover);
+    }
 
     .spectrum-Icon {
       color: var(--spectrum-tabs-icon-color-hover)
@@ -38,7 +42,9 @@ governing permissions and limitations under the License.
   }
 
   &.is-selected {
-    color: var(--spectrum-tabs-text-color-selected);
+    .spectrum-Tabs-itemLabel {
+      color: var(--spectrum-tabs-text-color-selected);
+    }
 
     .spectrum-Icon {
       color: var(--spectrum-tabs-icon-color-selected)
@@ -46,7 +52,9 @@ governing permissions and limitations under the License.
   }
 
   &:focus-ring {
-    color: var(--spectrum-tabs-text-color-key-focus);
+    .spectrum-Tabs-itemLabel {
+      color: var(--spectrum-tabs-text-color-key-focus);
+    }
 
     &::before {
       border-color: var(--spectrum-tabs-focus-ring-color);
@@ -58,7 +66,9 @@ governing permissions and limitations under the License.
   }
 
   &.is-disabled {
-    color: var(--spectrum-tabs-text-color-disabled);
+    .spectrum-Tabs-itemLabel {
+      color: var(--spectrum-tabs-text-color-disabled);
+    }
 
     .spectrum-Icon {
       color: var(--spectrum-tabs-icon-color-disabled)


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->
Implements support for Tab labels as `<a>` tags, closes #670 
Corrects tab document to use `<span>` instead of `<label>`, fixes #671 

## How and where has this been tested?
 - **How this was tested:** Scroll, observe
 - **Browser(s) and OS(s) this was tested with:** Chrome on macOS

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->

![image](https://user-images.githubusercontent.com/201344/79156533-f0aabe00-7d87-11ea-93ce-26d90ae2dd5c.png)

## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
