### PR TITLE
fix(fieldlabel): use unique id for each input

### DIFF
--- a/components/fieldlabel/metadata/fieldlabel.yml
+++ b/components/fieldlabel/metadata/fieldlabel.yml
@@ -18,56 +18,56 @@ examples:
     name: Left
     description: A left aligned field label.
     markup: |
-      <label for="lifestory" class="spectrum-FieldLabel spectrum-FieldLabel--left" style="width: 72px">Life Story</label>
+      <label for="lifestory3" class="spectrum-FieldLabel spectrum-FieldLabel--left" style="width: 72px">Life Story</label>
 
       <div class="spectrum-Textfield spectrum-Textfield--multiline">
-        <textarea id="lifestory" placeholder="Enter your life story" name="field" value="" class="spectrum-Textfield-input"></textarea>
+        <textarea id="lifestory3" placeholder="Enter your life story" name="field" value="" class="spectrum-Textfield-input"></textarea>
       </div>
   - id: fieldlabel-side
     name: Right
     description: A right aligned field label.
     markup: |
-      <label for="lifestory" class="spectrum-FieldLabel spectrum-FieldLabel--right" style="width: 72px">Life Story</label>
+      <label for="lifestory4" class="spectrum-FieldLabel spectrum-FieldLabel--right" style="width: 72px">Life Story</label>
 
       <div class="spectrum-Textfield spectrum-Textfield--multiline">
-        <textarea id="lifestory" placeholder="Enter your life story" name="field" value="" class="spectrum-Textfield-input"></textarea>
+        <textarea id="lifestory4" placeholder="Enter your life story" name="field" value="" class="spectrum-Textfield-input"></textarea>
       </div>
   - id: fieldlabel
     name: Required
     description: Field label for a required field.
     markup: |
-      <label for="lifestory3" class="spectrum-FieldLabel">Life Story
+      <label for="lifestory5" class="spectrum-FieldLabel">Life Story
         <svg class="spectrum-Icon spectrum-UIIcon-Asterisk spectrum-FieldLabel-requiredIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-css-icon-Asterisk" />
         </svg>
       </label>
       <div class="spectrum-Textfield">
-        <input id="lifestory3" placeholder="Enter your life story" name="field" value="" class="spectrum-Textfield-input">
+        <input id="lifestory5" placeholder="Enter your life story" name="field" value="" class="spectrum-Textfield-input">
       </div>
 
-      <label for="lifestory4" class="spectrum-FieldLabel">Life Story (Required)</label>
+      <label for="lifestory6" class="spectrum-FieldLabel">Life Story (Required)</label>
       <div class="spectrum-Textfield">
-        <input id="lifestory4" placeholder="Enter your life story" name="field" value="" class="spectrum-Textfield-input">
+        <input id="lifestory6" placeholder="Enter your life story" name="field" value="" class="spectrum-Textfield-input">
       </div>
 
       <br/>
       <br/>
 
-      <label for="lifestory5" class="spectrum-FieldLabel spectrum-FieldLabel--left">Life Story
+      <label for="lifestory7" class="spectrum-FieldLabel spectrum-FieldLabel--left">Life Story
         <svg class="spectrum-Icon spectrum-UIIcon-Asterisk spectrum-FieldLabel-requiredIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-css-icon-Asterisk" />
         </svg>
       </label>
       <div class="spectrum-Textfield spectrum-Textfield--multiline">
-        <textarea id="lifestory5" placeholder="Enter your life story" name="field" value="" class="spectrum-Textfield-input"></textarea>
+        <textarea id="lifestory7" placeholder="Enter your life story" name="field" value="" class="spectrum-Textfield-input"></textarea>
       </div>
 
 
-      <label for="lifestory6" class="spectrum-FieldLabel is-disabled">Life Story
+      <label for="lifestory8" class="spectrum-FieldLabel is-disabled">Life Story
         <svg class="spectrum-Icon spectrum-UIIcon-Asterisk spectrum-FieldLabel-requiredIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-css-icon-Asterisk" />
         </svg>
       </label>
       <div class="spectrum-Textfield is-disabled">
-        <input id="lifestory6" placeholder="Enter your life story" name="field" value="" class="spectrum-Textfield-input" disabled>
+        <input id="lifestory8" placeholder="Enter your life story" name="field" value="" class="spectrum-Textfield-input" disabled>
       </div>


### PR DESCRIPTION
## Description

Fixed the issue that wrong input box could get activated when clicking on a label.

## How and where has this been tested?

 - **How this was tested:** Click on each label on the "Field Label" page and ensure that the input box that's activated is the one referred to by the label (i.e. the one next to the label).
 - **Browser(s) and OS(s) this was tested with:** Chrome 81 on macOS

## To-do list

- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] This pull request is ready to merge.
