### PR TITLE
chore(tokens): use latest core tokens release

### DIFF
--- a/components/tokens/package.json
+++ b/components/tokens/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
   "devDependencies": {
-    "@adobe/spectrum-tokens": "^12.0.0-beta.45",
+    "@adobe/spectrum-tokens": "^12.0.0-beta.47",
     "gulp": "^4.0.0",
     "gulp-concat": "^2.6.1",
     "style-dictionary": "^3.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,10 +22,10 @@
   resolved "https://registry.yarnpkg.com/@adobe/spectrum-tokens-deprecated/-/spectrum-tokens-deprecated-11.8.0.tgz#7edf6f7b7e3c22581e0732c8de97fa0a68ed66b9"
   integrity sha512-LW2SA/8VhW868tEcgIcugx7xdtgFG3KiUoEz+4s2nHTdmKj0h2A9pnTNplVTNAMq2uPSfp6wKKvQNNnMSIXqCg==
 
-"@adobe/spectrum-tokens@^12.0.0-beta.45":
-  version "12.0.0-beta.45"
-  resolved "https://registry.yarnpkg.com/@adobe/spectrum-tokens/-/spectrum-tokens-12.0.0-beta.45.tgz#77e44dc06cbb39122820bab410afe9ea7a931aa2"
-  integrity sha512-md05PUy235LJU8HwSfi93WFDQySR+LG8JxgIbwccPdVbgXSwOu4p2y0ouLFRjKlT1oQytFBb31IHX7GgVXeEYA==
+"@adobe/spectrum-tokens@^12.0.0-beta.47":
+  version "12.0.0-beta.47"
+  resolved "https://registry.yarnpkg.com/@adobe/spectrum-tokens/-/spectrum-tokens-12.0.0-beta.47.tgz#989ffd8c9fbba3210fad84b98adc1949cea0c9d1"
+  integrity sha512-UXFNL6lKvQHxv2CBNU2jeA6eSrEhMuxTMVPFX/A1nX21FTtmN+8KTmOWXRABcvRYuCoS5nC6cbTzieaqrWk3rw==
 
 "@babel/code-frame@^7.0.0":
   version "7.15.8"
@@ -1447,10 +1447,10 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/radio/-/radio-3.0.24.tgz#7a08476edf42be2007b75f7765c18c26eb3a9880"
   integrity sha512-C/saSKXb3dNCWprsP4iXkFFEmRrxwsdm2Al04myZ6pxOJ4tr1WjHAAtorwUgaUiyR87OnL1mGX2aWrFEN1mvtQ==
 
-"@spectrum-css/spectrum-css-vr-test-assets-essential@^1.0.45":
-  version "1.0.45"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/spectrum-css-vr-test-assets-essential/-/spectrum-css-vr-test-assets-essential-1.0.45.tgz#a850e194fb7cb3044d5a58b611728fcb174aab31"
-  integrity sha512-tJHCHTrR8De/SQfJGQ5qh8OYZd2t1pFj7xr5DPey+tDdYw3NAHDGO+MHMBZQfthsEs18jJIcNsxWr+Jg5dR5vQ==
+"@spectrum-css/spectrum-css-vr-test-assets-essential@^1.0.46":
+  version "1.0.46"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/spectrum-css-vr-test-assets-essential/-/spectrum-css-vr-test-assets-essential-1.0.46.tgz#8a8c9007003f5c7c1501b3a0ecb721f751f9f68b"
+  integrity sha512-09KcehdKIxpVTxmC3bkaCGiLwbxakFNZIirGQlwryu0qnuu1uzst+ELnZdh0s/O2akfmo43PRbaKiIL0x23NQg==
 
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"


### PR DESCRIPTION
This adds:
* additional color alias tokens
* overlay-color and overlay opacity values

<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->


## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
