### PR TITLE
Adds Windows High contast mode support for tabs

### DIFF
--- a/components/tabs/skin.css
+++ b/components/tabs/skin.css
@@ -84,3 +84,53 @@ governing permissions and limitations under the License.
     }
   }
 }
+
+
+@media (forced-colors: active) {
+  .spectrum-Tabs {
+    --spectrum-tabs-m-focus-ring-color: CanvasText;
+    --spectrum-tabs-m-icon-color-disabled: GrayText;
+    --spectrum-tabs-m-icon-color-hover: ButtonText;
+    --spectrum-tabs-m-icon-color-key-focus: ButtonText;
+    --spectrum-tabs-m-icon-color-selected: ButtonText;
+    --spectrum-tabs-m-icon-color: ButtonText;
+    --spectrum-tabs-m-rule-color: transparent;
+    --spectrum-tabs-m-selection-indicator-color: transparent;
+    --spectrum-tabs-m-text-color-disabled: GrayText;
+    --spectrum-tabs-m-text-color-hover: ButtonText;
+    --spectrum-tabs-m-text-color-key-focus: ButtonText;
+    --spectrum-tabs-m-text-color-selected: ButtonText;
+    --spectrum-tabs-m-text-color: ButtonText;
+    --spectrum-tabs-m-vertical-rule-color: transparent;
+    --spectrum-tabs-quiet-m-rule-color: transparent;
+    --spectrum-tabs-quiet-m-selection-indicator-color: transparent;
+    --spectrum-tabs-quiet-m-vertical-rule-color: transparent;
+    forced-color-adjust: none;
+    .spectrum-Tabs-item {
+      &:before {
+        background-color: ButtonFace;
+      }
+      .spectrum-Icon {
+        z-index: 1;
+        position: relative;
+      }
+      .spectrum-Tabs-itemLabel {
+        position: relative;
+        z-index: 1;
+      }
+    }
+    .is-selected {
+      color: HighlightText;
+      .spectrum-Icon {
+        color: HighlightText;
+      }
+      &:before {
+        background-color: Highlight;
+        color: HighlightText;
+      }
+      .spectrum-Tabs-itemLabel {
+        color: HighlightText;
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
Added mappings to Windows System colors for variables
changed how selection rendered in high contrast mode

## How and where has this been tested?
 - **How this was tested:** Using steps in #1175
 - **Browser(s) and OS(s) this was tested with:** Edge 90.x on Windows 10 - in High Contrast mode

## Screenshots
### Before
![Tabs - Spectrum CSS and 3 more pages - Work - Microsoft​ Edge 4_29_2021 4_50_03 PM](https://user-images.githubusercontent.com/1724479/116632535-43600500-a90c-11eb-9358-fcca0d6bd7e4.png)

### After
![Tabs - Spectrum CSS and 3 more pages - Work - Microsoft​ Edge 4_29_2021 4_50_41 PM](https://user-images.githubusercontent.com/1724479/116632539-45c25f00-a90c-11eb-9014-af5158bc601e.png)

### Windows System Dialog for comparison
![CN=Microsoft Windows, O=Microsoft Corporation, L=Redmond, S=Washington, C=US 4_29_2021 4_51_03 PM](https://user-images.githubusercontent.com/1724479/116632565-507cf400-a90c-11eb-8a19-0c67fc8ca950.png)

## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
