### PR TITLE
Lunarfusion/css 107 field group core tokens

### DIFF
--- a/components/fieldgroup/gulpfile.js
+++ b/components/fieldgroup/gulpfile.js
@@ -1,1 +1,1 @@
-module.exports = require('@spectrum-css/component-builder');
+module.exports = require('@spectrum-css/component-builder-simple');

--- a/components/fieldgroup/index.css
+++ b/components/fieldgroup/index.css
@@ -21,6 +21,8 @@ governing permissions and limitations under the License.
   display: flex;
   vertical-align: top;
   flex-wrap: wrap;
+  padding: 0;
+  border: 0;
 
   /* horizontal fieldgroup */
   &--horizontal {
@@ -35,8 +37,6 @@ governing permissions and limitations under the License.
     flex-direction: column;
   }
 }
-
-
 
 /* read only checkbox group */
 .spectrum-FieldGroup {
@@ -56,8 +56,3 @@ governing permissions and limitations under the License.
     }
   }
 }
-
-/* TODO - display of readOnly checkbox delimeter in right to left text direction */
-/* :dir(rtl) {
-
-} */

--- a/components/fieldgroup/index.css
+++ b/components/fieldgroup/index.css
@@ -21,8 +21,24 @@ governing permissions and limitations under the License.
   display: flex;
   vertical-align: top;
   flex-wrap: wrap;
+
+  /* horizontal fieldgroup */
+  &--horizontal {
+    .spectrum-FieldGroup-item:not(:last-child) {
+      margin-inline-end: var(--spectrum-fieldgroup-margin);
+    }
+  }
+
+  /* vertical fieldgroup */
+  &--vertical {
+    display: inline-flex;
+    flex-direction: column;
+  }
 }
 
