### PR TITLE
fix(fieldgroup): support content direction sensitive horizontal spacing

### DIFF
--- a/components/fieldgroup/index.css
+++ b/components/fieldgroup/index.css
@@ -23,8 +23,8 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-FieldGroup--horizontal {
-  .spectrum-FieldGroup-item + .spectrum-FieldGroup-item {
-    margin: 0 0 0 var(--spectrum-fieldgroup-margin);
+  .spectrum-FieldGroup-item:not(:last-child) {
+    margin-inline-end: var(--spectrum-fieldgroup-margin);
   }
 }
 


### PR DESCRIPTION
## Description 
fixes #1050
Apply margin at the _end_ of items for balanced content direction support and so that start alignment can be correct when wrapping.


## How and where has this been tested?
 - **How this was tested:** Follow steps in #1050 in local build.
 - **Browser(s) and OS(s) this was tested with:** Chrome on macOS

## Screenshots
![image](https://user-images.githubusercontent.com/1156657/96179270-9e955180-0efe-11eb-86f8-d56ca2eb941e.png)

## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
