### PR TITLE
Fix side nav item with long text cutting off icon

### DIFF
--- a/components/sidenav/index.css
+++ b/components/sidenav/index.css
@@ -74,6 +74,7 @@ governing permissions and limitations under the License.
   }
 
   .spectrum-SideNav-itemIcon {
+    flex-shrink: 0;
     margin-inline-end: var(--spectrum-sidenav-icon-gap);
   }
 }


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->
When a [side nav item with icon](https://opensource.adobe.com/spectrum-css/sidenav.html#icon) has long text, the icon no longer gets cut off. Fixes #895 and https://git.corp.adobe.com/React/react-spectrum-v2/issues/613.

This is needed for the upcoming GA release of a new AEP feature.


## How and where has this been tested?
 - **How this was tested:** Using steps in issue #895
 - **Browser(s) and OS(s) this was tested with:** Chrome 85.0.4183.102, Safari 13.1.2, Firefox 80.0.1 on Mac OS 10.14.6

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->
**Before**
![Screen Shot 2020-09-08 at 2 32 02 PM](https://user-images.githubusercontent.com/2606744/92529856-21c8d680-f1e0-11ea-84d4-c700e10fe023.png)


**After**
![Screen Shot 2020-09-08 at 2 32 09 PM](https://user-images.githubusercontent.com/2606744/92529864-255c5d80-f1e0-11ea-8a63-de5fb352912f.png)


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] Bump version and update CHANGELOG (should this fix go into both v2 and v3? How do I do that?)
- [ ] This pull request is ready to merge.
