### PR TITLE
fix(calendar): .is-today.is-focused should have blue focus ring #1051

### DIFF
--- a/components/calendar/skin.css
+++ b/components/calendar/skin.css
@@ -116,6 +116,10 @@ governing permissions and limitations under the License.
         background: var(--spectrum-calendar-day-background-color-selected-hover);
       }
     }
+
+    &:before {
+      border-color: var(--spectrum-calendar-day-border-color-key-focus);
+    }
   }
 
   &.is-disabled {


### PR DESCRIPTION
## Description

See https://opensource.adobe.com/spectrum-css/calendar.html#focused

The grey background color for the .is-focused style on today's date is insufficient to communicate that the date has focus. We should use either the blue focus ring as we do for other focused styles, or to continue communicating that the date is today, some sort of double border.

#1051


## How and where has this been tested?
 - **How this was tested:** Verified in documentation example.
 - **Browser(s) and OS(s) this was tested with:** Chrome Version 85.0.4183.121 (Official Build) (64-bit) on macOS 

## Screenshots

### Before (with black focus ring, making it impossible to perceive Today as the focused date)
<img width="420" alt="Calendar - Before, with black focus ring on Today" src="https://user-images.githubusercontent.com/154077/96018788-ab8c4500-0e19-11eb-877c-e6c9df4f5ee2.png">

### After (with blue focus ring, making it possible to perceive Today as the focused date, but Today's is only distinguished by the bold text when the date has focus)
<img width="420" alt="Calendar - After, with blue focus ring on Today" src="https://user-images.githubusercontent.com/154077/96018970-e4c4b500-0e19-11eb-8d3a-5e693fc5adad.png">

## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
