### PR TITLE
fix: correct focus-ring border-radius, fixes #1378

### DIFF
--- a/components/button/index.css
+++ b/components/button/index.css
@@ -111,6 +111,11 @@ governing permissions and limitations under the License.
   }
 
   --spectrum-button-focus-ring-color: var(--spectrum-button-m-primary-fill-texticon-focus-ring-color-key-focus);
+
+  /* correct focus-ring radius for t-shirt sizing */
+  &:after {
+    border-radius: calc(var(--spectrum-button-primary-fill-texticon-border-radius) + var(--spectrum-alias-focus-ring-gap));
+  }
 }
 
 a.spectrum-Button {


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->
Use the t-shirt sized border-radius variable for the focus-ring's border-radius.

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->
<img width="212" alt="image" src="https://user-images.githubusercontent.com/201344/153513543-fc6f7e8f-c16b-41b3-adc5-7705b87715a0.png">
<img width="225" alt="image" src="https://user-images.githubusercontent.com/201344/153513554-49120949-163f-4da3-bb7c-66a68d9be2fc.png">


## To-do list
- [x] This pull request is ready to merge.
