### PR TITLE
fix: #1045 chevron icon in picker got squeezed

### DIFF
--- a/components/picker/index.css
+++ b/components/picker/index.css
@@ -108,6 +108,7 @@ governing permissions and limitations under the License.
   position: relative;
   vertical-align: top;
   transition: color var(--spectrum-global-animation-duration-100) ease-out;
+  flex-shrink: 0;
 
   /* Fix Safari 10 bug where align-items is ignored inside of buttons */
   margin-block-start: calc(
@@ -131,6 +132,7 @@ governing permissions and limitations under the License.
 /* Error icons */
 .spectrum-Picker-trigger {
   .spectrum-Icon:not(.spectrum-Picker-icon) {
+    flex-shrink: 0;
     /* Fix Safari 10 bug where align-items is ignored inside of buttons */
     margin-block-start: calc(
       calc(


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
Since the new chevron ui icon increased its size to 10x10. It got squeezed in some scenarios.

Fixed #1045 


## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots

Before:
![image](https://user-images.githubusercontent.com/1207520/96184312-2a9e7d80-0eed-11eb-95a4-a7d56e8064e9.png)

After:
![localhost_3000_docs_picker html (1)](https://user-images.githubusercontent.com/1207520/96184491-689ba180-0eed-11eb-8cb5-efd112bbdfcd.png)



## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