+
+
+/* read only checkbox group */
 .spectrum-FieldGroup {
   .spectrum-Checkbox.is-readOnly {
     .spectrum-Checkbox-box {
@@ -41,13 +57,7 @@ governing permissions and limitations under the License.
   }
 }
 
-.spectrum-FieldGroup--horizontal {
-  .spectrum-FieldGroup-item:not(:last-child) {
-    margin-inline-end: var(--spectrum-fieldgroup-margin);
-  }
-}
+/* TODO - display of readOnly checkbox delimeter in right to left text direction */
+/* :dir(rtl) {
 
-.spectrum-FieldGroup--vertical {
-  display: inline-flex;
-  flex-direction: column;
-}
+} */

--- a/components/fieldgroup/index.css
+++ b/components/fieldgroup/index.css
@@ -10,7 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import "../vars/css/components/spectrum-helptext.css";
 
 /* fieldgroup/index.css
  *

--- a/components/fieldgroup/index.css
+++ b/components/fieldgroup/index.css
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Adobe. All rights reserved.
+Copyright 2022 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -9,6 +9,8 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
+
+@import "../vars/css/components/spectrum-helptext.css";
 
 .spectrum-FieldGroup {
   --spectrum-fieldgroup-margin: var(--spectrum-spacing-300);
@@ -28,6 +30,7 @@ governing permissions and limitations under the License.
     }
 
     /* ReadOnly checkbox fields delimited by commas */
+    /* TO DO - check right to left display of comma */
     &:not(:last-child) {
       .spectrum-Checkbox-label {
         &:after {

--- a/components/fieldgroup/index.css
+++ b/components/fieldgroup/index.css
@@ -11,8 +11,8 @@ governing permissions and limitations under the License.
 */
 
 .spectrum-FieldGroup {
-  --spectrum-fieldgroup-margin: var(--spectrum-global-dimension-size-200);
-  --spectrum-fieldgroup-readonly-delineator: '\002c';
+  --spectrum-fieldgroup-margin: var(--spectrum-spacing-300);
+  --spectrum-fieldgroup-readonly-delimiter: '\002c';
 }
 
 .spectrum-FieldGroup {
@@ -27,10 +27,11 @@ governing permissions and limitations under the License.
       display: none;
     }
 
+    /* ReadOnly checkbox fields delimited by commas */
     &:not(:last-child) {
       .spectrum-Checkbox-label {
         &:after {
-          content: var(--spectrum-fieldgroup-readonly-delineator)
+          content: var(--spectrum-fieldgroup-readonly-delimiter)
         }
       }
     }

--- a/components/fieldgroup/index.css
+++ b/components/fieldgroup/index.css
@@ -68,14 +68,14 @@ governing permissions and limitations under the License.
   }
 }
 
-/* read only checkbox group */
+/* read-only checkbox group */
 .spectrum-FieldGroup {
   .spectrum-Checkbox.is-readOnly {
     .spectrum-Checkbox-box {
       display: none;
     }
 
-    /* ReadOnly checkbox fields delimited by commas */
+    /* read-only checkbox fields delimited by commas */
     &:not(:last-child) {
       .spectrum-Checkbox-label {
         &:after {

--- a/components/fieldgroup/index.css
+++ b/components/fieldgroup/index.css
@@ -12,11 +12,13 @@ governing permissions and limitations under the License.
 
 @import "../vars/css/components/spectrum-helptext.css";
 
+/* custom properties */
 .spectrum-FieldGroup {
   --spectrum-fieldgroup-margin: var(--spectrum-spacing-300);
   --spectrum-fieldgroup-readonly-delimiter: '\002c';
 }
 
+/* field group */
 .spectrum-FieldGroup {
   display: flex;
   vertical-align: top;
@@ -24,19 +26,35 @@ governing permissions and limitations under the License.
   padding: 0;
   border: 0;
 
-  /* horizontal fieldgroup */
+  /* horizontal field group */
   &--horizontal {
     .spectrum-FieldGroup-item:not(:last-child) {
       margin-inline-end: var(--spectrum-fieldgroup-margin);
     }
+
+    /* help text appears below horizontal fields */
+    .spectrum-HelpText {
+      flex-basis: 100%;
+    }
   }
 
-  /* vertical fieldgroup */
+  /* vertical field group */
   &--vertical {
     display: inline-flex;
     flex-direction: column;
   }
+
+  /* field group label - top position */
+  .spectrum-FieldLabel {
+    display: block;
+  }
+
+  /* field group label - side position */
+  .spectrum-FieldLabel--right {
+    display: table-cell;
+  }
 }
+
 
 /* read only checkbox group */
 .spectrum-FieldGroup {
@@ -46,7 +64,6 @@ governing permissions and limitations under the License.
     }
 
     /* ReadOnly checkbox fields delimited by commas */
-    /* TO DO - check right to left display of comma */
     &:not(:last-child) {
       .spectrum-Checkbox-label {
         &:after {

--- a/components/fieldgroup/index.css
+++ b/components/fieldgroup/index.css
@@ -12,6 +12,13 @@ governing permissions and limitations under the License.
 
 @import "../vars/css/components/spectrum-helptext.css";
 
+/* fieldgroup/index.css
+ *
+ * fieldgroup contains four component dependences:
+ * radio, checkbox, helptext, fieldlabel
+ *
+ */
+
 /* custom properties */
 .spectrum-FieldGroup {
   --spectrum-fieldgroup-margin: var(--spectrum-spacing-300);
@@ -21,40 +28,46 @@ governing permissions and limitations under the License.
 /* field group */
 .spectrum-FieldGroup {
   display: flex;
-  vertical-align: top;
+  align-items: top;
   flex-wrap: wrap;
-  padding: 0;
-  border: 0;
 
-  /* horizontal field group */
+  /* field group label top aligned */
+  &--toplabel {
+    flex-direction: column;
+  }
+
+  /* field group label side aligned */
+  &--sidelabel {
+    flex-direction: row;
+  }
+}
+
+/* input fields layout */
+.spectrum-FieldGroupInputLayout {
+  display: flex;
+  align-items: top;
+  flex-wrap: wrap;
+
+  /* input fields stacked vertically */
+  &--vertical {
+    flex-direction: column;
+  }
+
+  /* input fields aligned horizontally */
   &--horizontal {
+    flex-direction: row;
+
+    /* space between horizontal fields */
     .spectrum-FieldGroup-item:not(:last-child) {
       margin-inline-end: var(--spectrum-fieldgroup-margin);
     }
 
-    /* help text appears below horizontal fields */
+    /* move help text down to new row */
     .spectrum-HelpText {
       flex-basis: 100%;
     }
   }
-
-  /* vertical field group */
-  &--vertical {
-    display: inline-flex;
-    flex-direction: column;
-  }
-
-  /* field group label - top position */
-  .spectrum-FieldLabel {
-    display: block;
-  }
-
-  /* field group label - side position */
-  .spectrum-FieldLabel--right {
-    display: table-cell;
-  }
 }
-
 
 /* read only checkbox group */
 .spectrum-FieldGroup {

--- a/components/fieldgroup/index.css
+++ b/components/fieldgroup/index.css
@@ -48,12 +48,12 @@ governing permissions and limitations under the License.
   flex-wrap: wrap;
 
   /* input fields stacked vertically */
-  &--vertical {
+  .spectrum-FieldGroup--vertical & {
     flex-direction: column;
   }
 
-  /* input fields aligned horizontally */
-  &--horizontal {
+   /* input fields aligned horizontally */
+  .spectrum-FieldGroup--horizontal & {
     flex-direction: row;
 
     /* space between horizontal fields */

--- a/components/fieldgroup/index.css
+++ b/components/fieldgroup/index.css
@@ -29,6 +29,7 @@ governing permissions and limitations under the License.
   display: flex;
   align-items: top;
   flex-wrap: wrap;
+  flex-direction: column;
 
   /* field group label top aligned */
   &--toplabel {
@@ -46,6 +47,7 @@ governing permissions and limitations under the License.
   display: flex;
   align-items: top;
   flex-wrap: wrap;
+  flex-direction: column;
 
   /* input fields stacked vertically */
   .spectrum-FieldGroup--vertical & {

--- a/components/fieldgroup/metadata/fieldgroup.yml
+++ b/components/fieldgroup/metadata/fieldgroup.yml
@@ -39,7 +39,6 @@ examples:
           </form>
         </div>
 
-
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Checkbox</h4>
 
@@ -78,6 +77,7 @@ examples:
 
       </div>
 
+
   - id: fieldgroup-horizontal
     name: Horizontal
     description: A horizontal group of fields.
@@ -110,7 +110,6 @@ examples:
             </div>
           </form>
         </div>
-
 
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Checkbox</h4>
@@ -149,6 +148,7 @@ examples:
         </div>
 
       </div>
+
 
   - id: fieldgroup-invalid
     name: Invalid
@@ -229,17 +229,17 @@ examples:
 
       </div>
 
-  - id: fieldgroup
-    name: Label Position
+
+  - id: fieldgroup-required-optional
+    name: Required or Optional
+    description: An optional or required group of fields.
     markup: |
       <div class="spectrum-Examples">
-
         <div class="spectrum-Examples-item">
-          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Side Label Vertical Radio</h4>
-
+          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Required</h4>
           <form class="spectrum-Form">
-            <div class="spectrum-FieldGroup spectrum-FieldGroup--sidelabel" role="radiogroup" aria-labelledby="radiogroup-label-4">
-              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--right" id="radiogroup-label-4">Radio Group Label</div>
+            <div class="spectrum-FieldGroup spectrum-FieldGroup--toplabel" role="radiogroup" aria-labelledby="radiogroup-label-4">
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel" id="radiogroup-label-4">Radio Group Label (required)</div>
 
               <div class="spectrum-FieldGroupInputLayout spectrum-FieldGroupInputLayout--vertical" aria-describedby="helptext-radio-4">
                 <div class="spectrum-Radio spectrum-FieldGroup-item">
@@ -255,6 +255,95 @@ examples:
                 </div>
 
                 <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText" id="helptext-radio-4">
+                  <div class="spectrum-HelpText-text">Select an option.</div>
+                </div>
+              </div>
+            </div>
+          </form>
+        </div>
+
+        <div class="spectrum-Examples-item">
+          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Required Asterisk</h4>
+          <form class="spectrum-Form">
+            <div class="spectrum-FieldGroup spectrum-FieldGroup--toplabel" role="radiogroup" aria-labelledby="radiogroup-label-5">
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel" id="radiogroup-label-5">Radio Group Label
+                <svg class="spectrum-Icon spectrum-UIIcon-Asterisk100 spectrum-FieldLabel-requiredIcon" focusable="false" aria-hidden="true">
+                  <use xlink:href="#spectrum-css-icon-Asterisk100" />
+                </svg>
+              </div>
+
+              <div class="spectrum-FieldGroupInputLayout spectrum-FieldGroupInputLayout--vertical" aria-describedby="helptext-radio-5">
+                <div class="spectrum-Radio spectrum-FieldGroup-item">
+                  <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-8">
+                  <span class="spectrum-Radio-button"></span>
+                  <label class="spectrum-Radio-label" for="radio-0">Kittens</label>
+                </div>
+
+                <div class="spectrum-Radio spectrum-FieldGroup-item">
+                  <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-9" checked>
+                  <span class="spectrum-Radio-button"></span>
+                  <label class="spectrum-Radio-label" for="radio-1">Puppies</label>
+                </div>
+
+                <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText" id="helptext-radio-5">
+                  <div class="spectrum-HelpText-text">Select an option.</div>
+                </div>
+              </div>
+            </div>
+          </form>
+        </div>
+
+        <div class="spectrum-Examples-item">
+          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Optional</h4>
+          <form class="spectrum-Form">
+            <div class="spectrum-FieldGroup spectrum-FieldGroup--toplabel" role="radiogroup" aria-labelledby="radiogroup-label-6">
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel" id="radiogroup-label-6">Radio Group Label (optional)</div>
+
+              <div class="spectrum-FieldGroupInputLayout spectrum-FieldGroupInputLayout--vertical">
+                <div class="spectrum-Radio spectrum-FieldGroup-item">
+                  <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-10">
+                  <span class="spectrum-Radio-button"></span>
+                  <label class="spectrum-Radio-label" for="radio-0">Kittens</label>
+                </div>
+
+                <div class="spectrum-Radio spectrum-FieldGroup-item">
+                  <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-11" checked>
+                  <span class="spectrum-Radio-button"></span>
+                  <label class="spectrum-Radio-label" for="radio-1">Puppies</label>
+                </div>
+              </div>
+            </div>
+          </form>
+        </div>
+      </div>
+
+
+  - id: fieldgroup-sidelabel
+    name: Side Label Position
+    markup: |
+      <div class="spectrum-Examples">
+
+        <div class="spectrum-Examples-item">
+          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Side Label Vertical Radio</h4>
+
+          <form class="spectrum-Form">
+            <div class="spectrum-FieldGroup spectrum-FieldGroup--sidelabel" role="radiogroup" aria-labelledby="radiogroup-label-7">
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--right" id="radiogroup-label-7">Radio Group Label</div>
+
+              <div class="spectrum-FieldGroupInputLayout spectrum-FieldGroupInputLayout--vertical" aria-describedby="helptext-radio-7">
+                <div class="spectrum-Radio spectrum-FieldGroup-item">
+                  <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-12">
+                  <span class="spectrum-Radio-button"></span>
+                  <label class="spectrum-Radio-label" for="radio-0">Kittens</label>
+                </div>
+
+                <div class="spectrum-Radio spectrum-FieldGroup-item">
+                  <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-13" checked>
+                  <span class="spectrum-Radio-button"></span>
+                  <label class="spectrum-Radio-label" for="radio-1">Puppies</label>
+                </div>
+
+                <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText" id="helptext-radio-7">
                   <div class="spectrum-HelpText-text">Select an option.</div>
                 </div>
               </div>
@@ -301,32 +390,31 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Side Label Horizontal Radio</h4>
 
           <form class="spectrum-Form">
-            <div class="spectrum-FieldGroup spectrum-FieldGroup--sidelabel" role="radiogroup" aria-labelledby="radiogroup-label-5">
-              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--right" id="radiogroup-label-5">Radio Group Label</div>
+            <div class="spectrum-FieldGroup spectrum-FieldGroup--sidelabel" role="radiogroup" aria-labelledby="radiogroup-label-8">
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--right" id="radiogroup-label-8">Radio Group Label</div>
 
-              <div class="spectrum-FieldGroupInputLayout spectrum-FieldGroupInputLayout--horizontal" aria-describedby="helptext-radio-5">
+              <div class="spectrum-FieldGroupInputLayout spectrum-FieldGroupInputLayout--horizontal" aria-describedby="helptext-radio-8">
                 <div class="spectrum-Radio spectrum-FieldGroup-item">
-                  <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-8">
+                  <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-14">
                   <span class="spectrum-Radio-button"></span>
                   <label class="spectrum-Radio-label" for="radio-0">Kittens</label>
                 </div>
 
                 <div class="spectrum-Radio spectrum-FieldGroup-item">
-                  <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-9" checked>
+                  <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-15" checked>
                   <span class="spectrum-Radio-button"></span>
                   <label class="spectrum-Radio-label" for="radio-1">Puppies</label>
                 </div>
 
-                <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText" id="helptext-radio-5">
+                <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText" id="helptext-radio-8">
                   <div class="spectrum-HelpText-text">Select an option.</div>
                 </div>
               </div>
             </div>
           </form>
-        </div>
 
+          <hr>
 
-        <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Side Label Horizontal Checkbox</h4>
 
           <form class="spectrum-Form">
@@ -363,6 +451,7 @@ examples:
         </div>
 
       </div>
+
 
   - id: fieldgroup-readonly-checkboxes
     name: Read-only Checkboxes

--- a/components/fieldgroup/metadata/fieldgroup.yml
+++ b/components/fieldgroup/metadata/fieldgroup.yml
@@ -17,6 +17,32 @@ examples:
         </div>
       </div>
       <div class="spectrum-FieldGroup spectrum-FieldGroup--horizontal">
+          <label class="spectrum-Checkbox spectrum-Checkbox--sizeM is-disabled is-indeterminate is-readOnly">
+            <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-0" disabled>
+            <span class="spectrum-Checkbox-box">
+              <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-Checkmark100" />
+              </svg>
+              <svg class="spectrum-Icon spectrum-UIIcon-Dash100 spectrum-Checkbox-partialCheckmark" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-Dash100" />
+              </svg>
+            </span>
+            <span class="spectrum-Checkbox-label">Checkbox</span>
+          </label>
+        <label class="spectrum-Checkbox spectrum-Checkbox--sizeM is-disabled is-indeterminate is-readOnly">
+          <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-1" checked disabled>
+          <span class="spectrum-Checkbox-box">
+            <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Checkmark100" />
+            </svg>
+            <svg class="spectrum-Icon spectrum-UIIcon-Dash100 spectrum-Checkbox-partialCheckmark" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Dash100" />
+            </svg>
+          </span>
+          <span class="spectrum-Checkbox-label">Checkbox</span>
+        </label>
+      </div>
+      <div class="spectrum-FieldGroup spectrum-FieldGroup--horizontal">
         <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
           <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-0">
           <span class="spectrum-Checkbox-box">
@@ -73,7 +99,26 @@ examples:
           <span class="spectrum-Checkbox-label">Bits</span>
         </label>
       </div>
-    
+      <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical">
+        <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
+          <input type="checkbox" class="spectrum-Checkbox-input">
+          <span class="spectrum-Checkbox-box">
+            <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Checkmark100" />
+            </svg>
+          </span>
+          <span class="spectrum-Checkbox-label">Kibble</span>
+        </label>
+        <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
+          <input type="checkbox" class="spectrum-Checkbox-input" checked>
+          <span class="spectrum-Checkbox-box">
+            <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Checkmark100" />
+            </svg>
+          </span>
+          <span class="spectrum-Checkbox-label">Bits</span>
+        </label>
+      </div>
   - id: fieldgroup-readonly-checkboxes
     name: Read-only Checkboxes
     description: A group of read-only checkboxes that have been `checked`. In U.S. English, use commas to delineate items within read-only checkbox groups. In other languages, use the locale-specific formatting.

--- a/components/fieldgroup/metadata/fieldgroup.yml
+++ b/components/fieldgroup/metadata/fieldgroup.yml
@@ -1,5 +1,10 @@
 name: Field Group
-description: 'A group of fields, usually Radios or Checkboxes.'
+description: |
+  - A group of fields, usually Radios or Checkboxes.
+  - Fieldgroup incorporates the help text component which may appear below a fieldgroup.
+  - Help text is necesary to denote invalid checkbox and radio button fields.
+  - Invalid radio buttons are signified only by alert help text.
+  - Invalid checkboxes are signified by alert help text and alert input box color.
 examples:
   - id: fieldgroup
     name: Standard
@@ -8,87 +13,103 @@ examples:
 
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Radio</h4>
-
-          <div class="spectrum-FieldGroup spectrum-FieldGroup--horizontal">
-            <div class="spectrum-Radio spectrum-FieldGroup-item">
-              <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-0">
-              <span class="spectrum-Radio-button"></span>
-              <label class="spectrum-Radio-label" for="radio-0">Kittens</label>
+          <form>
+            <div class="spectrum-FieldGroup spectrum-FieldGroup--horizontal">
+              <div class="spectrum-Radio spectrum-FieldGroup-item">
+                <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-0">
+                <span class="spectrum-Radio-button"></span>
+                <label class="spectrum-Radio-label" for="radio-0">Kittens</label>
+              </div>
+              <div class="spectrum-Radio spectrum-FieldGroup-item">
+                <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-1" checked>
+                <span class="spectrum-Radio-button"></span>
+                <label class="spectrum-Radio-label" for="radio-1">Puppies</label>
+              </div>
             </div>
-            <div class="spectrum-Radio spectrum-FieldGroup-item">
-              <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-1" checked>
-              <span class="spectrum-Radio-button"></span>
-              <label class="spectrum-Radio-label" for="radio-1">Dogs</label>
-            </div>
-          </div>
+          </form>
         </div>
 
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Radio Invalid</h4>
-
-          <div class="spectrum-FieldGroup spectrum-FieldGroup--horizontal">
-            <div class="spectrum-Radio spectrum-FieldGroup-item is-invalid">
-              <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-0">
-              <span class="spectrum-Radio-button"></span>
-              <label class="spectrum-Radio-label" for="radio-0">Kittens</label>
+          <form>
+            <div class="spectrum-FieldGroup spectrum-FieldGroup--horizontal">
+              <div class="spectrum-Radio spectrum-FieldGroup-item is-invalid">
+                <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-0">
+                <span class="spectrum-Radio-button"></span>
+                <label class="spectrum-Radio-label" for="radio-0">Kittens</label>
+              </div>
+              <div class="spectrum-Radio spectrum-FieldGroup-item is-invalid">
+                <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-1" checked>
+                <span class="spectrum-Radio-button"></span>
+                <label class="spectrum-Radio-label" for="radio-1">Puppies</label>
+              </div>
             </div>
-            <div class="spectrum-Radio spectrum-FieldGroup-item is-invalid">
-              <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-1" checked>
-              <span class="spectrum-Radio-button"></span>
-              <label class="spectrum-Radio-label" for="radio-1">Dogs</label>
+            <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--negative">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-HelpText-validationIcon" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-icon-18-Alert" />
+              </svg>
+              <div class="spectrum-HelpText-text">Select an option.</div>
             </div>
-          </div>
+          </form>
         </div>
 
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Checkbox</h4>
 
-          <div class="spectrum-FieldGroup spectrum-FieldGroup--horizontal">
-            <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
-              <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-0">
-              <span class="spectrum-Checkbox-box">
-                <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-                  <use xlink:href="#spectrum-css-icon-Checkmark100" />
-                </svg>
-              </span>
-              <span class="spectrum-Checkbox-label">Checkbox</span>
-            </label>
-            <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
-              <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-1" checked>
-              <span class="spectrum-Checkbox-box">
-                <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-                  <use xlink:href="#spectrum-css-icon-Checkmark100" />
-                </svg>
-              </span>
-              <span class="spectrum-Checkbox-label">Checkbox</span>
-            </label>
-          </div>
+          <form>
+            <div class="spectrum-FieldGroup spectrum-FieldGroup--horizontal">
+              <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
+                <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-0">
+                <span class="spectrum-Checkbox-box">
+                  <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                    <use xlink:href="#spectrum-css-icon-Checkmark100" />
+                  </svg>
+                </span>
+                <span class="spectrum-Checkbox-label">Checkbox</span>
+              </label>
+              <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
+                <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-1" checked>
+                <span class="spectrum-Checkbox-box">
+                  <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                    <use xlink:href="#spectrum-css-icon-Checkmark100" />
+                  </svg>
+                </span>
+                <span class="spectrum-Checkbox-label">Checkbox</span>
+              </label>
+            </div>
+          </form>
         </div>
 
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Checkbox Invalid</h4>
-
-          <div class="spectrum-FieldGroup spectrum-FieldGroup--horizontal">
-            <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item is-invalid">
-              <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-0">
-              <span class="spectrum-Checkbox-box">
-                <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-                  <use xlink:href="#spectrum-css-icon-Checkmark100" />
-                </svg>
-              </span>
-              <span class="spectrum-Checkbox-label">Checkbox</span>
-            </label>
-            <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item is-invalid">
-              <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-1" checked>
-              <span class="spectrum-Checkbox-box">
-                <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-                  <use xlink:href="#spectrum-css-icon-Checkmark100" />
-                </svg>
-              </span>
-              <span class="spectrum-Checkbox-label">Checkbox</span>
-            </label>
-          </div>
-
+          <form>
+            <div class="spectrum-FieldGroup spectrum-FieldGroup--horizontal">
+              <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item is-invalid">
+                <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-0">
+                <span class="spectrum-Checkbox-box">
+                  <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                    <use xlink:href="#spectrum-css-icon-Checkmark100" />
+                  </svg>
+                </span>
+                <span class="spectrum-Checkbox-label">Checkbox</span>
+              </label>
+              <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item is-invalid">
+                <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-1" checked>
+                <span class="spectrum-Checkbox-box">
+                  <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                    <use xlink:href="#spectrum-css-icon-Checkmark100" />
+                  </svg>
+                </span>
+                <span class="spectrum-Checkbox-label">Checkbox</span>
+              </label>
+            </div>
+            <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--negative">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-HelpText-validationIcon" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-icon-18-Alert" />
+              </svg>
+              <div class="spectrum-HelpText-text">Select a checkbox.</div>
+            </div>
+          </form>
         </div>
       </div>
 
@@ -100,85 +121,102 @@ examples:
 
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Radio</h4>
-
-          <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical">
-            <div class="spectrum-Radio spectrum-FieldGroup-item">
-              <input type="radio" name="animals" class="spectrum-Radio-input" id="radio-fieldgroup-vertical-1">
-              <span class="spectrum-Radio-button"></span>
-              <label class="spectrum-Radio-label" for="radio-fieldgroup-vertical-1">Kittens</label>
+          <form>
+            <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical">
+              <div class="spectrum-Radio spectrum-FieldGroup-item">
+                <input type="radio" name="animals" class="spectrum-Radio-input" id="radio-fieldgroup-vertical-1">
+                <span class="spectrum-Radio-button"></span>
+                <label class="spectrum-Radio-label" for="radio-fieldgroup-vertical-1">Kittens</label>
+              </div>
+              <div class="spectrum-Radio spectrum-FieldGroup-item">
+                <input type="radio" name="animals" class="spectrum-Radio-input" id="radio-fieldgroup-vertical-2" checked>
+                <span class="spectrum-Radio-button"></span>
+                <label class="spectrum-Radio-label" for="radio-fieldgroup-vertical-2">Puppies</label>
+              </div>
             </div>
-            <div class="spectrum-Radio spectrum-FieldGroup-item">
-              <input type="radio" name="animals" class="spectrum-Radio-input" id="radio-fieldgroup-vertical-2">
-              <span class="spectrum-Radio-button"></span>
-              <label class="spectrum-Radio-label" for="radio-fieldgroup-vertical-2">Dogs</label>
-            </div>
-          </div>
+          </form>
         </div>
+
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Radio Invalid</h4>
-
-          <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical">
-            <div class="spectrum-Radio spectrum-FieldGroup-item is-invalid">
-              <input type="radio" name="animals" class="spectrum-Radio-input" id="radio-fieldgroup-vertical-1">
-              <span class="spectrum-Radio-button"></span>
-              <label class="spectrum-Radio-label" for="radio-fieldgroup-vertical-1">Kittens</label>
+          <form>
+            <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical">
+              <div class="spectrum-Radio spectrum-FieldGroup-item is-invalid">
+                <input type="radio" name="animals" class="spectrum-Radio-input" id="radio-fieldgroup-vertical-1">
+                <span class="spectrum-Radio-button"></span>
+                <label class="spectrum-Radio-label" for="radio-fieldgroup-vertical-1">Kittens</label>
+              </div>
+              <div class="spectrum-Radio spectrum-FieldGroup-item">
+                <input type="radio" name="animals" class="spectrum-Radio-input" id="radio-fieldgroup-vertical-2" checked>
+                <span class="spectrum-Radio-button"></span>
+                <label class="spectrum-Radio-label" for="radio-fieldgroup-vertical-2">Puppies</label>
+              </div>
             </div>
-            <div class="spectrum-Radio spectrum-FieldGroup-item">
-              <input type="radio" name="animals" class="spectrum-Radio-input" id="radio-fieldgroup-vertical-2">
-              <span class="spectrum-Radio-button"></span>
-              <label class="spectrum-Radio-label" for="radio-fieldgroup-vertical-2">Dogs</label>
+            <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--negative">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-HelpText-validationIcon" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-icon-18-Alert" />
+              </svg>
+              <div class="spectrum-HelpText-text">Select an option.</div>
             </div>
-          </div>
+          </form>
         </div>
 
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Checkbox</h4>
-
-          <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical">
-            <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
-              <input type="checkbox" class="spectrum-Checkbox-input">
-              <span class="spectrum-Checkbox-box">
-                <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-                  <use xlink:href="#spectrum-css-icon-Checkmark100" />
-                </svg>
-              </span>
-              <span class="spectrum-Checkbox-label">Kibble</span>
-            </label>
-            <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
-              <input type="checkbox" class="spectrum-Checkbox-input" checked>
-              <span class="spectrum-Checkbox-box">
-                <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-                  <use xlink:href="#spectrum-css-icon-Checkmark100" />
-                </svg>
-              </span>
-              <span class="spectrum-Checkbox-label">Bits</span>
-            </label>
-          </div>
+          <form>
+            <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical">
+              <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
+                <input type="checkbox" class="spectrum-Checkbox-input">
+                <span class="spectrum-Checkbox-box">
+                  <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                    <use xlink:href="#spectrum-css-icon-Checkmark100" />
+                  </svg>
+                </span>
+                <span class="spectrum-Checkbox-label">Checkbox</span>
+              </label>
+              <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
+                <input type="checkbox" class="spectrum-Checkbox-input" checked>
+                <span class="spectrum-Checkbox-box">
+                  <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                    <use xlink:href="#spectrum-css-icon-Checkmark100" />
+                  </svg>
+                </span>
+                <span class="spectrum-Checkbox-label">Checkbox</span>
+              </label>
+            </div>
+          </form>
         </div>
 
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Checkbox Invalid</h4>
-
-          <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical">
-            <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item is-invalid">
-              <input type="checkbox" class="spectrum-Checkbox-input">
-              <span class="spectrum-Checkbox-box">
-                <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-                  <use xlink:href="#spectrum-css-icon-Checkmark100" />
-                </svg>
-              </span>
-              <span class="spectrum-Checkbox-label">Kibble</span>
-            </label>
-            <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item is-invalid">
-              <input type="checkbox" class="spectrum-Checkbox-input" checked>
-              <span class="spectrum-Checkbox-box">
-                <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-                  <use xlink:href="#spectrum-css-icon-Checkmark100" />
-                </svg>
-              </span>
-              <span class="spectrum-Checkbox-label">Bits</span>
-            </label>
-          </div>
+          <form>
+            <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical">
+              <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item is-invalid">
+                <input type="checkbox" class="spectrum-Checkbox-input">
+                <span class="spectrum-Checkbox-box">
+                  <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                    <use xlink:href="#spectrum-css-icon-Checkmark100" />
+                  </svg>
+                </span>
+                <span class="spectrum-Checkbox-label">Checkbox</span>
+              </label>
+              <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item is-invalid">
+                <input type="checkbox" class="spectrum-Checkbox-input" checked>
+                <span class="spectrum-Checkbox-box">
+                  <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                    <use xlink:href="#spectrum-css-icon-Checkmark100" />
+                  </svg>
+                </span>
+                <span class="spectrum-Checkbox-label">Checkbox</span>
+              </label>
+            </div>
+            <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--negative">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-HelpText-validationIcon" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-icon-18-Alert" />
+              </svg>
+              <div class="spectrum-HelpText-text">Select a checkbox.</div>
+            </div>
+          </form>
         </div>
       </div>
   - id: fieldgroup-readonly-checkboxes

--- a/components/fieldgroup/metadata/fieldgroup.yml
+++ b/components/fieldgroup/metadata/fieldgroup.yml
@@ -2,7 +2,7 @@ name: Field Group
 description: |
   - A group of fields, usually Radios or Checkboxes.
   - Fieldgroup incorporates the help text component which may appear below a fieldgroup.
-  - Help text is necessary to denote invalid checkbox and radio button fields.
+  - Help text is necessary to denote invalid checkbox fields, invalid radio button fields, and required fields.
   - Invalid radio buttons are signified only by alert help text.
   - Invalid checkboxes are signified by alert help text and alert input box color.
 examples:

--- a/components/fieldgroup/metadata/fieldgroup.yml
+++ b/components/fieldgroup/metadata/fieldgroup.yml
@@ -13,8 +13,10 @@ examples:
 
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Radio</h4>
+
           <form>
-            <div class="spectrum-FieldGroup spectrum-FieldGroup--horizontal">
+            <fieldset class="spectrum-FieldGroup spectrum-FieldGroup--horizontal">
+              <legend class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Radio Group Legend</legend>
               <div class="spectrum-Radio spectrum-FieldGroup-item">
                 <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-0">
                 <span class="spectrum-Radio-button"></span>
@@ -25,25 +27,33 @@ examples:
                 <span class="spectrum-Radio-button"></span>
                 <label class="spectrum-Radio-label" for="radio-1">Puppies</label>
               </div>
+            </fieldset>
+
+            <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText">
+              <div class="spectrum-HelpText-text">Select an option.</div>
             </div>
           </form>
+
         </div>
 
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Radio Invalid</h4>
+
           <form>
-            <div class="spectrum-FieldGroup spectrum-FieldGroup--horizontal">
+            <fieldset class="spectrum-FieldGroup spectrum-FieldGroup--horizontal">
+              <legend class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Radio Group Legend</legend>
               <div class="spectrum-Radio spectrum-FieldGroup-item is-invalid">
-                <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-0">
+                <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-2">
                 <span class="spectrum-Radio-button"></span>
                 <label class="spectrum-Radio-label" for="radio-0">Kittens</label>
               </div>
               <div class="spectrum-Radio spectrum-FieldGroup-item is-invalid">
-                <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-1" checked>
+                <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-3" checked>
                 <span class="spectrum-Radio-button"></span>
                 <label class="spectrum-Radio-label" for="radio-1">Puppies</label>
               </div>
-            </div>
+            </fieldset>
+
             <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--negative">
               <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-HelpText-validationIcon" focusable="false" aria-hidden="true">
                 <use xlink:href="#spectrum-icon-18-Alert" />
@@ -51,13 +61,15 @@ examples:
               <div class="spectrum-HelpText-text">Select an option.</div>
             </div>
           </form>
+
         </div>
 
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Checkbox</h4>
 
           <form>
-            <div class="spectrum-FieldGroup spectrum-FieldGroup--horizontal">
+            <fieldset class="spectrum-FieldGroup spectrum-FieldGroup--horizontal">
+              <legend class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Checkbox Group Legend</legend>
               <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
                 <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-0">
                 <span class="spectrum-Checkbox-box">
@@ -76,16 +88,23 @@ examples:
                 </span>
                 <span class="spectrum-Checkbox-label">Checkbox</span>
               </label>
+            </fieldset>
+
+            <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText">
+              <div class="spectrum-HelpText-text">Select an option.</div>
             </div>
           </form>
+
         </div>
 
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Checkbox Invalid</h4>
+
           <form>
-            <div class="spectrum-FieldGroup spectrum-FieldGroup--horizontal">
+            <fieldset class="spectrum-FieldGroup spectrum-FieldGroup--horizontal">
+              <legend class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Checkbox Group Legend</legend>
               <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item is-invalid">
-                <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-0">
+                <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-2">
                 <span class="spectrum-Checkbox-box">
                   <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
                     <use xlink:href="#spectrum-css-icon-Checkmark100" />
@@ -94,7 +113,7 @@ examples:
                 <span class="spectrum-Checkbox-label">Checkbox</span>
               </label>
               <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item is-invalid">
-                <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-1" checked>
+                <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-3" checked>
                 <span class="spectrum-Checkbox-box">
                   <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
                     <use xlink:href="#spectrum-css-icon-Checkmark100" />
@@ -102,7 +121,8 @@ examples:
                 </span>
                 <span class="spectrum-Checkbox-label">Checkbox</span>
               </label>
-            </div>
+            </fieldset>
+
             <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--negative">
               <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-HelpText-validationIcon" focusable="false" aria-hidden="true">
                 <use xlink:href="#spectrum-icon-18-Alert" />
@@ -110,7 +130,74 @@ examples:
               <div class="spectrum-HelpText-text">Select a checkbox.</div>
             </div>
           </form>
+
         </div>
+      </div>
+
+  - id: fieldgroup
+    name: Label Position
+    markup: |
+      <div class="spectrum-Examples">
+
+        <div class="spectrum-Examples-item">
+          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Radio Side Label</h4>
+
+          <form>
+            <fieldset class="spectrum-FieldGroup spectrum-FieldGroup--horizontal">
+              <legend class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Radio Group Legend</legend>
+              <div class="spectrum-Radio spectrum-FieldGroup-item">
+                <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-0">
+                <span class="spectrum-Radio-button"></span>
+                <label class="spectrum-Radio-label" for="radio-0">Kittens</label>
+              </div>
+              <div class="spectrum-Radio spectrum-FieldGroup-item">
+                <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-1" checked>
+                <span class="spectrum-Radio-button"></span>
+                <label class="spectrum-Radio-label" for="radio-1">Puppies</label>
+              </div>
+            </fieldset>
+
+            <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText">
+              <div class="spectrum-HelpText-text">Select an option.</div>
+            </div>
+          </form>
+
+        </div>
+
+
+        <div class="spectrum-Examples-item">
+          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Checkbox Side Label</h4>
+
+          <form>
+            <fieldset class="spectrum-FieldGroup spectrum-FieldGroup--horizontal">
+              <legend class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Checkbox Group Legend</legend>
+              <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
+                <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-0">
+                <span class="spectrum-Checkbox-box">
+                  <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                    <use xlink:href="#spectrum-css-icon-Checkmark100" />
+                  </svg>
+                </span>
+                <span class="spectrum-Checkbox-label">Checkbox</span>
+              </label>
+              <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
+                <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-1" checked>
+                <span class="spectrum-Checkbox-box">
+                  <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                    <use xlink:href="#spectrum-css-icon-Checkmark100" />
+                  </svg>
+                </span>
+                <span class="spectrum-Checkbox-label">Checkbox</span>
+              </label>
+            </fieldset>
+
+            <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText">
+              <div class="spectrum-HelpText-text">Select an option.</div>
+            </div>
+          </form>
+
+        </div>
+
       </div>
 
   - id: fieldgroup-vertical
@@ -121,37 +208,50 @@ examples:
 
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Radio</h4>
+
           <form>
+            <fieldset class="spectrum-FieldGroup spectrum-FieldGroup--horizontal">
+            <legend class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Radio Group Legend</legend>
             <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical">
               <div class="spectrum-Radio spectrum-FieldGroup-item">
-                <input type="radio" name="animals" class="spectrum-Radio-input" id="radio-fieldgroup-vertical-1">
+                <input type="radio" name="animals" class="spectrum-Radio-input" id="radio-4">
                 <span class="spectrum-Radio-button"></span>
                 <label class="spectrum-Radio-label" for="radio-fieldgroup-vertical-1">Kittens</label>
               </div>
               <div class="spectrum-Radio spectrum-FieldGroup-item">
-                <input type="radio" name="animals" class="spectrum-Radio-input" id="radio-fieldgroup-vertical-2" checked>
+                <input type="radio" name="animals" class="spectrum-Radio-input" id="radio-5" checked>
                 <span class="spectrum-Radio-button"></span>
                 <label class="spectrum-Radio-label" for="radio-fieldgroup-vertical-2">Puppies</label>
               </div>
+            </fieldset>
+
+            <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText">
+              <div class="spectrum-HelpText-text">Select an option.</div>
             </div>
           </form>
+
         </div>
 
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Radio Invalid</h4>
+
           <form>
-            <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical">
-              <div class="spectrum-Radio spectrum-FieldGroup-item is-invalid">
-                <input type="radio" name="animals" class="spectrum-Radio-input" id="radio-fieldgroup-vertical-1">
-                <span class="spectrum-Radio-button"></span>
-                <label class="spectrum-Radio-label" for="radio-fieldgroup-vertical-1">Kittens</label>
+            <fieldset class="spectrum-FieldGroup spectrum-FieldGroup--horizontal">
+              <legend class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Radio Group Legend</legend>
+              <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical">
+                <div class="spectrum-Radio spectrum-FieldGroup-item is-invalid">
+                  <input type="radio" name="animals" class="spectrum-Radio-input" id="radio-6">
+                  <span class="spectrum-Radio-button"></span>
+                  <label class="spectrum-Radio-label" for="radio-fieldgroup-vertical-1">Kittens</label>
+                </div>
+                <div class="spectrum-Radio spectrum-FieldGroup-item">
+                  <input type="radio" name="animals" class="spectrum-Radio-input" id="radio-7" checked>
+                  <span class="spectrum-Radio-button"></span>
+                  <label class="spectrum-Radio-label" for="radio-fieldgroup-vertical-2">Puppies</label>
+                </div>
               </div>
-              <div class="spectrum-Radio spectrum-FieldGroup-item">
-                <input type="radio" name="animals" class="spectrum-Radio-input" id="radio-fieldgroup-vertical-2" checked>
-                <span class="spectrum-Radio-button"></span>
-                <label class="spectrum-Radio-label" for="radio-fieldgroup-vertical-2">Puppies</label>
-              </div>
-            </div>
+            </fieldset>
+
             <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--negative">
               <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-HelpText-validationIcon" focusable="false" aria-hidden="true">
                 <use xlink:href="#spectrum-icon-18-Alert" />
@@ -159,57 +259,72 @@ examples:
               <div class="spectrum-HelpText-text">Select an option.</div>
             </div>
           </form>
+
         </div>
 
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Checkbox</h4>
+
           <form>
-            <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical">
-              <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
-                <input type="checkbox" class="spectrum-Checkbox-input">
-                <span class="spectrum-Checkbox-box">
-                  <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-                    <use xlink:href="#spectrum-css-icon-Checkmark100" />
-                  </svg>
-                </span>
-                <span class="spectrum-Checkbox-label">Checkbox</span>
-              </label>
-              <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
-                <input type="checkbox" class="spectrum-Checkbox-input" checked>
-                <span class="spectrum-Checkbox-box">
-                  <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-                    <use xlink:href="#spectrum-css-icon-Checkmark100" />
-                  </svg>
-                </span>
-                <span class="spectrum-Checkbox-label">Checkbox</span>
-              </label>
+            <fieldset class="spectrum-FieldGroup spectrum-FieldGroup--horizontal">
+              <legend class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Checkbox Group Legend</legend>
+              <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical" id="checkboxgroup-c">
+                <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
+                  <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-4">
+                  <span class="spectrum-Checkbox-box">
+                    <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                      <use xlink:href="#spectrum-css-icon-Checkmark100" />
+                    </svg>
+                  </span>
+                  <span class="spectrum-Checkbox-label">Checkbox</span>
+                </label>
+                <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
+                  <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-5" checked>
+                  <span class="spectrum-Checkbox-box">
+                    <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                      <use xlink:href="#spectrum-css-icon-Checkmark100" />
+                    </svg>
+                  </span>
+                  <span class="spectrum-Checkbox-label">Checkbox</span>
+                </label>
+              </div>
+            </fieldset>
+
+            <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText">
+              <div class="spectrum-HelpText-text">Select an option.</div>
             </div>
           </form>
+
         </div>
 
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Checkbox Invalid</h4>
+
           <form>
-            <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical">
-              <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item is-invalid">
-                <input type="checkbox" class="spectrum-Checkbox-input">
-                <span class="spectrum-Checkbox-box">
-                  <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-                    <use xlink:href="#spectrum-css-icon-Checkmark100" />
-                  </svg>
-                </span>
-                <span class="spectrum-Checkbox-label">Checkbox</span>
-              </label>
-              <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item is-invalid">
-                <input type="checkbox" class="spectrum-Checkbox-input" checked>
-                <span class="spectrum-Checkbox-box">
-                  <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-                    <use xlink:href="#spectrum-css-icon-Checkmark100" />
-                  </svg>
-                </span>
-                <span class="spectrum-Checkbox-label">Checkbox</span>
-              </label>
-            </div>
+            <fieldset class="spectrum-FieldGroup spectrum-FieldGroup--horizontal">
+              <legend class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Checkbox Group Legend</legend>
+              <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical" id="checkboxgroup-d">
+                <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item is-invalid">
+                  <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-6">
+                  <span class="spectrum-Checkbox-box">
+                    <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                      <use xlink:href="#spectrum-css-icon-Checkmark100" />
+                    </svg>
+                  </span>
+                  <span class="spectrum-Checkbox-label">Checkbox</span>
+                </label>
+                <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item is-invalid">
+                  <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-7" checked>
+                  <span class="spectrum-Checkbox-box">
+                    <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                      <use xlink:href="#spectrum-css-icon-Checkmark100" />
+                    </svg>
+                  </span>
+                  <span class="spectrum-Checkbox-label">Checkbox</span>
+                </label>
+              </div>
+            </fieldset>
+
             <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--negative">
               <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-HelpText-validationIcon" focusable="false" aria-hidden="true">
                 <use xlink:href="#spectrum-icon-18-Alert" />
@@ -217,15 +332,16 @@ examples:
               <div class="spectrum-HelpText-text">Select a checkbox.</div>
             </div>
           </form>
+
         </div>
       </div>
   - id: fieldgroup-readonly-checkboxes
     name: Read-only Checkboxes
     description: A group of read-only checkboxes that have been `checked`. In U.S. English, use commas to delineate items within read-only checkbox groups. In other languages, use the locale-specific formatting.
     markup: |
-      <div class="spectrum-FieldGroup">
+      <fieldset class="spectrum-FieldGroup">
         <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item is-disabled is-readOnly">
-          <input type="checkbox" class="spectrum-Checkbox-input" checked disabled>
+          <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-8" checked disabled>
           <span class="spectrum-Checkbox-box">
             <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
               <use xlink:href="#spectrum-css-icon-Checkmark100" />
@@ -234,7 +350,7 @@ examples:
           <span class="spectrum-Checkbox-label">Apples</span>
         </label>
         <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item is-disabled is-readOnly">
-          <input type="checkbox" class="spectrum-Checkbox-input" checked disabled>
+          <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-9" checked disabled>
           <span class="spectrum-Checkbox-box">
             <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
               <use xlink:href="#spectrum-css-icon-Checkmark100" />
@@ -244,7 +360,7 @@ examples:
         </label>
 
         <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item is-disabled is-readOnly">
-          <input type="checkbox" class="spectrum-Checkbox-input" checked disabled>
+          <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-10" checked disabled>
           <span class="spectrum-Checkbox-box">
             <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
               <use xlink:href="#spectrum-css-icon-Checkmark100" />
@@ -253,7 +369,7 @@ examples:
           <span class="spectrum-Checkbox-label">Grapes</span>
         </label>
         <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item is-disabled is-readOnly">
-          <input type="checkbox" class="spectrum-Checkbox-input" checked disabled>
+          <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-11" checked disabled>
           <span class="spectrum-Checkbox-box">
             <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
               <use xlink:href="#spectrum-css-icon-Checkmark100" />
@@ -261,4 +377,4 @@ examples:
           </span>
           <span class="spectrum-Checkbox-label">Bananas</span>
         </label>
-      </div>
+      </fieldset>

--- a/components/fieldgroup/metadata/fieldgroup.yml
+++ b/components/fieldgroup/metadata/fieldgroup.yml
@@ -2,20 +2,23 @@ name: Field Group
 description: |
   - A group of fields, usually Radios or Checkboxes.
   - Fieldgroup incorporates the help text component which may appear below a fieldgroup.
-  - Help text is necesary to denote invalid checkbox and radio button fields.
+  - Help text is necessary to denote invalid checkbox and radio button fields.
   - Invalid radio buttons are signified only by alert help text.
   - Invalid checkboxes are signified by alert help text and alert input box color.
 examples:
-  - id: fieldgroup
-    name: Horizontal
+  - id: fieldgroup-vertical
+    name: Vertical
+    description: A vertical group of fields.
     markup: |
       <div class="spectrum-Examples">
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Radio</h4>
+
           <form class="spectrum-Form">
-            <div class="spectrum-Form-item" role="radiogroup" aria-labelledby="radiogroup-label-1">
-              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="radiogroup-label-1">Radio Group Label</div>
-              <div class="spectrum-FieldGroup spectrum-FieldGroup--horizontal" aria-describedby="helptext-radio-1">
+            <div class="spectrum-FieldGroup spectrum-FieldGroup--toplabel" role="radiogroup" aria-labelledby="radiogroup-label-1">
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel" id="radiogroup-label-1">Radio Group Label</div>
+
+              <div class="spectrum-FieldGroupInputLayout spectrum-FieldGroupInputLayout--vertical" aria-describedby="helptext-radio-1">
                 <div class="spectrum-Radio spectrum-FieldGroup-item">
                   <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-0">
                   <span class="spectrum-Radio-button"></span>
@@ -36,12 +39,15 @@ examples:
           </form>
         </div>
 
+
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Checkbox</h4>
+
           <form class="spectrum-Form">
-            <div class="spectrum-Form-item" role="group" aria-labelledby="checkboxgroup-label-1">
-              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="checkboxgroup-label-1">Checkbox Group Label</div>
-              <div class="spectrum-FieldGroup spectrum-FieldGroup--horizontal" aria-describedby="helptext-checkbox-1">
+            <div class="spectrum-FieldGroup spectrum-FieldGroup--toplabel" role="group" aria-labelledby="checkboxgroup-label-1">
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel" id="checkboxgroup-label-1">Checkbox Group Label</div>
+
+              <div class="spectrum-FieldGroupInputLayout spectrum-FieldGroupInputLayout--vertical" aria-describedby="helptext-checkbox-1">
                 <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
                   <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-0">
                   <span class="spectrum-Checkbox-box">
@@ -69,19 +75,22 @@ examples:
             </div>
           </form>
         </div>
+
       </div>
 
-  - id: fieldgroup-vertical
-    name: Vertical
-    description: A vertical group of fields.
+  - id: fieldgroup-horizontal
+    name: Horizontal
+    description: A horizontal group of fields.
     markup: |
       <div class="spectrum-Examples">
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Radio</h4>
+
           <form class="spectrum-Form">
-            <div class="spectrum-Form-item" role="radiogroup" aria-labelledby="radiogroup-label-2">
-              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="radiogroup-label-2">Radio Group Label</div>
-              <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical" aria-describedby="helptext-radio-2">
+            <div class="spectrum-FieldGroup spectrum-FieldGroup--toplabel" role="radiogroup" aria-labelledby="radiogroup-label-2">
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel" id="radiogroup-label-2">Radio Group Label</div>
+
+              <div class="spectrum-FieldGroupInputLayout spectrum-FieldGroupInputLayout--horizontal" aria-describedby="helptext-radio-2">
                 <div class="spectrum-Radio spectrum-FieldGroup-item">
                   <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-2">
                   <span class="spectrum-Radio-button"></span>
@@ -102,12 +111,15 @@ examples:
           </form>
         </div>
 
+
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Checkbox</h4>
+
           <form class="spectrum-Form">
-            <div class="spectrum-Form-item" role="group" aria-labelledby="checkboxgroup-label-2">
-              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="checkboxgroup-label-2">Checkbox Group Label</div>
-              <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical" aria-describedby="helptext-checkbox-2">
+            <div class="spectrum-FieldGroup spectrum-FieldGroup--toplabel" role="group" aria-labelledby="checkboxgroup-label-2">
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel" id="checkboxgroup-label-2">Checkbox Group Label</div>
+
+              <div class="spectrum-FieldGroupInputLayout spectrum-FieldGroupInputLayout--horizontal" aria-describedby="helptext-checkbox-2">
                 <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
                   <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-2">
                   <span class="spectrum-Checkbox-box">
@@ -135,19 +147,55 @@ examples:
             </div>
           </form>
         </div>
+
       </div>
 
-  - id: fieldgroup-vertical
+  - id: fieldgroup-invalid
     name: Invalid
-    description: A vertical group of fields.
+    description: An invalid group of fields.
     markup: |
+
       <div class="spectrum-Examples">
         <div class="spectrum-Examples-item">
-          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Checkbox Invalid</h4>
+          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Radio</h4>
+
           <form class="spectrum-Form">
-            <div class="spectrum-Form-item" role="group" aria-labelledby="checkboxgroup-label-3">
-              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="checkboxgroup-label-3">Checkbox Group Label</div>
-              <div class="spectrum-FieldGroup spectrum-FieldGroup--horizontal" aria-describedby="helptext-checkbox-3">
+            <div class="spectrum-FieldGroup spectrum-FieldGroup--toplabel" role="radiogroup" aria-labelledby="radiogroup-label-3">
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel" id="radiogroup-label-3">Radio Group Label</div>
+
+              <div class="spectrum-FieldGroupInputLayout spectrum-FieldGroupInputLayout--horizontal" aria-describedby="helptext-radio-3">
+                <div class="spectrum-Radio spectrum-FieldGroup-item is-invalid">
+                  <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-4">
+                  <span class="spectrum-Radio-button"></span>
+                  <label class="spectrum-Radio-label" for="radio-0">Kittens</label>
+                </div>
+
+                <div class="spectrum-Radio spectrum-FieldGroup-item is-invalid">
+                  <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-5" checked>
+                  <span class="spectrum-Radio-button"></span>
+                  <label class="spectrum-Radio-label" for="radio-1">Puppies</label>
+                </div>
+
+                <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--negative" id="helptext-radio-3">
+                  <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-HelpText-validationIcon" focusable="false" aria-hidden="true">
+                    <use xlink:href="#spectrum-icon-18-Alert" />
+                  </svg>
+                  <div class="spectrum-HelpText-text">Select an option.</div>
+                </div>
+              </div>
+            </div>
+          </form>
+        </div>
+
+
+        <div class="spectrum-Examples-item">
+          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Checkbox</h4>
+
+          <form class="spectrum-Form">
+            <div class="spectrum-FieldGroup spectrum-FieldGroup--toplabel" role="group" aria-labelledby="checkboxgroup-label-3">
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel" id="checkboxgroup-label-3">Checkbox Group Label</div>
+
+              <div class="spectrum-FieldGroupInputLayout spectrum-FieldGroupInputLayout--horizontal" aria-describedby="helptext-checkbox-3">
                 <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item is-invalid">
                   <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-4">
                   <span class="spectrum-Checkbox-box">
@@ -179,49 +227,21 @@ examples:
           </form>
         </div>
 
-        <div class="spectrum-Examples-item">
-          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Radio Invalid</h4>
-          <form class="spectrum-Form">
-            <div class="spectrum-Form-item" role="radiogroup" aria-labelledby="radiogroup-label-4">
-              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="radiogroup-label-4">Radio Group Label</div>
-
-              <div class="spectrum-FieldGroup spectrum-FieldGroup--horizontal" aria-describedby="helptext-radio-4">
-                <div class="spectrum-Radio spectrum-FieldGroup-item is-invalid">
-                  <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-4">
-                  <span class="spectrum-Radio-button"></span>
-                  <label class="spectrum-Radio-label" for="radio-0">Kittens</label>
-                </div>
-
-                <div class="spectrum-Radio spectrum-FieldGroup-item is-invalid">
-                  <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-5" checked>
-                  <span class="spectrum-Radio-button"></span>
-                  <label class="spectrum-Radio-label" for="radio-1">Puppies</label>
-                </div>
-
-                <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--negative" id="helptext-radio-4">
-                  <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-HelpText-validationIcon" focusable="false" aria-hidden="true">
-                    <use xlink:href="#spectrum-icon-18-Alert" />
-                  </svg>
-                  <div class="spectrum-HelpText-text">Select an option.</div>
-                </div>
-              </div>
-            </div>
-          </form>
-        </div>
       </div>
 
   - id: fieldgroup
     name: Label Position
     markup: |
       <div class="spectrum-Examples">
+
         <div class="spectrum-Examples-item">
-          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Top Label</h4>
+          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Side Label Vertical Radio</h4>
 
           <form class="spectrum-Form">
-            <div class="spectrum-Form-item" role="radiogroup" aria-labelledby="radiogroup-label-5">
-              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="radiogroup-label-5">Radio Group Label</div>
+            <div class="spectrum-FieldGroup spectrum-FieldGroup--sidelabel" role="radiogroup" aria-labelledby="radiogroup-label-4">
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--right" id="radiogroup-label-4">Radio Group Label</div>
 
-              <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical" aria-describedby="helptext-radio-5">
+              <div class="spectrum-FieldGroupInputLayout spectrum-FieldGroupInputLayout--vertical" aria-describedby="helptext-radio-4">
                 <div class="spectrum-Radio spectrum-FieldGroup-item">
                   <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-6">
                   <span class="spectrum-Radio-button"></span>
@@ -234,7 +254,7 @@ examples:
                   <label class="spectrum-Radio-label" for="radio-1">Puppies</label>
                 </div>
 
-                <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText" id="helptext-radio-5">
+                <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText" id="helptext-radio-4">
                   <div class="spectrum-HelpText-text">Select an option.</div>
                 </div>
               </div>
@@ -243,13 +263,48 @@ examples:
         </div>
 
         <div class="spectrum-Examples-item">
-          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Side Label</h4>
+          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Side Label Vertical Checkbox</h4>
 
           <form class="spectrum-Form">
-            <div class="spectrum-Form-item" role="radiogroup" aria-labelledby="radiogroup-label-6">
-              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--right" id="radiogroup-label-6">Radio Group Label</div>
+            <div class="spectrum-FieldGroup spectrum-FieldGroup--sidelabel" role="radiogroup" aria-labelledby="checkboxgroup-label-4">
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--right" id="checkboxgroup-label-4">Checkbox Group Label</div>
 
-              <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical" aria-describedby="helptext-radio-6">
+              <div class="spectrum-FieldGroupInputLayout spectrum-FieldGroupInputLayout--vertical" aria-describedby="helptext-checkbox-4">
+                <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
+                  <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-6">
+                  <span class="spectrum-Checkbox-box">
+                    <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                      <use xlink:href="#spectrum-css-icon-Checkmark100" />
+                    </svg>
+                  </span>
+                  <span class="spectrum-Checkbox-label">Checkbox</span>
+                </label>
+
+                <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
+                  <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-7" checked>
+                  <span class="spectrum-Checkbox-box">
+                    <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                      <use xlink:href="#spectrum-css-icon-Checkmark100" />
+                    </svg>
+                  </span>
+                  <span class="spectrum-Checkbox-label">Checkbox</span>
+                </label>
+                <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText" id="helptext-checkbox-4">
+                  <div class="spectrum-HelpText-text">Select an option.</div>
+                </div>
+              </div>
+            </div>
+          </form>
+        </div>
+
+        <div class="spectrum-Examples-item">
+          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Side Label Horizontal Radio</h4>
+
+          <form class="spectrum-Form">
+            <div class="spectrum-FieldGroup spectrum-FieldGroup--sidelabel" role="radiogroup" aria-labelledby="radiogroup-label-5">
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--right" id="radiogroup-label-5">Radio Group Label</div>
+
+              <div class="spectrum-FieldGroupInputLayout spectrum-FieldGroupInputLayout--horizontal" aria-describedby="helptext-radio-5">
                 <div class="spectrum-Radio spectrum-FieldGroup-item">
                   <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-8">
                   <span class="spectrum-Radio-button"></span>
@@ -262,7 +317,44 @@ examples:
                   <label class="spectrum-Radio-label" for="radio-1">Puppies</label>
                 </div>
 
-                <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText" id="helptext-radio-6">
+                <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText" id="helptext-radio-5">
+                  <div class="spectrum-HelpText-text">Select an option.</div>
+                </div>
+              </div>
+            </div>
+          </form>
+        </div>
+
+
+        <div class="spectrum-Examples-item">
+          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Side Label Horizontal Checkbox</h4>
+
+          <form class="spectrum-Form">
+            <div class="spectrum-FieldGroup spectrum-FieldGroup--sidelabel" role="radiogroup" aria-labelledby="checkboxgroup-label-5">
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--right" id="checkboxgroup-label-5">Checkbox Group Label</div>
+
+              <div class="spectrum-FieldGroupInputLayout spectrum-FieldGroupInputLayout--horizontal" aria-describedby="helptext-checkbox-5">
+                <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
+                  <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-8">
+                  <span class="spectrum-Checkbox-box">
+                    <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                      <use xlink:href="#spectrum-css-icon-Checkmark100" />
+                    </svg>
+                  </span>
+                  <span class="spectrum-Checkbox-label">Checkbox</span>
+                </label>
+
+                <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
+                  <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-9" checked>
+                  <span class="spectrum-Checkbox-box">
+                    <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                      <use xlink:href="#spectrum-css-icon-Checkmark100" />
+                    </svg>
+                  </span>
+                  <span class="spectrum-Checkbox-label">Checkbox</span>
+                </label>
+
+                <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText" id="helptext-checkbox-5">
                   <div class="spectrum-HelpText-text">Select an option.</div>
                 </div>
               </div>
@@ -278,7 +370,7 @@ examples:
     markup: |
       <div class="spectrum-FieldGroup">
         <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item is-disabled is-readOnly">
-          <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-6" checked disabled>
+          <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-10" checked disabled>
           <span class="spectrum-Checkbox-box">
             <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
               <use xlink:href="#spectrum-css-icon-Checkmark100" />
@@ -287,7 +379,7 @@ examples:
           <span class="spectrum-Checkbox-label">Apples</span>
         </label>
         <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item is-disabled is-readOnly">
-          <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-7" checked disabled>
+          <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-11" checked disabled>
           <span class="spectrum-Checkbox-box">
             <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
               <use xlink:href="#spectrum-css-icon-Checkmark100" />
@@ -297,7 +389,7 @@ examples:
         </label>
 
         <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item is-disabled is-readOnly">
-          <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-8" checked disabled>
+          <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-12" checked disabled>
           <span class="spectrum-Checkbox-box">
             <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
               <use xlink:href="#spectrum-css-icon-Checkmark100" />
@@ -306,7 +398,7 @@ examples:
           <span class="spectrum-Checkbox-label">Grapes</span>
         </label>
         <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item is-disabled is-readOnly">
-          <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-9" checked disabled>
+          <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-13" checked disabled>
           <span class="spectrum-Checkbox-box">
             <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
               <use xlink:href="#spectrum-css-icon-Checkmark100" />

--- a/components/fieldgroup/metadata/fieldgroup.yml
+++ b/components/fieldgroup/metadata/fieldgroup.yml
@@ -10,194 +10,65 @@ examples:
     name: Standard
     markup: |
       <div class="spectrum-Examples">
-
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Radio</h4>
+          <form class="spectrum-Form">
+            <div class="spectrum-Form-item" role="radiogroup" aria-labelledby="radiogroup-label-1">
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="radiogroup-label-1">Radio Group Label</div>
+              <div class="spectrum-FieldGroup spectrum-FieldGroup--horizontal" aria-describedby="helptext-radio-0-1">
+                <div class="spectrum-Radio spectrum-FieldGroup-item">
+                  <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-0">
+                  <span class="spectrum-Radio-button"></span>
+                  <label class="spectrum-Radio-label" for="radio-0">Kittens</label>
+                </div>
 
-          <form>
-            <fieldset class="spectrum-FieldGroup spectrum-FieldGroup--horizontal">
-              <legend class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Radio Group Legend</legend>
-              <div class="spectrum-Radio spectrum-FieldGroup-item">
-                <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-0">
-                <span class="spectrum-Radio-button"></span>
-                <label class="spectrum-Radio-label" for="radio-0">Kittens</label>
-              </div>
-              <div class="spectrum-Radio spectrum-FieldGroup-item">
-                <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-1" checked>
-                <span class="spectrum-Radio-button"></span>
-                <label class="spectrum-Radio-label" for="radio-1">Puppies</label>
-              </div>
-            </fieldset>
+                <div class="spectrum-Radio spectrum-FieldGroup-item">
+                  <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-1" checked>
+                  <span class="spectrum-Radio-button"></span>
+                  <label class="spectrum-Radio-label" for="radio-1">Puppies</label>
+                </div>
 
-            <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText">
-              <div class="spectrum-HelpText-text">Select an option.</div>
+                <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText" id="helptext-radio-0-1">
+                  <div class="spectrum-HelpText-text">Select an option.</div>
+                </div>
+              </div>
             </div>
           </form>
-
-        </div>
-
-        <div class="spectrum-Examples-item">
-          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Radio Invalid</h4>
-
-          <form>
-            <fieldset class="spectrum-FieldGroup spectrum-FieldGroup--horizontal">
-              <legend class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Radio Group Legend</legend>
-              <div class="spectrum-Radio spectrum-FieldGroup-item is-invalid">
-                <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-2">
-                <span class="spectrum-Radio-button"></span>
-                <label class="spectrum-Radio-label" for="radio-0">Kittens</label>
-              </div>
-              <div class="spectrum-Radio spectrum-FieldGroup-item is-invalid">
-                <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-3" checked>
-                <span class="spectrum-Radio-button"></span>
-                <label class="spectrum-Radio-label" for="radio-1">Puppies</label>
-              </div>
-            </fieldset>
-
-            <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--negative">
-              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-HelpText-validationIcon" focusable="false" aria-hidden="true">
-                <use xlink:href="#spectrum-icon-18-Alert" />
-              </svg>
-              <div class="spectrum-HelpText-text">Select an option.</div>
-            </div>
-          </form>
-
         </div>
 
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Checkbox</h4>
+          <form class="spectrum-Form">
+            <div class="spectrum-Form-item" role="group" aria-labelledby="checkboxgroup-label-1">
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="checkboxgroup-label-1">Checkbox Group Label</div>
+              <div class="spectrum-FieldGroup spectrum-FieldGroup--horizontal" aria-describedby="helptext-checkbox-0-1">
+                <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
+                  <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-0">
+                  <span class="spectrum-Checkbox-box">
+                    <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                      <use xlink:href="#spectrum-css-icon-Checkmark100" />
+                    </svg>
+                  </span>
+                  <span class="spectrum-Checkbox-label">Checkbox</span>
+                </label>
 
-          <form>
-            <fieldset class="spectrum-FieldGroup spectrum-FieldGroup--horizontal">
-              <legend class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Checkbox Group Legend</legend>
-              <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
-                <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-0">
-                <span class="spectrum-Checkbox-box">
-                  <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-                    <use xlink:href="#spectrum-css-icon-Checkmark100" />
-                  </svg>
-                </span>
-                <span class="spectrum-Checkbox-label">Checkbox</span>
-              </label>
-              <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
-                <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-1" checked>
-                <span class="spectrum-Checkbox-box">
-                  <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-                    <use xlink:href="#spectrum-css-icon-Checkmark100" />
-                  </svg>
-                </span>
-                <span class="spectrum-Checkbox-label">Checkbox</span>
-              </label>
-            </fieldset>
+                <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
+                  <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-1" checked>
+                  <span class="spectrum-Checkbox-box">
+                    <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                      <use xlink:href="#spectrum-css-icon-Checkmark100" />
+                    </svg>
+                  </span>
+                  <span class="spectrum-Checkbox-label">Checkbox</span>
+                </label>
 
-            <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText">
-              <div class="spectrum-HelpText-text">Select an option.</div>
-            </div>
-          </form>
-
-        </div>
-
-        <div class="spectrum-Examples-item">
-          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Checkbox Invalid</h4>
-
-          <form>
-            <fieldset class="spectrum-FieldGroup spectrum-FieldGroup--horizontal">
-              <legend class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Checkbox Group Legend</legend>
-              <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item is-invalid">
-                <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-2">
-                <span class="spectrum-Checkbox-box">
-                  <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-                    <use xlink:href="#spectrum-css-icon-Checkmark100" />
-                  </svg>
-                </span>
-                <span class="spectrum-Checkbox-label">Checkbox</span>
-              </label>
-              <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item is-invalid">
-                <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-3" checked>
-                <span class="spectrum-Checkbox-box">
-                  <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-                    <use xlink:href="#spectrum-css-icon-Checkmark100" />
-                  </svg>
-                </span>
-                <span class="spectrum-Checkbox-label">Checkbox</span>
-              </label>
-            </fieldset>
-
-            <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--negative">
-              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-HelpText-validationIcon" focusable="false" aria-hidden="true">
-                <use xlink:href="#spectrum-icon-18-Alert" />
-              </svg>
-              <div class="spectrum-HelpText-text">Select a checkbox.</div>
-            </div>
-          </form>
-
-        </div>
-      </div>
-
-  - id: fieldgroup
-    name: Label Position
-    markup: |
-      <div class="spectrum-Examples">
-
-        <div class="spectrum-Examples-item">
-          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Radio Side Label</h4>
-
-          <form>
-            <fieldset class="spectrum-FieldGroup spectrum-FieldGroup--horizontal">
-              <legend class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Radio Group Legend</legend>
-              <div class="spectrum-Radio spectrum-FieldGroup-item">
-                <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-0">
-                <span class="spectrum-Radio-button"></span>
-                <label class="spectrum-Radio-label" for="radio-0">Kittens</label>
+                <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText" id="helptext-radio-0-1">
+                  <div class="spectrum-HelpText-text">Select an option.</div>
+                </div>
               </div>
-              <div class="spectrum-Radio spectrum-FieldGroup-item">
-                <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-1" checked>
-                <span class="spectrum-Radio-button"></span>
-                <label class="spectrum-Radio-label" for="radio-1">Puppies</label>
-              </div>
-            </fieldset>
-
-            <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText">
-              <div class="spectrum-HelpText-text">Select an option.</div>
             </div>
           </form>
-
         </div>
-
-
-        <div class="spectrum-Examples-item">
-          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Checkbox Side Label</h4>
-
-          <form>
-            <fieldset class="spectrum-FieldGroup spectrum-FieldGroup--horizontal">
-              <legend class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Checkbox Group Legend</legend>
-              <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
-                <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-0">
-                <span class="spectrum-Checkbox-box">
-                  <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-                    <use xlink:href="#spectrum-css-icon-Checkmark100" />
-                  </svg>
-                </span>
-                <span class="spectrum-Checkbox-label">Checkbox</span>
-              </label>
-              <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
-                <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-1" checked>
-                <span class="spectrum-Checkbox-box">
-                  <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-                    <use xlink:href="#spectrum-css-icon-Checkmark100" />
-                  </svg>
-                </span>
-                <span class="spectrum-Checkbox-label">Checkbox</span>
-              </label>
-            </fieldset>
-
-            <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText">
-              <div class="spectrum-HelpText-text">Select an option.</div>
-            </div>
-          </form>
-
-        </div>
-
       </div>
 
   - id: fieldgroup-vertical
@@ -205,72 +76,50 @@ examples:
     description: A vertical group of fields.
     markup: |
       <div class="spectrum-Examples">
-
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Radio</h4>
-
-          <form>
-            <fieldset class="spectrum-FieldGroup spectrum-FieldGroup--horizontal">
-            <legend class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Radio Group Legend</legend>
-            <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical">
-              <div class="spectrum-Radio spectrum-FieldGroup-item">
-                <input type="radio" name="animals" class="spectrum-Radio-input" id="radio-4">
-                <span class="spectrum-Radio-button"></span>
-                <label class="spectrum-Radio-label" for="radio-fieldgroup-vertical-1">Kittens</label>
-              </div>
-              <div class="spectrum-Radio spectrum-FieldGroup-item">
-                <input type="radio" name="animals" class="spectrum-Radio-input" id="radio-5" checked>
-                <span class="spectrum-Radio-button"></span>
-                <label class="spectrum-Radio-label" for="radio-fieldgroup-vertical-2">Puppies</label>
-              </div>
-            </fieldset>
-
-            <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText">
-              <div class="spectrum-HelpText-text">Select an option.</div>
-            </div>
-          </form>
-
-        </div>
-
-        <div class="spectrum-Examples-item">
-          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Radio Invalid</h4>
-
-          <form>
-            <fieldset class="spectrum-FieldGroup spectrum-FieldGroup--horizontal">
-              <legend class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Radio Group Legend</legend>
-              <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical">
-                <div class="spectrum-Radio spectrum-FieldGroup-item is-invalid">
-                  <input type="radio" name="animals" class="spectrum-Radio-input" id="radio-6">
-                  <span class="spectrum-Radio-button"></span>
-                  <label class="spectrum-Radio-label" for="radio-fieldgroup-vertical-1">Kittens</label>
-                </div>
+          <form class="spectrum-Form">
+            <div class="spectrum-Form-item" role="radiogroup" aria-labelledby="radiogroup-label-1">
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="radiogroup-label-1">Radio Group Label</div>
+              <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical" aria-describedby="helptext-radio-0-1">
                 <div class="spectrum-Radio spectrum-FieldGroup-item">
-                  <input type="radio" name="animals" class="spectrum-Radio-input" id="radio-7" checked>
+                  <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-0">
                   <span class="spectrum-Radio-button"></span>
-                  <label class="spectrum-Radio-label" for="radio-fieldgroup-vertical-2">Puppies</label>
+                  <label class="spectrum-Radio-label" for="radio-0">Kittens</label>
+                </div>
+
+                <div class="spectrum-Radio spectrum-FieldGroup-item">
+                  <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-1" checked>
+                  <span class="spectrum-Radio-button"></span>
+                  <label class="spectrum-Radio-label" for="radio-1">Puppies</label>
+                </div>
+
+                <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText" id="helptext-radio-0-1">
+                  <div class="spectrum-HelpText-text">Select an option.</div>
                 </div>
               </div>
-            </fieldset>
-
-            <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--negative">
-              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-HelpText-validationIcon" focusable="false" aria-hidden="true">
-                <use xlink:href="#spectrum-icon-18-Alert" />
-              </svg>
-              <div class="spectrum-HelpText-text">Select an option.</div>
             </div>
           </form>
-
         </div>
 
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Checkbox</h4>
+          <form class="spectrum-Form">
+            <div class="spectrum-Form-item" role="group" aria-labelledby="checkboxgroup-label-1">
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="checkboxgroup-label-1">Checkbox Group Label</div>
+              <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical" aria-describedby="helptext-checkbox-0-1">
+                <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
+                  <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-0">
+                  <span class="spectrum-Checkbox-box">
+                    <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                      <use xlink:href="#spectrum-css-icon-Checkmark100" />
+                    </svg>
+                  </span>
+                  <span class="spectrum-Checkbox-label">Checkbox</span>
+                </label>
 
-          <form>
-            <fieldset class="spectrum-FieldGroup spectrum-FieldGroup--horizontal">
-              <legend class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Checkbox Group Legend</legend>
-              <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical" id="checkboxgroup-c">
                 <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
-                  <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-4">
+                  <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-1" checked>
                   <span class="spectrum-Checkbox-box">
                     <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
                       <use xlink:href="#spectrum-css-icon-Checkmark100" />
@@ -278,68 +127,156 @@ examples:
                   </span>
                   <span class="spectrum-Checkbox-label">Checkbox</span>
                 </label>
-                <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
-                  <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-5" checked>
-                  <span class="spectrum-Checkbox-box">
-                    <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-                      <use xlink:href="#spectrum-css-icon-Checkmark100" />
-                    </svg>
-                  </span>
-                  <span class="spectrum-Checkbox-label">Checkbox</span>
-                </label>
+
+                <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText" id="helptext-radio-0-1">
+                  <div class="spectrum-HelpText-text">Select an option.</div>
+                </div>
               </div>
-            </fieldset>
-
-            <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText">
-              <div class="spectrum-HelpText-text">Select an option.</div>
             </div>
           </form>
+        </div>
+      </div>
 
+  - id: fieldgroup-vertical
+    name: Invalid
+    description: A vertical group of fields.
+    markup: |
+      <div class="spectrum-Examples">
+        <div class="spectrum-Examples-item">
+          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Checkbox Invalid</h4>
+          <form class="spectrum-Form">
+            <div class="spectrum-Form-item" role="group" aria-labelledby="checkboxgroup-label-1">
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="checkboxgroup-label-1">Checkbox Group Label</div>
+              <div class="spectrum-FieldGroup spectrum-FieldGroup--horizontal" aria-describedby="helptext-checkbox-0-1">
+                <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item is-invalid">
+                  <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-0">
+                  <span class="spectrum-Checkbox-box">
+                    <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                      <use xlink:href="#spectrum-css-icon-Checkmark100" />
+                    </svg>
+                  </span>
+                  <span class="spectrum-Checkbox-label">Checkbox</span>
+                </label>
+
+                <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item is-invalid">
+                  <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-1" checked>
+                  <span class="spectrum-Checkbox-box">
+                    <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                      <use xlink:href="#spectrum-css-icon-Checkmark100" />
+                    </svg>
+                  </span>
+                  <span class="spectrum-Checkbox-label">Checkbox</span>
+                </label>
+
+                <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--negative">
+                  <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-HelpText-validationIcon" focusable="false" aria-hidden="true">
+                    <use xlink:href="#spectrum-icon-18-Alert" />
+                  </svg>
+                  <div class="spectrum-HelpText-text">Select an option.</div>
+                </div>
+              </div>
+            </div>
+          </form>
         </div>
 
         <div class="spectrum-Examples-item">
-          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Checkbox Invalid</h4>
+          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Radio Invalid</h4>
+          <form class="spectrum-Form">
+            <div class="spectrum-Form-item" role="radiogroup" aria-labelledby="radiogroup-label-1">
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="radiogroup-label-1">Radio Group Label</div>
 
-          <form>
-            <fieldset class="spectrum-FieldGroup spectrum-FieldGroup--horizontal">
-              <legend class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Checkbox Group Legend</legend>
-              <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical" id="checkboxgroup-d">
-                <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item is-invalid">
-                  <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-6">
-                  <span class="spectrum-Checkbox-box">
-                    <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-                      <use xlink:href="#spectrum-css-icon-Checkmark100" />
-                    </svg>
-                  </span>
-                  <span class="spectrum-Checkbox-label">Checkbox</span>
-                </label>
-                <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item is-invalid">
-                  <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-7" checked>
-                  <span class="spectrum-Checkbox-box">
-                    <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-                      <use xlink:href="#spectrum-css-icon-Checkmark100" />
-                    </svg>
-                  </span>
-                  <span class="spectrum-Checkbox-label">Checkbox</span>
-                </label>
+              <div class="spectrum-FieldGroup spectrum-FieldGroup--horizontal" aria-describedby="helptext-radio-0-1">
+                <div class="spectrum-Radio spectrum-FieldGroup-item is-invalid">
+                  <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-0">
+                  <span class="spectrum-Radio-button"></span>
+                  <label class="spectrum-Radio-label" for="radio-0">Kittens</label>
+                </div>
+
+                <div class="spectrum-Radio spectrum-FieldGroup-item is-invalid">
+                  <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-1" checked>
+                  <span class="spectrum-Radio-button"></span>
+                  <label class="spectrum-Radio-label" for="radio-1">Puppies</label>
+                </div>
+
+                <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--negative">
+                  <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-HelpText-validationIcon" focusable="false" aria-hidden="true">
+                    <use xlink:href="#spectrum-icon-18-Alert" />
+                  </svg>
+                  <div class="spectrum-HelpText-text">Select an option.</div>
+                </div>
               </div>
-            </fieldset>
-
-            <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--negative">
-              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-HelpText-validationIcon" focusable="false" aria-hidden="true">
-                <use xlink:href="#spectrum-icon-18-Alert" />
-              </svg>
-              <div class="spectrum-HelpText-text">Select a checkbox.</div>
             </div>
           </form>
-
         </div>
       </div>
+
+  - id: fieldgroup
+    name: Label Position
+    markup: |
+      <div class="spectrum-Examples">
+        <div class="spectrum-Examples-item">
+          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Top Label</h4>
+
+          <form class="spectrum-Form">
+            <div class="spectrum-Form-item" role="radiogroup" aria-labelledby="radiogroup-label-1">
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="radiogroup-label-1">Radio Group Label</div>
+
+              <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical" aria-describedby="helptext-radio-0-1">
+                <div class="spectrum-Radio spectrum-FieldGroup-item">
+                  <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-0">
+                  <span class="spectrum-Radio-button"></span>
+                  <label class="spectrum-Radio-label" for="radio-0">Kittens</label>
+                </div>
+
+                <div class="spectrum-Radio spectrum-FieldGroup-item">
+                  <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-1" checked>
+                  <span class="spectrum-Radio-button"></span>
+                  <label class="spectrum-Radio-label" for="radio-1">Puppies</label>
+                </div>
+
+                <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText" id="helptext-radio-0-1">
+                  <div class="spectrum-HelpText-text">Select an option.</div>
+                </div>
+              </div>
+            </div>
+          </form>
+        </div>
+
+        <div class="spectrum-Examples-item">
+          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Side Label</h4>
+
+          <form class="spectrum-Form">
+            <div class="spectrum-Form-item" role="radiogroup" aria-labelledby="radiogroup-label-1">
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--right" id="radiogroup-label-1">Radio Group Label</div>
+
+              <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical" aria-describedby="helptext-radio-0-1">
+                <div class="spectrum-Radio spectrum-FieldGroup-item">
+                  <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-0">
+                  <span class="spectrum-Radio-button"></span>
+                  <label class="spectrum-Radio-label" for="radio-0">Kittens</label>
+                </div>
+
+                <div class="spectrum-Radio spectrum-FieldGroup-item">
+                  <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-1" checked>
+                  <span class="spectrum-Radio-button"></span>
+                  <label class="spectrum-Radio-label" for="radio-1">Puppies</label>
+                </div>
+
+                <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText" id="helptext-radio-0-1">
+                  <div class="spectrum-HelpText-text">Select an option.</div>
+                </div>
+              </div>
+            </div>
+          </form>
+        </div>
+
+      </div>
+
   - id: fieldgroup-readonly-checkboxes
     name: Read-only Checkboxes
     description: A group of read-only checkboxes that have been `checked`. In U.S. English, use commas to delineate items within read-only checkbox groups. In other languages, use the locale-specific formatting.
     markup: |
-      <fieldset class="spectrum-FieldGroup">
+      <div class="spectrum-FieldGroup">
         <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item is-disabled is-readOnly">
           <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-8" checked disabled>
           <span class="spectrum-Checkbox-box">
@@ -377,4 +314,4 @@ examples:
           </span>
           <span class="spectrum-Checkbox-label">Bananas</span>
         </label>
-      </fieldset>
+      </div>

--- a/components/fieldgroup/metadata/fieldgroup.yml
+++ b/components/fieldgroup/metadata/fieldgroup.yml
@@ -7,7 +7,7 @@ description: |
   - Invalid checkboxes are signified by alert help text and alert input box color.
 examples:
   - id: fieldgroup
-    name: Standard
+    name: Horizontal
     markup: |
       <div class="spectrum-Examples">
         <div class="spectrum-Examples-item">
@@ -15,7 +15,7 @@ examples:
           <form class="spectrum-Form">
             <div class="spectrum-Form-item" role="radiogroup" aria-labelledby="radiogroup-label-1">
               <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="radiogroup-label-1">Radio Group Label</div>
-              <div class="spectrum-FieldGroup spectrum-FieldGroup--horizontal" aria-describedby="helptext-radio-0-1">
+              <div class="spectrum-FieldGroup spectrum-FieldGroup--horizontal" aria-describedby="helptext-radio-1">
                 <div class="spectrum-Radio spectrum-FieldGroup-item">
                   <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-0">
                   <span class="spectrum-Radio-button"></span>
@@ -28,7 +28,7 @@ examples:
                   <label class="spectrum-Radio-label" for="radio-1">Puppies</label>
                 </div>
 
-                <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText" id="helptext-radio-0-1">
+                <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText" id="helptext-radio-1">
                   <div class="spectrum-HelpText-text">Select an option.</div>
                 </div>
               </div>
@@ -41,7 +41,7 @@ examples:
           <form class="spectrum-Form">
             <div class="spectrum-Form-item" role="group" aria-labelledby="checkboxgroup-label-1">
               <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="checkboxgroup-label-1">Checkbox Group Label</div>
-              <div class="spectrum-FieldGroup spectrum-FieldGroup--horizontal" aria-describedby="helptext-checkbox-0-1">
+              <div class="spectrum-FieldGroup spectrum-FieldGroup--horizontal" aria-describedby="helptext-checkbox-1">
                 <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
                   <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-0">
                   <span class="spectrum-Checkbox-box">
@@ -62,7 +62,7 @@ examples:
                   <span class="spectrum-Checkbox-label">Checkbox</span>
                 </label>
 
-                <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText" id="helptext-radio-0-1">
+                <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText" id="helptext-checkbox-1">
                   <div class="spectrum-HelpText-text">Select an option.</div>
                 </div>
               </div>
@@ -79,22 +79,22 @@ examples:
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Radio</h4>
           <form class="spectrum-Form">
-            <div class="spectrum-Form-item" role="radiogroup" aria-labelledby="radiogroup-label-1">
-              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="radiogroup-label-1">Radio Group Label</div>
-              <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical" aria-describedby="helptext-radio-0-1">
+            <div class="spectrum-Form-item" role="radiogroup" aria-labelledby="radiogroup-label-2">
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="radiogroup-label-2">Radio Group Label</div>
+              <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical" aria-describedby="helptext-radio-2">
                 <div class="spectrum-Radio spectrum-FieldGroup-item">
-                  <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-0">
+                  <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-2">
                   <span class="spectrum-Radio-button"></span>
                   <label class="spectrum-Radio-label" for="radio-0">Kittens</label>
                 </div>
 
                 <div class="spectrum-Radio spectrum-FieldGroup-item">
-                  <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-1" checked>
+                  <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-3" checked>
                   <span class="spectrum-Radio-button"></span>
                   <label class="spectrum-Radio-label" for="radio-1">Puppies</label>
                 </div>
 
-                <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText" id="helptext-radio-0-1">
+                <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText" id="helptext-radio-2">
                   <div class="spectrum-HelpText-text">Select an option.</div>
                 </div>
               </div>
@@ -105,11 +105,11 @@ examples:
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Checkbox</h4>
           <form class="spectrum-Form">
-            <div class="spectrum-Form-item" role="group" aria-labelledby="checkboxgroup-label-1">
-              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="checkboxgroup-label-1">Checkbox Group Label</div>
-              <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical" aria-describedby="helptext-checkbox-0-1">
+            <div class="spectrum-Form-item" role="group" aria-labelledby="checkboxgroup-label-2">
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="checkboxgroup-label-2">Checkbox Group Label</div>
+              <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical" aria-describedby="helptext-checkbox-2">
                 <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
-                  <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-0">
+                  <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-2">
                   <span class="spectrum-Checkbox-box">
                     <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
                       <use xlink:href="#spectrum-css-icon-Checkmark100" />
@@ -119,7 +119,7 @@ examples:
                 </label>
 
                 <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
-                  <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-1" checked>
+                  <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-3" checked>
                   <span class="spectrum-Checkbox-box">
                     <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
                       <use xlink:href="#spectrum-css-icon-Checkmark100" />
@@ -128,7 +128,7 @@ examples:
                   <span class="spectrum-Checkbox-label">Checkbox</span>
                 </label>
 
-                <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText" id="helptext-radio-0-1">
+                <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText" id="helptext-checkbox-2">
                   <div class="spectrum-HelpText-text">Select an option.</div>
                 </div>
               </div>
@@ -145,11 +145,11 @@ examples:
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Checkbox Invalid</h4>
           <form class="spectrum-Form">
-            <div class="spectrum-Form-item" role="group" aria-labelledby="checkboxgroup-label-1">
-              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="checkboxgroup-label-1">Checkbox Group Label</div>
-              <div class="spectrum-FieldGroup spectrum-FieldGroup--horizontal" aria-describedby="helptext-checkbox-0-1">
+            <div class="spectrum-Form-item" role="group" aria-labelledby="checkboxgroup-label-3">
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="checkboxgroup-label-3">Checkbox Group Label</div>
+              <div class="spectrum-FieldGroup spectrum-FieldGroup--horizontal" aria-describedby="helptext-checkbox-3">
                 <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item is-invalid">
-                  <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-0">
+                  <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-4">
                   <span class="spectrum-Checkbox-box">
                     <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
                       <use xlink:href="#spectrum-css-icon-Checkmark100" />
@@ -159,7 +159,7 @@ examples:
                 </label>
 
                 <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item is-invalid">
-                  <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-1" checked>
+                  <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-5" checked>
                   <span class="spectrum-Checkbox-box">
                     <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
                       <use xlink:href="#spectrum-css-icon-Checkmark100" />
@@ -168,7 +168,7 @@ examples:
                   <span class="spectrum-Checkbox-label">Checkbox</span>
                 </label>
 
-                <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--negative">
+                <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--negative" id="helptext-checkbox-3">
                   <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-HelpText-validationIcon" focusable="false" aria-hidden="true">
                     <use xlink:href="#spectrum-icon-18-Alert" />
                   </svg>
@@ -182,23 +182,23 @@ examples:
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Radio Invalid</h4>
           <form class="spectrum-Form">
-            <div class="spectrum-Form-item" role="radiogroup" aria-labelledby="radiogroup-label-1">
-              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="radiogroup-label-1">Radio Group Label</div>
+            <div class="spectrum-Form-item" role="radiogroup" aria-labelledby="radiogroup-label-4">
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="radiogroup-label-4">Radio Group Label</div>
 
-              <div class="spectrum-FieldGroup spectrum-FieldGroup--horizontal" aria-describedby="helptext-radio-0-1">
+              <div class="spectrum-FieldGroup spectrum-FieldGroup--horizontal" aria-describedby="helptext-radio-4">
                 <div class="spectrum-Radio spectrum-FieldGroup-item is-invalid">
-                  <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-0">
+                  <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-4">
                   <span class="spectrum-Radio-button"></span>
                   <label class="spectrum-Radio-label" for="radio-0">Kittens</label>
                 </div>
 
                 <div class="spectrum-Radio spectrum-FieldGroup-item is-invalid">
-                  <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-1" checked>
+                  <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-5" checked>
                   <span class="spectrum-Radio-button"></span>
                   <label class="spectrum-Radio-label" for="radio-1">Puppies</label>
                 </div>
 
-                <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--negative">
+                <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--negative" id="helptext-radio-4">
                   <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-HelpText-validationIcon" focusable="false" aria-hidden="true">
                     <use xlink:href="#spectrum-icon-18-Alert" />
                   </svg>
@@ -218,23 +218,23 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Top Label</h4>
 
           <form class="spectrum-Form">
-            <div class="spectrum-Form-item" role="radiogroup" aria-labelledby="radiogroup-label-1">
-              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="radiogroup-label-1">Radio Group Label</div>
+            <div class="spectrum-Form-item" role="radiogroup" aria-labelledby="radiogroup-label-5">
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="radiogroup-label-5">Radio Group Label</div>
 
-              <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical" aria-describedby="helptext-radio-0-1">
+              <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical" aria-describedby="helptext-radio-5">
                 <div class="spectrum-Radio spectrum-FieldGroup-item">
-                  <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-0">
+                  <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-6">
                   <span class="spectrum-Radio-button"></span>
                   <label class="spectrum-Radio-label" for="radio-0">Kittens</label>
                 </div>
 
                 <div class="spectrum-Radio spectrum-FieldGroup-item">
-                  <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-1" checked>
+                  <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-7" checked>
                   <span class="spectrum-Radio-button"></span>
                   <label class="spectrum-Radio-label" for="radio-1">Puppies</label>
                 </div>
 
-                <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText" id="helptext-radio-0-1">
+                <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText" id="helptext-radio-5">
                   <div class="spectrum-HelpText-text">Select an option.</div>
                 </div>
               </div>
@@ -246,23 +246,23 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Side Label</h4>
 
           <form class="spectrum-Form">
-            <div class="spectrum-Form-item" role="radiogroup" aria-labelledby="radiogroup-label-1">
-              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--right" id="radiogroup-label-1">Radio Group Label</div>
+            <div class="spectrum-Form-item" role="radiogroup" aria-labelledby="radiogroup-label-6">
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--right" id="radiogroup-label-6">Radio Group Label</div>
 
-              <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical" aria-describedby="helptext-radio-0-1">
+              <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical" aria-describedby="helptext-radio-6">
                 <div class="spectrum-Radio spectrum-FieldGroup-item">
-                  <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-0">
+                  <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-8">
                   <span class="spectrum-Radio-button"></span>
                   <label class="spectrum-Radio-label" for="radio-0">Kittens</label>
                 </div>
 
                 <div class="spectrum-Radio spectrum-FieldGroup-item">
-                  <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-1" checked>
+                  <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-9" checked>
                   <span class="spectrum-Radio-button"></span>
                   <label class="spectrum-Radio-label" for="radio-1">Puppies</label>
                 </div>
 
-                <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText" id="helptext-radio-0-1">
+                <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText" id="helptext-radio-6">
                   <div class="spectrum-HelpText-text">Select an option.</div>
                 </div>
               </div>
@@ -278,7 +278,7 @@ examples:
     markup: |
       <div class="spectrum-FieldGroup">
         <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item is-disabled is-readOnly">
-          <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-8" checked disabled>
+          <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-6" checked disabled>
           <span class="spectrum-Checkbox-box">
             <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
               <use xlink:href="#spectrum-css-icon-Checkmark100" />
@@ -287,7 +287,7 @@ examples:
           <span class="spectrum-Checkbox-label">Apples</span>
         </label>
         <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item is-disabled is-readOnly">
-          <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-9" checked disabled>
+          <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-7" checked disabled>
           <span class="spectrum-Checkbox-box">
             <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
               <use xlink:href="#spectrum-css-icon-Checkmark100" />
@@ -297,7 +297,7 @@ examples:
         </label>
 
         <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item is-disabled is-readOnly">
-          <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-10" checked disabled>
+          <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-8" checked disabled>
           <span class="spectrum-Checkbox-box">
             <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
               <use xlink:href="#spectrum-css-icon-Checkmark100" />
@@ -306,7 +306,7 @@ examples:
           <span class="spectrum-Checkbox-label">Grapes</span>
         </label>
         <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item is-disabled is-readOnly">
-          <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-11" checked disabled>
+          <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-9" checked disabled>
           <span class="spectrum-Checkbox-box">
             <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
               <use xlink:href="#spectrum-css-icon-Checkmark100" />

--- a/components/fieldgroup/metadata/fieldgroup.yml
+++ b/components/fieldgroup/metadata/fieldgroup.yml
@@ -4,120 +4,182 @@ examples:
   - id: fieldgroup
     name: Standard
     markup: |
-      <div class="spectrum-FieldGroup spectrum-FieldGroup--horizontal">
-        <div class="spectrum-Radio spectrum-FieldGroup-item">
-          <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-0">
-          <span class="spectrum-Radio-button"></span>
-          <label class="spectrum-Radio-label" for="radio-0">Kittens</label>
+      <div class="spectrum-Examples">
+
+        <div class="spectrum-Examples-item">
+          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Radio</h4>
+
+          <div class="spectrum-FieldGroup spectrum-FieldGroup--horizontal">
+            <div class="spectrum-Radio spectrum-FieldGroup-item">
+              <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-0">
+              <span class="spectrum-Radio-button"></span>
+              <label class="spectrum-Radio-label" for="radio-0">Kittens</label>
+            </div>
+            <div class="spectrum-Radio spectrum-FieldGroup-item">
+              <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-1" checked>
+              <span class="spectrum-Radio-button"></span>
+              <label class="spectrum-Radio-label" for="radio-1">Dogs</label>
+            </div>
+          </div>
         </div>
-        <div class="spectrum-Radio spectrum-FieldGroup-item">
-          <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-1">
-          <span class="spectrum-Radio-button"></span>
-          <label class="spectrum-Radio-label" for="radio-1">Dogs</label>
+
+        <div class="spectrum-Examples-item">
+          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Radio Invalid</h4>
+
+          <div class="spectrum-FieldGroup spectrum-FieldGroup--horizontal">
+            <div class="spectrum-Radio spectrum-FieldGroup-item is-invalid">
+              <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-0">
+              <span class="spectrum-Radio-button"></span>
+              <label class="spectrum-Radio-label" for="radio-0">Kittens</label>
+            </div>
+            <div class="spectrum-Radio spectrum-FieldGroup-item is-invalid">
+              <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-1" checked>
+              <span class="spectrum-Radio-button"></span>
+              <label class="spectrum-Radio-label" for="radio-1">Dogs</label>
+            </div>
+          </div>
+        </div>
+
+        <div class="spectrum-Examples-item">
+          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Checkbox</h4>
+
+          <div class="spectrum-FieldGroup spectrum-FieldGroup--horizontal">
+            <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
+              <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-0">
+              <span class="spectrum-Checkbox-box">
+                <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                  <use xlink:href="#spectrum-css-icon-Checkmark100" />
+                </svg>
+              </span>
+              <span class="spectrum-Checkbox-label">Checkbox</span>
+            </label>
+            <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
+              <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-1" checked>
+              <span class="spectrum-Checkbox-box">
+                <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                  <use xlink:href="#spectrum-css-icon-Checkmark100" />
+                </svg>
+              </span>
+              <span class="spectrum-Checkbox-label">Checkbox</span>
+            </label>
+          </div>
+        </div>
+
+        <div class="spectrum-Examples-item">
+          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Checkbox Invalid</h4>
+
+          <div class="spectrum-FieldGroup spectrum-FieldGroup--horizontal">
+            <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item is-invalid">
+              <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-0">
+              <span class="spectrum-Checkbox-box">
+                <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                  <use xlink:href="#spectrum-css-icon-Checkmark100" />
+                </svg>
+              </span>
+              <span class="spectrum-Checkbox-label">Checkbox</span>
+            </label>
+            <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item is-invalid">
+              <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-1" checked>
+              <span class="spectrum-Checkbox-box">
+                <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                  <use xlink:href="#spectrum-css-icon-Checkmark100" />
+                </svg>
+              </span>
+              <span class="spectrum-Checkbox-label">Checkbox</span>
+            </label>
+          </div>
+
         </div>
       </div>
-      <div class="spectrum-FieldGroup spectrum-FieldGroup--horizontal">
-          <label class="spectrum-Checkbox spectrum-Checkbox--sizeM is-disabled is-indeterminate is-readOnly">
-            <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-0" disabled>
-            <span class="spectrum-Checkbox-box">
-              <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-                <use xlink:href="#spectrum-css-icon-Checkmark100" />
-              </svg>
-              <svg class="spectrum-Icon spectrum-UIIcon-Dash100 spectrum-Checkbox-partialCheckmark" focusable="false" aria-hidden="true">
-                <use xlink:href="#spectrum-css-icon-Dash100" />
-              </svg>
-            </span>
-            <span class="spectrum-Checkbox-label">Checkbox</span>
-          </label>
-        <label class="spectrum-Checkbox spectrum-Checkbox--sizeM is-disabled is-indeterminate is-readOnly">
-          <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-1" checked disabled>
-          <span class="spectrum-Checkbox-box">
-            <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-              <use xlink:href="#spectrum-css-icon-Checkmark100" />
-            </svg>
-            <svg class="spectrum-Icon spectrum-UIIcon-Dash100 spectrum-Checkbox-partialCheckmark" focusable="false" aria-hidden="true">
-              <use xlink:href="#spectrum-css-icon-Dash100" />
-            </svg>
-          </span>
-          <span class="spectrum-Checkbox-label">Checkbox</span>
-        </label>
-      </div>
-      <div class="spectrum-FieldGroup spectrum-FieldGroup--horizontal">
-        <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
-          <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-0">
-          <span class="spectrum-Checkbox-box">
-            <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-              <use xlink:href="#spectrum-css-icon-Checkmark100" />
-            </svg>
-          </span>
-          <span class="spectrum-Checkbox-label">Checkbox</span>
-        </label>
-        <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
-          <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-1" checked>
-          <span class="spectrum-Checkbox-box">
-            <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-              <use xlink:href="#spectrum-css-icon-Checkmark100" />
-            </svg>
-          </span>
-          <span class="spectrum-Checkbox-label">Checkbox</span>
-        </label>
-      </div>
+
   - id: fieldgroup-vertical
     name: Vertical
     description: A vertical group of fields.
     markup: |
-      <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical">
-        <div class="spectrum-Radio spectrum-FieldGroup-item">
-          <input type="radio" name="animals" class="spectrum-Radio-input" id="radio-fieldgroup-vertical-1">
-          <span class="spectrum-Radio-button"></span>
-          <label class="spectrum-Radio-label" for="radio-fieldgroup-vertical-1">Kittens</label>
-        </div>
-        <div class="spectrum-Radio spectrum-FieldGroup-item">
-          <input type="radio" name="animals" class="spectrum-Radio-input" id="radio-fieldgroup-vertical-2">
-          <span class="spectrum-Radio-button"></span>
-          <label class="spectrum-Radio-label" for="radio-fieldgroup-vertical-2">Dogs</label>
-        </div>
-      </div>
+      <div class="spectrum-Examples">
 
-      <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical">
-        <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
-          <input type="checkbox" class="spectrum-Checkbox-input">
-          <span class="spectrum-Checkbox-box">
-            <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-              <use xlink:href="#spectrum-css-icon-Checkmark100" />
-            </svg>
-          </span>
-          <span class="spectrum-Checkbox-label">Kibble</span>
-        </label>
-        <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
-          <input type="checkbox" class="spectrum-Checkbox-input" checked>
-          <span class="spectrum-Checkbox-box">
-            <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-              <use xlink:href="#spectrum-css-icon-Checkmark100" />
-            </svg>
-          </span>
-          <span class="spectrum-Checkbox-label">Bits</span>
-        </label>
-      </div>
-      <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical">
-        <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
-          <input type="checkbox" class="spectrum-Checkbox-input">
-          <span class="spectrum-Checkbox-box">
-            <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-              <use xlink:href="#spectrum-css-icon-Checkmark100" />
-            </svg>
-          </span>
-          <span class="spectrum-Checkbox-label">Kibble</span>
-        </label>
-        <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
-          <input type="checkbox" class="spectrum-Checkbox-input" checked>
-          <span class="spectrum-Checkbox-box">
-            <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-              <use xlink:href="#spectrum-css-icon-Checkmark100" />
-            </svg>
-          </span>
-          <span class="spectrum-Checkbox-label">Bits</span>
-        </label>
+        <div class="spectrum-Examples-item">
+          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Radio</h4>
+
+          <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical">
+            <div class="spectrum-Radio spectrum-FieldGroup-item">
+              <input type="radio" name="animals" class="spectrum-Radio-input" id="radio-fieldgroup-vertical-1">
+              <span class="spectrum-Radio-button"></span>
+              <label class="spectrum-Radio-label" for="radio-fieldgroup-vertical-1">Kittens</label>
+            </div>
+            <div class="spectrum-Radio spectrum-FieldGroup-item">
+              <input type="radio" name="animals" class="spectrum-Radio-input" id="radio-fieldgroup-vertical-2">
+              <span class="spectrum-Radio-button"></span>
+              <label class="spectrum-Radio-label" for="radio-fieldgroup-vertical-2">Dogs</label>
+            </div>
+          </div>
+        </div>
+        <div class="spectrum-Examples-item">
+          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Radio Invalid</h4>
+
+          <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical">
+            <div class="spectrum-Radio spectrum-FieldGroup-item is-invalid">
+              <input type="radio" name="animals" class="spectrum-Radio-input" id="radio-fieldgroup-vertical-1">
+              <span class="spectrum-Radio-button"></span>
+              <label class="spectrum-Radio-label" for="radio-fieldgroup-vertical-1">Kittens</label>
+            </div>
+            <div class="spectrum-Radio spectrum-FieldGroup-item">
+              <input type="radio" name="animals" class="spectrum-Radio-input" id="radio-fieldgroup-vertical-2">
+              <span class="spectrum-Radio-button"></span>
+              <label class="spectrum-Radio-label" for="radio-fieldgroup-vertical-2">Dogs</label>
+            </div>
+          </div>
+        </div>
+
+        <div class="spectrum-Examples-item">
+          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Checkbox</h4>
+
+          <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical">
+            <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
+              <input type="checkbox" class="spectrum-Checkbox-input">
+              <span class="spectrum-Checkbox-box">
+                <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                  <use xlink:href="#spectrum-css-icon-Checkmark100" />
+                </svg>
+              </span>
+              <span class="spectrum-Checkbox-label">Kibble</span>
+            </label>
+            <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
+              <input type="checkbox" class="spectrum-Checkbox-input" checked>
+              <span class="spectrum-Checkbox-box">
+                <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                  <use xlink:href="#spectrum-css-icon-Checkmark100" />
+                </svg>
+              </span>
+              <span class="spectrum-Checkbox-label">Bits</span>
+            </label>
+          </div>
+        </div>
+
+        <div class="spectrum-Examples-item">
+          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Checkbox Invalid</h4>
+
+          <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical">
+            <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item is-invalid">
+              <input type="checkbox" class="spectrum-Checkbox-input">
+              <span class="spectrum-Checkbox-box">
+                <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                  <use xlink:href="#spectrum-css-icon-Checkmark100" />
+                </svg>
+              </span>
+              <span class="spectrum-Checkbox-label">Kibble</span>
+            </label>
+            <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item is-invalid">
+              <input type="checkbox" class="spectrum-Checkbox-input" checked>
+              <span class="spectrum-Checkbox-box">
+                <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                  <use xlink:href="#spectrum-css-icon-Checkmark100" />
+                </svg>
+              </span>
+              <span class="spectrum-Checkbox-label">Bits</span>
+            </label>
+          </div>
+        </div>
       </div>
   - id: fieldgroup-readonly-checkboxes
     name: Read-only Checkboxes
@@ -161,26 +223,4 @@ examples:
           </span>
           <span class="spectrum-Checkbox-label">Bananas</span>
         </label>
-      </div>
-
-  - id: fieldgroup-labelsbelow
-    name: Radios with labels below
-    description: Put the labels below by adding the modifier class to the field itself.
-    markup: |
-      <div class="spectrum-FieldGroup spectrum-FieldGroup--horizontal">
-        <div class="spectrum-Radio spectrum-Radio--labelBelow spectrum-FieldGroup-item">
-          <input type="radio" name="rating" class="spectrum-Radio-input" id="radio-2">
-          <span class="spectrum-Radio-button"></span>
-          <label class="spectrum-Radio-label" for="radio-2">1</label>
-        </div>
-        <div class="spectrum-Radio spectrum-Radio--labelBelow spectrum-FieldGroup-item">
-          <input type="radio" name="rating" class="spectrum-Radio-input" id="radio-3">
-          <span class="spectrum-Radio-button"></span>
-          <label class="spectrum-Radio-label" for="radio-3">2</label>
-        </div>
-        <div class="spectrum-Radio spectrum-Radio--labelBelow spectrum-FieldGroup-item">
-          <input type="radio" name="rating" class="spectrum-Radio-input" id="radio-4">
-          <span class="spectrum-Radio-button"></span>
-          <label class="spectrum-Radio-label" for="radio-4">3</label>
-        </div>
       </div>

--- a/components/fieldgroup/metadata/fieldgroup.yml
+++ b/components/fieldgroup/metadata/fieldgroup.yml
@@ -5,6 +5,18 @@ description: |
   - Help text is necessary to denote invalid checkbox fields, invalid radio button fields, and required fields.
   - Invalid radio buttons are signified only by alert help text.
   - Invalid checkboxes are signified by alert help text and alert input box color.
+sections:
+  - name: Migration Guide
+    description: |
+      ### Field Group Now Includes Label and Helptext
+      - Include Field Label as size medium, `spectrum-FieldLabel spectrum-FieldLabel--sizeM`.
+      - Include Helptext as `spectrum-HelpText-text`.
+      ### Field Group Label has two layout options
+      - Label can be top aligned with `spectrum-FieldGroup spectrum-FieldGroup--toplabel`.
+      - Label can be side aligned with `spectrum-FieldGroup spectrum-FieldGroup--sidelabel`.
+      ### Field Group must now include `spectrum-FieldGroupInputLayout` as the immediate parent of the FieldGroup items
+      - Due to the addition of label, a new nested div must wrap the fieldgroup items to control their layout separately from the label
+
 examples:
   - id: fieldgroup-vertical
     name: Vertical
@@ -16,7 +28,7 @@ examples:
 
           <form class="spectrum-Form">
             <div class="spectrum-FieldGroup spectrum-FieldGroup--toplabel spectrum-FieldGroup--vertical" role="radiogroup" aria-labelledby="radiogroup-label-1">
-              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel" id="radiogroup-label-1">Radio Group Label</div>
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="radiogroup-label-1">Radio Group Label</div>
 
               <div class="spectrum-FieldGroupInputLayout" aria-describedby="helptext-radio-1">
                 <div class="spectrum-Radio spectrum-FieldGroup-item">
@@ -44,7 +56,7 @@ examples:
 
           <form class="spectrum-Form">
             <div class="spectrum-FieldGroup spectrum-FieldGroup--toplabel spectrum-FieldGroup--vertical" role="group" aria-labelledby="checkboxgroup-label-1">
-              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel" id="checkboxgroup-label-1">Checkbox Group Label</div>
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="checkboxgroup-label-1">Checkbox Group Label</div>
 
               <div class="spectrum-FieldGroupInputLayout" aria-describedby="helptext-checkbox-1">
                 <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
@@ -88,7 +100,7 @@ examples:
 
           <form class="spectrum-Form">
             <div class="spectrum-FieldGroup spectrum-FieldGroup--toplabel spectrum-FieldGroup--horizontal" role="radiogroup" aria-labelledby="radiogroup-label-2">
-              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel" id="radiogroup-label-2">Radio Group Label</div>
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="radiogroup-label-2">Radio Group Label</div>
 
               <div class="spectrum-FieldGroupInputLayout" aria-describedby="helptext-radio-2">
                 <div class="spectrum-Radio spectrum-FieldGroup-item">
@@ -116,7 +128,7 @@ examples:
 
           <form class="spectrum-Form">
             <div class="spectrum-FieldGroup spectrum-FieldGroup--toplabel spectrum-FieldGroup--horizontal" role="group" aria-labelledby="checkboxgroup-label-2">
-              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel" id="checkboxgroup-label-2">Checkbox Group Label</div>
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="checkboxgroup-label-2">Checkbox Group Label</div>
 
               <div class="spectrum-FieldGroupInputLayout" aria-describedby="helptext-checkbox-2">
                 <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
@@ -161,7 +173,7 @@ examples:
 
           <form class="spectrum-Form">
             <div class="spectrum-FieldGroup spectrum-FieldGroup--toplabel spectrum-FieldGroup--horizontal" role="radiogroup" aria-labelledby="radiogroup-label-3">
-              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel" id="radiogroup-label-3">Radio Group Label</div>
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="radiogroup-label-3">Radio Group Label</div>
 
               <div class="spectrum-FieldGroupInputLayout" aria-describedby="helptext-radio-3">
                 <div class="spectrum-Radio spectrum-FieldGroup-item is-invalid">
@@ -193,7 +205,7 @@ examples:
 
           <form class="spectrum-Form">
             <div class="spectrum-FieldGroup spectrum-FieldGroup--toplabel spectrum-FieldGroup--horizontal" role="group" aria-labelledby="checkboxgroup-label-3">
-              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel" id="checkboxgroup-label-3">Checkbox Group Label</div>
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="checkboxgroup-label-3">Checkbox Group Label</div>
 
               <div class="spectrum-FieldGroupInputLayout" aria-describedby="helptext-checkbox-3">
                 <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item is-invalid">
@@ -239,7 +251,7 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Required</h4>
           <form class="spectrum-Form">
             <div class="spectrum-FieldGroup spectrum-FieldGroup--toplabel spectrum-FieldGroup--vertical" role="radiogroup" aria-labelledby="radiogroup-label-4">
-              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel" id="radiogroup-label-4">Radio Group Label (required)</div>
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="radiogroup-label-4">Radio Group Label (required)</div>
 
               <div class="spectrum-FieldGroupInputLayout" aria-describedby="helptext-radio-4">
                 <div class="spectrum-Radio spectrum-FieldGroup-item">
@@ -266,7 +278,7 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Required Asterisk</h4>
           <form class="spectrum-Form">
             <div class="spectrum-FieldGroup spectrum-FieldGroup--toplabel spectrum-FieldGroup--vertical" role="radiogroup" aria-labelledby="radiogroup-label-5">
-              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel" id="radiogroup-label-5">Radio Group Label
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="radiogroup-label-5">Radio Group Label
                 <svg class="spectrum-Icon spectrum-UIIcon-Asterisk100 spectrum-FieldLabel-requiredIcon" focusable="false" aria-hidden="true">
                   <use xlink:href="#spectrum-css-icon-Asterisk100" />
                 </svg>
@@ -297,7 +309,7 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Optional</h4>
           <form class="spectrum-Form">
             <div class="spectrum-FieldGroup spectrum-FieldGroup--toplabel spectrum-FieldGroup--vertical" role="radiogroup" aria-labelledby="radiogroup-label-6">
-              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel" id="radiogroup-label-6">Radio Group Label (optional)</div>
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="radiogroup-label-6">Radio Group Label (optional)</div>
 
               <div class="spectrum-FieldGroupInputLayout">
                 <div class="spectrum-Radio spectrum-FieldGroup-item">
@@ -328,7 +340,7 @@ examples:
 
           <form class="spectrum-Form">
             <div class="spectrum-FieldGroup spectrum-FieldGroup--sidelabel spectrum-FieldGroup--vertical" role="radiogroup" aria-labelledby="radiogroup-label-7">
-              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--right" id="radiogroup-label-7">Radio Group Label</div>
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM--right" id="radiogroup-label-7">Radio Group Label</div>
 
               <div class="spectrum-FieldGroupInputLayout" aria-describedby="helptext-radio-7">
                 <div class="spectrum-Radio spectrum-FieldGroup-item">
@@ -356,7 +368,7 @@ examples:
 
           <form class="spectrum-Form">
             <div class="spectrum-FieldGroup spectrum-FieldGroup--sidelabel spectrum-FieldGroup--vertical" role="radiogroup" aria-labelledby="checkboxgroup-label-4">
-              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--right" id="checkboxgroup-label-4">Checkbox Group Label</div>
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM--right" id="checkboxgroup-label-4">Checkbox Group Label</div>
 
               <div class="spectrum-FieldGroupInputLayout" aria-describedby="helptext-checkbox-4">
                 <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
@@ -391,7 +403,7 @@ examples:
 
           <form class="spectrum-Form">
             <div class="spectrum-FieldGroup spectrum-FieldGroup--sidelabel spectrum-FieldGroup--horizontal" role="radiogroup" aria-labelledby="radiogroup-label-8">
-              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--right" id="radiogroup-label-8">Radio Group Label</div>
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM--right" id="radiogroup-label-8">Radio Group Label</div>
 
               <div class="spectrum-FieldGroupInputLayout" aria-describedby="helptext-radio-8">
                 <div class="spectrum-Radio spectrum-FieldGroup-item">
@@ -419,7 +431,7 @@ examples:
 
           <form class="spectrum-Form">
             <div class="spectrum-FieldGroup spectrum-FieldGroup--sidelabel spectrum-FieldGroup--horizontal" role="radiogroup" aria-labelledby="checkboxgroup-label-5">
-              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--right" id="checkboxgroup-label-5">Checkbox Group Label</div>
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM--right" id="checkboxgroup-label-5">Checkbox Group Label</div>
 
               <div class="spectrum-FieldGroupInputLayout" aria-describedby="helptext-checkbox-5">
                 <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">

--- a/components/fieldgroup/metadata/fieldgroup.yml
+++ b/components/fieldgroup/metadata/fieldgroup.yml
@@ -15,10 +15,10 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Radio</h4>
 
           <form class="spectrum-Form">
-            <div class="spectrum-FieldGroup spectrum-FieldGroup--toplabel" role="radiogroup" aria-labelledby="radiogroup-label-1">
+            <div class="spectrum-FieldGroup spectrum-FieldGroup--toplabel spectrum-FieldGroup--vertical" role="radiogroup" aria-labelledby="radiogroup-label-1">
               <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel" id="radiogroup-label-1">Radio Group Label</div>
 
-              <div class="spectrum-FieldGroupInputLayout spectrum-FieldGroupInputLayout--vertical" aria-describedby="helptext-radio-1">
+              <div class="spectrum-FieldGroupInputLayout" aria-describedby="helptext-radio-1">
                 <div class="spectrum-Radio spectrum-FieldGroup-item">
                   <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-0">
                   <span class="spectrum-Radio-button"></span>
@@ -43,10 +43,10 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Checkbox</h4>
 
           <form class="spectrum-Form">
-            <div class="spectrum-FieldGroup spectrum-FieldGroup--toplabel" role="group" aria-labelledby="checkboxgroup-label-1">
+            <div class="spectrum-FieldGroup spectrum-FieldGroup--toplabel spectrum-FieldGroup--vertical" role="group" aria-labelledby="checkboxgroup-label-1">
               <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel" id="checkboxgroup-label-1">Checkbox Group Label</div>
 
-              <div class="spectrum-FieldGroupInputLayout spectrum-FieldGroupInputLayout--vertical" aria-describedby="helptext-checkbox-1">
+              <div class="spectrum-FieldGroupInputLayout" aria-describedby="helptext-checkbox-1">
                 <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
                   <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-0">
                   <span class="spectrum-Checkbox-box">
@@ -87,10 +87,10 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Radio</h4>
 
           <form class="spectrum-Form">
-            <div class="spectrum-FieldGroup spectrum-FieldGroup--toplabel" role="radiogroup" aria-labelledby="radiogroup-label-2">
+            <div class="spectrum-FieldGroup spectrum-FieldGroup--toplabel spectrum-FieldGroup--horizontal" role="radiogroup" aria-labelledby="radiogroup-label-2">
               <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel" id="radiogroup-label-2">Radio Group Label</div>
 
-              <div class="spectrum-FieldGroupInputLayout spectrum-FieldGroupInputLayout--horizontal" aria-describedby="helptext-radio-2">
+              <div class="spectrum-FieldGroupInputLayout" aria-describedby="helptext-radio-2">
                 <div class="spectrum-Radio spectrum-FieldGroup-item">
                   <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-2">
                   <span class="spectrum-Radio-button"></span>
@@ -115,10 +115,10 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Checkbox</h4>
 
           <form class="spectrum-Form">
-            <div class="spectrum-FieldGroup spectrum-FieldGroup--toplabel" role="group" aria-labelledby="checkboxgroup-label-2">
+            <div class="spectrum-FieldGroup spectrum-FieldGroup--toplabel spectrum-FieldGroup--horizontal" role="group" aria-labelledby="checkboxgroup-label-2">
               <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel" id="checkboxgroup-label-2">Checkbox Group Label</div>
 
-              <div class="spectrum-FieldGroupInputLayout spectrum-FieldGroupInputLayout--horizontal" aria-describedby="helptext-checkbox-2">
+              <div class="spectrum-FieldGroupInputLayout" aria-describedby="helptext-checkbox-2">
                 <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
                   <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-2">
                   <span class="spectrum-Checkbox-box">
@@ -160,10 +160,10 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Radio</h4>
 
           <form class="spectrum-Form">
-            <div class="spectrum-FieldGroup spectrum-FieldGroup--toplabel" role="radiogroup" aria-labelledby="radiogroup-label-3">
+            <div class="spectrum-FieldGroup spectrum-FieldGroup--toplabel spectrum-FieldGroup--horizontal" role="radiogroup" aria-labelledby="radiogroup-label-3">
               <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel" id="radiogroup-label-3">Radio Group Label</div>
 
-              <div class="spectrum-FieldGroupInputLayout spectrum-FieldGroupInputLayout--horizontal" aria-describedby="helptext-radio-3">
+              <div class="spectrum-FieldGroupInputLayout" aria-describedby="helptext-radio-3">
                 <div class="spectrum-Radio spectrum-FieldGroup-item is-invalid">
                   <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-4">
                   <span class="spectrum-Radio-button"></span>
@@ -192,10 +192,10 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Checkbox</h4>
 
           <form class="spectrum-Form">
-            <div class="spectrum-FieldGroup spectrum-FieldGroup--toplabel" role="group" aria-labelledby="checkboxgroup-label-3">
+            <div class="spectrum-FieldGroup spectrum-FieldGroup--toplabel spectrum-FieldGroup--horizontal" role="group" aria-labelledby="checkboxgroup-label-3">
               <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel" id="checkboxgroup-label-3">Checkbox Group Label</div>
 
-              <div class="spectrum-FieldGroupInputLayout spectrum-FieldGroupInputLayout--horizontal" aria-describedby="helptext-checkbox-3">
+              <div class="spectrum-FieldGroupInputLayout" aria-describedby="helptext-checkbox-3">
                 <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item is-invalid">
                   <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-4">
                   <span class="spectrum-Checkbox-box">
@@ -238,10 +238,10 @@ examples:
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Required</h4>
           <form class="spectrum-Form">
-            <div class="spectrum-FieldGroup spectrum-FieldGroup--toplabel" role="radiogroup" aria-labelledby="radiogroup-label-4">
+            <div class="spectrum-FieldGroup spectrum-FieldGroup--toplabel spectrum-FieldGroup--vertical" role="radiogroup" aria-labelledby="radiogroup-label-4">
               <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel" id="radiogroup-label-4">Radio Group Label (required)</div>
 
-              <div class="spectrum-FieldGroupInputLayout spectrum-FieldGroupInputLayout--vertical" aria-describedby="helptext-radio-4">
+              <div class="spectrum-FieldGroupInputLayout" aria-describedby="helptext-radio-4">
                 <div class="spectrum-Radio spectrum-FieldGroup-item">
                   <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-6">
                   <span class="spectrum-Radio-button"></span>
@@ -265,14 +265,14 @@ examples:
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Required Asterisk</h4>
           <form class="spectrum-Form">
-            <div class="spectrum-FieldGroup spectrum-FieldGroup--toplabel" role="radiogroup" aria-labelledby="radiogroup-label-5">
+            <div class="spectrum-FieldGroup spectrum-FieldGroup--toplabel spectrum-FieldGroup--vertical" role="radiogroup" aria-labelledby="radiogroup-label-5">
               <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel" id="radiogroup-label-5">Radio Group Label
                 <svg class="spectrum-Icon spectrum-UIIcon-Asterisk100 spectrum-FieldLabel-requiredIcon" focusable="false" aria-hidden="true">
                   <use xlink:href="#spectrum-css-icon-Asterisk100" />
                 </svg>
               </div>
 
-              <div class="spectrum-FieldGroupInputLayout spectrum-FieldGroupInputLayout--vertical" aria-describedby="helptext-radio-5">
+              <div class="spectrum-FieldGroupInputLayout" aria-describedby="helptext-radio-5">
                 <div class="spectrum-Radio spectrum-FieldGroup-item">
                   <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-8">
                   <span class="spectrum-Radio-button"></span>
@@ -296,10 +296,10 @@ examples:
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Optional</h4>
           <form class="spectrum-Form">
-            <div class="spectrum-FieldGroup spectrum-FieldGroup--toplabel" role="radiogroup" aria-labelledby="radiogroup-label-6">
+            <div class="spectrum-FieldGroup spectrum-FieldGroup--toplabel spectrum-FieldGroup--vertical" role="radiogroup" aria-labelledby="radiogroup-label-6">
               <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel" id="radiogroup-label-6">Radio Group Label (optional)</div>
 
-              <div class="spectrum-FieldGroupInputLayout spectrum-FieldGroupInputLayout--vertical">
+              <div class="spectrum-FieldGroupInputLayout">
                 <div class="spectrum-Radio spectrum-FieldGroup-item">
                   <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-10">
                   <span class="spectrum-Radio-button"></span>
@@ -327,10 +327,10 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Side Label Vertical Radio</h4>
 
           <form class="spectrum-Form">
-            <div class="spectrum-FieldGroup spectrum-FieldGroup--sidelabel" role="radiogroup" aria-labelledby="radiogroup-label-7">
+            <div class="spectrum-FieldGroup spectrum-FieldGroup--sidelabel spectrum-FieldGroup--vertical" role="radiogroup" aria-labelledby="radiogroup-label-7">
               <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--right" id="radiogroup-label-7">Radio Group Label</div>
 
-              <div class="spectrum-FieldGroupInputLayout spectrum-FieldGroupInputLayout--vertical" aria-describedby="helptext-radio-7">
+              <div class="spectrum-FieldGroupInputLayout" aria-describedby="helptext-radio-7">
                 <div class="spectrum-Radio spectrum-FieldGroup-item">
                   <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-12">
                   <span class="spectrum-Radio-button"></span>
@@ -355,10 +355,10 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Side Label Vertical Checkbox</h4>
 
           <form class="spectrum-Form">
-            <div class="spectrum-FieldGroup spectrum-FieldGroup--sidelabel" role="radiogroup" aria-labelledby="checkboxgroup-label-4">
+            <div class="spectrum-FieldGroup spectrum-FieldGroup--sidelabel spectrum-FieldGroup--vertical" role="radiogroup" aria-labelledby="checkboxgroup-label-4">
               <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--right" id="checkboxgroup-label-4">Checkbox Group Label</div>
 
-              <div class="spectrum-FieldGroupInputLayout spectrum-FieldGroupInputLayout--vertical" aria-describedby="helptext-checkbox-4">
+              <div class="spectrum-FieldGroupInputLayout" aria-describedby="helptext-checkbox-4">
                 <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
                   <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-6">
                   <span class="spectrum-Checkbox-box">
@@ -390,10 +390,10 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Side Label Horizontal Radio</h4>
 
           <form class="spectrum-Form">
-            <div class="spectrum-FieldGroup spectrum-FieldGroup--sidelabel" role="radiogroup" aria-labelledby="radiogroup-label-8">
+            <div class="spectrum-FieldGroup spectrum-FieldGroup--sidelabel spectrum-FieldGroup--horizontal" role="radiogroup" aria-labelledby="radiogroup-label-8">
               <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--right" id="radiogroup-label-8">Radio Group Label</div>
 
-              <div class="spectrum-FieldGroupInputLayout spectrum-FieldGroupInputLayout--horizontal" aria-describedby="helptext-radio-8">
+              <div class="spectrum-FieldGroupInputLayout" aria-describedby="helptext-radio-8">
                 <div class="spectrum-Radio spectrum-FieldGroup-item">
                   <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-14">
                   <span class="spectrum-Radio-button"></span>
@@ -418,10 +418,10 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Side Label Horizontal Checkbox</h4>
 
           <form class="spectrum-Form">
-            <div class="spectrum-FieldGroup spectrum-FieldGroup--sidelabel" role="radiogroup" aria-labelledby="checkboxgroup-label-5">
+            <div class="spectrum-FieldGroup spectrum-FieldGroup--sidelabel spectrum-FieldGroup--horizontal" role="radiogroup" aria-labelledby="checkboxgroup-label-5">
               <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--right" id="checkboxgroup-label-5">Checkbox Group Label</div>
 
-              <div class="spectrum-FieldGroupInputLayout spectrum-FieldGroupInputLayout--horizontal" aria-describedby="helptext-checkbox-5">
+              <div class="spectrum-FieldGroupInputLayout" aria-describedby="helptext-checkbox-5">
                 <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
                   <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-8">
                   <span class="spectrum-Checkbox-box">

--- a/components/fieldgroup/metadata/fieldgroup.yml
+++ b/components/fieldgroup/metadata/fieldgroup.yml
@@ -27,6 +27,34 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Radio</h4>
 
           <form class="spectrum-Form">
+            <div class="spectrum-FieldGroup" role="radiogroup" aria-labelledby="radiogroup-label-1">
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="radiogroup-label-1">Radio Group Label</div>
+
+              <div class="spectrum-FieldGroupInputLayout" aria-describedby="helptext-radio-1">
+                <div class="spectrum-Radio spectrum-FieldGroup-item">
+                  <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-0">
+                  <span class="spectrum-Radio-button"></span>
+                  <label class="spectrum-Radio-label" for="radio-0">Kittens</label>
+                </div>
+
+                <div class="spectrum-Radio spectrum-FieldGroup-item">
+                  <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-1" checked>
+                  <span class="spectrum-Radio-button"></span>
+                  <label class="spectrum-Radio-label" for="radio-1">Puppies</label>
+                </div>
+
+                <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText" id="helptext-radio-1">
+                  <div class="spectrum-HelpText-text">Select an option.</div>
+                </div>
+              </div>
+            </div>
+          </form>
+        </div>
+
+        <div class="spectrum-Examples-item">
+          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Radio</h4>
+
+          <form class="spectrum-Form">
             <div class="spectrum-FieldGroup spectrum-FieldGroup--toplabel spectrum-FieldGroup--vertical" role="radiogroup" aria-labelledby="radiogroup-label-1">
               <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="radiogroup-label-1">Radio Group Label</div>
 
@@ -340,7 +368,7 @@ examples:
 
           <form class="spectrum-Form">
             <div class="spectrum-FieldGroup spectrum-FieldGroup--sidelabel spectrum-FieldGroup--vertical" role="radiogroup" aria-labelledby="radiogroup-label-7">
-              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM--right" id="radiogroup-label-7">Radio Group Label</div>
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--right" id="radiogroup-label-7">Radio Group Label</div>
 
               <div class="spectrum-FieldGroupInputLayout" aria-describedby="helptext-radio-7">
                 <div class="spectrum-Radio spectrum-FieldGroup-item">
@@ -368,7 +396,7 @@ examples:
 
           <form class="spectrum-Form">
             <div class="spectrum-FieldGroup spectrum-FieldGroup--sidelabel spectrum-FieldGroup--vertical" role="radiogroup" aria-labelledby="checkboxgroup-label-4">
-              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM--right" id="checkboxgroup-label-4">Checkbox Group Label</div>
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--right" id="checkboxgroup-label-4">Checkbox Group Label</div>
 
               <div class="spectrum-FieldGroupInputLayout" aria-describedby="helptext-checkbox-4">
                 <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
@@ -403,7 +431,7 @@ examples:
 
           <form class="spectrum-Form">
             <div class="spectrum-FieldGroup spectrum-FieldGroup--sidelabel spectrum-FieldGroup--horizontal" role="radiogroup" aria-labelledby="radiogroup-label-8">
-              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM--right" id="radiogroup-label-8">Radio Group Label</div>
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--right" id="radiogroup-label-8">Radio Group Label</div>
 
               <div class="spectrum-FieldGroupInputLayout" aria-describedby="helptext-radio-8">
                 <div class="spectrum-Radio spectrum-FieldGroup-item">
@@ -431,7 +459,7 @@ examples:
 
           <form class="spectrum-Form">
             <div class="spectrum-FieldGroup spectrum-FieldGroup--sidelabel spectrum-FieldGroup--horizontal" role="radiogroup" aria-labelledby="checkboxgroup-label-5">
-              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM--right" id="checkboxgroup-label-5">Checkbox Group Label</div>
+              <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--right" id="checkboxgroup-label-5">Checkbox Group Label</div>
 
               <div class="spectrum-FieldGroupInputLayout" aria-describedby="helptext-checkbox-5">
                 <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">

--- a/components/fieldgroup/package.json
+++ b/components/fieldgroup/package.json
@@ -18,16 +18,17 @@
   "peerDependencies": {
     "@spectrum-css/checkbox": "^3.1.1",
     "@spectrum-css/icon": "^3.0.21",
-    "@spectrum-css/radio": "^3.0.22",
-    "@spectrum-css/helptext": "^1.0.20",
-    "@spectrum-css/tokens": "^1.0.1"
+    "@spectrum-css/radio": "^4.0.1",
+    "@spectrum-css/helptext": "^2.0.5",
+    "@spectrum-css/tokens": "^1.0.7"
   },
   "devDependencies": {
     "@spectrum-css/component-builder-simple": "^1.0.0-beta",
     "@spectrum-css/checkbox": "^3.1.3",
     "@spectrum-css/icon": "^3.0.23",
-    "@spectrum-css/radio": "^3.0.24",
-    "@spectrum-css/helptext": "^1.0.20",
+    "@spectrum-css/radio": "^4.0.1",
+    "@spectrum-css/helptext": "^2.0.5",
+    "@spectrum-css/tokens": "^1.0.7",
     "@spectrum-css/vars": "^8.0.0",
     "gulp": "^4.0.0"
   },

--- a/components/fieldgroup/package.json
+++ b/components/fieldgroup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spectrum-css/fieldgroup",
-  "version": "3.1.4",
+  "version": "4.0.0-beta.0",
   "description": "The Spectrum CSS fieldgroup component",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",

--- a/components/fieldgroup/package.json
+++ b/components/fieldgroup/package.json
@@ -19,11 +19,11 @@
     "@spectrum-css/checkbox": "^3.1.1",
     "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/radio": "^3.0.22",
-    "@spectrum-css/vars": "^8.0.0"
+    "@spectrum-css/tokens": "^1.0.1"
   },
   "devDependencies": {
     "@spectrum-css/checkbox": "^3.1.3",
-    "@spectrum-css/component-builder": "^3.2.0",
+    "@spectrum-css/component-builder-simple": "^1.0.0-beta",
     "@spectrum-css/icon": "^3.0.23",
     "@spectrum-css/radio": "^3.0.24",
     "@spectrum-css/vars": "^8.0.0",

--- a/components/fieldgroup/package.json
+++ b/components/fieldgroup/package.json
@@ -23,8 +23,8 @@
     "@spectrum-css/tokens": "^1.0.1"
   },
   "devDependencies": {
-    "@spectrum-css/checkbox": "^3.1.3",
     "@spectrum-css/component-builder-simple": "^1.0.0-beta",
+    "@spectrum-css/checkbox": "^3.1.3",
     "@spectrum-css/icon": "^3.0.23",
     "@spectrum-css/radio": "^3.0.24",
     "@spectrum-css/helptext": "^1.0.20",

--- a/components/fieldgroup/package.json
+++ b/components/fieldgroup/package.json
@@ -19,6 +19,7 @@
     "@spectrum-css/checkbox": "^3.1.1",
     "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/radio": "^3.0.22",
+    "@spectrum-css/helptext": "^1.0.20",
     "@spectrum-css/tokens": "^1.0.1"
   },
   "devDependencies": {
@@ -26,6 +27,7 @@
     "@spectrum-css/component-builder-simple": "^1.0.0-beta",
     "@spectrum-css/icon": "^3.0.23",
     "@spectrum-css/radio": "^3.0.24",
+    "@spectrum-css/helptext": "^1.0.20",
     "@spectrum-css/vars": "^8.0.0",
     "gulp": "^4.0.0"
   },

--- a/components/fieldgroup/package.json
+++ b/components/fieldgroup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spectrum-css/fieldgroup",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-beta.1",
   "description": "The Spectrum CSS fieldgroup component",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",

--- a/components/fieldgroup/package.json
+++ b/components/fieldgroup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spectrum-css/fieldgroup",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "description": "The Spectrum CSS fieldgroup component",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",
@@ -23,7 +23,7 @@
     "@spectrum-css/tokens": "^4.0.0"
   },
   "devDependencies": {
-    "@spectrum-css/component-builder-simple": "^1.0.0-beta",
+    "@spectrum-css/component-builder-simple": "^2.0.0",
     "@spectrum-css/checkbox": "^3.1.3",
     "@spectrum-css/icon": "^3.0.23",
     "@spectrum-css/radio": "^4.0.1",

--- a/components/fieldgroup/package.json
+++ b/components/fieldgroup/package.json
@@ -20,7 +20,7 @@
     "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/radio": "^4.0.1",
     "@spectrum-css/helptext": "^2.0.5",
-    "@spectrum-css/tokens": "^1.0.7"
+    "@spectrum-css/tokens": "^4.0.0"
   },
   "devDependencies": {
     "@spectrum-css/component-builder-simple": "^1.0.0-beta",
@@ -28,7 +28,7 @@
     "@spectrum-css/icon": "^3.0.23",
     "@spectrum-css/radio": "^4.0.1",
     "@spectrum-css/helptext": "^2.0.5",
-    "@spectrum-css/tokens": "^1.0.7",
+    "@spectrum-css/tokens": "^4.0.0",
     "@spectrum-css/vars": "^8.0.0",
     "gulp": "^4.0.0"
   },

--- a/components/fieldgroup/package.json
+++ b/components/fieldgroup/package.json
@@ -16,20 +16,19 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/checkbox": "^3.1.1",
+    "@spectrum-css/checkbox": "^5.0.0",
     "@spectrum-css/icon": "^3.0.21",
-    "@spectrum-css/radio": "^4.0.1",
-    "@spectrum-css/helptext": "^2.0.5",
+    "@spectrum-css/radio": "^5.0.1",
+    "@spectrum-css/helptext": "^3.0.0",
     "@spectrum-css/tokens": "^4.0.0"
   },
   "devDependencies": {
     "@spectrum-css/component-builder-simple": "^2.0.0",
-    "@spectrum-css/checkbox": "^3.1.3",
+    "@spectrum-css/checkbox": "^5.0.0",
     "@spectrum-css/icon": "^3.0.23",
-    "@spectrum-css/radio": "^4.0.1",
-    "@spectrum-css/helptext": "^2.0.5",
+    "@spectrum-css/radio": "^5.0.1",
+    "@spectrum-css/helptext": "^3.0.0",
     "@spectrum-css/tokens": "^4.0.0",
-    "@spectrum-css/vars": "^8.0.0",
     "gulp": "^4.0.0"
   },
   "publishConfig": {

--- a/components/fieldgroup/themes/express.css
+++ b/components/fieldgroup/themes/express.css
@@ -1,0 +1,15 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+@container (--system: express) {
+
+}

--- a/components/fieldgroup/themes/spectrum.css
+++ b/components/fieldgroup/themes/spectrum.css
@@ -1,0 +1,15 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+@container (--system: spectrum) {
+
+}

--- a/components/radio/metadata/radio.yml
+++ b/components/radio/metadata/radio.yml
@@ -183,6 +183,7 @@ examples:
           </form>
 
         </div>
+
       </div>
 
   - id: radio-emphasized

--- a/yarn.lock
+++ b/yarn.lock
@@ -1475,20 +1475,30 @@
   dependencies:
     "@spectrum-css/vars" "^8.0.0"
 
+"@spectrum-css/fieldgroup@^3.1.4":
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/fieldgroup/-/fieldgroup-3.1.4.tgz#aede57bda56c41310d262774a8805eefc89ddf74"
+  integrity sha512-ynqkD1OWicCEW7hgYQWzJUrUih+guJHjDtPbTKYhCbnxPqi6aifKmLstBehCgs4iG4+YfGDdZTppW64A3o5foQ==
+
 "@spectrum-css/fieldlabel@^4.0.29":
   version "4.0.29"
   resolved "https://registry.yarnpkg.com/@spectrum-css/fieldlabel/-/fieldlabel-4.0.29.tgz#c09de2495b041a308b0cf110b1185cbb77c188fe"
   integrity sha512-MRputoPSSiIC0PoPOaX5zeDHyVcHdbfib7lCBk9di8R/eed3UzHvQeBwclAvCxkVHuyfIIzgaK3mlIt4flAvlw==
+
+"@spectrum-css/helptext@^2.0.5":
+  version "2.0.9"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/helptext/-/helptext-2.0.9.tgz#a3549e87aaf2f8b693bd30d14229584dd4de6beb"
+  integrity sha512-L2nXKbfdP4xx+oHHau996xhUqh9QmAv2pY8IRj7bq1FR5ARNoNzwdSLCwUD8buLtVJklFmrbULE0nx7ouUE5xA==
 
 "@spectrum-css/link@^3.1.23":
   version "3.1.23"
   resolved "https://registry.yarnpkg.com/@spectrum-css/link/-/link-3.1.23.tgz#9d9ff64c41366edbfdb19d04a5deec88bf2ea8fd"
   integrity sha512-CAJQGnGTrTtR4tF1L94ou9Y+c4vnx9d5rWhb3AMzKb2Focqz02xSkTyaCCH7OM/3CwD8TCLOMANon8LcRpGAjA==
 
-"@spectrum-css/radio@^3.0.24":
-  version "3.0.24"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/radio/-/radio-3.0.24.tgz#7a08476edf42be2007b75f7765c18c26eb3a9880"
-  integrity sha512-C/saSKXb3dNCWprsP4iXkFFEmRrxwsdm2Al04myZ6pxOJ4tr1WjHAAtorwUgaUiyR87OnL1mGX2aWrFEN1mvtQ==
+"@spectrum-css/radio@^4.0.1":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/radio/-/radio-4.0.5.tgz#ce9e38c3c500d88145afd27b10d781d3e1cf9ced"
+  integrity sha512-RGYLxgjzCyjRwocxckZl2V5ZeX2iWbwI8dzaaB0vw4cT7RiZHSFWnUC0eLo7K27tde14a6QbGYe6dlYjKL6J7g==
 
 "@spectrum-css/spectrum-css-vr-test-assets-essential@^1.0.46":
   version "1.0.46"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1485,20 +1485,10 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/fieldlabel/-/fieldlabel-4.0.29.tgz#c09de2495b041a308b0cf110b1185cbb77c188fe"
   integrity sha512-MRputoPSSiIC0PoPOaX5zeDHyVcHdbfib7lCBk9di8R/eed3UzHvQeBwclAvCxkVHuyfIIzgaK3mlIt4flAvlw==
 
-"@spectrum-css/helptext@^2.0.5":
-  version "2.0.9"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/helptext/-/helptext-2.0.9.tgz#a3549e87aaf2f8b693bd30d14229584dd4de6beb"
-  integrity sha512-L2nXKbfdP4xx+oHHau996xhUqh9QmAv2pY8IRj7bq1FR5ARNoNzwdSLCwUD8buLtVJklFmrbULE0nx7ouUE5xA==
-
 "@spectrum-css/link@^3.1.23":
   version "3.1.23"
   resolved "https://registry.yarnpkg.com/@spectrum-css/link/-/link-3.1.23.tgz#9d9ff64c41366edbfdb19d04a5deec88bf2ea8fd"
   integrity sha512-CAJQGnGTrTtR4tF1L94ou9Y+c4vnx9d5rWhb3AMzKb2Focqz02xSkTyaCCH7OM/3CwD8TCLOMANon8LcRpGAjA==
-
-"@spectrum-css/radio@^4.0.1":
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/radio/-/radio-4.0.5.tgz#ce9e38c3c500d88145afd27b10d781d3e1cf9ced"
-  integrity sha512-RGYLxgjzCyjRwocxckZl2V5ZeX2iWbwI8dzaaB0vw4cT7RiZHSFWnUC0eLo7K27tde14a6QbGYe6dlYjKL6J7g==
 
 "@spectrum-css/spectrum-css-vr-test-assets-essential@^1.0.46":
   version "1.0.46"


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
BREAKING CHANGE: This migrates the Radio button component to core tokens.
- Jira issue CSS-107 https://jira.corp.adobe.com/browse/CSS-107
- Adds fieldgroup label with top and side aligned layouts
- Adds nested input layout classes for horizontal and vertical inputs
- Adds required and optional variants
- Incorporates helptext dependency
- Adds Spectrum and Express themes
- Adds examples and documentation to the YML
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->


## How and where has this been tested?
 - Chrome 103 for macOS
 - Firefox 102 for macOS
 - **How this was tested:** comparing local build of http://localhost:3000/docs/fieldgroup.html with XD redline components batch and with https://spectrum.adobe.com/page/checkbox-group/ and https://spectrum.adobe.com/page/radio-group/

## Screenshots
Vertically aligned inputs
<img width="1067" alt="Screen Shot 2022-07-28 at 10 30 57 AM" src="https://user-images.githubusercontent.com/25614178/181549527-5e019c30-f8a8-4afa-99fd-9a4cb8d14e54.png">

Horizontally aligned inputs
<img width="1066" alt="Screen Shot 2022-07-28 at 10 31 04 AM" src="https://user-images.githubusercontent.com/25614178/181549695-1ac648ce-b65e-4282-9ea0-ce13f1a1a982.png">

Required and optional
<img width="1071" alt="Screen Shot 2022-07-28 at 10 31 47 AM" src="https://user-images.githubusercontent.com/25614178/181550438-55564825-3f50-4164-88d1-6c4b85b3b9ad.png">

Side label with horizontal and vertical inputs
<img width="1070" alt="Screen Shot 2022-07-28 at 10 32 25 AM" src="https://user-images.githubusercontent.com/25614178/181550835-def5bd42-d334-4412-b011-f1c7d439f3c6.png">


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
