### PR TITLE
test: tags renamed to tag in backstop scenarios

### DIFF
--- a/backstop_data/backstop_scenarios.json
+++ b/backstop_data/backstop_scenarios.json
@@ -364,8 +364,8 @@
     "package": "@spectrum-css/tabs"
   },
   {
-    "label": "tags",
-    "url": "tags.html",
+    "label": "tag",
+    "url": "tag.html",
     "package": "@spectrum-css/tags"
   },
   {


### PR DESCRIPTION
This updates the Backstop scenarios to reflect the new file name for the tag component.