### PR TITLE
feat: ActionButton staticColor

### DIFF
--- a/components/actionbutton/actionbutton-generated.css
+++ b/components/actionbutton/actionbutton-generated.css
@@ -1,0 +1,492 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+/* begin generated CSS for actionbutton */
+.spectrum-ActionButton {
+  &.spectrum-ActionButton--staticBlack {
+    &:not(.spectrum-ActionButton--quiet) {
+      &:disabled {
+        border-color: var(--spectrum-alias-actionbutton-staticBlack-border-color-disabled);
+
+        &.is-selected {
+          border-color: var(--spectrum-alias-actionbutton-staticBlack-border-color-disabled-selected)
+        }
+
+        &:not(.is-selected) {
+          background-color: var(--spectrum-alias-actionbutton-staticBlack-background-color-disabled)
+        }
+      }
+
+      &:not(:disabled) {
+        border-color: var(--spectrum-alias-actionbutton-staticBlack-border-color-default);
+
+        &:hover {
+          border-color: var(--spectrum-alias-actionbutton-staticBlack-border-color-hover)
+        }
+
+        &:active {
+          border-color: var(--spectrum-alias-actionbutton-staticBlack-border-color-down)
+        }
+
+        &:focus-visible {
+          border-color: var(--spectrum-alias-actionbutton-staticBlack-border-color-key-focus)
+        }
+
+        &.is-keyboardFocused {
+          border-color: var(--spectrum-alias-actionbutton-staticBlack-border-color-key-focus)
+        }
+
+        &:not(.is-selected) {
+          background-color: var(--spectrum-alias-actionbutton-staticBlack-background-color-default);
+
+          &:hover {
+            background-color: var(--spectrum-alias-actionbutton-staticBlack-background-color-hover)
+          }
+
+          &:active {
+            background-color: var(--spectrum-alias-actionbutton-staticBlack-background-color-down)
+          }
+
+          &:focus-visible {
+            background-color: var(--spectrum-alias-actionbutton-staticBlack-background-color-key-focus)
+          }
+
+          &.is-keyboardFocused {
+            background-color: var(--spectrum-alias-actionbutton-staticBlack-background-color-key-focus)
+          }
+        }
+      }
+    }
+
+    &.spectrum-ActionButton--quiet {
+      &:disabled {
+        border-color: transparent;
+
+        &:not(.is-selected) {
+          background-color: transparent
+        }
+      }
+
+      &:not(:disabled) {
+        border-color: transparent;
+
+        &:not(.is-selected) {
+          background-color: var(--spectrum-alias-component-background-color-quiet-default);
+
+          &:hover {
+            background-color: rgba(var(--spectrum-global-color-static-black-rgb), var(--spectrum-global-color-opacity-25))
+          }
+
+          &:active {
+            background-color: rgba(var(--spectrum-global-color-static-black-rgb), var(--spectrum-global-color-opacity-40))
+          }
+
+          &:focus-visible {
+            background-color: rgba(var(--spectrum-global-color-static-black-rgb), var(--spectrum-global-color-opacity-25))
+          }
+
+          &.is-keyboardFocused {
+            background-color: rgba(var(--spectrum-global-color-static-black-rgb), var(--spectrum-global-color-opacity-25))
+          }
+        }
+      }
+    }
+
+    &:disabled {
+      &.is-selected {
+        background-color: var(--spectrum-alias-actionbutton-staticBlack-background-color-disabled-selected);
+
+        .spectrum-ActionButton-holdIcon {
+          color: rgba(var(--spectrum-global-color-static-black-rgb), var(--spectrum-global-color-opacity-40))
+        }
+
+        .spectrum-ActionButton-label {
+          color: rgba(var(--spectrum-global-color-static-black-rgb), var(--spectrum-global-color-opacity-40))
+        }
+
+        .spectrum-Icon {
+          color: rgba(var(--spectrum-global-color-static-black-rgb), var(--spectrum-global-color-opacity-40))
+        }
+      }
+
+      .spectrum-ActionButton-holdIcon {
+        color: rgba(var(--spectrum-global-color-static-black-rgb), var(--spectrum-global-color-opacity-40))
+      }
+
+      .spectrum-ActionButton-label {
+        color: rgba(var(--spectrum-global-color-static-black-rgb), var(--spectrum-global-color-opacity-40))
+      }
+
+      .spectrum-Icon {
+        color: rgba(var(--spectrum-global-color-static-black-rgb), var(--spectrum-global-color-opacity-40))
+      }
+    }
+
+    &.is-selected {
+      &:not(:disabled) {
+        background-color: rgba(var(--spectrum-global-color-static-black-rgb), var(--spectrum-global-color-opacity-90));
+
+        &:hover {
+          background-color: var(--spectrum-global-color-static-black)
+        }
+
+        &:active {
+          background-color: var(--spectrum-global-color-static-black)
+        }
+
+        &:focus-visible {
+          background-color: var(--spectrum-global-color-static-black)
+        }
+
+        &.is-keyboardFocused {
+          background-color: var(--spectrum-global-color-static-black)
+        }
+
+        .spectrum-ActionButton-holdIcon {
+          color: inherit
+        }
+
+        .spectrum-ActionButton-label {
+          color: inherit
+        }
+
+        .spectrum-Icon {
+          color: inherit
+        }
+      }
+    }
+
+    .spectrum-ActionButton-holdIcon {
+      color: var(--spectrum-ActionButton-static-black-color)
+    }
+
+    &:not(:disabled) {
+      &:not(.is-selected) {
+        .spectrum-ActionButton-holdIcon {
+          color: rgba(var(--spectrum-global-color-static-black-rgb), var(--spectrum-global-color-opacity-90))
+        }
+
+        &:hover {
+          .spectrum-ActionButton-holdIcon {
+            color: var(--spectrum-global-color-static-black)
+          }
+
+          .spectrum-ActionButton-label {
+            color: var(--spectrum-global-color-static-black)
+          }
+
+          .spectrum-Icon {
+            color: var(--spectrum-global-color-static-black)
+          }
+        }
+
+        &:active {
+          .spectrum-ActionButton-holdIcon {
+            color: var(--spectrum-global-color-static-black)
+          }
+
+          .spectrum-ActionButton-label {
+            color: var(--spectrum-global-color-static-black)
+          }
+
+          .spectrum-Icon {
+            color: var(--spectrum-global-color-static-black)
+          }
+        }
+
+        &:focus-visible {
+          .spectrum-ActionButton-holdIcon {
+            color: var(--spectrum-global-color-static-black)
+          }
+
+          .spectrum-ActionButton-label {
+            color: var(--spectrum-global-color-static-black)
+          }
+
+          .spectrum-Icon {
+            color: var(--spectrum-global-color-static-black)
+          }
+        }
+
+        &.is-keyboardFocused {
+          .spectrum-ActionButton-holdIcon {
+            color: var(--spectrum-global-color-static-black)
+          }
+
+          .spectrum-ActionButton-label {
+            color: var(--spectrum-global-color-static-black)
+          }
+
+          .spectrum-Icon {
+            color: var(--spectrum-global-color-static-black)
+          }
+        }
+
+        .spectrum-ActionButton-label {
+          color: rgba(var(--spectrum-global-color-static-black-rgb), var(--spectrum-global-color-opacity-90))
+        }
+
+        .spectrum-Icon {
+          color: rgba(var(--spectrum-global-color-static-black-rgb), var(--spectrum-global-color-opacity-90))
+        }
+      }
+    }
+
+    .spectrum-ActionButton-label {
+      color: var(--spectrum-ActionButton-static-black-color)
+    }
+
+    .spectrum-Icon {
+      color: var(--spectrum-ActionButton-static-black-color)
+    }
+  }
+
+  &.spectrum-ActionButton--staticWhite {
+    &:not(.spectrum-ActionButton--quiet) {
+      &:disabled {
+        border-color: var(--spectrum-alias-actionbutton-staticWhite-border-color-disabled);
+
+        &.is-selected {
+          border-color: var(--spectrum-alias-actionbutton-staticWhite-border-color-disabled-selected)
+        }
+
+        &:not(.is-selected) {
+          background-color: var(--spectrum-alias-actionbutton-staticWhite-background-color-disabled)
+        }
+      }
+
+      &:not(:disabled) {
+        border-color: var(--spectrum-alias-actionbutton-staticWhite-border-color-default);
+
+        &:hover {
+          border-color: var(--spectrum-alias-actionbutton-staticWhite-border-color-hover)
+        }
+
+        &:active {
+          border-color: var(--spectrum-alias-actionbutton-staticWhite-border-color-down)
+        }
+
+        &:focus-visible {
+          border-color: var(--spectrum-alias-actionbutton-staticWhite-border-color-key-focus)
+        }
+
+        &.is-keyboardFocused {
+          border-color: var(--spectrum-alias-actionbutton-staticWhite-border-color-key-focus)
+        }
+
+        &:not(.is-selected) {
+          background-color: var(--spectrum-alias-actionbutton-staticWhite-background-color-default);
+
+          &:hover {
+            background-color: var(--spectrum-alias-actionbutton-staticWhite-background-color-hover)
+          }
+
+          &:active {
+            background-color: var(--spectrum-alias-actionbutton-staticWhite-background-color-down)
+          }
+
+          &:focus-visible {
+            background-color: var(--spectrum-alias-actionbutton-staticWhite-background-color-key-focus)
+          }
+
+          &.is-keyboardFocused {
+            background-color: var(--spectrum-alias-actionbutton-staticWhite-background-color-key-focus)
+          }
+        }
+      }
+    }
+
+    &.spectrum-ActionButton--quiet {
+      &:disabled {
+        border-color: transparent;
+
+        &:not(.is-selected) {
+          background-color: transparent
+        }
+      }
+
+      &:not(:disabled) {
+        border-color: transparent;
+
+        &:not(.is-selected) {
+          background-color: var(--spectrum-alias-component-background-color-quiet-default);
+
+          &:hover {
+            background-color: rgba(var(--spectrum-global-color-static-white-rgb), var(--spectrum-global-color-opacity-25))
+          }
+
+          &:active {
+            background-color: rgba(var(--spectrum-global-color-static-white-rgb), var(--spectrum-global-color-opacity-40))
+          }
+
+          &:focus-visible {
+            background-color: rgba(var(--spectrum-global-color-static-white-rgb), var(--spectrum-global-color-opacity-25))
+          }
+
+          &.is-keyboardFocused {
+            background-color: rgba(var(--spectrum-global-color-static-white-rgb), var(--spectrum-global-color-opacity-25))
+          }
+        }
+      }
+    }
+
+    &:disabled {
+      &.is-selected {
+        background-color: var(--spectrum-alias-actionbutton-staticWhite-background-color-disabled-selected);
+
+        .spectrum-ActionButton-holdIcon {
+          color: rgba(var(--spectrum-global-color-static-white-rgb), var(--spectrum-global-color-opacity-40))
+        }
+
+        .spectrum-ActionButton-label {
+          color: rgba(var(--spectrum-global-color-static-white-rgb), var(--spectrum-global-color-opacity-40))
+        }
+
+        .spectrum-Icon {
+          color: rgba(var(--spectrum-global-color-static-white-rgb), var(--spectrum-global-color-opacity-40))
+        }
+      }
+
+      .spectrum-ActionButton-holdIcon {
+        color: rgba(var(--spectrum-global-color-static-white-rgb), var(--spectrum-global-color-opacity-40))
+      }
+
+      .spectrum-ActionButton-label {
+        color: rgba(var(--spectrum-global-color-static-white-rgb), var(--spectrum-global-color-opacity-40))
+      }
+
+      .spectrum-Icon {
+        color: rgba(var(--spectrum-global-color-static-white-rgb), var(--spectrum-global-color-opacity-40))
+      }
+    }
+
+    &.is-selected {
+      &:not(:disabled) {
+        background-color: rgba(var(--spectrum-global-color-static-white-rgb), var(--spectrum-global-color-opacity-90));
+
+        &:hover {
+          background-color: var(--spectrum-global-color-static-white)
+        }
+
+        &:active {
+          background-color: var(--spectrum-global-color-static-white)
+        }
+
+        &:focus-visible {
+          background-color: var(--spectrum-global-color-static-white)
+        }
+
+        &.is-keyboardFocused {
+          background-color: var(--spectrum-global-color-static-white)
+        }
+
+        .spectrum-ActionButton-holdIcon {
+          color: inherit
+        }
+
+        .spectrum-ActionButton-label {
+          color: inherit
+        }
+
+        .spectrum-Icon {
+          color: inherit
+        }
+      }
+    }
+
+    .spectrum-ActionButton-holdIcon {
+      color: var(--spectrum-ActionButton-static-white-color)
+    }
+
+    &:not(:disabled) {
+      &:not(.is-selected) {
+        .spectrum-ActionButton-holdIcon {
+          color: rgba(var(--spectrum-global-color-static-white-rgb), var(--spectrum-global-color-opacity-90))
+        }
+
+        &:hover {
+          .spectrum-ActionButton-holdIcon {
+            color: var(--spectrum-global-color-static-white)
+          }
+
+          .spectrum-ActionButton-label {
+            color: var(--spectrum-global-color-static-white)
+          }
+
+          .spectrum-Icon {
+            color: var(--spectrum-global-color-static-white)
+          }
+        }
+
+        &:active {
+          .spectrum-ActionButton-holdIcon {
+            color: var(--spectrum-global-color-static-white)
+          }
+
+          .spectrum-ActionButton-label {
+            color: var(--spectrum-global-color-static-white)
+          }
+
+          .spectrum-Icon {
+            color: var(--spectrum-global-color-static-white)
+          }
+        }
+
+        &:focus-visible {
+          .spectrum-ActionButton-holdIcon {
+            color: var(--spectrum-global-color-static-white)
+          }
+
+          .spectrum-ActionButton-label {
+            color: var(--spectrum-global-color-static-white)
+          }
+
+          .spectrum-Icon {
+            color: var(--spectrum-global-color-static-white)
+          }
+        }
+
+        &.is-keyboardFocused {
+          .spectrum-ActionButton-holdIcon {
+            color: var(--spectrum-global-color-static-white)
+          }
+
+          .spectrum-ActionButton-label {
+            color: var(--spectrum-global-color-static-white)
+          }
+
+          .spectrum-Icon {
+            color: var(--spectrum-global-color-static-white)
+          }
+        }
+
+        .spectrum-ActionButton-label {
+          color: rgba(var(--spectrum-global-color-static-white-rgb), var(--spectrum-global-color-opacity-90))
+        }
+
+        .spectrum-Icon {
+          color: rgba(var(--spectrum-global-color-static-white-rgb), var(--spectrum-global-color-opacity-90))
+        }
+      }
+    }
+
+    .spectrum-ActionButton-label {
+      color: var(--spectrum-ActionButton-static-white-color)
+    }
+
+    .spectrum-Icon {
+      color: var(--spectrum-ActionButton-static-white-color)
+    }
+  }
+}
+
+/* end generated CSS for actionbutton */

