### PR TITLE
Slider: add side label variant

### DIFF
--- a/components/slider/index.css
+++ b/components/slider/index.css
@@ -419,3 +419,22 @@ governing permissions and limitations under the License.
     }
   }
 }
+
+.spectrum-Slider--label-side {
+  display: flex;
+  gap: 7px;
+  align-items: center;
+
+  & > * {
+    display: inline-block;
+  }
+
+  & .spectrum-Slider-labelContainer {
+    padding-top: 0;
+    flex-shrink: 0;
+  }
+
+  & .spectrum-Slider-label {
+    margin-inline-end: var(--spectrum-slider-label-gap-x);
+  }
+}

--- a/components/slider/metadata/slider.yml
+++ b/components/slider/metadata/slider.yml
@@ -60,6 +60,39 @@ examples:
           <div class="spectrum-Slider-track"></div>
         </div>
       </div>
+  - id: slider
+    name: Side Label
+    markup: |
+      <div class="spectrum-Slider spectrum-Slider--label-side">
+        <div class="spectrum-Slider-labelContainer">
+          <label class="spectrum-Slider-label" id="spectrum-Slider-label-8" for="spectrum-Slider-input-8">Slider Label</label>
+        </div>
+        <div class="spectrum-Slider-controls">
+          <div class="spectrum-Slider-track"></div>
+          <div class="spectrum-Slider-handle" style="left: 40%;">
+            <input type="range" class="spectrum-Slider-input" value="14" step="2" min="10" max="20" id="spectrum-Slider-input-8">
+          </div>
+          <div class="spectrum-Slider-track"></div>
+        </div>
+        <div class="spectrum-Slider-labelContainer">
+          <div class="spectrum-Slider-value" role="textbox" aria-readonly="true" aria-labelledby="spectrum-Slider-label-8">14</div>
+        </div>
+      </div>
+      <div class="spectrum-Slider is-disabled spectrum-Slider--label-side">
+        <div class="spectrum-Slider-labelContainer">
+          <label class="spectrum-Slider-label" id="spectrum-Slider-label-8" for="spectrum-Slider-input-8">Slider Label</label>
+        </div>
+        <div class="spectrum-Slider-controls">
+          <div class="spectrum-Slider-track"></div>
+          <div class="spectrum-Slider-handle" style="left: 40%;">
+            <input type="range" class="spectrum-Slider-input" value="14" step="2" min="10" max="20" id="spectrum-Slider-input-8">
+          </div>
+          <div class="spectrum-Slider-track"></div>
+        </div>
+        <div class="spectrum-Slider-labelContainer">
+          <div class="spectrum-Slider-value" role="textbox" aria-readonly="true" aria-labelledby="spectrum-Slider-label-8">14</div>
+        </div>
+      </div>
   - id: slider-fill
     name: Filled
     description: With fill.


### PR DESCRIPTION
## Description

Opening to get feedback...

Closes https://github.com/adobe/spectrum-css/issues/970


## How and where has this been tested?
 - **Browser(s) and OS(s) this was tested with:** Chrome 85.0.4183.121, macOS 10.15

## Screenshots

<img width="492" alt="Bildschirmfoto 2020-09-28 um 11 40 31" src="https://user-images.githubusercontent.com/4586894/94416673-6b716500-017f-11eb-80d1-a76d79de085a.png">



## To-do list
- [ ] Update the Javascript for the docs website to use correct width
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
