### PR TITLE
docs: ensure tables in docs are sized

### DIFF
--- a/site/util.js
+++ b/site/util.js
@@ -25,7 +25,7 @@ function defaultRenderer(tokens, idx, options, env, self) {
 
 let ruleClassnames = {
   'link_open': 'spectrum-Link',
-  'table_open': 'spectrum-Table',
+  'table_open': 'spectrum-Table spectrum-Table--sizeM',
   'thead_open': 'spectrum-Table-head',
   'tr_open': 'spectrum-Table-row',
   'tbody_open': 'spectrum-Table-body',


### PR DESCRIPTION
## Descriptionfixes #1310 by adding `spectrum-Table--sizeM` to the `markdown-in` processing.


## How and where has this been tested?
 - **How this was tested:** Running docs site locally
 - **Browser(s) and OS(s) this was tested with:** MacOS, Chrome

## Screenshots
![image](https://user-images.githubusercontent.com/1156657/140771060-07c2321e-8a65-4eae-abd6-dd598e95590e.png)

## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
