### PR TITLE
feat(swatch)!: migrate swatch to core tokens

### DIFF
--- a/components/swatch/gulpfile.js
+++ b/components/swatch/gulpfile.js
@@ -1,1 +1,1 @@
-module.exports = require('@spectrum-css/component-builder');
+module.exports = require('@spectrum-css/component-builder-simple');

--- a/components/swatch/index.css
+++ b/components/swatch/index.css
@@ -116,8 +116,15 @@ governing permissions and limitations under the License.
   &.is-selected {
     background-color: var(--highcontrast-swatch-border-color-selected, var(--mod-swatch-inner-border-color-selected, var(--spectrum-swatch-inner-border-color-selected)));
     .spectrum-Swatch-fill {
-      width: calc(100% - var(--mod-swatch-spacing-selected, var(--spectrum-swatch-spacing-selected)));
-      height: calc(100% - var(--mod-swatch-spacing-selected, var(--spectrum-swatch-spacing-selected)));
+      clip-path: polygon(
+        calc(var(--mod-swatch-border-thickness-selected, var(--spectrum-swatch-border-thickness-selected)) * 2)
+        calc(var(--mod-swatch-border-thickness-selected, var(--spectrum-swatch-border-thickness-selected)) * 2),
+        calc(100% - var(--mod-swatch-border-thickness-selected, var(--spectrum-swatch-border-thickness-selected)) * 2)
+        calc(var(--mod-swatch-border-thickness-selected, var(--spectrum-swatch-border-thickness-selected)) * 2),
+        calc(100% - var(--mod-swatch-border-thickness-selected, var(--spectrum-swatch-border-thickness-selected)) * 2)
+        calc(100% - var(--mod-swatch-border-thickness-selected, var(--spectrum-swatch-border-thickness-selected)) * 2),
+        calc(var(--mod-swatch-border-thickness-selected, var(--spectrum-swatch-border-thickness-selected)) * 2)
+        calc(100% - var(--mod-swatch-border-thickness-selected, var(--spectrum-swatch-border-thickness-selected)) * 2));
 
       /* no border radius when selected */
       border-radius: 0;
@@ -183,8 +190,6 @@ governing permissions and limitations under the License.
       visibility: visible;
     }
   }
-
-
 
   /* selection indicator */
   &:before {
@@ -347,6 +352,10 @@ governing permissions and limitations under the License.
     &.is-selected .spectrum-Swatch-fill,
     &.is-selected .spectrum-Swatch-fill:before {
       border-radius: 100%;
+    }
+
+    &.is-selected .spectrum-Swatch-fill {
+      clip-path: circle(calc(50% - (var(--mod-swatch-border-thickness-selected, var(--spectrum-swatch-border-thickness-selected)) * 2)) at 50% 50%);
     }
   }
 }

--- a/components/swatch/index.css
+++ b/components/swatch/index.css
@@ -30,6 +30,8 @@ governing permissions and limitations under the License.
   --spectrum-swatch-slash-thickness-medium: 4px;
   --spectrum-swatch-slash-thickness-large: 5px;
 
+  --spectrum-swatch-focus-ring-border-radius: 8px;
+
   /* --spectrum-swatch-size-xs: var(--spectrum-global-dimension-size-200); */
   /* --spectrum-swatch-size-s: var(--spectrum-global-dimension-size-300); */
   /* --spectrum-swatch-size-m: var(--spectrum-global-dimension-size-400); */
@@ -227,11 +229,7 @@ governing permissions and limitations under the License.
     }
   }
 
-  &:focus-visible {
-    &:after {
-      opacity: 1;
-    }
-  }
+
 
   /* selection indicator */
   &:before {
@@ -250,15 +248,22 @@ governing permissions and limitations under the License.
   &:after {
     content: '';
     position: absolute;
-    /* Review */
-    inset: calc(-1 * var(--spectrum-swatch-border-thickness));
+    /* inset: calc(-2 * var(--spectrum-swatch-border-thickness-selected)); */
+    inset: calc(-2 * var(--spectrum-swatch-focus-ring-gap));
 
     opacity: 0;
 
     border: var(--spectrum-swatch-focus-ring-thickness) solid var(--spectrum-swatch-focus-ring-color);
-    border-radius: var(--spectrum-swatch-border-radius);
+    /* border-radius: var(--spectrum-swatch-border-radius); */
+    border-radius: var(--spectrum-swatch-focus-ring-border-radius);
 
     transition: opacity var(--spectrum-animation-duration-100) ease-in-out;
+  }
+
+  &:focus-visible {
+    &:after {
+      opacity: 1;
+    }
   }
 }
 
@@ -282,20 +287,21 @@ governing permissions and limitations under the License.
   background-color: var(--spectrum-swatch-background-color);
 
   /* background-size: */
-    /* calc(var(--spectrum-swatch-checkerboard-size) * 2) */
-    /* calc(var(--spectrum-swatch-checkerboard-size) * 2); */
+  /*   calc(var(--spectrum-swatch-checkerboard-size) * 2) */
+  /*   calc(var(--spectrum-swatch-checkerboard-size) * 2); */
+
   /* background-position: */
-    /* var(--spectrum-swatch-background-offset) var(--spectrum-swatch-background-offset), */
-    /* var(--spectrum-swatch-background-offset) calc(var(--spectrum-swatch-checkerboard-size) + var(--spectrum-swatch-background-offset)), */
-    /* calc(var(--spectrum-swatch-checkerboard-size) + var(--spectrum-swatch-background-offset)) calc(-1 * var(--spectrum-swatch-checkerboard-size) + var(--spectrum-swatch-background-offset)), */
-    /* calc(-1 * var(--spectrum-swatch-checkerboard-size) + var(--spectrum-swatch-background-offset)) var(--spectrum-swatch-background-offset); */
+  /*   var(--spectrum-swatch-background-offset) var(--spectrum-swatch-background-offset), */
+  /*   var(--spectrum-swatch-background-offset) calc(var(--spectrum-swatch-checkerboard-size) + var(--spectrum-swatch-background-offset)), */
+  /*   calc(var(--spectrum-swatch-checkerboard-size) + var(--spectrum-swatch-background-offset)) calc(-1 * var(--spectrum-swatch-checkerboard-size) + var(--spectrum-swatch-background-offset)), */
+  /*   calc(-1 * var(--spectrum-swatch-checkerboard-size) + var(--spectrum-swatch-background-offset)) var(--spectrum-swatch-background-offset); */
 
   /* Add a half-percent to fix diagonal line issue in Chrome on non-retina displays */
   /* background-image: */
