### PR TITLE
fix: resolve peerDependencies issues

### DIFF
--- a/components/accordion/package.json
+++ b/components/accordion/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/actionbar/package.json
+++ b/components/actionbar/package.json
@@ -18,7 +18,7 @@
   "peerDependencies": {
     "@spectrum-css/actionbutton": "^1.1.13",
     "@spectrum-css/actiongroup": "^1.0.25",
-    "@spectrum-css/checkbox": "^3.0.11-beta.0",
+    "@spectrum-css/checkbox": "^3.1.1",
     "@spectrum-css/icon": "^3.0.11-beta.0",
     "@spectrum-css/popover": "^5.0.0",
     "@spectrum-css/vars": "^8.0.0"

--- a/components/actionbar/package.json
+++ b/components/actionbar/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/actionbutton": "^1.1.1-beta.0",
+    "@spectrum-css/actionbutton": "^1.1.13",
     "@spectrum-css/actiongroup": "^1.0.12-beta.0",
     "@spectrum-css/checkbox": "^3.0.11-beta.0",
     "@spectrum-css/icon": "^3.0.11-beta.0",

--- a/components/actionbar/package.json
+++ b/components/actionbar/package.json
@@ -19,7 +19,7 @@
     "@spectrum-css/actionbutton": "^1.1.13",
     "@spectrum-css/actiongroup": "^1.0.25",
     "@spectrum-css/checkbox": "^3.1.1",
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/popover": "^5.0.0",
     "@spectrum-css/vars": "^8.0.0"
   },

--- a/components/actionbar/package.json
+++ b/components/actionbar/package.json
@@ -17,7 +17,7 @@
   },
   "peerDependencies": {
     "@spectrum-css/actionbutton": "^1.1.13",
-    "@spectrum-css/actiongroup": "^1.0.12-beta.0",
+    "@spectrum-css/actiongroup": "^1.0.25",
     "@spectrum-css/checkbox": "^3.0.11-beta.0",
     "@spectrum-css/icon": "^3.0.11-beta.0",
     "@spectrum-css/popover": "^5.0.0",

--- a/components/actiongroup/package.json
+++ b/components/actiongroup/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/actionbutton": "^1.1.1-beta.0",
+    "@spectrum-css/actionbutton": "^1.1.13",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/actionmenu/package.json
+++ b/components/actionmenu/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/actionbutton": "^1.1.1-beta.0",
+    "@spectrum-css/actionbutton": "^1.1.13",
     "@spectrum-css/icon": "^3.0.11-beta.0",
     "@spectrum-css/menu": "^4.0.0",
     "@spectrum-css/popover": "^5.0.0",

--- a/components/actionmenu/package.json
+++ b/components/actionmenu/package.json
@@ -17,7 +17,7 @@
   },
   "peerDependencies": {
     "@spectrum-css/actionbutton": "^1.1.13",
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/menu": "^4.0.0",
     "@spectrum-css/popover": "^5.0.0",
     "@spectrum-css/vars": "^8.0.0"

--- a/components/assetcard/package.json
+++ b/components/assetcard/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/checkbox": "^3.0.11-beta.0",
+    "@spectrum-css/checkbox": "^3.1.1",
     "@spectrum-css/icon": "^3.0.11-beta.0",
     "@spectrum-css/typography": "^4.0.8-beta.0",
     "@spectrum-css/vars": "^8.0.0"

--- a/components/assetcard/package.json
+++ b/components/assetcard/package.json
@@ -18,7 +18,7 @@
   "peerDependencies": {
     "@spectrum-css/checkbox": "^3.1.1",
     "@spectrum-css/icon": "^3.0.21",
-    "@spectrum-css/typography": "^4.0.8-beta.0",
+    "@spectrum-css/typography": "^4.0.18",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/assetcard/package.json
+++ b/components/assetcard/package.json
@@ -17,7 +17,7 @@
   },
   "peerDependencies": {
     "@spectrum-css/checkbox": "^3.1.1",
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/typography": "^4.0.8-beta.0",
     "@spectrum-css/vars": "^8.0.0"
   },

--- a/components/assetlist/package.json
+++ b/components/assetlist/package.json
@@ -17,7 +17,7 @@
   },
   "peerDependencies": {
     "@spectrum-css/checkbox": "^3.1.1",
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/assetlist/package.json
+++ b/components/assetlist/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/checkbox": "^3.0.11-beta.0",
+    "@spectrum-css/checkbox": "^3.1.1",
     "@spectrum-css/icon": "^3.0.11-beta.0",
     "@spectrum-css/vars": "^8.0.0"
   },

