### PR TITLE
fix: correct focus-ring on Textarea when resized

### DIFF
--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -54,8 +54,6 @@ governing permissions and limitations under the License.
 .spectrum-Textfield {
   display: inline-flex;
   position: relative;
-  min-inline-size: var(--spectrum-textfield-texticon-min-width);
-  inline-size: var(--spectrum-alias-single-line-width);
 
   &.spectrum-Textfield--quiet.spectrum-Textfield--multiline
     .spectrum-Textfield-input {
@@ -98,7 +96,8 @@ governing permissions and limitations under the License.
   /* Use padding instead of text-indent because text-indent does not left align the text in Edge browser  */
   text-indent: 0;
 
-  inline-size: 100%;
+  min-inline-size: var(--spectrum-textfield-texticon-min-width);
+  inline-size: var(--spectrum-alias-single-line-width);
   block-size: var(--spectrum-textfield-texticon-height);
 
   vertical-align: top; /* used to align them correctly in forms. */


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->
Fixes the misalignment of focus-ring when resizing Textarea. Fixes #1383 

Side effect: width of textarea must be set on the input now, not the outer element.

## How and where has this been tested?
 - **How this was tested:** i resize, i focus, i smile
 - **Browser(s) and OS(s) this was tested with:** Chrome

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->
<img width="127" alt="image" src="https://user-images.githubusercontent.com/201344/154127008-69078e03-3ae2-4093-b86f-92dd99074cae.png">


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] Verify approach with @Westbrook 
- [ ] This pull request is ready to merge.
