### PR TITLE
test: Exclude animation scenario for progresscircle

### DIFF
--- a/backstop_data/backstop_scenarios.json
+++ b/backstop_data/backstop_scenarios.json
@@ -282,6 +282,9 @@
   {
     "label": "progresscircle",
     "url": "progresscircle.html",
+    "removeSelectors": [
+      "#indeterminate + .spectrum-CSSExample-container .spectrum-CSSExample-example"
+    ],
     "package": "@spectrum-css/progresscircle"
   },
   {


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
After re-generating the VRT baseline images, we still got one scenarios constantly failed. It turns out to be an animation of progresscircle component which should be excluded.

402 passed / 1 failed - https://spectrum-visual-regression.ci.corp.adobe.com/job/spectrum-css-vr-essential-test/17/artifact/light_medium/backstop_data/html_report/index.html

![image](https://user-images.githubusercontent.com/1207520/94286735-3f997980-ff0a-11ea-95c5-bd56618110f0.png)



## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
