### PR TITLE
feat: add ability to toggle between default & express vars

### DIFF
--- a/site/resources/js/SpectrumSwitcher.js
+++ b/site/resources/js/SpectrumSwitcher.js
@@ -16,6 +16,7 @@ function SpectrumSwitcher(options) {
   this._theme = options.theme || 'light';
   this._scale = options.scale || 'medium';
   this._direction = options.direction || 'ltr';
+  this._varsVersion = options.varsVersion || 'default';
   this._callback = options.callback || null;
 
   document.addEventListener('keydown', function(event) {
@@ -30,6 +31,9 @@ function SpectrumSwitcher(options) {
       }
       else if (value = SpectrumSwitcher.DirectionKeys[event.key]) {
         property = 'direction';
+      }
+      else if (value = SpectrumSwitcher.VarsVersionKeys[event.key]) {
+        property = 'varsVersion';
       }
 
       this[property] = value;
@@ -60,6 +64,16 @@ SpectrumSwitcher.Direction = [
   'ltr',
   'rtl'
 ];
+
+SpectrumSwitcher.VarsVersion = [
+  'default',
+  'express'
+];
+
+SpectrumSwitcher.VarsVersionKeys = {
+  'd': 'default',
+  'e': 'express',
+};
 
 SpectrumSwitcher.ThemeKeys = {
   '1': 'lightest',
@@ -112,6 +126,33 @@ Object.defineProperty(SpectrumSwitcher.prototype, 'theme', {
     return this._theme;
   }
 });
+
+Object.defineProperty(SpectrumSwitcher.prototype, 'varsVersion', {
+  set: function(varsVersion) {
+    // default and express path names
+    const defaultName = 'vars';
+    const expressName = 'expressvars';
+
+    // if the selection is 'default', switch the path to be 'express', and vice-versa
+    const pathNameToUpdate = (varsVersion === 'default') ? expressName : defaultName;
+
+    // get all relevant stylesheets that need to be switched
+    const styleSheets = document.querySelectorAll(`link[href*="/components/${pathNameToUpdate}/"]`);
+
+    // update each relevant stylesheet with the selected path
+    [...styleSheets].map(sheet => {
+      if (pathNameToUpdate === defaultName) {
+        sheet.setAttribute('href', sheet.href.replaceAll(defaultName, expressName));
+      } else {
+        sheet.setAttribute('href', sheet.href.replaceAll(expressName, defaultName));
+      }
+    });
+    this._varsVersion = varsVersion;
+  },
+  get: function() {
+    return this._varsVersion;
+  }
+})
 
 Object.defineProperty(SpectrumSwitcher.prototype, 'scale', {
   set: function(scale) {

--- a/site/resources/js/site.js
+++ b/site/resources/js/site.js
@@ -224,6 +224,9 @@ window.addEventListener('DOMContentLoaded', function() {
     else if (event.target.id === 'switcher-direction') {
       switcher.direction = event.detail.value;
     }
+    else if (event.target.id === 'switcher-vars-version') {
+      switcher.varsVersion = event.detail.value;
+    }
   });
 
   let scalePicker = document.querySelector('#switcher-scale');

--- a/site/templates/siteComponent.pug
+++ b/site/templates/siteComponent.pug
@@ -126,6 +126,23 @@ html(lang='en-US' dir="ltr").spectrum.spectrum--light.spectrum--medium
                         span.spectrum-Menu-itemLabel RTL
                         svg.spectrum-Icon.spectrum-UIIcon-Checkmark100.spectrum-Menu-checkmark.spectrum-Menu-itemIcon(focusable='false' aria-hidden='true')
                           use(xlink:href='#spectrum-css-icon-Checkmark100')
+                div.spectrum-CSS-switcherContainer
+                  label.spectrum-FieldLabel.spectrum-FieldLabel--left(for='switcher-theme') Vars Version
+
+                  button.spectrum-Picker.spectrum-Picker--quiet(aria-haspopup="true",id="switcher-vars-version")
+                    span.spectrum-Picker-label Default
+                    svg.spectrum-Icon.spectrum-UIIcon-ChevronDown100.spectrum-Picker-menuIcon(focusable="false" aria-hidden="true")
+                      use(xlink:href="#spectrum-css-icon-Chevron100")
+                  .spectrum-Popover.spectrum-Popover--bottom.spectrum-Picker-popover.spectrum-Picker-popover--quiet
+                    ul.spectrum-Menu(role='listbox')
+                      li.spectrum-Menu-item.is-selected(role='option' aria-selected='true' tabindex='0' value="default")
+                        span.spectrum-Menu-itemLabel Default
+                        svg.spectrum-Icon.spectrum-UIIcon-Checkmark100.spectrum-Menu-checkmark.spectrum-Menu-itemIcon(focusable='false' aria-hidden='true')
+                          use(xlink:href='#spectrum-css-icon-Checkmark100')
+                      li.spectrum-Menu-item(role='option' tabindex='0' value="express")
+                        span.spectrum-Menu-itemLabel Express
+                        svg.spectrum-Icon.spectrum-UIIcon-Checkmark100.spectrum-Menu-checkmark.spectrum-Menu-itemIcon(focusable='false' aria-hidden='true')
+                          use(xlink:href='#spectrum-css-icon-Checkmark100')
 
               header(id=component.slug).spectrum-CSSComponent-heading
                 h1.spectrum-CSSComponent-title.spectrum-Heading.spectrum-Heading--sizeXXXL.spectrum-Heading--serif


### PR DESCRIPTION
This adds a new switch to the website that allows for users to toggle back and forth between the default and express versions of the CSS vars.

We listen for a click or a key event that corresponds to the "vars version" drop down, get the version of the vars that the user has chosen, and change the resource URL in the `<link>` tags in the DOM. Key events will correspond to `control + e` (for expressvars) and `control + d` (for vars/the default option).

Refs #1238

## How and where has this been tested?
 - Manually tested in a local dev environment.
 - Tested on MacOS in the latest versions of Firefox (91.0.2), Chrome (92.0.4515.159), and Safari (14.1.2 (16611.3.10.1.6)).

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->
#### New Drop Down:
<img width="1266" alt="Screen Shot 2021-08-31 at 11 11 56 AM" src="https://user-images.githubusercontent.com/360251/131528747-5774ae71-6811-4cc7-968a-c8556d8d37a2.png">

#### Before:
<img width="813" alt="Screen Shot 2021-08-31 at 11 13 23 AM" src="https://user-images.githubusercontent.com/360251/131528962-83a506b0-5ce4-41c6-acb6-ecbdfb8e8085.png">

#### After:
<img width="801" alt="Screen Shot 2021-08-31 at 11 12 21 AM" src="https://user-images.githubusercontent.com/360251/131528748-47c8e9f9-40da-45a8-80a5-126abbaa4e94.png">

## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [X] This pull request is ready to merge.

## Validation
1. Pull down this branch and run it locally (`gulp dev`)
2. Navigate to any component page (ie: `http://localhost:3000/docs/accordion.html`)
3. Observe that a new "Vars Version" drop down is available in the upper right portion of the window.
4. Open your browser's inspector, click the drop down, and switch the vars version from "default" to "express".
5. In your browser's inspector, observe that the markup for the `<link>` tags containing the style assets in the `<head>` has changed the `href` attribute from a path that had `vars` to a path that now has `expressvars`.
6. Click the vars version drop down once again, and observe that the `<link>` tag paths have switched back to `vars` from `expressvars`.
7. Using your keyboard, hold the `control` key and press the `e` key, and observe that the `<link>` paths switch to `expressvars`.
8. Using your keyboard, hold the `control` key and press the `d` key, and observe that the `<link>` paths switch to `vars`.
