### PR TITLE
WHCM fixes for button, logicButton, clearButton

### DIFF
--- a/components/button/index.css
+++ b/components/button/index.css
@@ -122,7 +122,6 @@ a.spectrum-Button {
   padding-block-end: calc(var(--spectrum-button-primary-textonly-text-padding-bottom) - var(--spectrum-button-primary-textonly-border-size));
 }
 
-.spectrum-LogicButton,
 .spectrum-Button {
   &:focus-ring,
   &.is-focused {

--- a/components/button/skin.css
+++ b/components/button/skin.css
@@ -300,144 +300,200 @@ governing permissions and limitations under the License.
 }
 
 
+
 @media (forced-colors: active) {
   .spectrum-Button {
-    --spectrum-button-cta-m-background-color : ButtonText;
-    --spectrum-button-cta-m-background-color-disabled: ButtonFace;
-    --spectrum-button-cta-m-background-color-down: Highlight;
-    --spectrum-button-cta-m-background-color-hover: Highlight;
-    --spectrum-button-cta-m-background-color-key-focus: Highlight;
-    --spectrum-button-cta-m-border-color-disabled: GrayText;
-    --spectrum-button-cta-m-border-color-down: Highlight;
-    --spectrum-button-cta-m-border-color-hover: Highlight;
-    --spectrum-button-cta-m-border-color-key-focus: Highlight;
-    --spectrum-button-cta-m-border-color: ButtonText;
-    --spectrum-button-cta-m-text-color-disabled: GrayText;
-    --spectrum-button-cta-m-text-color-down: ButtonFace;
-    --spectrum-button-cta-m-text-color-hover: ButtonFace;
-    --spectrum-button-cta-m-text-color-key-focus: ButtonFace;
-    --spectrum-button-cta-m-text-color: ButtonFace;
-    --spectrum-button-over-background-m-background-color: ButtonFace;
-    --spectrum-button-over-background-m-background-color-disabled: ButtonFace;
-    --spectrum-button-over-background-m-background-color-down: ButtonFace;
-    --spectrum-button-over-background-m-background-color-hover: ButtonFace;
-    --spectrum-button-over-background-m-background-color-key-focus: ButtonFace;
-    --spectrum-button-over-background-m-border-color-disabled: GrayText;
-    --spectrum-button-over-background-m-border-color-down: Highlight;
-    --spectrum-button-over-background-m-border-color-hover: Highlight;
-    --spectrum-button-over-background-m-border-color-key-focus: ButtonText;
-    --spectrum-button-over-background-m-border-color: ButtonText;
-    --spectrum-button-over-background-m-text-color-disabled: GrayText;
-    --spectrum-button-over-background-m-text-color-down: ButtonText;
-    --spectrum-button-over-background-m-text-color-hover: ButtonText;
-    --spectrum-button-over-background-m-text-color-key-focus: ButtonText;
-    --spectrum-button-over-background-m-text-color: ButtonText;
-    --spectrum-button-quiet-over-background-m-background-color-disabled: ButtonFace;
-    --spectrum-button-quiet-over-background-m-background-color-down: ButtonFace;
-    --spectrum-button-quiet-over-background-m-background-color-hover: ButtonFace;
-    --spectrum-button-quiet-over-background-m-background-color-key-focus: ButtonFace;
-    --spectrum-button-quiet-over-background-m-border-color-disabled: ButtonFace;
-    --spectrum-button-quiet-over-background-m-border-color-down: Highlight;
-    --spectrum-button-quiet-over-background-m-border-color-hover: Highlight;
-    --spectrum-button-quiet-over-background-m-border-color-key-focus: Highlight;
-    --spectrum-button-quiet-over-background-m-border-color: ButtonFace;
-    --spectrum-button-quiet-over-background-m-text-color-disabled: GrayText;
-    --spectrum-button-quiet-over-background-m-text-color-down: ButtonText;
-    --spectrum-button-quiet-over-background-m-text-color-hover: ButtonText;
-    --spectrum-button-quiet-over-background-m-text-color-key-focus: ButtonText;
-    --spectrum-button-quiet-over-background-m-text-color: ButtonText;
-    --spectrum-button-primary-m-background-color : ButtonFace;
-    --spectrum-button-primary-m-background-color-disabled: ButtonFace;
-    --spectrum-button-primary-m-background-color-down: ButtonFace;
-    --spectrum-button-primary-m-background-color-hover: ButtonFace;
-    --spectrum-button-primary-m-background-color-key-focus: ButtonFace;
-    --spectrum-button-primary-m-border-color-disabled: GrayText;
-    --spectrum-button-primary-m-border-color-down: Highlight;
-    --spectrum-button-primary-m-border-color-hover: Highlight;
-    --spectrum-button-primary-m-border-color-key-focus: Highlight;
-    --spectrum-button-primary-m-border-color: ButtonText;
-    --spectrum-button-primary-m-text-color-disabled: GrayText;
-    --spectrum-button-primary-m-text-color-down: ButtonText;
-    --spectrum-button-primary-m-text-color-hover: ButtonText;
-    --spectrum-button-primary-m-text-color-key-focus: ButtonText;
-    --spectrum-button-primary-m-text-color: ButtonText;
-    --spectrum-button-quiet-primary-m-background-color-disabled: ButtonFace;
-    --spectrum-button-quiet-primary-m-background-color-down: ButtonFace;
-    --spectrum-button-quiet-primary-m-background-color-hover: ButtonFace;
-    --spectrum-button-quiet-primary-m-background-color-key-focus: ButtonFace;
-    --spectrum-button-quiet-primary-m-border-color-disabled: ButtonFace;
-    --spectrum-button-quiet-primary-m-border-color-down: Highlight;
-    --spectrum-button-quiet-primary-m-border-color-hover: Highlight;
-    --spectrum-button-quiet-primary-m-border-color-key-focus: Highlight;
-    --spectrum-button-quiet-primary-m-border-color: ButtonFace;
-    --spectrum-button-quiet-primary-m-text-color-disabled: GrayText;
-    --spectrum-button-quiet-primary-m-text-color-down: ButtonText;
-    --spectrum-button-quiet-primary-m-text-color-hover: ButtonText;
-    --spectrum-button-quiet-primary-m-text-color-key-focus: ButtonText;
-    --spectrum-button-quiet-primary-m-text-color: ButtonText;
-    --spectrum-button-secondary-m-background-color : ButtonFace;
-    --spectrum-button-secondary-m-background-color-disabled: ButtonFace;
-    --spectrum-button-secondary-m-background-color-down: ButtonFace;
-    --spectrum-button-secondary-m-background-color-hover: ButtonFace;
-    --spectrum-button-secondary-m-background-color-key-focus: ButtonFace;
-    --spectrum-button-secondary-m-border-color-disabled: GrayText;
-    --spectrum-button-secondary-m-border-color-down: Highlight;
-    --spectrum-button-secondary-m-border-color-hover: Highlight;
-    --spectrum-button-secondary-m-border-color-key-focus: Highlight;
-    --spectrum-button-secondary-m-border-color: ButtonText;
-    --spectrum-button-secondary-m-text-color-disabled: GrayText;
-    --spectrum-button-secondary-m-text-color-down: ButtonText;
-    --spectrum-button-secondary-m-text-color-hover: ButtonText;
-    --spectrum-button-secondary-m-text-color-key-focus: ButtonText;
-    --spectrum-button-secondary-m-text-color: ButtonText;
-    --spectrum-button-quiet-secondary-m-background-color-disabled: ButtonFace;
-    --spectrum-button-quiet-secondary-m-background-color-down: ButtonFace;
-    --spectrum-button-quiet-secondary-m-background-color-hover: ButtonFace;
-    --spectrum-button-quiet-secondary-m-background-color-key-focus: ButtonFace;
-    --spectrum-button-quiet-secondary-m-border-color-disabled: ButtonFace;
-    --spectrum-button-quiet-secondary-m-border-color-down: Highlight;
-    --spectrum-button-quiet-secondary-m-border-color-hover: Highlight;
-    --spectrum-button-quiet-secondary-m-border-color-key-focus: Highlight;
-    --spectrum-button-quiet-secondary-m-border-color: ButtonFace;
-    --spectrum-button-quiet-secondary-m-text-color-disabled: GrayText;
-    --spectrum-button-quiet-secondary-m-text-color-down: ButtonText;
-    --spectrum-button-quiet-secondary-m-text-color-hover: ButtonText;
-    --spectrum-button-quiet-secondary-m-text-color-key-focus: ButtonText;
-    --spectrum-button-quiet-secondary-m-text-color: ButtonText;
-    --spectrum-button-warning-m-background-color : ButtonFace;
-    --spectrum-button-warning-m-background-color-disabled: ButtonFace;
-    --spectrum-button-warning-m-background-color-down: ButtonFace;
-    --spectrum-button-warning-m-background-color-hover: ButtonFace;
-    --spectrum-button-warning-m-background-color-key-focus: ButtonFace;
-    --spectrum-button-warning-m-border-color-disabled: GrayText;
-    --spectrum-button-warning-m-border-color-down: Highlight;
-    --spectrum-button-warning-m-border-color-hover: Highlight;
-    --spectrum-button-warning-m-border-color-key-focus: Highlight;
-    --spectrum-button-warning-m-border-color: ButtonText;
-    --spectrum-button-warning-m-text-color-disabled: GrayText;
-    --spectrum-button-warning-m-text-color-down: ButtonText;
-    --spectrum-button-warning-m-text-color-hover: ButtonText;
-    --spectrum-button-warning-m-text-color-key-focus: ButtonText;
-    --spectrum-button-warning-m-text-color: ButtonText;
-    --spectrum-button-quiet-warning-m-background-color-disabled: ButtonFace;
-    --spectrum-button-quiet-warning-m-background-color-down: ButtonFace;
-    --spectrum-button-quiet-warning-m-background-color-hover: ButtonFace;
-    --spectrum-button-quiet-warning-m-background-color-key-focus: ButtonFace;
-    --spectrum-button-quiet-warning-m-border-color-disabled: ButtonFace;
-    --spectrum-button-quiet-warning-m-border-color-down: Highlight;
-    --spectrum-button-quiet-warning-m-border-color-hover: Highlight;
-    --spectrum-button-quiet-warning-m-border-color-key-focus: Highlight;
-    --spectrum-button-quiet-warning-m-border-color: ButtonFace;
-    --spectrum-button-quiet-warning-m-text-color-disabled: GrayText;
-    --spectrum-button-quiet-warning-m-text-color-down: ButtonText;
-    --spectrum-button-quiet-warning-m-text-color-hover: ButtonText;
-    --spectrum-button-quiet-warning-m-text-color-key-focus: ButtonText;
-    --spectrum-button-quiet-warning-m-text-color: ButtonText;
-    --spectrum-button-secondary-m-background-color-disabled: ButtonFace;
-    --spectrum-button-warning-m-background-color-disabled: ButtonFace;
-    --spectrum-button-primary-m-focus-ring-color-key-focus: ButtonText;
+    --spectrum-button-m-cta-texticon-background-color: ButtonText;
+    --spectrum-button-m-cta-texticon-background-color-disabled: ButtonFace;
+    --spectrum-button-m-cta-texticon-background-color-down: Highlight;
+    --spectrum-button-m-cta-texticon-background-color-hover: Highlight;
+    --spectrum-button-m-cta-texticon-background-color-key-focus: Highlight;
+    --spectrum-button-m-cta-texticon-border-color: ButtonFace;
+    --spectrum-button-m-cta-texticon-border-color-disabled: GrayText;
+    --spectrum-button-m-cta-texticon-border-color-down: Highlight;
+    --spectrum-button-m-cta-texticon-border-color-hover: Highlight;
+    --spectrum-button-m-cta-texticon-border-color-key-focus: Highlight;
+    --spectrum-button-m-cta-texticon-text-color: ButtonFace;
+    --spectrum-button-m-cta-texticon-text-color-disabled: GrayText;
+    --spectrum-button-m-cta-texticon-text-color-down: Buttonface;
+    --spectrum-button-m-cta-texticon-text-color-hover: Buttonface;
+    --spectrum-button-m-cta-texticon-text-color-key-focus: Buttonface;
+    --spectrum-button-m-negative-quiet-texticon-background-color: ButtonFace;
+    --spectrum-button-m-negative-quiet-texticon-background-color-disabled: ButtonFace;
+    --spectrum-button-m-negative-quiet-texticon-background-color-down: ButtonFace;
+    --spectrum-button-m-negative-quiet-texticon-background-color-hover: ButtonFace;
+    --spectrum-button-m-negative-quiet-texticon-background-color-key-focus: ButtonFace;
+    --spectrum-button-m-negative-quiet-texticon-border-color: ButtonText;
+    --spectrum-button-m-negative-quiet-texticon-border-color-disabled: GrayText;
+    --spectrum-button-m-negative-quiet-texticon-border-color-down: Highlight;
+    --spectrum-button-m-negative-quiet-texticon-border-color-hover: Highlight;
+    --spectrum-button-m-negative-quiet-texticon-border-color-key-focus: Highlight;
+    --spectrum-button-m-negative-quiet-texticon-text-color: ButtonText;
+    --spectrum-button-m-negative-quiet-texticon-text-color-disabled: GrayText;
+    --spectrum-button-m-negative-quiet-texticon-text-color-down: ButtonText;
+    --spectrum-button-m-negative-quiet-texticon-text-color-hover: ButtonText;
+    --spectrum-button-m-negative-quiet-texticon-text-color-key-focus: ButtonText;
+    --spectrum-button-m-negative-texticon-background-color: ButtonFace;
+    --spectrum-button-m-negative-texticon-background-color-disabled: ButtonFace;
+    --spectrum-button-m-negative-texticon-background-color-down: ButtonFace;
+    --spectrum-button-m-negative-texticon-background-color-hover: ButtonFace;
+    --spectrum-button-m-negative-texticon-background-color-key-focus: ButtonFace;
+    --spectrum-button-m-negative-texticon-border-color: ButtonText;
+    --spectrum-button-m-negative-texticon-border-color-disabled: GrayText;
+    --spectrum-button-m-negative-texticon-border-color-down: Highlight;
+    --spectrum-button-m-negative-texticon-border-color-hover: Highlight;
+    --spectrum-button-m-negative-texticon-border-color-key-focus: Highlight;
+    --spectrum-button-m-negative-texticon-text-color: ButtonText;
+    --spectrum-button-m-negative-texticon-text-color-disabled: GrayText;
+    --spectrum-button-m-negative-texticon-text-color-down: ButtonText;
+    --spectrum-button-m-negative-texticon-text-color-hover: ButtonText;
+    --spectrum-button-m-negative-texticon-text-color-key-focus: ButtonText;
+    --spectrum-button-m-primary-overbackground-texticon-background-color: ButtonFace;
+    --spectrum-button-m-primary-overbackground-texticon-background-color-disabled: ButtonFace;
+    --spectrum-button-m-primary-overbackground-texticon-background-color-down: ButtonFace;
+    --spectrum-button-m-primary-overbackground-texticon-background-color-hover: ButtonFace;
+    --spectrum-button-m-primary-overbackground-texticon-border-color: ButtonText;
+    --spectrum-button-m-primary-overbackground-texticon-border-color-disabled: GrayText;
+    --spectrum-button-m-primary-overbackground-texticon-border-color-down: Highlight;
+    --spectrum-button-m-primary-overbackground-texticon-border-color-hover: Highlight;
+    --spectrum-button-m-primary-overbackground-texticon-border-color-key-focus: Highlight;
+    --spectrum-button-m-primary-overbackground-texticon-text-color: ButtonText;
+    --spectrum-button-m-primary-overbackground-texticon-text-color-disabled: GrayText;
+    --spectrum-button-m-primary-quiet-overbackground-texticon-background-color: ButtonFace;
+    --spectrum-button-m-primary-quiet-overbackground-texticon-background-color-disabled: ButtonFace;
+    --spectrum-button-m-primary-quiet-overbackground-texticon-background-color-down: ButtonFace;
+    --spectrum-button-m-primary-quiet-overbackground-texticon-background-color-hover: ButtonFace;
+    --spectrum-button-m-primary-quiet-overbackground-texticon-border-color: ButtonText;
+    --spectrum-button-m-primary-quiet-overbackground-texticon-border-color-disabled: GrayText;
+    --spectrum-button-m-primary-quiet-overbackground-texticon-border-color-down: Highlight;
+    --spectrum-button-m-primary-quiet-overbackground-texticon-border-color-hover: Highlight;
+    --spectrum-button-m-primary-quiet-overbackground-texticon-text-color: ButtonText;
+    --spectrum-button-m-primary-quiet-overbackground-texticon-text-color-disabled: GrayText;
+    --spectrum-button-m-primary-quiet-overbackground-texticon-text-color-down: ButtonText;
+    --spectrum-button-m-primary-quiet-overbackground-texticon-text-color-hover: ButtonText;
+    --spectrum-button-m-primary-quiet-texticon-background-color: ButtonFace;
+    --spectrum-button-m-primary-quiet-texticon-background-color-disabled: ButtonFace;
+    --spectrum-button-m-primary-quiet-texticon-background-color-down: ButtonFace;
+    --spectrum-button-m-primary-quiet-texticon-background-color-hover: ButtonFace;
+    --spectrum-button-m-primary-quiet-texticon-background-color-key-focus: ButtonFace;
+    --spectrum-button-m-primary-quiet-texticon-border-color: ButtonText;
+    --spectrum-button-m-primary-quiet-texticon-border-color-disabled: GrayText;
+    --spectrum-button-m-primary-quiet-texticon-border-color-down: Highlight;
+    --spectrum-button-m-primary-quiet-texticon-border-color-hover: Highlight;
+    --spectrum-button-m-primary-quiet-texticon-border-color-key-focus: Highlight;
+    --spectrum-button-m-primary-quiet-texticon-text-color: ButtonText;
+    --spectrum-button-m-primary-quiet-texticon-text-color-disabled: GrayText;
+    --spectrum-button-m-primary-quiet-texticon-text-color-down: ButtonText;
+    --spectrum-button-m-primary-quiet-texticon-text-color-hover: ButtonText;
+    --spectrum-button-m-primary-quiet-texticon-text-color-key-focus: ButtonText;
+    --spectrum-button-m-primary-texticon-background-color: ButtonFace;
+    --spectrum-button-m-primary-texticon-background-color-disabled: ButtonFace;
+    --spectrum-button-m-primary-texticon-background-color-down: ButtonFace;
+    --spectrum-button-m-primary-texticon-background-color-hover: ButtonFace;
+    --spectrum-button-m-primary-texticon-background-color-key-focus: ButtonFace;
+    --spectrum-button-m-primary-texticon-border-color: ButtonText;
+    --spectrum-button-m-primary-texticon-border-color-disabled: GrayText;
+    --spectrum-button-m-primary-texticon-border-color-down: Highlight;
+    --spectrum-button-m-primary-texticon-border-color-hover: Highlight;
+    --spectrum-button-m-primary-texticon-border-color-key-focus: Highlight;
+    --spectrum-button-m-primary-texticon-text-color: ButtonText;
+    --spectrum-button-m-primary-texticon-text-color-disabled: GrayText;
+    --spectrum-button-m-primary-texticon-text-color-down: ButtonText;
+    --spectrum-button-m-primary-texticon-text-color-hover: ButtonText;
+    --spectrum-button-m-primary-texticon-text-color-key-focus: ButtonText;
+    --spectrum-button-m-secondary-quiet-texticon-background-color: ButtonFace;
+    --spectrum-button-m-secondary-quiet-texticon-background-color-disabled: ButtonFace;
+    --spectrum-button-m-secondary-quiet-texticon-background-color-down: ButtonFace;
+    --spectrum-button-m-secondary-quiet-texticon-background-color-hover: ButtonFace;
+    --spectrum-button-m-secondary-quiet-texticon-background-color-key-focus: ButtonFace;
+    --spectrum-button-m-secondary-quiet-texticon-border-color: ButtonText;
+    --spectrum-button-m-secondary-quiet-texticon-border-color-disabled: GrayText;
+    --spectrum-button-m-secondary-quiet-texticon-border-color-down: Highlight;
+    --spectrum-button-m-secondary-quiet-texticon-border-color-hover: Highlight;
+    --spectrum-button-m-secondary-quiet-texticon-border-color-key-focus: Highlight;
+    --spectrum-button-m-secondary-quiet-texticon-text-color: ButtonText;
+    --spectrum-button-m-secondary-quiet-texticon-text-color-disabled: GrayText;
+    --spectrum-button-m-secondary-quiet-texticon-text-color-down: ButtonText;
+    --spectrum-button-m-secondary-quiet-texticon-text-color-hover: ButtonText;
+    --spectrum-button-m-secondary-quiet-texticon-text-color-key-focus: ButtonText;
+    --spectrum-button-m-secondary-texticon-background-color: ButtonFace;
+    --spectrum-button-m-secondary-texticon-background-color-disabled: ButtonFace;
+    --spectrum-button-m-secondary-texticon-background-color-down: ButtonFace;
+    --spectrum-button-m-secondary-texticon-background-color-hover: ButtonFace;
+    --spectrum-button-m-secondary-texticon-background-color-key-focus: ButtonFace;
+    --spectrum-button-m-secondary-texticon-border-color: ButtonText;
+    --spectrum-button-m-secondary-texticon-border-color-disabled: GrayText;
+    --spectrum-button-m-secondary-texticon-border-color-down: Highlight;
+    --spectrum-button-m-secondary-texticon-border-color-hover: Highlight;
+    --spectrum-button-m-secondary-texticon-border-color-key-focus: Highlight;
+    --spectrum-button-m-secondary-texticon-text-color: ButtonText;
+    --spectrum-button-m-secondary-texticon-text-color-disabled: GrayText;
+    --spectrum-button-m-secondary-texticon-text-color-down: ButtonText;
+    --spectrum-button-m-secondary-texticon-text-color-hover: ButtonText;
+    --spectrum-button-m-secondary-texticon-text-color-key-focus: ButtonText;
+
+  }
+  .spectrum-Button {
+    &:focus-ring,
+    &.is-focused {
+      &:after {
+        box-shadow: 0 0 0 var(--spectrum-button-primary-texticon-focus-ring-size) Highlight;
+      }
+    }
   }
   .spectrum-Button {
     forced-color-adjust:none;
   }
+  .spectrum-Button--overBackground {
+    &:hover {
+      color: ButtonText;
+    }
+    &:focus-ring {
+      color: ButtonText;
+    }
+    &:active {
+      color: ButtonText;
+    }
+  }
 }
+
+@media (forced-colors: active) {
+  .spectrum-ClearButton {
+    forced-color-adjust: none;
+    --spectrum-clearbutton-m-background-color: ButtonFace;
+    --spectrum-clearbutton-m-background-color-disabled: ButtonFace;
+    --spectrum-clearbutton-m-background-color-down: ButtonFace;
+    --spectrum-clearbutton-m-background-color-hover: ButtonFace;
+    --spectrum-clearbutton-m-background-color-key-focus: ButtonFace;
+    --spectrum-clearbutton-m-icon-color: ButtonText;
+    --spectrum-clearbutton-m-icon-color-disabled: GrayText;
+    --spectrum-clearbutton-m-icon-color-down: Highlight;
+    --spectrum-clearbutton-m-icon-color-hover: Highlight;
+    --spectrum-clearbutton-m-icon-color-key-focus: Highlight;
+  }
+  .spectrum-LogicButton::after {
+    --spectrum-button-m-primary-texticon-focus-ring-color-key-focus: Highlight;
+    forced-color-adjust: none;
+  }
+
+  .spectrum-LogicButton {
+    forced-color-adjust: none;
+    --spectrum-button-primary-texticon-focus-ring-size: 2;
+    --spectrum-button-m-secondary-texticon-background-color-disabled: ButtonFace;
+    --spectrum-button-m-secondary-texticon-border-color-disabled: GrayText;
+    --spectrum-logicbutton-and-background-color: ButtonFace;
+    --spectrum-logicbutton-and-background-color-disabled: ButtonFace;
+    --spectrum-logicbutton-and-background-color-hover: ButtonFace;
+    --spectrum-logicbutton-and-border-color: ButtonText;
+    --spectrum-logicbutton-and-border-color-disabled: GrayText;
+    --spectrum-logicbutton-and-border-color-hover: Highlight;
+    --spectrum-logicbutton-and-text-color: ButtonText;
+    --spectrum-logicbutton-and-text-color-disabled: GrayText;
+    --spectrum-logicbutton-or-background-color: ButtonFace;
+    --spectrum-logicbutton-or-background-color-hover: ButtonFace;
+    --spectrum-logicbutton-or-border-color: ButtonText;
+    --spectrum-logicbutton-or-border-color-hover: Highlight;
+    --spectrum-logicbutton-or-text-color: ButtonText;
+  }
+}
+


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
#1301

Also re-adds the keyboard focus ring for keyboard operation of LogicButton when high contrast mode is not turned on

## How and where has this been tested?
 - **How this was tested:** Windows High Contrast mode on relevant demo pages
 - **Browser(s) and OS(s) this was tested with:** Edge 94 on Windows 10

## Screenshots
###Before
![Button - CTA - Spectrum CSS and 1 more page - Work - Microsoft​ Edge 10_27_2021 4_29_38 PM](https://user-images.githubusercontent.com/1724479/139162228-f96a1ba2-bce0-40b2-aeb9-b69310277643.png)
![Button - CTA - Spectrum CSS and 1 more page - Work - Microsoft​ Edge 10_27_2021 4_30_26 PM](https://user-images.githubusercontent.com/1724479/139162232-dc63711d-1993-4b97-b4d4-9ed428abb314.png)
![Button - CTA - Spectrum CSS and 1 more page - Work - Microsoft​ Edge 10_27_2021 4_31_18 PM](https://user-images.githubusercontent.com/1724479/139162264-d1166d98-0230-4657-9bca-ba4a38ff5a82.png)
![Button - CTA - Spectrum CSS and 1 more page - Work - Microsoft​ Edge 10_27_2021 4_32_16 PM](https://user-images.githubusercontent.com/1724479/139162237-d3927845-5b0f-473d-8eed-b633bbeeaf1f.png)
### After
![Button - CTA - Spectrum CSS and 1 more page - Work - Microsoft​ Edge 10_27_2021 4_29_49 PM](https://user-images.githubusercontent.com/1724479/139162259-f020aac8-1158-4315-b722-da2058630306.png)
![Button - CTA - Spectrum CSS and 1 more page - Work - Microsoft​ Edge 10_27_2021 4_30_36 PM](https://user-images.githubusercontent.com/1724479/139162263-f8a6dfef-7b65-4a1a-9994-b2e891539b17.png)
![Button - CTA - Spectrum CSS and 1 more page - Work - Microsoft​ Edge 10_27_2021 4_30_53 PM](https://user-images.githubusercontent.com/1724479/139162236-ae5ab66e-509d-4305-9926-738d046e8c30.png)
![Button - CTA - Spectrum CSS and 1 more page - Work - Microsoft​ Edge 10_27_2021 4_32_39 PM](https://user-images.githubusercontent.com/1724479/139162265-6a82c2da-de83-469a-b874-d3de431cccbc.png)



## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
