### PR TITLE
Spectrum tokens 17 - Tooltip

### DIFF
--- a/components/tooltip/index.css
+++ b/components/tooltip/index.css
@@ -142,6 +142,7 @@ governing permissions and limitations under the License.
   width: var(--spectrum-tooltip-icon-size);
   height: var(--spectrum-tooltip-icon-size);
   align-self: flex-start;
+  flex-shrink: 0;
 
   /* Adjusts for weird misalignment */
   margin-block-start: 1px;


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
Avoid the tooltip label overlaps on the icon and still preserved the max-width.

Fixed #847 

## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/1207520/93810050-f512b700-fc02-11ea-85ee-8a1364ac50f7.png)
After:
![image](https://user-images.githubusercontent.com/1207520/93810095-04920000-fc03-11ea-9968-ac2f8dd4fb02.png)


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
