### PR TITLE
fix: correct match for stylesheets to replace

### DIFF
--- a/site/resources/js/SpectrumSwitcher.js
+++ b/site/resources/js/SpectrumSwitcher.js
@@ -137,7 +137,7 @@ Object.defineProperty(SpectrumSwitcher.prototype, 'varsVersion', {
     const pathNameToUpdate = (varsVersion === 'default') ? expressName : defaultName;
 
     // get all relevant stylesheets that need to be switched
-    const styleSheets = document.querySelectorAll(`link[href*="/components/${pathNameToUpdate}/"]`);
+    const styleSheets = document.querySelectorAll(`link[href*="components/${pathNameToUpdate}/"]`);
 
     // update each relevant stylesheet with the selected path
     [...styleSheets].map(sheet => {


### PR DESCRIPTION
## Description

JS code assumed the path to `components/` was always at `/`, but it's in a sub-directory on the public site.

Fixes #1351 