### PR TITLE
feat: add --spectrum-custom-static-content-color for setting color

### DIFF
--- a/components/actionbutton/index.css
+++ b/components/actionbutton/index.css
@@ -14,6 +14,11 @@ governing permissions and limitations under the License.
 @import "../vars/css/components/spectrum-actionbutton.css";
 @import "./actionbutton-generated.css";
 
+/* hack: don't complain about this being undefined */
+.🤫 {
+  --spectrum-custom-static-content-color: none;
+}
+
 .spectrum-ActionButton--sizeS {
   @remapvars {
     find: --spectrum-actionbutton-s-;
@@ -173,6 +178,17 @@ a.spectrum-ActionButton {
 
     &:after {
       box-shadow: 0 0 0 var(--spectrum-actionbutton-focus-ring-size) var(--spectrum-actionbutton-focus-ring-color);
+    }
+  }
+}
+
+.spectrum-ActionButton {
+  &.is-selected {
+    &.spectrum-ActionButton--staticWhite {
+      color: var(--spectrum-custom-static-content-color, black);
+    }
+    &.spectrum-ActionButton--staticBlack {
+      color: var(--spectrum-custom-static-content-color, white);
     }
   }
 }

--- a/components/actionbutton/metadata/actionbutton.yml
+++ b/components/actionbutton/metadata/actionbutton.yml
@@ -5,6 +5,7 @@ description: |
   - For Action Buttons that only contain an icon with no label, do not include the element with the `.spectrum-ActionButton-label` class in the markup
   - If an icon and a label are both used, ensure that the element with the `.spectrum-ActionButton-label` class comes after the `.spectrum-Icon` element.
   - If the hold icon is used, ensure that the element with the `.spectrum-ActionButton-hold` class comes before the `.spectrum-Icon` element.
+  - When using `.spectrum-ActionButton--staticWhite` or `.spectrum-ActionButton--staticblack`, use the `--spectrum-custom-static-content-color` custom property to set the text color when selected.
 sections:
   - name: Migration Guide
     description: |
@@ -695,8 +696,9 @@ examples:
 
   - id: actionbutton-staticwhite
     name: Static White
+    description: Use the `--spectrum-custom-static-content-color` custom property to set the text color when selected. The default is black for static white buttons.
     markup: |
-      <div style="background-color: rgb(15, 121, 125); color: rgb(15, 121, 125); padding: 15px 20px;">
+      <div style="background-color: rgb(15, 121, 125); --spectrum-custom-static-content-color: rgb(15, 121, 125); padding: 15px 20px;">
         <div class="spectrum-Examples">
           <div class="spectrum-Examples-item">
             <h4 style="color: white" class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Default</h4>
@@ -827,8 +829,9 @@ examples:
 
   - id: actionbutton-staticblack
     name: Static Black
+    description: Use the `--spectrum-custom-static-content-color` custom property to set the text color when selected. The default is white for static black buttons.
     markup: |
-      <div style="background-color: rgb(181, 209, 211); color: rgb(181, 209, 211); padding: 15px 20px;">
+      <div style="background-color: rgb(181, 209, 211); --spectrum-custom-static-content-color: rgb(181, 209, 211); padding: 15px 20px;">
         <div class="spectrum-Examples">
           <div class="spectrum-Examples-item">
             <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Default</h4>
@@ -961,7 +964,7 @@ examples:
   - id: actionbutton-staticwhite-quiet
     name: Static White (quiet)
     markup: |
-      <div style="background-color: rgb(15, 121, 125); color: rgb(15, 121, 125); padding: 15px 20px;">
+      <div style="background-color: rgb(15, 121, 125); --spectrum-custom-static-content-color: rgb(15, 121, 125); padding: 15px 20px;">
         <div class="spectrum-Examples">
           <div class="spectrum-Examples-item">
             <h4 style="color: white" class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Default</h4>
@@ -1093,7 +1096,7 @@ examples:
   - id: actionbutton-staticblack-quiet
     name: Static Black (quiet)
     markup: |
-      <div style="background-color: rgb(181, 209, 211); color: rgb(181, 209, 211); padding: 15px 20px;">
+      <div style="background-color: rgb(181, 209, 211); --spectrum-custom-static-content-color: rgb(181, 209, 211); padding: 15px 20px;">
         <div class="spectrum-Examples">
           <div class="spectrum-Examples-item">
             <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Default</h4>

--- a/components/actionbutton/skin.css
+++ b/components/actionbutton/skin.css
@@ -264,11 +264,6 @@ governing permissions and limitations under the License.
   --spectrum-global-color-static-white-rgb: 255, 255, 255;
   --spectrum-ActionButton-static-black-color: var(--spectrum-global-color-static-black);
   --spectrum-ActionButton-static-white-color: var(--spectrum-global-color-static-white);
-
-  &.is-selected {
-    /* let selected styles get their color from parent elements */
-    color: inherit !important;
-  }
 }
 
 @media (forced-colors: active) {

--- a/components/button/index.css
+++ b/components/button/index.css
@@ -17,6 +17,11 @@ governing permissions and limitations under the License.
 
 @import "./skin.css";
 
+/* hack: don't complain about this being undefined */
+.🤫 {
+  --spectrum-custom-static-content-color: none;
+}
+
 .spectrum-Button--sizeS {
   @remapvars {
     find: /--spectrum-button(.*)-s-/;
@@ -141,10 +146,12 @@ a.spectrum-Button {
 
 .spectrum-Button--staticWhite {
   --spectrum-button-focus-ring-color: var(--spectrum-button-m-primary-fill-white-texticon-focus-ring-color-key-focus);
+  color: var(--spectrum-custom-static-content-color, black);
 }
 
 .spectrum-Button--staticBlack {
   --spectrum-button-focus-ring-color: var(--spectrum-button-m-primary-fill-black-texticon-focus-ring-color-key-focus);
+  color: var(--spectrum-custom-static-content-color, white);
 }
 
 /* todo all of this will have to change */

--- a/components/button/metadata/button-staticcolor.yml
+++ b/components/button/metadata/button-staticcolor.yml
@@ -1,6 +1,8 @@
 name: Button - Static Color
 status: Verified
-description: 'When a button needs to be placed on top of a colored background or a visual, use the over background button. In order to implement this button, you must set the CSS color property of a parent element to the same value as the background the button is placed against.'
+description: |
+  When a button needs to be placed on top of a colored background or a visual, use the static color button.
+  To customize the content color, set the `--spectrum-custom-static-content-color` CSS custom property of a parent element to the same value as the background the button is placed against.
 SpectrumSiteSlug: https://spectrum.adobe.com/page/button/#Over-background
 sections:
   - name: Migration Guide
@@ -30,8 +32,9 @@ sections:
 examples:
   - id: button-staticcolor
     name: Static White
+    description: Use the `--spectrum-custom-static-content-color` custom property to set the text color. The default is black for static white buttons.
     markup: |
-      <div style="background-color: rgb(15, 121, 125); color: rgb(15, 121, 125); --spectrum-alias-heading-text-color: white; padding: 15px 20px;">
+      <div style="background-color: rgb(15, 121, 125); --spectrum-custom-static-content-color: rgb(15, 121, 125); --spectrum-alias-heading-text-color: white; padding: 15px 20px;">
         <div class="spectrum-Examples">
           <div class="spectrum-Examples-item">
             <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">S</h4>
@@ -97,7 +100,7 @@ examples:
   - id: button-staticcolor
     name: Static White - Disabled
     markup: |
-      <div style="background-color: rgb(15, 121, 125); color: rgb(15, 121, 125); padding: 15px 20px;">
+      <div style="background-color: rgb(15, 121, 125); --spectrum-custom-static-content-color: rgb(15, 121, 125); padding: 15px 20px;">
         <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--fill spectrum-Button--staticWhite" disabled>
           <span class="spectrum-Button-label">Edit</span>
         </button>
@@ -113,7 +116,7 @@ examples:
   - id: button-staticcolor
     name: Static White - Secondary
     markup: |
-      <div style="background-color: rgb(15, 121, 125); color: rgb(15, 121, 125); padding: 15px 20px;">
+      <div style="background-color: rgb(15, 121, 125); --spectrum-custom-static-content-color: rgb(15, 121, 125); padding: 15px 20px;">
         <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--fill spectrum-Button--staticWhite spectrum-Button--secondary">
           <span class="spectrum-Button-label">Edit</span>
         </button>
@@ -128,8 +131,9 @@ examples:
 
   - id: button-staticcolor
     name: Static Black
+    description: Use the `--spectrum-custom-static-content-color` custom property to set the text color. The default is white for static black buttons.
     markup: |
-      <div style="background-color: rgb(181, 209, 211); color: rgb(181, 209, 211); padding: 15px 20px;">
+      <div style="background-color: rgb(181, 209, 211); --spectrum-custom-static-content-color: rgb(181, 209, 211); padding: 15px 20px;">
         <div class="spectrum-Examples">
           <div class="spectrum-Examples-item">
             <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">S</h4>
@@ -195,7 +199,7 @@ examples:
   - id: button-staticcolor
     name: Static Black - Disabled
     markup: |
-      <div style="background-color: rgb(181, 209, 211); color: rgb(181, 209, 211); padding: 15px 20px;">
+      <div style="background-color: rgb(181, 209, 211); --spectrum-custom-static-content-color: rgb(181, 209, 211); padding: 15px 20px;">
         <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--fill spectrum-Button--staticBlack" disabled>
           <span class="spectrum-Button-label">Edit</span>
         </button>
@@ -211,7 +215,7 @@ examples:
   - id: button-staticcolor
     name: Static Black - Secondary
     markup: |
-      <div style="background-color: rgb(181, 209, 211); color: rgb(181, 209, 211); padding: 15px 20px;">
+      <div style="background-color: rgb(181, 209, 211); --spectrum-custom-static-content-color: rgb(181, 209, 211); padding: 15px 20px;">
         <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--fill spectrum-Button--staticBlack spectrum-Button--secondary">
           <span class="spectrum-Button-label">Edit</span>
         </button>
@@ -227,7 +231,7 @@ examples:
   - id: button-staticcolor
     name: Static White - Outline
     markup: |
-      <div style="background-color: rgb(15, 121, 125); color: rgb(15, 121, 125); --spectrum-alias-heading-text-color: white; padding: 15px 20px;">
+      <div style="background-color: rgb(15, 121, 125); --spectrum-custom-static-content-color: rgb(15, 121, 125); --spectrum-alias-heading-text-color: white; padding: 15px 20px;">
         <div class="spectrum-Examples">
           <div class="spectrum-Examples-item">
             <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">S</h4>
@@ -293,7 +297,7 @@ examples:
   - id: button-staticcolor
     name: Static White - Outline, Disabled
     markup: |
-      <div style="background-color: rgb(15, 121, 125); color: rgb(15, 121, 125); padding: 15px 20px;">
+      <div style="background-color: rgb(15, 121, 125); --spectrum-custom-static-content-color: rgb(15, 121, 125); padding: 15px 20px;">
         <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--outline spectrum-Button--staticWhite" disabled>
           <span class="spectrum-Button-label">Edit</span>
         </button>
@@ -309,7 +313,7 @@ examples:
   - id: button-staticcolor
     name: Static White - Outline, Secondary
     markup: |
-      <div style="background-color: rgb(15, 121, 125); color: rgb(15, 121, 125); padding: 15px 20px;">
+      <div style="background-color: rgb(15, 121, 125); --spectrum-custom-static-content-color: rgb(15, 121, 125); padding: 15px 20px;">
         <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--outline spectrum-Button--staticWhite spectrum-Button--secondary">
           <span class="spectrum-Button-label">Edit</span>
         </button>
@@ -325,7 +329,7 @@ examples:
   - id: button-staticcolor
     name: Static Black - Outline
     markup: |
-      <div style="background-color: rgb(181, 209, 211); color: rgb(181, 209, 211); padding: 15px 20px;">
+      <div style="background-color: rgb(181, 209, 211); --spectrum-custom-static-content-color: rgb(181, 209, 211); padding: 15px 20px;">
         <div class="spectrum-Examples">
           <div class="spectrum-Examples-item">
             <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">S</h4>
@@ -391,7 +395,7 @@ examples:
   - id: button-staticcolor
     name: Static Black - Outline, Disabled
     markup: |
-      <div style="background-color: rgb(181, 209, 211); color: rgb(181, 209, 211); padding: 15px 20px;">
+      <div style="background-color: rgb(181, 209, 211); --spectrum-custom-static-content-color: rgb(181, 209, 211); padding: 15px 20px;">
         <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--outline spectrum-Button--staticBlack" disabled>
           <span class="spectrum-Button-label">Edit</span>
         </button>
@@ -407,7 +411,7 @@ examples:
   - id: button-staticcolor
     name: Static Black - Outline, Secondary
     markup: |
-      <div style="background-color: rgb(181, 209, 211); color: rgb(181, 209, 211); padding: 15px 20px;">
+      <div style="background-color: rgb(181, 209, 211); --spectrum-custom-static-content-color: rgb(181, 209, 211); padding: 15px 20px;">
         <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--outline spectrum-Button--staticBlack spectrum-Button--secondary">
           <span class="spectrum-Button-label">Edit</span>
         </button>


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description

This replaces `color` as a mechanism for customizing the content color and adds a default color for static white and static  black Buttons and ActionButtons

BREAKING CHANGE: this replaces the usage of color

Closes #1425 

## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] Validate this API with Spectrum Web Components
- [ ] Consider the `-custom` suffix with engineering
- [ ] Nail the naming of the custom property with content strategy
