### PR TITLE
feat(textfield): add read-only state

### DIFF
--- a/components/inputgroup/metadata/datepicker.yml
+++ b/components/inputgroup/metadata/datepicker.yml
@@ -36,6 +36,14 @@ examples:
           </div>
         </button>
       </div>
+  - id: datepicker-readonly
+    name: Read-only
+    markup: |
+      <div aria-disabled="false" aria-invalid="false" class="spectrum-InputGroup spectrum-Datepicker" aria-readonly="true" aria-required="false">
+        <div class="spectrum-Textfield spectrum-InputGroup-textfield is-readOnly">
+          <input type="text" class="spectrum-Textfield-input spectrum-InputGroup-input" placeholder="Choose a date" value="02/14/2020" readonly="readonly">
+        </div>
+      </div>
   - id: datepicker-quiet
     name: Quiet
     markup: |

--- a/components/textfield/metadata/textfield.yml
+++ b/components/textfield/metadata/textfield.yml
@@ -48,6 +48,13 @@ examples:
         <input type="text" placeholder="Enter your name" name="field" value="" class="spectrum-Textfield-input" disabled>
       </div>
 
+  - id: textfield-readonly
+    name: Read-only
+    markup: |
+      <div class="spectrum-Textfield is-readOnly">
+        <input type="text" placeholder="Enter your name" name="field" value="This text is read-only" class="spectrum-Textfield-input" readonly="readonly">
+      </div>
+
   - id: textfield
     name: Valid
     markup: |

--- a/components/textfield/skin.css
+++ b/components/textfield/skin.css
@@ -142,6 +142,16 @@ governing permissions and limitations under the License.
       color: var(--spectrum-textfield-m-texticon-placeholder-text-color-disabled);
     }
   }
+
+  .spectrum-Textfield.is-readOnly &,
+  .spectrum-Textfield.is-readOnly:hover &,
+  &:read-only {
+    background-color: var(--spectrum-alias-background-color-transparent);
+    border-color: var(--spectrum-alias-background-color-transparent);
+    color: var(--spectrum-global-color-gray-800);
+
+    -webkit-text-fill-color: var(--spectrum-global-color-gray-800);
+  }
 }
 
 .spectrum-Textfield--quiet {

--- a/site/resources/js/enhancement.js
+++ b/site/resources/js/enhancement.js
@@ -133,7 +133,7 @@ governing permissions and limitations under the License.
     var pickerButton = inputgroup.querySelector('.spectrum-PickerButton');
     if (focused) {
       inputgroup.classList.add(focusClass);
-      pickerButton.classList.add(focusClass);
+      if (pickerButton) pickerButton.classList.add(focusClass);
       if (event.target.tagName !== 'INPUT') {
         input.focus();
       }
@@ -142,8 +142,8 @@ governing permissions and limitations under the License.
         textfield.classList.add(focusClass);
       });
     } else {
-      pickerButton.classList.remove('is-keyboardFocused');
-      pickerButton.classList.remove('is-focused');
+      if (pickerButton) pickerButton.classList.remove('is-keyboardFocused');
+      if (pickerButton) pickerButton.classList.remove('is-focused');
       inputgroup.classList.remove('is-keyboardFocused');
       inputgroup.classList.remove('is-focused');
 

--- a/site/resources/js/enhancement.js
+++ b/site/resources/js/enhancement.js
@@ -469,6 +469,7 @@ function toggleInputGroupFocus(event) {
   var classList = event.target.classList;
   var closestSelector;
   // target within InputGroup
+  if (!classList) return;
   if (classList.contains('spectrum-InputGroup-input') ||
     classList.contains('spectrum-ActionButton spectrum-ActionButton--sizeM')) {
     closestSelector = '.spectrum-InputGroup';


### PR DESCRIPTION
In order to support future use cases, this adds and styles a `readonly` state to the textfield component.

It ultimately addresses the request in [CSS-30 (add readonly state to Datepicker)](https://jira.corp.adobe.com/secure/RapidBoard.jspa?rapidView=33123&projectKey=CSS&view=detail&selectedIssue=CSS-30) and adds an example to the Datepicker's documentation to show the proper markup to achieve a `readonly` Datepicker.

Additionally, this fixes two browser console errors where we were attempting to manipulate classes for elements that did not always exist.

URL for validation:
https://git.corp.adobe.com/pages/pfulton/spectrum-css-ccx-verify/docs/textfield.html

<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->


## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
