### PR TITLE
fix(tabs): vertically center tab item text in vertical tabs

### DIFF
--- a/components/tabs/index.css
+++ b/components/tabs/index.css
@@ -59,7 +59,7 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Tabs {
-  --spectrum-tabs-item-height: calc(var(--spectrum-tabs-height) - var(--spectrum-tabs-divider-size));
+  --spectrum-tabs-item-height-adjusted: calc(var(--spectrum-tabs-height) - var(--spectrum-tabs-divider-size));
   --spectrum-tabs-compact-item-height: calc(var(--spectrum-tabs-compact-quiet-height) - var(--spectrum-tabs-divider-size));
 }
 
@@ -219,6 +219,7 @@ governing permissions and limitations under the License.
 
   .spectrum-Tabs-item {
     block-size: var(--spectrum-tabs-vertical-item-height);
+    line-height: var(--spectrum-tabs-vertical-item-height);
     padding-block: 0;
     padding-inline: var(--spectrum-tabs-focus-ring-padding-x);
     /* Subtract focus ring padding from margin-left since the padding value already offsets tabs-items */
@@ -231,6 +232,11 @@ governing permissions and limitations under the License.
       inset-inline-end: calc(-1 * var(--spectrum-tabs-focus-ring-size));
       margin-block-start: calc(calc(var(--spectrum-tabs-focus-ring-height) / -2));
     }
+  }
+
+  .spectrum-Icon {
+    height: var(--spectrum-tabs-vertical-item-height);
+    line-height: var(--spectrum-tabs-vertical-item-height);
   }
 
   &.spectrum-Tabs--compact {


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->

This fixes #1235, where we noticed that the vertical tab text was not vertically centered.

## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - Tested locally in the docs site
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->
 - Latest version of Firefox on MacOS

## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
