### PR TITLE
fix: add missing classes to Dialog's ActionButton, fixes #1314

### DIFF
--- a/components/dialog/metadata/dialog.yml
+++ b/components/dialog/metadata/dialog.yml
@@ -77,7 +77,7 @@ examples:
                 Quisque egestas diam in arcu cursus euismod quis viverra. Posuere ac ut consequat semper viverra nam libero justo laoreet. Enim ut tellus elementum sagittis vitae et leo duis ut. Neque laoreet suspendisse interdum consectetur libero id
                 faucibus nisl. Diam volutpat commodo sed egestas egestas. Dolor magna eget est lorem ipsum dolor. Vitae suscipit tellus mauris a diam maecenas sed. Turpis in eu mi bibendum neque egestas congue. Rhoncus est pellentesque elit ullamcorper
                 dignissim cras lobortis.</section>
-              <button aria-label="Dismiss" class="spectrum-ActionButton spectrum-ActionButton--quiet spectrum-Dialog-closeButton" type="button" onclick="closeDialog(this.closest('.spectrum-Modal-wrapper'))">
+              <button aria-label="Dismiss" class="spectrum-ActionButton spectrum-ActionButton--quiet spectrum-ActionButton--sizeM spectrum-Dialog-closeButton" type="button" onclick="closeDialog(this.closest('.spectrum-Modal-wrapper'))">
                 <svg class="spectrum-Icon spectrum-UIIcon-Cross500" focusable="false" aria-hidden="true">
                   <use xlink:href="#spectrum-css-icon-Cross500"></use>
                 </svg>
@@ -103,7 +103,7 @@ examples:
                 Quisque egestas diam in arcu cursus euismod quis viverra. Posuere ac ut consequat semper viverra nam libero justo laoreet. Enim ut tellus elementum sagittis vitae et leo duis ut. Neque laoreet suspendisse interdum consectetur libero id
                 faucibus nisl. Diam volutpat commodo sed egestas egestas. Dolor magna eget est lorem ipsum dolor. Vitae suscipit tellus mauris a diam maecenas sed. Turpis in eu mi bibendum neque egestas congue. Rhoncus est pellentesque elit ullamcorper
                 dignissim cras lobortis.</section>
-              <button aria-label="Dismiss" class="spectrum-ActionButton spectrum-ActionButton--quiet spectrum-Dialog-closeButton" type="button" onclick="closeDialog(this.closest('.spectrum-Modal-wrapper'))">
+              <button aria-label="Dismiss" class="spectrum-ActionButton spectrum-ActionButton--quiet spectrum-ActionButton--sizeM spectrum-Dialog-closeButton" type="button" onclick="closeDialog(this.closest('.spectrum-Modal-wrapper'))">
                 <svg class="spectrum-Icon spectrum-UIIcon-Cross500" focusable="false" aria-hidden="true">
                   <use xlink:href="#spectrum-css-icon-Cross500"></use>
                 </svg>
@@ -128,7 +128,7 @@ examples:
               <section class="spectrum-Dialog-content">
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Auctor augue mauris augue neque gravida. Libero volutpat sed ornare arcu. Quisque egestas diam in arcu cursus euismod quis viverra. Posuere ac ut consequat semper viverra nam libero justo laoreet. Enim ut tellus elementum sagittis vitae et leo duis ut. Neque laoreet suspendisse interdum consectetur libero id faucibus nisl. Diam volutpat commodo sed egestas egestas. Dolor magna eget est lorem ipsum dolor. Vitae suscipit tellus mauris a diam maecenas sed. Turpis in eu mi bibendum neque egestas congue. Rhoncus est pellentesque elit ullamcorper dignissim cras lobortis.
               </section>
-              <button aria-label="Dismiss" class="spectrum-ActionButton spectrum-ActionButton--quiet spectrum-Dialog-closeButton" type="button" onclick="closeDialog(this.closest('.spectrum-Modal-wrapper'))">
+              <button aria-label="Dismiss" class="spectrum-ActionButton spectrum-ActionButton--quiet spectrum-ActionButton--sizeM spectrum-Dialog-closeButton" type="button" onclick="closeDialog(this.closest('.spectrum-Modal-wrapper'))">
                 <svg class="spectrum-Icon spectrum-UIIcon-Cross500" focusable="false" aria-hidden="true">
                   <use xlink:href="#spectrum-css-icon-Cross500"></use>
                 </svg>


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description

Fixes #1314, size and positioning verified against [Spectrum website](https://spectrum-contributions.corp.adobe.com/page/standard-dialog-beta/)
![image](https://user-images.githubusercontent.com/201344/141132820-7ac4c7b1-a42c-4176-9b79-bfc96e45563f.png)
