### PR TITLE
refactor(tokens): remove custom med, lg radio tokens

### DIFF
--- a/components/tokens/custom-spectrum/custom-large-vars.css
+++ b/components/tokens/custom-spectrum/custom-large-vars.css
@@ -18,15 +18,4 @@ governing permissions and limitations under the License.
   --spectrum-edge-to-visual-only-100: 9px;
   --spectrum-edge-to-visual-only-200: 13px;
   --spectrum-edge-to-visual-only-300: 16px;
-
-  /* tokens for button control size medium, large, extra large are available only as -desktop and -mobile */
-  --spectrum-radio-button-control-size-medium: var(--spectrum-radio-button-control-size-medium-mobile);
-  --spectrum-radio-button-control-size-large: var(--spectrum-radio-button-control-size-large-mobile);
-  --spectrum-radio-button-control-size-extra-large: var(--spectrum-radio-button-control-size-extra-large-mobile);
-
-  /* tokens for button top to control are available only as -desktop and -mobile */
-  --spectrum-radio-button-top-to-control-small: var(--spectrum-radio-button-top-to-control-small-mobile);
-  --spectrum-radio-button-top-to-control-medium: var(--spectrum-radio-button-top-to-control-medium-mobile);
-  --spectrum-radio-button-top-to-control-large: var(--spectrum-radio-button-top-to-control-large-mobile);
-  --spectrum-radio-button-top-to-control-extra-large: var(--spectrum-radio-button-top-to-control-extra-large-mobile);
 }

--- a/components/tokens/custom-spectrum/custom-medium-vars.css
+++ b/components/tokens/custom-spectrum/custom-medium-vars.css
@@ -18,15 +18,4 @@ governing permissions and limitations under the License.
   --spectrum-edge-to-visual-only-100: 7px;
   --spectrum-edge-to-visual-only-200: 10px;
   --spectrum-edge-to-visual-only-300: 13px;
-
-  /* tokens for button control size medium, large, extra large are available only as -desktop and -mobile */
-  --spectrum-radio-button-control-size-medium: var(--spectrum-radio-button-control-size-medium-desktop);
-  --spectrum-radio-button-control-size-large: var(--spectrum-radio-button-control-size-large-desktop);
-  --spectrum-radio-button-control-size-extra-large: var(--spectrum-radio-button-control-size-extra-large-desktop);
-
-  /* tokens for button top to control are available only as -desktop and -mobile */
-  --spectrum-radio-button-top-to-control-small: var(--spectrum-radio-button-top-to-control-small-desktop);
-  --spectrum-radio-button-top-to-control-medium: var(--spectrum-radio-button-top-to-control-medium-desktop);
-  --spectrum-radio-button-top-to-control-large: var(--spectrum-radio-button-top-to-control-large-desktop);
-  --spectrum-radio-button-top-to-control-extra-large: var(--spectrum-radio-button-top-to-control-extra-large-desktop);
 }


### PR DESCRIPTION
This removes the custom medium and large radio tokens, as they are now implemented in `@adobe/spectrum-tokens`.

<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->


## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
