### PR TITLE
docs: add prerelease information

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,3 +388,15 @@ npm run release:bundles
 ```
 
 Version numbers for dependencies and then bundle itself will be updated automatically, a changelog generated, the package published, and the documentation site deployed.
+
+### Publishing prereleases
+
+Occasionally, it can be helpful for our subscribers to test CSS changes before they're considered ready to be part of a stable release. To facilitate this, we can publish prerelease versions.
+
+To publish prerelease versions:
+
+* First, be sure that you're working on a branch other than `main`.
+* Once your change(s) are ready to be committed, be aware of the severity of the change(s), and be sure to author your commit message so that Lerna understands how to increase the version number(s) of the affected components.
+* Once your changes are committed, run the following command to bump the version numbers (a `beta` release is shown in this example): `npx lerna publish --conventional-prerelease --preid beta --pre-dist-tag`
+* Depending on the severity of your change(s), Lerna should show a preview of your version numbers that look something like: `@spectrum-css/tag: 3.3.8 => 3.3.9-beta.0`
+* If the version number(s) look correct, you should be ready to publish to npm by running: `npm publish`


### PR DESCRIPTION
This adds documentation for how we handle prerelease versions of our components.

<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->


## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
