### PR TITLE
Add tshirt sizes to tabs dna 7.0 beta

### DIFF
--- a/components/tabs/index.css
+++ b/components/tabs/index.css
@@ -14,7 +14,18 @@ governing permissions and limitations under the License.
 @import "../vars/css/scales/spectrum-large.css";
 @import "../vars/css/scales/spectrum-medium.css";
 
-.spectrum-Tabs {
+.spectrum-Tabs--sizeS {
+  @remapvars {
+    find: --spectrum-tabs-s-;
+    replace: --spectrum-tabs-;
+  }
+  @remapvars {
+    find: --spectrum-tabs-quiet-s-;
+    replace: --spectrum-tabs-quiet-;
+  }
+}
+
+.spectrum-Tabs--sizeM {
   @remapvars {
     find: --spectrum-tabs-m-;
     replace: --spectrum-tabs-;
@@ -25,12 +36,31 @@ governing permissions and limitations under the License.
   }
 }
 
-.spectrum-Tabs {
-  --spectrum-tabs-item-height: calc(var(--spectrum-tabs-height) - var(--spectrum-tabs-divider-size));
-  --spectrum-tabs-compact-item-height: calc(var(--spectrum-tabs-compact-quiet-height) - var(--spectrum-tabs-divider-size));
+.spectrum-Tabs--sizeL {
+  @remapvars {
+    find: --spectrum-tabs-l-;
+    replace: --spectrum-tabs-;
+  }
+  @remapvars {
+    find: --spectrum-tabs-quiet-l-;
+    replace: --spectrum-tabs-quiet-;
+  }
+}
 
-  /* todo: remove when this is added back to DNA */
-  --spectrum-tabs-text-size: var(--spectrum-alias-font-size-default);
+.spectrum-Tabs--sizeXL {
+  @remapvars {
+    find: --spectrum-tabs-xl-;
+    replace: --spectrum-tabs-;
+  }
+  @remapvars {
+    find: --spectrum-tabs-quiet-xl-;
+    replace: --spectrum-tabs-quiet-;
+  }
+}
+
+.spectrum-Tabs {
+  --spectrum-tabs-item-height: calc(var(--spectrum-tabs-height) - var(--spectrum-tabs-rule-size));
+  --spectrum-tabs-compact-item-height: calc(var(--spectrum-tabs-quiet-compact-height) - var(--spectrum-tabs-rule-size));
 }
 
 .spectrum-Tabs {

--- a/components/tabs/index.css
+++ b/components/tabs/index.css
@@ -72,7 +72,6 @@ governing permissions and limitations under the License.
 
   margin: 0;
   padding-block: 0;
-  padding-inline: var(--spectrum-tabs-focus-ring-padding-x);
 
   /* Friends should align to the top of the tabs */
   vertical-align: top;

--- a/components/tabs/index.css
+++ b/components/tabs/index.css
@@ -59,8 +59,8 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Tabs {
-  --spectrum-tabs-item-height: calc(var(--spectrum-tabs-height) - var(--spectrum-tabs-rule-size));
-  --spectrum-tabs-compact-item-height: calc(var(--spectrum-tabs-quiet-compact-height) - var(--spectrum-tabs-rule-size));
+  --spectrum-tabs-item-height: calc(var(--spectrum-tabs-height) - var(--spectrum-tabs-divider-size));
+  --spectrum-tabs-compact-item-height: calc(var(--spectrum-tabs-compact-quiet-height) - var(--spectrum-tabs-divider-size));
 }
 
 .spectrum-Tabs {

--- a/components/tabs/metadata/tabs.yml
+++ b/components/tabs/metadata/tabs.yml
@@ -3,6 +3,9 @@ SpectrumSiteSlug: https://spectrum.adobe.com/page/tabs/
 sections:
   - name: Migration Guide
     description: |
+      ### T-shirt sizing
+      Tabs now support t-shirt sizing and require that you specify the size by adding a `.spectrum-Tabs--size*` class.
+      
       ### Change workflow icon size to medium
       If you use a workflow icon with tab items, please replace `.spectrum-Icon--sizeS` with `.spectrum-Icon--sizeM`.
 examples:

--- a/components/tabs/metadata/tabs.yml
+++ b/components/tabs/metadata/tabs.yml
@@ -26,7 +26,7 @@ examples:
         <div class="spectrum-Tabs-item" tabindex="0">
           <span class="spectrum-Tabs-itemLabel">Tab 4</span>
         </div>
-        <div class="spectrum-Tabs-selectionIndicator" style="width: 27px; left: 0px;"></div>
+        <div class="spectrum-Tabs-selectionIndicator" style="width: 24px; left: 0px;"></div>
       </div>
       <h4 style="margin-top: 62px;" class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">M (default)</h4>
       <div class="spectrum-Tabs spectrum-Tabs--sizeM spectrum-Tabs--horizontal">
@@ -42,7 +42,7 @@ examples:
         <div class="spectrum-Tabs-item" tabindex="0">
           <span class="spectrum-Tabs-itemLabel">Tab 4</span>
         </div>
-        <div class="spectrum-Tabs-selectionIndicator" style="width: 27px; left: 0px;"></div>
+        <div class="spectrum-Tabs-selectionIndicator" style="width: 28px; left: 0px;"></div>
       </div>
       <h4 style="margin-top: 62px;" class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">L</h4>
       <div class="spectrum-Tabs spectrum-Tabs--sizeL spectrum-Tabs--horizontal">
@@ -58,7 +58,7 @@ examples:
         <div class="spectrum-Tabs-item" tabindex="0">
           <span class="spectrum-Tabs-itemLabel">Tab 4</span>
         </div>
-        <div class="spectrum-Tabs-selectionIndicator" style="width: 27px; left: 0px;"></div>
+        <div class="spectrum-Tabs-selectionIndicator" style="width: 32px; left: 0px;"></div>
       </div>
       <h4 style="margin-top: 62px;" class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">XL</h4>
       <div class="spectrum-Tabs spectrum-Tabs--sizeXL spectrum-Tabs--horizontal">
@@ -74,7 +74,7 @@ examples:
         <div class="spectrum-Tabs-item" tabindex="0">
           <span class="spectrum-Tabs-itemLabel">Tab 4</span>
         </div>
-        <div class="spectrum-Tabs-selectionIndicator" style="width: 27px; left: 0px;"></div>
+        <div class="spectrum-Tabs-selectionIndicator" style="width: 36px; left: 0px;"></div>
       </div>
   - id: tabs
     name: Basic tabs
@@ -93,7 +93,7 @@ examples:
         <div class="spectrum-Tabs-item" tabindex="0">
           <span class="spectrum-Tabs-itemLabel">Tab 4</span>
         </div>
-        <div class="spectrum-Tabs-selectionIndicator" style="width: 27px; left: 0px;"></div>
+        <div class="spectrum-Tabs-selectionIndicator" style="width: 28px; left: 0px;"></div>
       </div>
   - id: tabs-icon
     name: Tabs with icons
@@ -143,7 +143,7 @@ examples:
         <div class="spectrum-Tabs-item" tabindex="0">
           <span class="spectrum-Tabs-itemLabel">Tab 4</span>
         </div>
-        <div class="spectrum-Tabs-selectionIndicator" style="width: 27px; left: 0px;"></div>
+        <div class="spectrum-Tabs-selectionIndicator" style="width: 28px; left: 0px;"></div>
       </div>
   - id: tabs-quiet-icon
     name: Quiet tabs with icons
@@ -193,7 +193,7 @@ examples:
         <div class="spectrum-Tabs-item" tabindex="0">
           <span class="spectrum-Tabs-itemLabel">Tab 4</span>
         </div>
-        <div class="spectrum-Tabs-selectionIndicator" style="width: 27px; left: 0px;"></div>
+        <div class="spectrum-Tabs-selectionIndicator" style="width: 28px; left: 0px;"></div>
       </div>
   - id: tabs-quiet-compact-icon
     name: Compact tabs with icons and text
@@ -268,7 +268,7 @@ examples:
         <div class="spectrum-Tabs-item" tabindex="0">
           <span class="spectrum-Tabs-itemLabel">Tab 4</span>
         </div>
-        <div class="spectrum-Tabs-selectionIndicator" style="width: 27px; left: 0px;"></div>
+        <div class="spectrum-Tabs-selectionIndicator" style="width: 28px; left: 0px;"></div>
       </div>
   - id: tabs-quiet-compact
     name: Compact tabs with icons and text (quiet)
@@ -434,7 +434,7 @@ examples:
             <use xlink:href="#spectrum-css-icon-Chevron100" />
           </svg>
         </button>
-        <div class="spectrum-Tabs-selectionIndicator" style="width: 50px; left: 8px;"></div>
+        <div class="spectrum-Tabs-selectionIndicator" style="width: 50px; left: 0;"></div>
       </div>
 
       <h4 style="margin-top: 62px;">Open</h4>
@@ -445,7 +445,7 @@ examples:
             <use xlink:href="#spectrum-css-icon-Chevron100" />
           </svg>
         </button>
-        <div class="spectrum-Tabs-selectionIndicator" style="width: 50px; left: 8px;"></div>
+        <div class="spectrum-Tabs-selectionIndicator" style="width: 50px; left: 0;"></div>
       </div>
       <div class="spectrum-Popover spectrum-Popover--bottom spectrum-Picker-popover spectrum-Picker-popover--quiet is-open" style="margin-left: -5px; margin-top: -9px;">
         <ul class="spectrum-Menu" role="listbox">
@@ -480,7 +480,7 @@ examples:
               <use xlink:href="#spectrum-css-icon-Chevron100" />
             </svg>
           </button>
-        <div class="spectrum-Tabs-selectionIndicator" style="width: 50px; left: 8px;"></div>
+        <div class="spectrum-Tabs-selectionIndicator" style="width: 50px; left: 0;"></div>
       </div>
 
       <h4 style="margin-top: 62px;">Open</h4>
@@ -491,7 +491,7 @@ examples:
               <use xlink:href="#spectrum-css-icon-Chevron100" />
             </svg>
           </button>
-        <div class="spectrum-Tabs-selectionIndicator" style="width: 50px; left: 8px;"></div>
+        <div class="spectrum-Tabs-selectionIndicator" style="width: 50px; left: 0;"></div>
       </div>
       <br>
       <div class="spectrum-Popover spectrum-Popover--bottom spectrum-Picker-popover spectrum-Picker-popover--quiet is-open" style="margin-left: -5px; margin-top: -9px;">
@@ -532,5 +532,5 @@ examples:
         <a href="#4" class="spectrum-Tabs-item">
           <span class="spectrum-Tabs-itemLabel">Tab 4</span>
         </a>
-        <div class="spectrum-Tabs-selectionIndicator" style="width: 27px; left: 0px;"></div>
+        <div class="spectrum-Tabs-selectionIndicator" style="width: 28px; left: 0;"></div>
       </div>

--- a/components/tabs/metadata/tabs.yml
+++ b/components/tabs/metadata/tabs.yml
@@ -6,11 +6,78 @@ sections:
       ### Change workflow icon size to medium
       If you use a workflow icon with tab items, please replace `.spectrum-Icon--sizeS` with `.spectrum-Icon--sizeM`.
 examples:
+  - id: tabs-sizing
+    name: Sizing
+    markup: |
+      <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">S</h4>
+      <div class="spectrum-Tabs spectrum-Tabs--sizeS spectrum-Tabs--horizontal">
+        <div class="spectrum-Tabs-item is-selected" tabindex="0">
+          <span class="spectrum-Tabs-itemLabel">Tab 1</span>
+        </div>
+        <div class="spectrum-Tabs-item" tabindex="0">
+          <span class="spectrum-Tabs-itemLabel">Tab 2</span>
+        </div>
+        <div class="spectrum-Tabs-item" tabindex="0">
+          <span class="spectrum-Tabs-itemLabel">Tab 3</span>
+        </div>
+        <div class="spectrum-Tabs-item" tabindex="0">
+          <span class="spectrum-Tabs-itemLabel">Tab 4</span>
+        </div>
+        <div class="spectrum-Tabs-selectionIndicator" style="width: 27px; left: 0px;"></div>
+      </div>
+      <h4 style="margin-top: 62px;" class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">M (default)</h4>
+      <div class="spectrum-Tabs spectrum-Tabs--sizeM spectrum-Tabs--horizontal">
+        <div class="spectrum-Tabs-item is-selected" tabindex="0">
+          <span class="spectrum-Tabs-itemLabel">Tab 1</span>
+        </div>
+        <div class="spectrum-Tabs-item" tabindex="0">
+          <span class="spectrum-Tabs-itemLabel">Tab 2</span>
+        </div>
+        <div class="spectrum-Tabs-item" tabindex="0">
+          <span class="spectrum-Tabs-itemLabel">Tab 3</span>
+        </div>
+        <div class="spectrum-Tabs-item" tabindex="0">
+          <span class="spectrum-Tabs-itemLabel">Tab 4</span>
+        </div>
+        <div class="spectrum-Tabs-selectionIndicator" style="width: 27px; left: 0px;"></div>
+      </div>
+      <h4 style="margin-top: 62px;" class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">L</h4>
+      <div class="spectrum-Tabs spectrum-Tabs--sizeL spectrum-Tabs--horizontal">
+        <div class="spectrum-Tabs-item is-selected" tabindex="0">
+          <span class="spectrum-Tabs-itemLabel">Tab 1</span>
+        </div>
+        <div class="spectrum-Tabs-item" tabindex="0">
+          <span class="spectrum-Tabs-itemLabel">Tab 2</span>
+        </div>
+        <div class="spectrum-Tabs-item" tabindex="0">
+          <span class="spectrum-Tabs-itemLabel">Tab 3</span>
+        </div>
+        <div class="spectrum-Tabs-item" tabindex="0">
+          <span class="spectrum-Tabs-itemLabel">Tab 4</span>
+        </div>
+        <div class="spectrum-Tabs-selectionIndicator" style="width: 27px; left: 0px;"></div>
+      </div>
+      <h4 style="margin-top: 62px;" class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">XL</h4>
+      <div class="spectrum-Tabs spectrum-Tabs--sizeXL spectrum-Tabs--horizontal">
+        <div class="spectrum-Tabs-item is-selected" tabindex="0">
+          <span class="spectrum-Tabs-itemLabel">Tab 1</span>
+        </div>
+        <div class="spectrum-Tabs-item" tabindex="0">
+          <span class="spectrum-Tabs-itemLabel">Tab 2</span>
+        </div>
+        <div class="spectrum-Tabs-item" tabindex="0">
+          <span class="spectrum-Tabs-itemLabel">Tab 3</span>
+        </div>
+        <div class="spectrum-Tabs-item" tabindex="0">
+          <span class="spectrum-Tabs-itemLabel">Tab 4</span>
+        </div>
+        <div class="spectrum-Tabs-selectionIndicator" style="width: 27px; left: 0px;"></div>
+      </div>
   - id: tabs
     name: Basic tabs
     status: Verified
     markup: |
-      <div class="spectrum-Tabs spectrum-Tabs--horizontal">
+      <div class="spectrum-Tabs spectrum-Tabs--sizeM spectrum-Tabs--horizontal">
         <div class="spectrum-Tabs-item is-selected" tabindex="0">
           <span class="spectrum-Tabs-itemLabel">Tab 1</span>
         </div>
@@ -29,7 +96,7 @@ examples:
     name: Tabs with icons
     status: Verified
     markup: |
-      <div class="spectrum-Tabs spectrum-Tabs--horizontal">
+      <div class="spectrum-Tabs spectrum-Tabs--sizeM spectrum-Tabs--horizontal">
         <div class="spectrum-Tabs-item is-selected" tabindex="0">
           <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Folder">
             <use xlink:href="#spectrum-icon-18-Folder" />
@@ -60,7 +127,7 @@ examples:
     name: Quiet
     status: Verified
     markup: |
-      <div class="spectrum-Tabs spectrum-Tabs--horizontal spectrum-Tabs--quiet">
+      <div class="spectrum-Tabs spectrum-Tabs--sizeM spectrum-Tabs--horizontal spectrum-Tabs--quiet">
         <div class="spectrum-Tabs-item is-selected" tabindex="0">
           <span class="spectrum-Tabs-itemLabel">Tab 1</span>
         </div>
@@ -79,7 +146,7 @@ examples:
     name: Quiet tabs with icons
     status: Verified
     markup: |
-      <div class="spectrum-Tabs spectrum-Tabs--horizontal spectrum-Tabs--quiet">
+      <div class="spectrum-Tabs spectrum-Tabs--sizeM spectrum-Tabs--horizontal spectrum-Tabs--quiet">
         <div class="spectrum-Tabs-item is-selected" tabindex="0">
           <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Folder">
             <use xlink:href="#spectrum-icon-18-Folder" />
@@ -110,7 +177,7 @@ examples:
     name: Compact
     description: 'Compact tabs should never be used without the quiet variation. Please use [Quiet Compact Tabs instead](#quiet-compact).'
     markup: |
-      <div class="spectrum-Tabs spectrum-Tabs--horizontal spectrum-Tabs--compact">
+      <div class="spectrum-Tabs spectrum-Tabs--sizeM spectrum-Tabs--horizontal spectrum-Tabs--compact">
         <div class="spectrum-Tabs-item is-selected" tabindex="0">
           <span class="spectrum-Tabs-itemLabel">Tab 1</span>
         </div>
@@ -128,7 +195,7 @@ examples:
   - id: tabs-quiet-compact-icon
     name: Compact tabs with icons and text
     markup: |
-      <div class="spectrum-Tabs spectrum-Tabs--horizontal spectrum-Tabs--compact">
+      <div class="spectrum-Tabs spectrum-Tabs--sizeM spectrum-Tabs--horizontal spectrum-Tabs--compact">
         <div class="spectrum-Tabs-item is-selected" tabindex="0">
           <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Folder">
             <use xlink:href="#spectrum-icon-18-Folder" />
@@ -158,7 +225,7 @@ examples:
   - id: tabs-quiet-compact-icon
     name: Compact tabs with icons
     markup: |
-      <div class="spectrum-Tabs spectrum-Tabs--horizontal spectrum-Tabs--compact">
+      <div class="spectrum-Tabs spectrum-Tabs--sizeM spectrum-Tabs--horizontal spectrum-Tabs--compact">
         <div class="spectrum-Tabs-item is-selected" tabindex="0">
           <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Folder">
             <use xlink:href="#spectrum-icon-18-Folder" />
@@ -185,7 +252,7 @@ examples:
     name: Compact (quiet)
     status: Verified
     markup: |
-      <div class="spectrum-Tabs spectrum-Tabs--horizontal spectrum-Tabs--compact spectrum-Tabs--quiet">
+      <div class="spectrum-Tabs spectrum-Tabs--sizeM spectrum-Tabs--horizontal spectrum-Tabs--compact spectrum-Tabs--quiet">
         <div class="spectrum-Tabs-item is-selected" tabindex="0">
           <span class="spectrum-Tabs-itemLabel">Tab 1</span>
         </div>
@@ -203,7 +270,7 @@ examples:
   - id: tabs-quiet-compact
     name: Compact tabs with icons and text (quiet)
     markup: |
-      <div class="spectrum-Tabs spectrum-Tabs--horizontal spectrum-Tabs--compact spectrum-Tabs--quiet">
+      <div class="spectrum-Tabs spectrum-Tabs--sizeM spectrum-Tabs--horizontal spectrum-Tabs--compact spectrum-Tabs--quiet">
         <div class="spectrum-Tabs-item is-selected" tabindex="0">
           <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Folder">
             <use xlink:href="#spectrum-icon-18-Folder" />
@@ -233,7 +300,7 @@ examples:
   - id: tabs-quiet-compact
     name: Compact tabs with icons only (quiet)
     markup: |
-      <div class="spectrum-Tabs spectrum-Tabs--horizontal spectrum-Tabs--compact spectrum-Tabs--quiet">
+      <div class="spectrum-Tabs spectrum-Tabs--sizeM spectrum-Tabs--horizontal spectrum-Tabs--compact spectrum-Tabs--quiet">
         <div class="spectrum-Tabs-item is-selected" tabindex="0">
           <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Folder">
             <use xlink:href="#spectrum-icon-18-Folder" />
@@ -259,7 +326,7 @@ examples:
   - id: tabs-vertical
     name: Vertical tabs
     markup: |
-      <div class="spectrum-Tabs spectrum-Tabs--vertical">
+      <div class="spectrum-Tabs spectrum-Tabs--sizeM spectrum-Tabs--vertical">
         <div class="spectrum-Tabs-item is-selected" tabindex="0">
           <span class="spectrum-Tabs-itemLabel">Tab 1</span>
         </div>
@@ -277,7 +344,7 @@ examples:
   - id: tabs-vertical
     name: Vertical tabs with icon and text
     markup: |
-      <div class="spectrum-Tabs spectrum-Tabs--vertical">
+      <div class="spectrum-Tabs spectrum-Tabs--sizeM spectrum-Tabs--vertical">
         <div class="spectrum-Tabs-item is-selected" tabindex="0">
           <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Folder">
             <use xlink:href="#spectrum-icon-18-Folder" />
@@ -307,7 +374,7 @@ examples:
   - id: tabs-compact-vertical
     name: Compact vertical tabs
     markup: |
-      <div class="spectrum-Tabs spectrum-Tabs--vertical spectrum-Tabs--compact">
+      <div class="spectrum-Tabs spectrum-Tabs--sizeM spectrum-Tabs--vertical spectrum-Tabs--compact">
         <div class="spectrum-Tabs-item is-selected" tabindex="0">
           <span class="spectrum-Tabs-itemLabel">Tab 1</span>
         </div>
@@ -325,7 +392,7 @@ examples:
   - id: tabs-compact-vertical
     name: Compact vertical tabs with icon and text
     markup: |
-      <div class="spectrum-Tabs spectrum-Tabs--vertical spectrum-Tabs--compact">
+      <div class="spectrum-Tabs spectrum-Tabs--sizeM spectrum-Tabs--vertical spectrum-Tabs--compact">
         <div class="spectrum-Tabs-item is-selected" tabindex="0">
           <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Folder">
             <use xlink:href="#spectrum-icon-18-Folder" />
@@ -357,7 +424,7 @@ examples:
     status: Verified
     markup: |
       <h4>Closed</h4>
-      <div class="spectrum-Tabs spectrum-Tabs--horizontal" style="width: 409px">
+      <div class="spectrum-Tabs spectrum-Tabs--sizeM spectrum-Tabs--horizontal" style="width: 409px">
         <button class="spectrum-Picker spectrum-Picker--quiet" aria-haspopup="true">
           <span class="spectrum-Picker-label">Tab 1</span>
           <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
@@ -368,7 +435,7 @@ examples:
       </div>
 
       <h4 style="margin-top: 62px;">Open</h4>
-      <div class="spectrum-Tabs spectrum-Tabs--horizontal" style="width: 409px">
+      <div class="spectrum-Tabs spectrum-Tabs--sizeM spectrum-Tabs--horizontal" style="width: 409px">
         <button class="spectrum-Picker spectrum-Picker--quiet is-open" aria-haspopup="true">
           <span class="spectrum-Picker-label">Tab 1</span>
           <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
@@ -403,7 +470,7 @@ examples:
     status: Verified
     markup: |
       <h4>Closed</h4>
-      <div class="spectrum-Tabs spectrum-Tabs--horizontal spectrum-Tabs--quiet spectrum-Tabs--compact" style="width: 409px">
+      <div class="spectrum-Tabs spectrum-Tabs--sizeM spectrum-Tabs--horizontal spectrum-Tabs--quiet spectrum-Tabs--compact" style="width: 409px">
           <button class="spectrum-Picker spectrum-Picker--quiet is-open" aria-haspopup="true">
             <span class="spectrum-Picker-label">Tab 1</span>
             <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
@@ -414,7 +481,7 @@ examples:
       </div>
 
       <h4 style="margin-top: 62px;">Open</h4>
-      <div class="spectrum-Tabs spectrum-Tabs--horizontal spectrum-Tabs--quiet spectrum-Tabs--compact" style="width: 409px">
+      <div class="spectrum-Tabs spectrum-Tabs--sizeM spectrum-Tabs--horizontal spectrum-Tabs--quiet spectrum-Tabs--compact" style="width: 409px">
           <button class="spectrum-Picker spectrum-Picker--quiet is-open" aria-haspopup="true">
             <span class="spectrum-Picker-label">Tab 1</span>
             <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
@@ -449,7 +516,7 @@ examples:
     name: Tabs with anchors
     status: Verified
     markup: |
-      <div class="spectrum-Tabs spectrum-Tabs--horizontal">
+      <div class="spectrum-Tabs spectrum-Tabs--sizeM spectrum-Tabs--horizontal">
         <a href="#1" class="spectrum-Tabs-item is-selected">
           <span class="spectrum-Tabs-itemLabel">Tab 1</span>
         </a>


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
This adds t-shirt sizes to the Tabs component as requested in #688.

### Breaking Change
A size must now be specified by adding a .spectrum-Tabs--size* class to the markup.

<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->


## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] Browser tested
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
