### PR TITLE
fix: support high contrast mode in color components

### DIFF
--- a/components/colorarea/skin.css
+++ b/components/colorarea/skin.css
@@ -3,6 +3,12 @@
     box-shadow: inset 0 0 0 var(--spectrum-colorarea-border-size) var(--spectrum-colorarea-border-color);
   }
 }
+.spectrum-ColorArea-gradient {
+  forced-color-adjust: none;
+}
+.spectrum-ColorHandle-color {
+  forced-color-adjust: none;
+}
 
 .spectrum-ColorArea {
   &.is-disabled {
@@ -14,6 +20,17 @@
 
     .spectrum-ColorArea-gradient {
       display: none;
+    }
+  }
+}
+
+@media (forced-colors: active) {
+  :root {
+    --spectrum-colorarea-fill-color-disabled : GrayText;
+  }
+  .spectrum-ColorArea {
+    &.is-disabled {
+      forced-color-adjust: none;
     }
   }
 }

--- a/components/colorhandle/skin.css
+++ b/components/colorhandle/skin.css
@@ -34,3 +34,16 @@
 .spectrum-ColorHandle-color {
   box-shadow: inset 0 0 0 var(--spectrum-colorhandle-outer-border-size) var(--spectrum-colorhandle-outer-border-color);
 }
+
+@media (forced-colors: active) {
+  :root {
+    --spectrum-colorhandle-inner-border-color-disabled : GrayText;
+    --spectrum-colorhandle-fill-color-disabled: Canvas;
+    --spectrum-colorhandle-inner-border-color: CanvasText;
+  }
+  .spectrum-ColorHandle {
+    &.is-disabled {
+      forced-color-adjust: none;
+    }
+  }
+}

--- a/components/colorloupe/skin.css
+++ b/components/colorloupe/skin.css
@@ -2,3 +2,8 @@
   fill: var(--spectrum-colorloupe-inner-border-color);
   stroke: var(--spectrum-colorloupe-outer-border-color);
 }
+@media (forced-colors: active) {
+  :root {
+    --spectrum-colorloupe-outer-border-color: CanvasText;
+  }
+}

--- a/components/colorslider/skin.css
+++ b/components/colorslider/skin.css
@@ -35,3 +35,13 @@
     }
   }
 }
+
+@media (forced-colors: active) {
+  :root {
+    --spectrum-colorslider-border-color-disabled : GrayText;
+    --spectrum-colorslider-fill-color-disabled : Canvas;
+  }
+  .spectrum-ColorSlider {
+    forced-color-adjust: none;
+  }
+}

--- a/components/colorwheel/skin.css
+++ b/components/colorwheel/skin.css
@@ -29,3 +29,13 @@
 .spectrum-ColorWheel-innerCircle {
   stroke: var(--spectrum-colorwheel-border-color);
 }
+
+@media (forced-colors: active) {
+  :root {
+    --spectrum-colorwheel-border-color-disabled : GrayText;
+    --spectrum-colorwheel-fill-color-disabled : Canvas;
+  }
+  .spectrum-ColorWheel {
+    forced-color-adjust: none;
+  }
+}


### PR DESCRIPTION
## Description
https://github.com/adobe/spectrum-css/issues/1037

Made the following Changes
### ColorArea
* force-color-adjust: none on the handle and the gradient so the colors show even in high contrast mode
* Add disabled color when disabled
### ColorHandle
* Added colors for the border and fill when disabled
### ColorLoupe
* Ensure there is always a visible border
### ColorSlider & ColorWheel
* Set disabled colors
* Add force-color-adjust so colors show through


## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots
![Color Area - Spectrum CSS - Profile 1 - Microsoft​ Edge 10_5_2020 11_09_21 AM](https://user-images.githubusercontent.com/1724479/95130409-61b4a800-0711-11eb-9ed9-a7287282a273.png)
![Color Area - Spectrum CSS - Profile 1 - Microsoft​ Edge 10_5_2020 11_07_41 AM](https://user-images.githubusercontent.com/1724479/95130415-637e6b80-0711-11eb-886f-a1f72c928a26.png)
![Color Area - Spectrum CSS - Profile 1 - Microsoft​ Edge 10_5_2020 11_07_05 AM](https://user-images.githubusercontent.com/1724479/95130418-64170200-0711-11eb-8ca2-063eff8da18a.png)
![Color Area - Spectrum CSS - Profile 1 - Microsoft​ Edge 10_5_2020 10_12_28 AM](https://user-images.githubusercontent.com/1724479/95130423-65482f00-0711-11eb-9c96-b2c9078459d3.png)
![Color Area - Spectrum CSS - Profile 1 - Microsoft​ Edge 10_5_2020 10_11_37 AM](https://user-images.githubusercontent.com/1724479/95130425-65e0c580-0711-11eb-92b1-dd0bc32a77ba.png)
![Color Area - Spectrum CSS - Profile 1 - Microsoft​ Edge 10_5_2020 10_10_32 AM](https://user-images.githubusercontent.com/1724479/95130427-65e0c580-0711-11eb-83f3-7b0bbfb142d9.png)
![Color Area - Spectrum CSS - Profile 1 - Microsoft​ Edge 10_5_2020 10_07_38 AM](https://user-images.githubusercontent.com/1724479/95130429-66795c00-0711-11eb-8f9d-157a5c8cca8a.png)



## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] This pull request is ready to merge.
