### PR TITLE
build: run buildMedium when built fron the top level

### DIFF
--- a/components/icon/gulpfile.js
+++ b/components/icon/gulpfile.js
@@ -115,5 +115,5 @@ const build = gulp.parallel(
 );
 
 exports.updateIcons = updateIcons;
-exports.build = exports.buildLite = exports.buildHeavy = build;
+exports.build = exports.buildLite = exports.buildHeavy = exports.buildMedium = build;
 exports.default = build;

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "release:site": "gulp prepareSite && gh-pages -d dist-site/ -f -e .",
     "release:bundles": "gulp releaseBundles",
     "version": "gulp version",
+    "preversion": "yarn build",
     "backstop:approve": "backstop approve --config=backstop_data/backstop_test.js",
     "backstop:test": "backstop test --config=backstop_data/backstop_test.js --env=local",
     "backstop:clean": "rm -rf backstop_data/bitmaps_test backstop_data/html_report",

--- a/tools/bundle-builder/index.js
+++ b/tools/bundle-builder/index.js
@@ -148,6 +148,17 @@ let buildLite = gulp.series(
   )
 );
 
+let buildMedium = gulp.series(
+  clean,
+  function buildComponentsLite() {
+    return subrunner.runTaskOnAllComponents('buildMedium');
+  },
+  gulp.parallel(
+    docs.build,
+    copyPackages
+  )
+);
+
 let buildHeavy = gulp.series(
   clean,
   function buildComponentsLite() {
@@ -215,6 +226,6 @@ exports.dev = devTask;
 exports.clean = clean;
 exports.build = build;
 exports.watch = dev.watch;
-exports.default = buildLite;
+exports.default = buildMedium;
 
 exports.updateAndTagRelease = release.updateAndTagRelease;

--- a/tools/bundle-builder/subrunner/index.js
+++ b/tools/bundle-builder/subrunner/index.js
@@ -93,7 +93,7 @@ function runTaskOnPackages(task, packages) {
         runComponentTask(packageDir, task, function(err) {
           if (err) {
             if (!process.env.FORCE) {
-              process.exit();
+              process.exit(1);
             }
           }
           processPackage();


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description

This makes it so `yarn build` will catch undefined variable usage.