### PR TITLE
chore: add high contrast checkbox in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,5 +22,6 @@
 - [ ] If my change impacts other components, I have tested to make sure they don't break.
 - [ ] If my change impacts documentation, I have updated the documentation accordingly.
 - [ ] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
+- [ ] I have tested these changes in Windows High Contrast mode.
 <!-- If this pull request isn't ready, add any remaining tasks here -->
 - [ ] This pull request is ready to merge.


### PR DESCRIPTION
Add a Checkbox to the PR template to prompt folks to check in High Contrast mode.
## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->


## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