--- a/components/actionbutton/index.css
+++ b/components/actionbutton/index.css
@@ -12,6 +12,7 @@ governing permissions and limitations under the License.
 
 @import "../commons/basebutton.css";
 @import "../vars/css/components/spectrum-actionbutton.css";
+@import "./actionbutton-generated.css";
 
 .spectrum-ActionButton--sizeS {
   @remapvars {
@@ -22,6 +23,9 @@ governing permissions and limitations under the License.
   /* todo: remove hardcoded values when we update DNA */
   --spectrum-actionbutton-hold-icon-padding-bottom: var(--spectrum-global-dimension-size-25);
   --spectrum-actionbutton-hold-icon-padding-right: var(--spectrum-global-dimension-size-25);
+
+  /* hack to fix the incorrect min-width */
+  --spectrum-actionbutton-textonly-min-width: var(--spectrum-global-dimension-size-300);
 }
 
 .spectrum-ActionButton--sizeM {
@@ -88,6 +92,9 @@ a.spectrum-ActionButton {
   font-weight: var(--spectrum-actionbutton-textonly-text-font-weight);
   line-height: var(--spectrum-actionbutton-textonly-text-line-height);
 
+  /* Let static variants inherit their color */
+  color: inherit;
+
   .spectrum-Icon {
     @inherit: %spectrum-ButtonIcon;
 
@@ -136,4 +143,50 @@ a.spectrum-ActionButton {
 
   font-size: var(--spectrum-actionbutton-quiet-textonly-text-size);
   font-weight: var(--spectrum-actionbutton-quiet-textonly-text-font-weight);
+}
+
+/* special cases for focus-ring */
+.spectrum-ActionButton {
+  --spectrum-actionbutton-focus-ring-gap: var(--spectrum-alias-component-focusring-gap);
+  --spectrum-actionbutton-focus-ring-size: var(--spectrum-alias-component-focusring-size);
+  --spectrum-actionbutton-focus-ring-color: var(--spectrum-actionbutton-m-textonly-focus-ring-border-color-key-focus);
+
+  transition: border-color var(--spectrum-global-animation-duration-100) ease-in-out;
+
+  &:after {
+    pointer-events: none;
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    top: 0;
+    margin: calc((var(--spectrum-actionbutton-focus-ring-gap) + var(--spectrum-actionbutton-textonly-border-size)) * -1);
+    border-radius: calc(var(--spectrum-actionbutton-quiet-textonly-border-radius) + var(--spectrum-actionbutton-focus-ring-gap));
+    transition: box-shadow var(--spectrum-global-animation-duration-100) ease-in-out;
+  }
+
+  &:focus-ring {
+    /* kill the default ring */
+    box-shadow: none !important;
+
+    &:after {
+      box-shadow: 0 0 0 var(--spectrum-actionbutton-focus-ring-size) var(--spectrum-actionbutton-focus-ring-color);
+    }
+  }
+}
+
+.spectrum-ActionButton--staticWhite {
+  --spectrum-actionbutton-focus-ring-color: var(--spectrum-global-color-static-white);
+}
+
+.spectrum-ActionButton--staticBlack {
+  --spectrum-actionbutton-focus-ring-color: var(--spectrum-global-color-static-black);
+}
+
+.spectrum-ActionButton--emphasized.is-selected,
+.spectrum-ActionButton--staticWhite,
+.spectrum-ActionButton--staticBlack {
+  --spectrum-actionbutton-focus-ring-gap: var(--spectrum-alias-component-focusring-gap-emphasized);
+  --spectrum-actionbutton-focus-ring-size: var(--spectrum-alias-component-focusring-size-emphasized);
 }

--- a/components/actionbutton/metadata/actionbutton.yml
+++ b/components/actionbutton/metadata/actionbutton.yml
@@ -39,249 +39,265 @@ sections:
       ### Include markup for hold icon before workflow icon
       Because of the way padding is calculated, the hold icon must be placed before the workflow icon.
 examples:
-  - id: actionbutton
+  - id: actionbutton-sizing
     name: Sizing
     markup: |
       <div class="spectrum-Examples">
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">S</h4>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeS">
-            <span class="spectrum-ActionButton-label">Edit</span>
-          </button>
+          <div class="spectrum-Examples-itemGroup">
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeS">
+              <span class="spectrum-ActionButton-label">Edit</span>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeS">
-            <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-            <span class="spectrum-ActionButton-label">Edit</span>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeS">
+              <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+              <span class="spectrum-ActionButton-label">Edit</span>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeS">
-            <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeS">
+              <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeS">
-            <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle75 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
-              <use xlink:href="#spectrum-css-icon-CornerTriangle75" />
-            </svg>
-            <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeS">
+              <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle75 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-CornerTriangle75" />
+              </svg>
+              <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
+          </div>
         </div>
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">M (default)</h4>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM">
-            <span class="spectrum-ActionButton-label">Edit</span>
-          </button>
+          <div class="spectrum-Examples-itemGroup">
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM">
+              <span class="spectrum-ActionButton-label">Edit</span>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM">
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-            <span class="spectrum-ActionButton-label">Edit</span>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+              <span class="spectrum-ActionButton-label">Edit</span>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM">
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM">
-            <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
-              <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
-            </svg>
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM">
+              <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
+              </svg>
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
+          </div>
         </div>
 
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">L</h4>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeL">
-            <span class="spectrum-ActionButton-label">Edit</span>
-          </button>
+          <div class="spectrum-Examples-itemGroup">
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeL">
+              <span class="spectrum-ActionButton-label">Edit</span>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeL">
-            <svg class="spectrum-Icon spectrum-Icon--sizeL" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-            <span class="spectrum-ActionButton-label">Edit</span>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeL">
+              <svg class="spectrum-Icon spectrum-Icon--sizeL" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+              <span class="spectrum-ActionButton-label">Edit</span>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeL">
-            <svg class="spectrum-Icon spectrum-Icon--sizeL" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeL">
+              <svg class="spectrum-Icon spectrum-Icon--sizeL" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeL">
-            <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle200 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
-              <use xlink:href="#spectrum-css-icon-CornerTriangle200" />
-            </svg>
-            <svg class="spectrum-Icon spectrum-Icon--sizeL" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeL">
+              <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle200 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-CornerTriangle200" />
+              </svg>
+              <svg class="spectrum-Icon spectrum-Icon--sizeL" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
+          </div>
         </div>
 
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">XL</h4>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeXL">
-            <span class="spectrum-ActionButton-label">Edit</span>
-          </button>
+          <div class="spectrum-Examples-itemGroup">
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeXL">
+              <span class="spectrum-ActionButton-label">Edit</span>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeXL">
-            <svg class="spectrum-Icon spectrum-Icon--sizeXL" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-            <span class="spectrum-ActionButton-label">Edit</span>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeXL">
+              <svg class="spectrum-Icon spectrum-Icon--sizeXL" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+              <span class="spectrum-ActionButton-label">Edit</span>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeXL">
-            <svg class="spectrum-Icon spectrum-Icon--sizeXL" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeXL">
+              <svg class="spectrum-Icon spectrum-Icon--sizeXL" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeXL">
-            <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle300 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
-              <use xlink:href="#spectrum-css-icon-CornerTriangle300" />
-            </svg>
-            <svg class="spectrum-Icon spectrum-Icon--sizeXL" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeXL">
+              <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle300 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-CornerTriangle300" />
+              </svg>
+              <svg class="spectrum-Icon spectrum-Icon--sizeXL" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
+          </div>
         </div>
       </div>
 
-  - id: actionbutton
+  - id: actionbutton-standard
     name: Standard
     markup: |
       <div class="spectrum-Examples">
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Default</h4>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM">
-            <span class="spectrum-ActionButton-label">Edit</span>
-          </button>
+          <div class="spectrum-Examples-itemGroup">
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM">
+              <span class="spectrum-ActionButton-label">Edit</span>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM">
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-            <span class="spectrum-ActionButton-label">Edit</span>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+              <span class="spectrum-ActionButton-label">Edit</span>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM">
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM">
-            <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
-              <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
-            </svg>
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM">
+              <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
+              </svg>
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
+          </div>
         </div>
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Selected</h4>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM is-selected">
-            <span class="spectrum-ActionButton-label">Edit</span>
-          </button>
+          <div class="spectrum-Examples-itemGroup">
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM is-selected">
+              <span class="spectrum-ActionButton-label">Edit</span>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM is-selected">
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-            <span class="spectrum-ActionButton-label">Edit</span>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM is-selected">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+              <span class="spectrum-ActionButton-label">Edit</span>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM is-selected">
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM is-selected">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM is-selected">
-            <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
-              <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
-            </svg>
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM is-selected">
+              <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
+              </svg>
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
+          </div>
         </div>
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Disabled</h4>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM" disabled>
-            <span class="spectrum-ActionButton-label">Edit</span>
-          </button>
+          <div class="spectrum-Examples-itemGroup">
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM" disabled>
+              <span class="spectrum-ActionButton-label">Edit</span>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM" disabled>
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-            <span class="spectrum-ActionButton-label">Edit</span>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM" disabled>
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+              <span class="spectrum-ActionButton-label">Edit</span>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM" disabled>
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM" disabled>
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM" disabled>
-            <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
-              <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
-            </svg>
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM" disabled>
+              <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
+              </svg>
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
+          </div>
         </div>
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Selected + Disabled</h4>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM is-selected" disabled>
-            <span class="spectrum-ActionButton-label">Edit</span>
-          </button>
+          <div class="spectrum-Examples-itemGroup">
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM is-selected" disabled>
+              <span class="spectrum-ActionButton-label">Edit</span>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM is-selected" disabled>
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-            <span class="spectrum-ActionButton-label">Edit</span>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM is-selected" disabled>
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+              <span class="spectrum-ActionButton-label">Edit</span>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM is-selected" disabled>
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM is-selected" disabled>
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM is-selected" disabled>
-            <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
-              <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
-            </svg>
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM is-selected" disabled>
+              <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
+              </svg>
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
+          </div>
         </div>
       </div>
 
@@ -293,362 +309,915 @@ examples:
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Default</h4>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet">
-            <span class="spectrum-ActionButton-label">Edit</span>
-          </button>
+          <div class="spectrum-Examples-itemGroup">
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet">
+              <span class="spectrum-ActionButton-label">Edit</span>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet">
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-            <span class="spectrum-ActionButton-label">Edit</span>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+              <span class="spectrum-ActionButton-label">Edit</span>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet">
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet">
-            <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
-              <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
-            </svg>
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet">
+              <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
+              </svg>
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
+          </div>
         </div>
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Selected</h4>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet is-selected">
-            <span class="spectrum-ActionButton-label">Edit</span>
-          </button>
+          <div class="spectrum-Examples-itemGroup">
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet is-selected">
+              <span class="spectrum-ActionButton-label">Edit</span>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet is-selected">
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-            <span class="spectrum-ActionButton-label">Edit</span>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet is-selected">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+              <span class="spectrum-ActionButton-label">Edit</span>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet is-selected">
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet is-selected">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet is-selected">
-            <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
-              <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
-            </svg>
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet is-selected">
+              <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
+              </svg>
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
+          </div>
         </div>
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Disabled</h4>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet" disabled>
-            <span class="spectrum-ActionButton-label">Edit</span>
-          </button>
+          <div class="spectrum-Examples-itemGroup">
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet" disabled>
+              <span class="spectrum-ActionButton-label">Edit</span>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet" disabled>
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-            <span class="spectrum-ActionButton-label">Edit</span>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet" disabled>
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+              <span class="spectrum-ActionButton-label">Edit</span>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet" disabled>
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet" disabled>
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet" disabled>
-            <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
-              <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
-            </svg>
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet" disabled>
+              <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
+              </svg>
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
+          </div>
         </div>
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Selected + Disabled</h4>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet is-selected" disabled>
-            <span class="spectrum-ActionButton-label">Edit</span>
-          </button>
+          <div class="spectrum-Examples-itemGroup">
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet is-selected" disabled>
+              <span class="spectrum-ActionButton-label">Edit</span>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet is-selected" disabled>
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-            <span class="spectrum-ActionButton-label">Edit</span>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet is-selected" disabled>
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+              <span class="spectrum-ActionButton-label">Edit</span>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet is-selected" disabled>
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet is-selected" disabled>
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet is-selected" disabled>
-            <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
-              <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
-            </svg>
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet is-selected" disabled>
+              <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
+              </svg>
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
+          </div>
         </div>
       </div>
 
 
-  - id: actionbutton
+  - id: actionbutton-emphasized
     name: Emphasized
     markup: |
       <div class="spectrum-Examples">
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Default</h4>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized">
-            <span class="spectrum-ActionButton-label">Edit</span>
-          </button>
+          <div class="spectrum-Examples-itemGroup">
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized">
+              <span class="spectrum-ActionButton-label">Edit</span>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized">
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-            <span class="spectrum-ActionButton-label">Edit</span>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+              <span class="spectrum-ActionButton-label">Edit</span>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized">
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized">
-            <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
-              <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
-            </svg>
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized">
+              <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
+              </svg>
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
+          </div>
         </div>
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Selected</h4>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized is-selected">
-            <span class="spectrum-ActionButton-label">Edit</span>
-          </button>
+          <div class="spectrum-Examples-itemGroup">
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized is-selected">
+              <span class="spectrum-ActionButton-label">Edit</span>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized is-selected">
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-            <span class="spectrum-ActionButton-label">Edit</span>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized is-selected">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+              <span class="spectrum-ActionButton-label">Edit</span>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized is-selected">
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized is-selected">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized is-selected">
-            <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
-              <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
-            </svg>
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized is-selected">
+              <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
+              </svg>
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
+          </div>
         </div>
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Disabled</h4>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized" disabled>
-            <span class="spectrum-ActionButton-label">Edit</span>
-          </button>
+          <div class="spectrum-Examples-itemGroup">
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized" disabled>
+              <span class="spectrum-ActionButton-label">Edit</span>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized" disabled>
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-            <span class="spectrum-ActionButton-label">Edit</span>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized" disabled>
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+              <span class="spectrum-ActionButton-label">Edit</span>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized" disabled>
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized" disabled>
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized" disabled>
-            <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
-              <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
-            </svg>
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized" disabled>
+              <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
+              </svg>
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
+          </div>
         </div>
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Selected + Disabled</h4>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized is-selected" disabled>
-            <span class="spectrum-ActionButton-label">Edit</span>
-          </button>
+          <div class="spectrum-Examples-itemGroup">
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized is-selected" disabled>
+              <span class="spectrum-ActionButton-label">Edit</span>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized is-selected" disabled>
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-            <span class="spectrum-ActionButton-label">Edit</span>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized is-selected" disabled>
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+              <span class="spectrum-ActionButton-label">Edit</span>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized is-selected" disabled>
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized is-selected" disabled>
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized is-selected" disabled>
-            <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
-              <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
-            </svg>
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized is-selected" disabled>
+              <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
+              </svg>
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
+          </div>
         </div>
       </div>
 
-  - id: actionbutton
+  - id: actionbutton-emphasized-quiet
     name: Emphasized (quiet)
     markup: |
       <div class="spectrum-Examples">
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Default</h4>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized spectrum-ActionButton--quiet">
-            <span class="spectrum-ActionButton-label">Edit</span>
-          </button>
+          <div class="spectrum-Examples-itemGroup">
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized spectrum-ActionButton--quiet">
+              <span class="spectrum-ActionButton-label">Edit</span>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized spectrum-ActionButton--quiet">
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-            <span class="spectrum-ActionButton-label">Edit</span>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized spectrum-ActionButton--quiet">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+              <span class="spectrum-ActionButton-label">Edit</span>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized spectrum-ActionButton--quiet">
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized spectrum-ActionButton--quiet">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized spectrum-ActionButton--quiet">
-            <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
-              <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
-            </svg>
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized spectrum-ActionButton--quiet">
+              <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
+              </svg>
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
+          </div>
         </div>
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Selected</h4>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized spectrum-ActionButton--quiet is-selected">
-            <span class="spectrum-ActionButton-label">Edit</span>
-          </button>
+          <div class="spectrum-Examples-itemGroup">
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized spectrum-ActionButton--quiet is-selected">
+              <span class="spectrum-ActionButton-label">Edit</span>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized spectrum-ActionButton--quiet is-selected">
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-            <span class="spectrum-ActionButton-label">Edit</span>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized spectrum-ActionButton--quiet is-selected">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+              <span class="spectrum-ActionButton-label">Edit</span>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized spectrum-ActionButton--quiet is-selected">
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized spectrum-ActionButton--quiet is-selected">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized spectrum-ActionButton--quiet is-selected">
-            <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
-              <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
-            </svg>
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized spectrum-ActionButton--quiet is-selected">
+              <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
+              </svg>
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
+          </div>
         </div>
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Disabled</h4>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized spectrum-ActionButton--quiet" disabled>
-            <span class="spectrum-ActionButton-label">Edit</span>
-          </button>
+          <div class="spectrum-Examples-itemGroup">
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized spectrum-ActionButton--quiet" disabled>
+              <span class="spectrum-ActionButton-label">Edit</span>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized spectrum-ActionButton--quiet" disabled>
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-            <span class="spectrum-ActionButton-label">Edit</span>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized spectrum-ActionButton--quiet" disabled>
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+              <span class="spectrum-ActionButton-label">Edit</span>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized spectrum-ActionButton--quiet" disabled>
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized spectrum-ActionButton--quiet" disabled>
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized spectrum-ActionButton--quiet" disabled>
-            <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
-              <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
-            </svg>
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized spectrum-ActionButton--quiet" disabled>
+              <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
+              </svg>
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
+          </div>
         </div>
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Selected + Disabled</h4>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized spectrum-ActionButton--quiet is-selected" disabled>
-            <span class="spectrum-ActionButton-label">Edit</span>
-          </button>
+          <div class="spectrum-Examples-itemGroup">
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized spectrum-ActionButton--quiet is-selected" disabled>
+              <span class="spectrum-ActionButton-label">Edit</span>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized spectrum-ActionButton--quiet is-selected" disabled>
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-            <span class="spectrum-ActionButton-label">Edit</span>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized spectrum-ActionButton--quiet is-selected" disabled>
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+              <span class="spectrum-ActionButton-label">Edit</span>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized spectrum-ActionButton--quiet is-selected" disabled>
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized spectrum-ActionButton--quiet is-selected" disabled>
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
 
-          <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized spectrum-ActionButton--quiet is-selected" disabled>
-            <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
-              <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
-            </svg>
-            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
-              <use xlink:href="#spectrum-icon-18-Edit" />
-            </svg>
-          </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized spectrum-ActionButton--quiet is-selected" disabled>
+              <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
+              </svg>
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+
+  - id: actionbutton-staticwhite
+    name: Static White
+    markup: |
+      <div style="background-color: rgb(15, 121, 125); color: rgb(15, 121, 125); padding: 15px 20px;">
+        <div class="spectrum-Examples">
+          <div class="spectrum-Examples-item">
+            <h4 style="color: white" class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Default</h4>
+
+            <div class="spectrum-Examples-itemGroup">
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticWhite">
+                <span class="spectrum-ActionButton-label">Edit</span>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticWhite">
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+                <span class="spectrum-ActionButton-label">Edit</span>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticWhite">
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticWhite">
+                <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
+                  <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
+                </svg>
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+              </button>
+            </div>
+          </div>
+          <div class="spectrum-Examples-item">
+            <h4 style="color: white" class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Selected</h4>
+
+            <div class="spectrum-Examples-itemGroup">
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticWhite is-selected">
+                <span class="spectrum-ActionButton-label">Edit</span>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticWhite is-selected">
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+                <span class="spectrum-ActionButton-label">Edit</span>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticWhite is-selected">
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticWhite is-selected">
+                <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
+                  <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
+                </svg>
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+              </button>
+            </div>
+          </div>
+          <div class="spectrum-Examples-item">
+            <h4 style="color: white" class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Disabled</h4>
+
+            <div class="spectrum-Examples-itemGroup">
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticWhite" disabled>
+                <span class="spectrum-ActionButton-label">Edit</span>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticWhite" disabled>
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+                <span class="spectrum-ActionButton-label">Edit</span>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticWhite" disabled>
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticWhite" disabled>
+                <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
+                  <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
+                </svg>
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+              </button>
+            </div>
+          </div>
+          <div class="spectrum-Examples-item">
+            <h4 style="color: white" class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Selected + Disabled</h4>
+
+            <div class="spectrum-Examples-itemGroup">
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticWhite is-selected" disabled>
+                <span class="spectrum-ActionButton-label">Edit</span>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticWhite is-selected" disabled>
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+                <span class="spectrum-ActionButton-label">Edit</span>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticWhite is-selected" disabled>
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticWhite is-selected" disabled>
+                <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
+                  <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
+                </svg>
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+  - id: actionbutton-staticblack
+    name: Static Black
+    markup: |
+      <div style="background-color: rgb(181, 209, 211); color: rgb(181, 209, 211); padding: 15px 20px;">
+        <div class="spectrum-Examples">
+          <div class="spectrum-Examples-item">
+            <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Default</h4>
+
+            <div class="spectrum-Examples-itemGroup">
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticBlack">
+                <span class="spectrum-ActionButton-label">Edit</span>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticBlack">
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+                <span class="spectrum-ActionButton-label">Edit</span>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticBlack">
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticBlack">
+                <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
+                  <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
+                </svg>
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+              </button>
+            </div>
+          </div>
+          <div class="spectrum-Examples-item">
+            <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Selected</h4>
+
+            <div class="spectrum-Examples-itemGroup">
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticBlack is-selected">
+                <span class="spectrum-ActionButton-label">Edit</span>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticBlack is-selected">
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+                <span class="spectrum-ActionButton-label">Edit</span>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticBlack is-selected">
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticBlack is-selected">
+                <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
+                  <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
+                </svg>
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+              </button>
+            </div>
+          </div>
+          <div class="spectrum-Examples-item">
+            <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Disabled</h4>
+
+            <div class="spectrum-Examples-itemGroup">
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticBlack" disabled>
+                <span class="spectrum-ActionButton-label">Edit</span>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticBlack" disabled>
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+                <span class="spectrum-ActionButton-label">Edit</span>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticBlack" disabled>
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticBlack" disabled>
+                <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
+                  <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
+                </svg>
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+              </button>
+            </div>
+          </div>
+          <div class="spectrum-Examples-item">
+            <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Selected + Disabled</h4>
+
+            <div class="spectrum-Examples-itemGroup">
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticBlack is-selected" disabled>
+                <span class="spectrum-ActionButton-label">Edit</span>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticBlack is-selected" disabled>
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+                <span class="spectrum-ActionButton-label">Edit</span>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticBlack is-selected" disabled>
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticBlack is-selected" disabled>
+                <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
+                  <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
+                </svg>
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+
+  - id: actionbutton-staticwhite-quiet
+    name: Static White (quiet)
+    markup: |
+      <div style="background-color: rgb(15, 121, 125); color: rgb(15, 121, 125); padding: 15px 20px;">
+        <div class="spectrum-Examples">
+          <div class="spectrum-Examples-item">
+            <h4 style="color: white" class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Default</h4>
+
+            <div class="spectrum-Examples-itemGroup">
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticWhite spectrum-ActionButton--quiet">
+                <span class="spectrum-ActionButton-label">Edit</span>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticWhite spectrum-ActionButton--quiet">
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+                <span class="spectrum-ActionButton-label">Edit</span>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticWhite spectrum-ActionButton--quiet">
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticWhite spectrum-ActionButton--quiet">
+                <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
+                  <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
+                </svg>
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+              </button>
+            </div>
+          </div>
+          <div class="spectrum-Examples-item">
+            <h4 style="color: white" class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Selected</h4>
+
+            <div class="spectrum-Examples-itemGroup">
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticWhite spectrum-ActionButton--quiet is-selected">
+                <span class="spectrum-ActionButton-label">Edit</span>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticWhite spectrum-ActionButton--quiet is-selected">
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+                <span class="spectrum-ActionButton-label">Edit</span>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticWhite spectrum-ActionButton--quiet is-selected">
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticWhite spectrum-ActionButton--quiet is-selected">
+                <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
+                  <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
+                </svg>
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+              </button>
+            </div>
+          </div>
+          <div class="spectrum-Examples-item">
+            <h4 style="color: white" class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Disabled</h4>
+
+            <div class="spectrum-Examples-itemGroup">
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticWhite spectrum-ActionButton--quiet" disabled>
+                <span class="spectrum-ActionButton-label">Edit</span>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticWhite spectrum-ActionButton--quiet" disabled>
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+                <span class="spectrum-ActionButton-label">Edit</span>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticWhite spectrum-ActionButton--quiet" disabled>
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticWhite spectrum-ActionButton--quiet" disabled>
+                <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
+                  <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
+                </svg>
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+              </button>
+            </div>
+          </div>
+          <div class="spectrum-Examples-item">
+            <h4 style="color: white" class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Selected + Disabled</h4>
+
+            <div class="spectrum-Examples-itemGroup">
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticWhite spectrum-ActionButton--quiet is-selected" disabled>
+                <span class="spectrum-ActionButton-label">Edit</span>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticWhite spectrum-ActionButton--quiet is-selected" disabled>
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+                <span class="spectrum-ActionButton-label">Edit</span>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticWhite spectrum-ActionButton--quiet is-selected" disabled>
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticWhite spectrum-ActionButton--quiet is-selected" disabled>
+                <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
+                  <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
+                </svg>
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+  - id: actionbutton-staticblack-quiet
+    name: Static Black (quiet)
+    markup: |
+      <div style="background-color: rgb(181, 209, 211); color: rgb(181, 209, 211); padding: 15px 20px;">
+        <div class="spectrum-Examples">
+          <div class="spectrum-Examples-item">
+            <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Default</h4>
+
+            <div class="spectrum-Examples-itemGroup">
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticBlack spectrum-ActionButton--quiet">
+                <span class="spectrum-ActionButton-label">Edit</span>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticBlack spectrum-ActionButton--quiet">
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+                <span class="spectrum-ActionButton-label">Edit</span>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticBlack spectrum-ActionButton--quiet">
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticBlack spectrum-ActionButton--quiet">
+                <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
+                  <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
+                </svg>
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+              </button>
+            </div>
+          </div>
+          <div class="spectrum-Examples-item">
+            <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Selected</h4>
+
+            <div class="spectrum-Examples-itemGroup">
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticBlack spectrum-ActionButton--quiet is-selected">
+                <span class="spectrum-ActionButton-label">Edit</span>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticBlack spectrum-ActionButton--quiet is-selected">
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+                <span class="spectrum-ActionButton-label">Edit</span>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticBlack spectrum-ActionButton--quiet is-selected">
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticBlack spectrum-ActionButton--quiet is-selected">
+                <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
+                  <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
+                </svg>
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+              </button>
+            </div>
+          </div>
+          <div class="spectrum-Examples-item">
+            <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Disabled</h4>
+
+            <div class="spectrum-Examples-itemGroup">
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticBlack spectrum-ActionButton--quiet" disabled>
+                <span class="spectrum-ActionButton-label">Edit</span>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticBlack spectrum-ActionButton--quiet" disabled>
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+                <span class="spectrum-ActionButton-label">Edit</span>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticBlack spectrum-ActionButton--quiet" disabled>
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticBlack spectrum-ActionButton--quiet" disabled>
+                <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
+                  <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
+                </svg>
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+              </button>
+            </div>
+          </div>
+          <div class="spectrum-Examples-item">
+            <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Selected + Disabled</h4>
+
+            <div class="spectrum-Examples-itemGroup">
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticBlack spectrum-ActionButton--quiet is-selected" disabled>
+                <span class="spectrum-ActionButton-label">Edit</span>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticBlack spectrum-ActionButton--quiet is-selected" disabled>
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+                <span class="spectrum-ActionButton-label">Edit</span>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticBlack spectrum-ActionButton--quiet is-selected" disabled>
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+              </button>
+
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticBlack spectrum-ActionButton--quiet is-selected" disabled>
+                <svg class="spectrum-Icon spectrum-UIIcon-CornerTriangle100 spectrum-ActionButton-hold" focusable="false" aria-hidden="true">
+                  <use xlink:href="#spectrum-css-icon-CornerTriangle100" />
+                </svg>
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit" />
+                </svg>
+              </button>
+            </div>
+          </div>
         </div>
       </div>

--- a/components/actionbutton/skin.css
+++ b/components/actionbutton/skin.css
@@ -45,7 +45,6 @@ governing permissions and limitations under the License.
   &:focus-ring {
     background-color: var(--spectrum-actionbutton-m-textonly-background-color-key-focus);
     border-color: var(--spectrum-actionbutton-m-textonly-border-color-key-focus);
-    box-shadow: 0 0 0 var(--spectrum-actionbutton-m-quiet-textonly-border-size-key-focus) var(--spectrum-actionbutton-m-textonly-border-color-key-focus);
     color: var(--spectrum-actionbutton-m-textonly-text-color-key-focus);
 
     &:active {
@@ -143,86 +142,6 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-ActionButton--emphasized {
-  background-color: var(--spectrum-actionbutton-m-emphasized-textonly-background-color);
-  border-color: var(--spectrum-actionbutton-m-emphasized-textonly-border-color);
-  color: var(--spectrum-actionbutton-m-emphasized-textonly-text-color);
-
-  .spectrum-Icon {
-    color: var(--spectrum-actionbutton-m-emphasized-texticon-icon-color);
-  }
-
-  .spectrum-ActionButton-hold {
-    color: var(--spectrum-actionbutton-m-emphasized-textonly-hold-icon-color);
-  }
-
-  &.is-selected {
-    .spectrum-ActionButton-hold {
-      color: var(--spectrum-actionbutton-m-emphasized-textonly-hold-icon-color-selected);
-    }
-
-    &:hover {
-      .spectrum-ActionButton-hold {
-        color: var(--spectrum-actionbutton-m-emphasized-textonly-text-color-selected-hover);
-      }
-    }
-  }
-
-  &:hover {
-    background-color: var(--spectrum-actionbutton-m-emphasized-textonly-background-color-hover);
-    border-color: var(--spectrum-actionbutton-m-emphasized-textonly-border-color-hover);
-    box-shadow: none;
-    color: var(--spectrum-actionbutton-m-emphasized-textonly-text-color-hover);
-
-    .spectrum-Icon {
-      color: var(--spectrum-actionbutton-m-emphasized-texticon-icon-color-hover);
-    }
-
-    .spectrum-ActionButton-hold {
-      color: var(--spectrum-actionbutton-m-emphasized-textonly-hold-icon-color-hover);
-    }
-  }
-
-  &:focus-ring {
-    background-color: var(--spectrum-actionbutton-m-emphasized-textonly-background-color-key-focus);
-    border-color: var(--spectrum-actionbutton-m-emphasized-textonly-border-color-key-focus);
-    box-shadow: 0 0 0 var(--spectrum-actionbutton-m-quiet-textonly-border-size-key-focus) var(--spectrum-actionbutton-m-textonly-border-color-key-focus);
-    color: var(--spectrum-actionbutton-m-emphasized-textonly-text-color-key-focus);
-
-    .spectrum-Icon {
-      color: var(--spectrum-actionbutton-m-emphasized-texticon-icon-color-key-focus);
-    }
-
-    .spectrum-ActionButton-hold {
-      color: var(--spectrum-actionbutton-m-emphasized-textonly-hold-icon-color-key-focus);
-    }
-  }
-
-  &.is-active {
-    background-color: var(--spectrum-actionbutton-m-emphasized-textonly-background-color-down);
-    border-color: var(--spectrum-actionbutton-m-emphasized-textonly-border-color-down);
-    box-shadow: none;
-    color: var(--spectrum-actionbutton-m-emphasized-textonly-text-color-down);
-
-    .spectrum-ActionButton-hold {
-      color: var(--spectrum-actionbutton-m-emphasized-textonly-hold-icon-color-down);
-    }
-  }
-
-  &:disabled,
-  &.is-disabled {
-    background-color: var(--spectrum-actionbutton-m-emphasized-textonly-background-color-disabled);
-    border-color: var(--spectrum-actionbutton-m-emphasized-textonly-border-color-disabled);
-    color: var(--spectrum-actionbutton-m-emphasized-textonly-text-color-disabled);
-
-    .spectrum-Icon {
-      color: var(--spectrum-actionbutton-m-emphasized-texticon-icon-color-disabled);
-    }
-
-    .spectrum-ActionButton-hold {
-      color: var(--spectrum-actionbutton-m-emphasized-textonly-hold-icon-color-disabled);
-    }
-  }
-
   &.spectrum-ActionButton--quiet.is-selected,
   &.is-selected {
     background-color: var(--spectrum-actionbutton-m-emphasized-textonly-background-color-selected);
@@ -289,7 +208,6 @@ governing permissions and limitations under the License.
 
   &:focus-ring {
     background-color: var(--spectrum-actionbutton-m-quiet-textonly-background-color-key-focus);
-    box-shadow: 0 0 0 var(--spectrum-actionbutton-m-quiet-textonly-border-size-key-focus) var(--spectrum-actionbutton-m-quiet-textonly-border-color-key-focus);
     border-color: var(--spectrum-actionbutton-m-quiet-textonly-border-color-key-focus);
     color: var(--spectrum-actionbutton-m-quiet-textonly-text-color-key-focus);
   }
@@ -336,6 +254,20 @@ governing permissions and limitations under the License.
       border-color: var(--spectrum-actionbutton-m-quiet-textonly-border-color-selected-disabled);
       color: var(--spectrum-actionbutton-m-quiet-textonly-text-color-selected-disabled);
     }
+  }
+}
+
+.spectrum-ActionButton--staticBlack,
+.spectrum-ActionButton--staticWhite {
+  /* required to make rgba() work with vars */
+  --spectrum-global-color-static-black-rgb: 0, 0, 0;
+  --spectrum-global-color-static-white-rgb: 255, 255, 255;
+  --spectrum-ActionButton-static-black-color: var(--spectrum-global-color-static-black);
+  --spectrum-ActionButton-static-white-color: var(--spectrum-global-color-static-white);
+
+  &.is-selected {
+    /* let selected styles get their color from parent elements */
+    color: inherit !important;
   }
 }
 

--- a/components/site/index.css
+++ b/components/site/index.css
@@ -494,6 +494,8 @@ governing permissions and limitations under the License.
   display: flex;
   flex-direction: row;
   justify-content: space-between;
+  gap: 6px;
+  flex-wrap: wrap;
 }
 .spectrum-Examples--vertical {
   flex-direction: column;
@@ -506,6 +508,14 @@ governing permissions and limitations under the License.
 
 .spectrum-Examples-item .spectrum-Examples-itemHeading {
   margin-bottom: var(--spectrum-global-dimension-size-100);
+}
+
+.spectrum-Examples-itemGroup {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 6px;
 }
 
 .spectrum-Button.spectrum-CSSExample-overlayShowButton {


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->
## Description

This PR adds static colors for ActionButton with `.spectrum-ActionButton--staticWhite` and  `.spectrum-ActionButton--staticBlack`, closes #1224.

![image](https://user-images.githubusercontent.com/201344/142227834-da34ce64-b195-405f-b7e3-40bcab0d8d9f.png)

![image](https://user-images.githubusercontent.com/201344/142227851-08b9a01b-df8a-4632-afa0-40871bc7663e.png)

It also fixes the focus-ring for Emphasized Selected ActionButtons, fixes #1177

![image](https://user-images.githubusercontent.com/201344/142227898-bbcce4fc-70a4-43f2-877d-7f88418f925e.png)

It also fixes the down state of the emphasized ActionButton, closes #877 

![image](https://user-images.githubusercontent.com/201344/145096625-535827b9-dfad-47cd-945f-49708030f277.png)

Finally, it fixes the incorrect sizing of the small icon-only ActionButton, closes #1237

![image](https://user-images.githubusercontent.com/201344/145097566-96d0b847-f8d6-4fc7-bb28-a016ef82b47e.png)

## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] ~CSS generation discussion~ Generated CSS removed and refactored manually
- [x] Design verification (deployed [here](https://git.corp.adobe.com/pages/lawdavis/spectrum-css-ccx-verify/docs/actionbutton.html))
  - [x] Update border for Spectrum non-quiet per feedback
  - [x] Get design re-verified for border change