### PR TITLE
fix: ramp slider (#829)

### DIFF
--- a/components/slider/index.css
+++ b/components/slider/index.css
@@ -47,6 +47,8 @@ governing permissions and limitations under the License.
   --spectrum-slider-color-track-margin-left: 0;
   --spectrum-slider-color-track-margin-right: 0;
   --spectrum-slider-color-handle-top: 50%;
+  
+  --spectrum-slider-ramp-margin-top: 0;
 
   --spectrum-slider-range-track-reset: 0;
   --spectrum-label-text-size: var(--spectrum-global-dimension-font-size-75);
@@ -173,6 +175,24 @@ governing permissions and limitations under the License.
       inset-inline-end: var(--spectrum-slider-range-track-reset);
       margin-inline-end: var(--spectrum-slider-track-margin-offset);
     }
+  }
+}
+
+.spectrum-Slider-ramp {
+  margin-block-start: var(--spectrum-slider-ramp-margin-top);
+  block-size: var(--spectrum-slider-ramp-track-height);
+
+  position: absolute;
+  inset-inline-start: var(--spectrum-slider-track-margin-offset);
+  inset-inline-end: var(--spectrum-slider-track-margin-offset);
+  inset-block-start: calc(var(--spectrum-slider-ramp-track-height) / 2);
+
+  svg {
+    inline-size: 100%;
+    block-size: 100%;
+
+    /* Flip the ramp automatically for RTL */
+    transform: logical rotate(0deg);
   }
 }
 
@@ -368,6 +388,7 @@ governing permissions and limitations under the License.
   }
 }
 
+
 .spectrum-Slider {
   &.is-disabled {
     cursor: default;
@@ -378,6 +399,7 @@ governing permissions and limitations under the License.
     }
   }
 }
+
 
 .u-isGrabbing {
   cursor: ns-resize;

--- a/components/slider/metadata/slider.yml
+++ b/components/slider/metadata/slider.yml
@@ -352,45 +352,4 @@ examples:
           </div>
         </div>
       </div>
-  - id: slider-color
-    name: Color
-    status: Deprecated
-    details: A new color slider is forthcoming.
-    description: Spectrum Color slider
-    markup: |
-      <div class="spectrum-Slider spectrum-Slider--color">
-        <div class="spectrum-Slider-labelContainer">
-          <label class="spectrum-Slider-label" id="spectrum-Slider--color-label-0" for="spectrum-Slider--color-input-0">Color</label>
-          <div class="spectrum-Slider-value" role="textbox" aria-readonly="true" aria-labelledby="spectrum-Slider--color-label-0">#2680eb</div>
-        </div>
-        <div class="spectrum-Slider-controls">
-          <div class="spectrum-Slider-track" style="background: linear-gradient(to right, rgb(38, 128, 235), rgb(9, 90, 186))"></div>
-          <div class="spectrum-Slider-handle" style="left: 40%;">
-            <input type="range" class="spectrum-Slider-input" value="14" aria-valuetext="#2680eb" step="2" min="10" max="20" id="spectrum-Slider--color-input-0">
-          </div>
-        </div>
-      </div>
-      <div class="spectrum-Slider spectrum-Slider--color">
-        <div class="spectrum-Slider-labelContainer">
-          <label class="spectrum-Slider-label" id="spectrum-Slider--color-label-1" for="spectrum-Slider--color-input-1">Color (showing alpha)</label>
-          <div class="spectrum-Slider-value" role="textbox" aria-readonly="true" aria-labelledby="spectrum-Slider--color-label-1">#2680eb</div>
-        </div>
-        <div class="spectrum-Slider-controls">
-          <div class="spectrum-Slider-track" style="background: linear-gradient(to right, rgba(38, 128, 235, .5), rgb(9, 90, 186))"></div>
-          <div class="spectrum-Slider-handle" style="left: 40%;">
-            <input type="range" class="spectrum-Slider-input" value="14" aria-valuetext="#2680eb" step="2" min="10" max="20" id="spectrum-Slider--color-input-1">
-          </div>
-        </div>
-      </div>
-      <div class="spectrum-Slider spectrum-Slider--color is-disabled">
-        <div class="spectrum-Slider-labelContainer">
-          <label class="spectrum-Slider-label" id="spectrum-Slider--color-label-2" for="spectrum-Slider--color-input-2">Color</label>
-          <div class="spectrum-Slider-value" role="textbox" aria-readonly="true" aria-labelledby="spectrum-Slider--color-label-2">#2680eb</div>
-        </div>
-        <div class="spectrum-Slider-controls">
-          <div class="spectrum-Slider-track" style="background: linear-gradient(to right, rgba(38, 128, 235, .5), rgb(9, 90, 186))"></div>
-          <div class="spectrum-Slider-handle" style="left: 40%;">
-            <input type="range" class="spectrum-Slider-input" value="14" aria-valuetext="#2680eb" step="2" min="10" max="20" disabled id="spectrum-Slider--color-input-2">
-          </div>
-        </div>
-      </div>
+      

--- a/components/slider/skin.css
+++ b/components/slider/skin.css
@@ -52,6 +52,12 @@ governing permissions and limitations under the License.
   }
 }
 
+.spectrum-Slider-ramp {
+  path {
+    fill: var(--spectrum-slider-track-color);
+  }
+}
+
 .spectrum-Slider-handle {
   border-color: var(--spectrum-slider-handle-border-color);
   background: var(--spectrum-slider-handle-background-color);
@@ -75,6 +81,14 @@ governing permissions and limitations under the License.
   }
 }
 
+
+.spectrum-Slider--ramp {
+  .spectrum-Slider-handle {
+    /* We can't draw this one correctly without this hack : ( */
+    box-shadow: 0 0 0 4px var(--spectrum-alias-background-color-default);
+  }
+}
+
 .spectrum-Slider-input {
   background: transparent;
 }
@@ -84,6 +98,7 @@ governing permissions and limitations under the License.
     background-color: var(--spectrum-slider-tick-mark-color);
   }
 }
+
 
 .spectrum-Slider-handle {
   &.is-dragged {
@@ -101,6 +116,7 @@ governing permissions and limitations under the License.
     }
   }
 }
+
 
 .spectrum-Slider {
   &.is-disabled {
@@ -135,6 +151,13 @@ governing permissions and limitations under the License.
         background: var(--spectrum-slider-fill-track-color-disabled);
       }
     }
+
+    .spectrum-Slider-ramp {
+      path {
+        fill: var(--spectrum-slider-ramp-track-color-disabled);
+      }
+    }
+
 
     &.spectrum-Slider--range {
       .spectrum-Slider-track {


### PR DESCRIPTION
Adding back ramp-slider and removing color-slider.


## Description
Addresses issue #829 

- added back ramp-slider
- removed color-slider from slider page that is now it's own component under [/docs/colorslider.html](/docs/colorslider.html)


## How and where has this been tested?
URL: http://localhost:3000/docs/slider.html
Chrome Version 85.0.4183.102 (Official Build) (64-bit) on MacOS


## Screenshots
<!-- If applicable, add screenshots to show what you changed -->

<img width="635" alt="Screen Shot 2020-09-17 at 15 07 53" src="https://user-images.githubusercontent.com/52184321/93517961-284f0080-f8fa-11ea-92bd-85bba0e0021b.png">

## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
