### PR TITLE
fix: use stricter comparision for peerDependency version semver checks

### DIFF
--- a/components/accordion/package.json
+++ b/components/accordion/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/actionbar/package.json
+++ b/components/actionbar/package.json
@@ -16,11 +16,11 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/actionbutton": "^1.1.1-beta.0",
-    "@spectrum-css/actiongroup": "^1.0.12-beta.0",
-    "@spectrum-css/checkbox": "^3.0.11-beta.0",
-    "@spectrum-css/icon": "^3.0.11-beta.0",
-    "@spectrum-css/popover": "^5.0.0",
+    "@spectrum-css/actionbutton": "^1.1.13",
+    "@spectrum-css/actiongroup": "^1.0.25",
+    "@spectrum-css/checkbox": "^3.1.1",
+    "@spectrum-css/icon": "^3.0.21",
+    "@spectrum-css/popover": "^5.0.14",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/actiongroup/package.json
+++ b/components/actiongroup/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/actionbutton": "^1.1.1-beta.0",
+    "@spectrum-css/actionbutton": "^1.1.13",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/actionmenu/package.json
+++ b/components/actionmenu/package.json
@@ -16,10 +16,10 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/actionbutton": "^1.1.1-beta.0",
-    "@spectrum-css/icon": "^3.0.11-beta.0",
-    "@spectrum-css/menu": "^4.0.0",
-    "@spectrum-css/popover": "^5.0.0",
+    "@spectrum-css/actionbutton": "^1.1.13",
+    "@spectrum-css/icon": "^3.0.21",
+    "@spectrum-css/menu": "^4.0.2",
+    "@spectrum-css/popover": "^5.0.14",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/assetcard/package.json
+++ b/components/assetcard/package.json
@@ -16,9 +16,9 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/checkbox": "^3.0.11-beta.0",
-    "@spectrum-css/icon": "^3.0.11-beta.0",
-    "@spectrum-css/typography": "^4.0.8-beta.0",
+    "@spectrum-css/checkbox": "^3.1.1",
+    "@spectrum-css/icon": "^3.0.21",
+    "@spectrum-css/typography": "^4.0.18",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/assetlist/package.json
+++ b/components/assetlist/package.json
@@ -16,8 +16,8 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/checkbox": "^3.0.11-beta.0",
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/checkbox": "^3.1.1",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/breadcrumb/package.json
+++ b/components/breadcrumb/package.json
@@ -16,8 +16,8 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/actionbutton": "^1.1.1-beta.0",
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/actionbutton": "^1.1.13",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/buttongroup/package.json
+++ b/components/buttongroup/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/button": "^6.0.0",
+    "@spectrum-css/button": "^6.0.11",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/calendar/package.json
+++ b/components/calendar/package.json
@@ -16,8 +16,8 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/actionbutton": "^1.1.1-beta.0",
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/actionbutton": "^1.1.13",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/card/package.json
+++ b/components/card/package.json
@@ -16,12 +16,12 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/actionbutton": "^1.1.1-beta.0",
-    "@spectrum-css/asset": "^3.0.10-beta.0",
-    "@spectrum-css/checkbox": "^3.0.11-beta.0",
-    "@spectrum-css/icon": "^3.0.11-beta.0",
-    "@spectrum-css/quickaction": "^3.0.12-beta.0",
-    "@spectrum-css/typography": "^4.0.8-beta.0",
+    "@spectrum-css/actionbutton": "^1.1.13",
+    "@spectrum-css/asset": "^3.0.20",
+    "@spectrum-css/checkbox": "^3.1.1",
+    "@spectrum-css/icon": "^3.0.21",
+    "@spectrum-css/quickaction": "^3.0.24",
+    "@spectrum-css/typography": "^4.0.18",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/checkbox/package.json
+++ b/components/checkbox/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/coachmark/package.json
+++ b/components/coachmark/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/button": "^6.0.0",
+    "@spectrum-css/button": "^6.0.11",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/colorarea/package.json
+++ b/components/colorarea/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/colorhandle": "^2.0.0",
+    "@spectrum-css/colorhandle": "^2.0.6",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/colorhandle/package.json
+++ b/components/colorhandle/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/colorloupe": "^2.0.0",
+    "@spectrum-css/colorloupe": "^2.0.6",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/colorslider/package.json
+++ b/components/colorslider/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/colorhandle": "^2.0.0",
+    "@spectrum-css/colorhandle": "^2.0.6",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/colorwheel/package.json
+++ b/components/colorwheel/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/colorhandle": "^2.0.0",
+    "@spectrum-css/colorhandle": "^2.0.6",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/cyclebutton/package.json
+++ b/components/cyclebutton/package.json
@@ -16,8 +16,8 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/actionbutton": "^1.1.1-beta.0",
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/actionbutton": "^1.1.13",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/dial/package.json
+++ b/components/dial/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/dialog/package.json
+++ b/components/dialog/package.json
@@ -16,13 +16,13 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/button": "^6.0.1",
-    "@spectrum-css/buttongroup": "^5.0.1",
-    "@spectrum-css/closebutton": "^1.2.1",
-    "@spectrum-css/divider": "^1.0.14",
-    "@spectrum-css/icon": "^3.0.13",
-    "@spectrum-css/modal": "^3.0.12",
-    "@spectrum-css/underlay": "^2.0.21",
+    "@spectrum-css/button": "^6.0.11",
+    "@spectrum-css/buttongroup": "^5.0.11",
+    "@spectrum-css/closebutton": "^1.2.10",
+    "@spectrum-css/divider": "^1.0.25",
+    "@spectrum-css/icon": "^3.0.21",
+    "@spectrum-css/modal": "^3.0.20",
+    "@spectrum-css/underlay": "^2.0.29",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/dropindicator/package.json
+++ b/components/dropindicator/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/dropzone/package.json
+++ b/components/dropzone/package.json
@@ -16,8 +16,8 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/illustratedmessage": "^4.0.0",
-    "@spectrum-css/link": "^3.1.11-beta.0",
+    "@spectrum-css/illustratedmessage": "^4.0.4",
+    "@spectrum-css/link": "^3.1.21",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/fieldgroup/package.json
+++ b/components/fieldgroup/package.json
@@ -16,9 +16,9 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/checkbox": "^3.0.11-beta.0",
-    "@spectrum-css/icon": "^3.0.11-beta.0",
-    "@spectrum-css/radio": "^3.0.11-beta.0",
+    "@spectrum-css/checkbox": "^3.1.1",
+    "@spectrum-css/icon": "^3.0.21",
+    "@spectrum-css/radio": "^3.0.22",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/fieldlabel/package.json
+++ b/components/fieldlabel/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/helptext/package.json
+++ b/components/helptext/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/illustratedmessage/package.json
+++ b/components/illustratedmessage/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/typography": "^4.0.8-beta.0",
+    "@spectrum-css/typography": "^4.0.18",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/inlinealert/package.json
+++ b/components/inlinealert/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/inputgroup/package.json
+++ b/components/inputgroup/package.json
@@ -16,8 +16,8 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/pickerbutton": "^1.1.3-beta.0",
-    "@spectrum-css/popover": "^5.0.0",
+    "@spectrum-css/pickerbutton": "^1.1.18",
+    "@spectrum-css/popover": "^5.0.14",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/menu/package.json
+++ b/components/menu/package.json
@@ -16,8 +16,8 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/divider": "^1.0.23",
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/divider": "^1.0.25",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/miller/package.json
+++ b/components/miller/package.json
@@ -16,9 +16,9 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/assetlist": "^3.0.11-beta.0",
-    "@spectrum-css/checkbox": "^3.0.11-beta.0",
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/assetlist": "^3.0.22",
+    "@spectrum-css/checkbox": "^3.1.1",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/pagination/package.json
+++ b/components/pagination/package.json
@@ -16,11 +16,11 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/actionbutton": "^1.1.1-beta.0",
-    "@spectrum-css/button": "^6.0.0",
-    "@spectrum-css/icon": "^3.0.11-beta.0",
-    "@spectrum-css/splitbutton": "^5.0.0",
-    "@spectrum-css/textfield": "^3.1.2-beta.0",
+    "@spectrum-css/actionbutton": "^1.1.13",
+    "@spectrum-css/button": "^6.0.11",
+    "@spectrum-css/icon": "^3.0.21",
+    "@spectrum-css/splitbutton": "^5.0.11",
+    "@spectrum-css/textfield": "^3.2.2",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/picker/package.json
+++ b/components/picker/package.json
@@ -16,10 +16,10 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/actionbutton": "^1.1.1-beta.0",
-    "@spectrum-css/icon": "^3.0.11-beta.0",
-    "@spectrum-css/menu": "^4.0.0",
-    "@spectrum-css/popover": "^5.0.0",
+    "@spectrum-css/actionbutton": "^1.1.13",
+    "@spectrum-css/icon": "^3.0.21",
+    "@spectrum-css/menu": "^4.0.2",
+    "@spectrum-css/popover": "^5.0.14",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/pickerbutton/package.json
+++ b/components/pickerbutton/package.json
@@ -16,9 +16,9 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/icon": "^3.0.11-beta.0",
-    "@spectrum-css/menu": "^4.0.0",
-    "@spectrum-css/popover": "^5.0.0",
+    "@spectrum-css/icon": "^3.0.21",
+    "@spectrum-css/menu": "^4.0.2",
+    "@spectrum-css/popover": "^5.0.14",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/popover/package.json
+++ b/components/popover/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/dialog": "^6.0.0",
+    "@spectrum-css/dialog": "^6.0.11",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/progressbar/package.json
+++ b/components/progressbar/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/fieldlabel": "^4.0.8-beta.0",
+    "@spectrum-css/fieldlabel": "^4.0.24",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/quickaction/package.json
+++ b/components/quickaction/package.json
@@ -16,8 +16,8 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/actionbutton": "^1.1.1-beta.0",
-    "@spectrum-css/checkbox": "^3.0.11-beta.0",
+    "@spectrum-css/actionbutton": "^1.1.13",
+    "@spectrum-css/checkbox": "^3.1.1",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/radio/package.json
+++ b/components/radio/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/rating/package.json
+++ b/components/rating/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/search/package.json
+++ b/components/search/package.json
@@ -16,9 +16,9 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/clearbutton": "^1.1.0-beta.0",
-    "@spectrum-css/icon": "^3.0.11-beta.0",
-    "@spectrum-css/textfield": "^3.1.2-beta.0",
+    "@spectrum-css/clearbutton": "^1.2.10",
+    "@spectrum-css/icon": "^3.0.21",
+    "@spectrum-css/textfield": "^3.2.2",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/splitbutton/package.json
+++ b/components/splitbutton/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/button": "^6.0.0",
+    "@spectrum-css/button": "^6.0.11",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/steplist/package.json
+++ b/components/steplist/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/stepper/package.json
+++ b/components/stepper/package.json
@@ -16,9 +16,9 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/actionbutton": "^1.1.1-beta.0",
-    "@spectrum-css/icon": "^3.0.11-beta.0",
-    "@spectrum-css/textfield": "^3.1.2-beta.0",
+    "@spectrum-css/actionbutton": "^1.1.13",
+    "@spectrum-css/icon": "^3.0.21",
+    "@spectrum-css/textfield": "^3.2.2",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/table/package.json
+++ b/components/table/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/tabs/package.json
+++ b/components/tabs/package.json
@@ -16,8 +16,8 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/menu": "^4.0.0",
-    "@spectrum-css/picker": "^1.1.6-beta.0",
+    "@spectrum-css/menu": "^4.0.2",
+    "@spectrum-css/picker": "^1.2.7",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/tag/package.json
+++ b/components/tag/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/clearbutton": "^1.1.0-beta.0",
+    "@spectrum-css/clearbutton": "^1.2.10",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/taggroup/package.json
+++ b/components/taggroup/package.json
@@ -16,8 +16,8 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/clearbutton": "^1.1.0-beta.0",
-    "@spectrum-css/tag": "^3.2.0-beta.0",
+    "@spectrum-css/clearbutton": "^1.2.10",
+    "@spectrum-css/tag": "^3.3.12",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/toast/package.json
+++ b/components/toast/package.json
@@ -16,9 +16,9 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/button": "^6.0.0",
-    "@spectrum-css/closebutton": "^1.2.1",
-    "@spectrum-css/icon": "^3.0.13",
+    "@spectrum-css/button": "^6.0.11",
+    "@spectrum-css/closebutton": "^1.2.10",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/tooltip/package.json
+++ b/components/tooltip/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/tray/package.json
+++ b/components/tray/package.json
@@ -16,9 +16,9 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/button": "^6.0.0",
-    "@spectrum-css/icon": "^3.0.11-beta.0",
-    "@spectrum-css/modal": "^3.0.10-beta.0",
+    "@spectrum-css/button": "^6.0.11",
+    "@spectrum-css/icon": "^3.0.21",
+    "@spectrum-css/modal": "^3.0.20",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/treeview/package.json
+++ b/components/treeview/package.json
@@ -16,7 +16,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/icon": "^3.0.11-beta.0",
+    "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -42,12 +42,13 @@ async function checkPeerDependencies() {
     if (package.peerDependencies) {
       Object.keys(package.peerDependencies).forEach((dependency) => {
         let devDepVer = package.devDependencies[dependency].replace('^', '');
-        let peerDepVer = package.peerDependencies[dependency];
+        let peerDepVer = package.peerDependencies[dependency].replace('^', '');
+        
         if (devDepVer) {
-          if (!semver.satisfies(devDepVer, peerDepVer)) {
+          if (devDepVer !== peerDepVer) {
             console.error(`${component} has out of date peerDependencies ${dependency} (found ${devDepVer}, does not satisfy ${peerDepVer})`);
 
-            // Set a new peer dependency, stripping the beta version number
+            // Set the peer dependency version to be the same as the dev dependency version
             let newPeerDepVer = '^' + devDepVer.replace(/-\d+$/, '');
             package.peerDependencies[dependency] = newPeerDepVer
             console.error(`  Updated ${dependency} to ${newPeerDepVer}`);


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
This changes the way that we check to see if a package's `peerDependencies` match (or would be 'satisfied') by the version required in the package's `devDependencies`. Our previous comparison was not properly handling prerelease version satisfaction (or, at least, it wasn't handling it in a way that we needed it to). This change updates the `satisfies` args so that they compare exact version numbers (instead of the "^" range).

More details on semver & prerelease tag satisfaction [here](https://github.com/npm/node-semver#prerelease-tags).


## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
