### PR TITLE
fix(breadcrumb): use flex-start for justify content

### DIFF
--- a/components/breadcrumb/index.css
+++ b/components/breadcrumb/index.css
@@ -36,7 +36,7 @@ governing permissions and limitations under the License.
 
 .spectrum-Breadcrumbs {
   display: flex;
-  justify-content: start;
+  justify-content: flex-start;
   list-style-type: none;
   flex-wrap: nowrap;
   flex-grow: 1;
@@ -83,7 +83,7 @@ governing permissions and limitations under the License.
 .spectrum-Breadcrumbs-item {
   display: inline-flex;
   align-items: center;
-  justify-content: start;
+  justify-content: flex-start;
 
   box-sizing: border-box;
   block-size: var(--spectrum-breadcrumb-list-height);
@@ -114,7 +114,7 @@ governing permissions and limitations under the License.
 
   display: inline-flex;
   align-items: center;
-  justify-content: start;
+  justify-content: flex-start;
 
   padding-block: 0;
   padding-inline: var(--spectrum-breadcrumb-item-padding-x);


### PR DESCRIPTION
ENG: this was probably a typo in the first place - autoprefixer flagged this when using spectrum-css, so fixing it here to get rid of the linter warning


## To-do list
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] This pull request is ready to merge.
