### PR TITLE
feat: drop even more unused vars

### DIFF
--- a/tools/postcss-dropunusedvars/expected/varRefs.css
+++ b/tools/postcss-dropunusedvars/expected/varRefs.css
@@ -1,6 +1,7 @@
 :root {
   --gray: gray;
   --blue: blue;
+  --orange: orange;
   --default: var(--gray);
   --focus: var(--blue);
 }
@@ -11,4 +12,8 @@
 
 .component:focus {
   background-color: var(--focus);
+}
+
+.component:active {
+  background-color: var(--orange);
 }

--- a/tools/postcss-dropunusedvars/expected/varRefs.css
+++ b/tools/postcss-dropunusedvars/expected/varRefs.css
@@ -1,0 +1,14 @@
+:root {
+  --gray: gray;
+  --blue: blue;
+  --default: var(--gray);
+  --focus: var(--blue);
+}
+
+.component {
+  background-color: var(--default);
+}
+
+.component:focus {
+  background-color: var(--focus);
+}

--- a/tools/postcss-dropunusedvars/fixtures/varRefs.css
+++ b/tools/postcss-dropunusedvars/fixtures/varRefs.css
@@ -1,0 +1,16 @@
+:root {
+  --gray: gray;
+  --blue: blue;
+  --green: green;
+  --default: var(--gray);
+  --focus: var(--blue);
+  --selected: var(--green);
+}
+
+.component {
+  background-color: var(--default);
+}
+
+.component:focus {
+  background-color: var(--focus);
+}

--- a/tools/postcss-dropunusedvars/fixtures/varRefs.css
+++ b/tools/postcss-dropunusedvars/fixtures/varRefs.css
@@ -2,9 +2,11 @@
   --gray: gray;
   --blue: blue;
   --green: green;
+  --orange: orange;
   --default: var(--gray);
   --focus: var(--blue);
   --selected: var(--green);
+  --active: var(--orange);
 }
 
 .component {
@@ -13,4 +15,8 @@
 
 .component:focus {
   background-color: var(--focus);
+}
+
+.component:active {
+  background-color: var(--orange);
 }

--- a/tools/postcss-dropunusedvars/test.js
+++ b/tools/postcss-dropunusedvars/test.js
@@ -24,3 +24,7 @@ function readFile(filename) {
 test('drop unused vars', t => {
   return compare(t, 'unused.css', 'unused.css');
 });
+
+test('drop unused vars, even if referenced by other vars', t => {
+  return compare(t, 'varRefs.css', 'varRefs.css');
+});


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->
This PR makes `postcss-dropunusedvars` even more aggressive, removing variables if everything that references them has been removed.

## How and where has this been tested?
 - **How this was tested:** tests!
 - **Browser(s) and OS(s) this was tested with:** n/a/
