### PR TITLE
fix: actiongroup wrapping, fixes #749

### DIFF
--- a/components/actiongroup/index.css
+++ b/components/actiongroup/index.css
@@ -23,8 +23,17 @@ governing permissions and limitations under the License.
     flex-shrink: 0;
   }
 
-  .spectrum-ActionGroup-item + .spectrum-ActionGroup-item {
-    margin-inline-start: var(--spectrum-actionbuttongroup-text-button-gap-x);
+  &:not(.spectrum-ActionGroup--vertical)&:not(.spectrum-ActionGroup--compact) {
+    margin-block-start: calc(-1 * var(--spectrum-actionbuttongroup-text-button-gap-y));
+
+    .spectrum-ActionGroup-item {
+      flex-shrink: 0;
+      margin-block-start: var(--spectrum-actionbuttongroup-text-button-gap-y);
+
+      &:not(:last-child) {
+        margin-inline-end: var(--spectrum-actionbuttongroup-text-button-gap-x);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Original PR from @Martskin . Thank you very much for your contribution.
I am re-creating this PR so we can have the Visual Regression Testing handled by Jenkins. Unfortunately we don't don't support that yet on forks. 

Original PR description from #758:
This PR modifies the CSS of ActionGroup to add top (block start) and right (inline-end) margins to fix the wrapping issue reported in Issue #749

## Description


## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots
https://user-images.githubusercontent.com/3717760/85166502-3bc7ce00-b21c-11ea-8a22-01809ea7dbff.png
![image](https://user-images.githubusercontent.com/52184321/88740670-a826ce80-d0f2-11ea-8b12-716f1c3b68ae.png)


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