--- a/components/breadcrumb/package.json
+++ b/components/breadcrumb/package.json
@@ -17,7 +17,7 @@
   },
   "peerDependencies": {
     "@spectrum-css/actionbutton": "^1.1.13",
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/breadcrumb/package.json
+++ b/components/breadcrumb/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/actionbutton": "^1.1.1-beta.0",
+    "@spectrum-css/actionbutton": "^1.1.13",
     "@spectrum-css/icon": "^3.0.11-beta.0",
     "@spectrum-css/vars": "^8.0.0"
   },

--- a/components/calendar/package.json
+++ b/components/calendar/package.json
@@ -17,7 +17,7 @@
   },
   "peerDependencies": {
     "@spectrum-css/actionbutton": "^1.1.13",
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/calendar/package.json
+++ b/components/calendar/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/actionbutton": "^1.1.1-beta.0",
+    "@spectrum-css/actionbutton": "^1.1.13",
     "@spectrum-css/icon": "^3.0.11-beta.0",
     "@spectrum-css/vars": "^8.0.0"
   },

--- a/components/card/package.json
+++ b/components/card/package.json
@@ -17,10 +17,10 @@
   },
   "peerDependencies": {
     "@spectrum-css/actionbutton": "^1.1.13",
-    "@spectrum-css/asset": "^3.0.10-beta.0",
+    "@spectrum-css/asset": "^3.0.20",
     "@spectrum-css/checkbox": "^3.1.1",
     "@spectrum-css/icon": "^3.0.21",
-    "@spectrum-css/quickaction": "^3.0.12-beta.0",
+    "@spectrum-css/quickaction": "^3.0.24",
     "@spectrum-css/typography": "^4.0.18",
     "@spectrum-css/vars": "^8.0.0"
   },

--- a/components/card/package.json
+++ b/components/card/package.json
@@ -18,7 +18,7 @@
   "peerDependencies": {
     "@spectrum-css/actionbutton": "^1.1.13",
     "@spectrum-css/asset": "^3.0.10-beta.0",
-    "@spectrum-css/checkbox": "^3.0.11-beta.0",
+    "@spectrum-css/checkbox": "^3.1.1",
     "@spectrum-css/icon": "^3.0.11-beta.0",
     "@spectrum-css/quickaction": "^3.0.12-beta.0",
     "@spectrum-css/typography": "^4.0.8-beta.0",

--- a/components/card/package.json
+++ b/components/card/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/actionbutton": "^1.1.1-beta.0",
+    "@spectrum-css/actionbutton": "^1.1.13",
     "@spectrum-css/asset": "^3.0.10-beta.0",
     "@spectrum-css/checkbox": "^3.0.11-beta.0",
     "@spectrum-css/icon": "^3.0.11-beta.0",

--- a/components/card/package.json
+++ b/components/card/package.json
@@ -21,7 +21,7 @@
     "@spectrum-css/checkbox": "^3.1.1",
     "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/quickaction": "^3.0.12-beta.0",
-    "@spectrum-css/typography": "^4.0.8-beta.0",
+    "@spectrum-css/typography": "^4.0.18",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/card/package.json
+++ b/components/card/package.json
@@ -19,7 +19,7 @@
     "@spectrum-css/actionbutton": "^1.1.13",
     "@spectrum-css/asset": "^3.0.10-beta.0",
     "@spectrum-css/checkbox": "^3.1.1",
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/quickaction": "^3.0.12-beta.0",
     "@spectrum-css/typography": "^4.0.8-beta.0",
     "@spectrum-css/vars": "^8.0.0"

--- a/components/checkbox/package.json
+++ b/components/checkbox/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/cyclebutton/package.json
+++ b/components/cyclebutton/package.json
@@ -17,7 +17,7 @@
   },
   "peerDependencies": {
     "@spectrum-css/actionbutton": "^1.1.13",
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/cyclebutton/package.json
+++ b/components/cyclebutton/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/actionbutton": "^1.1.1-beta.0",
+    "@spectrum-css/actionbutton": "^1.1.13",
     "@spectrum-css/icon": "^3.0.11-beta.0",
     "@spectrum-css/vars": "^8.0.0"
   },

