### PR TITLE
feat(checkbox, fieldgroup): add `readonly` state

### DIFF
--- a/components/checkbox/metadata/checkbox.yml
+++ b/components/checkbox/metadata/checkbox.yml
@@ -159,6 +159,53 @@ examples:
             <span class="spectrum-Checkbox-label">Checkbox</span>
           </label>
         </div>
+
+        <div class="spectrum-Examples-item">
+          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Read-only</h4>
+
+          <label class="spectrum-Checkbox spectrum-Checkbox--sizeM is-disabled is-readOnly">
+            <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-3" disabled>
+            <span class="spectrum-Checkbox-box">
+              <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-Checkmark100" />
+              </svg>
+              <svg class="spectrum-Icon spectrum-UIIcon-Dash100 spectrum-Checkbox-partialCheckmark" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-Dash100" />
+              </svg>
+            </span>
+            <span class="spectrum-Checkbox-label">Checkbox</span>
+          </label>
+
+          <br>
+
+          <label class="spectrum-Checkbox spectrum-Checkbox--sizeM is-disabled is-readOnly">
+            <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-4" disabled checked>
+            <span class="spectrum-Checkbox-box">
+              <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-Checkmark100" />
+              </svg>
+              <svg class="spectrum-Icon spectrum-UIIcon-Dash100 spectrum-Checkbox-partialCheckmark" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-Dash100" />
+              </svg>
+            </span>
+            <span class="spectrum-Checkbox-label">Checkbox</span>
+          </label>
+
+          <br>
+
+          <label class="spectrum-Checkbox spectrum-Checkbox--sizeM is-disabled is-indeterminate is-readOnly">
+            <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-5" disabled>
+            <span class="spectrum-Checkbox-box">
+              <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-Checkmark100" />
+              </svg>
+              <svg class="spectrum-Icon spectrum-UIIcon-Dash100 spectrum-Checkbox-partialCheckmark" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-Dash100" />
+              </svg>
+            </span>
+            <span class="spectrum-Checkbox-label">Checkbox</span>
+          </label>
+        </div>
       </div>
 
   - id: checkbox-emphasized
@@ -292,6 +339,53 @@ examples:
           <br>
 
           <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-Checkbox--emphasized is-disabled is-indeterminate">
+            <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-5" disabled>
+            <span class="spectrum-Checkbox-box">
+              <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-Checkmark100" />
+              </svg>
+              <svg class="spectrum-Icon spectrum-UIIcon-Dash100 spectrum-Checkbox-partialCheckmark" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-Dash100" />
+              </svg>
+            </span>
+            <span class="spectrum-Checkbox-label">Checkbox</span>
+          </label>
+        </div>
+
+        <div class="spectrum-Examples-item">
+          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Read-only</h4>
+
+          <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-Checkbox--emphasized is-disabled is-readOnly">
+            <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-3" disabled>
+            <span class="spectrum-Checkbox-box">
+              <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-Checkmark100" />
+              </svg>
+              <svg class="spectrum-Icon spectrum-UIIcon-Dash100 spectrum-Checkbox-partialCheckmark" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-Dash100" />
+              </svg>
+            </span>
+            <span class="spectrum-Checkbox-label">Checkbox</span>
+          </label>
+
+          <br>
+
+          <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-Checkbox--emphasized is-disabled is-readOnly">
+            <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-4" disabled checked>
+            <span class="spectrum-Checkbox-box">
+              <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-Checkmark100" />
+              </svg>
+              <svg class="spectrum-Icon spectrum-UIIcon-Dash100 spectrum-Checkbox-partialCheckmark" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-Dash100" />
+              </svg>
+            </span>
+            <span class="spectrum-Checkbox-label">Checkbox</span>
+          </label>
+
+          <br>
+
+          <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-Checkbox--emphasized is-disabled is-indeterminate is-readOnly">
             <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-5" disabled>
             <span class="spectrum-Checkbox-box">
               <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">

--- a/components/checkbox/skin.css
+++ b/components/checkbox/skin.css
@@ -95,6 +95,54 @@ governing permissions and limitations under the License.
   }
 }
 
