### PR TITLE
fix(textfield): prevent pointer-events on icons over the form element

### DIFF
--- a/components/textfield/skin.css
+++ b/components/textfield/skin.css
@@ -74,6 +74,11 @@ governing permissions and limitations under the License.
   color: var(--spectrum-textfield-m-icon-color);
 }
 
+.spectrum-Textfield-icon,
+.spectrum-Textfield-validationIcon {
+  pointer-events: none;
+}
+
 .spectrum-Textfield-input {
   background-color: var(--spectrum-textfield-m-background-color);
   border-color: var(--spectrum-textfield-m-border-color);


### PR DESCRIPTION
## Description
fixes #1181

Addes `pointer-events: none` to non-interactive icons used over the form element in a Textfield.


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
