### PR TITLE
fix(progresscircle): force compositing to fix safari rendering quirk

### DIFF
--- a/components/progresscircle/index.css
+++ b/components/progresscircle/index.css
@@ -18,6 +18,10 @@ governing permissions and limitations under the License.
   block-size: var(--spectrum-progresscircle-m-height);
   position: relative;
   direction: ltr;
+
+  /* Fix for Safari rendering bug */
+  /* more info: https://github.com/adobe/spectrum-web-components/issues/1392 */
+  transform: translate3d(0, 0, 0);
 }
 .spectrum-ProgressCircle-track {
   box-sizing: border-box;


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->

Safari sometimes mis-renders progress circles when a scrollbar is present: https://github.com/adobe/spectrum-web-components/issues/1392

## How and where has this been tested?

Safari 14.1.2 (16611.3.10.1.6) on OSX

## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [X] This pull request is ready to merge.
