### PR TITLE
fix(thumbnail): prefer separate class for image covering

### DIFF
--- a/components/thumbnail/index.css
+++ b/components/thumbnail/index.css
@@ -81,9 +81,14 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Thumbnail-image {
+  max-height: 100%;
+  max-width: 100%;
+  z-index: 1;
+}
+
+.spectrum-Thumbnail-image--cover {
   height: 100%;
   width: 100%;
-  z-index: 1;
   object-fit: cover;
   object-position: center;
 }

--- a/components/thumbnail/index.css
+++ b/components/thumbnail/index.css
@@ -86,11 +86,13 @@ governing permissions and limitations under the License.
   z-index: 1;
 }
 
-.spectrum-Thumbnail-image--cover {
-  height: 100%;
-  width: 100%;
-  object-fit: cover;
-  object-position: center;
+.spectrum-Thumbnail--cover {
+  .spectrum-Thumbnail-image {
+    height: 100%;
+    width: 100%;
+    object-fit: cover;
+    object-position: center;
+  }
 }
 
 .spectrum-Thumbnail-background {

--- a/components/thumbnail/metadata/thumbnail.yml
+++ b/components/thumbnail/metadata/thumbnail.yml
@@ -18,6 +18,9 @@ sections:
       | | `.spectrum-Thumbnail--sizeXS` |
       | | `.spectrum-Thumbnail--sizeXXS` |
 
+      ### Image Cover
+      Thumbnail now offers a way to control the content inside an `img` tag via the `.spectrum-Thumbnail-image--cover` class.
+
 examples:
   - id: thumbnail-image
     description: Rectangular images will fill the entire space.
@@ -51,6 +54,13 @@ examples:
     markup: |
       <div class="spectrum-Thumbnail spectrum-Thumbnail--sizeM">
         <img class="spectrum-Thumbnail-image" src="img/example-card-portrait.jpg" alt="Eiffel Tower at night">
+      </div>
+  - id: thumbnail-landscape-image-cover
+    name: Thumbnail Cover (landscape image)
+    description: Images will maintain their aspect ratio while filling the entire content box.
+    markup: |
+      <div class="spectrum-Thumbnail spectrum-Thumbnail--sizeM">
+        <img class="spectrum-Thumbnail-image--cover" src="img/example-card-landscape.jpeg" alt="Landscape with mountains and lake">
       </div>
   - id: thumbnail-image-over-background
     name: Thumbnail (image against background)

--- a/components/thumbnail/metadata/thumbnail.yml
+++ b/components/thumbnail/metadata/thumbnail.yml
@@ -19,7 +19,7 @@ sections:
       | | `.spectrum-Thumbnail--sizeXXS` |
 
       ### Image Cover
-      Thumbnail now offers a way to control the content inside an `img` tag via the `.spectrum-Thumbnail-image--cover` class.
+      Thumbnail now offers a way to control the content inside a child `img` tag by adding a modifier `spectrum-Thumbnail--cover` class in addition to the `spectrum-Thumbnail` class.
 
 examples:
   - id: thumbnail-image
@@ -59,8 +59,8 @@ examples:
     name: Thumbnail Cover (landscape image)
     description: Images will maintain their aspect ratio while filling the entire content box.
     markup: |
-      <div class="spectrum-Thumbnail spectrum-Thumbnail--sizeM">
-        <img class="spectrum-Thumbnail-image--cover" src="img/example-card-landscape.jpeg" alt="Landscape with mountains and lake">
+      <div class="spectrum-Thumbnail spectrum-Thumbnail--cover spectrum-Thumbnail--sizeM">
+        <img class="spectrum-Thumbnail-image" src="img/example-card-landscape.jpeg" alt="Landscape with mountains and lake">
       </div>
   - id: thumbnail-image-over-background
     name: Thumbnail (image against background)


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description

This adds an additional class (`.spectrum-Thumbnail-image--cover`) for supporting image "covering" via `object-fit` and `object-position` and restores the previous behavior wherein landscape or portrait images filled horizontally or vertically, but left space between their container edges.

<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->
Closes #1134 


## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
