### PR TITLE
fix: actionButton focus-ring active state visual issue #755

### DIFF
--- a/components/button/skin.css
+++ b/components/button/skin.css
@@ -347,6 +347,10 @@ governing permissions and limitations under the License.
     box-shadow: 0 0 0 var(--spectrum-button-primary-border-size-increase-key-focus) var(--spectrum-actionbutton-border-color-key-focus);
     color: var(--spectrum-actionbutton-text-color-key-focus);
 
+    &:active {
+      border-color: var(--spectrum-actionbutton-border-color-key-focus);
+    }
+
     .spectrum-Icon {
       color: var(--spectrum-actionbutton-icon-color-key-focus);
     }
@@ -394,6 +398,10 @@ governing permissions and limitations under the License.
       background-color: var(--spectrum-actionbutton-background-color-selected-key-focus);
       border-color: var(--spectrum-actionbutton-border-color-selected-key-focus);
       color: var(--spectrum-actionbutton-text-color-selected-key-focus);
+
+      &:active {
+        border-color: var(--spectrum-actionbutton-border-color-key-focus);
+      }
 
       .spectrum-Icon {
         color: var(--spectrum-actionbutton-icon-color-selected-key-focus);


### PR DESCRIPTION
Original PR from @Martskin . Thank you very much for your contribution.
I am re-creating this PR so we can have the Visual Regression Testing handled by Jenkins (like for #77). Unfortunately we don't don't support that yet on forks.

Original description from #759: 
This PR fixes ActionButton Focus-ring Active state visual issue #755

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->


## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->
![image](https://user-images.githubusercontent.com/52184321/88857821-cef50b80-d1ab-11ea-9919-b908d74ad89e.png)



## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
