### PR TITLE
feat: show vars switch when running in dev environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "gulp -LL",
-    "dev": "gulp dev",
+    "dev": "NODE_ENV=development gulp dev",
     "clean": "gulp clean",
     "start": "npm run dev",
     "ci-all": "npm run build",

--- a/site/templates/siteComponent.pug
+++ b/site/templates/siteComponent.pug
@@ -126,23 +126,24 @@ html(lang='en-US' dir="ltr").spectrum.spectrum--light.spectrum--medium
                         span.spectrum-Menu-itemLabel RTL
                         svg.spectrum-Icon.spectrum-UIIcon-Checkmark100.spectrum-Menu-checkmark.spectrum-Menu-itemIcon(focusable='false' aria-hidden='true')
                           use(xlink:href='#spectrum-css-icon-Checkmark100')
-                div.spectrum-CSS-switcherContainer
-                  label.spectrum-FieldLabel.spectrum-FieldLabel--left(for='switcher-theme') Vars Version
+                if (process.env.NODE_ENV === 'development')
+                  div.spectrum-CSS-switcherContainer
+                    label.spectrum-FieldLabel.spectrum-FieldLabel--left(for='switcher-theme') Vars Version
 
-                  button.spectrum-Picker.spectrum-Picker--quiet(aria-haspopup="true",id="switcher-vars-version")
-                    span.spectrum-Picker-label Default
-                    svg.spectrum-Icon.spectrum-UIIcon-ChevronDown100.spectrum-Picker-menuIcon(focusable="false" aria-hidden="true")
-                      use(xlink:href="#spectrum-css-icon-Chevron100")
-                  .spectrum-Popover.spectrum-Popover--bottom.spectrum-Picker-popover.spectrum-Picker-popover--quiet
-                    ul.spectrum-Menu(role='listbox')
-                      li.spectrum-Menu-item.is-selected(role='option' aria-selected='true' tabindex='0' value="default")
-                        span.spectrum-Menu-itemLabel Default
-                        svg.spectrum-Icon.spectrum-UIIcon-Checkmark100.spectrum-Menu-checkmark.spectrum-Menu-itemIcon(focusable='false' aria-hidden='true')
-                          use(xlink:href='#spectrum-css-icon-Checkmark100')
-                      li.spectrum-Menu-item(role='option' tabindex='0' value="express")
-                        span.spectrum-Menu-itemLabel Express
-                        svg.spectrum-Icon.spectrum-UIIcon-Checkmark100.spectrum-Menu-checkmark.spectrum-Menu-itemIcon(focusable='false' aria-hidden='true')
-                          use(xlink:href='#spectrum-css-icon-Checkmark100')
+                    button.spectrum-Picker.spectrum-Picker--quiet(aria-haspopup="true",id="switcher-vars-version")
+                      span.spectrum-Picker-label Default
+                      svg.spectrum-Icon.spectrum-UIIcon-ChevronDown100.spectrum-Picker-menuIcon(focusable="false" aria-hidden="true")
+                        use(xlink:href="#spectrum-css-icon-Chevron100")
+                    .spectrum-Popover.spectrum-Popover--bottom.spectrum-Picker-popover.spectrum-Picker-popover--quiet
+                      ul.spectrum-Menu(role='listbox')
+                        li.spectrum-Menu-item.is-selected(role='option' aria-selected='true' tabindex='0' value="default")
+                          span.spectrum-Menu-itemLabel Default
+                          svg.spectrum-Icon.spectrum-UIIcon-Checkmark100.spectrum-Menu-checkmark.spectrum-Menu-itemIcon(focusable='false' aria-hidden='true')
+                            use(xlink:href='#spectrum-css-icon-Checkmark100')
+                        li.spectrum-Menu-item(role='option' tabindex='0' value="express")
+                          span.spectrum-Menu-itemLabel Express
+                          svg.spectrum-Icon.spectrum-UIIcon-Checkmark100.spectrum-Menu-checkmark.spectrum-Menu-itemIcon(focusable='false' aria-hidden='true')
+                            use(xlink:href='#spectrum-css-icon-Checkmark100')
 
               header(id=component.slug).spectrum-CSSComponent-heading
                 h1.spectrum-CSSComponent-title.spectrum-Heading.spectrum-Heading--sizeXXXL.spectrum-Heading--serif


### PR DESCRIPTION
This changes the `dev` task by setting a `development` NODE_ENV variable at run time.

The `siteComponent` Pug template has been updated to conditionally display the vars version switch, depending on what value is read from the NODE_ENV.

--

Currently, we'd only like to show the "Vars Version" switch when running the site locally. We can do this by restricting that drop down to only run when a specified environment variable is set. We're not currently asking folks to use `.env` files for environment variable management, so I've gone the route of setting the `NODE_ENV` to `development` when the `yarn start` task is invoked.

Once merged, these changes will close #1263 

<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->


## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
   - Tested locally by changing the environment variables to see how the Pug conditional renders

## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
