### PR TITLE
fix: refine checkboxes for spectrum's High Contrast mode

### DIFF
--- a/components/checkbox/skin.css
+++ b/components/checkbox/skin.css
@@ -237,25 +237,35 @@ governing permissions and limitations under the License.
   }
 
   .spectrum-Checkbox {
-    --spectrum-checkbox-m-emphasized-box-background-color: var(--spectrum-alias-background-color-transparent);
-    --spectrum-checkbox-m-emphasized-box-background-color-disabled: var(--spectrum-alias-background-color-transparent);
-    --spectrum-checkbox-m-emphasized-box-border-color-disabled: GrayText;
-    --spectrum-checkbox-m-text-color-disabled: GrayText;
-    --spectrum-checkbox-m-box-border-color-key-focus: FieldText;
-    --spectrum-checkbox-m-emphasized-box-border-color: FieldText;
-    --spectrum-checkbox-m-quiet-box-border-color: FieldText;
+    --spectrum-checkbox-m-box-background-color-disabled: ButtonFace;
+    --spectrum-checkbox-m-box-background-color: ButtonFace;
+    --spectrum-checkbox-m-box-border-color-disabled: GrayText;
+    --spectrum-checkbox-m-box-border-color-down: Highlight;
+    --spectrum-checkbox-m-box-border-color-error-down: Highlight;
+    --spectrum-checkbox-m-box-border-color-error-hover: Highlight;
+    --spectrum-checkbox-m-box-border-color-error: Highlight;
+    --spectrum-checkbox-m-box-border-color-hover: Highlight;
+    --spectrum-checkbox-m-box-border-color-key-focus: Highlight;
+    --spectrum-checkbox-m-box-border-color-selected-down: Highlight;
     --spectrum-checkbox-m-box-border-color-selected-hover: Highlight;
-    --spectrum-checkbox-m-emphasized-box-border-color-selected-hover: Highlight;
-    --spectrum-checkbox-m-quiet-box-border-color-selected-hover: Highlight;
-    --spectrum-checkbox-m-emphasized-box-border-color-selected: Highlight;
-    --spectrum-checkbox-m-quiet-box-border-color-selected: Highlight;
+    --spectrum-checkbox-m-box-border-color-selected-key-focus: Highlight;
+    --spectrum-checkbox-m-box-border-color-selected: Highlight;
+    --spectrum-checkbox-m-box-border-color: ButtonText;
     --spectrum-checkbox-m-checkmark-color: HighlightText;
+    --spectrum-checkbox-m-emphasized-box-border-color-selected-down: Highlight;
+    --spectrum-checkbox-m-emphasized-box-border-color-selected-hover: Highlight;
+    --spectrum-checkbox-m-emphasized-box-border-color-selected-hover: Highlight;
+    --spectrum-checkbox-m-emphasized-box-border-color-selected: Highlight;
+    --spectrum-checkbox-m-emphasized-text-color-hover: FieldText;
     --spectrum-checkbox-m-focus-ring-color-key-focus: Highlight;
-    --spectrum-checkbox-m-focus-ring-gap-key-focus: var(--spectrum-global-dimension-static-size-25);
-    --spectrum-checkbox-m-focus-ring-size-key-focus: var(--spectrum-global-dimension-static-size-40);
-    --spectrum-checkbox-m-box-border-color-error: FieldText;
-    --spectrum-checkbox-m-box-border-color-error-hover: FieldText;
-    --spectrum-checkbox-m-box-border-color-error-selected: FieldText;
+    --spectrum-checkbox-m-text-color-disabled: GrayText;
+    --spectrum-checkbox-m-text-color-down: FieldText;
+    --spectrum-checkbox-m-text-color-error-down: FieldText;
+    --spectrum-checkbox-m-text-color-error-hover: FieldText;
     --spectrum-checkbox-m-text-color-error: FieldText;
+    --spectrum-checkbox-m-text-color-hover: FieldText;
+    --spectrum-checkbox-m-text-color-key-focus: FieldText;
+    --spectrum-checkbox-m-text-color: FieldText;
+
   }
 }

