### PR TITLE
Spectrum tokens 17 for Action Bar

### DIFF
--- a/components/actionbar/index.css
+++ b/components/actionbar/index.css
@@ -13,7 +13,8 @@ governing permissions and limitations under the License.
 
 :root {
   --spectrum-actionbar-height: var(--spectrum-global-dimension-size-600);
-  --spectrum-actionbar-padding-x: var(--spectrum-global-dimension-size-200);
+  --spectrum-actionbar-padding-left: var(--spectrum-global-dimension-size-200);
+  --spectrum-actionbar-padding-right: calc(var(--spectrum-global-dimension-size-200) / 2);
   --spectrum-actionbar-margin-x: var(--spectrum-global-dimension-size-200);
   --spectrum-actionbar-offset-y: var(--spectrum-global-dimension-size-200);
 
@@ -84,7 +85,7 @@ governing permissions and limitations under the License.
   block-size: var(--spectrum-actionbar-height);
   min-inline-size: var(--spectrum-actionbar-min-width);
   max-inline-size: var(--spectrum-actionbar-max-width);
-  padding: 0 var(--spectrum-actionbar-padding-x);
+  padding: 0 var(--spectrum-actionbar-padding-right) 0 var(--spectrum-actionbar-padding-left);
 
   flex-direction: row;
   align-items: center;

--- a/components/actionbar/metadata/actionbar.yml
+++ b/components/actionbar/metadata/actionbar.yml
@@ -19,14 +19,14 @@ examples:
             </span>
             <span class="spectrum-Checkbox-label">2 selected</span>
           </label>
-          <div class="spectrum-ButtonGroup">
-            <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
+          <div class="spectrum-ActionGroup">
+            <button class="spectrum-ActionButton spectrum-ActionButton--quiet spectrum-ActionGroup-item">
               <span class="spectrum-ActionButton-label">Edit</span>
             </button>
-            <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
+            <button class="spectrum-ActionButton spectrum-ActionButton--quiet spectrum-ActionGroup-item">
               <span class="spectrum-ActionButton-label">Copy</span>
             </button>
-            <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
+            <button class="spectrum-ActionButton spectrum-ActionButton--quiet spectrum-ActionGroup-item">
               <span class="spectrum-ActionButton-label">Delete</span>
             </button>
           </div>
@@ -47,20 +47,20 @@ examples:
             </span>
             <span class="spectrum-Checkbox-label">4 selected</span>
           </label>
-          <div class="spectrum-ButtonGroup">
-            <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
+          <div class="spectrum-ActionGroup">
+            <button class="spectrum-ActionButton spectrum-ActionButton--quiet spectrum-ActionGroup-item">
               <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
                 <use xlink:href="#spectrum-icon-18-Edit"></use>
               </svg>
               <span class="spectrum-ActionButton-label">Edit</span>
             </button>
-            <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
+            <button class="spectrum-ActionButton spectrum-ActionButton--quiet spectrum-ActionGroup-item">
               <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Copy">
                 <use xlink:href="#spectrum-icon-18-Copy"></use>
               </svg>
               <span class="spectrum-ActionButton-label">Copy</span>
             </button>
-            <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
+            <button class="spectrum-ActionButton spectrum-ActionButton--quiet spectrum-ActionGroup-item">
               <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Delete">
                 <use xlink:href="#spectrum-icon-18-Delete"></use>
               </svg>
@@ -84,18 +84,18 @@ examples:
             </span>
             <span class="spectrum-Checkbox-label">6 selected</span>
           </label>
-          <div class="spectrum-ButtonGroup">
-            <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
+          <div class="spectrum-ActionGroup">
+            <button class="spectrum-ActionButton spectrum-ActionButton--quiet spectrum-ActionGroup-item">
               <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
                 <use xlink:href="#spectrum-icon-18-Edit"></use>
               </svg>
             </button>
-            <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
+            <button class="spectrum-ActionButton spectrum-ActionButton--quiet spectrum-ActionGroup-item">
               <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Copy">
                 <use xlink:href="#spectrum-icon-18-Copy"></use>
               </svg>
             </button>
-            <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
+            <button class="spectrum-ActionButton spectrum-ActionButton--quiet spectrum-ActionGroup-item">
               <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Delete">
                 <use xlink:href="#spectrum-icon-18-Delete"></use>
               </svg>
@@ -121,13 +121,13 @@ examples:
             </span>
             <span class="spectrum-Checkbox-label">228 selected</span>
           </label>
-          <div class="spectrum-ButtonGroup">
-            <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
+          <div class="spectrum-ActionGroup">
+            <button class="spectrum-ActionButton spectrum-ActionButton--quiet spectrum-ActionGroup-item">
               <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
                 <use xlink:href="#spectrum-icon-18-Edit"></use>
               </svg>
             </button>
-            <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
+            <button class="spectrum-ActionButton spectrum-ActionButton--quiet spectrum-ActionGroup-item">
               <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="More">
                 <use xlink:href="#spectrum-icon-18-More"></use>
               </svg>
@@ -318,20 +318,20 @@ examples:
                 </span>
                 <span class="spectrum-Checkbox-label">4 selected</span>
               </label>
-              <div class="spectrum-ButtonGroup">
-                <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
+              <div class="spectrum-ActionGroup">
+                <button class="spectrum-ActionButton spectrum-ActionButton--quiet spectrum-ActionGroup-item">
                   <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
                     <use xlink:href="#spectrum-icon-18-Edit"></use>
                   </svg>
                   <span class="spectrum-ActionButton-label">Edit</span>
                 </button>
-                <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
+                <button class="spectrum-ActionButton spectrum-ActionButton--quiet spectrum-ActionGroup-item">
                   <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Copy">
                     <use xlink:href="#spectrum-icon-18-Copy"></use>
                   </svg>
                   <span class="spectrum-ActionButton-label">Copy</span>
                 </button>
-                <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
+                <button class="spectrum-ActionButton spectrum-ActionButton--quiet spectrum-ActionGroup-item">
                   <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Delete">
                     <use xlink:href="#spectrum-icon-18-Delete"></use>
                   </svg>

--- a/components/actionbar/metadata/actionbar.yml
+++ b/components/actionbar/metadata/actionbar.yml
@@ -49,19 +49,19 @@ examples:
           </label>
           <div class="spectrum-ButtonGroup">
             <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
-              <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Edit">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
                 <use xlink:href="#spectrum-icon-18-Edit"></use>
               </svg>
               <span class="spectrum-ActionButton-label">Edit</span>
             </button>
             <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
-              <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Copy">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Copy">
                 <use xlink:href="#spectrum-icon-18-Copy"></use>
               </svg>
               <span class="spectrum-ActionButton-label">Copy</span>
             </button>
             <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
-              <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Delete">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Delete">
                 <use xlink:href="#spectrum-icon-18-Delete"></use>
               </svg>
               <span class="spectrum-ActionButton-label">Delete</span>
@@ -86,17 +86,17 @@ examples:
           </label>
           <div class="spectrum-ButtonGroup">
             <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
-              <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Edit">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
                 <use xlink:href="#spectrum-icon-18-Edit"></use>
               </svg>
             </button>
             <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
-              <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Copy">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Copy">
                 <use xlink:href="#spectrum-icon-18-Copy"></use>
               </svg>
             </button>
             <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
-              <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Delete">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Delete">
                 <use xlink:href="#spectrum-icon-18-Delete"></use>
               </svg>
             </button>
@@ -123,12 +123,12 @@ examples:
           </label>
           <div class="spectrum-ButtonGroup">
             <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
-              <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Edit">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
                 <use xlink:href="#spectrum-icon-18-Edit"></use>
               </svg>
             </button>
             <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
-              <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="More">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="More">
                 <use xlink:href="#spectrum-icon-18-More"></use>
               </svg>
             </button>
@@ -320,19 +320,19 @@ examples:
               </label>
               <div class="spectrum-ButtonGroup">
                 <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
-                  <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
                     <use xlink:href="#spectrum-icon-18-Edit"></use>
                   </svg>
                   <span class="spectrum-ActionButton-label">Edit</span>
                 </button>
                 <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
-                  <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Copy">
+                  <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Copy">
                     <use xlink:href="#spectrum-icon-18-Copy"></use>
                   </svg>
                   <span class="spectrum-ActionButton-label">Copy</span>
                 </button>
                 <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
-                  <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Delete">
+                  <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Delete">
                     <use xlink:href="#spectrum-icon-18-Delete"></use>
                   </svg>
                   <span class="spectrum-ActionButton-label">Delete</span>

--- a/components/actionbar/metadata/actionbar.yml
+++ b/components/actionbar/metadata/actionbar.yml
@@ -1,5 +1,13 @@
 name: Action Bar
 description: Floating action bar that appears in selection mode.
+sections:
+  - name: Migration Guide
+    description: |
+      ### New ActionGroup markup
+      Action Bar now uses the new ActionGroup markup. Replace `.spectrum-ButtonGroup` with `.spectrum-ActionGroup` and apply `.spectrum-ActionGroup-item` to each action button. See the [Action Group](actiongroup.html) for more information.
+
+      ### Change workflow icon size to medium
+      If you use icon action button in your markup, please replace `.spectrum-Icon--sizeS` with `.spectrum-Icon--sizeM`.
 examples:
   - id: actionbar
     name: Standard

--- a/components/actionbar/metadata/actionbar.yml
+++ b/components/actionbar/metadata/actionbar.yml
@@ -17,7 +17,7 @@ examples:
                 <use xlink:href="#spectrum-css-icon-DashSmall" />
               </svg>
             </span>
-            <span class="spectrum-Checkbox-label">2 Selected</span>
+            <span class="spectrum-Checkbox-label">2 selected</span>
           </label>
           <div class="spectrum-ButtonGroup">
             <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
@@ -45,7 +45,7 @@ examples:
                 <use xlink:href="#spectrum-css-icon-DashSmall" />
               </svg>
             </span>
-            <span class="spectrum-Checkbox-label">4 Selected</span>
+            <span class="spectrum-Checkbox-label">4 selected</span>
           </label>
           <div class="spectrum-ButtonGroup">
             <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
@@ -82,7 +82,7 @@ examples:
                 <use xlink:href="#spectrum-css-icon-DashSmall" />
               </svg>
             </span>
-            <span class="spectrum-Checkbox-label">6 Selected</span>
+            <span class="spectrum-Checkbox-label">6 selected</span>
           </label>
           <div class="spectrum-ButtonGroup">
             <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
@@ -119,7 +119,7 @@ examples:
                 <use xlink:href="#spectrum-css-icon-DashSmall" />
               </svg>
             </span>
-            <span class="spectrum-Checkbox-label">228 Selected</span>
+            <span class="spectrum-Checkbox-label">228 selected</span>
           </label>
           <div class="spectrum-ButtonGroup">
             <button class="spectrum-ActionButton spectrum-ActionButton--quiet">
@@ -316,7 +316,7 @@ examples:
                     <use xlink:href="#spectrum-css-icon-DashSmall" />
                   </svg>
                 </span>
-                <span class="spectrum-Checkbox-label">4 Selected</span>
+                <span class="spectrum-Checkbox-label">4 selected</span>
               </label>
               <div class="spectrum-ButtonGroup">
                 <button class="spectrum-ActionButton spectrum-ActionButton--quiet">

--- a/components/actionbar/package.json
+++ b/components/actionbar/package.json
@@ -16,6 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
+    "@spectrum-css/actiongroup": "1.0.0-beta.2",
     "@spectrum-css/button": "^3.0.0-beta.0",
     "@spectrum-css/checkbox": "^3.0.0-beta.0",
     "@spectrum-css/icon": "^2.0.0",
@@ -23,6 +24,7 @@
     "@spectrum-css/vars": "^2.0.0"
   },
   "devDependencies": {
+    "@spectrum-css/actiongroup": "1.0.0-beta.2",
     "@spectrum-css/button": "^3.0.0-beta.3",
     "@spectrum-css/checkbox": "^3.0.0-beta.3",
     "@spectrum-css/component-builder": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1082,10 +1082,20 @@
   dependencies:
     "@types/node" ">= 8"
 
+"@spectrum-css/button@^2.1.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/button/-/button-2.2.0.tgz#7372e8b107f3ba645a69f3994b84a6753c47ddea"
+  integrity sha512-1dccGF47Xf8uKEThnAjwXMsOE5PPMDrWK1S1x6ZWWXHJ1kQAkx7ZtekLYLvh588/IuEHUcPW3M4r9gvUuGXR5g==
+
 "@spectrum-css/spectrum-css-vr-test-assets-essential@^1.0.3":
   version "1.0.19"
   resolved "https://registry.yarnpkg.com/@spectrum-css/spectrum-css-vr-test-assets-essential/-/spectrum-css-vr-test-assets-essential-1.0.19.tgz#bb647d24184230c8d5fedef0074394f46a3ea567"
   integrity sha512-mmd8uJTx4U62Kv+Rzja1NUGOsAPpExlBFdoyUP4RxG5g3ZA8+cIZ1ONdzo+pirb/YpriznXszo0DEq5AzDxFBA==
+
+"@spectrum-css/vars@^2.1.0", "@spectrum-css/vars@^2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/vars/-/vars-2.3.0.tgz#0ce716fb5ee65f4af9e2d2a7aaae55e8ba4d4c8f"
+  integrity sha512-k4YwFbv9+7QzBrc3ezvGuHxI3nDTG/6qJsAmhYS1vEyxpxjKmRfiz59P+fqT12PQNjxeNYHyVz1kRgaLA6gw2w==
 
 "@spectrum/spectrum-icons@^2.3.0":
   version "2.3.0"
@@ -7473,7 +7483,7 @@ postcss-load-plugins@^2.3.0:
     cosmiconfig "^2.1.1"
     object-assign "^4.1.0"
 
-postcss-logical@^4.0.0:
+postcss-logical@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/postcss-logical/-/postcss-logical-4.0.2.tgz#63f5207bae63f1f646462c26509185c2eae22c72"
   integrity sha512-tlX1n19np6/JznvyymZM6SIe0FymD5Ngwcg2j825vNKhADu0p1PTgEmsCjakCbvn78kaIFzYTI32NpgOEwgifQ==


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
Fixed #807 and when parent branch was merged to main, it will fix `#894`

1. Example change
- Changed string capitalization
- Switched to use `ActionGroup`
- Changed Workflow icon size from small to medium

2. Add `@spectrum-css/actiongroup` as dependency

3. Change action bar content padding-right to be half of the padding-left to match [UI kit](https://spectrum-contributions.corp.adobe.com/page/action-bar-beta/)

## How and where has this been tested?
Chrome/Firefox/Safari on MacOS

## Screenshots
1. Desktop scale
![image](https://user-images.githubusercontent.com/1207520/92037829-38c28100-ed27-11ea-87a9-0a05b1b3b68f.png)
2. Mobile scale
![image](https://user-images.githubusercontent.com/1207520/92037877-51329b80-ed27-11ea-9cbd-d7bcd6ab9a5c.png)


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
