### PR TITLE
fix(dialog): apply the same color to footer content as content content

### DIFF
--- a/components/dialog/skin.css
+++ b/components/dialog/skin.css
@@ -18,6 +18,10 @@ governing permissions and limitations under the License.
   color: var(--spectrum-dialog-confirm-description-text-color);
 }
 
+.spectrum-Dialog-footer {
+  color: var(--spectrum-dialog-confirm-description-text-color);
+}
+
 .spectrum-Dialog-typeIcon {
   color: var(--spectrum-dialog-confirm-icon-color);
 }


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
Apply the same color to the Footer as to the Body content of a Dialog component.

The metadata for Dialog does not explicitly leverage the `.spectrum-Dialog-footer` class anywhere, but this is leveraged into Spectrum Web Components.

fixes #1203

## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