-    /* linear-gradient(-45deg, transparent 75.5%, var(--spectrum-colorcontrol-checkerboard-dark-color) 75.5%), */
-    /* linear-gradient(45deg, transparent 75.5%, var(--spectrum-colorcontrol-checkerboard-dark-color) 75.5%), */
-    /* linear-gradient(-45deg, var(--spectrum-colorcontrol-checkerboard-dark-color) 25.5%, transparent 25.5%), */
-    /* linear-gradient(45deg, var(--spectrum-colorcontrol-checkerboard-dark-color) 25.5%, transparent 25.5%); */
+  /*   linear-gradient(-45deg, transparent 75.5%, var(--spectrum-colorcontrol-checkerboard-dark-color) 75.5%), */
+  /*   linear-gradient(45deg, transparent 75.5%, var(--spectrum-colorcontrol-checkerboard-dark-color) 75.5%), */
+  /*   linear-gradient(-45deg, var(--spectrum-colorcontrol-checkerboard-dark-color) 25.5%, transparent 25.5%), */
+  /*   linear-gradient(45deg, var(--spectrum-colorcontrol-checkerboard-dark-color) 25.5%, transparent 25.5%); */
 
   /* Swatch fill */
   &:before {

--- a/components/swatch/index.css
+++ b/components/swatch/index.css
@@ -16,34 +16,58 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Swatch {
-  --spectrum-swatch-size-xs: var(--spectrum-global-dimension-size-200);
-  --spectrum-swatch-size-s: var(--spectrum-global-dimension-size-300);
-  --spectrum-swatch-size-m: var(--spectrum-global-dimension-size-400);
-  --spectrum-swatch-size-l: var(--spectrum-global-dimension-size-500);
+  /* --spectrum-swatch-size-xs: var(--spectrum-global-dimension-size-200); */
+  /* --spectrum-swatch-size-s: var(--spectrum-global-dimension-size-300); */
+  /* --spectrum-swatch-size-m: var(--spectrum-global-dimension-size-400); */
+  /* --spectrum-swatch-size-l: var(--spectrum-global-dimension-size-500); */
 
-  --spectrum-swatch-disabled-icon-size-xs: var(--spectrum-global-dimension-size-150);
-  --spectrum-swatch-disabled-icon-size-s: var(--spectrum-global-dimension-size-200);
-  --spectrum-swatch-disabled-icon-size-m: var(--spectrum-global-dimension-size-225);
-  --spectrum-swatch-disabled-icon-size-l: var(--spectrum-global-dimension-size-250);
-  --spectrum-swatch-disabled-icon-color: var(--spectrum-global-color-static-gray-50);
-  --spectrum-swatch-disabled-icon-stroke-color: rgba(var(--spectrum-global-color-static-black-rgb), 0.51);
+  /* --spectrum-swatch-disabled-icon-size-xs: var(--spectrum-global-dimension-size-150); */
+  /* --spectrum-swatch-disabled-icon-size-s: var(--spectrum-global-dimension-size-200); */
+  /* --spectrum-swatch-disabled-icon-size-m: var(--spectrum-global-dimension-size-225); */
+  /* --spectrum-swatch-disabled-icon-size-l: var(--spectrum-global-dimension-size-250); */
+  /* --spectrum-swatch-disabled-icon-color: var(--spectrum-global-color-static-gray-50); */
+  /* --spectrum-swatch-disabled-icon-stroke-color: rgba(var(--spectrum-global-color-static-black-rgb), 0.51); */
 
-  --spectrum-swatch-selection-padding: var(--spectrum-global-dimension-size-100);
-  --spectrum-swatch-selection-indicator-border-width: var(--spectrum-global-dimension-size-25);
-  --spectrum-swatch-selection-indicator-border-color: var(--spectrum-global-color-gray-900);
-  --spectrum-swatch-background-color-selected: var(--spectrum-global-color-gray-50);
+  /* --spectrum-swatch-selection-padding: var(--spectrum-global-dimension-size-100); */
+  /* --spectrum-swatch-selection-indicator-border-width: var(--spectrum-global-dimension-size-25); */
+  /* --spectrum-swatch-selection-indicator-border-color: var(--spectrum-global-color-gray-900); */
+  /* --spectrum-swatch-background-color-selected: var(--spectrum-global-color-gray-50); */
 
-  --spectrum-swatch-border-radius: var(--spectrum-alias-border-radius-regular);
-  --spectrum-swatch-fill-border-radius-selected: var(--spectrum-alias-border-radius-small);
+  /* --spectrum-swatch-border-radius: var(--spectrum-alias-border-radius-regular); */
+  /* --spectrum-swatch-fill-border-radius-selected: var(--spectrum-alias-border-radius-small); */
 
-  --spectrum-swatch-fill-border-width: var(--spectrum-alias-border-size-thin);
-  --spectrum-swatch-fill-border-color: rgba(var(--spectrum-global-color-gray-900-rgb), 0.51);
-  --spectrum-swatch-fill-border-color-light: rgba(var(--spectrum-global-color-gray-900-rgb), 0.20);
+  /* --spectrum-swatch-fill-border-width: var(--spectrum-alias-border-size-thin); */
+  /* --spectrum-swatch-fill-border-color: rgba(var(--spectrum-global-color-gray-900-rgb), 0.51); */
+  /* --spectrum-swatch-fill-border-color-light: rgba(var(--spectrum-global-color-gray-900-rgb), 0.20); */
 
-  --spectrum-swatch-background-offset: 0px;
-  --spectrum-swatch-checkerboard-size: var(--spectrum-global-dimension-static-size-100);
+  /* --spectrum-swatch-background-offset: 0px; */
+  /* --spectrum-swatch-checkerboard-size: var(--spectrum-global-dimension-static-size-100); */
 
-  display: flex;
+  --spectrum-swatch-size: var(--spectrum-swatch-size-small);
+}
+
+.spectrum-Swatch--sizeS {
+  --spectrum-swatch-size: var(--spectrum-swatch-size-extra-small);
+
+}
+
+.spectrum-Swatch--sizeM {
+  --spectrum-swatch-size: var(--spectrum-swatch-size-small);
+
+}
+
+.spectrum-Swatch--sizeL {
+  --spectrum-swatch-size: var(--spectrum-swatch-size-medium);
+
+}
+
+.spectrum-Swatch--sizeXL {
+  --spectrum-swatch-size: var(--spectrum-swatch-size-large);
+
+}
+
+.spectrum-Swatch {
+    display: flex;
   align-items: center;
   justify-content: center;
 
@@ -266,8 +290,8 @@ governing permissions and limitations under the License.
 
 /* shape = square is default */
 .spectrum-Swatch--sizeXS {
-  width: var(--spectrum-swatch-size-xs);
-  height: var(--spectrum-swatch-size-xs);
+  width: var(--spectrum-swatch-size);
+  height: var(--spectrum-swatch-size);
 
   .spectrum-Swatch-disabledIcon {
     width: var(--spectrum-swatch-disabled-icon-size-xs);
@@ -276,8 +300,8 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Swatch--sizeS {
-  width: var(--spectrum-swatch-size-s);
-  height: var(--spectrum-swatch-size-s);
+  width: var(--spectrum-swatch-size);
+  height: var(--spectrum-swatch-size);
 
   .spectrum-Swatch-disabledIcon {
     width: var(--spectrum-swatch-disabled-icon-size-s);
@@ -286,18 +310,18 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Swatch--sizeM {
-  width: var(--spectrum-swatch-size-m);
-  height: var(--spectrum-swatch-size-m);
+  width: var(--spectrum-swatch-size);
+  height: var(--spectrum-swatch-size);
 
   .spectrum-Swatch-disabledIcon {
-    width: var(--spectrum-swatch-disabled-icon-size-m);
-    height: var(--spectrum-swatch-disabled-icon-size-m);
+    width: var(--spectrum-swatch-disabled-icon-size);
+    height: var(--spectrum-swatch-disabled-icon-size);
   }
 }
 
 .spectrum-Swatch--sizeL {
-  width: var(--spectrum-swatch-size-l);
-  height: var(--spectrum-swatch-size-l);
+  width: var(--spectrum-swatch-size);
+  height: var(--spectrum-swatch-size);
 
   .spectrum-Swatch-disabledIcon {
     width: var(--spectrum-swatch-disabled-icon-size-l);
@@ -307,19 +331,19 @@ governing permissions and limitations under the License.
 
 .spectrum-Swatch--rectangle {
   &.spectrum-Swatch--sizeXS {
-    width: calc(var(--spectrum-swatch-size-xs) * 2);
+    width: calc(var(--spectrum-swatch-size) * 2);
   }
 
   &.spectrum-Swatch--sizeS {
-    width: calc(var(--spectrum-swatch-size-s) * 2);
+    width: calc(var(--spectrum-swatch-size) * 2);
   }
 
   &.spectrum-Swatch--sizeM {
-    width: calc(var(--spectrum-swatch-size-m) * 2);
+    width: calc(var(--spectrum-swatch-size) * 2);
   }
 
   &.spectrum-Swatch--sizeL {
-    width: calc(var(--spectrum-swatch-size-l) * 2);
+    width: calc(var(--spectrum-swatch-size) * 2);
   }
 }
 

--- a/components/swatch/index.css
+++ b/components/swatch/index.css
@@ -26,7 +26,6 @@ governing permissions and limitations under the License.
   --spectrum-swatch-disabled-icon-size: var(--spectrum-workflow-icon-size-75);
   --spectrum-swatch-slash-thickness: var(--spectrum-swatch-slash-thickness-small);
   --spectrum-swatch-focus-ring-thickness: var(--spectrum-focus-ring-thickness);
-  --spectrum-swatch-spacing-selected: var(--spectrum-swatch-border-thickness-selected) * 4;
   --spectrum-swatch-focus-ring-gap: var(--spectrum-focus-ring-gap);
 
   /* Color */
@@ -217,7 +216,7 @@ governing permissions and limitations under the License.
     border-width: var(--mod-swatch-focus-ring-thickness, var(--spectrum-swatch-focus-ring-thickness));
     border-style: solid;
     border-color: var(--highcontrast-swatch-focus-ring-color, var(--mod-swatch-focus-ring-color, var(--spectrum-swatch-focus-ring-color)));
-    border-radius: var(--mod-swatch-focus-ring-border-radius, var(--mod-swatch-focus-ring-border-radius, var(--spectrum-swatch-focus-ring-border-radius)));
+    border-radius: var(--mod-swatch-focus-ring-border-radius, var(--spectrum-swatch-focus-ring-border-radius));
 
     transition: opacity var(--mod-animation-duration-100, var(--spectrum-animation-duration-100)) ease-in-out;
   }

--- a/components/swatch/index.css
+++ b/components/swatch/index.css
@@ -12,10 +12,24 @@ governing permissions and limitations under the License.
 
 .🤫 {
   /* hack: make sure we don't complain about this color being undefined */
-  --spectrum-picked-color: 0;
+  /* --spectrum-picked-color: 0; */
 }
 
+/* shape = square is default */
+
+/* Swatch tokens */
 .spectrum-Swatch {
+  /* Static swatch sizes for medium scale */
+  --spectrum-swatch-size-extra-small: 16px;
+  --spectrum-swatch-size-small: 24px;
+  --spectrum-swatch-size-medium: 32px;
+  --spectrum-swatch-size-large: 40px;
+
+  --spectrum-swatch-slash-thickness-extra-small: 2px;
+  --spectrum-swatch-slash-thickness-small: 3px;
+  --spectrum-swatch-slash-thickness-medium: 4px;
+  --spectrum-swatch-slash-thickness-large: 5px;
+
   /* --spectrum-swatch-size-xs: var(--spectrum-global-dimension-size-200); */
   /* --spectrum-swatch-size-s: var(--spectrum-global-dimension-size-300); */
   /* --spectrum-swatch-size-m: var(--spectrum-global-dimension-size-400); */
@@ -40,34 +54,88 @@ governing permissions and limitations under the License.
   /* --spectrum-swatch-fill-border-color: rgba(var(--spectrum-global-color-gray-900-rgb), 0.51); */
   /* --spectrum-swatch-fill-border-color-light: rgba(var(--spectrum-global-color-gray-900-rgb), 0.20); */
 
+  /* Used for background-position */
   /* --spectrum-swatch-background-offset: 0px; */
   /* --spectrum-swatch-checkerboard-size: var(--spectrum-global-dimension-static-size-100); */
 
   --spectrum-swatch-size: var(--spectrum-swatch-size-small);
+  --spectrum-swatch-border-radius: var(--spectrum-corner-radius-100);
+  --spectrum-swatch-border-thickness: var(--spectrum-border-width-100);
+  --spectrum-swatch-border-thickness-selected: var(--spectrum-border-width-200);
+  --spectrum-swatch-disabled-icon-size: var(--spectrum-workflow-icon-size-75);
+  --spectrum-swatch-slash-thickness: var(--spectrum-swatch-slash-thickness-small);
+  --spectrum-swatch-focus-ring-thickness: var(--spectrum-focus-ring-thickness);
+  --spectrum-swatch-focus-ring-gap: var(--spectrum-focus-ring-gap);
+
+  --spectrum-swatch-border-color: var(--spectrum-swatch-border-color);
+  --spectrum-swatch-border-color-selected: var(--spectrum-gray-900);
+  /* --spectrum-swatch-inner-border-color-selected: var(--spectrum-gray-50); */
+  --spectrum-swatch-disabled-icon-border-color: var(--spectrum-swatch-disabled-icon-border-color);
+  --spectrum-swatch-disabled-icon-color: var(--spectrum-white);
+  --spectrum-swatch-background-color: var(--spectrum-gray-50);
+  /* --spectrum-swatch-dash-icon-color: var(--spectrum-gray-800); */
+  --spectrum-swatch-slash-icon-color: var(--spectrum-red-500);
+  --spectrum-swatch-focus-ring-color: var(--spectrum-focus-ring-color);
 }
 
 .spectrum-Swatch--sizeS {
   --spectrum-swatch-size: var(--spectrum-swatch-size-extra-small);
-
+  --spectrum-swatch-disabled-icon-size: var(--spectrum-workflow-icon-size-50);
+  --spectrum-swatch-slash-thickness: var(--spectrum-swatch-slash-thickness-extra-small);
 }
 
 .spectrum-Swatch--sizeM {
   --spectrum-swatch-size: var(--spectrum-swatch-size-small);
-
+  --spectrum-swatch-disabled-icon-size: var(--spectrum-workflow-icon-size-75);
+  --spectrum-swatch-slash-thickness: var(--spectrum-swatch-slash-thickness-small);
 }
 
 .spectrum-Swatch--sizeL {
   --spectrum-swatch-size: var(--spectrum-swatch-size-medium);
-
+  --spectrum-swatch-disabled-icon-size: var(--spectrum-workflow-icon-size-100);
+  --spectrum-swatch-slash-thickness: var(--spectrum-swatch-slash-thickness-medium);
 }
 
 .spectrum-Swatch--sizeXL {
   --spectrum-swatch-size: var(--spectrum-swatch-size-large);
-
+  --spectrum-swatch-disabled-icon-size: var(--spectrum-workflow-icon-size-200);
+  --spectrum-swatch-slash-thickness: var(--spectrum-swatch-slash-thickness-large);
 }
 
+/* Windows high contrast mode */
+@media (forced-colors: active) {
+  .spectrum-Swatch-fill {
+    forced-color-adjust: none;
+  }
+  .spectrum-Swatch {
+    /* --spectrum-swatch-disabled-icon-color: grayText; */
+    /* --spectrum-swatch-focus-ring-color: ButtonText; */
+    /* --spectrum-swatch-selection-indicator-border-color: Highlight; */
+    /* --spectrum-swatch-fill-border-color: ButtonText; */
+    /* --spectrum-swatch-fill-border-color-light: ButtonText; */
+    /* --spectrum-swatch-background-color-selected: ButtonFace; */
+    &.is-disabled {
+      .spectrum-Swatch-fill {
+        forced-color-adjust: auto;
+      }
+    }
+    /* Slash */
+    &.is-nothing {
+      .spectrum-Swatch-fill {
+        &:after {
+          background: ButtonText;
+        }
+      }
+    }
+  }
+}
+
+/* Swatch styles */
 .spectrum-Swatch {
-    display: flex;
+  width: var(--spectrum-swatch-size);
+  height: var(--spectrum-swatch-size);
+
+  display: flex;
   align-items: center;
   justify-content: center;
 
@@ -79,6 +147,11 @@ governing permissions and limitations under the License.
   /* don't let double clicking select stuff */
   user-select: none;
 
+ .spectrum-Swatch-disabledIcon {
+    width: var(--spectrum-swatch-disabled-icon-size);
+    height: var(--spectrum-swatch-disabled-icon-size);
+  }
+
   /* rounding = default is default */
   &,
   &:before {
@@ -86,19 +159,23 @@ governing permissions and limitations under the License.
   }
 
   &.is-selected {
-    background-color: var(--spectrum-swatch-background-color-selected);
+    /* background-color: var(--spectrum-swatch-background-color-selected); */
+    background-color: var(--spectrum-swatch-background-color);
 
-    --spectrum-swatch-background-offset: -4px; /* correct for selected size */
+    /* --spectrum-swatch-background-offset: -4px; /\* correct for selected size *\/ */
 
     .spectrum-Swatch-fill {
-      width: calc(100% - var(--spectrum-swatch-selection-padding));
-      height: calc(100% - var(--spectrum-swatch-selection-padding));
+      width: calc(100% - var(--spectrum-swatch-focus-ring-gap));
+      height: calc(100% - var(--spectrum-swatch-focus-ring-gap));
 
-      border-radius: var(--spectrum-swatch-fill-border-radius-selected);
+      /* border-radius: var(--spectrum-swatch-fill-border-radius-selected); */
+      border-radius: var(--spectrum-swatch-border-radius);
 
       /* no border when selected */
       &:before {
-        border-radius: var(--spectrum-swatch-fill-border-radius-selected);
+        /* Use 2px border-radius here? */
+        /* border-radius: var(--spectrum-swatch-fill-border-radius-selected); */
+        border-radius: var(--spectrum-swatch-border-radius);
 
         box-shadow: none;
       }
@@ -111,7 +188,7 @@ governing permissions and limitations under the License.
 
   &.is-mixedValue {
     .spectrum-Swatch-fill {
-      background: var(--spectrum-swatch-background-color-selected);
+      background: var(--spectrum-swatch-background-color);
     }
 
     .spectrum-Swatch-mixedValueIcon {
@@ -119,16 +196,18 @@ governing permissions and limitations under the License.
     }
   }
 
+  /* Slash */
   &.is-nothing {
     .spectrum-Swatch-fill {
-      background: var(--spectrum-swatch-background-color-selected);
+      background: var(--spectrum-swatch-background-color);
 
       &:after {
+        height: var(--spectrum-swatch-slash-thickness);
         content: '';
         position: absolute;
         transform: rotate(-45deg);
         width: 200%; /* just needs to be bigger than a swatch */
-        background: var(--spectrum-global-color-red-500);
+        background: var(--spectrum-swatch-slash-icon-color);
       }
     }
 
@@ -140,29 +219,29 @@ governing permissions and limitations under the License.
       }
     }
 
-    &.spectrum-Swatch--sizeXS {
-      .spectrum-Swatch-fill:after  {
-        height: 2px;
-      }
-    }
+    /* &.spectrum-Swatch--sizeXS { */
+    /*   .spectrum-Swatch-fill:after  { */
+    /*     height: 2px; */
+    /*   } */
+    /* } */
 
-    &.spectrum-Swatch--sizeS {
-      .spectrum-Swatch-fill:after  {
-        height: 3px;
-      }
-    }
+    /* &.spectrum-Swatch--sizeS { */
+    /*   .spectrum-Swatch-fill:after  { */
+    /*     height: 3px; */
+    /*   } */
+    /* } */
 
-    &.spectrum-Swatch--sizeM {
-      .spectrum-Swatch-fill:after  {
-        height: 4px;
-      }
-    }
+    /* &.spectrum-Swatch--sizeM { */
+    /*   .spectrum-Swatch-fill:after  { */
+    /*     height: 4px; */
+    /*   } */
+    /* } */
 
-    &.spectrum-Swatch--sizeL {
-      .spectrum-Swatch-fill:after  {
-        height: 5px;
-      }
-    }
+    /* &.spectrum-Swatch--sizeL { */
+    /*   .spectrum-Swatch-fill:after  { */
+    /*     height: 5px; */
+    /*   } */
+    /* } */
   }
 
   &[disabled],
@@ -172,7 +251,7 @@ governing permissions and limitations under the License.
     }
   }
 
-  &:focus-ring {
+  &:focus-visible {
     &:after {
       opacity: 1;
     }
@@ -184,7 +263,7 @@ governing permissions and limitations under the License.
     position: absolute;
     inset: 0;
 
-    border: var(--spectrum-swatch-selection-indicator-border-width) solid var(--spectrum-swatch-selection-indicator-border-color);
+    border: var(--spectrum-swatch-border-thickness-selected) solid var(--spectrum-swatch-border-color-selected);
 
     opacity: 0;
 
@@ -195,16 +274,18 @@ governing permissions and limitations under the License.
   &:after {
     content: '';
     position: absolute;
-    inset: calc(-1 * var(--spectrum-global-dimension-size-50));
+    /* Review */
+    inset: calc(-1 * var(--spectrum-swatch-border-thickness));
 
     opacity: 0;
 
-    border: var(--spectrum-global-dimension-static-size-25) solid var(--spectrum-alias-focus-ring-color);
-    border-radius: var(--spectrum-alias-focus-ring-border-radius-regular);
+    border: var(--spectrum-swatch-focus-ring-thickness) solid var(--spectrum-swatch-focus-ring-color);
+    border-radius: var(--spectrum-swatch-border-radius);
 
-    transition: opacity var(--spectrum-global-animation-duration-100) ease-in-out;
+    transition: opacity var(--spectrum-animation-duration-100) ease-in-out;
   }
 }
+
 
 .spectrum-Swatch-fill {
   display: flex;
@@ -221,23 +302,24 @@ governing permissions and limitations under the License.
 
   border-radius: var(--spectrum-swatch-border-radius);
 
-  background-color: var(--spectrum-colorcontrol-checkerboard-light-color);
+  /* background-color: var(--spectrum-color-control-checkerboard-light-color); */
+  background-color: var(--spectrum-swatch-background-color);
 
-  background-size:
-    calc(var(--spectrum-swatch-checkerboard-size) * 2)
-    calc(var(--spectrum-swatch-checkerboard-size) * 2);
-  background-position:
-    var(--spectrum-swatch-background-offset) var(--spectrum-swatch-background-offset),
-    var(--spectrum-swatch-background-offset) calc(var(--spectrum-swatch-checkerboard-size) + var(--spectrum-swatch-background-offset)),
-    calc(var(--spectrum-swatch-checkerboard-size) + var(--spectrum-swatch-background-offset)) calc(-1 * var(--spectrum-swatch-checkerboard-size) + var(--spectrum-swatch-background-offset)),
-    calc(-1 * var(--spectrum-swatch-checkerboard-size) + var(--spectrum-swatch-background-offset)) var(--spectrum-swatch-background-offset);
+  /* background-size: */
+    /* calc(var(--spectrum-swatch-checkerboard-size) * 2) */
+    /* calc(var(--spectrum-swatch-checkerboard-size) * 2); */
+  /* background-position: */
+    /* var(--spectrum-swatch-background-offset) var(--spectrum-swatch-background-offset), */
+    /* var(--spectrum-swatch-background-offset) calc(var(--spectrum-swatch-checkerboard-size) + var(--spectrum-swatch-background-offset)), */
+    /* calc(var(--spectrum-swatch-checkerboard-size) + var(--spectrum-swatch-background-offset)) calc(-1 * var(--spectrum-swatch-checkerboard-size) + var(--spectrum-swatch-background-offset)), */
+    /* calc(-1 * var(--spectrum-swatch-checkerboard-size) + var(--spectrum-swatch-background-offset)) var(--spectrum-swatch-background-offset); */
 
   /* Add a half-percent to fix diagonal line issue in Chrome on non-retina displays */
-  background-image:
-    linear-gradient(-45deg, transparent 75.5%, var(--spectrum-colorcontrol-checkerboard-dark-color) 75.5%),
-    linear-gradient(45deg, transparent 75.5%, var(--spectrum-colorcontrol-checkerboard-dark-color) 75.5%),
-    linear-gradient(-45deg, var(--spectrum-colorcontrol-checkerboard-dark-color) 25.5%, transparent 25.5%),
-    linear-gradient(45deg, var(--spectrum-colorcontrol-checkerboard-dark-color) 25.5%, transparent 25.5%);
+  /* background-image: */
+    /* linear-gradient(-45deg, transparent 75.5%, var(--spectrum-colorcontrol-checkerboard-dark-color) 75.5%), */
+    /* linear-gradient(45deg, transparent 75.5%, var(--spectrum-colorcontrol-checkerboard-dark-color) 75.5%), */
+    /* linear-gradient(-45deg, var(--spectrum-colorcontrol-checkerboard-dark-color) 25.5%, transparent 25.5%), */
+    /* linear-gradient(45deg, var(--spectrum-colorcontrol-checkerboard-dark-color) 25.5%, transparent 25.5%); */
 
   &:before {
     content: '';
@@ -246,9 +328,12 @@ governing permissions and limitations under the License.
 
     z-index: 0;
 
-    background-color: var(--spectrum-picked-color, transparent);
+    /* background-color: var(--spectrum-picked-color, transparent); */
+    background-color: teal;
 
-    box-shadow: inset 0 0 0 var(--spectrum-swatch-fill-border-width) var(--spectrum-swatch-fill-border-color);
+    /* Swatch border */
+    /* box-shadow: inset 0 0 0 var(--spectrum-swatch-fill-border-width) var(--spectrum-swatch-fill-border-color); */
+    box-shadow: inset 0 0 0 var(--spectrum-swatch-border-thickness) var(--spectrum-swatch-border-color);
 
     border-radius: var(--spectrum-swatch-border-radius);
   }
@@ -257,7 +342,8 @@ governing permissions and limitations under the License.
 .spectrum-Swatch--lightBorder {
   .spectrum-Swatch-fill {
     &:before {
-      box-shadow: inset 0 0 0 var(--spectrum-swatch-fill-border-width) var(--spectrum-swatch-fill-border-color-light);
+      /* box-shadow: inset 0 0 0 var(--spectrum-swatch-fill-border-width) var(--spectrum-swatch-fill-border-color-light); */
+      box-shadow: inset 0 0 0 var(--spectrum-swatch-border-thickness) var(--spectrum-swatch-border-color);
     }
   }
 }
@@ -274,7 +360,8 @@ governing permissions and limitations under the License.
   visibility: hidden;
   pointer-events: none;
 
-  color: var(--spectrum-global-color-gray-700);
+  /* color: var(--spectrum-global-color-gray-700); */
+  color: var(--spectrum-swatch-background-color);
 }
 
 .spectrum-Swatch-disabledIcon {
@@ -284,49 +371,9 @@ governing permissions and limitations under the License.
   visibility: hidden;
   pointer-events: none;
 
+  /* Review */
   color: var(--spectrum-swatch-disabled-icon-color);
-  stroke: var(--spectrum-swatch-disabled-icon-stroke-color);
-}
-
-/* shape = square is default */
-.spectrum-Swatch--sizeXS {
-  width: var(--spectrum-swatch-size);
-  height: var(--spectrum-swatch-size);
-
-  .spectrum-Swatch-disabledIcon {
-    width: var(--spectrum-swatch-disabled-icon-size-xs);
-    height: var(--spectrum-swatch-disabled-icon-size-xs);
-  }
-}
-
-.spectrum-Swatch--sizeS {
-  width: var(--spectrum-swatch-size);
-  height: var(--spectrum-swatch-size);
-
-  .spectrum-Swatch-disabledIcon {
-    width: var(--spectrum-swatch-disabled-icon-size-s);
-    height: var(--spectrum-swatch-disabled-icon-size-s);
-  }
-}
-
-.spectrum-Swatch--sizeM {
-  width: var(--spectrum-swatch-size);
-  height: var(--spectrum-swatch-size);
-
-  .spectrum-Swatch-disabledIcon {
-    width: var(--spectrum-swatch-disabled-icon-size);
-    height: var(--spectrum-swatch-disabled-icon-size);
-  }
-}
-
-.spectrum-Swatch--sizeL {
-  width: var(--spectrum-swatch-size);
-  height: var(--spectrum-swatch-size);
-
-  .spectrum-Swatch-disabledIcon {
-    width: var(--spectrum-swatch-disabled-icon-size-l);
-    height: var(--spectrum-swatch-disabled-icon-size-l);
-  }
+  stroke: var(--spectrum-swatch-disabled-icon-color);
 }
 
 .spectrum-Swatch--rectangle {
@@ -379,32 +426,6 @@ governing permissions and limitations under the License.
   width: 100%;
   height: 100%;
 
-  transition: width var(--spectrum-global-animation-duration-100) ease-in-out,
-              height var(--spectrum-global-animation-duration-100) ease-in-out;
-}
-
-@media (forced-colors: active) {
-  .spectrum-Swatch-fill {
-    forced-color-adjust: none;
-  }
-  .spectrum-Swatch {
-    --spectrum-swatch-disabled-icon-color: grayText;
-    --spectrum-alias-focus-ring-color: ButtonText;
-    --spectrum-swatch-selection-indicator-border-color: Highlight;
-    --spectrum-swatch-fill-border-color: ButtonText;
-    --spectrum-swatch-fill-border-color-light: ButtonText;
-    --spectrum-swatch-background-color-selected: ButtonFace;
-    &.is-disabled {
-      .spectrum-Swatch-fill {
-        forced-color-adjust: auto;
-      }
-    }
-    &.is-nothing {
-      .spectrum-Swatch-fill {
-        &:after {
-          background: ButtonText;
-        }
-      }
-    }
-  }
+  transition: width var(--spectrum-animation-duration-100) ease-in-out,
+              height var(--spectrum-animation-duration-100) ease-in-out;
 }

--- a/components/swatch/index.css
+++ b/components/swatch/index.css
@@ -19,47 +19,26 @@ governing permissions and limitations under the License.
 
 /* Swatch tokens */
 .spectrum-Swatch {
-  /* Static swatch sizes for medium scale */
+  /* Static swatch t-shirt sizes for medium scale */
   --spectrum-swatch-size-extra-small: 16px;
   --spectrum-swatch-size-small: 24px;
   --spectrum-swatch-size-medium: 32px;
   --spectrum-swatch-size-large: 40px;
 
+  /* Static slash thickness t-shirt sizes */
   --spectrum-swatch-slash-thickness-extra-small: 2px;
   --spectrum-swatch-slash-thickness-small: 3px;
   --spectrum-swatch-slash-thickness-medium: 4px;
   --spectrum-swatch-slash-thickness-large: 5px;
 
+  /* Static swatch focus ring border radius */
   --spectrum-swatch-focus-ring-border-radius: 8px;
 
-  /* --spectrum-swatch-size-xs: var(--spectrum-global-dimension-size-200); */
-  /* --spectrum-swatch-size-s: var(--spectrum-global-dimension-size-300); */
-  /* --spectrum-swatch-size-m: var(--spectrum-global-dimension-size-400); */
-  /* --spectrum-swatch-size-l: var(--spectrum-global-dimension-size-500); */
+  /* Static swatch border radius */
+  --spectrum-swatch-border-color-regular: rgba(0, 0, 0, 0.5);
+  --spectrum-swatch-border-color-light: rgba(0, 0, 0, 0.2);
 
-  /* --spectrum-swatch-disabled-icon-size-xs: var(--spectrum-global-dimension-size-150); */
-  /* --spectrum-swatch-disabled-icon-size-s: var(--spectrum-global-dimension-size-200); */
-  /* --spectrum-swatch-disabled-icon-size-m: var(--spectrum-global-dimension-size-225); */
-  /* --spectrum-swatch-disabled-icon-size-l: var(--spectrum-global-dimension-size-250); */
-  /* --spectrum-swatch-disabled-icon-color: var(--spectrum-global-color-static-gray-50); */
-  /* --spectrum-swatch-disabled-icon-stroke-color: rgba(var(--spectrum-global-color-static-black-rgb), 0.51); */
-
-  /* --spectrum-swatch-selection-padding: var(--spectrum-global-dimension-size-100); */
-  /* --spectrum-swatch-selection-indicator-border-width: var(--spectrum-global-dimension-size-25); */
-  /* --spectrum-swatch-selection-indicator-border-color: var(--spectrum-global-color-gray-900); */
-  /* --spectrum-swatch-background-color-selected: var(--spectrum-global-color-gray-50); */
-
-  /* --spectrum-swatch-border-radius: var(--spectrum-alias-border-radius-regular); */
-  /* --spectrum-swatch-fill-border-radius-selected: var(--spectrum-alias-border-radius-small); */
-
-  /* --spectrum-swatch-fill-border-width: var(--spectrum-alias-border-size-thin); */
-  /* --spectrum-swatch-fill-border-color: rgba(var(--spectrum-global-color-gray-900-rgb), 0.51); */
-  /* --spectrum-swatch-fill-border-color-light: rgba(var(--spectrum-global-color-gray-900-rgb), 0.20); */
-
-  /* Used for background-position */
-  /* --spectrum-swatch-background-offset: 0px; */
-  /* --spectrum-swatch-checkerboard-size: var(--spectrum-global-dimension-static-size-100); */
-
+  /*  */
   --spectrum-swatch-size: var(--spectrum-swatch-size-small);
   --spectrum-swatch-border-radius: var(--spectrum-corner-radius-100);
   --spectrum-swatch-border-thickness: var(--spectrum-border-width-100);
@@ -69,7 +48,8 @@ governing permissions and limitations under the License.
   --spectrum-swatch-focus-ring-thickness: var(--spectrum-focus-ring-thickness);
   --spectrum-swatch-focus-ring-gap: var(--spectrum-focus-ring-gap);
 
-  --spectrum-swatch-border-color: var(--spectrum-swatch-border-color);
+  /* Missing token */
+  /* --spectrum-swatch-border-color: var(--spectrum-swatch-border-color); */
   --spectrum-swatch-border-color-selected: var(--spectrum-gray-900);
   /* --spectrum-swatch-inner-border-color-selected: var(--spectrum-gray-50); */
   --spectrum-swatch-disabled-icon-border-color: var(--spectrum-swatch-disabled-icon-border-color);
@@ -314,22 +294,22 @@ governing permissions and limitations under the License.
     background-color: var(--spectrum-picked-color, transparent);
 
     /* Swatch border */
-    /* box-shadow: inset 0 0 0 var(--spectrum-swatch-fill-border-width) var(--spectrum-swatch-fill-border-color); */
-    box-shadow: inset 0 0 0 var(--spectrum-swatch-border-thickness) var(--spectrum-swatch-border-color);
+    box-shadow: inset 0 0 0 var(--spectrum-swatch-border-thickness) var(--spectrum-swatch-border-color-regular);
 
     border-radius: var(--spectrum-swatch-border-radius);
   }
 }
 
+/* Variant: Light border */
 .spectrum-Swatch--lightBorder {
   .spectrum-Swatch-fill {
     &:before {
-      /* box-shadow: inset 0 0 0 var(--spectrum-swatch-fill-border-width) var(--spectrum-swatch-fill-border-color-light); */
-      box-shadow: inset 0 0 0 var(--spectrum-swatch-border-thickness) var(--spectrum-swatch-border-color);
+      box-shadow: inset 0 0 0 var(--spectrum-swatch-border-thickness) var(--spectrum-swatch-border-color-light);
     }
   }
 }
 
+/* Variant: No border */
 .spectrum-Swatch--noBorder {
   .spectrum-Swatch-fill {
     &:before {
@@ -376,6 +356,7 @@ governing permissions and limitations under the License.
   }
 }
 
+/* Variant: Rounding - None */
 .spectrum-Swatch--roundingNone {
   &,
   &:before,
@@ -388,6 +369,7 @@ governing permissions and limitations under the License.
   }
 }
 
+/* Variant: Rounding - Full */
 .spectrum-Swatch--roundingFull {
   &:not(.spectrum-Swatch--rectangle) {
     &,

--- a/components/swatch/index.css
+++ b/components/swatch/index.css
@@ -31,7 +31,7 @@ governing permissions and limitations under the License.
   --spectrum-swatch-focus-ring-gap: var(--spectrum-focus-ring-gap);
 
   --spectrum-swatch-border-color: var(--spectrum-swatch-border-color);
-  --spectrum-swatch-border-color-selected: var(--spectrum-gray-900);
+  /* --spectrum-swatch-border-color-selected: var(--spectrum-gray-900); */
   --spectrum-swatch-inner-border-color-selected: var(--spectrum-gray-50);
   --spectrum-swatch-disabled-icon-border-color: var(--spectrum-swatch-disabled-icon-border-color);
   --spectrum-swatch-disabled-icon-color: var(--spectrum-white);
@@ -71,12 +71,13 @@ governing permissions and limitations under the License.
     forced-color-adjust: none;
   }
   .spectrum-Swatch {
-    /* --spectrum-swatch-disabled-icon-color: grayText; */
-    /* --spectrum-swatch-focus-ring-color: ButtonText; */
-    /* --spectrum-swatch-selection-indicator-border-color: Highlight; */
-    /* --spectrum-swatch-fill-border-color: ButtonText; */
-    /* --spectrum-swatch-fill-border-color-light: ButtonText; */
-    /* --spectrum-swatch-fill-background-color-selected: ButtonFace; */
+    --highcontrast-swatch-disabled-icon-color: grayText;
+    --highcontrast-swatch-focus-ring-color: ButtonText;
+    --highcontrast-swatch-border-color-selected: Highlight;
+    --highcontrast-swatch-border-color: ButtonText;
+    --highcontrast-swatch-border-color-light: ButtonText;
+    /* --highcontrast-swatch-fill-background-color-selected: ButtonFace; */
+    --highcontrast-swatch-fill-background-color: ButtonFace;
     &.is-disabled {
       .spectrum-Swatch-fill {
         forced-color-adjust: auto;
@@ -121,7 +122,7 @@ governing permissions and limitations under the License.
   }
 
   &.is-selected {
-    background-color: var(--spectrum-swatch-inner-border-color-selected);
+    background-color: var(--highcontrast-swatch-border-color-selected, var(--mod-swatch-inner-border-color-selected, var(--spectrum-swatch-inner-border-color-selected)));
     .spectrum-Swatch-fill {
       width: calc(100% - var(--mod-swatch-spacing-selected, var(--spectrum-swatch-spacing-selected)));
       height: calc(100% - var(--mod-swatch-spacing-selected, var(--spectrum-swatch-spacing-selected)));
@@ -140,9 +141,18 @@ governing permissions and limitations under the License.
     }
   }
 
+  /* Swatch fill with transparent background-color for images, gradients, and svgs  */
+  &.is-image {
+    .spectrum-Swatch-fill {
+      &::before {
+        background-color: transparent;
+      }
+    }
+  }
+
   &.is-mixedValue {
     .spectrum-Swatch-fill {
-      background: var(--spectrum-swatch-fill-background-color);
+      background: var(--highcontrast-swatch-fill-background-color, var(--mod-swatch-fill-background-color, var(--spectrum-swatch-fill-background-color)));
     }
 
     .spectrum-Swatch-mixedValueIcon {
@@ -151,10 +161,9 @@ governing permissions and limitations under the License.
     }
   }
 
-  /* What does is-nothing mean? */
   &.is-nothing {
     .spectrum-Swatch-fill {
-      background: var(--spectrum-swatch-fill-background-color);
+      background-color: var(--highcontrast-swatch-fill-background-color, var(--mod-swatch-fill-background-color, var(--spectrum-swatch-fill-background-color)));
 
       /* Slash */
       &:after {
@@ -191,7 +200,9 @@ governing permissions and limitations under the License.
     position: absolute;
     inset: 0;
 
-    border: var(--spectrum-swatch-border-thickness-selected) solid var(--spectrum-swatch-border-color-selected);
+    border-width: var(--mod-swatch-border-thickness-selected, var(--spectrum-swatch-border-thickness-selected));
+    border-style: solid;
+    border-color: var(--highcontrast-swatch-border-color, var(--mod-swatch-border-color, var(--spectrum-swatch-border-color)));
 
     opacity: 0;
 
@@ -202,14 +213,16 @@ governing permissions and limitations under the License.
   &:after {
     content: '';
     position: absolute;
-    inset: calc(-2 * var(--spectrum-swatch-focus-ring-gap));
+    inset: calc(-2 * var(--mod-swatch-focus-ring-gap, var(--spectrum-swatch-focus-ring-gap)));
 
     opacity: 0;
 
-    border: var(--mod-swatch-focus-ring-thickness, var(--spectrum-swatch-focus-ring-thickness)) solid var(--spectrum-swatch-focus-ring-color);
+    border-width: var(--mod-swatch-focus-ring-thickness, var(--spectrum-swatch-focus-ring-thickness));
+    border-style: solid;
+    border-color: var(--highcontrast-swatch-focus-ring-color, var(--mod-swatch-focus-ring-color, var(--spectrum-swatch-focus-ring-color)));
     border-radius: var(--mod-swatch-focus-ring-border-radius, var(--mod-swatch-focus-ring-border-radius, var(--spectrum-swatch-focus-ring-border-radius)));
 
-    transition: opacity var(--spectrum-animation-duration-100) ease-in-out;
+    transition: opacity var(--mod-animation-duration-100, var(--spectrum-animation-duration-100)) ease-in-out;
   }
 
   &:focus-visible {
@@ -234,13 +247,15 @@ governing permissions and limitations under the License.
 
   border-radius: var(--mod-swatch-border-radius, var(--spectrum-swatch-border-radius));
 
-  background-color: var(--spectrum-swatch-fill-background-color);
 
   /* Checkerboard fill */
   /* Static checkerboard properties */
   --spectrum-swatch-checkerboard-size: 8px;
   --spectrum-swatch-checkerboard-background-offset: 0px;
   --spectrum-swatch-checkerboard-dark-color: rgb(217, 217, 217);
+  --spectrum-swatch-checkerboard-light-color: rgb(255, 255, 255);
+
+  background-color: var(--spectrum-swatch-checkerboard-light-color);
 
   background-size:
     calc(var(--mod-swatch-checkerboard-size, var(--spectrum-swatch-checkerboard-size)) * 2)
@@ -259,18 +274,17 @@ governing permissions and limitations under the License.
     linear-gradient(-45deg, var(--spectrum-swatch-checkerboard-dark-color) 25.5%, transparent 25.5%),
     linear-gradient(45deg, var(--spectrum-swatch-checkerboard-dark-color) 25.5%, transparent 25.5%);
 
-  /* Swatch fill */
+  /* Swatch fill - default */
   &:before {
     content: '';
     position: absolute;
     inset: 0;
-
     z-index: 0;
 
-    background-color: var(--mod-swatch-fill-background-color, var(--spectrum-swatch-fill-background-color), transparent);
+    background-color: var(--highcontrast-swatch-fill-background-color, var(--mod-swatch-fill-background-color, var(--spectrum-swatch-fill-background-color)));
 
     /* Swatch border */
-    box-shadow: inset 0 0 0 var(--mod-swatch-border-thickness, var(--spectrum-swatch-border-thickness)) var(--spectrum-swatch-border-color-regular);
+    box-shadow: inset 0 0 0 var(--mod-swatch-border-thickness, var(--spectrum-swatch-border-thickness)) var(--highcontrast-swatch-border-color, var(--mod-swatch-border-color-regular, var(--spectrum-swatch-border-color-regular)));
 
     border-radius: var(--mod-swatch-border-radius, var(--spectrum-swatch-border-radius));
   }
@@ -280,7 +294,7 @@ governing permissions and limitations under the License.
 .spectrum-Swatch--lightBorder {
   .spectrum-Swatch-fill {
     &:before {
-      box-shadow: inset 0 0 0 var(--mod-swatch-border-thickness, var(--spectrum-swatch-border-thickness)) var(--spectrum-swatch-border-color-light);
+      box-shadow: inset 0 0 0 var(--mod-swatch-border-thickness, var(--spectrum-swatch-border-thickness)) var(--highcontrast-swatch-border-color-light, var(--mod-swatch-border-color-light, var(--spectrum-swatch-border-color-light)));
     }
   }
 }
@@ -298,7 +312,7 @@ governing permissions and limitations under the License.
   visibility: hidden;
   pointer-events: none;
 
-  color: var(--spectrum-swatch-fill-background-color);
+  color: var(--highcontrast-swatch-fill-background-color, var(--mod-swatch-fill-background-color, var(--spectrum-swatch-fill-background-color)));
 }
 
 .spectrum-Swatch-disabledIcon {
@@ -308,8 +322,8 @@ governing permissions and limitations under the License.
   visibility: hidden;
   pointer-events: none;
 
-  color: var(--spectrum-swatch-disabled-icon-color);
-  stroke: var(--spectrum-swatch-disabled-icon-color);
+  color: var(--highcontrast-swatch-disabled-icon-color, var(--mod-swatch-disabled-icon-color, var(--spectrum-swatch-disabled-icon-color)));
+  stroke: var(--highcontrast-swatch-disabled-icon-color, var(--mod-swatch-disabled-icon-color, var(--spectrum-swatch-disabled-icon-color)));
 }
 
 .spectrum-Swatch--rectangle {

--- a/components/swatch/index.css
+++ b/components/swatch/index.css
@@ -217,13 +217,11 @@ governing permissions and limitations under the License.
   &:after {
     content: '';
     position: absolute;
-    /* inset: calc(-2 * var(--spectrum-swatch-border-thickness-selected)); */
     inset: calc(-2 * var(--spectrum-swatch-focus-ring-gap));
 
     opacity: 0;
 
     border: var(--spectrum-swatch-focus-ring-thickness) solid var(--spectrum-swatch-focus-ring-color);
-    /* border-radius: var(--spectrum-swatch-border-radius); */
     border-radius: var(--spectrum-swatch-focus-ring-border-radius);
 
     transition: opacity var(--spectrum-animation-duration-100) ease-in-out;
@@ -255,22 +253,28 @@ governing permissions and limitations under the License.
   /* background-color: var(--spectrum-color-control-checkerboard-light-color); */
   background-color: var(--spectrum-swatch-background-color);
 
-  /* background-size: */
-  /*   calc(var(--spectrum-swatch-checkerboard-size) * 2) */
-  /*   calc(var(--spectrum-swatch-checkerboard-size) * 2); */
+  /* Checkerboard fill */
+  /* Static checkerboard fill tokens */
+  --spectrum-swatch-checkerboard-size: 8px;
+  --spectrum-swatch-checkerboard-background-offset: 0px;
+  --spectrum-swatch-checkerboard-dark-color: rgb(217, 217, 217);
 
-  /* background-position: */
-  /*   var(--spectrum-swatch-background-offset) var(--spectrum-swatch-background-offset), */
-  /*   var(--spectrum-swatch-background-offset) calc(var(--spectrum-swatch-checkerboard-size) + var(--spectrum-swatch-background-offset)), */
-  /*   calc(var(--spectrum-swatch-checkerboard-size) + var(--spectrum-swatch-background-offset)) calc(-1 * var(--spectrum-swatch-checkerboard-size) + var(--spectrum-swatch-background-offset)), */
-  /*   calc(-1 * var(--spectrum-swatch-checkerboard-size) + var(--spectrum-swatch-background-offset)) var(--spectrum-swatch-background-offset); */
+  background-size:
+    calc(var(--spectrum-swatch-checkerboard-size) * 2)
+    calc(var(--spectrum-swatch-checkerboard-size) * 2);
+
+  background-position:
+    var(--spectrum-swatch-checkerboard-background-offset) var(--spectrum-swatch-checkerboard-background-offset),
+    var(--spectrum-swatch-checkerboard-background-offset) calc(var(--spectrum-swatch-checkerboard-size) + var(--spectrum-swatch-checkerboard-background-offset)),
+    calc(var(--spectrum-swatch-checkerboard-size) + var(--spectrum-swatch-checkerboard-background-offset)) calc(-1 * var(--spectrum-swatch-checkerboard-size) + var(--spectrum-swatch-checkerboard-background-offset)),
+    calc(-1 * var(--spectrum-swatch-checkerboard-size) + var(--spectrum-swatch-checkerboard-background-offset)) var(--spectrum-swatch-checkerboard-background-offset);
 
   /* Add a half-percent to fix diagonal line issue in Chrome on non-retina displays */
-  /* background-image: */
-  /*   linear-gradient(-45deg, transparent 75.5%, var(--spectrum-colorcontrol-checkerboard-dark-color) 75.5%), */
-  /*   linear-gradient(45deg, transparent 75.5%, var(--spectrum-colorcontrol-checkerboard-dark-color) 75.5%), */
-  /*   linear-gradient(-45deg, var(--spectrum-colorcontrol-checkerboard-dark-color) 25.5%, transparent 25.5%), */
-  /*   linear-gradient(45deg, var(--spectrum-colorcontrol-checkerboard-dark-color) 25.5%, transparent 25.5%); */
+  background-image:
+    linear-gradient(-45deg, transparent 75.5%, var(--spectrum-swatch-checkerboard-dark-color) 75.5%),
+    linear-gradient(45deg, transparent 75.5%, var(--spectrum-swatch-checkerboard-dark-color) 75.5%),
+    linear-gradient(-45deg, var(--spectrum-swatch-checkerboard-dark-color) 25.5%, transparent 25.5%),
+    linear-gradient(45deg, var(--spectrum-swatch-checkerboard-dark-color) 25.5%, transparent 25.5%);
 
   /* Swatch fill */
   &:before {

--- a/components/swatch/index.css
+++ b/components/swatch/index.css
@@ -10,6 +10,11 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+.🤫 {
+  /* hack: make sure we don't complain about this color being undefined */
+  --spectrum-picked-color: 0;
+}
+
 /* Swatch tokens */
 .spectrum-Swatch {
   /* Static properties - no tokens */
@@ -33,7 +38,7 @@ governing permissions and limitations under the License.
   --spectrum-swatch-inner-border-color-selected: var(--spectrum-gray-50);
   --spectrum-swatch-disabled-icon-border-color: var(--spectrum-swatch-disabled-icon-border-color);
   --spectrum-swatch-disabled-icon-color: var(--spectrum-white);
-  --spectrum-swatch-fill-background-color: var(--spectrum-gray-50);
+  /*--spectrum-swatch-fill-background-color: var(--spectrum-gray-50);*/
   --spectrum-swatch-dash-icon-color: var(--spectrum-gray-800);
   --spectrum-swatch-slash-icon-color: var(--spectrum-red-900);
   --spectrum-swatch-focus-ring-color: var(--spectrum-focus-ring-color);
@@ -70,7 +75,7 @@ governing permissions and limitations under the License.
     --highcontrast-swatch-focus-ring-color: Highlight;
     --highcontrast-swatch-border-color-selected: Highlight;
     --highcontrast-swatch-border-color: ButtonText;
-    --highcontrast-swatch-fill-background-color: ButtonFace;
+    /*--highcontrast-swatch-fill-background-color: ButtonFace;*/
     --highcontrast-swatch-fill-foreground-color: ButtonText;
 
     .spectrum-Swatch-fill {
@@ -150,7 +155,7 @@ governing permissions and limitations under the License.
 
   &.is-mixedValue {
     .spectrum-Swatch-fill {
-      background: var(--highcontrast-swatch-fill-background-color, var(--mod-swatch-fill-background-color, var(--spectrum-swatch-fill-background-color)));
+      background: var(--spectrum-picked-color, transparent);
     }
 
     .spectrum-Swatch-mixedValueIcon {
@@ -162,7 +167,7 @@ governing permissions and limitations under the License.
   /* Swatch fill: Not fill with Slash */
   &.is-nothing {
     .spectrum-Swatch-fill {
-      background-color: var(--highcontrast-swatch-fill-background-color, var(--mod-swatch-fill-background-color, var(--spectrum-swatch-fill-background-color)));
+      background-color: var(--spectrum-picked-color, transparent);
 
       &:after {
         height: var(--mod-swatch-slash-thickness, var(--spectrum-swatch-slash-thickness));
@@ -277,7 +282,7 @@ governing permissions and limitations under the License.
     inset: 0;
     z-index: 0;
 
-    background-color: var(--highcontrast-swatch-fill-background-color, var(--mod-swatch-fill-background-color, var(--spectrum-swatch-fill-background-color)));
+    background-color: var(--spectrum-picked-color, transparent);
 
     /* Swatch border */
     box-shadow: inset 0 0 0 var(--mod-swatch-border-thickness, var(--spectrum-swatch-border-thickness)) var(--highcontrast-swatch-border-color, var(--mod-swatch-border-color-regular, var(--spectrum-swatch-border-color-regular)));
@@ -300,7 +305,7 @@ governing permissions and limitations under the License.
   .spectrum-Swatch-fill {
     &:before {
       box-shadow: none;
-      background-color: var(--highcontrast-swatch-fill-foreground-color, var(--mod-swatch-fill-background-color, var(--spectrum-swatch-fill-background-color)));
+      background-color: var(--highcontrast-swatch-fill-foreground-color, var(--spectrum-picked-color));
     }
   }
 }
@@ -309,7 +314,7 @@ governing permissions and limitations under the License.
   visibility: hidden;
   pointer-events: none;
 
-  color: var(--highcontrast-swatch-fill-background-color, var(--mod-swatch-fill-background-color, var(--spectrum-swatch-fill-background-color)));
+  color: var(--spectrum-picked-color, transparent);
 }
 
 .spectrum-Swatch-disabledIcon {

--- a/components/swatch/index.css
+++ b/components/swatch/index.css
@@ -19,14 +19,14 @@ governing permissions and limitations under the License.
 
 /* Swatch tokens */
 .spectrum-Swatch {
-  /* Static swatch focus ring border radius */
+  /* Missing: Static swatch focus ring border radius */
   --spectrum-swatch-focus-ring-border-radius: 8px;
 
-  /* Static swatch border radius */
+  /* Static swatch border colors in place of missing swatch-border-color */
   --spectrum-swatch-border-color-regular: rgba(0, 0, 0, 0.5);
   --spectrum-swatch-border-color-light: rgba(0, 0, 0, 0.2);
 
-  /* Static watch fil height */
+  /* Static watch fill height border-width-200 isn't thick enough */
   --spectrum-swatch-spacing-selected: 8px;
 
   /*  */
@@ -39,8 +39,7 @@ governing permissions and limitations under the License.
   --spectrum-swatch-focus-ring-thickness: var(--spectrum-focus-ring-thickness);
   --spectrum-swatch-focus-ring-gap: var(--spectrum-focus-ring-gap);
 
-  /* Missing token */
-  /* --spectrum-swatch-border-color: var(--spectrum-swatch-border-color); */
+  --spectrum-swatch-border-color: var(--spectrum-swatch-border-color);
   --spectrum-swatch-border-color-selected: var(--spectrum-gray-900);
   /* --spectrum-swatch-inner-border-color-selected: var(--spectrum-gray-50); */
   --spectrum-swatch-disabled-icon-border-color: var(--spectrum-swatch-disabled-icon-border-color);
@@ -141,15 +140,11 @@ governing permissions and limitations under the License.
       width: calc(100% - var(--spectrum-swatch-spacing-selected));
       height: calc(100% - var(--spectrum-swatch-spacing-selected));
 
-      /* border-radius: var(--spectrum-swatch-fill-border-radius-selected); */
-      border-radius: var(--spectrum-swatch-border-radius);
+      /* no border radius when selected */
+      border-radius: 0;
 
-      /* no border when selected */
       &:before {
-        /* Use 2px border-radius here? */
-        /* border-radius: var(--spectrum-swatch-fill-border-radius-selected); */
-        border-radius: var(--spectrum-swatch-border-radius);
-
+        border-radius: 0;
         box-shadow: none;
       }
     }

--- a/components/swatch/index.css
+++ b/components/swatch/index.css
@@ -45,7 +45,7 @@ governing permissions and limitations under the License.
   --spectrum-swatch-disabled-icon-border-color: var(--spectrum-swatch-disabled-icon-border-color);
   --spectrum-swatch-disabled-icon-color: var(--spectrum-white);
   --spectrum-swatch-background-color: var(--spectrum-gray-50);
-  /* --spectrum-swatch-dash-icon-color: var(--spectrum-gray-800); */
+  --spectrum-swatch-dash-icon-color: var(--spectrum-gray-800);
   --spectrum-swatch-slash-icon-color: var(--spectrum-red-500);
   --spectrum-swatch-focus-ring-color: var(--spectrum-focus-ring-color);
 }
@@ -154,12 +154,14 @@ governing permissions and limitations under the License.
     }
   }
 
+  /* Why is this variant called mixed? */
   &.is-mixedValue {
     .spectrum-Swatch-fill {
       background: var(--spectrum-swatch-background-color);
     }
 
     .spectrum-Swatch-mixedValueIcon {
+      color: var(--spectrum-swatch-dash-icon-color);
       visibility: visible;
     }
   }

--- a/components/swatch/index.css
+++ b/components/swatch/index.css
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 
 .🤫 {
   /* hack: make sure we don't complain about this color being undefined */
-  /* --spectrum-picked-color: 0; */
+  --spectrum-picked-color: 0;
 }
 
 /* shape = square is default */
@@ -78,25 +78,25 @@ governing permissions and limitations under the License.
   --spectrum-swatch-focus-ring-color: var(--spectrum-focus-ring-color);
 }
 
-.spectrum-Swatch--sizeS {
+.spectrum-Swatch--sizeXS {
   --spectrum-swatch-size: var(--spectrum-swatch-size-extra-small);
   --spectrum-swatch-disabled-icon-size: var(--spectrum-workflow-icon-size-50);
   --spectrum-swatch-slash-thickness: var(--spectrum-swatch-slash-thickness-extra-small);
 }
 
-.spectrum-Swatch--sizeM {
+.spectrum-Swatch--sizeS {
   --spectrum-swatch-size: var(--spectrum-swatch-size-small);
   --spectrum-swatch-disabled-icon-size: var(--spectrum-workflow-icon-size-75);
   --spectrum-swatch-slash-thickness: var(--spectrum-swatch-slash-thickness-small);
 }
 
-.spectrum-Swatch--sizeL {
+.spectrum-Swatch--sizeM {
   --spectrum-swatch-size: var(--spectrum-swatch-size-medium);
   --spectrum-swatch-disabled-icon-size: var(--spectrum-workflow-icon-size-100);
   --spectrum-swatch-slash-thickness: var(--spectrum-swatch-slash-thickness-medium);
 }
 
-.spectrum-Swatch--sizeXL {
+.spectrum-Swatch--sizeL {
   --spectrum-swatch-size: var(--spectrum-swatch-size-large);
   --spectrum-swatch-disabled-icon-size: var(--spectrum-workflow-icon-size-200);
   --spectrum-swatch-slash-thickness: var(--spectrum-swatch-slash-thickness-large);
@@ -218,30 +218,6 @@ governing permissions and limitations under the License.
         }
       }
     }
-
-    /* &.spectrum-Swatch--sizeXS { */
-    /*   .spectrum-Swatch-fill:after  { */
-    /*     height: 2px; */
-    /*   } */
-    /* } */
-
-    /* &.spectrum-Swatch--sizeS { */
-    /*   .spectrum-Swatch-fill:after  { */
-    /*     height: 3px; */
-    /*   } */
-    /* } */
-
-    /* &.spectrum-Swatch--sizeM { */
-    /*   .spectrum-Swatch-fill:after  { */
-    /*     height: 4px; */
-    /*   } */
-    /* } */
-
-    /* &.spectrum-Swatch--sizeL { */
-    /*   .spectrum-Swatch-fill:after  { */
-    /*     height: 5px; */
-    /*   } */
-    /* } */
   }
 
   &[disabled],
@@ -321,6 +297,7 @@ governing permissions and limitations under the License.
     /* linear-gradient(-45deg, var(--spectrum-colorcontrol-checkerboard-dark-color) 25.5%, transparent 25.5%), */
     /* linear-gradient(45deg, var(--spectrum-colorcontrol-checkerboard-dark-color) 25.5%, transparent 25.5%); */
 
+  /* Swatch fill */
   &:before {
     content: '';
     position: absolute;
@@ -328,8 +305,7 @@ governing permissions and limitations under the License.
 
     z-index: 0;
 
-    /* background-color: var(--spectrum-picked-color, transparent); */
-    background-color: teal;
+    background-color: var(--spectrum-picked-color, transparent);
 
     /* Swatch border */
     /* box-shadow: inset 0 0 0 var(--spectrum-swatch-fill-border-width) var(--spectrum-swatch-fill-border-color); */

--- a/components/swatch/index.css
+++ b/components/swatch/index.css
@@ -29,7 +29,7 @@ governing permissions and limitations under the License.
   /* Static watch fill height border-width-200 isn't thick enough */
   --spectrum-swatch-spacing-selected: 8px;
 
-  /*  */
+  /* Size */
   --spectrum-swatch-size: var(--spectrum-swatch-size-small);
   --spectrum-swatch-border-radius: var(--spectrum-corner-radius-100);
   --spectrum-swatch-border-thickness: var(--spectrum-border-width-100);
@@ -46,7 +46,7 @@ governing permissions and limitations under the License.
   --spectrum-swatch-disabled-icon-color: var(--spectrum-white);
   --spectrum-swatch-background-color: var(--spectrum-gray-50);
   --spectrum-swatch-dash-icon-color: var(--spectrum-gray-800);
-  --spectrum-swatch-slash-icon-color: var(--spectrum-red-500);
+  --spectrum-swatch-slash-icon-color: var(--spectrum-red-900);
   --spectrum-swatch-focus-ring-color: var(--spectrum-focus-ring-color);
 }
 
@@ -166,11 +166,12 @@ governing permissions and limitations under the License.
     }
   }
 
-  /* Slash */
+  /* What does is-nothing mean? */
   &.is-nothing {
     .spectrum-Swatch-fill {
       background: var(--spectrum-swatch-background-color);
 
+      /* Slash */
       &:after {
         height: var(--spectrum-swatch-slash-thickness);
         content: '';

--- a/components/swatch/index.css
+++ b/components/swatch/index.css
@@ -12,14 +12,12 @@ governing permissions and limitations under the License.
 
 /* Swatch tokens */
 .spectrum-Swatch {
-  /* Missing: Static swatch focus ring border radius */
+  /* Static properties - no tokens */
   --spectrum-swatch-focus-ring-border-radius: 8px;
 
-  /* Static swatch border colors in place of missing swatch-border-color */
   --spectrum-swatch-border-color-regular: rgba(0, 0, 0, 0.5);
   --spectrum-swatch-border-color-light: rgba(0, 0, 0, 0.2);
 
-  /* Static watch fill height border-width-200 isn't thick enough */
   --spectrum-swatch-spacing-selected: 8px;
 
   /* Size */
@@ -117,7 +115,6 @@ governing permissions and limitations under the License.
     height: var(--spectrum-swatch-disabled-icon-size);
   }
 
-  /* rounding = default is default */
   &,
   &:before {
     border-radius: var(--spectrum-swatch-border-radius);
@@ -125,9 +122,6 @@ governing permissions and limitations under the License.
 
   &.is-selected {
     background-color: var(--spectrum-swatch-inner-border-color-selected);
-
-    /* --spectrum-swatch-background-offset: -4px; /\* correct for selected size *\/ */
-
     .spectrum-Swatch-fill {
       width: calc(100% - var(--spectrum-swatch-spacing-selected));
       height: calc(100% - var(--spectrum-swatch-spacing-selected));
@@ -240,11 +234,10 @@ governing permissions and limitations under the License.
 
   border-radius: var(--spectrum-swatch-border-radius);
 
-  /* background-color: var(--spectrum-color-control-checkerboard-light-color); */
   background-color: var(--spectrum-swatch-fill-background-color);
 
   /* Checkerboard fill */
-  /* Static checkerboard fill tokens */
+  /* Static checkerboard properties */
   --spectrum-swatch-checkerboard-size: 8px;
   --spectrum-swatch-checkerboard-background-offset: 0px;
   --spectrum-swatch-checkerboard-dark-color: rgb(217, 217, 217);
@@ -305,7 +298,6 @@ governing permissions and limitations under the License.
   visibility: hidden;
   pointer-events: none;
 
-  /* color: var(--spectrum-global-color-gray-700); */
   color: var(--spectrum-swatch-fill-background-color);
 }
 
@@ -316,7 +308,6 @@ governing permissions and limitations under the License.
   visibility: hidden;
   pointer-events: none;
 
-  /* Review */
   color: var(--spectrum-swatch-disabled-icon-color);
   stroke: var(--spectrum-swatch-disabled-icon-color);
 }

--- a/components/swatch/index.css
+++ b/components/swatch/index.css
@@ -19,18 +19,6 @@ governing permissions and limitations under the License.
 
 /* Swatch tokens */
 .spectrum-Swatch {
-  /* Static swatch t-shirt sizes for medium scale */
-  --spectrum-swatch-size-extra-small: 16px;
-  --spectrum-swatch-size-small: 24px;
-  --spectrum-swatch-size-medium: 32px;
-  --spectrum-swatch-size-large: 40px;
-
-  /* Static slash thickness t-shirt sizes */
-  --spectrum-swatch-slash-thickness-extra-small: 2px;
-  --spectrum-swatch-slash-thickness-small: 3px;
-  --spectrum-swatch-slash-thickness-medium: 4px;
-  --spectrum-swatch-slash-thickness-large: 5px;
-
   /* Static swatch focus ring border radius */
   --spectrum-swatch-focus-ring-border-radius: 8px;
 

--- a/components/swatch/index.css
+++ b/components/swatch/index.css
@@ -34,7 +34,7 @@ governing permissions and limitations under the License.
 
   --spectrum-swatch-border-color: var(--spectrum-swatch-border-color);
   --spectrum-swatch-border-color-selected: var(--spectrum-gray-900);
-  /* --spectrum-swatch-inner-border-color-selected: var(--spectrum-gray-50); */
+  --spectrum-swatch-inner-border-color-selected: var(--spectrum-gray-50);
   --spectrum-swatch-disabled-icon-border-color: var(--spectrum-swatch-disabled-icon-border-color);
   --spectrum-swatch-disabled-icon-color: var(--spectrum-white);
   --spectrum-swatch-fill-background-color: var(--spectrum-gray-50);
@@ -124,8 +124,7 @@ governing permissions and limitations under the License.
   }
 
   &.is-selected {
-    /* background-color: var(--spectrum-swatch-fill-background-color-selected); */
-    background-color: var(--spectrum-swatch-fill-background-color);
+    background-color: var(--spectrum-swatch-inner-border-color-selected);
 
     /* --spectrum-swatch-background-offset: -4px; /\* correct for selected size *\/ */
 
@@ -147,7 +146,6 @@ governing permissions and limitations under the License.
     }
   }
 
-  /* Why is this variant called mixed? */
   &.is-mixedValue {
     .spectrum-Swatch-fill {
       background: var(--spectrum-swatch-fill-background-color);
@@ -226,7 +224,6 @@ governing permissions and limitations under the License.
     }
   }
 }
-
 
 .spectrum-Swatch-fill {
   display: flex;

--- a/components/swatch/index.css
+++ b/components/swatch/index.css
@@ -30,8 +30,8 @@ governing permissions and limitations under the License.
   --spectrum-swatch-focus-ring-thickness: var(--spectrum-focus-ring-thickness);
   --spectrum-swatch-focus-ring-gap: var(--spectrum-focus-ring-gap);
 
+  /* Color */
   --spectrum-swatch-border-color: var(--spectrum-swatch-border-color);
-  /* --spectrum-swatch-border-color-selected: var(--spectrum-gray-900); */
   --spectrum-swatch-inner-border-color-selected: var(--spectrum-gray-50);
   --spectrum-swatch-disabled-icon-border-color: var(--spectrum-swatch-disabled-icon-border-color);
   --spectrum-swatch-disabled-icon-color: var(--spectrum-white);
@@ -67,28 +67,21 @@ governing permissions and limitations under the License.
 
 /* Windows high contrast mode */
 @media (forced-colors: active) {
-  .spectrum-Swatch-fill {
-    forced-color-adjust: none;
-  }
   .spectrum-Swatch {
     --highcontrast-swatch-disabled-icon-color: grayText;
-    --highcontrast-swatch-focus-ring-color: ButtonText;
+    --highcontrast-swatch-focus-ring-color: Highlight;
     --highcontrast-swatch-border-color-selected: Highlight;
     --highcontrast-swatch-border-color: ButtonText;
-    --highcontrast-swatch-border-color-light: ButtonText;
-    /* --highcontrast-swatch-fill-background-color-selected: ButtonFace; */
     --highcontrast-swatch-fill-background-color: ButtonFace;
+    --highcontrast-swatch-fill-foreground-color: ButtonText;
+
+    .spectrum-Swatch-fill {
+      forced-color-adjust: none;
+    }
+
     &.is-disabled {
       .spectrum-Swatch-fill {
         forced-color-adjust: auto;
-      }
-    }
-    /* Slash */
-    &.is-nothing {
-      .spectrum-Swatch-fill {
-        &:after {
-          background: ButtonText;
-        }
       }
     }
   }
@@ -141,7 +134,7 @@ governing permissions and limitations under the License.
     }
   }
 
-  /* Swatch fill with transparent background-color for images, gradients, and svgs  */
+  /* Swatch fill: Image, Gradient, SVG */
   &.is-image {
     .spectrum-Swatch-fill {
       &::before {
@@ -161,18 +154,18 @@ governing permissions and limitations under the License.
     }
   }
 
+  /* Swatch fill: Not fill with Slash */
   &.is-nothing {
     .spectrum-Swatch-fill {
       background-color: var(--highcontrast-swatch-fill-background-color, var(--mod-swatch-fill-background-color, var(--spectrum-swatch-fill-background-color)));
 
-      /* Slash */
       &:after {
         height: var(--mod-swatch-slash-thickness, var(--spectrum-swatch-slash-thickness));
         content: '';
         position: absolute;
         transform: rotate(-45deg);
         width: 200%; /* just needs to be bigger than a swatch */
-        background: var(--spectrum-swatch-slash-icon-color);
+        background: var(--highcontrast-swatch-fill-foreground-color, var(--mod-swatch-slash-icon-color, var(--spectrum-swatch-slash-icon-color)));
       }
     }
 
@@ -274,7 +267,7 @@ governing permissions and limitations under the License.
     linear-gradient(-45deg, var(--spectrum-swatch-checkerboard-dark-color) 25.5%, transparent 25.5%),
     linear-gradient(45deg, var(--spectrum-swatch-checkerboard-dark-color) 25.5%, transparent 25.5%);
 
-  /* Swatch fill - default */
+  /* Swatch fill: Default */
   &:before {
     content: '';
     position: absolute;
@@ -294,7 +287,7 @@ governing permissions and limitations under the License.
 .spectrum-Swatch--lightBorder {
   .spectrum-Swatch-fill {
     &:before {
-      box-shadow: inset 0 0 0 var(--mod-swatch-border-thickness, var(--spectrum-swatch-border-thickness)) var(--highcontrast-swatch-border-color-light, var(--mod-swatch-border-color-light, var(--spectrum-swatch-border-color-light)));
+      box-shadow: inset 0 0 0 var(--mod-swatch-border-thickness, var(--spectrum-swatch-border-thickness)) var(--highcontrast-swatch-border-color, var(--mod-swatch-border-color-light, var(--spectrum-swatch-border-color-light)));
     }
   }
 }
@@ -304,6 +297,7 @@ governing permissions and limitations under the License.
   .spectrum-Swatch-fill {
     &:before {
       box-shadow: none;
+      background-color: var(--highcontrast-swatch-fill-foreground-color, var(--mod-swatch-fill-background-color, var(--spectrum-swatch-fill-background-color)));
     }
   }
 }

--- a/components/swatch/index.css
+++ b/components/swatch/index.css
@@ -38,6 +38,9 @@ governing permissions and limitations under the License.
   --spectrum-swatch-border-color-regular: rgba(0, 0, 0, 0.5);
   --spectrum-swatch-border-color-light: rgba(0, 0, 0, 0.2);
 
+  /* Static watch fil height */
+  --spectrum-swatch-spacing-selected: 8px;
+
   /*  */
   --spectrum-swatch-size: var(--spectrum-swatch-size-small);
   --spectrum-swatch-border-radius: var(--spectrum-corner-radius-100);
@@ -147,8 +150,8 @@ governing permissions and limitations under the License.
     /* --spectrum-swatch-background-offset: -4px; /\* correct for selected size *\/ */
 
     .spectrum-Swatch-fill {
-      width: calc(100% - var(--spectrum-swatch-focus-ring-gap));
-      height: calc(100% - var(--spectrum-swatch-focus-ring-gap));
+      width: calc(100% - var(--spectrum-swatch-spacing-selected));
+      height: calc(100% - var(--spectrum-swatch-spacing-selected));
 
       /* border-radius: var(--spectrum-swatch-fill-border-radius-selected); */
       border-radius: var(--spectrum-swatch-border-radius);

--- a/components/swatch/index.css
+++ b/components/swatch/index.css
@@ -95,8 +95,8 @@ governing permissions and limitations under the License.
 
 /* Swatch styles */
 .spectrum-Swatch {
-  width: var(--spectrum-swatch-size);
-  height: var(--spectrum-swatch-size);
+  width: var(--mod-swatch-size, var(--spectrum-swatch-size));
+  height: var(--mod-swatch-size, var(--spectrum-swatch-size));
 
   display: flex;
   align-items: center;
@@ -111,20 +111,20 @@ governing permissions and limitations under the License.
   user-select: none;
 
  .spectrum-Swatch-disabledIcon {
-    width: var(--spectrum-swatch-disabled-icon-size);
-    height: var(--spectrum-swatch-disabled-icon-size);
+    width: var(--mod-swatch-disabled-icon-size, var(--spectrum-swatch-disabled-icon-size));
+    height: var(--mod-swatch-disabled-icon-size, var(--spectrum-swatch-disabled-icon-size));
   }
 
   &,
   &:before {
-    border-radius: var(--spectrum-swatch-border-radius);
+    border-radius: var(--mod-swatch-border-radius, var(--spectrum-swatch-border-radius));
   }
 
   &.is-selected {
     background-color: var(--spectrum-swatch-inner-border-color-selected);
     .spectrum-Swatch-fill {
-      width: calc(100% - var(--spectrum-swatch-spacing-selected));
-      height: calc(100% - var(--spectrum-swatch-spacing-selected));
+      width: calc(100% - var(--mod-swatch-spacing-selected, var(--spectrum-swatch-spacing-selected)));
+      height: calc(100% - var(--mod-swatch-spacing-selected, var(--spectrum-swatch-spacing-selected)));
 
       /* no border radius when selected */
       border-radius: 0;
@@ -158,7 +158,7 @@ governing permissions and limitations under the License.
 
       /* Slash */
       &:after {
-        height: var(--spectrum-swatch-slash-thickness);
+        height: var(--mod-swatch-slash-thickness, var(--spectrum-swatch-slash-thickness));
         content: '';
         position: absolute;
         transform: rotate(-45deg);
@@ -206,8 +206,8 @@ governing permissions and limitations under the License.
 
     opacity: 0;
 
-    border: var(--spectrum-swatch-focus-ring-thickness) solid var(--spectrum-swatch-focus-ring-color);
-    border-radius: var(--spectrum-swatch-focus-ring-border-radius);
+    border: var(--mod-swatch-focus-ring-thickness, var(--spectrum-swatch-focus-ring-thickness)) solid var(--spectrum-swatch-focus-ring-color);
+    border-radius: var(--mod-swatch-focus-ring-border-radius, var(--mod-swatch-focus-ring-border-radius, var(--spectrum-swatch-focus-ring-border-radius)));
 
     transition: opacity var(--spectrum-animation-duration-100) ease-in-out;
   }
@@ -232,7 +232,7 @@ governing permissions and limitations under the License.
 
   overflow: hidden;
 
-  border-radius: var(--spectrum-swatch-border-radius);
+  border-radius: var(--mod-swatch-border-radius, var(--spectrum-swatch-border-radius));
 
   background-color: var(--spectrum-swatch-fill-background-color);
 
@@ -243,14 +243,14 @@ governing permissions and limitations under the License.
   --spectrum-swatch-checkerboard-dark-color: rgb(217, 217, 217);
 
   background-size:
-    calc(var(--spectrum-swatch-checkerboard-size) * 2)
-    calc(var(--spectrum-swatch-checkerboard-size) * 2);
+    calc(var(--mod-swatch-checkerboard-size, var(--spectrum-swatch-checkerboard-size)) * 2)
+    calc(var(--mod-swatch-checkerboard-size, var(--spectrum-swatch-checkerboard-size)) * 2);
 
   background-position:
     var(--spectrum-swatch-checkerboard-background-offset) var(--spectrum-swatch-checkerboard-background-offset),
-    var(--spectrum-swatch-checkerboard-background-offset) calc(var(--spectrum-swatch-checkerboard-size) + var(--spectrum-swatch-checkerboard-background-offset)),
-    calc(var(--spectrum-swatch-checkerboard-size) + var(--spectrum-swatch-checkerboard-background-offset)) calc(-1 * var(--spectrum-swatch-checkerboard-size) + var(--spectrum-swatch-checkerboard-background-offset)),
-    calc(-1 * var(--spectrum-swatch-checkerboard-size) + var(--spectrum-swatch-checkerboard-background-offset)) var(--spectrum-swatch-checkerboard-background-offset);
+    var(--spectrum-swatch-checkerboard-background-offset) calc(var(--mod-swatch-checkerboard-size, var(--spectrum-swatch-checkerboard-size)) + var(--spectrum-swatch-checkerboard-background-offset)),
+    calc(var(--mod-swatch-checkerboard-size, var(--spectrum-swatch-checkerboard-size)) + var(--spectrum-swatch-checkerboard-background-offset)) calc(-1 * var(--mod-swatch-checkerboard-size, var(--spectrum-swatch-checkerboard-size)) + var(--spectrum-swatch-checkerboard-background-offset)),
+    calc(-1 * var(--mod-swatch-checkerboard-size, var(--spectrum-swatch-checkerboard-size)) + var(--spectrum-swatch-checkerboard-background-offset)) var(--spectrum-swatch-checkerboard-background-offset);
 
   /* Add a half-percent to fix diagonal line issue in Chrome on non-retina displays */
   background-image:
@@ -270,9 +270,9 @@ governing permissions and limitations under the License.
     background-color: var(--mod-swatch-fill-background-color, var(--spectrum-swatch-fill-background-color), transparent);
 
     /* Swatch border */
-    box-shadow: inset 0 0 0 var(--spectrum-swatch-border-thickness) var(--spectrum-swatch-border-color-regular);
+    box-shadow: inset 0 0 0 var(--mod-swatch-border-thickness, var(--spectrum-swatch-border-thickness)) var(--spectrum-swatch-border-color-regular);
 
-    border-radius: var(--spectrum-swatch-border-radius);
+    border-radius: var(--mod-swatch-border-radius, var(--spectrum-swatch-border-radius));
   }
 }
 
@@ -280,7 +280,7 @@ governing permissions and limitations under the License.
 .spectrum-Swatch--lightBorder {
   .spectrum-Swatch-fill {
     &:before {
-      box-shadow: inset 0 0 0 var(--spectrum-swatch-border-thickness) var(--spectrum-swatch-border-color-light);
+      box-shadow: inset 0 0 0 var(--mod-swatch-border-thickness, var(--spectrum-swatch-border-thickness)) var(--spectrum-swatch-border-color-light);
     }
   }
 }
@@ -313,21 +313,7 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Swatch--rectangle {
-  &.spectrum-Swatch--sizeXS {
-    width: calc(var(--spectrum-swatch-size) * 2);
-  }
-
-  &.spectrum-Swatch--sizeS {
-    width: calc(var(--spectrum-swatch-size) * 2);
-  }
-
-  &.spectrum-Swatch--sizeM {
-    width: calc(var(--spectrum-swatch-size) * 2);
-  }
-
-  &.spectrum-Swatch--sizeL {
-    width: calc(var(--spectrum-swatch-size) * 2);
-  }
+  width: calc(var(--mod-swatch-size, var(--spectrum-swatch-size)) * 2);
 }
 
 /* Variant: Rounding - None */
@@ -364,6 +350,6 @@ governing permissions and limitations under the License.
   width: 100%;
   height: 100%;
 
-  transition: width var(--spectrum-animation-duration-100) ease-in-out,
-              height var(--spectrum-animation-duration-100) ease-in-out;
+  transition: width var(--mod-animation-duration-100, var(--spectrum-animation-duration-100)) ease-in-out,
+              height var(--mod-animation-duration-100, var(--spectrum-animation-duration-100)) ease-in-out;
 }

--- a/components/swatch/index.css
+++ b/components/swatch/index.css
@@ -18,8 +18,6 @@ governing permissions and limitations under the License.
   --spectrum-swatch-border-color-regular: rgba(0, 0, 0, 0.5);
   --spectrum-swatch-border-color-light: rgba(0, 0, 0, 0.2);
 
-  --spectrum-swatch-spacing-selected: 8px;
-
   /* Size */
   --spectrum-swatch-size: var(--spectrum-swatch-size-small);
   --spectrum-swatch-border-radius: var(--spectrum-corner-radius-100);
@@ -28,6 +26,7 @@ governing permissions and limitations under the License.
   --spectrum-swatch-disabled-icon-size: var(--spectrum-workflow-icon-size-75);
   --spectrum-swatch-slash-thickness: var(--spectrum-swatch-slash-thickness-small);
   --spectrum-swatch-focus-ring-thickness: var(--spectrum-focus-ring-thickness);
+  --spectrum-swatch-spacing-selected: var(--spectrum-swatch-border-thickness-selected) * 4;
   --spectrum-swatch-focus-ring-gap: var(--spectrum-focus-ring-gap);
 
   /* Color */

--- a/components/swatch/index.css
+++ b/components/swatch/index.css
@@ -10,13 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-.🤫 {
-  /* hack: make sure we don't complain about this color being undefined */
-  --spectrum-picked-color: 0;
-}
-
-/* shape = square is default */
-
 /* Swatch tokens */
 .spectrum-Swatch {
   /* Missing: Static swatch focus ring border radius */
@@ -44,7 +37,7 @@ governing permissions and limitations under the License.
   /* --spectrum-swatch-inner-border-color-selected: var(--spectrum-gray-50); */
   --spectrum-swatch-disabled-icon-border-color: var(--spectrum-swatch-disabled-icon-border-color);
   --spectrum-swatch-disabled-icon-color: var(--spectrum-white);
-  --spectrum-swatch-background-color: var(--spectrum-gray-50);
+  --spectrum-swatch-fill-background-color: var(--spectrum-gray-50);
   --spectrum-swatch-dash-icon-color: var(--spectrum-gray-800);
   --spectrum-swatch-slash-icon-color: var(--spectrum-red-900);
   --spectrum-swatch-focus-ring-color: var(--spectrum-focus-ring-color);
@@ -85,7 +78,7 @@ governing permissions and limitations under the License.
     /* --spectrum-swatch-selection-indicator-border-color: Highlight; */
     /* --spectrum-swatch-fill-border-color: ButtonText; */
     /* --spectrum-swatch-fill-border-color-light: ButtonText; */
-    /* --spectrum-swatch-background-color-selected: ButtonFace; */
+    /* --spectrum-swatch-fill-background-color-selected: ButtonFace; */
     &.is-disabled {
       .spectrum-Swatch-fill {
         forced-color-adjust: auto;
@@ -131,8 +124,8 @@ governing permissions and limitations under the License.
   }
 
   &.is-selected {
-    /* background-color: var(--spectrum-swatch-background-color-selected); */
-    background-color: var(--spectrum-swatch-background-color);
+    /* background-color: var(--spectrum-swatch-fill-background-color-selected); */
+    background-color: var(--spectrum-swatch-fill-background-color);
 
     /* --spectrum-swatch-background-offset: -4px; /\* correct for selected size *\/ */
 
@@ -157,7 +150,7 @@ governing permissions and limitations under the License.
   /* Why is this variant called mixed? */
   &.is-mixedValue {
     .spectrum-Swatch-fill {
-      background: var(--spectrum-swatch-background-color);
+      background: var(--spectrum-swatch-fill-background-color);
     }
 
     .spectrum-Swatch-mixedValueIcon {
@@ -169,7 +162,7 @@ governing permissions and limitations under the License.
   /* What does is-nothing mean? */
   &.is-nothing {
     .spectrum-Swatch-fill {
-      background: var(--spectrum-swatch-background-color);
+      background: var(--spectrum-swatch-fill-background-color);
 
       /* Slash */
       &:after {
@@ -251,7 +244,7 @@ governing permissions and limitations under the License.
   border-radius: var(--spectrum-swatch-border-radius);
 
   /* background-color: var(--spectrum-color-control-checkerboard-light-color); */
-  background-color: var(--spectrum-swatch-background-color);
+  background-color: var(--spectrum-swatch-fill-background-color);
 
   /* Checkerboard fill */
   /* Static checkerboard fill tokens */
@@ -284,7 +277,7 @@ governing permissions and limitations under the License.
 
     z-index: 0;
 
-    background-color: var(--spectrum-picked-color, transparent);
+    background-color: var(--mod-swatch-fill-background-color, var(--spectrum-swatch-fill-background-color), transparent);
 
     /* Swatch border */
     box-shadow: inset 0 0 0 var(--spectrum-swatch-border-thickness) var(--spectrum-swatch-border-color-regular);
@@ -316,7 +309,7 @@ governing permissions and limitations under the License.
   pointer-events: none;
 
   /* color: var(--spectrum-global-color-gray-700); */
-  color: var(--spectrum-swatch-background-color);
+  color: var(--spectrum-swatch-fill-background-color);
 }
 
 .spectrum-Swatch-disabledIcon {

--- a/components/swatch/index.css
+++ b/components/swatch/index.css
@@ -168,6 +168,7 @@ governing permissions and limitations under the License.
   &.is-nothing {
     .spectrum-Swatch-fill {
       background-color: var(--spectrum-picked-color, transparent);
+      background-image: none;
 
       &:after {
         height: var(--mod-swatch-slash-thickness, var(--spectrum-swatch-slash-thickness));

--- a/components/swatch/index.css
+++ b/components/swatch/index.css
@@ -19,9 +19,7 @@ governing permissions and limitations under the License.
 .spectrum-Swatch {
   /* Static properties - no tokens */
   --spectrum-swatch-focus-ring-border-radius: 8px;
-
   --spectrum-swatch-border-color-regular: rgba(0, 0, 0, 0.5);
-  --spectrum-swatch-border-color-light: rgba(0, 0, 0, 0.2);
 
   /* Size */
   --spectrum-swatch-size: var(--spectrum-swatch-size-small);
@@ -71,11 +69,11 @@ governing permissions and limitations under the License.
 /* Windows high contrast mode */
 @media (forced-colors: active) {
   .spectrum-Swatch {
-    --highcontrast-swatch-disabled-icon-color: grayText;
+    --highcontrast-swatch-disabled-icon-color: GrayText;
     --highcontrast-swatch-focus-ring-color: Highlight;
-    --highcontrast-swatch-border-color-selected: Highlight;
-    --highcontrast-swatch-border-color: ButtonText;
-    /*--highcontrast-swatch-fill-background-color: ButtonFace;*/
+    --highcontrast-swatch-background-color-selected: Background;
+    --highcontrast-swatch-border-color: Highlight;
+    --highcontrast-swatch-box-shadow-color: ButtonText;
     --highcontrast-swatch-fill-foreground-color: ButtonText;
 
     .spectrum-Swatch-fill {
@@ -118,7 +116,7 @@ governing permissions and limitations under the License.
   }
 
   &.is-selected {
-    background-color: var(--highcontrast-swatch-border-color-selected, var(--mod-swatch-inner-border-color-selected, var(--spectrum-swatch-inner-border-color-selected)));
+    background-color: var(--highcontrast-swatch-background-color-selected, var(--mod-swatch-inner-border-color-selected, var(--spectrum-swatch-inner-border-color-selected)));
     .spectrum-Swatch-fill {
       clip-path: polygon(
         calc(var(--mod-swatch-border-thickness-selected, var(--spectrum-swatch-border-thickness-selected)) * 2)
@@ -286,18 +284,8 @@ governing permissions and limitations under the License.
     background-color: var(--spectrum-picked-color, transparent);
 
     /* Swatch border */
-    box-shadow: inset 0 0 0 var(--mod-swatch-border-thickness, var(--spectrum-swatch-border-thickness)) var(--highcontrast-swatch-border-color, var(--mod-swatch-border-color-regular, var(--spectrum-swatch-border-color-regular)));
-
+    box-shadow: inset 0 0 0 var(--mod-swatch-border-thickness, var(--spectrum-swatch-border-thickness)) var(--highcontrast-swatch-box-shadow-color, var(--mod-swatch-border-color-regular, var(--spectrum-swatch-border-color-regular)));
     border-radius: var(--mod-swatch-border-radius, var(--spectrum-swatch-border-radius));
-  }
-}
-
-/* Variant: Light border */
-.spectrum-Swatch--lightBorder {
-  .spectrum-Swatch-fill {
-    &:before {
-      box-shadow: inset 0 0 0 var(--mod-swatch-border-thickness, var(--spectrum-swatch-border-thickness)) var(--highcontrast-swatch-border-color, var(--mod-swatch-border-color-light, var(--spectrum-swatch-border-color-light)));
-    }
   }
 }
 
@@ -306,7 +294,7 @@ governing permissions and limitations under the License.
   .spectrum-Swatch-fill {
     &:before {
       box-shadow: none;
-      background-color: var(--highcontrast-swatch-fill-foreground-color, var(--spectrum-picked-color));
+      background-color: var(--spectrum-picked-color, transparent);
     }
   }
 }
@@ -327,6 +315,16 @@ governing permissions and limitations under the License.
 
   color: var(--highcontrast-swatch-disabled-icon-color, var(--mod-swatch-disabled-icon-color, var(--spectrum-swatch-disabled-icon-color)));
   stroke: var(--highcontrast-swatch-disabled-icon-color, var(--mod-swatch-disabled-icon-color, var(--spectrum-swatch-disabled-icon-color)));
+
+  /* Icon fill color */
+  path:first-child {
+    fill: var(--highcontrast-swatch-disabled-icon-color, var(--mod-swatch-disabled-icon-color, var(--spectrum-swatch-disabled-icon-color)));
+  }
+
+  /* Icon outline color - does not need a highcontrast token because the icon fill color provides contrast. */
+  path:last-child {
+    fill: var(--mod-swatch-border-color-regular, var(--spectrum-swatch-border-color-regular));
+  }
 }
 
 .spectrum-Swatch--rectangle {

--- a/components/swatch/index.css
+++ b/components/swatch/index.css
@@ -17,9 +17,9 @@ governing permissions and limitations under the License.
 
 /* Swatch tokens */
 .spectrum-Swatch {
-  /* Static properties - no tokens */
+  /* Placeholder tokens */
   --spectrum-swatch-focus-ring-border-radius: 8px;
-  --spectrum-swatch-border-color-regular: rgba(0, 0, 0, 0.5);
+  --spectrum-swatch-icon-border-color: rgba(0, 0, 0, 0.51);
 
   /* Size */
   --spectrum-swatch-size: var(--spectrum-swatch-size-small);
@@ -32,11 +32,10 @@ governing permissions and limitations under the License.
   --spectrum-swatch-focus-ring-gap: var(--spectrum-focus-ring-gap);
 
   /* Color */
-  --spectrum-swatch-border-color: var(--spectrum-swatch-border-color);
+  --spectrum-swatch-border-color-selected: var(--spectrum-gray-900);
   --spectrum-swatch-inner-border-color-selected: var(--spectrum-gray-50);
   --spectrum-swatch-disabled-icon-border-color: var(--spectrum-swatch-disabled-icon-border-color);
   --spectrum-swatch-disabled-icon-color: var(--spectrum-white);
-  /*--spectrum-swatch-fill-background-color: var(--spectrum-gray-50);*/
   --spectrum-swatch-dash-icon-color: var(--spectrum-gray-800);
   --spectrum-swatch-slash-icon-color: var(--spectrum-red-900);
   --spectrum-swatch-focus-ring-color: var(--spectrum-focus-ring-color);
@@ -66,14 +65,26 @@ governing permissions and limitations under the License.
   --spectrum-swatch-slash-thickness: var(--spectrum-swatch-slash-thickness-large);
 }
 
+
+/* Light theme placeholder tokens */
+.spectrum--light {
+  --spectrum-swatch-border-color: rgba(0, 0, 0, 0.51);
+}
+
+/* Dark and Darkest theme placeholder tokens */
+.spectrum--dark,
+.spectrum--darkest {
+  --spectrum-swatch-border-color: rgba(255, 255, 255, 0.51);
+}
+
 /* Windows high contrast mode */
 @media (forced-colors: active) {
   .spectrum-Swatch {
     --highcontrast-swatch-disabled-icon-color: GrayText;
-    --highcontrast-swatch-focus-ring-color: Highlight;
+    --highcontrast-swatch-focus-ring-color:  ButtonText;
     --highcontrast-swatch-background-color-selected: Background;
-    --highcontrast-swatch-border-color: Highlight;
-    --highcontrast-swatch-box-shadow-color: ButtonText;
+    --highcontrast-swatch-border-color-selected: Highlight;
+    --highcontrast-swatch-border-color: ButtonText;
     --highcontrast-swatch-fill-foreground-color: ButtonText;
 
     .spectrum-Swatch-fill {
@@ -202,7 +213,7 @@ governing permissions and limitations under the License.
 
     border-width: var(--mod-swatch-border-thickness-selected, var(--spectrum-swatch-border-thickness-selected));
     border-style: solid;
-    border-color: var(--highcontrast-swatch-border-color, var(--mod-swatch-border-color, var(--spectrum-swatch-border-color)));
+    border-color: var(--highcontrast-swatch-border-color-selected, var(--mod-swatch-border-color-selected, var(--spectrum-swatch-border-color-selected)));
 
     opacity: 0;
 
@@ -284,7 +295,7 @@ governing permissions and limitations under the License.
     background-color: var(--spectrum-picked-color, transparent);
 
     /* Swatch border */
-    box-shadow: inset 0 0 0 var(--mod-swatch-border-thickness, var(--spectrum-swatch-border-thickness)) var(--highcontrast-swatch-box-shadow-color, var(--mod-swatch-border-color-regular, var(--spectrum-swatch-border-color-regular)));
+    box-shadow: inset 0 0 0 var(--mod-swatch-border-thickness, var(--spectrum-swatch-border-thickness)) var(--highcontrast-swatch-border-color, var(--mod-swatch-border-color, var(--spectrum-swatch-border-color)));
     border-radius: var(--mod-swatch-border-radius, var(--spectrum-swatch-border-radius));
   }
 }
@@ -323,7 +334,7 @@ governing permissions and limitations under the License.
 
   /* Icon outline color - does not need a highcontrast token because the icon fill color provides contrast. */
   path:last-child {
-    fill: var(--mod-swatch-border-color-regular, var(--spectrum-swatch-border-color-regular));
+    fill: var(--mod-swatch-icon-border-color, var(--spectrum-swatch-icon-border-color));
   }
 }
 

--- a/components/swatch/metadata/swatch.yml
+++ b/components/swatch/metadata/swatch.yml
@@ -2,7 +2,7 @@ name: Swatch
 status: Verified
 SpectrumSiteSlug: https://spectrum.adobe.com/page/swatch/
 description: |
-  - Set `--mod-swatch-fill-background-color` to customize the swatch fill background color.
+  - Set `--spectrum-picked-color` to customize the swatch fill background color.
 examples:
   - id: swatch-sizing
     name: Sizing
@@ -12,10 +12,10 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">XS</h4>
 
           <div class="spectrum-Examples-itemGroup">
-            <div class="spectrum-Swatch spectrum-Swatch--sizeXS" style="--mod-swatch-fill-background-color: rgb(174, 216, 230)" tabindex="0">
+            <div class="spectrum-Swatch spectrum-Swatch--sizeXS" style="--spectrum-picked-color: rgb(174, 216, 230)" tabindex="0">
               <div class="spectrum-Swatch-fill"></div>
             </div>
-            <div class="spectrum-Swatch spectrum-Swatch--sizeXS" style="--mod-swatch-fill-background-color: rgba(174, 216, 230, 0.3)" tabindex="0">
+            <div class="spectrum-Swatch spectrum-Swatch--sizeXS" style="--spectrum-picked-color: rgba(174, 216, 230, 0.3)" tabindex="0">
               <div class="spectrum-Swatch-fill"></div>
             </div>
           </div>
@@ -24,10 +24,10 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">S</h4>
 
           <div class="spectrum-Examples-itemGroup">
-            <div class="spectrum-Swatch spectrum-Swatch--sizeS" style="--mod-swatch-fill-background-color: rgb(174, 216, 230)" tabindex="0">
+            <div class="spectrum-Swatch spectrum-Swatch--sizeS" style="--spectrum-picked-color: rgb(174, 216, 230)" tabindex="0">
               <div class="spectrum-Swatch-fill"></div>
             </div>
-            <div class="spectrum-Swatch spectrum-Swatch--sizeS" style="--mod-swatch-fill-background-color: rgba(174, 216, 230, 0.3)" tabindex="0">
+            <div class="spectrum-Swatch spectrum-Swatch--sizeS" style="--spectrum-picked-color: rgba(174, 216, 230, 0.3)" tabindex="0">
               <div class="spectrum-Swatch-fill"></div>
             </div>
           </div>
@@ -36,10 +36,10 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">M (default)</h4>
 
           <div class="spectrum-Examples-itemGroup">
-            <div class="spectrum-Swatch spectrum-Swatch--sizeM" style="--mod-swatch-fill-background-color: rgb(174, 216, 230)" tabindex="0">
+            <div class="spectrum-Swatch spectrum-Swatch--sizeM" style="--spectrum-picked-color: rgb(174, 216, 230)" tabindex="0">
               <div class="spectrum-Swatch-fill"></div>
             </div>
-            <div class="spectrum-Swatch spectrum-Swatch--sizeM" style="--mod-swatch-fill-background-color: rgba(174, 216, 230, 0.3)" tabindex="0">
+            <div class="spectrum-Swatch spectrum-Swatch--sizeM" style="--spectrum-picked-color: rgba(174, 216, 230, 0.3)" tabindex="0">
               <div class="spectrum-Swatch-fill"></div>
             </div>
           </div>
@@ -49,10 +49,10 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">L</h4>
 
           <div class="spectrum-Examples-itemGroup">
-            <div class="spectrum-Swatch spectrum-Swatch--sizeL" style="--mod-swatch-fill-background-color: rgb(174, 216, 230)" tabindex="0">
+            <div class="spectrum-Swatch spectrum-Swatch--sizeL" style="--spectrum-picked-color: rgb(174, 216, 230)" tabindex="0">
               <div class="spectrum-Swatch-fill"></div>
             </div>
-            <div class="spectrum-Swatch spectrum-Swatch--sizeL" style="--mod-swatch-fill-background-color: rgba(174, 216, 230, 0.3)" tabindex="0">
+            <div class="spectrum-Swatch spectrum-Swatch--sizeL" style="--spectrum-picked-color: rgba(174, 216, 230, 0.3)" tabindex="0">
               <div class="spectrum-Swatch-fill"></div>
             </div>
           </div>
@@ -62,35 +62,35 @@ examples:
   - id: swatch-roundingnone
     name: Rounding - None
     markup: |
-      <div class="spectrum-Swatch spectrum-Swatch--sizeM spectrum-Swatch--roundingNone" style="--mod-swatch-fill-background-color: rgba(174, 216, 230, 0.25)" tabindex="0">
+      <div class="spectrum-Swatch spectrum-Swatch--sizeM spectrum-Swatch--roundingNone" style="--spectrum-picked-color: rgba(174, 216, 230, 0.25)" tabindex="0">
         <div class="spectrum-Swatch-fill">
         </div>
       </div>
   - id: swatch-roundingfull
     name: Rounding - Full
     markup: |
-      <div class="spectrum-Swatch spectrum-Swatch--sizeM spectrum-Swatch--roundingFull" style="--mod-swatch-fill-background-color: rgba(174, 216, 230, 0.25)" tabindex="0">
+      <div class="spectrum-Swatch spectrum-Swatch--sizeM spectrum-Swatch--roundingFull" style="--spectrum-picked-color: rgba(174, 216, 230, 0.25)" tabindex="0">
         <div class="spectrum-Swatch-fill">
         </div>
       </div>
   - id: swatch-lightborder
     name: Light border
     markup: |
-      <div class="spectrum-Swatch spectrum-Swatch--sizeM spectrum-Swatch--lightBorder" style="--mod-swatch-fill-background-color: rgba(174, 216, 230, 0.25)" tabindex="0">
+      <div class="spectrum-Swatch spectrum-Swatch--sizeM spectrum-Swatch--lightBorder" style="--spectrum-picked-color: rgba(174, 216, 230, 0.25)" tabindex="0">
         <div class="spectrum-Swatch-fill">
         </div>
       </div>
   - id: swatch-noborder
     name: No border
     markup: |
-      <div class="spectrum-Swatch spectrum-Swatch--sizeM spectrum-Swatch--noBorder" style="--mod-swatch-fill-background-color: rgb(120, 91, 199)" tabindex="0">
+      <div class="spectrum-Swatch spectrum-Swatch--sizeM spectrum-Swatch--noBorder" style="--spectrum-picked-color: rgb(120, 91, 199)" tabindex="0">
         <div class="spectrum-Swatch-fill">
         </div>
       </div>
   - id: swatch-rectangle
     name: Shape - Rectangle
     markup: |
-      <div class="spectrum-Swatch spectrum-Swatch--sizeM spectrum-Swatch--rectangle" style="--mod-swatch-fill-background-color: rgba(174, 216, 230, 0.25)" tabindex="0">
+      <div class="spectrum-Swatch spectrum-Swatch--sizeM spectrum-Swatch--rectangle" style="--spectrum-picked-color: rgba(174, 216, 230, 0.25)" tabindex="0">
         <div class="spectrum-Swatch-fill">
         </div>
       </div>
@@ -113,7 +113,7 @@ examples:
   - id: swatch-selection
     name: Selected
     markup: |
-      <div class="spectrum-Swatch spectrum-Swatch--sizeM is-selected" style="--mod-swatch-fill-background-color: rgb(174, 216, 230)" tabindex="0">
+      <div class="spectrum-Swatch spectrum-Swatch--sizeM is-selected" style="--spectrum-picked-color: rgb(174, 216, 230)" tabindex="0">
         <div class="spectrum-Swatch-fill"></div>
       </div>
   - id: swatch-mixedvalue
@@ -204,7 +204,7 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">XS</h4>
 
           <div class="spectrum-Examples-itemGroup">
-            <div class="spectrum-Swatch spectrum-Swatch--sizeXS is-disabled" style="--mod-swatch-fill-background-color: rgb(174, 216, 230)" tabindex="0">
+            <div class="spectrum-Swatch spectrum-Swatch--sizeXS is-disabled" style="--spectrum-picked-color: rgb(174, 216, 230)" tabindex="0">
               <div class="spectrum-Swatch-fill">
                 <svg xmlns="http://www.w3.org/2000/svg" class="spectrum-Swatch-disabledIcon" viewBox="0 0 20 20">
                   <path d="M9.889,1a8.889,8.889,0,1,0,8.889,8.889A8.889,8.889,0,0,0,9.889,1Zm6.667,8.889a6.635,6.635,0,0,1-1.233,3.863l-9.3-9.3A6.667,6.667,0,0,1,16.556,9.889Zm-13.333,0A6.636,6.636,0,0,1,4.455,6.026l9.3,9.3A6.667,6.667,0,0,1,3.222,9.889Z" stroke="none" fill="var(--spectrum-swatch-disabled-icon-color)"/>
@@ -212,7 +212,7 @@ examples:
                 </svg>
               </div>
             </div>
-            <div class="spectrum-Swatch spectrum-Swatch--sizeXS spectrum-Swatch--roundingFull is-disabled" style="--mod-swatch-fill-background-color: rgb(174, 216, 230)" tabindex="0">
+            <div class="spectrum-Swatch spectrum-Swatch--sizeXS spectrum-Swatch--roundingFull is-disabled" style="--spectrum-picked-color: rgb(174, 216, 230)" tabindex="0">
               <div class="spectrum-Swatch-fill">
                 <svg xmlns="http://www.w3.org/2000/svg" class="spectrum-Swatch-disabledIcon" viewBox="0 0 20 20">
                   <path d="M9.889,1a8.889,8.889,0,1,0,8.889,8.889A8.889,8.889,0,0,0,9.889,1Zm6.667,8.889a6.635,6.635,0,0,1-1.233,3.863l-9.3-9.3A6.667,6.667,0,0,1,16.556,9.889Zm-13.333,0A6.636,6.636,0,0,1,4.455,6.026l9.3,9.3A6.667,6.667,0,0,1,3.222,9.889Z" stroke="none" fill="var(--spectrum-swatch-disabled-icon-color)"/>
@@ -226,7 +226,7 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">S</h4>
 
           <div class="spectrum-Examples-itemGroup">
-            <div class="spectrum-Swatch spectrum-Swatch--sizeS is-disabled" style="--mod-swatch-fill-background-color: rgb(174, 216, 230)" tabindex="0">
+            <div class="spectrum-Swatch spectrum-Swatch--sizeS is-disabled" style="--spectrum-picked-color: rgb(174, 216, 230)" tabindex="0">
               <div class="spectrum-Swatch-fill">
                 <svg xmlns="http://www.w3.org/2000/svg" class="spectrum-Swatch-disabledIcon" viewBox="0 0 20 20">
                   <path d="M9.889,1a8.889,8.889,0,1,0,8.889,8.889A8.889,8.889,0,0,0,9.889,1Zm6.667,8.889a6.635,6.635,0,0,1-1.233,3.863l-9.3-9.3A6.667,6.667,0,0,1,16.556,9.889Zm-13.333,0A6.636,6.636,0,0,1,4.455,6.026l9.3,9.3A6.667,6.667,0,0,1,3.222,9.889Z" stroke="none" fill="var(--spectrum-swatch-disabled-icon-color)"/>
@@ -234,7 +234,7 @@ examples:
                 </svg>
               </div>
             </div>
-            <div class="spectrum-Swatch spectrum-Swatch--sizeS spectrum-Swatch--roundingFull is-disabled" style="--mod-swatch-fill-background-color: rgb(174, 216, 230)" tabindex="0">
+            <div class="spectrum-Swatch spectrum-Swatch--sizeS spectrum-Swatch--roundingFull is-disabled" style="--spectrum-picked-color: rgb(174, 216, 230)" tabindex="0">
               <div class="spectrum-Swatch-fill">
                 <svg xmlns="http://www.w3.org/2000/svg" class="spectrum-Swatch-disabledIcon" viewBox="0 0 20 20">
                   <path d="M9.889,1a8.889,8.889,0,1,0,8.889,8.889A8.889,8.889,0,0,0,9.889,1Zm6.667,8.889a6.635,6.635,0,0,1-1.233,3.863l-9.3-9.3A6.667,6.667,0,0,1,16.556,9.889Zm-13.333,0A6.636,6.636,0,0,1,4.455,6.026l9.3,9.3A6.667,6.667,0,0,1,3.222,9.889Z" stroke="none" fill="var(--spectrum-swatch-disabled-icon-color)"/>
@@ -248,7 +248,7 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">M (default)</h4>
 
           <div class="spectrum-Examples-itemGroup">
-            <div class="spectrum-Swatch spectrum-Swatch--sizeM is-disabled" style="--mod-swatch-fill-background-color: rgb(174, 216, 230)" tabindex="0">
+            <div class="spectrum-Swatch spectrum-Swatch--sizeM is-disabled" style="--spectrum-picked-color: rgb(174, 216, 230)" tabindex="0">
               <div class="spectrum-Swatch-fill">
                 <svg xmlns="http://www.w3.org/2000/svg" class="spectrum-Swatch-disabledIcon" viewBox="0 0 20 20">
                   <path d="M9.889,1a8.889,8.889,0,1,0,8.889,8.889A8.889,8.889,0,0,0,9.889,1Zm6.667,8.889a6.635,6.635,0,0,1-1.233,3.863l-9.3-9.3A6.667,6.667,0,0,1,16.556,9.889Zm-13.333,0A6.636,6.636,0,0,1,4.455,6.026l9.3,9.3A6.667,6.667,0,0,1,3.222,9.889Z" stroke="none" fill="var(--spectrum-swatch-disabled-icon-color)"/>
@@ -256,7 +256,7 @@ examples:
                 </svg>
               </div>
             </div>
-            <div class="spectrum-Swatch spectrum-Swatch--sizeM spectrum-Swatch--roundingFull is-disabled" style="--mod-swatch-fill-background-color: rgb(174, 216, 230)" tabindex="0">
+            <div class="spectrum-Swatch spectrum-Swatch--sizeM spectrum-Swatch--roundingFull is-disabled" style="--spectrum-picked-color: rgb(174, 216, 230)" tabindex="0">
               <div class="spectrum-Swatch-fill">
                 <svg xmlns="http://www.w3.org/2000/svg" class="spectrum-Swatch-disabledIcon" viewBox="0 0 20 20">
                   <path d="M9.889,1a8.889,8.889,0,1,0,8.889,8.889A8.889,8.889,0,0,0,9.889,1Zm6.667,8.889a6.635,6.635,0,0,1-1.233,3.863l-9.3-9.3A6.667,6.667,0,0,1,16.556,9.889Zm-13.333,0A6.636,6.636,0,0,1,4.455,6.026l9.3,9.3A6.667,6.667,0,0,1,3.222,9.889Z" stroke="none" fill="var(--spectrum-swatch-disabled-icon-color)"/>
@@ -271,7 +271,7 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">L</h4>
 
           <div class="spectrum-Examples-itemGroup">
-            <div class="spectrum-Swatch spectrum-Swatch--sizeL is-disabled" style="--mod-swatch-fill-background-color: rgb(174, 216, 230)" tabindex="0">
+            <div class="spectrum-Swatch spectrum-Swatch--sizeL is-disabled" style="--spectrum-picked-color: rgb(174, 216, 230)" tabindex="0">
               <div class="spectrum-Swatch-fill">
                 <svg xmlns="http://www.w3.org/2000/svg" class="spectrum-Swatch-disabledIcon" viewBox="0 0 20 20">
                   <path d="M9.889,1a8.889,8.889,0,1,0,8.889,8.889A8.889,8.889,0,0,0,9.889,1Zm6.667,8.889a6.635,6.635,0,0,1-1.233,3.863l-9.3-9.3A6.667,6.667,0,0,1,16.556,9.889Zm-13.333,0A6.636,6.636,0,0,1,4.455,6.026l9.3,9.3A6.667,6.667,0,0,1,3.222,9.889Z" stroke="none" fill="var(--spectrum-swatch-disabled-icon-color)"/>
@@ -279,7 +279,7 @@ examples:
                 </svg>
               </div>
             </div>
-            <div class="spectrum-Swatch spectrum-Swatch--sizeL spectrum-Swatch--roundingFull is-disabled" style="--mod-swatch-fill-background-color: rgb(174, 216, 230)" tabindex="0">
+            <div class="spectrum-Swatch spectrum-Swatch--sizeL spectrum-Swatch--roundingFull is-disabled" style="--spectrum-picked-color: rgb(174, 216, 230)" tabindex="0">
               <div class="spectrum-Swatch-fill">
                 <svg xmlns="http://www.w3.org/2000/svg" class="spectrum-Swatch-disabledIcon" viewBox="0 0 20 20">
                   <path d="M9.889,1a8.889,8.889,0,1,0,8.889,8.889A8.889,8.889,0,0,0,9.889,1Zm6.667,8.889a6.635,6.635,0,0,1-1.233,3.863l-9.3-9.3A6.667,6.667,0,0,1,16.556,9.889Zm-13.333,0A6.636,6.636,0,0,1,4.455,6.026l9.3,9.3A6.667,6.667,0,0,1,3.222,9.889Z" stroke="none" fill="var(--spectrum-swatch-disabled-icon-color)"/>

--- a/components/swatch/metadata/swatch.yml
+++ b/components/swatch/metadata/swatch.yml
@@ -97,7 +97,7 @@ examples:
   - id: swatch-image
     name: Image
     markup: |
-      <div class="spectrum-Swatch spectrum-Swatch--sizeM" tabindex="0">
+      <div class="spectrum-Swatch spectrum-Swatch--sizeM is-image" tabindex="0">
         <div class="spectrum-Swatch-fill">
           <img src="img/example-ava.jpg" class="spectrum-Swatch-image">
         </div>
@@ -105,7 +105,7 @@ examples:
   - id: swatch-gradient
     name: Gradient
     markup: |
-      <div class="spectrum-Swatch spectrum-Swatch--sizeM" tabindex="0">
+      <div class="spectrum-Swatch spectrum-Swatch--sizeM is-image" tabindex="0">
         <div class="spectrum-Swatch-fill">
           <div class="spectrum-Swatch-image" style="background: linear-gradient(to right, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, 0) 100%);"></div>
         </div>
@@ -119,7 +119,7 @@ examples:
   - id: swatch-mixedvalue
     name: Mixed Value
     markup: |
-      <div class="spectrum-Swatch spectrum-Swatch--sizeM is-mixedValue" tabindex="0">
+      <div class="spectrum-Swatch spectrum-Swatch--sizeM is-mixedValue is-image" tabindex="0">
         <div class="spectrum-Swatch-fill">
           <svg class="spectrum-Icon spectrum-UIIcon-Dash200 spectrum-Swatch-mixedValueIcon" focusable="false" aria-hidden="true">
             <use xlink:href="#spectrum-css-icon-Dash200" />

--- a/components/swatch/metadata/swatch.yml
+++ b/components/swatch/metadata/swatch.yml
@@ -2,7 +2,7 @@ name: Swatch
 status: Verified
 SpectrumSiteSlug: https://spectrum.adobe.com/page/swatch/
 description: |
-  - Set the `--spectrum-picked-color` custom property to the CSS color value you want to show
+  - Set `--mod-swatch-fill-background-color` to customize the swatch fill background color.
 examples:
   - id: swatch-sizing
     name: Sizing
@@ -12,10 +12,10 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">XS</h4>
 
           <div class="spectrum-Examples-itemGroup">
-            <div class="spectrum-Swatch spectrum-Swatch--sizeXS" style="--spectrum-picked-color: rgb(174, 216, 230)" tabindex="0">
+            <div class="spectrum-Swatch spectrum-Swatch--sizeXS" style="--mod-swatch-fill-background-color: rgb(174, 216, 230)" tabindex="0">
               <div class="spectrum-Swatch-fill"></div>
             </div>
-            <div class="spectrum-Swatch spectrum-Swatch--sizeXS" style="--spectrum-picked-color: rgba(174, 216, 230, 0.3)" tabindex="0">
+            <div class="spectrum-Swatch spectrum-Swatch--sizeXS" style="--mod-swatch-fill-background-color: rgba(174, 216, 230, 0.3)" tabindex="0">
               <div class="spectrum-Swatch-fill"></div>
             </div>
           </div>
@@ -24,10 +24,10 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">S</h4>
 
           <div class="spectrum-Examples-itemGroup">
-            <div class="spectrum-Swatch spectrum-Swatch--sizeS" style="--spectrum-picked-color: rgb(174, 216, 230)" tabindex="0">
+            <div class="spectrum-Swatch spectrum-Swatch--sizeS" style="--mod-swatch-fill-background-color: rgb(174, 216, 230)" tabindex="0">
               <div class="spectrum-Swatch-fill"></div>
             </div>
-            <div class="spectrum-Swatch spectrum-Swatch--sizeS" style="--spectrum-picked-color: rgba(174, 216, 230, 0.3)" tabindex="0">
+            <div class="spectrum-Swatch spectrum-Swatch--sizeS" style="--mod-swatch-fill-background-color: rgba(174, 216, 230, 0.3)" tabindex="0">
               <div class="spectrum-Swatch-fill"></div>
             </div>
           </div>
@@ -36,10 +36,10 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">M (default)</h4>
 
           <div class="spectrum-Examples-itemGroup">
-            <div class="spectrum-Swatch spectrum-Swatch--sizeM" style="--spectrum-picked-color: rgb(174, 216, 230)" tabindex="0">
+            <div class="spectrum-Swatch spectrum-Swatch--sizeM" style="--mod-swatch-fill-background-color: rgb(174, 216, 230)" tabindex="0">
               <div class="spectrum-Swatch-fill"></div>
             </div>
-            <div class="spectrum-Swatch spectrum-Swatch--sizeM" style="--spectrum-picked-color: rgba(174, 216, 230, 0.3)" tabindex="0">
+            <div class="spectrum-Swatch spectrum-Swatch--sizeM" style="--mod-swatch-fill-background-color: rgba(174, 216, 230, 0.3)" tabindex="0">
               <div class="spectrum-Swatch-fill"></div>
             </div>
           </div>
@@ -49,10 +49,10 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">L</h4>
 
           <div class="spectrum-Examples-itemGroup">
-            <div class="spectrum-Swatch spectrum-Swatch--sizeL" style="--spectrum-picked-color: rgb(174, 216, 230)" tabindex="0">
+            <div class="spectrum-Swatch spectrum-Swatch--sizeL" style="--mod-swatch-fill-background-color: rgb(174, 216, 230)" tabindex="0">
               <div class="spectrum-Swatch-fill"></div>
             </div>
-            <div class="spectrum-Swatch spectrum-Swatch--sizeL" style="--spectrum-picked-color: rgba(174, 216, 230, 0.3)" tabindex="0">
+            <div class="spectrum-Swatch spectrum-Swatch--sizeL" style="--mod-swatch-fill-background-color: rgba(174, 216, 230, 0.3)" tabindex="0">
               <div class="spectrum-Swatch-fill"></div>
             </div>
           </div>
@@ -62,35 +62,35 @@ examples:
   - id: swatch-roundingnone
     name: Rounding - None
     markup: |
-      <div class="spectrum-Swatch spectrum-Swatch--sizeM spectrum-Swatch--roundingNone" style="--spectrum-picked-color: rgba(174, 216, 230, 0.25)" tabindex="0">
+      <div class="spectrum-Swatch spectrum-Swatch--sizeM spectrum-Swatch--roundingNone" style="--mod-swatch-fill-background-color: rgba(174, 216, 230, 0.25)" tabindex="0">
         <div class="spectrum-Swatch-fill">
         </div>
       </div>
   - id: swatch-roundingfull
     name: Rounding - Full
     markup: |
-      <div class="spectrum-Swatch spectrum-Swatch--sizeM spectrum-Swatch--roundingFull" style="--spectrum-picked-color: rgba(174, 216, 230, 0.25)" tabindex="0">
+      <div class="spectrum-Swatch spectrum-Swatch--sizeM spectrum-Swatch--roundingFull" style="--mod-swatch-fill-background-color: rgba(174, 216, 230, 0.25)" tabindex="0">
         <div class="spectrum-Swatch-fill">
         </div>
       </div>
   - id: swatch-lightborder
     name: Light border
     markup: |
-      <div class="spectrum-Swatch spectrum-Swatch--sizeM spectrum-Swatch--lightBorder" style="--spectrum-picked-color: rgba(174, 216, 230, 0.25)" tabindex="0">
+      <div class="spectrum-Swatch spectrum-Swatch--sizeM spectrum-Swatch--lightBorder" style="--mod-swatch-fill-background-color: rgba(174, 216, 230, 0.25)" tabindex="0">
         <div class="spectrum-Swatch-fill">
         </div>
       </div>
   - id: swatch-noborder
     name: No border
     markup: |
-      <div class="spectrum-Swatch spectrum-Swatch--sizeM spectrum-Swatch--noBorder" style="--spectrum-picked-color: rgb(120, 91, 199)" tabindex="0">
+      <div class="spectrum-Swatch spectrum-Swatch--sizeM spectrum-Swatch--noBorder" style="--mod-swatch-fill-background-color: rgb(120, 91, 199)" tabindex="0">
         <div class="spectrum-Swatch-fill">
         </div>
       </div>
   - id: swatch-rectangle
     name: Shape - Rectangle
     markup: |
-      <div class="spectrum-Swatch spectrum-Swatch--sizeM spectrum-Swatch--rectangle" style="--spectrum-picked-color: rgba(174, 216, 230, 0.25)" tabindex="0">
+      <div class="spectrum-Swatch spectrum-Swatch--sizeM spectrum-Swatch--rectangle" style="--mod-swatch-fill-background-color: rgba(174, 216, 230, 0.25)" tabindex="0">
         <div class="spectrum-Swatch-fill">
         </div>
       </div>
@@ -113,7 +113,7 @@ examples:
   - id: swatch-selection
     name: Selected
     markup: |
-      <div class="spectrum-Swatch spectrum-Swatch--sizeM is-selected" style="--spectrum-picked-color: rgb(174, 216, 230)" tabindex="0">
+      <div class="spectrum-Swatch spectrum-Swatch--sizeM is-selected" style="--mod-swatch-fill-background-color: rgb(174, 216, 230)" tabindex="0">
         <div class="spectrum-Swatch-fill"></div>
       </div>
   - id: swatch-mixedvalue
@@ -204,7 +204,7 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">XS</h4>
 
           <div class="spectrum-Examples-itemGroup">
-            <div class="spectrum-Swatch spectrum-Swatch--sizeXS is-disabled" style="--spectrum-picked-color: rgb(174, 216, 230)" tabindex="0">
+            <div class="spectrum-Swatch spectrum-Swatch--sizeXS is-disabled" style="--mod-swatch-fill-background-color: rgb(174, 216, 230)" tabindex="0">
               <div class="spectrum-Swatch-fill">
                 <svg xmlns="http://www.w3.org/2000/svg" class="spectrum-Swatch-disabledIcon" viewBox="0 0 20 20">
                   <path d="M9.889,1a8.889,8.889,0,1,0,8.889,8.889A8.889,8.889,0,0,0,9.889,1Zm6.667,8.889a6.635,6.635,0,0,1-1.233,3.863l-9.3-9.3A6.667,6.667,0,0,1,16.556,9.889Zm-13.333,0A6.636,6.636,0,0,1,4.455,6.026l9.3,9.3A6.667,6.667,0,0,1,3.222,9.889Z" stroke="none" fill="var(--spectrum-swatch-disabled-icon-color)"/>
@@ -212,7 +212,7 @@ examples:
                 </svg>
               </div>
             </div>
-            <div class="spectrum-Swatch spectrum-Swatch--sizeXS spectrum-Swatch--roundingFull is-disabled" style="--spectrum-picked-color: rgb(174, 216, 230)" tabindex="0">
+            <div class="spectrum-Swatch spectrum-Swatch--sizeXS spectrum-Swatch--roundingFull is-disabled" style="--mod-swatch-fill-background-color: rgb(174, 216, 230)" tabindex="0">
               <div class="spectrum-Swatch-fill">
                 <svg xmlns="http://www.w3.org/2000/svg" class="spectrum-Swatch-disabledIcon" viewBox="0 0 20 20">
                   <path d="M9.889,1a8.889,8.889,0,1,0,8.889,8.889A8.889,8.889,0,0,0,9.889,1Zm6.667,8.889a6.635,6.635,0,0,1-1.233,3.863l-9.3-9.3A6.667,6.667,0,0,1,16.556,9.889Zm-13.333,0A6.636,6.636,0,0,1,4.455,6.026l9.3,9.3A6.667,6.667,0,0,1,3.222,9.889Z" stroke="none" fill="var(--spectrum-swatch-disabled-icon-color)"/>
@@ -226,7 +226,7 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">S</h4>
 
           <div class="spectrum-Examples-itemGroup">
-            <div class="spectrum-Swatch spectrum-Swatch--sizeS is-disabled" style="--spectrum-picked-color: rgb(174, 216, 230)" tabindex="0">
+            <div class="spectrum-Swatch spectrum-Swatch--sizeS is-disabled" style="--mod-swatch-fill-background-color: rgb(174, 216, 230)" tabindex="0">
               <div class="spectrum-Swatch-fill">
                 <svg xmlns="http://www.w3.org/2000/svg" class="spectrum-Swatch-disabledIcon" viewBox="0 0 20 20">
                   <path d="M9.889,1a8.889,8.889,0,1,0,8.889,8.889A8.889,8.889,0,0,0,9.889,1Zm6.667,8.889a6.635,6.635,0,0,1-1.233,3.863l-9.3-9.3A6.667,6.667,0,0,1,16.556,9.889Zm-13.333,0A6.636,6.636,0,0,1,4.455,6.026l9.3,9.3A6.667,6.667,0,0,1,3.222,9.889Z" stroke="none" fill="var(--spectrum-swatch-disabled-icon-color)"/>
@@ -234,7 +234,7 @@ examples:
                 </svg>
               </div>
             </div>
-            <div class="spectrum-Swatch spectrum-Swatch--sizeS spectrum-Swatch--roundingFull is-disabled" style="--spectrum-picked-color: rgb(174, 216, 230)" tabindex="0">
+            <div class="spectrum-Swatch spectrum-Swatch--sizeS spectrum-Swatch--roundingFull is-disabled" style="--mod-swatch-fill-background-color: rgb(174, 216, 230)" tabindex="0">
               <div class="spectrum-Swatch-fill">
                 <svg xmlns="http://www.w3.org/2000/svg" class="spectrum-Swatch-disabledIcon" viewBox="0 0 20 20">
                   <path d="M9.889,1a8.889,8.889,0,1,0,8.889,8.889A8.889,8.889,0,0,0,9.889,1Zm6.667,8.889a6.635,6.635,0,0,1-1.233,3.863l-9.3-9.3A6.667,6.667,0,0,1,16.556,9.889Zm-13.333,0A6.636,6.636,0,0,1,4.455,6.026l9.3,9.3A6.667,6.667,0,0,1,3.222,9.889Z" stroke="none" fill="var(--spectrum-swatch-disabled-icon-color)"/>
@@ -248,7 +248,7 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">M (default)</h4>
 
           <div class="spectrum-Examples-itemGroup">
-            <div class="spectrum-Swatch spectrum-Swatch--sizeM is-disabled" style="--spectrum-picked-color: rgb(174, 216, 230)" tabindex="0">
+            <div class="spectrum-Swatch spectrum-Swatch--sizeM is-disabled" style="--mod-swatch-fill-background-color: rgb(174, 216, 230)" tabindex="0">
               <div class="spectrum-Swatch-fill">
                 <svg xmlns="http://www.w3.org/2000/svg" class="spectrum-Swatch-disabledIcon" viewBox="0 0 20 20">
                   <path d="M9.889,1a8.889,8.889,0,1,0,8.889,8.889A8.889,8.889,0,0,0,9.889,1Zm6.667,8.889a6.635,6.635,0,0,1-1.233,3.863l-9.3-9.3A6.667,6.667,0,0,1,16.556,9.889Zm-13.333,0A6.636,6.636,0,0,1,4.455,6.026l9.3,9.3A6.667,6.667,0,0,1,3.222,9.889Z" stroke="none" fill="var(--spectrum-swatch-disabled-icon-color)"/>
@@ -256,7 +256,7 @@ examples:
                 </svg>
               </div>
             </div>
-            <div class="spectrum-Swatch spectrum-Swatch--sizeM spectrum-Swatch--roundingFull is-disabled" style="--spectrum-picked-color: rgb(174, 216, 230)" tabindex="0">
+            <div class="spectrum-Swatch spectrum-Swatch--sizeM spectrum-Swatch--roundingFull is-disabled" style="--mod-swatch-fill-background-color: rgb(174, 216, 230)" tabindex="0">
               <div class="spectrum-Swatch-fill">
                 <svg xmlns="http://www.w3.org/2000/svg" class="spectrum-Swatch-disabledIcon" viewBox="0 0 20 20">
                   <path d="M9.889,1a8.889,8.889,0,1,0,8.889,8.889A8.889,8.889,0,0,0,9.889,1Zm6.667,8.889a6.635,6.635,0,0,1-1.233,3.863l-9.3-9.3A6.667,6.667,0,0,1,16.556,9.889Zm-13.333,0A6.636,6.636,0,0,1,4.455,6.026l9.3,9.3A6.667,6.667,0,0,1,3.222,9.889Z" stroke="none" fill="var(--spectrum-swatch-disabled-icon-color)"/>
@@ -271,7 +271,7 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">L</h4>
 
           <div class="spectrum-Examples-itemGroup">
-            <div class="spectrum-Swatch spectrum-Swatch--sizeL is-disabled" style="--spectrum-picked-color: rgb(174, 216, 230)" tabindex="0">
+            <div class="spectrum-Swatch spectrum-Swatch--sizeL is-disabled" style="--mod-swatch-fill-background-color: rgb(174, 216, 230)" tabindex="0">
               <div class="spectrum-Swatch-fill">
                 <svg xmlns="http://www.w3.org/2000/svg" class="spectrum-Swatch-disabledIcon" viewBox="0 0 20 20">
                   <path d="M9.889,1a8.889,8.889,0,1,0,8.889,8.889A8.889,8.889,0,0,0,9.889,1Zm6.667,8.889a6.635,6.635,0,0,1-1.233,3.863l-9.3-9.3A6.667,6.667,0,0,1,16.556,9.889Zm-13.333,0A6.636,6.636,0,0,1,4.455,6.026l9.3,9.3A6.667,6.667,0,0,1,3.222,9.889Z" stroke="none" fill="var(--spectrum-swatch-disabled-icon-color)"/>
@@ -279,7 +279,7 @@ examples:
                 </svg>
               </div>
             </div>
-            <div class="spectrum-Swatch spectrum-Swatch--sizeL spectrum-Swatch--roundingFull is-disabled" style="--spectrum-picked-color: rgb(174, 216, 230)" tabindex="0">
+            <div class="spectrum-Swatch spectrum-Swatch--sizeL spectrum-Swatch--roundingFull is-disabled" style="--mod-swatch-fill-background-color: rgb(174, 216, 230)" tabindex="0">
               <div class="spectrum-Swatch-fill">
                 <svg xmlns="http://www.w3.org/2000/svg" class="spectrum-Swatch-disabledIcon" viewBox="0 0 20 20">
                   <path d="M9.889,1a8.889,8.889,0,1,0,8.889,8.889A8.889,8.889,0,0,0,9.889,1Zm6.667,8.889a6.635,6.635,0,0,1-1.233,3.863l-9.3-9.3A6.667,6.667,0,0,1,16.556,9.889Zm-13.333,0A6.636,6.636,0,0,1,4.455,6.026l9.3,9.3A6.667,6.667,0,0,1,3.222,9.889Z" stroke="none" fill="var(--spectrum-swatch-disabled-icon-color)"/>

--- a/components/swatch/package.json
+++ b/components/swatch/package.json
@@ -16,11 +16,11 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/tokens": "^1.0.5"
+    "@spectrum-css/tokens": "^1.0.7"
   },
   "devDependencies": {
     "@spectrum-css/component-builder": "^3.2.0",
-    "@spectrum-css/tokens": "^1.0.5",
+    "@spectrum-css/tokens": "^1.0.7",
     "gulp": "^4.0.0"
   },
   "publishConfig": {

--- a/components/swatch/package.json
+++ b/components/swatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spectrum-css/swatch",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "The Spectrum CSS Color swatch component",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",

--- a/components/swatch/package.json
+++ b/components/swatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spectrum-css/swatch",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "description": "The Spectrum CSS Color swatch component",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",

--- a/components/swatch/package.json
+++ b/components/swatch/package.json
@@ -16,11 +16,11 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/vars": "^8.0.0"
+    "@spectrum-css/tokens": "^1.0.4"
   },
   "devDependencies": {
     "@spectrum-css/component-builder": "^3.2.0",
-    "@spectrum-css/vars": "^8.0.0",
+    "@spectrum-css/tokens": "^1.0.4",
     "gulp": "^4.0.0"
   },
   "publishConfig": {

--- a/components/swatch/package.json
+++ b/components/swatch/package.json
@@ -16,11 +16,11 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/tokens": "^1.0.4"
+    "@spectrum-css/tokens": "^1.0.5"
   },
   "devDependencies": {
     "@spectrum-css/component-builder": "^3.2.0",
-    "@spectrum-css/tokens": "^1.0.4",
+    "@spectrum-css/tokens": "^1.0.5",
     "gulp": "^4.0.0"
   },
   "publishConfig": {

--- a/components/swatch/package.json
+++ b/components/swatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spectrum-css/swatch",
-  "version": "1.1.4",
+  "version": "2.0.0-beta.0",
   "description": "The Spectrum CSS Color swatch component",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",

--- a/components/swatch/package.json
+++ b/components/swatch/package.json
@@ -16,11 +16,11 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/tokens": "^1.0.7"
+    "@spectrum-css/tokens": "^3.0.0"
   },
   "devDependencies": {
-    "@spectrum-css/component-builder": "^3.2.0",
-    "@spectrum-css/tokens": "^1.0.7",
+    "@spectrum-css/component-builder-simple": "^1.0.0",
+    "@spectrum-css/tokens": "^3.0.0",
     "gulp": "^4.0.0"
   },
   "publishConfig": {

--- a/components/swatch/package.json
+++ b/components/swatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spectrum-css/swatch",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "description": "The Spectrum CSS Color swatch component",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",

--- a/components/swatch/package.json
+++ b/components/swatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spectrum-css/swatch",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.3",
   "description": "The Spectrum CSS Color swatch component",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",

--- a/components/swatch/themes/express.css
+++ b/components/swatch/themes/express.css
@@ -1,0 +1,15 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+@container (--system: express) {
+  .spectrum-Swatch {
+  }
+}

--- a/components/swatch/themes/spectrum.css
+++ b/components/swatch/themes/spectrum.css
@@ -1,0 +1,15 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+@container (--system: spectrum) {
+  .spectrum-Swatch {
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,9 +40,9 @@
   integrity sha512-XtIfWmeNY3i4t7t4D2t02q50HvqHybPqW2ki1kosnvWCwuCMeo81Jf0gwr85jy/neUdg5XDdeFE/80DXiO+njw==
 
 "@babel/helper-validator-identifier@^7.18.6":
-  version "7.18.6"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz#9c97e30d31b2b8c72a1d08984f2ca9b574d7a076"
-  integrity sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==
+  version "7.19.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz#7eea834cf32901ffdc1a7ee555e2f9c27e249ca2"
+  integrity sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==
 
 "@babel/highlight@^7.18.6":
   version "7.18.6"
@@ -54,21 +54,21 @@
     js-tokens "^4.0.0"
 
 "@babel/parser@^7.6.0", "@babel/parser@^7.9.6":
-  version "7.18.13"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.18.13.tgz#5b2dd21cae4a2c5145f1fbd8ca103f9313d3b7e4"
-  integrity sha512-dgXcIfMuQ0kgzLB2b9tRZs7TTFFaGM2AbtA4fJgUUYukzGH4jwsS7hzQHEGs67jdehpm22vkgKwvbU+aEflgwg==
+  version "7.19.1"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.19.1.tgz#6f6d6c2e621aad19a92544cc217ed13f1aac5b4c"
+  integrity sha512-h7RCSorm1DdTVGJf3P2Mhj3kdnkmF/EiysUkzS2TdgAYqyjFdMQJbVuXOBej2SBJaXan/lIVtT6KkGbyyq753A==
 
 "@babel/runtime@^7.7.2":
-  version "7.18.9"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.9.tgz#b4fcfce55db3d2e5e080d2490f608a3b9f407f4a"
-  integrity sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.19.0.tgz#22b11c037b094d27a8a2504ea4dcff00f50e2259"
+  integrity sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==
   dependencies:
     regenerator-runtime "^0.13.4"
 
 "@babel/types@^7.6.1", "@babel/types@^7.9.6":
-  version "7.18.13"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.18.13.tgz#30aeb9e514f4100f7c1cb6e5ba472b30e48f519a"
-  integrity sha512-ePqfTihzW0W6XAU+aMw2ykilisStJfDnsejDCXRchCcMJ4O0+8DhPXf2YUbZ6wjBlsEmZwLK/sPweWtu8hcJYQ==
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.19.0.tgz#75f21d73d73dc0351f3368d28db73465f4814600"
+  integrity sha512-YuGopBq3ke25BVSiS6fgF49Ul9gH1x70Bcr6bqRLjWCkcX8Hre1/5+z+IiWOIerRMSSEfGZVB9z9kyq7wVs9YA==
   dependencies:
     "@babel/helper-string-parser" "^7.18.10"
     "@babel/helper-validator-identifier" "^7.18.6"
@@ -233,22 +233,22 @@
   resolved "https://registry.yarnpkg.com/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz#98c23c950a3d9b6c8f0daed06da6c3af06981340"
   integrity sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==
 
-"@jimp/bmp@^0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@jimp/bmp/-/bmp-0.16.1.tgz#6e2da655b2ba22e721df0795423f34e92ef13768"
-  integrity sha512-iwyNYQeBawrdg/f24x3pQ5rEx+/GwjZcCXd3Kgc+ZUd+Ivia7sIqBsOnDaMZdKCBPlfW364ekexnlOqyVa0NWg==
+"@jimp/bmp@^0.16.2":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@jimp/bmp/-/bmp-0.16.2.tgz#3982879b10626fc8cf1b4ab8627158bad142ec9d"
+  integrity sha512-4g9vW45QfMoGhLVvaFj26h4e7cC+McHUQwyFQmNTLW4FfC1OonN9oUr2m/FEDGkTYKR7aqdXR5XUqqIkHWLaFw==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.16.1"
+    "@jimp/utils" "^0.16.2"
     bmp-js "^0.1.0"
 
-"@jimp/core@^0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@jimp/core/-/core-0.16.1.tgz#68c4288f6ef7f31a0f6b859ba3fb28dae930d39d"
-  integrity sha512-la7kQia31V6kQ4q1kI/uLimu8FXx7imWVajDGtwUG8fzePLWDFJyZl0fdIXVCL1JW2nBcRHidUot6jvlRDi2+g==
+"@jimp/core@^0.16.2":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@jimp/core/-/core-0.16.2.tgz#4f8e83a4af76a60610e794362d1deb5afaa03353"
+  integrity sha512-dp7HcyUMzjXphXYodI6PaXue+I9PXAavbb+AN+1XqFbotN22Z12DosNPEyy+UhLY/hZiQQqUkEaJHkvV31rs+w==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.16.1"
+    "@jimp/utils" "^0.16.2"
     any-base "^1.1.0"
     buffer "^5.2.0"
     exif-parser "^0.1.12"
@@ -259,266 +259,266 @@
     pixelmatch "^4.0.2"
     tinycolor2 "^1.4.1"
 
-"@jimp/custom@^0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@jimp/custom/-/custom-0.16.1.tgz#28b659c59e20a1d75a0c46067bd3f4bd302cf9c5"
-  integrity sha512-DNUAHNSiUI/j9hmbatD6WN/EBIyeq4AO0frl5ETtt51VN1SvE4t4v83ZA/V6ikxEf3hxLju4tQ5Pc3zmZkN/3A==
+"@jimp/custom@^0.16.2":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@jimp/custom/-/custom-0.16.2.tgz#e1ba6874551dd4d748825680c3a16bb7cd3595b6"
+  integrity sha512-GtNwOs4hcVS2GIbqRUf42rUuX07oLB92cj7cqxZb0ZGWwcwhnmSW0TFLAkNafXmqn9ug4VTpNvcJSUdiuECVKg==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/core" "^0.16.1"
+    "@jimp/core" "^0.16.2"
 
-"@jimp/gif@^0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@jimp/gif/-/gif-0.16.1.tgz#d1f7c3a58f4666482750933af8b8f4666414f3ca"
-  integrity sha512-r/1+GzIW1D5zrP4tNrfW+3y4vqD935WBXSc8X/wm23QTY9aJO9Lw6PEdzpYCEY+SOklIFKaJYUAq/Nvgm/9ryw==
+"@jimp/gif@^0.16.2":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@jimp/gif/-/gif-0.16.2.tgz#c049cf0fc781233aca418f130f8664c4cbab64c1"
+  integrity sha512-TMdyT9Q0paIKNtT7c5KzQD29CNCsI/t8ka28jMrBjEK7j5RRTvBfuoOnHv7pDJRCjCIqeUoaUSJ7QcciKic6CA==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.16.1"
+    "@jimp/utils" "^0.16.2"
     gifwrap "^0.9.2"
     omggif "^1.0.9"
 
-"@jimp/jpeg@^0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@jimp/jpeg/-/jpeg-0.16.1.tgz#3b7bb08a4173f2f6d81f3049b251df3ee2ac8175"
-  integrity sha512-8352zrdlCCLFdZ/J+JjBslDvml+fS3Z8gttdml0We759PnnZGqrnPRhkOEOJbNUlE+dD4ckLeIe6NPxlS/7U+w==
+"@jimp/jpeg@^0.16.2":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@jimp/jpeg/-/jpeg-0.16.2.tgz#1060cff9700d08802a0932a397cfb61a34b1d058"
+  integrity sha512-BW5gZydgq6wdIwHd+3iUNgrTklvoQc/FUKSj9meM6A0FU21lUaansRX5BDdJqHkyXJLnnlDGwDt27J+hQuBAVw==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.16.1"
-    jpeg-js "0.4.2"
+    "@jimp/utils" "^0.16.2"
+    jpeg-js "^0.4.2"
 
-"@jimp/plugin-blit@^0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@jimp/plugin-blit/-/plugin-blit-0.16.1.tgz#09ea919f9d326de3b9c2826fe4155da37dde8edb"
-  integrity sha512-fKFNARm32RoLSokJ8WZXHHH2CGzz6ire2n1Jh6u+XQLhk9TweT1DcLHIXwQMh8oR12KgjbgsMGvrMVlVknmOAg==
+"@jimp/plugin-blit@^0.16.2":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-blit/-/plugin-blit-0.16.2.tgz#65e683f3f2860a59999b6af068efde3625f86cf7"
+  integrity sha512-Z31rRfV80gC/r+B/bOPSVVpJEWXUV248j7MdnMOFLu4vr8DMqXVo9jYqvwU/s4LSTMAMXqm4Jg6E/jQfadPKAg==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.16.1"
+    "@jimp/utils" "^0.16.2"
 
-"@jimp/plugin-blur@^0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@jimp/plugin-blur/-/plugin-blur-0.16.1.tgz#e614fa002797dcd662e705d4cea376e7db968bf5"
-  integrity sha512-1WhuLGGj9MypFKRcPvmW45ht7nXkOKu+lg3n2VBzIB7r4kKNVchuI59bXaCYQumOLEqVK7JdB4glaDAbCQCLyw==
+"@jimp/plugin-blur@^0.16.2":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-blur/-/plugin-blur-0.16.2.tgz#05533c19973a16feb037d175bb77e4532f144e45"
+  integrity sha512-ShkJCAzRI+1fAKPuLLgEkixpSpVmKTYaKEFROUcgmrv9AansDXGNCupchqVMTdxf8zPyW8rR1ilvG3OJobufLQ==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.16.1"
+    "@jimp/utils" "^0.16.2"
 
-"@jimp/plugin-circle@^0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@jimp/plugin-circle/-/plugin-circle-0.16.1.tgz#20e3194a67ca29740aba2630fd4d0a89afa27491"
-  integrity sha512-JK7yi1CIU7/XL8hdahjcbGA3V7c+F+Iw+mhMQhLEi7Q0tCnZ69YJBTamMiNg3fWPVfMuvWJJKOBRVpwNTuaZRg==
+"@jimp/plugin-circle@^0.16.2":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-circle/-/plugin-circle-0.16.2.tgz#f66c7b8562ccced02688612f548b76952b14ab70"
+  integrity sha512-6T4z/48F4Z5+YwAVCLOvXQcyGmo0E3WztxCz6XGQf66r4JJK78+zcCDYZFLMx0BGM0091FogNK4QniP8JaOkrA==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.16.1"
+    "@jimp/utils" "^0.16.2"
 
-"@jimp/plugin-color@^0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@jimp/plugin-color/-/plugin-color-0.16.1.tgz#0f298ba74dee818b663834cd80d53e56f3755233"
-  integrity sha512-9yQttBAO5SEFj7S6nJK54f+1BnuBG4c28q+iyzm1JjtnehjqMg6Ljw4gCSDCvoCQ3jBSYHN66pmwTV74SU1B7A==
+"@jimp/plugin-color@^0.16.2":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-color/-/plugin-color-0.16.2.tgz#925d3b2fa41807c7119197bdf9c5694d92efe3be"
+  integrity sha512-6oBV0g0J17/7E+aTquvUsgSc85nUbUi+64tIK5eFIDzvjhlqhjGNJYlc46KJMCWIs61qRJayQoZdL/iT/iQuGQ==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.16.1"
+    "@jimp/utils" "^0.16.2"
     tinycolor2 "^1.4.1"
 
-"@jimp/plugin-contain@^0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@jimp/plugin-contain/-/plugin-contain-0.16.1.tgz#3c5f5c495fd9bb08a970739d83694934f58123f2"
-  integrity sha512-44F3dUIjBDHN+Ym/vEfg+jtjMjAqd2uw9nssN67/n4FdpuZUVs7E7wadKY1RRNuJO+WgcD5aDQcsvurXMETQTg==
+"@jimp/plugin-contain@^0.16.2":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-contain/-/plugin-contain-0.16.2.tgz#e5cf5ca7cc3eec1306cb1b92dbd2a1fad6146a94"
+  integrity sha512-pLcxO3hVN3LCEhMNvpZ9B7xILHVlS433Vv16zFFJxLRqZdYvPLsc+ZzJhjAiHHuEjVblQrktHE3LGeQwGJPo0w==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.16.1"
+    "@jimp/utils" "^0.16.2"
 
-"@jimp/plugin-cover@^0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@jimp/plugin-cover/-/plugin-cover-0.16.1.tgz#0e8caec16a40abe15b1b32e5383a603a3306dc41"
-  integrity sha512-YztWCIldBAVo0zxcQXR+a/uk3/TtYnpKU2CanOPJ7baIuDlWPsG+YE4xTsswZZc12H9Kl7CiziEbDtvF9kwA/Q==
+"@jimp/plugin-cover@^0.16.2":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-cover/-/plugin-cover-0.16.2.tgz#c4aadfaad718a14838219889936ad39a18021df4"
+  integrity sha512-gzWM7VvYeI8msyiwbUZxH+sGQEgO6Vd6adGxZ0CeKX00uQOe5lDzxb1Wjx7sHcJGz8a/5fmAuwz7rdDtpDUbkw==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.16.1"
+    "@jimp/utils" "^0.16.2"
 
-"@jimp/plugin-crop@^0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@jimp/plugin-crop/-/plugin-crop-0.16.1.tgz#b362497c873043fe47ba881ab08604bf7226f50f"
-  integrity sha512-UQdva9oQzCVadkyo3T5Tv2CUZbf0klm2cD4cWMlASuTOYgaGaFHhT9st+kmfvXjKL8q3STkBu/zUPV6PbuV3ew==
+"@jimp/plugin-crop@^0.16.2":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-crop/-/plugin-crop-0.16.2.tgz#2dd716b93a865b839143016acac53681d85362c3"
+  integrity sha512-qCd3hfMEE+Z2EuuyXewgXRTtKJGIerWzc1zLEJztsUkPz5i73IGgkOL+mrNutZwGaXZbm+8SwUaGb46sxAO6Tw==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.16.1"
+    "@jimp/utils" "^0.16.2"
 
-"@jimp/plugin-displace@^0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@jimp/plugin-displace/-/plugin-displace-0.16.1.tgz#4dd9db518c3e78de9d723f86a234bf98922afe8d"
-  integrity sha512-iVAWuz2+G6Heu8gVZksUz+4hQYpR4R0R/RtBzpWEl8ItBe7O6QjORAkhxzg+WdYLL2A/Yd4ekTpvK0/qW8hTVw==
+"@jimp/plugin-displace@^0.16.2":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-displace/-/plugin-displace-0.16.2.tgz#e4852c48f4b2095a4bcc61c8c1a5faa9618773ef"
+  integrity sha512-6nXdvNNjCdD95v2o3/jPeur903dz08lG4Y8gmr5oL2yVv9LSSbMonoXYrR/ASesdyXqGdXJLU4NL+yZs4zUqbQ==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.16.1"
+    "@jimp/utils" "^0.16.2"
 
-"@jimp/plugin-dither@^0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@jimp/plugin-dither/-/plugin-dither-0.16.1.tgz#b47de2c0bb09608bed228b41c3cd01a85ec2d45b"
-  integrity sha512-tADKVd+HDC9EhJRUDwMvzBXPz4GLoU6s5P7xkVq46tskExYSptgj5713J5Thj3NMgH9Rsqu22jNg1H/7tr3V9Q==
+"@jimp/plugin-dither@^0.16.2":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-dither/-/plugin-dither-0.16.2.tgz#e5cf77f5b0b8a4247c171b7e234c99031b6a59f3"
+  integrity sha512-DERpIzy21ZanMkVsD0Tdy8HQLbD1E41OuvIzaMRoW4183PA6AgGNlrQoFTyXmzjy6FTy1SxaQgTEdouInAWZ9Q==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.16.1"
+    "@jimp/utils" "^0.16.2"
 
-"@jimp/plugin-fisheye@^0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@jimp/plugin-fisheye/-/plugin-fisheye-0.16.1.tgz#f625047b6cdbe1b83b89e9030fd025ab19cdb1a4"
-  integrity sha512-BWHnc5hVobviTyIRHhIy9VxI1ACf4CeSuCfURB6JZm87YuyvgQh5aX5UDKtOz/3haMHXBLP61ZBxlNpMD8CG4A==
+"@jimp/plugin-fisheye@^0.16.2":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-fisheye/-/plugin-fisheye-0.16.2.tgz#ec6cab102959fd67a4061e6812db6135731f7731"
+  integrity sha512-Df7PsGIwiIpQu3EygYCnaJyTfOwvwtYV3cmYJS7yFLtdiFUuod+hlSo5GkwEPLAy+QBxhUbDuUqnsWo4NQtbiQ==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.16.1"
+    "@jimp/utils" "^0.16.2"
 
-"@jimp/plugin-flip@^0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@jimp/plugin-flip/-/plugin-flip-0.16.1.tgz#7a99ea22bde802641017ed0f2615870c144329bb"
-  integrity sha512-KdxTf0zErfZ8DyHkImDTnQBuHby+a5YFdoKI/G3GpBl3qxLBvC+PWkS2F/iN3H7wszP7/TKxTEvWL927pypT0w==
+"@jimp/plugin-flip@^0.16.2":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-flip/-/plugin-flip-0.16.2.tgz#3d6f5eac4a8d7d62251aba55259ecb4f8dfe42cf"
+  integrity sha512-+2uC8ioVQUr06mnjSWraskz2L33nJHze35LkQ8ZNsIpoZLkgvfiWatqAs5bj+1jGI/9kxoCFAaT1Is0f+a4/rw==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.16.1"
+    "@jimp/utils" "^0.16.2"
 
-"@jimp/plugin-gaussian@^0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@jimp/plugin-gaussian/-/plugin-gaussian-0.16.1.tgz#0845e314085ccd52e34fad9a83949bc0d81a68e8"
-  integrity sha512-u9n4wjskh3N1mSqketbL6tVcLU2S5TEaFPR40K6TDv4phPLZALi1Of7reUmYpVm8mBDHt1I6kGhuCJiWvzfGyg==
+"@jimp/plugin-gaussian@^0.16.2":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-gaussian/-/plugin-gaussian-0.16.2.tgz#6546886e8b0acfebf285c5aabc4fea476dc54159"
+  integrity sha512-2mnuDSg4ZEH8zcJig7DZZf4st/cYmQ5UYJKP76iGhZ+6JDACk6uejwAgT5xHecNhkVAaXMdCybA2eknH/9OE1w==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.16.1"
+    "@jimp/utils" "^0.16.2"
 
-"@jimp/plugin-invert@^0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@jimp/plugin-invert/-/plugin-invert-0.16.1.tgz#7e6f5a15707256f3778d06921675bbcf18545c97"
-  integrity sha512-2DKuyVXANH8WDpW9NG+PYFbehzJfweZszFYyxcaewaPLN0GxvxVLOGOPP1NuUTcHkOdMFbE0nHDuB7f+sYF/2w==
+"@jimp/plugin-invert@^0.16.2":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-invert/-/plugin-invert-0.16.2.tgz#6ca4f7b204c5d674d093d9aa4c32bf20a924a0ee"
+  integrity sha512-xFvHbVepTY/nus+6yXiYN1iq+UBRkT0MdnObbiQPstUrAsz0Imn6MWISsnAyMvcNxHGrxaxjuU777JT/esM0gg==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.16.1"
+    "@jimp/utils" "^0.16.2"
 
-"@jimp/plugin-mask@^0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@jimp/plugin-mask/-/plugin-mask-0.16.1.tgz#e7f2460e05c3cda7af5e76f33ccb0579f66f90df"
-  integrity sha512-snfiqHlVuj4bSFS0v96vo2PpqCDMe4JB+O++sMo5jF5mvGcGL6AIeLo8cYqPNpdO6BZpBJ8MY5El0Veckhr39Q==
+"@jimp/plugin-mask@^0.16.2":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-mask/-/plugin-mask-0.16.2.tgz#b352392bc8773f6b21b34901ed17f2bb90a8047e"
+  integrity sha512-AbdO85xxhfgEDdxYKpUotEI9ixiCMaIpfYHD5a5O/VWeimz2kuwhcrzlHGiyq1kKAgRcl0WEneTCZAHVSyvPKA==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.16.1"
+    "@jimp/utils" "^0.16.2"
 
-"@jimp/plugin-normalize@^0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@jimp/plugin-normalize/-/plugin-normalize-0.16.1.tgz#032dfd88eefbc4dedc8b1b2d243832e4f3af30c8"
-  integrity sha512-dOQfIOvGLKDKXPU8xXWzaUeB0nvkosHw6Xg1WhS1Z5Q0PazByhaxOQkSKgUryNN/H+X7UdbDvlyh/yHf3ITRaw==
+"@jimp/plugin-normalize@^0.16.2":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-normalize/-/plugin-normalize-0.16.2.tgz#e36a8ecaea6acb4711c543212863a570fe19901f"
+  integrity sha512-+ItBWFwmB0Od7OfOtTYT1gm543PpHUgU8/DN55z83l1JqS0OomDJAe7BmCppo2405TN6YtVm/csXo7p4iWd/SQ==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.16.1"
+    "@jimp/utils" "^0.16.2"
 
-"@jimp/plugin-print@^0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@jimp/plugin-print/-/plugin-print-0.16.1.tgz#66b803563f9d109825970714466e6ab9ae639ff6"
-  integrity sha512-ceWgYN40jbN4cWRxixym+csyVymvrryuKBQ+zoIvN5iE6OyS+2d7Mn4zlNgumSczb9GGyZZESIgVcBDA1ezq0Q==
+"@jimp/plugin-print@^0.16.2":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-print/-/plugin-print-0.16.2.tgz#8873338941498997cb2a0d2820e9d58d7c03ba61"
+  integrity sha512-ifTGEeJ5UZTCiqC70HMeU3iXk/vsOmhWiwVGOXSFXhFeE8ZpDWvlmBsrMYnRrJGuaaogHOIrrQPI+kCdDBSBIQ==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.16.1"
+    "@jimp/utils" "^0.16.2"
     load-bmfont "^1.4.0"
 
-"@jimp/plugin-resize@^0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@jimp/plugin-resize/-/plugin-resize-0.16.1.tgz#65e39d848ed13ba2d6c6faf81d5d590396571d10"
-  integrity sha512-u4JBLdRI7dargC04p2Ha24kofQBk3vhaf0q8FwSYgnCRwxfvh2RxvhJZk9H7Q91JZp6wgjz/SjvEAYjGCEgAwQ==
+"@jimp/plugin-resize@^0.16.2":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-resize/-/plugin-resize-0.16.2.tgz#7bcca41d9959667fb1e6e87bd6073ce0dbc43bc4"
+  integrity sha512-gE4N9l6xuwzacFZ2EPCGZCJ/xR+aX2V7GdMndIl/6kYIw5/eib1SFuF9AZLvIPSFuE1FnGo8+vT0pr++SSbhYg==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.16.1"
+    "@jimp/utils" "^0.16.2"
 
-"@jimp/plugin-rotate@^0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@jimp/plugin-rotate/-/plugin-rotate-0.16.1.tgz#53fb5d51a4b3d05af9c91c2a8fffe5d7a1a47c8c"
-  integrity sha512-ZUU415gDQ0VjYutmVgAYYxC9Og9ixu2jAGMCU54mSMfuIlmohYfwARQmI7h4QB84M76c9hVLdONWjuo+rip/zg==
+"@jimp/plugin-rotate@^0.16.2":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-rotate/-/plugin-rotate-0.16.2.tgz#deba6956eaf1d127e91389c53d5c6f59ef80d17f"
+  integrity sha512-/CTEYkR1HrgmnE0VqPhhbBARbDAfFX590LWGIpxcYIYsUUGQCadl+8Qo4UX13FH0Nt8UHEtPA+O2x08uPYg9UA==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.16.1"
+    "@jimp/utils" "^0.16.2"
 
-"@jimp/plugin-scale@^0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@jimp/plugin-scale/-/plugin-scale-0.16.1.tgz#89f6ba59feed3429847ed226aebda33a240cc647"
-  integrity sha512-jM2QlgThIDIc4rcyughD5O7sOYezxdafg/2Xtd1csfK3z6fba3asxDwthqPZAgitrLgiKBDp6XfzC07Y/CefUw==
+"@jimp/plugin-scale@^0.16.2":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-scale/-/plugin-scale-0.16.2.tgz#d297e6a83f860b5e29bc5bd30ec1556561cb71ab"
+  integrity sha512-3inuxfrlquyLaqFdiiiQNJUurR0WbvN5wAf1qcYX2LubG1AG8grayYD6H7XVoxfUGTZXh1kpmeirEYlqA2zxcw==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.16.1"
+    "@jimp/utils" "^0.16.2"
 
-"@jimp/plugin-shadow@^0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@jimp/plugin-shadow/-/plugin-shadow-0.16.1.tgz#a7af892a740febf41211e10a5467c3c5c521a04c"
-  integrity sha512-MeD2Is17oKzXLnsphAa1sDstTu6nxscugxAEk3ji0GV1FohCvpHBcec0nAq6/czg4WzqfDts+fcPfC79qWmqrA==
+"@jimp/plugin-shadow@^0.16.2":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-shadow/-/plugin-shadow-0.16.2.tgz#2365b0d4ade0f9641cf48b887431fe478a7ace45"
+  integrity sha512-Q0aIs2/L6fWMcEh9Ms73u34bT1hyUMw/oxaVoIzOLo6/E8YzCs2Bi63H0/qaPS0MQpEppI++kvosPbblABY79w==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.16.1"
+    "@jimp/utils" "^0.16.2"
 
-"@jimp/plugin-threshold@^0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@jimp/plugin-threshold/-/plugin-threshold-0.16.1.tgz#34f3078f9965145b7ae26c53a32ad74b1195bbf5"
-  integrity sha512-iGW8U/wiCSR0+6syrPioVGoSzQFt4Z91SsCRbgNKTAk7D+XQv6OI78jvvYg4o0c2FOlwGhqz147HZV5utoSLxA==
+"@jimp/plugin-threshold@^0.16.2":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-threshold/-/plugin-threshold-0.16.2.tgz#3b851659ab1db195b2b4e6c9901f19996a086568"
+  integrity sha512-gyOwmBgjtMPvcuyOhkP6dOGWbQdaTfhcBRN22mYeI/k/Wh/Zh1OI21F6eKLApsVRmg15MoFnkrCz64RROC34sw==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.16.1"
+    "@jimp/utils" "^0.16.2"
 
-"@jimp/plugins@^0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@jimp/plugins/-/plugins-0.16.1.tgz#9f08544c97226d6460a16ced79f57e85bec3257b"
-  integrity sha512-c+lCqa25b+4q6mJZSetlxhMoYuiltyS+ValLzdwK/47+aYsq+kcJNl+TuxIEKf59yr9+5rkbpsPkZHLF/V7FFA==
+"@jimp/plugins@^0.16.2":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@jimp/plugins/-/plugins-0.16.2.tgz#bba2a7247f926fe7e13e35b24ca9552b0aae4312"
+  integrity sha512-zCvYtCgctmC0tkYEu+y+kSwSIZBsNznqJ3/3vkpzxdyjd6wCfNY5Qc/68MPrLc1lmdeGo4cOOTYHG7Vc6myzRw==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/plugin-blit" "^0.16.1"
-    "@jimp/plugin-blur" "^0.16.1"
-    "@jimp/plugin-circle" "^0.16.1"
-    "@jimp/plugin-color" "^0.16.1"
-    "@jimp/plugin-contain" "^0.16.1"
-    "@jimp/plugin-cover" "^0.16.1"
-    "@jimp/plugin-crop" "^0.16.1"
-    "@jimp/plugin-displace" "^0.16.1"
-    "@jimp/plugin-dither" "^0.16.1"
-    "@jimp/plugin-fisheye" "^0.16.1"
-    "@jimp/plugin-flip" "^0.16.1"
-    "@jimp/plugin-gaussian" "^0.16.1"
-    "@jimp/plugin-invert" "^0.16.1"
-    "@jimp/plugin-mask" "^0.16.1"
-    "@jimp/plugin-normalize" "^0.16.1"
-    "@jimp/plugin-print" "^0.16.1"
-    "@jimp/plugin-resize" "^0.16.1"
-    "@jimp/plugin-rotate" "^0.16.1"
-    "@jimp/plugin-scale" "^0.16.1"
-    "@jimp/plugin-shadow" "^0.16.1"
-    "@jimp/plugin-threshold" "^0.16.1"
+    "@jimp/plugin-blit" "^0.16.2"
+    "@jimp/plugin-blur" "^0.16.2"
+    "@jimp/plugin-circle" "^0.16.2"
+    "@jimp/plugin-color" "^0.16.2"
+    "@jimp/plugin-contain" "^0.16.2"
+    "@jimp/plugin-cover" "^0.16.2"
+    "@jimp/plugin-crop" "^0.16.2"
+    "@jimp/plugin-displace" "^0.16.2"
+    "@jimp/plugin-dither" "^0.16.2"
+    "@jimp/plugin-fisheye" "^0.16.2"
+    "@jimp/plugin-flip" "^0.16.2"
+    "@jimp/plugin-gaussian" "^0.16.2"
+    "@jimp/plugin-invert" "^0.16.2"
+    "@jimp/plugin-mask" "^0.16.2"
+    "@jimp/plugin-normalize" "^0.16.2"
+    "@jimp/plugin-print" "^0.16.2"
+    "@jimp/plugin-resize" "^0.16.2"
+    "@jimp/plugin-rotate" "^0.16.2"
+    "@jimp/plugin-scale" "^0.16.2"
+    "@jimp/plugin-shadow" "^0.16.2"
+    "@jimp/plugin-threshold" "^0.16.2"
     timm "^1.6.1"
 
-"@jimp/png@^0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@jimp/png/-/png-0.16.1.tgz#f24cfc31529900b13a2dd9d4fdb4460c1e4d814e"
-  integrity sha512-iyWoCxEBTW0OUWWn6SveD4LePW89kO7ZOy5sCfYeDM/oTPLpR8iMIGvZpZUz1b8kvzFr27vPst4E5rJhGjwsdw==
+"@jimp/png@^0.16.2":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@jimp/png/-/png-0.16.2.tgz#45af82656aad2fde0489687a538f2af903867a1b"
+  integrity sha512-sFOtOSz/tzDwXEChFQ/Nxe+0+vG3Tj0eUxnZVDUG/StXE9dI8Bqmwj3MIa0EgK5s+QG3YlnDOmlPUa4JqmeYeQ==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.16.1"
+    "@jimp/utils" "^0.16.2"
     pngjs "^3.3.3"
 
-"@jimp/tiff@^0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@jimp/tiff/-/tiff-0.16.1.tgz#0e8756695687d7574b6bc73efab0acd4260b7a12"
-  integrity sha512-3K3+xpJS79RmSkAvFMgqY5dhSB+/sxhwTFA9f4AVHUK0oKW+u6r52Z1L0tMXHnpbAdR9EJ+xaAl2D4x19XShkQ==
+"@jimp/tiff@^0.16.2":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@jimp/tiff/-/tiff-0.16.2.tgz#613870065fe1387f6a09fe9d8230c00c35b7b640"
+  integrity sha512-ADcdqmtZF+U2YoaaHTzFX8D6NFpmN4WZUT0BPMerEuY7Cq8QoLYU22z2h034FrVW+Rbi1b3y04sB9iDiQAlf2w==
   dependencies:
     "@babel/runtime" "^7.7.2"
     utif "^2.0.1"
 
-"@jimp/types@^0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@jimp/types/-/types-0.16.1.tgz#0dbab37b3202315c91010f16c31766d35a2322cc"
-  integrity sha512-g1w/+NfWqiVW4CaXSJyD28JQqZtm2eyKMWPhBBDCJN9nLCN12/Az0WFF3JUAktzdsEC2KRN2AqB1a2oMZBNgSQ==
+"@jimp/types@^0.16.2":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@jimp/types/-/types-0.16.2.tgz#e245281495d0c92cd73174f7ac359211882288c7"
+  integrity sha512-0Ue5Sq0XnDF6TirisWv5E+8uOnRcd8vRLuwocJOhF76NIlcQrz+5r2k2XWKcr3d+11n28dHLXW5TKSqrUopxhA==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/bmp" "^0.16.1"
-    "@jimp/gif" "^0.16.1"
-    "@jimp/jpeg" "^0.16.1"
-    "@jimp/png" "^0.16.1"
-    "@jimp/tiff" "^0.16.1"
+    "@jimp/bmp" "^0.16.2"
+    "@jimp/gif" "^0.16.2"
+    "@jimp/jpeg" "^0.16.2"
+    "@jimp/png" "^0.16.2"
+    "@jimp/tiff" "^0.16.2"
     timm "^1.6.1"
 
-"@jimp/utils@^0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@jimp/utils/-/utils-0.16.1.tgz#2f51e6f14ff8307c4aa83d5e1a277da14a9fe3f7"
-  integrity sha512-8fULQjB0x4LzUSiSYG6ZtQl355sZjxbv8r9PPAuYHzS9sGiSHJQavNqK/nKnpDsVkU88/vRGcE7t3nMU0dEnVw==
+"@jimp/utils@^0.16.2":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@jimp/utils/-/utils-0.16.2.tgz#e78cb82c46f608b72179a31581065bf75b35166c"
+  integrity sha512-XENrPvmigiXZQ8E2nxJqO6UVvWBLzbNwyYi3Y8Q1IECoYhYI3kgOQ0fmy4G269Vz1V0omh1bNmC42r4OfXg1Jg==
   dependencies:
     "@babel/runtime" "^7.7.2"
     regenerator-runtime "^0.13.3"
@@ -1485,10 +1485,15 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/spectrum-css-vr-test-assets-essential/-/spectrum-css-vr-test-assets-essential-1.0.46.tgz#8a8c9007003f5c7c1501b3a0ecb721f751f9f68b"
   integrity sha512-09KcehdKIxpVTxmC3bkaCGiLwbxakFNZIirGQlwryu0qnuu1uzst+ELnZdh0s/O2akfmo43PRbaKiIL0x23NQg==
 
+"@spectrum-css/swatch@^1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/swatch/-/swatch-1.1.4.tgz#dfbc899a7145092e3f7b60c516176e393112f050"
+  integrity sha512-rgBH2gm2cRI2vC3BDCJ3oDHjNjbMh2bjGqtGERVccUsCpDitmF6YVwLDD1HeumwTystm/QEu0I26DPrIatrhSg==
+
 "@spectrum-css/tokens@^1.0.7":
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/tokens/-/tokens-1.0.7.tgz#7256ed9383ac4555f7bc0cf43a9ebe4f5e41b117"
-  integrity sha512-KGP78ZBPLVyj1+2uHU4IOVcPrQipqGkO9e9j3p3eQVbb4JuBJ9v9sJ5p5Z+z3nmcJV6wdg/zLpf1ZH0tnjl3hg==
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/tokens/-/tokens-1.0.8.tgz#2eb52b1b895668d09cf2dc2d4bf9f6a1f00a8cc5"
+  integrity sha512-IzfHeojEjE6G+YeZ/Rrwz31471V09dxBZ9RLloUpHUcLghwzzlkBqnkDIetgCBpsDyH/20jYvI0UaLM6zH+cKw==
 
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
@@ -1514,11 +1519,6 @@
   dependencies:
     "@types/babel-types" "*"
 
-"@types/component-emitter@^1.2.10":
-  version "1.2.11"
-  resolved "https://registry.yarnpkg.com/@types/component-emitter/-/component-emitter-1.2.11.tgz#50d47d42b347253817a39709fef03ce66a108506"
-  integrity sha512-SRXjM+tfsSlA9VuG8hGO2nft2p8zjXCK1VcC6N4NXbBbYbSia9kzCChYQajIjzIqOOOuh5Ock6MmV2oux4jDZQ==
-
 "@types/cookie@^0.4.1":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.4.1.tgz#bfd02c1f2224567676c1545199f87c3a861d878d"
@@ -1543,9 +1543,9 @@
     "@types/node" "*"
 
 "@types/minimatch@*":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-5.1.0.tgz#c3018161691376002f8a22ebb87f341e0dba3219"
-  integrity sha512-0RJHq5FqDWo17kdHe+SMDJLfxmLaqHbWnqZ6gNKzDvStUlrmx/eKIY17+ifLS1yybo7X86aUshQMlittDOVNnw==
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-5.1.2.tgz#07508b45797cb81ec3f273011b054cd0755eddca"
+  integrity sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
 
 "@types/minimatch@^3.0.3":
   version "3.0.5"
@@ -1558,9 +1558,9 @@
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
 "@types/node@*", "@types/node@>=10.0.0":
-  version "18.7.13"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.13.tgz#23e6c5168333480d454243378b69e861ab5c011a"
-  integrity sha512-46yIhxSe5xEaJZXWdIBP7GU4HDTG8/eo0qd9atdiL+lFpA03y8KS+lkTN834TWJj5767GbWv4n/P6efyTFt1Dw==
+  version "18.7.23"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.23.tgz#75c580983846181ebe5f4abc40fe9dfb2d65665f"
+  integrity sha512-DWNcCHolDq0ZKGizjx2DZjR/PqsYwAcYUJmfMWqtVU2MBMG5Mo+xFZrhGId5r/O5HOuMPyQEcM6KUBp5lBZZBg==
 
 "@types/node@16.9.1":
   version "16.9.1"
@@ -1568,9 +1568,9 @@
   integrity sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==
 
 "@types/node@^14.14.41":
-  version "14.18.26"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.26.tgz#239e19f8b4ea1a9eb710528061c1d733dc561996"
-  integrity sha512-0b+utRBSYj8L7XAp0d+DX7lI4cSmowNaaTkk6/1SKzbKkG+doLuPusB9EOvzLJ8ahJSk03bTLIL6cWaEd4dBKA==
+  version "14.18.31"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.31.tgz#4b873dea3122e71af4f77e65ec5841397ff254d3"
+  integrity sha512-vQAnaReSQkEDa8uwAyQby8bYGKu84R/deEc6mg5T8fX6gzCn8QW6rziSgsti1fNvsrswKUKPnVTi7uoB+u62Mw==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -2708,9 +2708,9 @@ camelcase@^6.2.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
-  version "1.0.30001384"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30001384.tgz#c8fcec45c7862c17a14183b4508f0edb37c40718"
-  integrity sha512-Yz+Kzpb2jjAX05W5vfzdnbdRiimdnxmIaxZQ6A62MQheyF1o8vPNI8PqshSBmN+TIAFFD6tsfBykkVP0Y9v6Kw==
+  version "1.0.30001412"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30001412.tgz#5dda04df2b11842f11bae77b9ce27343b4f70562"
+  integrity sha512-sza6maqop0bKC+KpGmgE3+ka7zw25zaCrGzZyhV59Il4TWnX2T3diFLf/CPPHWT8gSq1UEwaP3NwFOAxbJQFvA==
 
 capital-case@^1.0.4:
   version "1.0.4"
@@ -3178,7 +3178,7 @@ compare-func@^2.0.0:
     array-ify "^1.0.0"
     dot-prop "^5.1.0"
 
-component-emitter@^1.2.1, component-emitter@~1.3.0:
+component-emitter@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
@@ -4153,9 +4153,9 @@ ee-first@1.1.1:
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
 electron-to-chromium@^1.2.7:
-  version "1.4.233"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.233.tgz#aa142e45468bda111b88abc9cc59d573b75d6a60"
-  integrity sha512-ejwIKXTg1wqbmkcRJh9Ur3hFGHFDZDw1POzdsVrB2WZjgRuRMHIQQKNpe64N/qh3ZtH2otEoRoS+s6arAAuAAw==
+  version "1.4.264"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.264.tgz#2f68a062c38b7a04bf57f3e6954b868672fbdcd3"
+  integrity sha512-AZ6ZRkucHOQT8wke50MktxtmcWZr67kE17X/nAXFf62NIdMdgY6xfsaJD5Szoy84lnkuPWH+4tTNE3s2+bPCiw==
 
 email-addresses@^3.0.1:
   version "3.1.0"
@@ -4233,10 +4233,10 @@ entities@^2.0.0:
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
   integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
 
-entities@^4.2.0, entities@^4.3.0:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-4.3.1.tgz#c34062a94c865c322f9d67b4384e4169bcede6a4"
-  integrity sha512-o4q/dYJlmyjP2zfnaWDUC6A3BQFmVTX+tZPezK7k0GLSU9QYCauscf5Y+qcEPzKL+EixVouYDgLQK5H9GrLpkg==
+entities@^4.2.0, entities@^4.3.0, entities@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-4.4.0.tgz#97bdaba170339446495e653cfd2db78962900174"
+  integrity sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==
 
 entities@~2.1.0:
   version "2.1.0"
@@ -4271,30 +4271,31 @@ error-ex@^1.2.0, error-ex@^1.3.1:
     is-arrayish "^0.2.1"
 
 es-abstract@^1.17.2, es-abstract@^1.19.0, es-abstract@^1.19.1, es-abstract@^1.19.2, es-abstract@^1.19.5, es-abstract@^1.20.1:
-  version "1.20.1"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.20.1.tgz#027292cd6ef44bd12b1913b828116f54787d1814"
-  integrity sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==
+  version "1.20.3"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.20.3.tgz#90b143ff7aedc8b3d189bcfac7f1e3e3f81e9da1"
+  integrity sha512-AyrnaKVpMzljIdwjzrj+LxGmj8ik2LckwXacHqrJJ/jxz6dDDBcZ7I7nlHM0FvEW8MfbWJwOd+yT2XzYW49Frw==
   dependencies:
     call-bind "^1.0.2"
     es-to-primitive "^1.2.1"
     function-bind "^1.1.1"
     function.prototype.name "^1.1.5"
-    get-intrinsic "^1.1.1"
+    get-intrinsic "^1.1.3"
     get-symbol-description "^1.0.0"
     has "^1.0.3"
     has-property-descriptors "^1.0.0"
     has-symbols "^1.0.3"
     internal-slot "^1.0.3"
-    is-callable "^1.2.4"
+    is-callable "^1.2.6"
     is-negative-zero "^2.0.2"
     is-regex "^1.1.4"
     is-shared-array-buffer "^1.0.2"
     is-string "^1.0.7"
     is-weakref "^1.0.2"
-    object-inspect "^1.12.0"
+    object-inspect "^1.12.2"
     object-keys "^1.1.1"
-    object.assign "^4.1.2"
+    object.assign "^4.1.4"
     regexp.prototype.flags "^1.4.3"
+    safe-regex-test "^1.0.0"
     string.prototype.trimend "^1.0.5"
     string.prototype.trimstart "^1.0.5"
     unbox-primitive "^1.0.2"
@@ -4515,11 +4516,11 @@ express@^4.16.3:
     vary "~1.1.2"
 
 ext@^1.1.2:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/ext/-/ext-1.6.0.tgz#3871d50641e874cc172e2b53f919842d19db4c52"
-  integrity sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/ext/-/ext-1.7.0.tgz#0ea4383c0103d60e70be99e9a7f11027a33c4f5f"
+  integrity sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==
   dependencies:
-    type "^2.5.0"
+    type "^2.7.2"
 
 extend-shallow@^1.1.2:
   version "1.1.4"
@@ -4625,9 +4626,9 @@ fast-glob@^2.0.2:
     micromatch "^3.1.10"
 
 fast-glob@^3.0.3, fast-glob@^3.2.9:
-  version "3.2.11"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
-  integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
+  version "3.2.12"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.12.tgz#7f39ec99c2e6ab030337142da9e0c18f37afae80"
+  integrity sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
     "@nodelib/fs.walk" "^1.2.3"
@@ -4834,9 +4835,9 @@ flush-write-stream@^1.0.2:
     readable-stream "^2.3.6"
 
 follow-redirects@^1.0.0, follow-redirects@^1.14.0:
-  version "1.15.1"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.1.tgz#0ca6a452306c9b276e4d3127483e29575e207ad5"
-  integrity sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
+  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
@@ -5012,10 +5013,10 @@ get-caller-file@^2.0.5:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.2.tgz#336975123e05ad0b7ba41f152ee4aadbea6cf598"
-  integrity sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==
+get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.3.tgz#063c84329ad93e83893c7f4f243ef63ffa351385"
+  integrity sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==
   dependencies:
     function-bind "^1.1.1"
     has "^1.0.3"
@@ -6045,10 +6046,10 @@ is-buffer@^1.1.5:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
-is-callable@^1.1.4, is-callable@^1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.4.tgz#47301d58dd0259407865547853df6d61fe471945"
-  integrity sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==
+is-callable@^1.1.4, is-callable@^1.2.6:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
+  integrity sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==
 
 is-ci@^2.0.0:
   version "2.0.0"
@@ -6460,31 +6461,26 @@ istextorbinary@^3.0.0:
     textextensions "^3.2.0"
 
 jimp@^0.16.1:
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/jimp/-/jimp-0.16.1.tgz#192f851a30e5ca11112a3d0aa53137659a78ca7a"
-  integrity sha512-+EKVxbR36Td7Hfd23wKGIeEyHbxShZDX6L8uJkgVW3ESA9GiTEPK08tG1XI2r/0w5Ch0HyJF5kPqF9K7EmGjaw==
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/jimp/-/jimp-0.16.2.tgz#c03e296381ae37586e27f209d134d4596d112f7b"
+  integrity sha512-UpItBk81a92f8oEyoGYbO3YK4QcM0hoIyuGHmShoF9Ov63P5Qo7Q/X2xsAgnODmSuDJFOtrPtJd5GSWW4LKdOQ==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/custom" "^0.16.1"
-    "@jimp/plugins" "^0.16.1"
-    "@jimp/types" "^0.16.1"
+    "@jimp/custom" "^0.16.2"
+    "@jimp/plugins" "^0.16.2"
+    "@jimp/types" "^0.16.2"
     regenerator-runtime "^0.13.3"
 
 joi@^17.6.0:
-  version "17.6.0"
-  resolved "https://registry.yarnpkg.com/joi/-/joi-17.6.0.tgz#0bb54f2f006c09a96e75ce687957bd04290054b2"
-  integrity sha512-OX5dG6DTbcr/kbMFj0KGYxuew69HPcAE3K/sZpEV2nP6e/j/C0HV+HNiBPCASxdx5T7DMoa0s8UeHWMnb6n2zw==
+  version "17.6.1"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-17.6.1.tgz#e77422f277091711599634ac39a409e599d7bdaa"
+  integrity sha512-Hl7/iBklIX345OCM1TiFSCZRVaAOLDGlWCp0Df2vWYgBgjkezaR7Kvm3joBciBHQjZj5sxXs859r6eqsRSlG8w==
   dependencies:
     "@hapi/hoek" "^9.0.0"
     "@hapi/topo" "^5.0.0"
     "@sideway/address" "^4.1.3"
     "@sideway/formula" "^3.0.0"
     "@sideway/pinpoint" "^2.0.0"
-
-jpeg-js@0.4.2:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.4.2.tgz#8b345b1ae4abde64c2da2fe67ea216a114ac279d"
-  integrity sha512-+az2gi/hvex7eLTMTlbRLOhH6P6WFdk2ITI8HJsaH2VqYO0I594zXSYEP+tf4FW+8Cy68ScDXoAsQdyQanv3sw==
 
 jpeg-js@^0.4.2:
   version "0.4.4"
@@ -6565,9 +6561,9 @@ json5@^2.2.0:
   integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
 
 jsonc-parser@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.1.0.tgz#73b8f0e5c940b83d03476bc2e51a20ef0932615d"
-  integrity sha512-DRf0QjnNeCUds3xTjKlQQ3DpJD51GvDjJfnxUVWg6PZTo2otSm+slzNAxU/35hF8/oJIKoG9slq30JYOsF2azg==
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.2.0.tgz#31ff3f4c2b9793f89c67212627c51c6394f88e76"
+  integrity sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==
 
 jsonfile@^3.0.0:
   version "3.0.1"
@@ -7853,7 +7849,7 @@ object-hash@^3.0.0:
   resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-3.0.0.tgz#73f97f753e7baffc0e2cc9d6e079079744ac82e9"
   integrity sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==
 
-object-inspect@^1.12.0, object-inspect@^1.9.0:
+object-inspect@^1.12.2, object-inspect@^1.9.0:
   version "1.12.2"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.2.tgz#c0641f26394532f28ab8d796ab954e43c009a8ea"
   integrity sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==
@@ -7870,7 +7866,7 @@ object-visit@^1.0.0:
   dependencies:
     isobject "^3.0.0"
 
-object.assign@^4.0.4, object.assign@^4.1.2:
+object.assign@^4.0.4, object.assign@^4.1.4:
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.4.tgz#9673c7c7c351ab8c4d0b516f4343ebf4dfb7799f"
   integrity sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==
@@ -8338,11 +8334,11 @@ parse5-htmlparser2-tree-adapter@^7.0.0:
     parse5 "^7.0.0"
 
 parse5@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/parse5/-/parse5-7.0.0.tgz#51f74a5257f5fcc536389e8c2d0b3802e1bfa91a"
-  integrity sha512-y/t8IXSPWTuRZqXc0ajH/UwDj4mnqLEbSttNbThcFhGrZuOyoyvNBO85PBp2jQa55wY9d07PBNjsK8ZP3K5U6g==
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-7.1.1.tgz#4649f940ccfb95d8754f37f73078ea20afe0c746"
+  integrity sha512-kwpuwzB+px5WUg9pyK0IcK/shltJN5/OVhQagxhCQNtT9Y9QRZqNY2e1cmbu/paRh5LMnz/oVTVLBpjFmMZhSg==
   dependencies:
-    entities "^4.3.0"
+    entities "^4.4.0"
 
 parseurl@~1.3.2, parseurl@~1.3.3:
   version "1.3.3"
@@ -8536,17 +8532,17 @@ pkg-dir@4.2.0, pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-playwright-core@1.25.1:
-  version "1.25.1"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.25.1.tgz#abe56aec8bef645fba988320d9f9328fafab0446"
-  integrity sha512-lSvPCmA2n7LawD2Hw7gSCLScZ+vYRkhU8xH0AapMyzwN+ojoDqhkH/KIEUxwNu2PjPoE/fcE0wLAksdOhJ2O5g==
+playwright-core@1.26.0:
+  version "1.26.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.26.0.tgz#850228f0638d410a5cdd69800d552f60e4d295cd"
+  integrity sha512-p8huU8eU4gD3VkJd3DA1nA7R3XA6rFvFL+1RYS96cSljCF2yJE9CWEHTPF4LqX8KN9MoWCrAfVKP5381X3CZqg==
 
 playwright@^1.24.1:
-  version "1.25.1"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.25.1.tgz#23fe129ca05568a72ee2a3842baa0a1985d1b345"
-  integrity sha512-kOlW7mllnQ70ALTwAor73q/FhdH9EEXLUqjdzqioYLcSVC4n4NBfDqeCikGuayFZrLECLkU6Hcbziy/szqTXSA==
+  version "1.26.0"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.26.0.tgz#b351990ff03a7e422bf585233eb53651fc363896"
+  integrity sha512-XxTVlvFEYHdatxUkh1KiPq9BclNtFKMi3BgQnl/aactmhN4G9AkZUXwt0ck6NDAOrDFlfibhbM7A1kZwQJKSBw==
   dependencies:
-    playwright-core "1.25.1"
+    playwright-core "1.26.0"
 
 please-upgrade-node@^3.2.0:
   version "3.2.0"
@@ -9811,9 +9807,9 @@ rxjs@^6.4.0, rxjs@^6.6.0:
     tslib "^1.9.0"
 
 rxjs@^7.5.4:
-  version "7.5.6"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.6.tgz#0446577557862afd6903517ce7cae79ecb9662bc"
-  integrity sha512-dnyv2/YsXhnm461G+R/Pe5bWP41Nm6LBXEYWI6eiFP4fiwx6WRI/CD0zbdVAudd9xwLEF2IDcKXLHit0FYjUzw==
+  version "7.5.7"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.7.tgz#2ec0d57fdc89ece220d2e702730ae8f1e49def39"
+  integrity sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==
   dependencies:
     tslib "^2.1.0"
 
@@ -9826,6 +9822,15 @@ safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
+safe-regex-test@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/safe-regex-test/-/safe-regex-test-1.0.0.tgz#793b874d524eb3640d1873aad03596db2d4f2295"
+  integrity sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.1.3"
+    is-regex "^1.1.4"
 
 safe-regex@^1.1.0:
   version "1.1.0"
@@ -10115,23 +10120,14 @@ socket.io-adapter@~2.4.0:
   integrity sha512-W4N+o69rkMEGVuk2D/cvca3uYsvGlMwsySWV447y99gUPghxq42BxqLNMndb+a1mm/5/7NeXVQS7RLa2XyXvYg==
 
 socket.io-client@^4.4.1:
-  version "4.5.1"
-  resolved "https://registry.yarnpkg.com/socket.io-client/-/socket.io-client-4.5.1.tgz#cab8da71976a300d3090414e28c2203a47884d84"
-  integrity sha512-e6nLVgiRYatS+AHXnOnGi4ocOpubvOUCGhyWw8v+/FxW8saHkinG6Dfhi9TU0Kt/8mwJIAASxvw6eujQmjdZVA==
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/socket.io-client/-/socket.io-client-4.5.2.tgz#9481518c560388c980c88b01e3cf62f367f04c96"
+  integrity sha512-naqYfFu7CLDiQ1B7AlLhRXKX3gdeaIMfgigwavDzgJoIUYulc1qHH5+2XflTsXTPY7BlPH5rppJyUjhjrKQKLg==
   dependencies:
     "@socket.io/component-emitter" "~3.1.0"
     debug "~4.3.2"
     engine.io-client "~6.2.1"
     socket.io-parser "~4.2.0"
-
-socket.io-parser@~4.0.4:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-4.0.5.tgz#cb404382c32324cc962f27f3a44058cf6e0552df"
-  integrity sha512-sNjbT9dX63nqUFIOv95tTVm6elyIU4RvB1m8dOeZt+IgWwcWklFDOdmGcfo3zSiRsnR/3pJkjY5lfoGqEe4Eig==
-  dependencies:
-    "@types/component-emitter" "^1.2.10"
-    component-emitter "~1.3.0"
-    debug "~4.3.1"
 
 socket.io-parser@~4.2.0:
   version "4.2.1"
@@ -10142,16 +10138,16 @@ socket.io-parser@~4.2.0:
     debug "~4.3.1"
 
 socket.io@^4.4.1:
-  version "4.5.1"
-  resolved "https://registry.yarnpkg.com/socket.io/-/socket.io-4.5.1.tgz#aa7e73f8a6ce20ee3c54b2446d321bbb6b1a9029"
-  integrity sha512-0y9pnIso5a9i+lJmsCdtmTTgJFFSvNQKDnPQRz28mGNnxbmqYg2QPtJTLFxhymFZhAIn50eHAKzJeiNaKr+yUQ==
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/socket.io/-/socket.io-4.5.2.tgz#1eb25fd380ab3d63470aa8279f8e48d922d443ac"
+  integrity sha512-6fCnk4ARMPZN448+SQcnn1u8OHUC72puJcNtSgg2xS34Cu7br1gQ09YKkO1PFfDn/wyUE9ZgMAwosJed003+NQ==
   dependencies:
     accepts "~1.3.4"
     base64id "~2.0.0"
     debug "~4.3.2"
     engine.io "~6.2.0"
     socket.io-adapter "~2.4.0"
-    socket.io-parser "~4.0.4"
+    socket.io-parser "~4.2.0"
 
 socks-proxy-agent@^5.0.0:
   version "5.0.1"
@@ -10546,9 +10542,9 @@ strong-log-transformer@^2.1.0:
     through "^2.3.4"
 
 style-dictionary-sets@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/style-dictionary-sets/-/style-dictionary-sets-2.0.2.tgz#54462fc53d7b00e21aa67fe488a5a78768abb240"
-  integrity sha512-77STdaD9LGylq+sW3azJ6M0OCxd0y4XyckoahSKDjy961pBEHKR9JH/pgzv5SeoT6MMuDxmixlDBORno93C+Jw==
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/style-dictionary-sets/-/style-dictionary-sets-2.0.5.tgz#11d7cc85f603d0bbe76e46679ef9598c825916be"
+  integrity sha512-BeL+3GbtLRvkn21vjQN+si9RjVHbj+SJ208P9jexqM1ga+qzaZ7ofc6rgmG8zHTRdSjUXc+QbVLmDoMY68Pd7g==
   dependencies:
     deepmerge "^4.2.2"
 
@@ -11012,7 +11008,7 @@ type@^1.0.1:
   resolved "https://registry.yarnpkg.com/type/-/type-1.2.0.tgz#848dd7698dafa3e54a6c479e759c4bc3f18847a0"
   integrity sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==
 
-type@^2.5.0:
+type@^2.7.2:
   version "2.7.2"
   resolved "https://registry.yarnpkg.com/type/-/type-2.7.2.tgz#2376a15a3a28b1efa0f5350dcf72d24df6ef98d0"
   integrity sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==
@@ -11030,9 +11026,9 @@ typedarray@^0.0.6:
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
 typescript@^4.6.2:
-  version "4.8.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.2.tgz#e3b33d5ccfb5914e4eeab6699cf208adee3fd790"
-  integrity sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==
+  version "4.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.3.tgz#d59344522c4bc464a65a730ac695007fdb66dd88"
+  integrity sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==
 
 ua-parser-js@1.0.2:
   version "1.0.2"
@@ -11055,9 +11051,9 @@ uglify-js@^2.6.1:
     uglify-to-browserify "~1.0.0"
 
 uglify-js@^3.1.4:
-  version "3.17.0"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.17.0.tgz#55bd6e9d19ce5eef0d5ad17cd1f587d85b180a85"
-  integrity sha512-aTeNPVmgIMPpm1cxXr2Q/nEbvkmV8yq66F3om7X3P/cvOXQ0TMQ64Wk63iyT1gPlmdmGzjGpyLh1f3y8MZWXGg==
+  version "3.17.2"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.17.2.tgz#f55f668b9a64b213977ae688703b6bbb7ca861c6"
+  integrity sha512-bbxglRjsGQMchfvXZNusUcYgiB9Hx2K4AHYXQy2DITZ9Rd+JzhX7+hoocE5Winr7z2oHvPsekkBwXtigvxevXg==
 
 uglify-to-browserify@~1.0.0:
   version "1.0.2"


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description

- Update windows high contrast mode
- Update YAML examples
  - Rename `--spectrum-picked-color` to `--mod-swatch-fill-background-color`
  - Add `is-image` class to Image, Gradient, and Mixed Value swatches for transparent backgrounds 

Note: There are currently [two open questions](https://adobedesign.slack.com/archives/G019JTYMT6H/p1660685017664239) about border colors and the XS workflow icon size in Slack, however, these may not be blockers for this work.

## How and where has this been tested?
- Tested locally referencing the Swatch XD file.
- Tested WHCM with forced colors in Chrome Emulation
- Medium and Large scales

## Screenshots

## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] I have tested these changes in Windows High Contrast mode.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
