### PR TITLE
bug: replace fill-available with stretch

### DIFF
--- a/components/modal/index.css
+++ b/components/modal/index.css
@@ -37,11 +37,11 @@ governing permissions and limitations under the License.
   inline-size: 100vw;
   /* On mobile browsers, vh units are fixed based on the maximum height of the screen.
    * However, when you scroll, the toolbar and address bar shrink, making the viewport resize.
-   * We use the fill-available value to counteract this where supported. */
+   * We use the stretch value to counteract this where supported. */
   height: 100vh;
   height: -moz-available;
   height: -webkit-fill-available;
-  height: fill-available;
+  height: stretch;
 
   visibility: hidden;
 


### PR DESCRIPTION
## Description

This PR fixes issue [#1283 Modal: replace fill-available with stretch](https://github.com/adobe/spectrum-css/issues/1283). The `.spectrum-Modal-wrapper` class currently uses `height: fill-available;` [as shown here](https://github.com/adobe/spectrum-css/blob/7bd84e70209361c9b7bb787bf4263420c76d84c1/components/modal/index.css#L44). This is a webkit-specific value. The correct value is `stretch`.

## How and where has this been tested?

 The PR was tested locally by updating L46 in `/node_modules/@spectrum-css/modal/dist/index-vars.css` from `height: fill-available;` to `height: stretch;` and rebuilding the `aio-theme`.

![image](https://user-images.githubusercontent.com/1828494/171406082-bb97c29d-89c4-499b-b002-789682643941.png)

After this change, the warning was no longer triggered in the console.

## Screenshots

Warning from aio-theme dev build:

![image](https://user-images.githubusercontent.com/1828494/171402917-a23c9611-9bcc-4546-8700-db11f3829e88.png)

Warning no longer triggered after fix:

![image](https://user-images.githubusercontent.com/1828494/171406485-a0f359f5-f74d-451e-b98f-da157256716c.png)

## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