--- a/components/dial/package.json
+++ b/components/dial/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/dropindicator/package.json
+++ b/components/dropindicator/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/dropzone/package.json
+++ b/components/dropzone/package.json
@@ -17,7 +17,7 @@
   },
   "peerDependencies": {
     "@spectrum-css/illustratedmessage": "^4.0.0",
-    "@spectrum-css/link": "^3.1.11-beta.0",
+    "@spectrum-css/link": "^3.1.21",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/fieldgroup/package.json
+++ b/components/fieldgroup/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/checkbox": "^3.0.11-beta.0",
+    "@spectrum-css/checkbox": "^3.1.1",
     "@spectrum-css/icon": "^3.0.11-beta.0",
     "@spectrum-css/radio": "^3.0.11-beta.0",
     "@spectrum-css/vars": "^8.0.0"

--- a/components/fieldgroup/package.json
+++ b/components/fieldgroup/package.json
@@ -17,7 +17,7 @@
   },
   "peerDependencies": {
     "@spectrum-css/checkbox": "^3.1.1",
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/radio": "^3.0.11-beta.0",
     "@spectrum-css/vars": "^8.0.0"
   },

--- a/components/fieldgroup/package.json
+++ b/components/fieldgroup/package.json
@@ -18,7 +18,7 @@
   "peerDependencies": {
     "@spectrum-css/checkbox": "^3.1.1",
     "@spectrum-css/icon": "^3.0.21",
-    "@spectrum-css/radio": "^3.0.11-beta.0",
+    "@spectrum-css/radio": "^3.0.22",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/fieldlabel/package.json
+++ b/components/fieldlabel/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/helptext/package.json
+++ b/components/helptext/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/illustratedmessage/package.json
+++ b/components/illustratedmessage/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/typography": "^4.0.8-beta.0",
+    "@spectrum-css/typography": "^4.0.18",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/inlinealert/package.json
+++ b/components/inlinealert/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/inputgroup/package.json
+++ b/components/inputgroup/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/pickerbutton": "^1.1.3-beta.0",
+    "@spectrum-css/pickerbutton": "^1.1.18",
     "@spectrum-css/popover": "^5.0.0",
     "@spectrum-css/vars": "^8.0.0"
   },