--- a/components/checkbox/skin.css
+++ b/components/checkbox/skin.css
@@ -257,5 +257,24 @@ governing permissions and limitations under the License.
     --spectrum-checkbox-m-text-color-hover: FieldText;
     --spectrum-checkbox-m-text-color-key-focus: FieldText;
     --spectrum-checkbox-m-text-color: FieldText;
+    &.is-invalid {
+      .spectrum-Checkbox-box {
+        &:before {
+          border-color: var(--spectrum-checkbox-m-box-border-color);
+        }        
+      }
+      &.is-indeterminate .spectrum-Checkbox-box {
+          &:before {
+            border-color: var(--spectrum-checkbox-m-box-border-color-error);
+          }          
+        }
+      /* Extra-specific selectors added here to handle checked state */
+      .spectrum-Checkbox-input:checked + .spectrum-Checkbox-box
+      {
+        &:before {
+          border-color: var(--spectrum-checkbox-m-box-border-color-error);
+        }
+      }
+    }
   }
 }

--- a/components/checkbox/skin.css
+++ b/components/checkbox/skin.css
@@ -121,6 +121,7 @@ governing permissions and limitations under the License.
       border-color: var(--spectrum-checkbox-m-box-border-color-key-focus);
     }
     &:after {
+      forced-color-adjust:none;
       box-shadow: 0 0 0 var(--spectrum-checkbox-m-focus-ring-size-key-focus)
         var(--spectrum-checkbox-m-focus-ring-color-key-focus);
     }
@@ -226,16 +227,6 @@ governing permissions and limitations under the License.
 }
 
 @media (forced-colors: active) {
-  .spectrum-Checkbox-input {
-    &:focus-ring + .spectrum-Checkbox-box {
-      forced-color-adjust: none;
-      outline-color: var(--spectrum-checkbox-m-focus-ring-color-key-focus);
-      outline-style: auto;
-      outline-offset: var(--spectrum-checkbox-m-focus-ring-gap-key-focus);
-      outline-width: var(--spectrum-checkbox-m-focus-ring-size-key-focus);
-    }
-  }
-
   .spectrum-Checkbox {
     --spectrum-checkbox-m-box-background-color-disabled: ButtonFace;
     --spectrum-checkbox-m-box-background-color: ButtonFace;
@@ -257,7 +248,7 @@ governing permissions and limitations under the License.
     --spectrum-checkbox-m-emphasized-box-border-color-selected-hover: Highlight;
     --spectrum-checkbox-m-emphasized-box-border-color-selected: Highlight;
     --spectrum-checkbox-m-emphasized-text-color-hover: FieldText;
-    --spectrum-checkbox-m-focus-ring-color-key-focus: Highlight;
+    --spectrum-checkbox-m-focus-ring-color-key-focus: FieldText;
     --spectrum-checkbox-m-text-color-disabled: GrayText;
     --spectrum-checkbox-m-text-color-down: FieldText;
     --spectrum-checkbox-m-text-color-error-down: FieldText;
@@ -266,6 +257,5 @@ governing permissions and limitations under the License.
     --spectrum-checkbox-m-text-color-hover: FieldText;
     --spectrum-checkbox-m-text-color-key-focus: FieldText;
     --spectrum-checkbox-m-text-color: FieldText;
-
   }
 }


### PR DESCRIPTION
Modified to correctly support spectrum's WHCM defintion
## Description
#1117 

## How and where has this been tested?
 - **How this was tested:** Using steps in #1117 
 - **Browser(s) and OS(s) this was tested with:** Edge 88.0 on Windows 10 


## Screenshots
![Checkbox - Spectrum CSS and 2 more pages - Work - Microsoft​ Edge Beta 1_29_2021 3_32_47 PM](https://user-images.githubusercontent.com/1724479/106338980-15562080-624a-11eb-9b0d-eea492cad343.png)


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
