### PR TITLE
Try to make the slider value label less jumpy

### DIFF
--- a/components/slider/index.css
+++ b/components/slider/index.css
@@ -315,6 +315,8 @@ governing permissions and limitations under the License.
   flex-grow: 0;
   padding-inline-end: 0;
   cursor: default;
+  font-feature-settings: "tnum";
+  text-align: end;
 }
 
 .spectrum-Slider-value {


### PR DESCRIPTION
# Description

Closes https://github.com/adobe/spectrum-css/issues/968

See issue for more details


## How and where has this been tested?
 - **How this was tested:** 

Before: https://reactspectrum.blob.core.windows.net/reactspectrum/90e48ecca96b40cb4c4a90eb833e0e36871372b6/storybook/index.html?path=/story/slider--label-overflow

After: https://reactspectrum.blob.core.windows.net/reactspectrum/563b35205c55a6b38433830beca9aed9b8003256/storybook/index.html?path=/story/slider--label-overflow

 - **Browser(s) and OS(s) this was tested with:** 85.0.4183.102, macOS 10.15

## Screenshots



## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
