### PR TITLE
docs(tabs): resolve flaky visual regression tests

### DIFF
--- a/components/tabs/metadata/tabs.yml
+++ b/components/tabs/metadata/tabs.yml
@@ -195,7 +195,7 @@ examples:
         </div>
         <div class="spectrum-Tabs-selectionIndicator" style="width: 28px; left: 0px;"></div>
       </div>
-  - id: tabs-quiet-compact-icon
+  - id: tabs-quiet-compact-icons-text
     name: Compact tabs with icons and text
     markup: |
       <div class="spectrum-Tabs spectrum-Tabs--sizeM spectrum-Tabs--horizontal spectrum-Tabs--compact">
@@ -270,7 +270,7 @@ examples:
         </div>
         <div class="spectrum-Tabs-selectionIndicator" style="width: 28px; left: 0px;"></div>
       </div>
-  - id: tabs-quiet-compact
+  - id: tabs-quiet-compact-icons-text
     name: Compact tabs with icons and text (quiet)
     markup: |
       <div class="spectrum-Tabs spectrum-Tabs--sizeM spectrum-Tabs--horizontal spectrum-Tabs--compact spectrum-Tabs--quiet">
@@ -300,7 +300,7 @@ examples:
         </div>
         <div class="spectrum-Tabs-selectionIndicator" style="width: 55px; left: 0px;"></div>
       </div>
-  - id: tabs-quiet-compact
+  - id: tabs-quiet-compact-only-icons
     name: Compact tabs with icons only (quiet)
     markup: |
       <div class="spectrum-Tabs spectrum-Tabs--sizeM spectrum-Tabs--horizontal spectrum-Tabs--compact spectrum-Tabs--quiet">
@@ -344,7 +344,7 @@ examples:
         </div>
         <div class="spectrum-Tabs-selectionIndicator" style="height: 46px; top: 0px;"></div>
       </div>
-  - id: tabs-vertical
+  - id: tabs-vertical-icon
     name: Vertical tabs with icon and text
     markup: |
       <div class="spectrum-Tabs spectrum-Tabs--sizeM spectrum-Tabs--vertical">
@@ -392,7 +392,7 @@ examples:
         </div>
         <div class="spectrum-Tabs-selectionIndicator" style="height: 32px; top: 0px;"></div>
       </div>
-  - id: tabs-compact-vertical
+  - id: tabs-compact-vertical-icon
     name: Compact vertical tabs with icon and text
     markup: |
       <div class="spectrum-Tabs spectrum-Tabs--sizeM spectrum-Tabs--vertical spectrum-Tabs--compact">
@@ -422,7 +422,7 @@ examples:
         </div>
         <div class="spectrum-Tabs-selectionIndicator" style="height: 32px; top: 0px;"></div>
       </div>
-  - id: tabs
+  - id: tabs-with-overflow
     name: Basic tabs with overflow
     status: Verified
     markup: |
@@ -468,7 +468,7 @@ examples:
       </div>
 
       <div class="dummy-spacing"></div>
-  - id: tabs-compact
+  - id: tabs-compact-overflow
     name: Compact tabs with overflow
     status: Verified
     markup: |
@@ -515,7 +515,7 @@ examples:
       </div>
 
       <div class="dummy-spacing"></div>
-  - id: tabs
+  - id: tabs-with-anchors
     name: Tabs with anchors
     status: Verified
     markup: |


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->

This updates the Tabs component's examples page to add unique IDs for the examples. The Backstop visual regression tests were not accurate because we previously didn't provide unique IDs to each of our examples.

Refs: #1275 

## How and where has this been tested?
N/A

## Screenshots
N/A


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [X] If my change impacts documentation, I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
