### PR TITLE
chore: consume latest VRT reference images

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@adobe/spectrum-tokens-deprecated": "^11.8.0",
     "@commitlint/cli": "^8.3.3",
     "@commitlint/config-conventional": "^8.3.3",
-    "@spectrum-css/spectrum-css-vr-test-assets-essential": "^1.0.44",
+    "@spectrum-css/spectrum-css-vr-test-assets-essential": "^1.0.45",
     "audit-ci": "^2.0.1",
     "backstopjs-spectrum": "6.16.0",
     "del": "^5.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1437,10 +1437,15 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/actionbutton/-/actionbutton-1.1.14.tgz#4e12eb7f482fb5944c3d97547591964baebeb1d4"
   integrity sha512-ViBjdWi23J6vIR4t8JTRQ6jY/+KgpZgCALj3otgy495zMNG7jPeN7sKoy6i6JZJcdIRJA4MjOTVvcDOGkYWUZg==
 
-"@spectrum-css/spectrum-css-vr-test-assets-essential@^1.0.44":
-  version "1.0.44"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/spectrum-css-vr-test-assets-essential/-/spectrum-css-vr-test-assets-essential-1.0.44.tgz#718caaddecb9831bdb78fa3cfae6e76e8befac79"
-  integrity sha512-hyzcSsz1cRmgGbbDabX7tJdn1xObRJ2xM/I2si3NYTuS6fix0HVw/mdsaNKbCRu7za7Yre5FimPXBOItt3xWdA==
+"@spectrum-css/closebutton@^1.2.13":
+  version "1.2.13"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/closebutton/-/closebutton-1.2.13.tgz#a02a33e211349138bcde0988cd4317749a7618e4"
+  integrity sha512-V/P/XVWPh/TR2Qo66vn6o+vi5/utDbrMIdNV+zuF1dbl1wxH5QMOdCQrQOtzHrzcwulJRu3+Sk759VRPojLYCA==
+
+"@spectrum-css/spectrum-css-vr-test-assets-essential@^1.0.45":
+  version "1.0.45"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/spectrum-css-vr-test-assets-essential/-/spectrum-css-vr-test-assets-essential-1.0.45.tgz#a850e194fb7cb3044d5a58b611728fcb174aab31"
+  integrity sha512-tJHCHTrR8De/SQfJGQ5qh8OYZd2t1pFj7xr5DPey+tDdYw3NAHDGO+MHMBZQfthsEs18jJIcNsxWr+Jg5dR5vQ==
 
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
Increases the version number for our VRT reference images package


## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
