### PR TITLE
fix: exclude new animation scenario for VRT

### DIFF
--- a/backstop_data/backstop_scenarios.json
+++ b/backstop_data/backstop_scenarios.json
@@ -275,7 +275,8 @@
     "label": "progressbar",
     "url": "progressbar.html",
     "removeSelectors": [
-      "#indeterminate + .spectrum-CSSExample-container .spectrum-CSSExample-example"
+      "#indeterminate + .spectrum-CSSExample-container .spectrum-CSSExample-example",
+      "#indeterminatewithlabel + .spectrum-CSSExample-container .spectrum-CSSExample-example"
     ],
     "package": "@spectrum-css/progressbar"
   },


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
New animation example from progress bar component broke the VRT.


## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
