### PR TITLE
fix: table row dropzone shows extra blue, fix #225

### DIFF
--- a/components/table/skin.css
+++ b/components/table/skin.css
@@ -46,16 +46,6 @@ governing permissions and limitations under the License.
   }
 }
 
-/* Helper for shared drop target overlay */
-%drop-target {
-  border-color: var(--spectrum-alias-border-color-focus);
-  box-shadow: 0 0 0 1px var(--spectrum-alias-border-color-focus);
-
-  &::before {
-    background-color: var(--spectrum-alias-highlight-selected);
-  }
-}
-
 .spectrum-Table-cell,
 .spectrum-Table-headCell {
   &:focus-ring,


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->
fixes the double showing of blue on table
## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->
Issue Number:  #225 
There was a helper function that was being triggered which rendered the extra blue

## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->
This was tested by comparing the expected and actual behavior using Backstop.js
## Screenshots
<!-- If applicable, add screenshots to show what you changed -->
![Screen Shot 2021-03-03 at 4 24 59 PM](https://user-images.githubusercontent.com/25776618/109874439-20331500-7c3d-11eb-8221-90d9558ade1b.png)
![Screen Shot 2021-03-03 at 4 25 29 PM](https://user-images.githubusercontent.com/25776618/109874447-22956f00-7c3d-11eb-9dac-4b7de8f93c29.png)


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
