### PR TITLE
fix: add missing dependency for component-builder

### DIFF
--- a/tools/component-builder/package.json
+++ b/tools/component-builder/package.json
@@ -47,6 +47,7 @@
     "postcss-selector-parser": "^6.0.2",
     "postcss-svg": "^3.0.0",
     "postcss-values-parser": "^3.1.1",
+    "postcss-droproot": "^1.0.3",
     "pug": "^3.0.1",
     "replace-ext": "^1.0.0",
     "through2": "^3.0.1"


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
It wasn't possible to install this outside of the monorepo before this change.

This was discovered when trying to update @spectrum-css/component-builder in React Spectrum (install failed).