### PR TITLE
fix(slider): ensure margin-block is correct for range variant

### DIFF
--- a/components/slider/index.css
+++ b/components/slider/index.css
@@ -177,7 +177,7 @@ governing permissions and limitations under the License.
       inset-inline-start: auto;
       inset-inline-end: auto;
       margin-inline: var(--spectrum-slider-range-track-reset);
-      margin-block: var(--spectrum-slider-range-track-reset);
+      margin-block: calc(var(--spectrum-slider-track-height) / -2) var(--spectrum-slider-range-track-reset);
     }
     &:last-of-type {
       padding-block: 0;


### PR DESCRIPTION
## Description
Correct `margin-block-start` in Range variant of Slider component.

fixes #1205

## How and where has this been tested?
 - **How this was tested:** Visually inspecting the local build of the documentation site
 - **Browser(s) and OS(s) this was tested with:** Stable Chrome on Catalina

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/1156657/121670662-b025fd80-ca7b-11eb-8e75-59f9618587eb.png)
After:
![image](https://user-images.githubusercontent.com/1156657/121670484-7a811480-ca7b-11eb-87ac-a373c312d49f.png)

## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
