### PR TITLE
fix: remove duplicate class names in table examples

### DIFF
--- a/components/table/metadata/table.yml
+++ b/components/table/metadata/table.yml
@@ -53,7 +53,7 @@ examples:
   - id: table-medium
     name: Size Medium
     markup: |
-      <table class="spectrum-Table spectrum-Table--sizeM spectrum-Table--sizeM">
+      <table class="spectrum-Table spectrum-Table--sizeM">
         <thead class="spectrum-Table-head">
           <tr>
             <th class="spectrum-Table-headCell is-sortable is-sorted-desc" aria-sort="descending" tabindex="0">
@@ -201,7 +201,7 @@ examples:
     name: Multi-select
     description: The standard multi-select table
     markup: |
-      <table class="spectrum-Table spectrum-Table--sizeM spectrum-Table--sizeM">
+      <table class="spectrum-Table spectrum-Table--sizeM">
         <thead class="spectrum-Table-head">
           <tr>
             <th class="spectrum-Table-headCell spectrum-Table-checkboxCell">
@@ -491,7 +491,7 @@ examples:
     name: Column dividers
     description: The standard table with column dividers
     markup: |
-      <table class="spectrum-Table spectrum-Table--sizeM spectrum-Table--sizeM">
+      <table class="spectrum-Table spectrum-Table--sizeM">
         <thead class="spectrum-Table-head">
           <tr>
             <th class="spectrum-Table-headCell is-sortable is-sorted-asc" aria-sort="ascending" tabindex="0">
@@ -541,7 +541,7 @@ examples:
     name: Divs
     description: A table composed with `<div>` tags.
     markup: |
-      <div class="spectrum-Table spectrum-Table--sizeM spectrum-Table--sizeM" role="grid">
+      <div class="spectrum-Table spectrum-Table--sizeM" role="grid">
         <div class="spectrum-Table-head" style="display: flex" role="row">
           <div class="spectrum-Table-headCell is-sortable is-sorted-desc" style="flex: 1" role="columnheader" aria-sort="descending" tabindex="0">
             Column Title
@@ -636,7 +636,7 @@ examples:
     name: Body dropzone
     description: Tables that accept dropped content.
     markup: |
-      <div class="spectrum-Table spectrum-Table--sizeM spectrum-Table--sizeM" role="grid">
+      <div class="spectrum-Table spectrum-Table--sizeM" role="grid">
         <div class="spectrum-Table-head" style="display: flex" role="row">
           <div class="spectrum-Table-headCell is-sortable is-sorted-desc" style="flex: 1" role="columnheader" aria-sort="descending" tabindex="0">
             Column Title
@@ -730,7 +730,7 @@ examples:
   - id: table-row-dropzone
     name: Row dropzone
     markup: |
-      <div class="spectrum-Table spectrum-Table--sizeM spectrum-Table--sizeM" role="grid">
+      <div class="spectrum-Table spectrum-Table--sizeM" role="grid">
         <div class="spectrum-Table-head" style="display: flex" role="row">
           <div class="spectrum-Table-headCell is-sortable is-sorted-desc" style="flex: 1" role="columnheader" aria-sort="descending" tabindex="0">
             Column Title


### PR DESCRIPTION
Removes duplicate classes from the Table examples

