### PR TITLE
fix: swatch high contrast support

### DIFF
--- a/components/swatch/index.css
+++ b/components/swatch/index.css
@@ -358,3 +358,29 @@ governing permissions and limitations under the License.
   transition: width var(--spectrum-global-animation-duration-100) ease-in-out,
               height var(--spectrum-global-animation-duration-100) ease-in-out;
 }
+
+@media (forced-colors: active) {
+  .spectrum-Swatch-fill {
+    forced-color-adjust: none;
+  }
+  .spectrum-Swatch {
+    --spectrum-swatch-disabled-icon-color: grayText;
+    --spectrum-alias-focus-ring-color: ButtonText;
+    --spectrum-swatch-selection-indicator-border-color: Highlight;
+    --spectrum-swatch-fill-border-color: ButtonText;
+    --spectrum-swatch-fill-border-color-light: ButtonText;
+    --spectrum-swatch-background-color-selected: ButtonFace;
+    &.is-disabled {
+      .spectrum-Swatch-fill {
+        forced-color-adjust: auto;
+      }
+    }
+    &.is-nothing {
+      .spectrum-Swatch-fill {
+        &:after {
+          background: ButtonText;
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds WHCM for swatch

## Description
#1467


## How and where has this been tested?
Run Swatch and swatchgroup pages with WHCM enabled

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
