### PR TITLE
Thumbnail object-fit

### DIFF
--- a/components/thumbnail/index.css
+++ b/components/thumbnail/index.css
@@ -81,9 +81,11 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Thumbnail-image {
-  max-height: 100%;
-  max-width: 100%;
+  height: 100%;
+  width: 100%;
   z-index: 1;
+  object-fit: cover;
+  object-position: center;
 }
 
 .spectrum-Thumbnail-background {

--- a/components/thumbnail/metadata/thumbnail.yml
+++ b/components/thumbnail/metadata/thumbnail.yml
@@ -5,7 +5,7 @@ sections:
     description: |
       ### T-shirt sizing
       Thumbnail now supports t-shirt sizing with the standard naming convention and requires that you specify the size by adding a `.spectrum-Thumbnail--size*` class.
-      
+
       Additionally, the available sizes have changed: `XXL` and `XL` have been completely removed, and `XS` and `XXS` have been added.
 
       | Deprecated Classname | New Classname           |
@@ -51,20 +51,6 @@ examples:
     markup: |
       <div class="spectrum-Thumbnail spectrum-Thumbnail--sizeM">
         <img class="spectrum-Thumbnail-image" src="img/example-card-portrait.jpg" alt="Eiffel Tower at night">
-      </div>
-  - id: thumbnail
-    name: Thumbnail (background portrait)
-    description: Portrait images set as the background will fill horizontally
-    markup: |
-      <div class="spectrum-Thumbnail spectrum-Thumbnail--sizeM">
-        <div class="spectrum-Thumbnail-background" style="background-image: url(img/example-card-portrait.jpg)" title="Eiffel Tower at night"></div>
-      </div>
-  - id: thumbnail
-    name: Thumbnail (background landscape)
-    description: Portrait images set as the background will fill vertically
-    markup: |
-      <div class="spectrum-Thumbnail spectrum-Thumbnail--sizeM">
-        <div class="spectrum-Thumbnail-background" style="background-image: url(img/example-card-landscape.jpeg)" title="Eiffel Tower at night"></div>
       </div>
   - id: thumbnail
     name: Thumbnail (image against background)

--- a/components/thumbnail/metadata/thumbnail.yml
+++ b/components/thumbnail/metadata/thumbnail.yml
@@ -19,72 +19,72 @@ sections:
       | | `.spectrum-Thumbnail--sizeXXS` |
 
 examples:
-  - id: thumbnail
+  - id: thumbnail-image
     description: Rectangular images will fill the entire space.
     name: Thumbnail
     markup: |
       <div class="spectrum-Thumbnail spectrum-Thumbnail--sizeM">
         <img class="spectrum-Thumbnail-image" src="img/thumbnail.png" alt="Woman crouching">
       </div>
-  - id: thumbnail
+  - id: thumbnail-selected
     name: Thumbnail (selected)
     markup: |
       <div class="spectrum-Thumbnail spectrum-Thumbnail--sizeM is-selected">
         <img class="spectrum-Thumbnail-image" src="img/thumbnail.png" alt="Woman crouching">
       </div>
-  - id: thumbnail
+  - id: thumbnail-focus
     name: Thumbnail (focused)
     markup: |
       <div class="spectrum-Thumbnail spectrum-Thumbnail--sizeM is-focused">
         <img class="spectrum-Thumbnail-image" src="img/thumbnail.png" alt="Woman crouching">
       </div>
-  - id: thumbnail
+  - id: thumbnail-landscape-image
     name: Thumbnail (landscape image)
     description: Landscape images will fill horizontally and have space above and below.
     markup: |
       <div class="spectrum-Thumbnail spectrum-Thumbnail--sizeM">
         <img class="spectrum-Thumbnail-image" src="img/example-card-landscape.jpeg" alt="Landscape with mountains and lake">
       </div>
-  - id: thumbnail
+  - id: thumbnail-portrait-image
     name: Thumbnail (portrait image)
     description: Portrait images will fill vertically and have space on either side.
     markup: |
       <div class="spectrum-Thumbnail spectrum-Thumbnail--sizeM">
         <img class="spectrum-Thumbnail-image" src="img/example-card-portrait.jpg" alt="Eiffel Tower at night">
       </div>
-  - id: thumbnail
+  - id: thumbnail-image-over-background
     name: Thumbnail (image against background)
-    description: Portrait images set as the background will fill vertically
+    description: Thumbnail supports transparent images with a background (color or image) behind it.
     markup: |
       <div class="spectrum-Thumbnail spectrum-Thumbnail--sizeM">
         <div class="spectrum-Thumbnail-background" style="background-color: orange"></div>
         <img class="spectrum-Thumbnail-image" src="img/thumbnail.png" alt="Woman crouching">
       </div>
-  - id: thumbnail
+  - id: thumbnail-xxs
     name: Thumbnail (XXS)
     markup: |
       <div class="spectrum-Thumbnail spectrum-Thumbnail--sizeXXS">
         <img class="spectrum-Thumbnail-image" src="img/thumbnail.png" alt="Woman crouching">
       </div>
-  - id: thumbnail
+  - id: thumbnail-xs
     name: Thumbnail (XS)
     markup: |
       <div class="spectrum-Thumbnail spectrum-Thumbnail--sizeXS">
         <img class="spectrum-Thumbnail-image" src="img/thumbnail.png" alt="Woman crouching">
       </div>
-  - id: thumbnail
+  - id: thumbnail-s
     name: Thumbnail (S)
     markup: |
       <div class="spectrum-Thumbnail spectrum-Thumbnail--sizeS">
         <img class="spectrum-Thumbnail-image" src="img/thumbnail.png" alt="Woman crouching">
       </div>
-  - id: thumbnail
+  - id: thumbnail-m
     name: Thumbnail (M, default)
     markup: |
       <div class="spectrum-Thumbnail spectrum-Thumbnail--sizeM">
         <img class="spectrum-Thumbnail-image" src="img/thumbnail.png" alt="Woman crouching">
       </div>
-  - id: thumbnail
+  - id: thumbnail-l
     name: Thumbnail (L)
     markup: |
       <div class="spectrum-Thumbnail spectrum-Thumbnail--sizeL">


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description

Since we dropped support for IE, we can eliminate the hack. This is
not a breaking change because background still has the same properties,
but if image is dropped it, it will fill by default without the
background pseudo element hack.

## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.