### PR TITLE
fix: correct OverBackground ClearButton focus-ring, fixes #730

### DIFF
--- a/components/button/index.css
+++ b/components/button/index.css
@@ -157,15 +157,6 @@ governing permissions and limitations under the License.
   }
 }
 
-.spectrum-ClearButton--overBackground {
-  &:focus-ring {
-    &:after {
-      /* Adjust margin because ClearButton does not have a border */
-      margin: calc(var(--spectrum-alias-focus-ring-gap) * -1);
-    }
-  }
-}
-
 a.spectrum-Button,
 a.spectrum-ActionButton {
   /* Remove appearance for clickable types in iOS and Safari. */
@@ -327,6 +318,7 @@ a.spectrum-ActionButton {
 
 .spectrum-ClearButton {
   @inherit: %spectrum-BaseButton;
+  @inherit: %spectrum-ButtonWithFocusRing;
 
   inline-size: var(--spectrum-clearbutton-medium-width);
   block-size: var(--spectrum-clearbutton-medium-height);
@@ -342,6 +334,15 @@ a.spectrum-ActionButton {
     /* @safari10 Workaround for https://bugs.webkit.org/show_bug.cgi?id=169700 */
     margin-block: 0;
     margin-inline: auto;
+  }
+}
+
+.spectrum-ClearButton--overBackground {
+  &:focus-ring {
+    &:after {
+      /* Adjust margin because ClearButton does not have a border */
+      margin: calc(var(--spectrum-alias-focus-ring-gap) * -1);
+    }
   }
 }
 


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->
Lookit #730 

## How and where has this been tested?
 - **How this was tested:** Clicky click
 - **Browser(s) and OS(s) this was tested with:** Chrome on macOS

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->

![image](https://user-images.githubusercontent.com/201344/82362825-ccaf4d80-99c1-11ea-9db0-9091380e92b5.png)

## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
