### PR TITLE
fix: allow high contrast mode for checkboxes

### DIFF
--- a/components/checkbox/skin.css
+++ b/components/checkbox/skin.css
@@ -26,6 +26,7 @@ governing permissions and limitations under the License.
 
 .spectrum-Checkbox-box {
   &:before {
+    forced-color-adjust: none;
     border-color: var(--spectrum-checkbox-emphasized-box-border-color);
     background-color: var(--spectrum-checkbox-emphasized-box-background-color);
   }
@@ -97,6 +98,7 @@ governing permissions and limitations under the License.
   }
 
   &:disabled ~ .spectrum-Checkbox-label {
+    forced-color-adjust: none;
     color: var(--spectrum-checkbox-text-color-disabled);
   }
 }
@@ -199,4 +201,37 @@ governing permissions and limitations under the License.
       color: var(--spectrum-checkbox-text-color-error-down);
     }
   }
+}
+
+@media (forced-colors: active) {
+  .spectrum-Checkbox-input {
+    &:focus-ring + .spectrum-Checkbox-box {
+      forced-color-adjust: none;
+      outline-color: var(--spectrum-checkbox-focus-ring-color-key-focus);
+      outline-style: auto;
+      outline-offset: var(--spectrum-checkbox-focus-ring-gap-key-focus);
+      outline-width: var(--spectrum-checkbox-focus-ring-size-key-focus);    }
+  }
+  :root {
+    --spectrum-checkbox-emphasized-box-background-color : var(--spectrum-alias-background-color-transparent);
+    --spectrum-checkbox-emphasized-box-background-color-disabled : var(--spectrum-alias-background-color-transparent);
+    --spectrum-checkbox-emphasized-box-border-color-disabled : GrayText;
+    --spectrum-checkbox-text-color-disabled : GrayText;
+    --spectrum-checkbox-box-border-color-key-focus: FieldText;
+    --spectrum-checkbox-emphasized-box-border-color: FieldText;
+    --spectrum-checkbox-quiet-box-border-color: FieldText; 
+    --spectrum-checkbox-box-border-color-selected-hover : Highlight;
+    --spectrum-checkbox-emphasized-box-border-color-selected-hover : Highlight;
+    --spectrum-checkbox-quiet-box-border-color-selected-hover : Highlight;
+    --spectrum-checkbox-emphasized-box-border-color-selected: Highlight; 
+    --spectrum-checkbox-quiet-box-border-color-selected: Highlight;
+    --spectrum-checkbox-checkmark-color: HighlightText;
+    --spectrum-checkbox-focus-ring-color-key-focus: Highlight;
+    --spectrum-checkbox-focus-ring-gap-key-focus: var(--spectrum-global-dimension-static-size-25);
+    --spectrum-checkbox-focus-ring-size-key-focus: var(--spectrum-global-dimension-static-size-40);
+    --spectrum-checkbox-box-border-color-error: FieldText;
+    --spectrum-checkbox-box-border-color-error-hover: FieldText;
+    --spectrum-checkbox-box-border-color-error-selected: FieldText;
+    --spectrum-checkbox-text-color-error: FieldText;
+  }        
 }


### PR DESCRIPTION
## Description
Fix for checkbox part of #786.
This changes checkboxes to work in the following ways in WHCM
- Have a visible focus indicator using the highlight colour
- Use Disabled colour when disabled
- Not use error colour when in error
- be able to determine the checked/unchecked/mixed state 

Note - I am unsure how to mark error state and am in discussions with Spectrum. IMO this can be tackled in a later PR.


## How and where has this been tested?
 - Run using Windows High Contrast mode both White on Black and Black on White
 - Note that the colors now match the windows system colors
 - Edge 85.0.564.30 on Windows 10

## Screenshots
![Checkbox - Spectrum CSS and 1 more page - Profile 1 - Microsoft​ Edge 8_13_2020 4_30_30 PM](https://user-images.githubusercontent.com/1724479/90197149-aa3f8d00-dd82-11ea-91e9-969ee7cd2096.png)
![Checkbox - Spectrum CSS and 1 more page - Profile 1 - Microsoft​ Edge 8_13_2020 4_30_39 PM](https://user-images.githubusercontent.com/1724479/90197152-ad3a7d80-dd82-11ea-8a4b-759b6abc6746.png)
![Checkbox - Spectrum CSS and 1 more page - Profile 1 - Microsoft​ Edge 8_13_2020 4_31_37 PM](https://user-images.githubusercontent.com/1724479/90197161-b1669b00-dd82-11ea-86ea-b77cf6606dda.png)
![Checkbox - Spectrum CSS and 1 more page - Profile 1 - Microsoft​ Edge 8_13_2020 4_31_45 PM](https://user-images.githubusercontent.com/1724479/90197168-b6c3e580-dd82-11ea-89da-b3a15c500743.png)


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
