### PR TITLE
Remove lightest option from website switcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ If you're targeting modern browsers, start by including the base set of variable
 <link rel="stylesheet" href="node_modules/@spectrum-css/vars/dist/spectrum-large.css">
 
 <!-- Include only the colorstops your application needs -->
-<link rel="stylesheet" href="node_modules/@spectrum-css/vars/dist/spectrum-lightest.css">
 <link rel="stylesheet" href="node_modules/@spectrum-css/vars/dist/spectrum-light.css">
 <link rel="stylesheet" href="node_modules/@spectrum-css/vars/dist/spectrum-dark.css">
 <link rel="stylesheet" href="node_modules/@spectrum-css/vars/dist/spectrum-darkest.css">

--- a/site/includes/dependencies.pug
+++ b/site/includes/dependencies.pug
@@ -8,7 +8,6 @@ link(rel='stylesheet', type='text/css', href='css/prism/prism.css', data-prism)
 link(rel='stylesheet', type='text/css', href='../components/vars/spectrum-global.css')
 
 link(rel='stylesheet', type='text/css', href='../components/vars/spectrum-darkest.css')
-link(rel='stylesheet', type='text/css', href='../components/vars/spectrum-lightest.css')
 link(rel='stylesheet', type='text/css', href='../components/vars/spectrum-dark.css')
 link(rel='stylesheet', type='text/css', href='../components/vars/spectrum-light.css')
 

--- a/site/resources/js/SpectrumSwitcher.js
+++ b/site/resources/js/SpectrumSwitcher.js
@@ -54,7 +54,6 @@ SpectrumSwitcher.Scales = [
 ];
 
 SpectrumSwitcher.ColorStops = [
-  'lightest',
   'light',
   'dark',
   'darkest'
@@ -76,10 +75,9 @@ SpectrumSwitcher.VarsVersionKeys = {
 };
 
 SpectrumSwitcher.ThemeKeys = {
-  '1': 'lightest',
-  '2': 'light',
-  '3': 'dark',
-  '4': 'darkest',
+  '1': 'light',
+  '2': 'dark',
+  '3': 'darkest',
 };
 
 SpectrumSwitcher.ScaleKeys = {

--- a/site/templates/individualComponent.pug
+++ b/site/templates/individualComponent.pug
@@ -41,7 +41,6 @@ html(lang='en-US' dir="ltr").spectrum.spectrum--light.spectrum--medium
     title #{component.name} - Spectrum CSS
     meta(name="viewport", content="user-scalable=no,initial-scale = 1.0,maximum-scale = 1.0")
 
-    link(rel='stylesheet', type='text/css', href='dependencies/@spectrum-css/vars/spectrum-lightest.css')
     link(rel='stylesheet', type='text/css', href='dependencies/@spectrum-css/vars/spectrum-light.css')
     link(rel='stylesheet', type='text/css', href='dependencies/@spectrum-css/vars/spectrum-dark.css')
     link(rel='stylesheet', type='text/css', href='dependencies/@spectrum-css/vars/spectrum-darkest.css')

--- a/site/templates/siteComponent.pug
+++ b/site/templates/siteComponent.pug
@@ -76,10 +76,6 @@ html(lang='en-US' dir="ltr").spectrum.spectrum--light.spectrum--medium
                       use(xlink:href="#spectrum-css-icon-Chevron100")
                   .spectrum-Popover.spectrum-Popover--bottom.spectrum-Picker-popover.spectrum-Picker-popover--quiet
                     ul.spectrum-Menu(role='listbox')
-                      li.spectrum-Menu-item(role='option' aria-selected='true' tabindex='0' value="lightest")
-                        span.spectrum-Menu-itemLabel Lightest
-                        svg.spectrum-Icon.spectrum-UIIcon-Checkmark100.spectrum-Menu-checkmark.spectrum-Menu-itemIcon(focusable='false' aria-hidden='true')
-                          use(xlink:href='#spectrum-css-icon-Checkmark100')
                       li.spectrum-Menu-item.is-selected(role='option' tabindex='0' value="light")
                         span.spectrum-Menu-itemLabel Light
                         svg.spectrum-Icon.spectrum-UIIcon-Checkmark100.spectrum-Menu-checkmark.spectrum-Menu-itemIcon(focusable='false' aria-hidden='true')


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
This doesn't really remove the `lightest` option from the `vars` package, it just removes it from the Spectrum CSS website switcher.

## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
