### PR TITLE
test: update VRT references

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@adobe/spectrum-tokens-deprecated": "^11.8.0",
     "@commitlint/cli": "^8.3.3",
     "@commitlint/config-conventional": "^8.3.3",
-    "@spectrum-css/spectrum-css-vr-test-assets-essential": "^1.0.39",
+    "@spectrum-css/spectrum-css-vr-test-assets-essential": "^1.0.44",
     "audit-ci": "^2.0.1",
     "backstopjs-spectrum": "6.15.0",
     "del": "^5.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1437,10 +1437,10 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/actionbutton/-/actionbutton-1.1.14.tgz#4e12eb7f482fb5944c3d97547591964baebeb1d4"
   integrity sha512-ViBjdWi23J6vIR4t8JTRQ6jY/+KgpZgCALj3otgy495zMNG7jPeN7sKoy6i6JZJcdIRJA4MjOTVvcDOGkYWUZg==
 
-"@spectrum-css/spectrum-css-vr-test-assets-essential@^1.0.39":
-  version "1.0.39"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/spectrum-css-vr-test-assets-essential/-/spectrum-css-vr-test-assets-essential-1.0.39.tgz#4b22a22b43f311caa67f0a78708269dff5ee1163"
-  integrity sha512-Vy3n2LUhPZ9H9AhAiZH6MeZk3KxgJC7sYlQjs2Q0wlZLFj6guQ13BCwIOzcvt6r3Wxhw0lQ8gsGUbWle1/6k9Q==
+"@spectrum-css/spectrum-css-vr-test-assets-essential@^1.0.44":
+  version "1.0.44"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/spectrum-css-vr-test-assets-essential/-/spectrum-css-vr-test-assets-essential-1.0.44.tgz#718caaddecb9831bdb78fa3cfae6e76e8befac79"
+  integrity sha512-hyzcSsz1cRmgGbbDabX7tJdn1xObRJ2xM/I2si3NYTuS6fix0HVw/mdsaNKbCRu7za7Yre5FimPXBOItt3xWdA==
 
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
Updates the VRT references, which include the [`xs` size for ActionButton](1f18708d106ffa914b40db9ac3f4fa2cac3c3f7a) and the [core tokens version of HelpText](1d5a416e5bceb73e11aba9a471b39e0d5e13cf55)


## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
