### PR TITLE
fix: truncation picker and tabs examples

### DIFF
--- a/components/tabs/metadata/tabs.yml
+++ b/components/tabs/metadata/tabs.yml
@@ -358,7 +358,7 @@ examples:
     markup: |
       <h4>Closed</h4>
       <div class="spectrum-Tabs spectrum-Tabs--horizontal" style="width: 409px">
-        <button class="spectrum-Picker spectrum-Picker--quiet" aria-haspopup="true">
+        <button class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet" aria-haspopup="true">
           <span class="spectrum-Picker-label">Tab 1</span>
           <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
             <use xlink:href="#spectrum-css-icon-Chevron100" />
@@ -369,7 +369,7 @@ examples:
 
       <h4 style="margin-top: 62px;">Open</h4>
       <div class="spectrum-Tabs spectrum-Tabs--horizontal" style="width: 409px">
-        <button class="spectrum-Picker spectrum-Picker--quiet is-open" aria-haspopup="true">
+        <button class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet is-open" aria-haspopup="true">
           <span class="spectrum-Picker-label">Tab 1</span>
           <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
             <use xlink:href="#spectrum-css-icon-Chevron100" />
@@ -404,7 +404,7 @@ examples:
     markup: |
       <h4>Closed</h4>
       <div class="spectrum-Tabs spectrum-Tabs--horizontal spectrum-Tabs--quiet spectrum-Tabs--compact" style="width: 409px">
-          <button class="spectrum-Picker spectrum-Picker--quiet is-open" aria-haspopup="true">
+          <button class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet is-open" aria-haspopup="true">
             <span class="spectrum-Picker-label">Tab 1</span>
             <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
               <use xlink:href="#spectrum-css-icon-Chevron100" />
@@ -415,7 +415,7 @@ examples:
 
       <h4 style="margin-top: 62px;">Open</h4>
       <div class="spectrum-Tabs spectrum-Tabs--horizontal spectrum-Tabs--quiet spectrum-Tabs--compact" style="width: 409px">
-          <button class="spectrum-Picker spectrum-Picker--quiet is-open" aria-haspopup="true">
+          <button class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet is-open" aria-haspopup="true">
             <span class="spectrum-Picker-label">Tab 1</span>
             <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
               <use xlink:href="#spectrum-css-icon-Chevron100" />

--- a/site/truncation.pug
+++ b/site/truncation.pug
@@ -109,9 +109,9 @@ html(lang='en-US' dir="ltr").spectrum.spectrum--light.spectrum--medium
                 section.spectrum-CSSExample-container
                   .spectrum-CSSExample-example
                     <div class="spectrum-Tabs spectrum-Tabs--horizontal" style="width: 212px">
-                      <button class="spectrum-Picker spectrum-Picker--quiet" aria-haspopup="true">
+                      <button class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet" aria-haspopup="true">
                         <span class="spectrum-Picker-label">A comparative study of artificial intelligence as applied to choosing outfits for small dogs</span>
-                        <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-icon" focusable="false" aria-hidden="true">
+                        <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
                           <use xlink:href="#spectrum-css-icon-Chevron100" />
                         </svg>
                       </button>
@@ -137,9 +137,9 @@ html(lang='en-US' dir="ltr").spectrum.spectrum--light.spectrum--medium
                 h5.spectrum-CSSExample-heading.spectrum-Heading.spectrum-Heading--sizeS Picker (truncated)
                 section.spectrum-CSSExample-container
                   .spectrum-CSSExample-example
-                    <button class="spectrum-Picker" aria-haspopup="true">
+                    <button class="spectrum-Picker spectrum-Picker--sizeM" aria-haspopup="true">
                       <span class="spectrum-Picker-label is-placeholder">Lorem ipsum dolor sit amet, consectetur adipiscing elit</span>
-                      <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-icon" focusable="false" aria-hidden="true">
+                      <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
                         <use xlink:href="#spectrum-css-icon-Chevron100" />
                       </svg>
                     </button>


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->


## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->
### Tabs
![image](https://user-images.githubusercontent.com/1207520/108282928-4930b180-7137-11eb-9904-59928aaf77fa.png)

### Truncation Picker
![image](https://user-images.githubusercontent.com/1207520/108283079-82692180-7137-11eb-983f-4e03d0aab2f2.png)



## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
