### PR TITLE
feat: add plugins and docs on how to optimize/customize Spectrum CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,60 @@ When this file is imported, if in updated version of `@spectrum-css/vars` change
 
 In most cases, this file will not be required, so you can safely ignore it. If you see unexpected visual changes creeping into components that you have not updated, `dist/vars.css` may correct them.
 
+### Optimizing Spectrum CSS
+
+Spectrum CSS is designed to be as flexible as possible, and as such, leaves room for optimization. Let's assume you've included a few components as dependencies in your `package.json`:
+
+```
+{
+  "name": "my-project",
+  "devDependencies": {
+    "@spectrum-css/button": "^3.0.0",
+    "@spectrum-css/page": "^3.0.0",
+    "@spectrum-css/vars": "^3.0.0"
+  }
+}
+```
+
+You've created an `index.css` that imports a few components, a scale, and a color-theme:
+
+```
+@import 'node_modules/@spectrum-css/vars/dist/spectrum-global.css';
+@import 'node_modules/@spectrum-css/vars/dist/spectrum-medium.css';
+@import 'node_modules/@spectrum-css/vars/dist/spectrum-light.css';
+@import 'node_modules/@spectrum-css/page/dist/index-vars.css';
+@import 'node_modules/@spectrum-css/button/dist/index-vars.css';
+```
+
+To build an more optimized bundle, you can employ a few simple PostCSS plugins. First, install them:
+
+```sh
+npm i postcss-import postcss-varfallback postcss-dropunusedvars cssnano
+```
+
+Next, create a `postcss.config.js`:
+
+```js
+module.exports = {
+  plugins: [
+    require('postcss-import'),
+    require('postcss-varfallback'),
+    require('postcss-dropunusedvars'),
+    require('cssnano')
+  ],
+};
+```
+
+Finally, include PostCSS in your build process, or run it from the command line:
+
+```sh
+postcss -o dist/index.min.css index.css
+```
+
+The `dist/index.min.css` file will contain a much slimmer version of Spectrum CSS customized to only include the variables that the components you employed require. If you've referenced any of variables Spectrum CSS defines in your CSS, they will be perserved as well.
+
+If you want to go further, you can employ a tool such as [PurifyCSS](https://github.com/purifycss/purifycss) to strip unused CSS classes from the output, optimizing it further.
+
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ In most cases, this file will not be required, so you can safely ignore it. If y
 
 Spectrum CSS is designed to be as flexible as possible, and as such, leaves room for optimization. Let's assume you've included a few components as dependencies in your `package.json`:
 
-```
+```json
 {
   "name": "my-project",
   "devDependencies": {
@@ -162,7 +162,7 @@ Spectrum CSS is designed to be as flexible as possible, and as such, leaves room
 
 You've created an `index.css` that imports a few components, a scale, and a color-theme:
 
-```
+```css
 @import 'node_modules/@spectrum-css/vars/dist/spectrum-global.css';
 @import 'node_modules/@spectrum-css/vars/dist/spectrum-medium.css';
 @import 'node_modules/@spectrum-css/vars/dist/spectrum-light.css';
@@ -195,13 +195,13 @@ Finally, include PostCSS in your build process, or run it from the command line:
 postcss -o dist/index.min.css index.css
 ```
 
-The `dist/index.min.css` file will contain a much slimmer version of Spectrum CSS customized to only include the variables that the components you employed require. If you've referenced any of variables Spectrum CSS defines in your CSS, they will be perserved as well.
+`dist/index.min.css` file will contain a much slimmer version of Spectrum CSS customized to only include the variables used by the components that you imported. If you've referenced any of variables Spectrum CSS defines in your CSS, they will be perserved as well.
 
-If you want to go further, you can employ a tool such as [PurifyCSS](https://github.com/purifycss/purifycss) to strip unused CSS classes from the output, optimizing it further.
+If you need an even smaller bundle, you can employ a tool such as [PurifyCSS](https://github.com/purifycss/purifycss) to strip unused CSS classes from the output.
 
 ### Customizing Spectrum CSS
 
-You can employ `postcss-transformselectors` to change the way selectors are defined in Spectrum CSS. For instance, you may want to use bare `h1`/`h2`/`h3` instead of `.spectrum-Heading.spectrum-Heading--size*`.
+You can employ `postcss-transformselectors` to change the classnames Spectrum CSS uses. For instance, you may want to use bare `h1`/`h2`/`h3` instead of `.spectrum-Heading.spectrum-Heading--size*`.
 
 To do this, first install the plugin:
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ You've created an `index.css` that imports a few components, a scale, and a colo
 To build an more optimized bundle, you can employ a few simple PostCSS plugins. First, install them:
 
 ```sh
-npm i postcss-import postcss-varfallback postcss-dropunusedvars cssnano
+npm i postcss-import postcss-varfallback postcss-dropunusedvars cssnano --save-dev
 ```
 
 Next, create a `postcss.config.js`:
@@ -199,6 +199,47 @@ The `dist/index.min.css` file will contain a much slimmer version of Spectrum CS
 
 If you want to go further, you can employ a tool such as [PurifyCSS](https://github.com/purifycss/purifycss) to strip unused CSS classes from the output, optimizing it further.
 
+### Customizing Spectrum CSS
+
+You can employ `postcss-transformselectors` to change the way selectors are defined in Spectrum CSS. For instance, you may want to use bare `h1`/`h2`/`h3` instead of `.spectrum-Heading.spectrum-Heading--size*`.
+
+To do this, first install the plugin:
+
+```js
+npm i postcss-transformselectors --save-dev
+```
+
+Then, add something like this to your `postcss.config.js`:
+
+```js
+module.exports = {
+  plugins: [
+    require('postcss-transformselectors')({
+      replace: [
+        { search: '.spectrum-Heading--sizeXXL', replace: 'h1' },
+        { search: '.spectrum-Heading--sizeXL', replace: 'h2' },
+        { search: '.spectrum-Heading--sizeL', replace: 'h3' }
+      ],
+      transform: (selector) => {
+        if (selector.startsWith('.spectrum-Heading')) {
+          // Operate on each selector in a selector list
+          return selector.split(',')
+            .map(selectorPart => {
+              // Create separate selectors for each reference to .spectrum-Heading
+              return ['h1', 'h2', 'h3'].map(h => {
+                return selectorPart.replace('.spectrum-Heading', h);
+              }).join(',');
+            })
+            .join(',');
+        }
+
+        // Don't mess with things that don't have .spectrum-Heading in them
+        return selector;
+      }
+    })
+  ]
+};
+```
 
 ## Contributing
 

--- a/tools/postcss-dropdupedvars/README.md
+++ b/tools/postcss-dropdupedvars/README.md
@@ -1,5 +1,5 @@
 # postcss-dropdupedvars
-> Remap variables to create variable-driven CSS components
+> Drop duplicate vars
 
 ## Installation
 

--- a/tools/postcss-dropdupedvars/index.js
+++ b/tools/postcss-dropdupedvars/index.js
@@ -15,7 +15,7 @@ function dropDupes(root, variableList) {
   });
 }
 
-module.exports = postcss.plugin('postcss-remapvars', function() {
+module.exports = postcss.plugin('postcss-dropdupedvars', function() {
   return (root, result) => {
     dropDupes(root);
   }

--- a/tools/postcss-droproot/index.js
+++ b/tools/postcss-droproot/index.js
@@ -9,7 +9,7 @@ function process(root) {
 }
 
 let allVariables;
-module.exports = postcss.plugin('postcss-remapvars', function() {
+module.exports = postcss.plugin('postcss-droproot', function() {
   allVariables = [];
   return (root, result) => {
     process(root);

--- a/tools/postcss-dropunusedvars/README.md
+++ b/tools/postcss-dropunusedvars/README.md
@@ -1,5 +1,5 @@
 # postcss-dropunusedvars
-> Remap variables to create variable-driven CSS components
+> Remove unused variable definitions
 
 ## Installation
 

--- a/tools/postcss-dropunusedvars/index.js
+++ b/tools/postcss-dropunusedvars/index.js
@@ -89,7 +89,7 @@ function process(root) {
   dropUnused(root, variableUsage);
 }
 
-module.exports = postcss.plugin('postcss-remapvars', function() {
+module.exports = postcss.plugin('postcss-dropunusedvars', function() {
   return (root, result) => {
     process(root);
   }

--- a/tools/postcss-transformselectors/README.md
+++ b/tools/postcss-transformselectors/README.md
@@ -1,0 +1,40 @@
+# postcss-transformselectors
+> Re-map and transform selectors
+
+## Installation
+
+```sh
+npm install postcss-transformselectors
+```
+
+## Usage
+
+In your `postcss.config.js`, pass `options` to the plugin:
+
+```js
+module.exports = {
+  plugins: [
+    require('postcss-transformselectors')({
+      replace: [
+        // replace all instaces of .button in a selector with .btn (will catch .button:hover)
+        // when search is a string, replaces are automatically made global
+        { search: '.button', replace: '.btn' },
+        // replace all double dashes in classnames with an underscore
+        // note the g flag (global) is used to ensure every instance in a selector is replaced
+        { search: /\.(.*?)--([^ ]*?)/g, replace: '.$1_$2' },
+      ],
+      // lowercase all classnames
+      // you can use the PostCSS Rule object to determine the new selector (i.e. based off rule.parent)
+      transform: (selector, rule) => selector.toLowerCase()
+    }),
+  ],
+};
+````
+
+### `options.replace`
+
+An array of objects with `{ search: RegExp | string, replace: string }`.
+
+### `options.transform`
+
+A function that takes `(selector, rule)` and returns a new selector.

--- a/tools/postcss-transformselectors/expected/complex.css
+++ b/tools/postcss-transformselectors/expected/complex.css
@@ -1,0 +1,51 @@
+h1 {
+  font-size: var(--spectrum-heading-xxl-text-size, var(--spectrum-alias-heading-xxl-text-size));
+  font-weight: var(--spectrum-heading-xxl-text-font-weight, var(--spectrum-alias-heading-text-font-weight-regular));
+  line-height: var(--spectrum-heading-xxl-text-line-height, var(--spectrum-alias-heading-text-line-height));
+  font-style: var(--spectrum-heading-xxl-text-font-style, var(--spectrum-global-font-style-regular));
+  letter-spacing: var(--spectrum-heading-xxl-text-letter-spacing, var(--spectrum-global-font-letter-spacing-none));
+  text-transform: var(--spectrum-heading-xxl-text-transform, none);
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+h2 {
+  font-size: var(--spectrum-heading-xl-text-size, var(--spectrum-alias-heading-xl-text-size));
+  font-weight: var(--spectrum-heading-xl-text-font-weight, var(--spectrum-alias-heading-text-font-weight-regular));
+  line-height: var(--spectrum-heading-xl-text-line-height, var(--spectrum-alias-heading-text-line-height));
+  font-style: var(--spectrum-heading-xl-text-font-style, var(--spectrum-global-font-style-regular));
+  letter-spacing: var(--spectrum-heading-xl-text-letter-spacing, var(--spectrum-global-font-letter-spacing-none));
+  text-transform: var(--spectrum-heading-xl-text-transform, none);
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+h3 {
+  font-size: var(--spectrum-heading-l-text-size, var(--spectrum-alias-heading-l-text-size));
+  font-weight: var(--spectrum-heading-l-text-font-weight, var(--spectrum-alias-heading-text-font-weight-regular));
+  line-height: var(--spectrum-heading-l-text-line-height, var(--spectrum-alias-heading-text-line-height));
+  font-style: var(--spectrum-heading-l-text-font-style, var(--spectrum-global-font-style-regular));
+  letter-spacing: var(--spectrum-heading-l-text-letter-spacing, var(--spectrum-global-font-letter-spacing-none));
+  text-transform: var(--spectrum-heading-l-text-transform, none);
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+h1,h2,h3 {
+  font-family: var(--spectrum-heading-m-text-font-family, var(--spectrum-alias-body-text-font-family));
+  font-weight: var(--spectrum-heading-m-text-font-weight, var(--spectrum-alias-heading-text-font-weight-regular));
+}
+
+h1 em,h2 em,h3 em,
+h1 .spectrum-Heading-emphasis,
+h2 .spectrum-Heading-emphasis,
+h3 .spectrum-Heading-emphasis {
+  font-style: var(--spectrum-heading-m-emphasis-text-font-style, var(--spectrum-global-font-style-italic));
+}
+
+h1 strong,h2 strong,h3 strong,
+h1 .spectrum-Heading-strong,
+h2 .spectrum-Heading-strong,
+h3 .spectrum-Heading-strong {
+  font-weight: var(--spectrum-heading-m-strong-text-font-weight, var(--spectrum-global-font-weight-black));
+}

--- a/tools/postcss-transformselectors/expected/regex.css
+++ b/tools/postcss-transformselectors/expected/regex.css
@@ -1,0 +1,21 @@
+.button {
+  border-width: 2px;
+}
+
+.button_cta {
+  background-color: blue;
+}
+
+.button_cta:hover {
+  background-color: darkblue;
+}
+
+.light .button_cta .button-icon,
+.lightest .button_cta .button-icon {
+  color: black;
+}
+
+.dark .button_cta .button-icon,
+.darkest .button_cta .button-icon {
+  color: white;
+}

--- a/tools/postcss-transformselectors/expected/replace.css
+++ b/tools/postcss-transformselectors/expected/replace.css
@@ -1,0 +1,15 @@
+.btn {
+  border-width: 2px;
+}
+
+.btn:hover {
+  color: black;
+}
+
+.crd .btn, .btn--green {
+  color: green;
+}
+
+.crd {
+  border-width: 1px;
+}

--- a/tools/postcss-transformselectors/expected/transform.css
+++ b/tools/postcss-transformselectors/expected/transform.css
@@ -1,0 +1,7 @@
+.button {
+  border-width: 2px;
+}
+
+.card {
+  border-width: 1px;
+}

--- a/tools/postcss-transformselectors/fixtures/complex.css
+++ b/tools/postcss-transformselectors/fixtures/complex.css
@@ -1,0 +1,47 @@
+.spectrum-Heading--sizeXXL {
+  font-size: var(--spectrum-heading-xxl-text-size, var(--spectrum-alias-heading-xxl-text-size));
+  font-weight: var(--spectrum-heading-xxl-text-font-weight, var(--spectrum-alias-heading-text-font-weight-regular));
+  line-height: var(--spectrum-heading-xxl-text-line-height, var(--spectrum-alias-heading-text-line-height));
+  font-style: var(--spectrum-heading-xxl-text-font-style, var(--spectrum-global-font-style-regular));
+  letter-spacing: var(--spectrum-heading-xxl-text-letter-spacing, var(--spectrum-global-font-letter-spacing-none));
+  text-transform: var(--spectrum-heading-xxl-text-transform, none);
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.spectrum-Heading--sizeXL {
+  font-size: var(--spectrum-heading-xl-text-size, var(--spectrum-alias-heading-xl-text-size));
+  font-weight: var(--spectrum-heading-xl-text-font-weight, var(--spectrum-alias-heading-text-font-weight-regular));
+  line-height: var(--spectrum-heading-xl-text-line-height, var(--spectrum-alias-heading-text-line-height));
+  font-style: var(--spectrum-heading-xl-text-font-style, var(--spectrum-global-font-style-regular));
+  letter-spacing: var(--spectrum-heading-xl-text-letter-spacing, var(--spectrum-global-font-letter-spacing-none));
+  text-transform: var(--spectrum-heading-xl-text-transform, none);
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.spectrum-Heading--sizeL {
+  font-size: var(--spectrum-heading-l-text-size, var(--spectrum-alias-heading-l-text-size));
+  font-weight: var(--spectrum-heading-l-text-font-weight, var(--spectrum-alias-heading-text-font-weight-regular));
+  line-height: var(--spectrum-heading-l-text-line-height, var(--spectrum-alias-heading-text-line-height));
+  font-style: var(--spectrum-heading-l-text-font-style, var(--spectrum-global-font-style-regular));
+  letter-spacing: var(--spectrum-heading-l-text-letter-spacing, var(--spectrum-global-font-letter-spacing-none));
+  text-transform: var(--spectrum-heading-l-text-transform, none);
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.spectrum-Heading {
+  font-family: var(--spectrum-heading-m-text-font-family, var(--spectrum-alias-body-text-font-family));
+  font-weight: var(--spectrum-heading-m-text-font-weight, var(--spectrum-alias-heading-text-font-weight-regular));
+}
+
+.spectrum-Heading em,
+.spectrum-Heading .spectrum-Heading-emphasis {
+  font-style: var(--spectrum-heading-m-emphasis-text-font-style, var(--spectrum-global-font-style-italic));
+}
+
+.spectrum-Heading strong,
+.spectrum-Heading .spectrum-Heading-strong {
+  font-weight: var(--spectrum-heading-m-strong-text-font-weight, var(--spectrum-global-font-weight-black));
+}

--- a/tools/postcss-transformselectors/fixtures/regex.css
+++ b/tools/postcss-transformselectors/fixtures/regex.css
@@ -1,0 +1,21 @@
+.button {
+  border-width: 2px;
+}
+
+.button--cta {
+  background-color: blue;
+}
+
+.button--cta:hover {
+  background-color: darkblue;
+}
+
+.light .button--cta .button-icon,
+.lightest .button--cta .button-icon {
+  color: black;
+}
+
+.dark .button--cta .button-icon,
+.darkest .button--cta .button-icon {
+  color: white;
+}

--- a/tools/postcss-transformselectors/fixtures/replace.css
+++ b/tools/postcss-transformselectors/fixtures/replace.css
@@ -1,0 +1,15 @@
+.button {
+  border-width: 2px;
+}
+
+.button:hover {
+  color: black;
+}
+
+.card .button, .button--green {
+  color: green;
+}
+
+.card {
+  border-width: 1px;
+}

--- a/tools/postcss-transformselectors/fixtures/transform.css
+++ b/tools/postcss-transformselectors/fixtures/transform.css
@@ -1,0 +1,7 @@
+.Button {
+  border-width: 2px;
+}
+
+.Card {
+  border-width: 1px;
+}

--- a/tools/postcss-transformselectors/index.js
+++ b/tools/postcss-transformselectors/index.js
@@ -1,0 +1,34 @@
+const postcss = require('postcss');
+
+const defaultOptions = {
+  map: {}
+};
+
+module.exports = function(options) {
+  options = {
+    ...defaultOptions,
+    ...options
+  };
+
+  return {
+    postcssPlugin: 'postcss-transformselectors',
+    Rule(rule) {
+      if (options.replace) {
+        for (let {search, replace} of options.replace) {
+          if (typeof search === 'string') {
+            // always replace globally for strings
+            search = new RegExp(search, 'g');
+          }
+
+          rule.selector = rule.selector.replace(search, replace);
+        }
+      }
+
+      if (options.transform) {
+        rule.selector = options.transform(rule.selector, rule);
+      }
+    }
+  };
+};
+
+module.exports.postcss = true

--- a/tools/postcss-transformselectors/package.json
+++ b/tools/postcss-transformselectors/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "postcss-transformselectors",
+  "version": "1.0.0",
+  "description": "Re-map and transform selectors",
+  "main": "index.js",
+  "scripts": {
+    "test": "ava"
+  },
+  "author": "Larry Davis <lazdnet@gmail.com>",
+  "license": "BSD-2-Clause",
+  "dependencies": {
+    "postcss": "^8.2.6"
+  },
+  "devDependencies": {
+    "ava": "^3.9.0"
+  }
+}

--- a/tools/postcss-transformselectors/test.js
+++ b/tools/postcss-transformselectors/test.js
@@ -1,0 +1,47 @@
+const fs = require('fs');
+const test = require('ava');
+const postcss = require('postcss');
+const plugin = require('./index.js');
+
+function compare(t, fixtureFilePath, expectedFilePath, options = {}){
+  return postcss([ plugin(options) ])
+    .process(
+      readFile(`./fixtures/${fixtureFilePath}`),
+      { from: fixtureFilePath }
+    )
+    .then(result => {
+      const expected = result.css;
+      const actual = readFile(`./expected/${expectedFilePath}`);
+      t.is(expected, actual);
+      t.is(result.warnings().length, 0);
+    });
+}
+
+function readFile(filename) {
+  return fs.readFileSync(filename, 'utf8');
+}
+
+test('support options.replace', t => {
+  return compare(t, 'replace.css', 'replace.css', {
+    replace: [
+      { search: '.button', replace: '.btn' },
+      { search: '.card', replace: '.crd' }
+    ]
+  });
+});
+
+test('support options.replace with regex', t => {
+  return compare(t, 'regex.css', 'regex.css', {
+    replace: [
+      { search: /\.(.*?)--([^ ]*?)/g, replace: '.$1_$2' },
+    ]
+  });
+});
+
+test('support options.transform', t => {
+  return compare(t, 'transform.css', 'transform.css', {
+    transform: (selector, rule) => {
+      return selector.toLowerCase();
+    }
+  });
+});

--- a/tools/postcss-transformselectors/test.js
+++ b/tools/postcss-transformselectors/test.js
@@ -45,3 +45,26 @@ test('support options.transform', t => {
     }
   });
 });
+
+test('support complex examples', t => {
+  return compare(t, 'complex.css', 'complex.css', {
+    replace: [
+      { search: '.spectrum-Heading--sizeXXL', replace: 'h1' },
+      { search: '.spectrum-Heading--sizeXL', replace: 'h2' },
+      { search: '.spectrum-Heading--sizeL', replace: 'h3' }
+    ],
+    transform: (selector) => {
+      if (selector.startsWith('.spectrum-Heading')) {
+        return selector.split(',')
+          .map(selectorPart => {
+            return ['h1', 'h2', 'h3'].map(h => {
+              return selectorPart.replace('.spectrum-Heading', h);
+            }).join(',');
+          })
+          .join(',');
+      }
+
+      return selector;
+    }
+  });
+});

--- a/tools/postcss-varfallback/README.md
+++ b/tools/postcss-varfallback/README.md
@@ -1,0 +1,35 @@
+# postcss-varfallback
+> Use the fallback value of any var reference
+
+## Installation
+
+```sh
+npm install postcss-varfallback
+postcss -u postcss-varfallback -o dist/index.css src/index.css
+```
+
+## Usage
+
+Assuming you have some CSS defined that uses fallback variables:
+
+```css
+:root {
+  --component-background-color: blue;
+}
+
+.component {
+  background-color: var(--custom-background-color, var(--component-background-color));
+}
+```
+
+Running it through this plugin will produce:
+
+```css
+:root {
+  --component-background-color: blue;
+}
+
+.component {
+  background-color: var(--component-background-color);
+}
+```

--- a/tools/postcss-varfallback/expected/basic.css
+++ b/tools/postcss-varfallback/expected/basic.css
@@ -1,0 +1,7 @@
+:root {
+  --component-background-color: blue;
+}
+
+.component {
+  background-color: var(--component-background-color);
+}

--- a/tools/postcss-varfallback/expected/functions.css
+++ b/tools/postcss-varfallback/expected/functions.css
@@ -1,0 +1,8 @@
+:root {
+  --component-width: 12px;
+  --component-border-width: 12px;
+}
+
+.component {
+  width: calc(var(--component-width) - var(--component-border-width));
+}

--- a/tools/postcss-varfallback/expected/nested.css
+++ b/tools/postcss-varfallback/expected/nested.css
@@ -1,0 +1,8 @@
+:root {
+  --color-blue: blue;
+  --component-background-color: var(--color-blue);
+}
+
+.component {
+  background-color: var(--color-blue);
+}

--- a/tools/postcss-varfallback/fixtures/basic.css
+++ b/tools/postcss-varfallback/fixtures/basic.css
@@ -1,0 +1,7 @@
+:root {
+  --component-background-color: blue;
+}
+
+.component {
+  background-color: var(--custom-background-color, var(--component-background-color));
+}

--- a/tools/postcss-varfallback/fixtures/functions.css
+++ b/tools/postcss-varfallback/fixtures/functions.css
@@ -1,0 +1,8 @@
+:root {
+  --component-width: 12px;
+  --component-border-width: 12px;
+}
+
+.component {
+  width: calc(var(--custom-width, var(--component-width)) - var(--custom-border-width, var(--component-border-width)));
+}

--- a/tools/postcss-varfallback/fixtures/nested.css
+++ b/tools/postcss-varfallback/fixtures/nested.css
@@ -1,0 +1,8 @@
+:root {
+  --color-blue: blue;
+  --component-background-color: var(--color-blue);
+}
+
+.component {
+  background-color: var(--custom-background-color, var(--component-background-color, var(--color-blue)));
+}

--- a/tools/postcss-varfallback/index.js
+++ b/tools/postcss-varfallback/index.js
@@ -1,0 +1,47 @@
+const postcss = require('postcss');
+const valueParser = require('postcss-value-parser');
+
+function getFallbackValue(decl) {
+  const parsed = valueParser(decl.value);
+  if (!parsed.nodes || !parsed.nodes.length) {
+    return node.value;
+  }
+
+  parsed.walk(node => {
+    if (node.type === 'function' && node.value === 'var') {
+      // If it's a var, recursively find the fallback
+      const fallbackNode = getFallbackNode(node);
+
+      // Replace node properties with the fallback
+      node.type = fallbackNode.type;
+      node.value = fallbackNode.value;
+      node.nodes = fallbackNode.nodes;
+
+      // Do not investigate children
+      return false;
+    }
+  });
+
+  return valueParser.stringify(parsed);
+}
+
+function getFallbackNode(node) {
+  const nodes = node.nodes
+  if (nodes && nodes.length === 3) {
+    // It's got a fallback, go deeper
+    return getFallbackNode(nodes[2]);
+  }
+
+  return node;
+}
+
+module.exports = function() {
+  return {
+    postcssPlugin: 'postcss-varfallback',
+    Declaration(decl) {
+      decl.value = getFallbackValue(decl);
+    }
+  };
+};
+
+module.exports.postcss = true

--- a/tools/postcss-varfallback/package.json
+++ b/tools/postcss-varfallback/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "postcss-varfallback",
+  "version": "1.0.0",
+  "description": "Use the fallback value of any var reference",
+  "main": "index.js",
+  "scripts": {
+    "test": "ava"
+  },
+  "author": "Larry Davis <lazdnet@gmail.com>",
+  "license": "BSD-2-Clause",
+  "dependencies": {
+    "postcss": "^8.2.6",
+    "postcss-value-parser": "^4.1.0"
+  },
+  "devDependencies": {
+    "ava": "^3.9.0"
+  }
+}

--- a/tools/postcss-varfallback/test.js
+++ b/tools/postcss-varfallback/test.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const test = require('ava');
+const postcss = require('postcss');
+const plugin = require('./index.js');
+
+function compare(t, fixtureFilePath, expectedFilePath, options = {}){
+  return postcss([ plugin(options) ])
+    .process(
+      readFile(`./fixtures/${fixtureFilePath}`),
+      { from: fixtureFilePath }
+    )
+    .then(result => {
+      const expected = result.css;
+      const actual = readFile(`./expected/${expectedFilePath}`);
+      t.is(expected, actual);
+      t.is(result.warnings().length, 0);
+    });
+}
+
+function readFile(filename) {
+  return fs.readFileSync(filename, 'utf8');
+}
+
+test('basic fallbacks', t => {
+  return compare(t, 'basic.css', 'basic.css');
+});
+
+test('nested fallbacks', t => {
+  return compare(t, 'nested.css', 'nested.css');
+});
+
+test('function arguments', t => {
+  return compare(t, 'functions.css', 'functions.css');
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2970,6 +2970,11 @@ color-support@^1.1.3:
   resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
   integrity sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==
 
+colorette@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
+  integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
+
 colors@^1.3.3:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
@@ -7324,6 +7329,11 @@ nan@^2.12.1:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
 
+nanoid@^3.1.20:
+  version "3.1.20"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.20.tgz#badc263c6b1dcf14b71efaa85f6ab4c1d6cfc788"
+  integrity sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -8594,6 +8604,15 @@ postcss@^7.0.5:
     chalk "^2.4.2"
     source-map "^0.6.1"
     supports-color "^6.1.0"
+
+postcss@^8.2.6:
+  version "8.2.7"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.2.7.tgz#48ed8d88b4de10afa0dfd1c3f840aa57b55c4d47"
+  integrity sha512-DsVLH3xJzut+VT+rYr0mtvOtpTjSyqDwPf5EZWXcb0uAKfitGpTY9Ec+afi2+TgdN8rWS9Cs88UDYehKo/RvOw==
+  dependencies:
+    colorette "^1.2.2"
+    nanoid "^3.1.20"
+    source-map "^0.6.1"
 
 prepend-http@^1.0.0:
   version "1.0.4"


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->
This PR adds two PostCSS plugins and some documentation on how to use them to optimize Spectrum CSS:

* `postcss-varfallback` - Uses the fallback values of CSS custom properties
* `postcss-transformselectors` - Lets you remap and search/replace CSS selectors

The documentation instructs users on how to use PostCSS to process Spectrum CSS, slimming down their output bundle size.

Additionally, documentation is included showing how to customize Spectrum CSS classnames.

## How and where has this been tested?
 - **How this was tested:** test repo was created internally for the optimization example, tests are included for transform example and other basic functionalities of the plugins