--- a/components/menu/package.json
+++ b/components/menu/package.json
@@ -17,7 +17,7 @@
   },
   "peerDependencies": {
     "@spectrum-css/divider": "^1.0.23",
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/miller/package.json
+++ b/components/miller/package.json
@@ -18,7 +18,7 @@
   "peerDependencies": {
     "@spectrum-css/assetlist": "^3.0.11-beta.0",
     "@spectrum-css/checkbox": "^3.1.1",
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/miller/package.json
+++ b/components/miller/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/assetlist": "^3.0.11-beta.0",
+    "@spectrum-css/assetlist": "^3.0.22",
     "@spectrum-css/checkbox": "^3.1.1",
     "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/vars": "^8.0.0"

--- a/components/miller/package.json
+++ b/components/miller/package.json
@@ -17,7 +17,7 @@
   },
   "peerDependencies": {
     "@spectrum-css/assetlist": "^3.0.11-beta.0",
-    "@spectrum-css/checkbox": "^3.0.11-beta.0",
+    "@spectrum-css/checkbox": "^3.1.1",
     "@spectrum-css/icon": "^3.0.11-beta.0",
     "@spectrum-css/vars": "^8.0.0"
   },

--- a/components/pagination/package.json
+++ b/components/pagination/package.json
@@ -20,7 +20,7 @@
     "@spectrum-css/button": "^6.0.0",
     "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/splitbutton": "^5.0.0",
-    "@spectrum-css/textfield": "^3.1.2-beta.0",
+    "@spectrum-css/textfield": "^3.2.2",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/pagination/package.json
+++ b/components/pagination/package.json
@@ -18,7 +18,7 @@
   "peerDependencies": {
     "@spectrum-css/actionbutton": "^1.1.13",
     "@spectrum-css/button": "^6.0.0",
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/splitbutton": "^5.0.0",
     "@spectrum-css/textfield": "^3.1.2-beta.0",
     "@spectrum-css/vars": "^8.0.0"

--- a/components/pagination/package.json
+++ b/components/pagination/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/actionbutton": "^1.1.1-beta.0",
+    "@spectrum-css/actionbutton": "^1.1.13",
     "@spectrum-css/button": "^6.0.0",
     "@spectrum-css/icon": "^3.0.11-beta.0",
     "@spectrum-css/splitbutton": "^5.0.0",

--- a/components/picker/package.json
+++ b/components/picker/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/actionbutton": "^1.1.1-beta.0",
+    "@spectrum-css/actionbutton": "^1.1.13",
     "@spectrum-css/icon": "^3.0.11-beta.0",
     "@spectrum-css/menu": "^4.0.0",
     "@spectrum-css/popover": "^5.0.0",

--- a/components/picker/package.json
+++ b/components/picker/package.json
@@ -17,7 +17,7 @@
   },
   "peerDependencies": {
     "@spectrum-css/actionbutton": "^1.1.13",
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/menu": "^4.0.0",
     "@spectrum-css/popover": "^5.0.0",
     "@spectrum-css/vars": "^8.0.0"

--- a/components/pickerbutton/package.json
+++ b/components/pickerbutton/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/menu": "^4.0.0",
     "@spectrum-css/popover": "^5.0.0",
     "@spectrum-css/vars": "^8.0.0"

--- a/components/progressbar/package.json
+++ b/components/progressbar/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/fieldlabel": "^4.0.8-beta.0",
+    "@spectrum-css/fieldlabel": "^4.0.24",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/quickaction/package.json
+++ b/components/quickaction/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/actionbutton": "^1.1.1-beta.0",
+    "@spectrum-css/actionbutton": "^1.1.13",
     "@spectrum-css/checkbox": "^3.0.11-beta.0",
     "@spectrum-css/vars": "^8.0.0"
   },

--- a/components/quickaction/package.json
+++ b/components/quickaction/package.json
@@ -17,7 +17,7 @@
   },
   "peerDependencies": {
     "@spectrum-css/actionbutton": "^1.1.13",
-    "@spectrum-css/checkbox": "^3.0.11-beta.0",
+    "@spectrum-css/checkbox": "^3.1.1",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/radio/package.json
+++ b/components/radio/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/rating/package.json
+++ b/components/rating/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/search/package.json
+++ b/components/search/package.json
@@ -17,7 +17,7 @@
   },
   "peerDependencies": {
     "@spectrum-css/clearbutton": "^1.1.0-beta.0",
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/textfield": "^3.1.2-beta.0",
     "@spectrum-css/vars": "^8.0.0"
   },

