### PR TITLE
fix(#1123): placeholder text color alias for search, textarea, textfield

### DIFF
--- a/components/vars/css/components/spectrum-search.css
+++ b/components/vars/css/components/spectrum-search.css
@@ -1,6 +1,6 @@
 :root {
   --spectrum-search-quiet-l-border-size: var(--spectrum-alias-border-size-thin);
-  --spectrum-search-quiet-l-placeholder-text-color: var(--spectrum-global-color-gray-600);
+  --spectrum-search-quiet-l-placeholder-text-color: var(--spectrum-alias-placeholder-text-color);
   --spectrum-search-quiet-l-text-color: var(--spectrum-alias-text-color);
   --spectrum-search-quiet-l-validation-icon-color: var(--spectrum-alias-background-color-transparent);
   --spectrum-search-quiet-l-background-color: var(--spectrum-alias-background-color-transparent);
@@ -157,7 +157,7 @@
   --spectrum-search-quiet-l-label-gap-y: 0;
   --spectrum-search-quiet-l-label-gap-x: var(--spectrum-global-dimension-size-150);
   --spectrum-search-quiet-m-border-size: var(--spectrum-alias-border-size-thin);
-  --spectrum-search-quiet-m-placeholder-text-color: var(--spectrum-global-color-gray-600);
+  --spectrum-search-quiet-m-placeholder-text-color: var(--spectrum-alias-placeholder-text-color);
   --spectrum-search-quiet-m-text-color: var(--spectrum-alias-text-color);
   --spectrum-search-quiet-m-validation-icon-color: var(--spectrum-alias-background-color-transparent);
   --spectrum-search-quiet-m-background-color: var(--spectrum-alias-background-color-transparent);
@@ -314,7 +314,7 @@
   --spectrum-search-quiet-m-label-gap-y: 0;
   --spectrum-search-quiet-m-label-gap-x: var(--spectrum-global-dimension-size-150);
   --spectrum-search-quiet-s-border-size: var(--spectrum-alias-border-size-thin);
-  --spectrum-search-quiet-s-placeholder-text-color: var(--spectrum-global-color-gray-600);
+  --spectrum-search-quiet-s-placeholder-text-color: var(--spectrum-alias-placeholder-text-color);
   --spectrum-search-quiet-s-text-color: var(--spectrum-alias-text-color);
   --spectrum-search-quiet-s-validation-icon-color: var(--spectrum-alias-background-color-transparent);
   --spectrum-search-quiet-s-background-color: var(--spectrum-alias-background-color-transparent);
@@ -471,7 +471,7 @@
   --spectrum-search-quiet-s-label-gap-y: 0;
   --spectrum-search-quiet-s-label-gap-x: var(--spectrum-global-dimension-size-150);
   --spectrum-search-quiet-xl-border-size: var(--spectrum-alias-border-size-thin);
-  --spectrum-search-quiet-xl-placeholder-text-color: var(--spectrum-global-color-gray-600);
+  --spectrum-search-quiet-xl-placeholder-text-color: var(--spectrum-alias-placeholder-text-color);
   --spectrum-search-quiet-xl-text-color: var(--spectrum-alias-text-color);
   --spectrum-search-quiet-xl-validation-icon-color: var(--spectrum-alias-background-color-transparent);
   --spectrum-search-quiet-xl-background-color: var(--spectrum-alias-background-color-transparent);
@@ -628,7 +628,7 @@
   --spectrum-search-quiet-xl-label-gap-y: 0;
   --spectrum-search-quiet-xl-label-gap-x: var(--spectrum-global-dimension-size-150);
   --spectrum-search-l-border-size: var(--spectrum-alias-border-size-thin);
-  --spectrum-search-l-placeholder-text-color: var(--spectrum-global-color-gray-600);
+  --spectrum-search-l-placeholder-text-color: var(--spectrum-alias-placeholder-text-color);
   --spectrum-search-l-text-color: var(--spectrum-alias-text-color);
   --spectrum-search-l-validation-icon-color: var(--spectrum-alias-background-color-transparent);
   --spectrum-search-l-background-color: var(--spectrum-global-color-gray-50);
@@ -783,7 +783,7 @@
   --spectrum-search-l-border-radius: var(--spectrum-alias-border-radius-regular);
   --spectrum-search-l-cursor-hit-x: var(--spectrum-global-dimension-size-50);
   --spectrum-search-m-border-size: var(--spectrum-alias-border-size-thin);
-  --spectrum-search-m-placeholder-text-color: var(--spectrum-global-color-gray-600);
+  --spectrum-search-m-placeholder-text-color: var(--spectrum-alias-placeholder-text-color);
   --spectrum-search-m-text-color: var(--spectrum-alias-text-color);
   --spectrum-search-m-validation-icon-color: var(--spectrum-alias-background-color-transparent);
   --spectrum-search-m-background-color: var(--spectrum-global-color-gray-50);
@@ -938,7 +938,7 @@
   --spectrum-search-m-border-radius: var(--spectrum-alias-border-radius-regular);
   --spectrum-search-m-cursor-hit-x: var(--spectrum-global-dimension-size-50);
   --spectrum-search-s-border-size: var(--spectrum-alias-border-size-thin);
-  --spectrum-search-s-placeholder-text-color: var(--spectrum-global-color-gray-600);
+  --spectrum-search-s-placeholder-text-color: var(--spectrum-alias-placeholder-text-color);
   --spectrum-search-s-text-color: var(--spectrum-alias-text-color);
   --spectrum-search-s-validation-icon-color: var(--spectrum-alias-background-color-transparent);
   --spectrum-search-s-background-color: var(--spectrum-global-color-gray-50);
@@ -1093,7 +1093,7 @@
   --spectrum-search-s-border-radius: var(--spectrum-alias-border-radius-regular);
   --spectrum-search-s-cursor-hit-x: var(--spectrum-global-dimension-size-50);
   --spectrum-search-xl-border-size: var(--spectrum-alias-border-size-thin);
-  --spectrum-search-xl-placeholder-text-color: var(--spectrum-global-color-gray-600);
+  --spectrum-search-xl-placeholder-text-color: var(--spectrum-alias-placeholder-text-color);
   --spectrum-search-xl-text-color: var(--spectrum-alias-text-color);
   --spectrum-search-xl-validation-icon-color: var(--spectrum-alias-background-color-transparent);
   --spectrum-search-xl-background-color: var(--spectrum-global-color-gray-50);

--- a/components/vars/css/components/spectrum-textarea.css
+++ b/components/vars/css/components/spectrum-textarea.css
@@ -1,6 +1,6 @@
 :root {
   --spectrum-textarea-quiet-l-border-size: var(--spectrum-alias-border-size-thin);
-  --spectrum-textarea-quiet-l-placeholder-text-color: var(--spectrum-global-color-gray-600);
+  --spectrum-textarea-quiet-l-placeholder-text-color: var(--spectrum-alias-placeholder-text-color);
   --spectrum-textarea-quiet-l-text-color: var(--spectrum-alias-text-color);
   --spectrum-textarea-quiet-l-validation-icon-color: var(--spectrum-alias-background-color-transparent);
   --spectrum-textarea-quiet-l-background-color: var(--spectrum-alias-background-color-transparent);
@@ -153,7 +153,7 @@
   --spectrum-textarea-quiet-l-label-gap-y: 0;
   --spectrum-textarea-quiet-l-label-gap-x: var(--spectrum-global-dimension-size-150);
   --spectrum-textarea-quiet-m-border-size: var(--spectrum-alias-border-size-thin);
-  --spectrum-textarea-quiet-m-placeholder-text-color: var(--spectrum-global-color-gray-600);
+  --spectrum-textarea-quiet-m-placeholder-text-color: var(--spectrum-alias-placeholder-text-color);
   --spectrum-textarea-quiet-m-text-color: var(--spectrum-alias-text-color);
   --spectrum-textarea-quiet-m-validation-icon-color: var(--spectrum-alias-background-color-transparent);
   --spectrum-textarea-quiet-m-background-color: var(--spectrum-alias-background-color-transparent);
@@ -306,7 +306,7 @@
   --spectrum-textarea-quiet-m-label-gap-y: 0;
   --spectrum-textarea-quiet-m-label-gap-x: var(--spectrum-global-dimension-size-150);
   --spectrum-textarea-quiet-s-border-size: var(--spectrum-alias-border-size-thin);
-  --spectrum-textarea-quiet-s-placeholder-text-color: var(--spectrum-global-color-gray-600);
+  --spectrum-textarea-quiet-s-placeholder-text-color: var(--spectrum-alias-placeholder-text-color);
   --spectrum-textarea-quiet-s-text-color: var(--spectrum-alias-text-color);
   --spectrum-textarea-quiet-s-validation-icon-color: var(--spectrum-alias-background-color-transparent);
   --spectrum-textarea-quiet-s-background-color: var(--spectrum-alias-background-color-transparent);
@@ -459,7 +459,7 @@
   --spectrum-textarea-quiet-s-label-gap-y: 0;
   --spectrum-textarea-quiet-s-label-gap-x: var(--spectrum-global-dimension-size-150);
   --spectrum-textarea-quiet-xl-border-size: var(--spectrum-alias-border-size-thin);
-  --spectrum-textarea-quiet-xl-placeholder-text-color: var(--spectrum-global-color-gray-600);
+  --spectrum-textarea-quiet-xl-placeholder-text-color: var(--spectrum-alias-placeholder-text-color);
   --spectrum-textarea-quiet-xl-text-color: var(--spectrum-alias-text-color);
   --spectrum-textarea-quiet-xl-validation-icon-color: var(--spectrum-alias-background-color-transparent);
   --spectrum-textarea-quiet-xl-background-color: var(--spectrum-alias-background-color-transparent);
@@ -612,7 +612,7 @@
   --spectrum-textarea-quiet-xl-label-gap-y: 0;
   --spectrum-textarea-quiet-xl-label-gap-x: var(--spectrum-global-dimension-size-150);
   --spectrum-textarea-l-border-size: var(--spectrum-alias-border-size-thin);
-  --spectrum-textarea-l-placeholder-text-color: var(--spectrum-global-color-gray-600);
+  --spectrum-textarea-l-placeholder-text-color: var(--spectrum-alias-placeholder-text-color);
   --spectrum-textarea-l-text-color: var(--spectrum-alias-text-color);
   --spectrum-textarea-l-validation-icon-color: var(--spectrum-alias-background-color-transparent);
   --spectrum-textarea-l-background-color: var(--spectrum-global-color-gray-50);
@@ -763,7 +763,7 @@
   --spectrum-textarea-l-border-radius: var(--spectrum-alias-border-radius-regular);
   --spectrum-textarea-l-cursor-hit-x: var(--spectrum-global-dimension-size-50);
   --spectrum-textarea-m-border-size: var(--spectrum-alias-border-size-thin);
-  --spectrum-textarea-m-placeholder-text-color: var(--spectrum-global-color-gray-600);
+  --spectrum-textarea-m-placeholder-text-color: var(--spectrum-alias-placeholder-text-color);
   --spectrum-textarea-m-text-color: var(--spectrum-alias-text-color);
   --spectrum-textarea-m-validation-icon-color: var(--spectrum-alias-background-color-transparent);
   --spectrum-textarea-m-background-color: var(--spectrum-global-color-gray-50);
@@ -914,7 +914,7 @@
   --spectrum-textarea-m-border-radius: var(--spectrum-alias-border-radius-regular);
   --spectrum-textarea-m-cursor-hit-x: var(--spectrum-global-dimension-size-50);
   --spectrum-textarea-s-border-size: var(--spectrum-alias-border-size-thin);
-  --spectrum-textarea-s-placeholder-text-color: var(--spectrum-global-color-gray-600);
+  --spectrum-textarea-s-placeholder-text-color: var(--spectrum-alias-placeholder-text-color);
   --spectrum-textarea-s-text-color: var(--spectrum-alias-text-color);
   --spectrum-textarea-s-validation-icon-color: var(--spectrum-alias-background-color-transparent);
   --spectrum-textarea-s-background-color: var(--spectrum-global-color-gray-50);
@@ -1065,7 +1065,7 @@
   --spectrum-textarea-s-border-radius: var(--spectrum-alias-border-radius-regular);
   --spectrum-textarea-s-cursor-hit-x: var(--spectrum-global-dimension-size-50);
   --spectrum-textarea-xl-border-size: var(--spectrum-alias-border-size-thin);
-  --spectrum-textarea-xl-placeholder-text-color: var(--spectrum-global-color-gray-600);
+  --spectrum-textarea-xl-placeholder-text-color: var(--spectrum-alias-placeholder-text-color);
   --spectrum-textarea-xl-text-color: var(--spectrum-alias-text-color);
   --spectrum-textarea-xl-validation-icon-color: var(--spectrum-alias-background-color-transparent);
   --spectrum-textarea-xl-background-color: var(--spectrum-global-color-gray-50);

--- a/components/vars/css/components/spectrum-textfield.css
+++ b/components/vars/css/components/spectrum-textfield.css
@@ -1,6 +1,6 @@
 :root {
   --spectrum-textfield-quiet-l-border-size: var(--spectrum-alias-border-size-thin);
-  --spectrum-textfield-quiet-l-placeholder-text-color: var(--spectrum-global-color-gray-600);
+  --spectrum-textfield-quiet-l-placeholder-text-color: var(--spectrum-alias-placeholder-text-color);
   --spectrum-textfield-quiet-l-text-color: var(--spectrum-alias-text-color);
   --spectrum-textfield-quiet-l-validation-icon-color: var(--spectrum-alias-background-color-transparent);
   --spectrum-textfield-quiet-l-background-color: var(--spectrum-alias-background-color-transparent);
@@ -153,7 +153,7 @@
   --spectrum-textfield-quiet-l-label-gap-y: 0;
   --spectrum-textfield-quiet-l-label-gap-x: var(--spectrum-global-dimension-size-150);
   --spectrum-textfield-quiet-m-border-size: var(--spectrum-alias-border-size-thin);
-  --spectrum-textfield-quiet-m-placeholder-text-color: var(--spectrum-global-color-gray-600);
+  --spectrum-textfield-quiet-m-placeholder-text-color: var(--spectrum-alias-placeholder-text-color);
   --spectrum-textfield-quiet-m-text-color: var(--spectrum-alias-text-color);
   --spectrum-textfield-quiet-m-validation-icon-color: var(--spectrum-alias-background-color-transparent);
   --spectrum-textfield-quiet-m-background-color: var(--spectrum-alias-background-color-transparent);
@@ -306,7 +306,7 @@
   --spectrum-textfield-quiet-m-label-gap-y: 0;
   --spectrum-textfield-quiet-m-label-gap-x: var(--spectrum-global-dimension-size-150);
   --spectrum-textfield-quiet-s-border-size: var(--spectrum-alias-border-size-thin);
-  --spectrum-textfield-quiet-s-placeholder-text-color: var(--spectrum-global-color-gray-600);
+  --spectrum-textfield-quiet-s-placeholder-text-color: var(--spectrum-alias-placeholder-text-color);
   --spectrum-textfield-quiet-s-text-color: var(--spectrum-alias-text-color);
   --spectrum-textfield-quiet-s-validation-icon-color: var(--spectrum-alias-background-color-transparent);
   --spectrum-textfield-quiet-s-background-color: var(--spectrum-alias-background-color-transparent);
@@ -459,7 +459,7 @@
   --spectrum-textfield-quiet-s-label-gap-y: 0;
   --spectrum-textfield-quiet-s-label-gap-x: var(--spectrum-global-dimension-size-150);
   --spectrum-textfield-quiet-xl-border-size: var(--spectrum-alias-border-size-thin);
-  --spectrum-textfield-quiet-xl-placeholder-text-color: var(--spectrum-global-color-gray-600);
+  --spectrum-textfield-quiet-xl-placeholder-text-color: var(--spectrum-alias-placeholder-text-color);
   --spectrum-textfield-quiet-xl-text-color: var(--spectrum-alias-text-color);
   --spectrum-textfield-quiet-xl-validation-icon-color: var(--spectrum-alias-background-color-transparent);
   --spectrum-textfield-quiet-xl-background-color: var(--spectrum-alias-background-color-transparent);
@@ -612,7 +612,7 @@
   --spectrum-textfield-quiet-xl-label-gap-y: 0;
   --spectrum-textfield-quiet-xl-label-gap-x: var(--spectrum-global-dimension-size-150);
   --spectrum-textfield-l-border-size: var(--spectrum-alias-border-size-thin);
-  --spectrum-textfield-l-placeholder-text-color: var(--spectrum-global-color-gray-600);
+  --spectrum-textfield-l-placeholder-text-color: var(--spectrum-alias-placeholder-text-color);
   --spectrum-textfield-l-text-color: var(--spectrum-alias-text-color);
   --spectrum-textfield-l-validation-icon-color: var(--spectrum-alias-background-color-transparent);
   --spectrum-textfield-l-background-color: var(--spectrum-global-color-gray-50);
@@ -763,7 +763,7 @@
   --spectrum-textfield-l-border-radius: var(--spectrum-alias-border-radius-regular);
   --spectrum-textfield-l-cursor-hit-x: var(--spectrum-global-dimension-size-50);
   --spectrum-textfield-m-border-size: var(--spectrum-alias-border-size-thin);
-  --spectrum-textfield-m-placeholder-text-color: var(--spectrum-global-color-gray-600);
+  --spectrum-textfield-m-placeholder-text-color: var(--spectrum-alias-placeholder-text-color);
   --spectrum-textfield-m-text-color: var(--spectrum-alias-text-color);
   --spectrum-textfield-m-validation-icon-color: var(--spectrum-alias-background-color-transparent);
   --spectrum-textfield-m-background-color: var(--spectrum-global-color-gray-50);
@@ -914,7 +914,7 @@
   --spectrum-textfield-m-border-radius: var(--spectrum-alias-border-radius-regular);
   --spectrum-textfield-m-cursor-hit-x: var(--spectrum-global-dimension-size-50);
   --spectrum-textfield-s-border-size: var(--spectrum-alias-border-size-thin);
-  --spectrum-textfield-s-placeholder-text-color: var(--spectrum-global-color-gray-600);
+  --spectrum-textfield-s-placeholder-text-color: var(--spectrum-alias-placeholder-text-color);
   --spectrum-textfield-s-text-color: var(--spectrum-alias-text-color);
   --spectrum-textfield-s-validation-icon-color: var(--spectrum-alias-background-color-transparent);
   --spectrum-textfield-s-background-color: var(--spectrum-global-color-gray-50);
@@ -1065,7 +1065,7 @@
   --spectrum-textfield-s-border-radius: var(--spectrum-alias-border-radius-regular);
   --spectrum-textfield-s-cursor-hit-x: var(--spectrum-global-dimension-size-50);
   --spectrum-textfield-xl-border-size: var(--spectrum-alias-border-size-thin);
-  --spectrum-textfield-xl-placeholder-text-color: var(--spectrum-global-color-gray-600);
+  --spectrum-textfield-xl-placeholder-text-color: var(--spectrum-alias-placeholder-text-color);
   --spectrum-textfield-xl-text-color: var(--spectrum-alias-text-color);
   --spectrum-textfield-xl-validation-icon-color: var(--spectrum-alias-background-color-transparent);
   --spectrum-textfield-xl-background-color: var(--spectrum-global-color-gray-50);


### PR DESCRIPTION
### Description

Per #1123 

Currently, Spectrum-CSS uses `var(--spectrum-global-color-gray-600);` for the `::placeholder` text color in Search, Textarea and Textfield components, which results in placholder text that does not comply with WCAG 2.1 AA contrast ratio requirements, and is different than the value specified in Spectrum for `var(--spectrum-alias-placeholder-text-color)`, `gray-800`.

### Steps to reproduce

1. Go to https://opensource.adobe.com/spectrum-css/textfield.html
2. Inspect the placeholder text element in the sub-dom for any of the enabled textfield examples.
3. Observe the color specified in CSS is currently `var(--spectrum-global-color-gray-600);`

### Expected behavior
Placeholder text should use the token defined in Spectrum `var(--spectrum-alias-placeholder-text-color)` which corresponds to  `var(--spectrum-global-color-gray-800);`.

### Screenshots
#### Current behavior
![Non-compliant Placeholder text](https://user-images.githubusercontent.com/154077/106511085-c0124d00-649d-11eb-9957-00c76925dbd9.png)

#### Expected behavior
![Compliant Placeholder text](https://user-images.githubusercontent.com/154077/106511474-4464d000-649e-11eb-9080-c4052cf1d010.png)

### Environment
 - **Spectrum CSS version:**  2.18.0, @spectrum-css/search@3.0.0-beta.7, @spectrum-css/textfield@3.0.0-beta.6
 - **Browser(s) and OS(s):** Chrome Version 88.0.4324.96 (Official Build) (x86_64) on macOS


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
