### PR TITLE
fix: remove logical property usage from media queries

### DIFF
--- a/components/dialog/index.css
+++ b/components/dialog/index.css
@@ -311,7 +311,7 @@ governing permissions and limitations under the License.
   }
 }
 
-@media screen and (max-inline-size: 700px) {
+@media screen and (max-width: 700px) {
   .spectrum-Dialog .spectrum-Dialog-grid {
     grid-template-columns:
       var(--spectrum-dialog-confirm-padding) auto 1fr auto minmax(0, auto)

--- a/components/tray/index.css
+++ b/components/tray/index.css
@@ -72,7 +72,7 @@ governing permissions and limitations under the License.
 }
 
 /* Should match --spectrum-tray-max-width above */
-@media (max-inline-size: 375px) {
+@media (max-width: 375px) {
   .spectrum-Tray {
     border-radius: var(--spectrum-tray-border-radius);
   }


### PR DESCRIPTION
## Description
fixes #1306

I couldn't find any information about logical properties in media queries being a "thing" or tools to process them, so I've removed the two instances that I could find.


## How and where has this been tested?
 - **How this was tested:** Tried to run locally, but the build scripts failed. Will review that separately.
 - **Browser(s) and OS(s) this was tested with:** See above.

## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