--- a/components/search/package.json
+++ b/components/search/package.json
@@ -16,9 +16,9 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/clearbutton": "^1.1.0-beta.0",
+    "@spectrum-css/clearbutton": "^1.2.10",
     "@spectrum-css/icon": "^3.0.21",
-    "@spectrum-css/textfield": "^3.1.2-beta.0",
+    "@spectrum-css/textfield": "^3.2.2",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/steplist/package.json
+++ b/components/steplist/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/stepper/package.json
+++ b/components/stepper/package.json
@@ -18,7 +18,7 @@
   "peerDependencies": {
     "@spectrum-css/actionbutton": "^1.1.13",
     "@spectrum-css/icon": "^3.0.21",
-    "@spectrum-css/textfield": "^3.1.2-beta.0",
+    "@spectrum-css/textfield": "^3.2.2",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/stepper/package.json
+++ b/components/stepper/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/actionbutton": "^1.1.1-beta.0",
+    "@spectrum-css/actionbutton": "^1.1.13",
     "@spectrum-css/icon": "^3.0.11-beta.0",
     "@spectrum-css/textfield": "^3.1.2-beta.0",
     "@spectrum-css/vars": "^8.0.0"

--- a/components/stepper/package.json
+++ b/components/stepper/package.json
@@ -17,7 +17,7 @@
   },
   "peerDependencies": {
     "@spectrum-css/actionbutton": "^1.1.13",
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/textfield": "^3.1.2-beta.0",
     "@spectrum-css/vars": "^8.0.0"
   },

--- a/components/table/package.json
+++ b/components/table/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/tabs/package.json
+++ b/components/tabs/package.json
@@ -17,7 +17,7 @@
   },
   "peerDependencies": {
     "@spectrum-css/menu": "^4.0.0",
-    "@spectrum-css/picker": "^1.1.6-beta.0",
+    "@spectrum-css/picker": "^1.2.7",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/tag/package.json
+++ b/components/tag/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/clearbutton": "^1.1.0-beta.0",
+    "@spectrum-css/clearbutton": "^1.2.10",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/taggroup/package.json
+++ b/components/taggroup/package.json
@@ -16,8 +16,8 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/clearbutton": "^1.1.0-beta.0",
-    "@spectrum-css/tag": "^3.2.0-beta.0",
+    "@spectrum-css/clearbutton": "^1.2.10",
+    "@spectrum-css/tag": "^3.3.12",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/tooltip/package.json
+++ b/components/tooltip/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/tray/package.json
+++ b/components/tray/package.json
@@ -18,7 +18,7 @@
   "peerDependencies": {
     "@spectrum-css/button": "^6.0.0",
     "@spectrum-css/icon": "^3.0.21",
-    "@spectrum-css/modal": "^3.0.10-beta.0",
+    "@spectrum-css/modal": "^3.0.20",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/tray/package.json
+++ b/components/tray/package.json
@@ -17,7 +17,7 @@
   },
   "peerDependencies": {
     "@spectrum-css/button": "^6.0.0",
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/modal": "^3.0.10-beta.0",
     "@spectrum-css/vars": "^8.0.0"
   },

--- a/components/treeview/package.json
+++ b/components/treeview/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
This updates a number of components' `package.json` files, where the versions of dependencies listed as `peerDependencies` did not match the versions listed as `devDependencies`.

Another team tried to install `@spectrum-css/card` via `npm install` and encountered an "unable to resolve dependency tree" error. This error is due to how npm handles peer dependencies in versions newer than `6.x.x`. Running `npm install xxxx --legacy-peer-deps` will get around this issue, but shouldn't be relied upon in long-term scenarios. There's a good Stack Overflow post [here](https://stackoverflow.com/questions/66239691/what-does-npm-install-legacy-peer-deps-do-exactly-when-is-it-recommended-wh) with more information.

Specifically for Spectrum CSS, it appears that we have incorrect peer dependencies defined in a few of our packages which is causing this issue. This PR should fix that issue.


## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
