### PR TITLE
Text field whcm

### DIFF
--- a/components/textfield/skin.css
+++ b/components/textfield/skin.css
@@ -167,3 +167,47 @@ governing permissions and limitations under the License.
     }
   }
 }
+@media (forced-colors: active)
+{
+  :root {
+    --spectrum-textfield-background-color-disabled: Canvas;
+    --spectrum-textfield-background-color: Canvas;
+    --spectrum-textfield-border-color: CanvasText;
+    --spectrum-textfield-border-color-disabled: GrayText;
+    --spectrum-textfield-border-color-down: Highlight;
+    --spectrum-textfield-border-color-error-key-focus: Highlight;
+    --spectrum-textfield-border-color-error-hover: Highlight;
+    --spectrum-textfield-border-color-error: Highlight;
+    --spectrum-textfield-border-color-hover: Highlight;
+    --spectrum-textfield-border-color-key-focus: Highlight;
+    --spectrum-textfield-placeholder-text-color-disabled: GrayText;
+    --spectrum-textfield-placeholder-text-color-hover: GrayText;
+    --spectrum-textfield-placeholder-text-color: GrayText;
+    --spectrum-textfield-quiet-background-color: Canvas;
+    --spectrum-textfield-quiet-background-color-disabled: Canvas;
+    --spectrum-textfield-quiet-border-color: CanvasText;
+    --spectrum-textfield-quiet-border-color-down: Highlight;
+    --spectrum-textfield-quiet-border-color-disabled: GrayText;
+    --spectrum-textfield-quiet-border-color-error-mouse-focus: Highlight;
+    --spectrum-textfield-quiet-border-color-error-key-focus: Highlight;
+    --spectrum-textfield-quiet-border-color-error: Highlight;
+    --spectrum-textfield-quiet-border-color-hover: Highlight;
+    --spectrum-textfield-quiet-border-color-mouse-focus: Highlight;
+    --spectrum-textfield-text-color-disabled: GrayText;
+    --spectrum-textfield-text-color: CanvasText;
+  }
+  
+  .spectrum-Textfield {
+    forced-color-adjust: none;
+    &.is-valid {
+      .spectrum-Textfield-validationIcon {
+        color: inherit;
+      }
+    }
+    &.is-invalid {
+      .spectrum-Textfield-validationIcon {
+        color: inherit;
+      }
+    }    
+  }
+}

--- a/components/textfield/skin.css
+++ b/components/textfield/skin.css
@@ -172,31 +172,31 @@ governing permissions and limitations under the License.
   :root {
     --spectrum-textfield-background-color-disabled: Canvas;
     --spectrum-textfield-background-color: Canvas;
-    --spectrum-textfield-border-color: CanvasText;
     --spectrum-textfield-border-color-disabled: GrayText;
     --spectrum-textfield-border-color-down: Highlight;
-    --spectrum-textfield-border-color-error-key-focus: Highlight;
     --spectrum-textfield-border-color-error-hover: Highlight;
+    --spectrum-textfield-border-color-error-key-focus: Highlight;
     --spectrum-textfield-border-color-error: Highlight;
     --spectrum-textfield-border-color-hover: Highlight;
     --spectrum-textfield-border-color-key-focus: Highlight;
+    --spectrum-textfield-border-color: CanvasText;
     --spectrum-textfield-placeholder-text-color-disabled: GrayText;
     --spectrum-textfield-placeholder-text-color-hover: GrayText;
     --spectrum-textfield-placeholder-text-color: GrayText;
-    --spectrum-textfield-quiet-background-color: Canvas;
     --spectrum-textfield-quiet-background-color-disabled: Canvas;
-    --spectrum-textfield-quiet-border-color: CanvasText;
-    --spectrum-textfield-quiet-border-color-down: Highlight;
+    --spectrum-textfield-quiet-background-color: Canvas;
     --spectrum-textfield-quiet-border-color-disabled: GrayText;
-    --spectrum-textfield-quiet-border-color-error-mouse-focus: Highlight;
+    --spectrum-textfield-quiet-border-color-down: Highlight;
     --spectrum-textfield-quiet-border-color-error-key-focus: Highlight;
+    --spectrum-textfield-quiet-border-color-error-mouse-focus: Highlight;
     --spectrum-textfield-quiet-border-color-error: Highlight;
     --spectrum-textfield-quiet-border-color-hover: Highlight;
     --spectrum-textfield-quiet-border-color-mouse-focus: Highlight;
+    --spectrum-textfield-quiet-border-color: CanvasText;
     --spectrum-textfield-text-color-disabled: GrayText;
     --spectrum-textfield-text-color: CanvasText;
   }
-  
+
   .spectrum-Textfield {
     forced-color-adjust: none;
     &.is-valid {


### PR DESCRIPTION
Fixed text field for windows high contrast mode

## Description
https://github.com/adobe/spectrum-css/issues/1071

## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #1071 -->
 - **Browser(s) and OS(s) this was tested with:** Edge 86.0.622.63 on Win 10

## Screenshots
![192 168 3 212_3000_docs_textfield html (8)](https://user-images.githubusercontent.com/1724479/99487079-6a0c1f80-291a-11eb-8720-399ee691313b.png)
![192 168 3 212_3000_docs_textfield html (7)](https://user-images.githubusercontent.com/1724479/99487084-6b3d4c80-291a-11eb-82f1-654a1ea4189c.png)
![192 168 3 212_3000_docs_textfield html (6)](https://user-images.githubusercontent.com/1724479/99487086-6b3d4c80-291a-11eb-979e-15fb9b160b15.png)
![192 168 3 212_3000_docs_textfield html (5)](https://user-images.githubusercontent.com/1724479/99487088-6bd5e300-291a-11eb-8474-1fede55f7d68.png)
![192 168 3 212_3000_docs_textfield html (4)](https://user-images.githubusercontent.com/1724479/99487090-6bd5e300-291a-11eb-8d0f-44c69fd81a15.png)


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
