### PR TITLE
Fixes Toast separator for color stop builds

### DIFF
--- a/components/searchwithin/index.css
+++ b/components/searchwithin/index.css
@@ -39,7 +39,6 @@ governing permissions and limitations under the License.
 
 .spectrum-SearchWithin-input {
   flex: 1;
-  min-width: inherit;
   margin-inline-start: calc(-1 * var(--spectrum-textfield-border-size)); /* hides left border */
   border-start-start-radius: var(--spectrum-searchwithin-border-radius);
   border-end-start-radius: var(--spectrum-searchwithin-border-radius);
@@ -53,8 +52,4 @@ governing permissions and limitations under the License.
   position: absolute;
   inset-block-start: 0;
   inset-inline-end: 0;
-}
-
-.spectrum-SearchWithin > .spectrum-Textfield {
-  flex-grow: 1;
 }

--- a/components/searchwithin/index.css
+++ b/components/searchwithin/index.css
@@ -39,6 +39,7 @@ governing permissions and limitations under the License.
 
 .spectrum-SearchWithin-input {
   flex: 1;
+  min-width: inherit;
   margin-inline-start: calc(-1 * var(--spectrum-textfield-border-size)); /* hides left border */
   border-start-start-radius: var(--spectrum-searchwithin-border-radius);
   border-end-start-radius: var(--spectrum-searchwithin-border-radius);
@@ -52,4 +53,8 @@ governing permissions and limitations under the License.
   position: absolute;
   inset-block-start: 0;
   inset-inline-end: 0;
+}
+
+.spectrum-SearchWithin > .spectrum-Textfield {
+  flex-grow: 1;
 }

--- a/components/toast/index.css
+++ b/components/toast/index.css
@@ -59,6 +59,7 @@ governing permissions and limitations under the License.
   display: flex;
   flex: 0 0 auto;
   align-items: flex-start;
+  border-inline-start-color: rgba(255, 255, 255, 0.2);
 
   .spectrum-Button,
   .spectrum-ClearButton {

--- a/components/toast/skin.css
+++ b/components/toast/skin.css
@@ -23,10 +23,6 @@ governing permissions and limitations under the License.
   color: white;
 }
 
-.spectrum-Toast-buttons {
-  border-inline-start-color: rgba(255, 255, 255, 0.2);
-}
-
 .spectrum-Toast--warning {
   background-color: var(--spectrum-toast-warning-background-color);
   color: var(--spectrum-toast-warning-background-color);


### PR DESCRIPTION
Fixes Toast separator for color stop builds

## Description
Details in #884

## How and where has this been tested?
 - **How this was tested:** CSS copied to my project which uses the color stops and inspected visually.
 - **Browser(s) and OS(s) this was tested with:** Firefox and Chrome


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