+/*
+  readonly is not a valid attribute for input[type="checkbox"]
+  so we borrow the immutability of a disabled checkbox
+  while using the colors of a default checkbox
+*/
+.spectrum-Checkbox.is-readOnly {
+  border-color: var(--spectrum-checkbox-m-box-border-color);
+
+  &:hover {
+    .spectrum-Checkbox-box {
+      &:before {
+        border-color: var(
+          --spectrum-checkbox-m-box-border-color-hover
+        );
+      }
+    }
+    .spectrum-Checkbox-label {
+      color: var(--spectrum-checkbox-m-text-color-hover);
+    }
+  }
+
+  &:active {
+    .spectrum-Checkbox-box {
+      &:before {
+        border-color: var(--spectrum-checkbox-m-box-border-color-down);
+      }
+    }
+    .spectrum-Checkbox-label {
+      color: var(--spectrum-checkbox-m-text-color-down);
+    }
+  }
+}
+
+.spectrum-Checkbox.is-readOnly .spectrum-Checkbox-input,
+.spectrum-Checkbox.is-readOnly .spectrum-Checkbox-input:checked {
+  &:disabled + .spectrum-Checkbox-box {
+    &:before {
+      border-color: var(--spectrum-checkbox-m-box-border-color);
+      background-color: var(--spectrum-checkbox-m-box-background-color);
+    }
+  }
+
+  &:disabled ~ .spectrum-Checkbox-label {
+    forced-color-adjust: none;
+    color: var(--spectrum-checkbox-m-text-color);
+  }
+}
+
 .spectrum-Checkbox .spectrum-Checkbox-input,
 .spectrum-Checkbox .spectrum-Checkbox-input:checked {
   &:disabled + .spectrum-Checkbox-box {

--- a/components/fieldgroup/index.css
+++ b/components/fieldgroup/index.css
@@ -12,12 +12,29 @@ governing permissions and limitations under the License.
 
 .spectrum-FieldGroup {
   --spectrum-fieldgroup-margin: var(--spectrum-global-dimension-size-200);
+  --spectrum-fieldgroup-readonly-delineator: '\002c';
 }
 
 .spectrum-FieldGroup {
   display: flex;
   vertical-align: top;
   flex-wrap: wrap;
+}
+
+.spectrum-FieldGroup {
+  .spectrum-Checkbox.is-readOnly {
+    .spectrum-Checkbox-box {
+      display: none;
+    }
+
+    &:not(:last-child) {
+      .spectrum-Checkbox-label {
+        &:after {
+          content: var(--spectrum-fieldgroup-readonly-delineator)
+        }
+      }
+    }
+  }
 }
 
 .spectrum-FieldGroup--horizontal {

--- a/components/fieldgroup/metadata/fieldgroup.yml
+++ b/components/fieldgroup/metadata/fieldgroup.yml
@@ -73,6 +73,50 @@ examples:
           <span class="spectrum-Checkbox-label">Bits</span>
         </label>
       </div>
+    
+  - id: fieldgroup-readonly-checkboxes
+    name: Read-only Checkboxes
+    description: A group of read-only checkboxes that have been `checked`. In U.S. English, use commas to delineate items within read-only checkbox groups. In other languages, use the locale-specific formatting.
+    markup: |
+      <div class="spectrum-FieldGroup">
+        <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item is-disabled is-readOnly">
+          <input type="checkbox" class="spectrum-Checkbox-input" checked disabled>
+          <span class="spectrum-Checkbox-box">
+            <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Checkmark100" />
+            </svg>
+          </span>
+          <span class="spectrum-Checkbox-label">Apples</span>
+        </label>
+        <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item is-disabled is-readOnly">
+          <input type="checkbox" class="spectrum-Checkbox-input" checked disabled>
+          <span class="spectrum-Checkbox-box">
+            <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Checkmark100" />
+            </svg>
+          </span>
+          <span class="spectrum-Checkbox-label">Peaches</span>
+        </label>
+
+        <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item is-disabled is-readOnly">
+          <input type="checkbox" class="spectrum-Checkbox-input" checked disabled>
+          <span class="spectrum-Checkbox-box">
+            <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Checkmark100" />
+            </svg>
+          </span>
+          <span class="spectrum-Checkbox-label">Grapes</span>
+        </label>
+        <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item is-disabled is-readOnly">
+          <input type="checkbox" class="spectrum-Checkbox-input" checked disabled>
+          <span class="spectrum-Checkbox-box">
+            <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Checkmark100" />
+            </svg>
+          </span>
+          <span class="spectrum-Checkbox-label">Bananas</span>
+        </label>
+      </div>
 
   - id: fieldgroup-labelsbelow
     name: Radios with labels below


### PR DESCRIPTION
This adds a `readonly` option to a group of checkboxes by way of the Field Group component.

## Description
1. Provide a faux `readonly` state to the checkbox component by adopting the immutability of a `disabled` checkbox and the styles of a default checkbox. Read-only checkboxes should not be able to be changed, but their labels can be highlighted/copied/pasted.
2. Update Field Group to show a collection of `checked`, read-only checkboxes. As per design, the _actual_ checkbox UI element should be hidden, and the labels for the items should be displayed in a horizontal list, separated by a comma (in U.S. English).

For the separator character, I've provided a custom property that defaults to the unicode character for a comma. Downstream implementations will be able to modify that custom property if necessary (for internationalization, etc.)

## Design Source
* [Read-only checkbox group](https://spectrum.corp.adobe.com/page/checkbox-group/#Read-only)

## Verification URLs
* [Checkbox](https://git.corp.adobe.com/pages/pfulton/spectrum-css-ccx-verify/docs/checkbox.html)
* [Field Group](https://git.corp.adobe.com/pages/pfulton/spectrum-css-ccx-verify/docs/fieldgroup.html)

## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
