### PR TITLE
fix: don't adjust slider handle width

### DIFF
--- a/components/slider/index.css
+++ b/components/slider/index.css
@@ -26,23 +26,23 @@ governing permissions and limitations under the License.
   --spectrum-slider-label-gap-y: var(--spectrum-global-dimension-size-85);
 
   --spectrum-slider-controls-margin: calc(
-    var(--spectrum-slider-handle-width-adjusted) / 2
+    var(--spectrum-slider-handle-width) / 2
   );
   --spectrum-slider-track-margin-offset: calc(
     var(--spectrum-slider-controls-margin) * -1
   );
 
   --spectrum-slider-handle-margin-top: calc(
-    var(--spectrum-slider-handle-width-adjusted) / -2
+    var(--spectrum-slider-handle-width) / -2
   );
   --spectrum-slider-handle-margin-left: calc(
-    var(--spectrum-slider-handle-width-adjusted) / -2
+    var(--spectrum-slider-handle-width) / -2
   );
 
   --spectrum-slider-track-handleoffset: calc(var(--spectrum-slider-handle-gap));
   --spectrum-slider-track-middle-handleoffset: calc(
     var(--spectrum-slider-handle-gap) +
-      calc(var(--spectrum-slider-handle-width-adjusted) / 2)
+      calc(var(--spectrum-slider-handle-width) / 2)
   );
 
   --spectrum-slider-input-top: calc(
@@ -68,8 +68,6 @@ governing permissions and limitations under the License.
   );
   --spectrum-slide-label-margin-bottom: -3px;
   --spectrum-slider-label-gap-x: var(--spectrum-alias-item-control-gap-m);
-  --spectrum-slider-handle-width-adjusted: calc(var(--spectrum-slider-handle-width) + var(--spectrum-slider-handle-border-size));
-  --spectrum-slider-handle-height-adjusted: var(--spectrum-slider-handle-width-adjusted);
 }
 
 .spectrum-Slider {
@@ -220,11 +218,11 @@ governing permissions and limitations under the License.
   display: inline-block;
   box-sizing: border-box;
 
-  inline-size: var(--spectrum-slider-handle-width-adjusted);
-  block-size: var(--spectrum-slider-handle-height-adjusted);
+  inline-size: var(--spectrum-slider-handle-width);
+  block-size: var(--spectrum-slider-handle-height);
 
   margin-block: var(--spectrum-slider-handle-margin-top) 0;
-  margin-inline: calc(var(--spectrum-slider-handle-width-adjusted) / -2) 0;
+  margin-inline: calc(var(--spectrum-slider-handle-width) / -2) 0;
 
   border-width: var(--spectrum-slider-handle-border-size);
   border-style: solid;
@@ -260,8 +258,8 @@ governing permissions and limitations under the License.
       width var(--spectrum-global-animation-duration-100) ease-out,
       height var(--spectrum-global-animation-duration-100) ease-out;
 
-    width: var(--spectrum-slider-handle-width-adjusted);
-    height: var(--spectrum-slider-handle-height-adjusted);
+    width: var(--spectrum-slider-handle-width);
+    height: var(--spectrum-slider-handle-height);
 
     transform: translate(-50%, -50%);
 
@@ -271,11 +269,11 @@ governing permissions and limitations under the License.
   &.is-focused {
     &:before {
       width: calc(
-        var(--spectrum-slider-handle-width-adjusted) +
+        var(--spectrum-slider-handle-width) +
           var(--spectrum-alias-focus-ring-gap) * 2
       );
       height: calc(
-        var(--spectrum-slider-handle-height-adjusted) +
+        var(--spectrum-slider-handle-height) +
           var(--spectrum-alias-focus-ring-gap) * 2
       );
     }
@@ -286,8 +284,8 @@ governing permissions and limitations under the License.
   /*  Remove the margin for input in Firefox and Safari. */
   margin: 0;
 
-  inline-size: var(--spectrum-slider-handle-width-adjusted);
-  block-size: var(--spectrum-slider-handle-height-adjusted);
+  inline-size: var(--spectrum-slider-handle-width);
+  block-size: var(--spectrum-slider-handle-height);
   padding: 0;
   position: absolute;
   inset-block-start: var(--spectrum-slider-input-top);
@@ -389,12 +387,16 @@ governing permissions and limitations under the License.
   }
 
   &:first-of-type {
+    /* fix off-by-one alignment */
+    inset-inline-start: calc(var(--spectrum-slider-tick-mark-width) / -2);
     .spectrum-Slider-tickLabel {
       inset-inline-start: 0;
     }
   }
 
   &:last-of-type {
+    /* fix off-by-one alignment */
+    inset-inline-end: calc(var(--spectrum-slider-tick-mark-width) / -2);
     .spectrum-Slider-tickLabel {
       inset-inline-end: 0;
     }
@@ -411,4 +413,22 @@ governing permissions and limitations under the License.
       pointer-events: none;
     }
   }
+}
+
+/* backwards compatibility: these are not required, but they make the handle go to the edegs and align right */
+.spectrum-Slider-handleContainer,
+.spectrum-Slider-trackContainer {
+  width: calc(100% + var(--spectrum-slider-handle-width));
+
+  position: absolute;
+  top: calc(var(--spectrum-slider-track-height) / 2 - 1px);
+
+  margin-left: calc(var(--spectrum-slider-handle-width) / 2 * -1);
+}
+
+.spectrum-Slider-trackContainer {
+  height: var(--spectrum-slider-height);
+
+  /* stop edges from peeking out */
+  overflow: hidden;
 }


### PR DESCRIPTION
This should be applied after https://git.corp.adobe.com/Spectrum/dss/pull/346 is merged.

Previously, the value exported by DNA was incorrect. after recent fixes, the handle size is as expected and the border-width no longer needs to be added.
