### PR TITLE
fix: add a border to dialogs in high contrast mode

### DIFF
--- a/components/dialog/index.css
+++ b/components/dialog/index.css
@@ -392,3 +392,9 @@ governing permissions and limitations under the License.
     }
   }
 }
+
+@media (forced-colors: active) {
+  .spectrum-Dialog {
+    border: solid;
+  }
+}


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
fixes https://github.com/adobe/spectrum-css/issues/1039 by adding a border in Windows High Contrast mode


## How and where has this been tested?
 - **How this was tested:** using steps in #1039 1039
 - **Browser(s) and OS(s) this was tested with:** Edge 85.0 on Win 10

## Screenshots
![Dialog - Spectrum CSS and 2 more pages - Profile 1 - Microsoft​ Edge 10_5_2020 3_34_28 PM](https://user-images.githubusercontent.com/1724479/95139196-c4617000-0720-11eb-872e-e595a6c38466.png)


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] This pull request is ready to merge.
