### PR TITLE
fix: link shouldn't remap color variables, fixes #1108

### DIFF
--- a/components/link/index.css
+++ b/components/link/index.css
@@ -12,13 +12,6 @@ governing permissions and limitations under the License.
 
 @import "../vars/css/components/spectrum-link.css";
 
-.spectrum-Link {
-  @remapvars {
-    find: /--spectrum-link-(.*?)-m-/;
-    replace: --spectrum-link-$1-;
-  }
-}
-
 .spectrum-Link--sizeS {
   @remapvars {
     find: /--spectrum-link-(.*?)-s-/;

--- a/components/link/skin.css
+++ b/components/link/skin.css
@@ -11,18 +11,18 @@ governing permissions and limitations under the License.
 */
 
 .spectrum-Link {
-  color: var(--spectrum-link-primary-text-color);
+  color: var(--spectrum-link-primary-m-text-color);
 
   &:hover {
-    color: var(--spectrum-link-primary-text-color-hover);
+    color: var(--spectrum-link-primary-m-text-color-hover);
   }
 
   &:active {
-    color: var(--spectrum-link-primary-text-color-down);
+    color: var(--spectrum-link-primary-m-text-color-down);
   }
 
   &:focus-ring {
-    color: var(--spectrum-link-primary-text-color-key-focus);
+    color: var(--spectrum-link-primary-m-text-color-key-focus);
   }
 }
 
@@ -43,17 +43,17 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Link--overBackground {
-  color: var(--spectrum-link-over-background-text-color);
+  color: var(--spectrum-link-over-background-m-text-color);
 
   &:hover {
-    color: var(--spectrum-link-over-background-text-color-hover);
+    color: var(--spectrum-link-over-background-m-text-color-hover);
   }
 
   &:active {
-    color: var(--spectrum-link-over-background-text-color-down);
+    color: var(--spectrum-link-over-background-m-text-color-down);
   }
 
   &:focus {
-    color: var(--spectrum-link-over-background-text-color-key-focus);
+    color: var(--spectrum-link-over-background-m-text-color-key-focus);
   }
 }


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->
fixes #1108

## How and where has this been tested?
 - **How this was tested:** scrollyscroll.exe
 - **Browser(s) and OS(s) this was tested with:** a computer
