### PR TITLE
fix(accordion): simplify header sizing, remove unmanaged custom property

### DIFF
--- a/components/accordion/index.css
+++ b/components/accordion/index.css
@@ -44,8 +44,8 @@ governing permissions and limitations under the License.
   position: absolute;
   inset-inline-start: var(--spectrum-accordion-item-padding-x);
   inset-block-start: calc(
-    var(--spectrum-accordion-item-height-actual) / 2 -
-      var(--spectrum-accordion-icon-height) / 2
+    50% -
+    var(--spectrum-accordion-icon-height) / 2
   );
 
   transition: transform ease var(--spectrum-accordion-animation-duration);
@@ -69,7 +69,7 @@ governing permissions and limitations under the License.
 
 .spectrum-Accordion-itemHeading {
   margin: 0;
-  block-size: var(--spectrum-accordion-item-height);
+  position: relative;
   box-sizing: border-box;
 }
 
@@ -91,7 +91,10 @@ governing permissions and limitations under the License.
   padding-inline-end: var(--spectrum-accordion-item-padding-x);
   margin: 0;
 
-  min-block-size: var(--spectrum-accordion-item-height-actual);
+  min-block-size: calc(
+    100% -
+      var(--spectrum-accordion-item-border-size)
+  );
 
   font-size: var(--spectrum-accordion-item-title-text-size);
   line-height: var(--spectrum-accordion-item-line-height);
@@ -149,7 +152,10 @@ governing permissions and limitations under the License.
 
     > .spectrum-Accordion-itemHeader::after {
       /* No bottom border when open, so be less tall */
-      block-size: var(--spectrum-accordion-item-height-actual);
+      block-size: calc(
+        100% -
+            var(--spectrum-accordion-item-border-size)
+      );
     }
 
     > .spectrum-Accordion-itemContent {


### PR DESCRIPTION
## Description 
fixes #1033
supersedes #1043 
- simplify calculation of the Accordion heading to rely on %s rather than `--spectrum-accordion-item-height-actual`
- remove use of `--spectrum-accordion-item-height-actual` custom property (which was unmanaged across various scales)

## How and where has this been tested?
 - **How this was tested:** Steps in #1033 and the locally built demo site.
 - **Browser(s) and OS(s) this was tested with:**  Chrome on macOS

## Screenshots
![image](https://user-images.githubusercontent.com/1156657/95262883-f5ae6e80-07fa-11eb-8df3-db8fbc404d23.png)
![image](https://user-images.githubusercontent.com/1156657/95262900-fe06a980-07fa-11eb-92cf-916dcb227391.png)

## To-do list
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
