### PR TITLE
fix(actionbar): ensure Poppover padding is managed for content direction

### DIFF
--- a/components/actionbar/index.css
+++ b/components/actionbar/index.css
@@ -85,7 +85,8 @@ governing permissions and limitations under the License.
   block-size: var(--spectrum-actionbar-height);
   min-inline-size: var(--spectrum-actionbar-min-width);
   max-inline-size: var(--spectrum-actionbar-max-width);
-  padding: 0 var(--spectrum-actionbar-padding-right) 0 var(--spectrum-actionbar-padding-left);
+  padding-inline-start: var(--spectrum-actionbar-padding-left);
+  padding-inline-end: var(--spectrum-actionbar-padding-right);
 
   flex-direction: row;
   align-items: center;


### PR DESCRIPTION
## Description
fixes #1042 
- uses logical CSS properties to ensure padding is applied in a content direction relative manner


## How and where has this been tested?
 - **How this was tested:** Using steps in #1042 
 - **Browser(s) and OS(s) this was tested with:** Chrome on macOS

## Screenshots
![image](https://user-images.githubusercontent.com/1156657/95333457-ce978180-087a-11eb-8aaa-bf9655fa3f28.png)
![image](https://user-images.githubusercontent.com/1156657/95333483-d7885300-087a-11eb-8b01-0c33a532683f.png)

## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
