### PR TITLE
ColorLoupe: add checkerboard background

### DIFF
--- a/components/colorhandle/metadata/colorhandle.yml
+++ b/components/colorhandle/metadata/colorhandle.yml
@@ -28,6 +28,12 @@ examples:
         <div class="spectrum-ColorHandle-color" style="background-color: rgba(255, 0, 0, 0.5)"></div>
         <svg class="spectrum-ColorLoupe is-open">
           <g transform="translate(1 1)">
+            <pattern id="colorloupe-background" x="0" y="0" width="16" height="16" patternUnits="userSpaceOnUse">
+              <rect class="spectrum-ColorLoupe-inner-background" x="0" y="0" width="16" height="16" />
+              <rect class="spectrum-ColorLoupe-inner-checker" x="0" y="0" width="8" height="8" />
+              <rect class="spectrum-ColorLoupe-inner-checker" x="8" y="8" width="8" height="8" />
+            </pattern>
+            <path class="spectrum-ColorLoupe-inner" d="M24,0A24,24,0,0,1,48,24c0,16.255-24,40-24,40S0,40.255,0,24A24,24,0,0,1,24,0Z" fill="url(#colorloupe-background)" />
             <path class="spectrum-ColorLoupe-inner" d="M24,0A24,24,0,0,1,48,24c0,16.255-24,40-24,40S0,40.255,0,24A24,24,0,0,1,24,0Z" fill="rgba(255, 0, 0, 0.5)" />
             <path class="spectrum-ColorLoupe-outer" d="M24,2A21.98,21.98,0,0,0,2,24c0,6.2,4,14.794,11.568,24.853A144.233,144.233,0,0,0,24,61.132,144.085,144.085,0,0,0,34.4,48.893C41.99,38.816,46,30.209,46,24A21.98,21.98,0,0,0,24,2m0-2A24,24,0,0,1,48,24c0,16.255-24,40-24,40S0,40.255,0,24A24,24,0,0,1,24,0Z"/>
           </g>

--- a/components/colorloupe/metadata/colorloupe.yml
+++ b/components/colorloupe/metadata/colorloupe.yml
@@ -12,6 +12,12 @@ examples:
     markup: |
       <svg class="spectrum-ColorLoupe is-open" style="position: absolute; top: 25%; left: 50%;">
         <g transform="translate(1 1)">
+          <pattern id="colorloupe-background" x="0" y="0" width="16" height="16" patternUnits="userSpaceOnUse">
+            <rect class="spectrum-ColorLoupe-inner-background" x="0" y="0" width="16" height="16" />
+            <rect class="spectrum-ColorLoupe-inner-checker" x="0" y="0" width="8" height="8" />
+            <rect class="spectrum-ColorLoupe-inner-checker" x="8" y="8" width="8" height="8" />
+          </pattern>
+          <path class="spectrum-ColorLoupe-inner" d="M24,0A24,24,0,0,1,48,24c0,16.255-24,40-24,40S0,40.255,0,24A24,24,0,0,1,24,0Z" fill="url(#colorloupe-background)" />
           <path class="spectrum-ColorLoupe-inner" d="M24,0A24,24,0,0,1,48,24c0,16.255-24,40-24,40S0,40.255,0,24A24,24,0,0,1,24,0Z" fill="rgba(255, 0, 0, 0.5)" />
           <path class="spectrum-ColorLoupe-outer" d="M24,2A21.98,21.98,0,0,0,2,24c0,6.2,4,14.794,11.568,24.853A144.233,144.233,0,0,0,24,61.132,144.085,144.085,0,0,0,34.4,48.893C41.99,38.816,46,30.209,46,24A21.98,21.98,0,0,0,24,2m0-2A24,24,0,0,1,48,24c0,16.255-24,40-24,40S0,40.255,0,24A24,24,0,0,1,24,0Z"/>
         </g>

--- a/components/colorloupe/skin.css
+++ b/components/colorloupe/skin.css
@@ -2,3 +2,11 @@
   fill: var(--spectrum-colorloupe-inner-border-color);
   stroke: var(--spectrum-colorloupe-outer-border-color);
 }
+
+.spectrum-ColorLoupe-inner-background {
+  fill: var(--spectrum-global-color-static-white);
+}
+
+.spectrum-ColorLoupe-inner-checker {
+  fill: var(--spectrum-global-color-static-gray-500);
+}


### PR DESCRIPTION
## Description
Only the colorhandle had a checkerboard background (visible when alpha != 1), but not colorloupe.


## How and where has this been tested?
 - **How this was tested:** I've updated the examples on the colorhandle and colorloupe docs
 - **Browser(s) and OS(s) this was tested with:** Chrome 85.0.4183.121, macOS 10.15

## Screenshots

Before (colorloupe displaying red with alpha=0.5):
![Bildschirmfoto 2020-10-05 um 12 13 33](https://user-images.githubusercontent.com/4586894/95067480-324b6e80-0704-11eb-8ebf-ca7b29996c53.png)

After (same color):
![Bildschirmfoto 2020-10-05 um 12 13 57](https://user-images.githubusercontent.com/4586894/95067514-40998a80-0704-11eb-8b4c-1a8c45b528a5.png)



## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
