### PR TITLE
Update getting started page to include t-shirt sized button

### DIFF
--- a/site/get-started.pug
+++ b/site/get-started.pug
@@ -82,7 +82,7 @@ html(lang='en-US' dir="ltr").spectrum.spectrum--light.spectrum--medium
                 p.spectrum-Body.spectrum-Body--sizeL Inside the #[code.spectrum-Code.spectrum-Code--sizeS &lt;body&gt;] tag, add the markup for a Spectrum button. Note that the example also includes the CSS class name, #[code.spectrum-Code.spectrum-Code--sizeS spectrum-Button--cta], to use the call to action (CTA) option.
 
                 -
-                  htmlMarkup = util.Prism.highlight(`<button class="spectrum-Button spectrum-Button--cta">
+                  htmlMarkup = util.Prism.highlight(`<button class="spectrum-Button spectrum-Button--cta spectrum-Button--sizeM">
                     <span class="spectrum-Button-label">Button</span>
                   </button>`, util.Prism.languages.markup, 'markup');
                 pre.spectrum-CodeBlock
@@ -100,7 +100,7 @@ html(lang='en-US' dir="ltr").spectrum.spectrum--light.spectrum--medium
                       <link rel="stylesheet" href="node_modules/@spectrum-css/button/dist/index-vars.css">
                     </head>
                     <body>
-                      <button class="spectrum-Button spectrum-Button--cta">
+                      <button class="spectrum-Button spectrum-Button--cta spectrum-Button--sizeM">
                         <span class="spectrum-Button-label">Button</span>
                       </button>
                     </body>


### PR DESCRIPTION
## Description
Update the example on the [getting started page](https://opensource.adobe.com/spectrum-css/get-started.html) to use the t-shirt sizes for Button.

```html
<button class="spectrum-Button spectrum-Button--cta spectrum-Button--sizeM">
  <span class="spectrum-Button-label">Button</span>
</button>
```


## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->



## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
