### PR TITLE
refactor(actionbar)!: migrate to core tokens

### DIFF
--- a/components/actionbar/gulpfile.js
+++ b/components/actionbar/gulpfile.js
@@ -1,1 +1,1 @@
-module.exports = require('@spectrum-css/component-builder');
+module.exports = require('@spectrum-css/component-builder-simple');

--- a/components/actionbar/index.css
+++ b/components/actionbar/index.css
@@ -62,6 +62,7 @@ governing permissions and limitations under the License.
 
   /* Account for fixed width */
   box-sizing: border-box;
+
   /* Take up no space when not open */
   block-size: 0;
 
@@ -78,8 +79,7 @@ governing permissions and limitations under the License.
   pointer-events: none;
 
   &.is-open {
-    /* add bottom padding to height to allow space for popover and bottom padding */
-    block-size: calc(var(--spectrum-actionbar-height) + var(--spectrum-actionbar-spacing-outter-edge)); /* 64px */
+    block-size: var(--spectrum-actionbar-height); /* 56px / 48px */
     opacity: 1;
   }
 
@@ -141,12 +141,9 @@ governing permissions and limitations under the License.
   /* Let clicks do their thing */
   pointer-events: auto;
 
-  /* TODO - confirm new nesting on popover is copacetic */
-  /* popover-content controls inner layout */
-  .spectrum-Popover-content {
-    display: flex;
-    flex-direction: row;
-  }
+  /* inner layout of content items */
+  display: flex;
+  flex-direction: row;
 }
 
 .spectrum-ActionBar--emphasized {

--- a/components/actionbar/index.css
+++ b/components/actionbar/index.css
@@ -13,10 +13,6 @@ governing permissions and limitations under the License.
   --spectrum-actionbar-height: var(--spectrum-action-bar-height);
   --spectrum-actionbar-corner-radius: var(--spectrum-corner-radius-100);
 
-  /* colors */
-  --spectrum-actionbar-popover-background-color: var(--spectrum-gray-50);
-  --spectrum-actionbar-popover-border-color: var(--spectrum-gray-400);
-
   /* item counter field label */
   --spectrum-actionbar-item-counter-font-size : var(--spectrum-font-size-100);
   --spectrum-actionbar-item-counter-line-height : var(--spectrum-line-height-100);
@@ -29,11 +25,15 @@ governing permissions and limitations under the License.
     --spectrum-actionbar-item-counter-line-height-cjk : var(--spectrum-CJK-line-height-100);
   }
 
+  /* colors - applied to popover */
+  --spectrum-actionbar-popover-background-color: var(--spectrum-gray-50);
+  --spectrum-actionbar-popover-border-color: var(--spectrum-gray-400);
+
   /* emphasized variation colors */
   --spectrum-actionbar-emphasized-background-color : var(--spectrum-informative-background-color-default);
   --spectrum-actionbar-emphasized-item-counter-color: var(--spectrum-white);
 
-  /* spacing of action bar outer edge */
+  /* spacing of action bar bottom outer edge */
   --spectrum-actionbar-spacing-outter-edge: var(--spectrum-spacing-300);
 
   /* spacing of close button */
@@ -50,37 +50,55 @@ governing permissions and limitations under the License.
   --spectrum-actionbar-spacing-action-group-end: var(--spectrum-spacing-100);
 
   /* drop shadow */
-  --spectrum-actionbar-drop-shadow-horizontal : var(--spectrum-drop-shadow-x);
-  --spectrum-actionbar-drop-shadow-vertical : var(--spectrum-drop-shadow-y);
-  --spectrum-actionbar-drop-shadow-blur : var(--spectrum-drop-shadow-blur);
-  --spectrum-actionbar-drop-shadow-color : var(--spectrum-drop-shadow-color);
+  --spectrum-actionbar-shadow-horizontal : var(--spectrum-drop-shadow-x);
+  --spectrum-actionbar-shadow-vertical : var(--spectrum-drop-shadow-y);
+  --spectrum-actionbar-shadow-blur : var(--spectrum-drop-shadow-blur);
+  --spectrum-actionbar-shadow-color : var(--spectrum-drop-shadow-color);
 }
 
 /* ActionBar is outer wrapper with nested popover component within */
 .spectrum-ActionBar {
-  padding: 0 var(--spectrum-actionbar-spacing-outter-edge) var(--spectrum-actionbar-spacing-outter-edge) var(--spectrum-actionbar-spacing-outter-edge);
+  margin-block-end: var(--spectrum-actionbar-spacing-outter-edge);
+  inset-block-end: 0;
+  z-index: 1;
 
   /* Account for fixed width */
   box-sizing: border-box;
 
-  /* Take up no space when not open */
-  block-size: 0;
-
-  inset-block-end: 0;
-  z-index: 1;
-
-  opacity: 0;
-
-  /* Clip anything outside of us, whether we're open or not. This makes the animation smooth */
-  /* Hide overflow of closed and open to smooth animation */
-  overflow: hidden;
-
   /* Let clicks in blank space fall through */
   pointer-events: none;
 
+  /* Take up no space and be invisible when not open */
+  block-size: 0;
+  opacity: 0;
+
   &.is-open {
-    block-size: var(--spectrum-actionbar-height); /* 56px / 48px */
+    block-size: var(--spectrum-actionbar-height);
     opacity: 1;
+  }
+
+  .spectrum-ActionBar-popover {
+    box-sizing: border-box;
+    inline-size: 100%;
+    block-size: 100%;
+    margin: auto;
+    padding-block-start: 0;
+    padding-block-end: 0;
+
+    /* Be relative so our width can be restricted */
+    position: relative;
+
+    border-radius: var(--spectrum-actionbar-corner-radius);
+    border-color: var(--spectrum-actionbar-popover-border-color);
+    background-color: var(--spectrum-actionbar-popover-background-color);
+    filter: drop-shadow(var(--mod-actionbar-shadow-horizontal, var(--spectrum-actionbar-shadow-horizontal)) var(--mod-actionbar-shadow-vertical, var(--spectrum-actionbar-shadow-vertical)) var(--mod-actionbar-shadow-blur, var(--spectrum-actionbar-shadow-blur)) var(--mod-actionbar-shadow-color, var(--spectrum-actionbar-shadow-color)));
+
+    /* Let clicks do their thing */
+    pointer-events: auto;
+
+    /* inner layout of content items */
+    display: flex;
+    flex-direction: row;
   }
 
   /* close button */
@@ -88,19 +106,20 @@ governing permissions and limitations under the License.
     margin-inline-start: var(--spectrum-actionbar-spacing-close-button-start);
     margin-inline-end: var(--spectrum-actionbar-spacing-close-button-end);
     margin-block-start: var(--spectrum-actionbar-spacing-close-button-top);
+    flex-shrink: 0;
   }
 
   /* item counter */
   .spectrum-FieldLabel {
-    font-size: var(--spectrum-actionbar-item-counter-font-size);
-    color: var(--spectrum-actionbar-item-counter-color);
-    line-height: var(--spectrum-actionbar-item-counter-line-height);
+    margin-inline-end: var(--spectrum-actionbar-spacing-item-counter-end);
+    margin-block-start: var(--spectrum-actionbar-spacing-item-counter-top);
 
     /* neutralize padding for correct spacing within ActionBar */
     padding: 0;
 
-    margin-inline-end: var(--spectrum-actionbar-spacing-item-counter-end);
-    margin-block-start: var(--spectrum-actionbar-spacing-item-counter-top);
+    font-size: var(--spectrum-actionbar-item-counter-font-size);
+    color: var(--spectrum-actionbar-item-counter-color);
+    line-height: var(--spectrum-actionbar-item-counter-line-height);
 
     /* CJK language support */
     &:lang(ja),
@@ -110,9 +129,9 @@ governing permissions and limitations under the License.
     }
   }
 
-  /* TODO - ensure beta is loading properly */
-  /* action group - neutralize old non-logical top margin */
+  /* action group */
   .spectrum-ActionGroup,
+  /* TODO - the following ActionGroup class may be removed after all components are migrated */
   .spectrum-ActionGroup:not(.spectrum-ActionGroup--vertical).spectrum-ActionGroup:not(.spectrum-ActionGroup--compact) {
     margin-inline-end: var(--spectrum-actionbar-spacing-action-group-end);
     margin-block-start: var(--spectrum-actionbar-spacing-action-group-top);
@@ -120,35 +139,18 @@ governing permissions and limitations under the License.
     /* align to end by default */
     margin-inline-start: auto;
   }
-}
 
-.spectrum-ActionBar-popover {
-  height: 100%;
-
-  border-radius: var(--spectrum-actionbar-corner-radius);
-  background-color: var(--spectrum-actionbar-popover-background-color);
-  border-color: var(--spectrum-actionbar-popover-border-color);
-
-  filter: var(--spectrum-actionbar-drop-shadow-horizontal) var(--spectrum-actionbar-drop-shadow-vertical) var(--spectrum-actionbar-drop-shadow-blur) var(--spectrum-actionbar-drop-shadow-color);
-
-  /* Be relative so our width can be restricted */
-  position: relative;
-
-  box-sizing: border-box;
-  inline-size: 100%;
-  margin: auto;
-
-  /* Let clicks do their thing */
-  pointer-events: auto;
-
-  /* inner layout of content items */
-  display: flex;
-  flex-direction: row;
+  /* TODO - may be removed after all components are migrated */
+  /* action group items - neutralize top margin */
+  .spectrum-ActionGroup-item,
+  .spectrum-ActionGroup:not(.spectrum-ActionGroup--vertical).spectrum-ActionGroup:not(.spectrum-ActionGroup--compact) .spectrum-ActionGroup-item {
+    margin-block-start: 0;
+    margin-top: 0;
+  }
 }
 
 .spectrum-ActionBar--emphasized {
   .spectrum-ActionBar-popover {
-    box-shadow: none;
     filter: none;
     background-color: var(--spectrum-actionbar-emphasized-background-color);
     border: none;
@@ -156,8 +158,11 @@ governing permissions and limitations under the License.
 
   /* ensure text is legible on emphasized background */
   .spectrum-ActionButton,
-  .spectrum-FieldLabel {
+  .spectrum-FieldLabel,
+  .spectrum-CloseButton-UIIcon {
     color: var(--spectrum-actionbar-emphasized-item-counter-color);
+    /* apply fill so SVG icon is the correct color */
+    fill: var(--spectrum-actionbar-emphasized-item-counter-color);
   }
 }
 

--- a/components/actionbar/index.css
+++ b/components/actionbar/index.css
@@ -144,22 +144,34 @@ governing permissions and limitations under the License.
   }
 
   /* action group */
-  .spectrum-ActionGroup,
-  /* TODO - the following ActionGroup class may be removed after all components are migrated */
-  .spectrum-ActionGroup:not(.spectrum-ActionGroup--vertical).spectrum-ActionGroup:not(.spectrum-ActionGroup--compact) {
+  .spectrum-ActionGroup {
     margin-inline-end: var(--mod-actionbar-spacing-action-group-end, var(--spectrum-actionbar-spacing-action-group-end));
     margin-block-start: var(--mod-actionbar-spacing-action-group-top, var(--spectrum-actionbar-spacing-action-group-top));
-
     /* align to end by default */
     margin-inline-start: auto;
   }
 
-  /* TODO - may be removed after all components are migrated */
-  /* action group items - neutralize top margin */
-  .spectrum-ActionGroup-item,
-  .spectrum-ActionGroup:not(.spectrum-ActionGroup--vertical).spectrum-ActionGroup:not(.spectrum-ActionGroup--compact) .spectrum-ActionGroup-item {
+  .spectrum-ActionGroup-item {
     margin-block-start: 0;
     margin-top: 0;
+  }
+
+  /* TODO - the following ActionGroup + item vertical and compact style overrides may be removed after all components are migrated */
+  .spectrum-ActionGroup {
+    &:not(.spectrum-ActionGroup--vertical) {
+    &:not(.spectrum-ActionGroup--compact) {
+        margin-inline-end: var(--mod-actionbar-spacing-action-group-end, var(--spectrum-actionbar-spacing-action-group-end));
+        margin-block-start: var(--mod-actionbar-spacing-action-group-top, var(--spectrum-actionbar-spacing-action-group-top));
+        /* align to end by default */
+        margin-inline-start: auto;
+
+        /* action group items - neutralize top margin */
+        .spectrum-ActionGroup-item {
+          margin-block-start: 0;
+          margin-top: 0;
+        }
+      }
+    }
   }
 }
 

--- a/components/actionbar/index.css
+++ b/components/actionbar/index.css
@@ -56,6 +56,19 @@ governing permissions and limitations under the License.
   --spectrum-actionbar-shadow-color : var(--mod-drop-shadow-color, var(--spectrum-drop-shadow-color));
 }
 
+/* windows high contrast mode */
+@media (forced-colors: active) {
+  .spectrum-ActionBar {
+    --highcontrast-actionbar-popover-border-color: CanvasText;
+  }
+
+  .spectrum-ActionBar--emphasized {
+    .spectrum-ActionBar-popover {
+      --highcontrast-actionbar-popover-border-color: CanvasText;
+    }
+  }
+}
+
 /* ActionBar is outer wrapper with nested popover component within */
 .spectrum-ActionBar {
   margin-block-end: var(--mod-actionbar-spacing-outter-edge, var(--spectrum-actionbar-spacing-outter-edge));
@@ -89,7 +102,7 @@ governing permissions and limitations under the License.
     position: relative;
 
     border-radius: var(--mod-actionbar-corner-radius, var(--spectrum-actionbar-corner-radius));
-    border-color: var(--mod-actionbar-popover-border-color, var(--spectrum-actionbar-popover-border-color));
+    border-color: var(--highcontrast-actionbar-popover-border-color, var(--mod-actionbar-popover-border-color, var(--spectrum-actionbar-popover-border-color)));
     background-color: var(--mod-actionbar-popover-background-color, var(--spectrum-actionbar-popover-background-color));
 
     filter: drop-shadow(var(--mod-actionbar-shadow-horizontal, var(--spectrum-actionbar-shadow-horizontal)) var(--mod-actionbar-shadow-vertical, var(--spectrum-actionbar-shadow-vertical)) var(--mod-actionbar-shadow-blur, var(--spectrum-actionbar-shadow-blur)) var(--mod-actionbar-shadow-color, var(--spectrum-actionbar-shadow-color)));
@@ -154,7 +167,8 @@ governing permissions and limitations under the License.
   .spectrum-ActionBar-popover {
     filter: none;
     background-color: var(--mod-actionbar-emphasized-background-color, var(--spectrum-actionbar-emphasized-background-color));
-    border: none;
+    /* border transparent instead of none so WHCM will have visible border */
+    border-color: transparent;
   }
 
   /* ensure text is legible on emphasized background */

--- a/components/actionbar/index.css
+++ b/components/actionbar/index.css
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Adobe. All rights reserved.
+Copyright 2022 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -10,28 +10,52 @@ governing permissions and limitations under the License.
 */
 
 .spectrum-ActionBar {
-  --spectrum-actionbar-height: var(--spectrum-global-dimension-size-600);
-  --spectrum-actionbar-padding-left: var(--spectrum-global-dimension-size-200);
-  --spectrum-actionbar-padding-right: calc(var(--spectrum-global-dimension-size-200) / 2);
-  --spectrum-actionbar-margin-x: var(--spectrum-global-dimension-size-200);
-  --spectrum-actionbar-offset-y: var(--spectrum-global-dimension-size-200);
+  --spectrum-actionbar-height: var(--spectrum-action-bar-height);
+  --spectrum-actionbar-corner-radius: var(--spectrum-corner-radius-100);
+  --spectrum-actionbar-popover-background-color: var(--spectrum-gray-50);
+  --spectrum-actionbar-popover-border-color: var(--spectrum-gray-400);
 
-  --spectrum-actionbar-min-width: 280px;
-  --spectrum-actionbar-max-width: 960px;
+  /* item counter */
+  --spectrum-actionbar-item-counter-font-size : var(--spectrum-font-size-100);
+  --spectrum-actionbar-item-counter-line-height : var(--spectrum-line-height-100);
+  --spectrum-actionbar-item-counter-color: var(--spectrum-neutral-content-color-default);
+
+  /* CJK language support */
+  &:lang(ja),
+  &:lang(zh),
+  &:lang(ko) {
+    --spectrum-actionbar-item-counter-line-height-cjk : var(--spectrum-CJK-line-height-100);
+  }
+
+  /* emphasized */
+  --spectrum-actionbar-emphasized-background-color : var(--spectrum-informative-background-color-default);
+  --spectrum-actionbar-emphasized-item-counter-color: var(--spectrum-white);
+
+  /* spacing */
+  --spectrum-actionbar-spacing-close-button-start-edge : var(--spectrum-spacing-100);
+  --spectrum-actionbar-spacing-close-button-to-item-counter : var(--spectrum-spacing-75);
+  --spectrum-actionbar-spacing-item-counter-to-action-group: var(--spectrum-spacing-400);
+  --spectrum-actionbar-spacing-action-group-to-end-edge : var(--spectrum-spacing-100);
+  --spectrum-actionbar-spacing-close-button-top-edge: var(--spectrum-spacing-100);
+  --spectrum-actionbar-spacing-item-counter-top-edge : var(--spectrum-action-bar-top-to-item-counter);
+  --spectrum-actionbar-spacing-actiongroup-top-edge: var(--spectrum-spacing-100);
+  --spectrum-actionbar-spacing-outter-edge: var(--spectrum-spacing-300);
+
+  /* drop shadow */
+  --spectrum-actionbar-drop-shadow-horizontal : var(--spectrum-drop-shadow-x);
+  --spectrum-actionbar-drop-shadow-vertical : var(--spectrum-drop-shadow-y);
+  --spectrum-actionbar-drop-shadow-blur : var(--spectrum-drop-shadow-blur);
+  --spectrum-actionbar-drop-shadow-color : var(--spectrum-drop-shadow-color);
 }
 
 .spectrum-ActionBar {
-  display: flex;
-  justify-content: center;
+  padding: 0 var(--spectrum-actionbar-spacing-outter-edge) var(--spectrum-actionbar-spacing-outter-edge) var(--spectrum-actionbar-spacing-outter-edge);
 
   inset-block-end: 0;
   z-index: 1;
 
   /* Account for fixed width */
   box-sizing: border-box;
-
-  /* Restrict the width of the child popover */
-  padding: 0 var(--spectrum-actionbar-margin-x);
 
   /* Take up no space when not open */
   block-size: 0;
@@ -43,17 +67,82 @@ governing permissions and limitations under the License.
   /* Let clicks in blank space fall through */
   pointer-events: none;
 
-  transition: height var(--spectrum-global-animation-duration-100) ease-in-out,
-              opacity var(--spectrum-global-animation-duration-100) ease-in-out;
-
-  /*
-    Toggle .is-open to show/hide the ActionBar.
-    Make sure the Popover has .is-open before you do this, and only remove .is-open from the popover once the animation is complete (if at all)
-  */
   &.is-open {
-    /* Take up space in the table only when open */
-    block-size: calc(var(--spectrum-actionbar-height) + var(--spectrum-actionbar-margin-x) * 2);
+    /* add bottom padding to height */
+    block-size: calc(var(--spectrum-actionbar-height) + var(--spectrum-actionbar-spacing-outter-edge));
     opacity: 1;
+  }
+
+  /* close button */
+  .spectrum-CloseButton {
+    margin-inline-start: var(--spectrum-actionbar-spacing-close-button-start-edge);
+    margin-inline-end: var(--spectrum-actionbar-spacing-close-button-to-item-counter);
+    margin-block-start: var(--spectrum-actionbar-spacing-close-button-top-edge);
+  }
+
+  /* item counter */
+  .spectrum-FieldLabel {
+    font-size: var(--spectrum-actionbar-item-counter-font-size);
+    color: var(--spectrum-actionbar-item-counter-color);
+    line-height: var(--spectrum-actionbar-item-counter-line-height);
+
+    margin-inline-end: var(--spectrum-actionbar-spacing-item-counter-to-action-group);
+    margin-block-start: var(--spectrum-actionbar-spacing-item-counter-top-edge);
+
+    /* CJK language support */
+    &:lang(ja),
+    &:lang(zh),
+    &:lang(ko) {
+      line-height: var(--spectrum-actionbar-item-counter-line-height-cjk);
+    }
+  }
+
+    /* action group */
+  .spectrum-ActionGroup {
+    margin-top: var(--spectrum-actionbar-spacing-actiongroup-top-edge);
+    margin-inline-end: var(--spectrum-actionbar-spacing-action-group-to-end-edge);
+    margin-block-start: var(--spectrum-actionbar-spacing-actiongroup-top-edge);
+  }
+}
+
+.spectrum-ActionBar-popover {
+  display: flex;
+  //place-items: center start;
+  justify-content: flex-start;
+
+  flex-direction: row;
+  align-items: center;
+  //justify-content: space-between;
+
+  height: 100%;
+
+  border-radius: var(--spectrum-actionbar-corner-radius);
+  background-color: var(--spectrum-actionbar-popover-background-color);
+  border-color: var(--spectrum-actionbar-popover-border-color);
+
+  filter: var(--spectrum-actionbar-drop-shadow-horizontal) var(--spectrum-actionbar-drop-shadow-vertical) var(--spectrum-actionbar-drop-shadow-blur) var(--spectrum-actionbar-drop-shadow-color);
+
+  /* Be relative so our width can be restricted */
+  position: relative;
+
+  box-sizing: border-box;
+  inline-size: 100%;
+  margin: auto;
+
+  /* Let clicks do their thing */
+  pointer-events: auto;
+}
+
+.spectrum-ActionBar--emphasized {
+  .spectrum-ActionBar-popover {
+    box-shadow: none;
+    filter: none;
+    background-color: var(--spectrum-actionbar-emphasized-background-color);
+    border: none;
+  }
+
+  .spectrum-FieldLabel {
+    color: var(--spectrum-actionbar-emphasized-item-counter-color);
   }
 }
 
@@ -63,33 +152,13 @@ governing permissions and limitations under the License.
   position: sticky;
 }
 
-.spectrum-ActionBar--flexible {
-  .spectrum-ActionBar-popover {
-    inline-size: auto;
-  }
-}
-
 .spectrum-ActionBar--fixed {
    position: fixed;
 }
 
-.spectrum-ActionBar-popover {
-  /* Be relative so our width can be restricted */
-  position: relative;
-
-  box-sizing: border-box;
-  inline-size: 100%;
-  margin: auto;
-  block-size: var(--spectrum-actionbar-height);
-  min-inline-size: var(--spectrum-actionbar-min-width);
-  max-inline-size: var(--spectrum-actionbar-max-width);
-  padding-inline-start: var(--spectrum-actionbar-padding-left);
-  padding-inline-end: var(--spectrum-actionbar-padding-right);
-
-  flex-direction: row;
-  align-items: center;
-  justify-content: space-between;
-
-  /* Let clicks do their thing */
-  pointer-events: auto;
+/* flexible width */
+.spectrum-ActionBar--flexible {
+  .spectrum-ActionBar-popover {
+    inline-size: auto;
+  }
 }

--- a/components/actionbar/index.css
+++ b/components/actionbar/index.css
@@ -10,50 +10,50 @@ governing permissions and limitations under the License.
 */
 
 .spectrum-ActionBar {
-  --spectrum-actionbar-height: var(--mod-action-bar-height, var(--spectrum-action-bar-height));
-  --spectrum-actionbar-corner-radius: var(--mod-corner-radius-100, var(--spectrum-corner-radius-100));
+  --spectrum-actionbar-height: var(--spectrum-action-bar-height);
+  --spectrum-actionbar-corner-radius: var(--spectrum-corner-radius-100);
 
   /* item counter field label */
-  --spectrum-actionbar-item-counter-font-size : var(--mod-font-size-100, var(--spectrum-font-size-100));
-  --spectrum-actionbar-item-counter-line-height : var(--mod-line-height-100, var(--spectrum-line-height-100));
-  --spectrum-actionbar-item-counter-color: var(--mod-neutral-content-color-default, var(--spectrum-neutral-content-color-default));
+  --spectrum-actionbar-item-counter-font-size : var(--spectrum-font-size-100);
+  --spectrum-actionbar-item-counter-line-height : var(--spectrum-line-height-100);
+  --spectrum-actionbar-item-counter-color: var(--spectrum-neutral-content-color-default);
 
   /* cjk language support for item counter */
   &:lang(ja),
   &:lang(zh),
   &:lang(ko) {
-    --spectrum-actionbar-item-counter-line-height-cjk : var(--mod-cjk-line-height-100, var(--spectrum-cjk-line-height-100));
+    --spectrum-actionbar-item-counter-line-height-cjk : var(--spectrum-cjk-line-height-100);
   }
 
   /* colors - applied to popover */
-  --spectrum-actionbar-popover-background-color: var(--mod-gray-50, var(--spectrum-gray-50));
-  --spectrum-actionbar-popover-border-color: var(--mod-gray-400, var(--spectrum-gray-400));
+  --spectrum-actionbar-popover-background-color: var(--spectrum-gray-50);
+  --spectrum-actionbar-popover-border-color: var(--spectrum-gray-400);
 
   /* emphasized variation colors */
-  --spectrum-actionbar-emphasized-background-color : var(--mod-informative-background-color-default, var(--spectrum-informative-background-color-default));
-  --spectrum-actionbar-emphasized-item-counter-color: var(--mod-white, var(--spectrum-white));
+  --spectrum-actionbar-emphasized-background-color : var(--spectrum-informative-background-color-default);
+  --spectrum-actionbar-emphasized-item-counter-color: var(--spectrum-white);
 
   /* spacing of action bar bottom and horizontal outer edge */
-  --spectrum-actionbar-spacing-outer-edge: var(--mod-spacing-300, var(--spectrum-spacing-300));
+  --spectrum-actionbar-spacing-outer-edge: var(--spectrum-spacing-300);
 
   /* spacing of close button */
-  --spectrum-actionbar-spacing-close-button-top: var(--mod-spacing-100, var(--spectrum-spacing-100));
-  --spectrum-actionbar-spacing-close-button-start : var(--mod-spacing-100, var(--spectrum-spacing-100));
-  --spectrum-actionbar-spacing-close-button-end: var(--mod-spacing-75, var(--spectrum-spacing-75));
+  --spectrum-actionbar-spacing-close-button-top: var(--spectrum-spacing-100);
+  --spectrum-actionbar-spacing-close-button-start : var(--spectrum-spacing-100);
+  --spectrum-actionbar-spacing-close-button-end: var(--spectrum-spacing-75);
 
   /* spacing of item counter field label */
-  --spectrum-actionbar-spacing-item-counter-top : var(--mod-action-bar-top-to-item-counter, var(--spectrum-action-bar-top-to-item-counter));
-  --spectrum-actionbar-spacing-item-counter-end: var(--mod-spacing-400, var(--spectrum-spacing-400));
+  --spectrum-actionbar-spacing-item-counter-top : var(--spectrum-action-bar-top-to-item-counter);
+  --spectrum-actionbar-spacing-item-counter-end: var(--spectrum-spacing-400);
 
   /* spacing of action group */
-  --spectrum-actionbar-spacing-action-group-top: var(--mod-spacing-100, var(--spectrum-spacing-100));
-  --spectrum-actionbar-spacing-action-group-end: var(--mod-spacing-100, var(--spectrum-spacing-100));
+  --spectrum-actionbar-spacing-action-group-top: var(--spectrum-spacing-100);
+  --spectrum-actionbar-spacing-action-group-end: var(--spectrum-spacing-100);
 
   /* drop shadow */
-  --spectrum-actionbar-shadow-horizontal : var(--mod-drop-shadow-x, var(--spectrum-drop-shadow-x));
-  --spectrum-actionbar-shadow-vertical : var(--mod-drop-shadow-y, var(--spectrum-drop-shadow-y));
-  --spectrum-actionbar-shadow-blur : var(--mod-drop-shadow-blur, var(--spectrum-drop-shadow-blur));
-  --spectrum-actionbar-shadow-color : var(--mod-drop-shadow-color, var(--spectrum-drop-shadow-color));
+  --spectrum-actionbar-shadow-horizontal : var(--spectrum-drop-shadow-x);
+  --spectrum-actionbar-shadow-vertical : var(--spectrum-drop-shadow-y);
+  --spectrum-actionbar-shadow-blur : var(--spectrum-drop-shadow-blur);
+  --spectrum-actionbar-shadow-color : var(--spectrum-drop-shadow-color);
 }
 
 /* windows high contrast mode */

--- a/components/actionbar/index.css
+++ b/components/actionbar/index.css
@@ -18,11 +18,11 @@ governing permissions and limitations under the License.
   --spectrum-actionbar-item-counter-line-height : var(--mod-line-height-100, var(--spectrum-line-height-100));
   --spectrum-actionbar-item-counter-color: var(--mod-neutral-content-color-default, var(--spectrum-neutral-content-color-default));
 
-  /* CJK language support for item counter */
+  /* cjk language support for item counter */
   &:lang(ja),
   &:lang(zh),
   &:lang(ko) {
-    --spectrum-actionbar-item-counter-line-height-cjk : var(--mod-CJK-line-height-100, var(--spectrum-CJK-line-height-100));
+    --spectrum-actionbar-item-counter-line-height-cjk : var(--mod-cjk-line-height-100, var(--spectrum-cjk-line-height-100));
   }
 
   /* colors - applied to popover */
@@ -135,7 +135,7 @@ governing permissions and limitations under the License.
     color: var(--mod-actionbar-item-counter-color, var(--spectrum-actionbar-item-counter-color));
     line-height: var(--mod-actionbar-item-counter-line-height, var(--spectrum-actionbar-item-counter-line-height));
 
-    /* CJK language support */
+    /* cjk language support */
     &:lang(ja),
     &:lang(zh),
     &:lang(ko) {

--- a/components/actionbar/index.css
+++ b/components/actionbar/index.css
@@ -12,34 +12,42 @@ governing permissions and limitations under the License.
 .spectrum-ActionBar {
   --spectrum-actionbar-height: var(--spectrum-action-bar-height);
   --spectrum-actionbar-corner-radius: var(--spectrum-corner-radius-100);
+
+  /* colors */
   --spectrum-actionbar-popover-background-color: var(--spectrum-gray-50);
   --spectrum-actionbar-popover-border-color: var(--spectrum-gray-400);
 
-  /* item counter */
+  /* item counter field label */
   --spectrum-actionbar-item-counter-font-size : var(--spectrum-font-size-100);
   --spectrum-actionbar-item-counter-line-height : var(--spectrum-line-height-100);
   --spectrum-actionbar-item-counter-color: var(--spectrum-neutral-content-color-default);
 
-  /* CJK language support */
+  /* CJK language support for item counter */
   &:lang(ja),
   &:lang(zh),
   &:lang(ko) {
     --spectrum-actionbar-item-counter-line-height-cjk : var(--spectrum-CJK-line-height-100);
   }
 
-  /* emphasized */
+  /* emphasized variation colors */
   --spectrum-actionbar-emphasized-background-color : var(--spectrum-informative-background-color-default);
   --spectrum-actionbar-emphasized-item-counter-color: var(--spectrum-white);
 
-  /* spacing */
-  --spectrum-actionbar-spacing-close-button-start-edge : var(--spectrum-spacing-100);
-  --spectrum-actionbar-spacing-close-button-to-item-counter : var(--spectrum-spacing-75);
-  --spectrum-actionbar-spacing-item-counter-to-action-group: var(--spectrum-spacing-400);
-  --spectrum-actionbar-spacing-action-group-to-end-edge : var(--spectrum-spacing-100);
-  --spectrum-actionbar-spacing-close-button-top-edge: var(--spectrum-spacing-100);
-  --spectrum-actionbar-spacing-item-counter-top-edge : var(--spectrum-action-bar-top-to-item-counter);
-  --spectrum-actionbar-spacing-actiongroup-top-edge: var(--spectrum-spacing-100);
+  /* spacing of action bar outer edge */
   --spectrum-actionbar-spacing-outter-edge: var(--spectrum-spacing-300);
+
+  /* spacing of close button */
+  --spectrum-actionbar-spacing-close-button-top: var(--spectrum-spacing-100);
+  --spectrum-actionbar-spacing-close-button-start : var(--spectrum-spacing-100);
+  --spectrum-actionbar-spacing-close-button-end: var(--spectrum-spacing-75);
+
+  /* spacing of item counter field label */
+  --spectrum-actionbar-spacing-item-counter-top : var(--spectrum-action-bar-top-to-item-counter);
+  --spectrum-actionbar-spacing-item-counter-end: var(--spectrum-spacing-400);
+
+  /* spacing of action group */
+  --spectrum-actionbar-spacing-action-group-top: var(--spectrum-spacing-100);
+  --spectrum-actionbar-spacing-action-group-end: var(--spectrum-spacing-100);
 
   /* drop shadow */
   --spectrum-actionbar-drop-shadow-horizontal : var(--spectrum-drop-shadow-x);
@@ -48,36 +56,38 @@ governing permissions and limitations under the License.
   --spectrum-actionbar-drop-shadow-color : var(--spectrum-drop-shadow-color);
 }
 
+/* ActionBar is outer wrapper with nested popover component within */
 .spectrum-ActionBar {
   padding: 0 var(--spectrum-actionbar-spacing-outter-edge) var(--spectrum-actionbar-spacing-outter-edge) var(--spectrum-actionbar-spacing-outter-edge);
+
+  /* Account for fixed width */
+  box-sizing: border-box;
+  /* Take up no space when not open */
+  block-size: 0;
 
   inset-block-end: 0;
   z-index: 1;
 
-  /* Account for fixed width */
-  box-sizing: border-box;
-
-  /* Take up no space when not open */
-  block-size: 0;
   opacity: 0;
 
   /* Clip anything outside of us, whether we're open or not. This makes the animation smooth */
+  /* Hide overflow of closed and open to smooth animation */
   overflow: hidden;
 
   /* Let clicks in blank space fall through */
   pointer-events: none;
 
   &.is-open {
-    /* add bottom padding to height */
-    block-size: calc(var(--spectrum-actionbar-height) + var(--spectrum-actionbar-spacing-outter-edge));
+    /* add bottom padding to height to allow space for popover and bottom padding */
+    block-size: calc(var(--spectrum-actionbar-height) + var(--spectrum-actionbar-spacing-outter-edge)); /* 64px */
     opacity: 1;
   }
 
   /* close button */
   .spectrum-CloseButton {
-    margin-inline-start: var(--spectrum-actionbar-spacing-close-button-start-edge);
-    margin-inline-end: var(--spectrum-actionbar-spacing-close-button-to-item-counter);
-    margin-block-start: var(--spectrum-actionbar-spacing-close-button-top-edge);
+    margin-inline-start: var(--spectrum-actionbar-spacing-close-button-start);
+    margin-inline-end: var(--spectrum-actionbar-spacing-close-button-end);
+    margin-block-start: var(--spectrum-actionbar-spacing-close-button-top);
   }
 
   /* item counter */
@@ -86,8 +96,8 @@ governing permissions and limitations under the License.
     color: var(--spectrum-actionbar-item-counter-color);
     line-height: var(--spectrum-actionbar-item-counter-line-height);
 
-    margin-inline-end: var(--spectrum-actionbar-spacing-item-counter-to-action-group);
-    margin-block-start: var(--spectrum-actionbar-spacing-item-counter-top-edge);
+    margin-inline-end: var(--spectrum-actionbar-spacing-item-counter-end);
+    margin-block-start: var(--spectrum-actionbar-spacing-item-counter-top);
 
     /* CJK language support */
     &:lang(ja),
@@ -97,11 +107,11 @@ governing permissions and limitations under the License.
     }
   }
 
-    /* action group */
-  .spectrum-ActionGroup {
-    margin-top: var(--spectrum-actionbar-spacing-actiongroup-top-edge);
-    margin-inline-end: var(--spectrum-actionbar-spacing-action-group-to-end-edge);
-    margin-block-start: var(--spectrum-actionbar-spacing-actiongroup-top-edge);
+  /* action group - neutralize old non-logical top margin */
+  .spectrum-ActionGroup,
+  .spectrum-ActionGroup:not(.spectrum-ActionGroup--vertical).spectrum-ActionGroup:not(.spectrum-ActionGroup--compact) {
+    margin-inline-end: var(--spectrum-actionbar-spacing-action-group-end);
+    margin-block-start: var(--spectrum-actionbar-spacing-action-group-top);
   }
 }
 
@@ -112,7 +122,6 @@ governing permissions and limitations under the License.
 
   flex-direction: row;
   align-items: center;
-  //justify-content: space-between;
 
   height: 100%;
 
@@ -141,6 +150,8 @@ governing permissions and limitations under the License.
     border: none;
   }
 
+  /* ensure text is legible on emphasized background */
+  .spectrum-ActionButton,
   .spectrum-FieldLabel {
     color: var(--spectrum-actionbar-emphasized-item-counter-color);
   }

--- a/components/actionbar/index.css
+++ b/components/actionbar/index.css
@@ -96,6 +96,9 @@ governing permissions and limitations under the License.
     color: var(--spectrum-actionbar-item-counter-color);
     line-height: var(--spectrum-actionbar-item-counter-line-height);
 
+    /* neutralize padding for correct spacing within ActionBar */
+    padding: 0;
+
     margin-inline-end: var(--spectrum-actionbar-spacing-item-counter-end);
     margin-block-start: var(--spectrum-actionbar-spacing-item-counter-top);
 
@@ -107,22 +110,19 @@ governing permissions and limitations under the License.
     }
   }
 
+  /* TODO - ensure beta is loading properly */
   /* action group - neutralize old non-logical top margin */
   .spectrum-ActionGroup,
   .spectrum-ActionGroup:not(.spectrum-ActionGroup--vertical).spectrum-ActionGroup:not(.spectrum-ActionGroup--compact) {
     margin-inline-end: var(--spectrum-actionbar-spacing-action-group-end);
     margin-block-start: var(--spectrum-actionbar-spacing-action-group-top);
+
+    /* align to end by default */
+    margin-inline-start: auto;
   }
 }
 
 .spectrum-ActionBar-popover {
-  display: flex;
-  //place-items: center start;
-  justify-content: flex-start;
-
-  flex-direction: row;
-  align-items: center;
-
   height: 100%;
 
   border-radius: var(--spectrum-actionbar-corner-radius);
@@ -140,6 +140,13 @@ governing permissions and limitations under the License.
 
   /* Let clicks do their thing */
   pointer-events: auto;
+
+  /* TODO - confirm new nesting on popover is copacetic */
+  /* popover-content controls inner layout */
+  .spectrum-Popover-content {
+    display: flex;
+    flex-direction: row;
+  }
 }
 
 .spectrum-ActionBar--emphasized {

--- a/components/actionbar/index.css
+++ b/components/actionbar/index.css
@@ -33,8 +33,8 @@ governing permissions and limitations under the License.
   --spectrum-actionbar-emphasized-background-color : var(--mod-informative-background-color-default, var(--spectrum-informative-background-color-default));
   --spectrum-actionbar-emphasized-item-counter-color: var(--mod-white, var(--spectrum-white));
 
-  /* spacing of action bar bottom outer edge */
-  --spectrum-actionbar-spacing-outter-edge: var(--mod-spacing-300, var(--spectrum-spacing-300));
+  /* spacing of action bar bottom and horizontal outer edge */
+  --spectrum-actionbar-spacing-outer-edge: var(--mod-spacing-300, var(--spectrum-spacing-300));
 
   /* spacing of close button */
   --spectrum-actionbar-spacing-close-button-top: var(--mod-spacing-100, var(--spectrum-spacing-100));
@@ -71,7 +71,8 @@ governing permissions and limitations under the License.
 
 /* ActionBar is outer wrapper with nested popover component within */
 .spectrum-ActionBar {
-  margin-block-end: var(--mod-actionbar-spacing-outter-edge, var(--spectrum-actionbar-spacing-outter-edge));
+  /* creates horizontal spacing to edge */
+  padding: 0 var(--mod-actionbar-spacing-outer-edge, var(--spectrum-actionbar-spacing-outer-edge));
   inset-block-end: 0;
   z-index: 1;
 
@@ -86,14 +87,16 @@ governing permissions and limitations under the License.
   opacity: 0;
 
   &.is-open {
-    block-size: var(--mod-actionbar-height, var(--spectrum-actionbar-height));
+    /* add ActionBar bottom margin to height for correct spacing even when sticky */
+    block-size: calc(var(--mod-actionbar-spacing-outer-edge, var(--spectrum-actionbar-spacing-outer-edge)) + var(--mod-actionbar-height, var(--spectrum-actionbar-height)));
     opacity: 1;
   }
 
   .spectrum-ActionBar-popover {
+    /* popover is ActionBar height */
+    block-size: var(--mod-actionbar-height, var(--spectrum-actionbar-height));
     box-sizing: border-box;
     inline-size: 100%;
-    block-size: 100%;
     margin: auto;
     padding-block-start: 0;
     padding-block-end: 0;

--- a/components/actionbar/index.css
+++ b/components/actionbar/index.css
@@ -10,55 +10,55 @@ governing permissions and limitations under the License.
 */
 
 .spectrum-ActionBar {
-  --spectrum-actionbar-height: var(--spectrum-action-bar-height);
-  --spectrum-actionbar-corner-radius: var(--spectrum-corner-radius-100);
+  --spectrum-actionbar-height: var(--mod-action-bar-height, var(--spectrum-action-bar-height));
+  --spectrum-actionbar-corner-radius: var(--mod-corner-radius-100, var(--spectrum-corner-radius-100));
 
   /* item counter field label */
-  --spectrum-actionbar-item-counter-font-size : var(--spectrum-font-size-100);
-  --spectrum-actionbar-item-counter-line-height : var(--spectrum-line-height-100);
-  --spectrum-actionbar-item-counter-color: var(--spectrum-neutral-content-color-default);
+  --spectrum-actionbar-item-counter-font-size : var(--mod-font-size-100, var(--spectrum-font-size-100));
+  --spectrum-actionbar-item-counter-line-height : var(--mod-line-height-100, var(--spectrum-line-height-100));
+  --spectrum-actionbar-item-counter-color: var(--mod-neutral-content-color-default, var(--spectrum-neutral-content-color-default));
 
   /* CJK language support for item counter */
   &:lang(ja),
   &:lang(zh),
   &:lang(ko) {
-    --spectrum-actionbar-item-counter-line-height-cjk : var(--spectrum-CJK-line-height-100);
+    --spectrum-actionbar-item-counter-line-height-cjk : var(--mod-CJK-line-height-100, var(--spectrum-CJK-line-height-100));
   }
 
   /* colors - applied to popover */
-  --spectrum-actionbar-popover-background-color: var(--spectrum-gray-50);
-  --spectrum-actionbar-popover-border-color: var(--spectrum-gray-400);
+  --spectrum-actionbar-popover-background-color: var(--mod-gray-50, var(--spectrum-gray-50));
+  --spectrum-actionbar-popover-border-color: var(--mod-gray-400, var(--spectrum-gray-400));
 
   /* emphasized variation colors */
-  --spectrum-actionbar-emphasized-background-color : var(--spectrum-informative-background-color-default);
-  --spectrum-actionbar-emphasized-item-counter-color: var(--spectrum-white);
+  --spectrum-actionbar-emphasized-background-color : var(--mod-informative-background-color-default, var(--spectrum-informative-background-color-default));
+  --spectrum-actionbar-emphasized-item-counter-color: var(--mod-white, var(--spectrum-white));
 
   /* spacing of action bar bottom outer edge */
-  --spectrum-actionbar-spacing-outter-edge: var(--spectrum-spacing-300);
+  --spectrum-actionbar-spacing-outter-edge: var(--mod-spacing-300, var(--spectrum-spacing-300));
 
   /* spacing of close button */
-  --spectrum-actionbar-spacing-close-button-top: var(--spectrum-spacing-100);
-  --spectrum-actionbar-spacing-close-button-start : var(--spectrum-spacing-100);
-  --spectrum-actionbar-spacing-close-button-end: var(--spectrum-spacing-75);
+  --spectrum-actionbar-spacing-close-button-top: var(--mod-spacing-100, var(--spectrum-spacing-100));
+  --spectrum-actionbar-spacing-close-button-start : var(--mod-spacing-100, var(--spectrum-spacing-100));
+  --spectrum-actionbar-spacing-close-button-end: var(--mod-spacing-75, var(--spectrum-spacing-75));
 
   /* spacing of item counter field label */
-  --spectrum-actionbar-spacing-item-counter-top : var(--spectrum-action-bar-top-to-item-counter);
-  --spectrum-actionbar-spacing-item-counter-end: var(--spectrum-spacing-400);
+  --spectrum-actionbar-spacing-item-counter-top : var(--mod-action-bar-top-to-item-counter, var(--spectrum-action-bar-top-to-item-counter));
+  --spectrum-actionbar-spacing-item-counter-end: var(--mod-spacing-400, var(--spectrum-spacing-400));
 
   /* spacing of action group */
-  --spectrum-actionbar-spacing-action-group-top: var(--spectrum-spacing-100);
-  --spectrum-actionbar-spacing-action-group-end: var(--spectrum-spacing-100);
+  --spectrum-actionbar-spacing-action-group-top: var(--mod-spacing-100, var(--spectrum-spacing-100));
+  --spectrum-actionbar-spacing-action-group-end: var(--mod-spacing-100, var(--spectrum-spacing-100));
 
   /* drop shadow */
-  --spectrum-actionbar-shadow-horizontal : var(--spectrum-drop-shadow-x);
-  --spectrum-actionbar-shadow-vertical : var(--spectrum-drop-shadow-y);
-  --spectrum-actionbar-shadow-blur : var(--spectrum-drop-shadow-blur);
-  --spectrum-actionbar-shadow-color : var(--spectrum-drop-shadow-color);
+  --spectrum-actionbar-shadow-horizontal : var(--mod-drop-shadow-x, var(--spectrum-drop-shadow-x));
+  --spectrum-actionbar-shadow-vertical : var(--mod-drop-shadow-y, var(--spectrum-drop-shadow-y));
+  --spectrum-actionbar-shadow-blur : var(--mod-drop-shadow-blur, var(--spectrum-drop-shadow-blur));
+  --spectrum-actionbar-shadow-color : var(--mod-drop-shadow-color, var(--spectrum-drop-shadow-color));
 }
 
 /* ActionBar is outer wrapper with nested popover component within */
 .spectrum-ActionBar {
-  margin-block-end: var(--spectrum-actionbar-spacing-outter-edge);
+  margin-block-end: var(--mod-actionbar-spacing-outter-edge, var(--spectrum-actionbar-spacing-outter-edge));
   inset-block-end: 0;
   z-index: 1;
 
@@ -73,7 +73,7 @@ governing permissions and limitations under the License.
   opacity: 0;
 
   &.is-open {
-    block-size: var(--spectrum-actionbar-height);
+    block-size: var(--mod-actionbar-height, var(--spectrum-actionbar-height));
     opacity: 1;
   }
 
@@ -88,9 +88,10 @@ governing permissions and limitations under the License.
     /* Be relative so our width can be restricted */
     position: relative;
 
-    border-radius: var(--spectrum-actionbar-corner-radius);
-    border-color: var(--spectrum-actionbar-popover-border-color);
-    background-color: var(--spectrum-actionbar-popover-background-color);
+    border-radius: var(--mod-actionbar-corner-radius, var(--spectrum-actionbar-corner-radius));
+    border-color: var(--mod-actionbar-popover-border-color, var(--spectrum-actionbar-popover-border-color));
+    background-color: var(--mod-actionbar-popover-background-color, var(--spectrum-actionbar-popover-background-color));
+
     filter: drop-shadow(var(--mod-actionbar-shadow-horizontal, var(--spectrum-actionbar-shadow-horizontal)) var(--mod-actionbar-shadow-vertical, var(--spectrum-actionbar-shadow-vertical)) var(--mod-actionbar-shadow-blur, var(--spectrum-actionbar-shadow-blur)) var(--mod-actionbar-shadow-color, var(--spectrum-actionbar-shadow-color)));
 
     /* Let clicks do their thing */
@@ -103,29 +104,29 @@ governing permissions and limitations under the License.
 
   /* close button */
   .spectrum-CloseButton {
-    margin-inline-start: var(--spectrum-actionbar-spacing-close-button-start);
-    margin-inline-end: var(--spectrum-actionbar-spacing-close-button-end);
-    margin-block-start: var(--spectrum-actionbar-spacing-close-button-top);
+    margin-inline-start: var(--mod-actionbar-spacing-close-button-start, var(--spectrum-actionbar-spacing-close-button-start));
+    margin-inline-end: var(--mod-actionbar-spacing-close-button-end, var(--spectrum-actionbar-spacing-close-button-end));
+    margin-block-start: var(--mod-actionbar-spacing-close-button-top, var(--spectrum-actionbar-spacing-close-button-top));
     flex-shrink: 0;
   }
 
   /* item counter */
   .spectrum-FieldLabel {
-    margin-inline-end: var(--spectrum-actionbar-spacing-item-counter-end);
-    margin-block-start: var(--spectrum-actionbar-spacing-item-counter-top);
+    margin-inline-end: var(--mod-actionbar-spacing-item-counter-end, var(--spectrum-actionbar-spacing-item-counter-end));
+    margin-block-start: var(--mod-actionbar-spacing-item-counter-top, var(--spectrum-actionbar-spacing-item-counter-top));
 
     /* neutralize padding for correct spacing within ActionBar */
     padding: 0;
 
-    font-size: var(--spectrum-actionbar-item-counter-font-size);
-    color: var(--spectrum-actionbar-item-counter-color);
-    line-height: var(--spectrum-actionbar-item-counter-line-height);
+    font-size: var(--mod-actionbar-item-counter-font-size, var(--spectrum-actionbar-item-counter-font-size));
+    color: var(--mod-actionbar-item-counter-color, var(--spectrum-actionbar-item-counter-color));
+    line-height: var(--mod-actionbar-item-counter-line-height, var(--spectrum-actionbar-item-counter-line-height));
 
     /* CJK language support */
     &:lang(ja),
     &:lang(zh),
     &:lang(ko) {
-      line-height: var(--spectrum-actionbar-item-counter-line-height-cjk);
+      line-height: var(--mod-actionbar-item-counter-line-height-cjk, var(--spectrum-actionbar-item-counter-line-height-cjk));
     }
   }
 
@@ -133,8 +134,8 @@ governing permissions and limitations under the License.
   .spectrum-ActionGroup,
   /* TODO - the following ActionGroup class may be removed after all components are migrated */
   .spectrum-ActionGroup:not(.spectrum-ActionGroup--vertical).spectrum-ActionGroup:not(.spectrum-ActionGroup--compact) {
-    margin-inline-end: var(--spectrum-actionbar-spacing-action-group-end);
-    margin-block-start: var(--spectrum-actionbar-spacing-action-group-top);
+    margin-inline-end: var(--mod-actionbar-spacing-action-group-end, var(--spectrum-actionbar-spacing-action-group-end));
+    margin-block-start: var(--mod-actionbar-spacing-action-group-top, var(--spectrum-actionbar-spacing-action-group-top));
 
     /* align to end by default */
     margin-inline-start: auto;
@@ -152,7 +153,7 @@ governing permissions and limitations under the License.
 .spectrum-ActionBar--emphasized {
   .spectrum-ActionBar-popover {
     filter: none;
-    background-color: var(--spectrum-actionbar-emphasized-background-color);
+    background-color: var(--mod-actionbar-emphasized-background-color, var(--spectrum-actionbar-emphasized-background-color));
     border: none;
   }
 
@@ -160,9 +161,9 @@ governing permissions and limitations under the License.
   .spectrum-ActionButton,
   .spectrum-FieldLabel,
   .spectrum-CloseButton-UIIcon {
-    color: var(--spectrum-actionbar-emphasized-item-counter-color);
+    color: var(--mod-actionbar-emphasized-item-counter-color, var(--spectrum-actionbar-emphasized-item-counter-color));
     /* apply fill so SVG icon is the correct color */
-    fill: var(--spectrum-actionbar-emphasized-item-counter-color);
+    fill: var(--mod-actionbar-emphasized-item-counter-color, var(--spectrum-actionbar-emphasized-item-counter-color));
   }
 }
 

--- a/components/actionbar/index.css
+++ b/components/actionbar/index.css
@@ -153,29 +153,6 @@ governing permissions and limitations under the License.
     /* align to end by default */
     margin-inline-start: auto;
   }
-
-  .spectrum-ActionGroup-item {
-    margin-block-start: 0;
-    margin-top: 0;
-  }
-
-  /* TODO - the following ActionGroup + item vertical and compact style overrides may be removed after all components are migrated */
-  .spectrum-ActionGroup {
-    &:not(.spectrum-ActionGroup--vertical) {
-    &:not(.spectrum-ActionGroup--compact) {
-        margin-inline-end: var(--mod-actionbar-spacing-action-group-end, var(--spectrum-actionbar-spacing-action-group-end));
-        margin-block-start: var(--mod-actionbar-spacing-action-group-top, var(--spectrum-actionbar-spacing-action-group-top));
-        /* align to end by default */
-        margin-inline-start: auto;
-
-        /* action group items - neutralize top margin */
-        .spectrum-ActionGroup-item {
-          margin-block-start: 0;
-          margin-top: 0;
-        }
-      }
-    }
-  }
 }
 
 .spectrum-ActionBar--emphasized {

--- a/components/actionbar/index.css
+++ b/components/actionbar/index.css
@@ -14,15 +14,15 @@ governing permissions and limitations under the License.
   --spectrum-actionbar-corner-radius: var(--spectrum-corner-radius-100);
 
   /* item counter field label */
-  --spectrum-actionbar-item-counter-font-size : var(--spectrum-font-size-100);
-  --spectrum-actionbar-item-counter-line-height : var(--spectrum-line-height-100);
+  --spectrum-actionbar-item-counter-font-size: var(--spectrum-font-size-100);
+  --spectrum-actionbar-item-counter-line-height: var(--spectrum-line-height-100);
   --spectrum-actionbar-item-counter-color: var(--spectrum-neutral-content-color-default);
 
   /* cjk language support for item counter */
   &:lang(ja),
   &:lang(zh),
   &:lang(ko) {
-    --spectrum-actionbar-item-counter-line-height-cjk : var(--spectrum-cjk-line-height-100);
+    --spectrum-actionbar-item-counter-line-height-cjk: var(--spectrum-cjk-line-height-100);
   }
 
   /* colors - applied to popover */
@@ -30,7 +30,7 @@ governing permissions and limitations under the License.
   --spectrum-actionbar-popover-border-color: var(--spectrum-gray-400);
 
   /* emphasized variation colors */
-  --spectrum-actionbar-emphasized-background-color : var(--spectrum-informative-background-color-default);
+  --spectrum-actionbar-emphasized-background-color: var(--spectrum-informative-background-color-default);
   --spectrum-actionbar-emphasized-item-counter-color: var(--spectrum-white);
 
   /* spacing of action bar bottom and horizontal outer edge */
@@ -38,11 +38,11 @@ governing permissions and limitations under the License.
 
   /* spacing of close button */
   --spectrum-actionbar-spacing-close-button-top: var(--spectrum-spacing-100);
-  --spectrum-actionbar-spacing-close-button-start : var(--spectrum-spacing-100);
+  --spectrum-actionbar-spacing-close-button-start: var(--spectrum-spacing-100);
   --spectrum-actionbar-spacing-close-button-end: var(--spectrum-spacing-75);
 
   /* spacing of item counter field label */
-  --spectrum-actionbar-spacing-item-counter-top : var(--spectrum-action-bar-top-to-item-counter);
+  --spectrum-actionbar-spacing-item-counter-top: var(--spectrum-action-bar-top-to-item-counter);
   --spectrum-actionbar-spacing-item-counter-end: var(--spectrum-spacing-400);
 
   /* spacing of action group */
@@ -50,10 +50,10 @@ governing permissions and limitations under the License.
   --spectrum-actionbar-spacing-action-group-end: var(--spectrum-spacing-100);
 
   /* drop shadow */
-  --spectrum-actionbar-shadow-horizontal : var(--spectrum-drop-shadow-x);
-  --spectrum-actionbar-shadow-vertical : var(--spectrum-drop-shadow-y);
-  --spectrum-actionbar-shadow-blur : var(--spectrum-drop-shadow-blur);
-  --spectrum-actionbar-shadow-color : var(--spectrum-drop-shadow-color);
+  --spectrum-actionbar-shadow-horizontal: var(--spectrum-drop-shadow-x);
+  --spectrum-actionbar-shadow-vertical: var(--spectrum-drop-shadow-y);
+  --spectrum-actionbar-shadow-blur: var(--spectrum-drop-shadow-blur);
+  --spectrum-actionbar-shadow-color: var(--spectrum-drop-shadow-color);
 }
 
 /* windows high contrast mode */

--- a/components/actionbar/metadata/actionbar.yml
+++ b/components/actionbar/metadata/actionbar.yml
@@ -28,26 +28,27 @@ examples:
     markup: |
       <div class="spectrum-ActionBar is-open">
         <div class="spectrum-Popover spectrum-ActionBar-popover is-open">
+          <div class="spectrum-Popover-content">
 
-          <button class="spectrum-CloseButton spectrum-CloseButton--sizeM">
-            <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
-              <use xlink:href="#spectrum-css-icon-Cross100" />
-            </svg>
-          </button>
-
-          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
-
-          <div class="spectrum-ActionGroup">
-            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-              <span class="spectrum-ActionButton-label">Edit</span>
-            </button>
-            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-              <span class="spectrum-ActionButton-label">Copy</span>
-            </button>
-            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-              <span class="spectrum-ActionButton-label">Delete</span>
+            <button class="spectrum-CloseButton spectrum-CloseButton--sizeM">
+              <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-Cross100" />
+              </svg>
             </button>
 
+            <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
+
+            <div class="spectrum-ActionGroup">
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+                <span class="spectrum-ActionButton-label">Edit</span>
+              </button>
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+                <span class="spectrum-ActionButton-label">Copy</span>
+              </button>
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+                <span class="spectrum-ActionButton-label">Delete</span>
+              </button>
+            </div>
           </div>
         </div>
       </div>
@@ -55,34 +56,36 @@ examples:
 
       <div class="spectrum-ActionBar is-open">
         <div class="spectrum-Popover spectrum-ActionBar-popover is-open">
+          <div class="spectrum-Popover-content">
 
-          <button class="spectrum-CloseButton spectrum-CloseButton--sizeM">
-            <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
-              <use xlink:href="#spectrum-css-icon-Cross100" />
-            </svg>
-          </button>
+            <button class="spectrum-CloseButton spectrum-CloseButton--sizeM">
+              <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-Cross100" />
+              </svg>
+            </button>
 
-          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
+            <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
 
-          <div class="spectrum-ActionGroup">
-            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Edit">
-                <use xlink:href="#spectrum-icon-18-Edit"></use>
-              </svg>
-              <span class="spectrum-ActionButton-label">Edit</span>
-            </button>
-            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Copy">
-                <use xlink:href="#spectrum-icon-18-Copy"></use>
-              </svg>
-              <span class="spectrum-ActionButton-label">Copy</span>
-            </button>
-            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Delete">
-                <use xlink:href="#spectrum-icon-18-Delete"></use>
-              </svg>
-              <span class="spectrum-ActionButton-label">Delete</span>
-            </button>
+            <div class="spectrum-ActionGroup">
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+                <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit"></use>
+                </svg>
+                <span class="spectrum-ActionButton-label">Edit</span>
+              </button>
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+                <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Copy">
+                  <use xlink:href="#spectrum-icon-18-Copy"></use>
+                </svg>
+                <span class="spectrum-ActionButton-label">Copy</span>
+              </button>
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+                <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Delete">
+                  <use xlink:href="#spectrum-icon-18-Delete"></use>
+                </svg>
+                <span class="spectrum-ActionButton-label">Delete</span>
+              </button>
+            </div>
           </div>
         </div>
       </div>
@@ -90,31 +93,32 @@ examples:
 
       <div class="spectrum-ActionBar is-open">
         <div class="spectrum-Popover spectrum-ActionBar-popover is-open">
-
-          <button class="spectrum-CloseButton spectrum-CloseButton--sizeM">
-            <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
-              <use xlink:href="#spectrum-css-icon-Cross100" />
-            </svg>
-          </button>
-
-          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
-
-          <div class="spectrum-ActionGroup">
-            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Edit">
-                <use xlink:href="#spectrum-icon-18-Edit"></use>
+          <div class="spectrum-Popover-content">
+            <button class="spectrum-CloseButton spectrum-CloseButton--sizeM">
+              <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-Cross100" />
               </svg>
             </button>
-            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Copy">
-                <use xlink:href="#spectrum-icon-18-Copy"></use>
-              </svg>
-            </button>
-            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Delete">
-                <use xlink:href="#spectrum-icon-18-Delete"></use>
-              </svg>
-            </button>
+
+            <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
+
+            <div class="spectrum-ActionGroup">
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+                <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit"></use>
+                </svg>
+              </button>
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+                <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Copy">
+                  <use xlink:href="#spectrum-icon-18-Copy"></use>
+                </svg>
+              </button>
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+                <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Delete">
+                  <use xlink:href="#spectrum-icon-18-Delete"></use>
+                </svg>
+              </button>
+            </div>
           </div>
         </div>
       </div>
@@ -126,26 +130,26 @@ examples:
     markup: |
       <div class="spectrum-ActionBar spectrum-ActionBar--emphasized is-open">
         <div class="spectrum-Popover spectrum-ActionBar-popover is-open">
-
-          <button class="spectrum-CloseButton spectrum-CloseButton--sizeM">
-            <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
-              <use xlink:href="#spectrum-css-icon-Cross100" />
-            </svg>
-          </button>
-
-          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
-
-          <div class="spectrum-ActionGroup">
-            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-              <span class="spectrum-ActionButton-label">Edit</span>
-            </button>
-            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-              <span class="spectrum-ActionButton-label">Copy</span>
-            </button>
-            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-              <span class="spectrum-ActionButton-label">Delete</span>
+          <div class="spectrum-Popover-content">
+            <button class="spectrum-CloseButton spectrum-CloseButton--sizeM">
+              <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-Cross100" />
+              </svg>
             </button>
 
+            <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
+
+            <div class="spectrum-ActionGroup">
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+                <span class="spectrum-ActionButton-label">Edit</span>
+              </button>
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+                <span class="spectrum-ActionButton-label">Copy</span>
+              </button>
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+                <span class="spectrum-ActionButton-label">Delete</span>
+              </button>
+            </div>
           </div>
         </div>
       </div>
@@ -153,34 +157,35 @@ examples:
 
       <div class="spectrum-ActionBar spectrum-ActionBar--emphasized is-open">
         <div class="spectrum-Popover spectrum-ActionBar-popover is-open">
-
-          <button class="spectrum-CloseButton spectrum-CloseButton--sizeM">
-            <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
-              <use xlink:href="#spectrum-css-icon-Cross100" />
-            </svg>
-          </button>
-
-          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
-
-          <div class="spectrum-ActionGroup">
-            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Edit">
-                <use xlink:href="#spectrum-icon-18-Edit"></use>
+          <div class="spectrum-Popover-content">
+            <button class="spectrum-CloseButton spectrum-CloseButton--sizeM">
+              <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-Cross100" />
               </svg>
-              <span class="spectrum-ActionButton-label">Edit</span>
             </button>
-            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Copy">
-                <use xlink:href="#spectrum-icon-18-Copy"></use>
-              </svg>
-              <span class="spectrum-ActionButton-label">Copy</span>
-            </button>
-            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Delete">
-                <use xlink:href="#spectrum-icon-18-Delete"></use>
-              </svg>
-              <span class="spectrum-ActionButton-label">Delete</span>
-            </button>
+
+            <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
+
+            <div class="spectrum-ActionGroup">
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+                <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit"></use>
+                </svg>
+                <span class="spectrum-ActionButton-label">Edit</span>
+              </button>
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+                <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Copy">
+                  <use xlink:href="#spectrum-icon-18-Copy"></use>
+                </svg>
+                <span class="spectrum-ActionButton-label">Copy</span>
+              </button>
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+                <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Delete">
+                  <use xlink:href="#spectrum-icon-18-Delete"></use>
+                </svg>
+                <span class="spectrum-ActionButton-label">Delete</span>
+              </button>
+            </div>
           </div>
         </div>
       </div>
@@ -188,31 +193,32 @@ examples:
 
       <div class="spectrum-ActionBar spectrum-ActionBar--emphasized is-open">
         <div class="spectrum-Popover spectrum-ActionBar-popover is-open">
-
-          <button class="spectrum-CloseButton spectrum-CloseButton--sizeM">
-            <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
-              <use xlink:href="#spectrum-css-icon-Cross100" />
-            </svg>
-          </button>
-
-          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
-
-          <div class="spectrum-ActionGroup">
-            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Edit">
-                <use xlink:href="#spectrum-icon-18-Edit"></use>
+          <div class="spectrum-Popover-content">
+            <button class="spectrum-CloseButton spectrum-CloseButton--sizeM">
+              <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-Cross100" />
               </svg>
             </button>
-            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Copy">
-                <use xlink:href="#spectrum-icon-18-Copy"></use>
-              </svg>
-            </button>
-            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Delete">
-                <use xlink:href="#spectrum-icon-18-Delete"></use>
-              </svg>
-            </button>
+
+            <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
+
+            <div class="spectrum-ActionGroup">
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+                <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit"></use>
+                </svg>
+              </button>
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+                <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Copy">
+                  <use xlink:href="#spectrum-icon-18-Copy"></use>
+                </svg>
+              </button>
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+                <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Delete">
+                  <use xlink:href="#spectrum-icon-18-Delete"></use>
+                </svg>
+              </button>
+            </div>
           </div>
         </div>
       </div>
@@ -224,26 +230,27 @@ examples:
     markup: |
       <div class="spectrum-ActionBar spectrum-ActionBar--flexible is-open">
         <div class="spectrum-Popover spectrum-ActionBar-popover is-open">
-
-          <button class="spectrum-CloseButton spectrum-CloseButton--sizeM">
-            <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
-              <use xlink:href="#spectrum-css-icon-Cross100" />
-            </svg>
-          </button>
-
-          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
-
-          <div class="spectrum-ActionGroup">
-            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Edit">
-                <use xlink:href="#spectrum-icon-18-Edit"></use>
+          <div class="spectrum-Popover-content">
+            <button class="spectrum-CloseButton spectrum-CloseButton--sizeM">
+              <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-Cross100" />
               </svg>
             </button>
-            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="More">
-                <use xlink:href="#spectrum-icon-18-More"></use>
-              </svg>
-            </button>
+
+            <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
+
+            <div class="spectrum-ActionGroup">
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+                <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Edit">
+                  <use xlink:href="#spectrum-icon-18-Edit"></use>
+                </svg>
+              </button>
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+                <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="More">
+                  <use xlink:href="#spectrum-icon-18-More"></use>
+                </svg>
+              </button>
+            </div>
           </div>
         </div>
       </div>
@@ -418,38 +425,41 @@ examples:
             <div class="spectrum-Table-cell" style="flex: 1" role="gridcell">Row Item Jake</div>
             <div class="spectrum-Table-cell" style="flex: 1" role="gridcell">Row Item Jake</div>
           </div>
+
           <div class="spectrum-ActionBar spectrum-ActionBar--sticky is-open">
             <div class="spectrum-Popover spectrum-ActionBar-popover is-open">
-
-          <button class="spectrum-CloseButton spectrum-CloseButton--sizeM">
-            <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
-              <use xlink:href="#spectrum-css-icon-Cross100" />
-            </svg>
-          </button>
-
-          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
-
-              <div class="spectrum-ActionGroup">
-                <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-                  <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Edit">
-                    <use xlink:href="#spectrum-icon-18-Edit"></use>
+              <div class="spectrum-Popover-content">
+                <button class="spectrum-CloseButton spectrum-CloseButton--sizeM">
+                  <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
+                    <use xlink:href="#spectrum-css-icon-Cross100" />
                   </svg>
-                  <span class="spectrum-ActionButton-label">Edit</span>
                 </button>
-                <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-                  <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Copy">
-                    <use xlink:href="#spectrum-icon-18-Copy"></use>
-                  </svg>
-                  <span class="spectrum-ActionButton-label">Copy</span>
-                </button>
-                <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-                  <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Delete">
-                    <use xlink:href="#spectrum-icon-18-Delete"></use>
-                  </svg>
-                  <span class="spectrum-ActionButton-label">Delete</span>
-                </button>
+
+                <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
+
+                    <div class="spectrum-ActionGroup">
+                      <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+                        <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Edit">
+                          <use xlink:href="#spectrum-icon-18-Edit"></use>
+                        </svg>
+                        <span class="spectrum-ActionButton-label">Edit</span>
+                      </button>
+                      <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+                        <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Copy">
+                          <use xlink:href="#spectrum-icon-18-Copy"></use>
+                        </svg>
+                        <span class="spectrum-ActionButton-label">Copy</span>
+                      </button>
+                      <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+                        <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Delete">
+                          <use xlink:href="#spectrum-icon-18-Delete"></use>
+                        </svg>
+                        <span class="spectrum-ActionButton-label">Delete</span>
+                      </button>
+                    </div>
+                  </div>
+                </div>
               </div>
-            </div>
-          </div>
+
         </div>
       </div>

--- a/components/actionbar/metadata/actionbar.yml
+++ b/components/actionbar/metadata/actionbar.yml
@@ -3,6 +3,15 @@ description: Floating action bar that appears in selection mode.
 sections:
   - name: Migration Guide
     description: |
+      ### Popover Dependency
+      Action Bar requires Popover, which is nested within Action Bar. Action Bar background, border, and corner radius are applied to the nested Popover component and can be overriden by Action Bar.
+
+      ### Action Bar Close Button
+      Checkbox has been replaced by close button.
+
+      ### Item Counter
+      Item counter has replaced the checkbox field label. Item counter is a Field Label component.
+
       ### New Action Button markup
       Action Button requires `.spectrum-ActionButton-icon` class on icons nested inside of Action Button.
 
@@ -11,6 +20,7 @@ sections:
 
       ### Change workflow icon size to medium
       If you use icon action button in your markup, please replace `.spectrum-Icon--sizeS` with `.spectrum-Icon--sizeM`.
+
 examples:
   - id: actionbar
     name: Standard
@@ -18,18 +28,15 @@ examples:
     markup: |
       <div class="spectrum-ActionBar is-open">
         <div class="spectrum-Popover spectrum-ActionBar-popover is-open">
-          <label class="spectrum-Checkbox spectrum-Checkbox--sizeM is-indeterminate">
-            <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-0">
-            <span class="spectrum-Checkbox-box">
-              <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-                <use xlink:href="#spectrum-css-icon-Checkmark100" />
-              </svg>
-              <svg class="spectrum-Icon spectrum-UIIcon-Dash100 spectrum-Checkbox-partialCheckmark" focusable="false" aria-hidden="true">
-                <use xlink:href="#spectrum-css-icon-Dash100" />
-              </svg>
-            </span>
-            <span class="spectrum-Checkbox-label">2 selected</span>
-          </label>
+
+          <button class="spectrum-CloseButton spectrum-CloseButton--sizeM">
+            <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Cross100" />
+            </svg>
+          </button>
+
+          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
+
           <div class="spectrum-ActionGroup">
             <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
               <span class="spectrum-ActionButton-label">Edit</span>
@@ -40,24 +47,23 @@ examples:
             <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
               <span class="spectrum-ActionButton-label">Delete</span>
             </button>
+
           </div>
         </div>
       </div>
 
+
       <div class="spectrum-ActionBar is-open">
         <div class="spectrum-Popover spectrum-ActionBar-popover is-open">
-          <label class="spectrum-Checkbox spectrum-Checkbox--sizeM is-indeterminate">
-            <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-1">
-            <span class="spectrum-Checkbox-box">
-              <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-                <use xlink:href="#spectrum-css-icon-Checkmark100" />
-              </svg>
-              <svg class="spectrum-Icon spectrum-UIIcon-Dash100 spectrum-Checkbox-partialCheckmark" focusable="false" aria-hidden="true">
-                <use xlink:href="#spectrum-css-icon-Dash100" />
-              </svg>
-            </span>
-            <span class="spectrum-Checkbox-label">4 selected</span>
-          </label>
+
+          <button class="spectrum-CloseButton spectrum-CloseButton--sizeM">
+            <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Cross100" />
+            </svg>
+          </button>
+
+          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
+
           <div class="spectrum-ActionGroup">
             <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
               <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Edit">
@@ -81,20 +87,18 @@ examples:
         </div>
       </div>
 
+
       <div class="spectrum-ActionBar is-open">
         <div class="spectrum-Popover spectrum-ActionBar-popover is-open">
-          <label class="spectrum-Checkbox spectrum-Checkbox--sizeM is-indeterminate">
-            <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-1">
-            <span class="spectrum-Checkbox-box">
-              <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-                <use xlink:href="#spectrum-css-icon-Checkmark100" />
-              </svg>
-              <svg class="spectrum-Icon spectrum-UIIcon-Dash100 spectrum-Checkbox-partialCheckmark" focusable="false" aria-hidden="true">
-                <use xlink:href="#spectrum-css-icon-Dash100" />
-              </svg>
-            </span>
-            <span class="spectrum-Checkbox-label">6 selected</span>
-          </label>
+
+          <button class="spectrum-CloseButton spectrum-CloseButton--sizeM">
+            <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Cross100" />
+            </svg>
+          </button>
+
+          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
+
           <div class="spectrum-ActionGroup">
             <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
               <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Edit">
@@ -114,24 +118,54 @@ examples:
           </div>
         </div>
       </div>
+
+
+  - id: actionbar-emphasized
+    name: Emphasized
+    description: Emphasized action bar.
+    markup: |
+      <div class="spectrum-ActionBar spectrum-ActionBar--emphasized is-open">
+        <div class="spectrum-Popover spectrum-ActionBar-popover is-open">
+
+          <button class="spectrum-CloseButton spectrum-CloseButton--sizeM">
+            <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Cross100" />
+            </svg>
+          </button>
+
+          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
+
+          <div class="spectrum-ActionGroup">
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+              <span class="spectrum-ActionButton-label">Edit</span>
+            </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+              <span class="spectrum-ActionButton-label">Copy</span>
+            </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+              <span class="spectrum-ActionButton-label">Delete</span>
+            </button>
+
+          </div>
+        </div>
+      </div>
+
+
   - id: actionbar
     name: Flexible
     description: Flexible Action Bars fit the width of their content.
     markup: |
       <div class="spectrum-ActionBar spectrum-ActionBar--flexible is-open">
         <div class="spectrum-Popover spectrum-ActionBar-popover is-open">
-          <label class="spectrum-Checkbox spectrum-Checkbox--sizeM is-indeterminate">
-            <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-1">
-            <span class="spectrum-Checkbox-box">
-              <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-                <use xlink:href="#spectrum-css-icon-Checkmark100" />
-              </svg>
-              <svg class="spectrum-Icon spectrum-UIIcon-Dash100 spectrum-Checkbox-partialCheckmark" focusable="false" aria-hidden="true">
-                <use xlink:href="#spectrum-css-icon-Dash100" />
-              </svg>
-            </span>
-            <span class="spectrum-Checkbox-label">228 selected</span>
-          </label>
+
+          <button class="spectrum-CloseButton spectrum-CloseButton--sizeM">
+            <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Cross100" />
+            </svg>
+          </button>
+
+          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
+
           <div class="spectrum-ActionGroup">
             <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
               <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Edit">
@@ -146,9 +180,11 @@ examples:
           </div>
         </div>
       </div>
+
+
   - id: actionbar
     name: Table with ActionBar
-    description: Example usage within a table.
+    description: Example usage of sticky ActionBar within a table.
     markup: |
       <div class="spectrum-Table spectrum-Table--sizeM spectrum-Table--quiet" role="grid">
         <div class="spectrum-Table-head" style="display: flex" role="row">
@@ -317,18 +353,15 @@ examples:
           </div>
           <div class="spectrum-ActionBar spectrum-ActionBar--sticky is-open">
             <div class="spectrum-Popover spectrum-ActionBar-popover is-open">
-              <label class="spectrum-Checkbox spectrum-Checkbox--sizeM is-indeterminate">
-                <input type="checkbox" class="spectrum-Checkbox-input">
-                <span class="spectrum-Checkbox-box">
-                  <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-                    <use xlink:href="#spectrum-css-icon-Checkmark100" />
-                  </svg>
-                  <svg class="spectrum-Icon spectrum-UIIcon-Dash100 spectrum-Checkbox-partialCheckmark" focusable="false" aria-hidden="true">
-                    <use xlink:href="#spectrum-css-icon-Dash100" />
-                  </svg>
-                </span>
-                <span class="spectrum-Checkbox-label">4 selected</span>
-              </label>
+
+          <button class="spectrum-CloseButton spectrum-CloseButton--sizeM">
+            <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Cross100" />
+            </svg>
+          </button>
+
+          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
+
               <div class="spectrum-ActionGroup">
                 <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
                   <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Edit">

--- a/components/actionbar/metadata/actionbar.yml
+++ b/components/actionbar/metadata/actionbar.yml
@@ -151,6 +151,73 @@ examples:
       </div>
 
 
+      <div class="spectrum-ActionBar spectrum-ActionBar--emphasized is-open">
+        <div class="spectrum-Popover spectrum-ActionBar-popover is-open">
+
+          <button class="spectrum-CloseButton spectrum-CloseButton--sizeM">
+            <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Cross100" />
+            </svg>
+          </button>
+
+          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
+
+          <div class="spectrum-ActionGroup">
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit"></use>
+              </svg>
+              <span class="spectrum-ActionButton-label">Edit</span>
+            </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Copy">
+                <use xlink:href="#spectrum-icon-18-Copy"></use>
+              </svg>
+              <span class="spectrum-ActionButton-label">Copy</span>
+            </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Delete">
+                <use xlink:href="#spectrum-icon-18-Delete"></use>
+              </svg>
+              <span class="spectrum-ActionButton-label">Delete</span>
+            </button>
+          </div>
+        </div>
+      </div>
+
+
+      <div class="spectrum-ActionBar spectrum-ActionBar--emphasized is-open">
+        <div class="spectrum-Popover spectrum-ActionBar-popover is-open">
+
+          <button class="spectrum-CloseButton spectrum-CloseButton--sizeM">
+            <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Cross100" />
+            </svg>
+          </button>
+
+          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
+
+          <div class="spectrum-ActionGroup">
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit"></use>
+              </svg>
+            </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Copy">
+                <use xlink:href="#spectrum-icon-18-Copy"></use>
+              </svg>
+            </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Delete">
+                <use xlink:href="#spectrum-icon-18-Delete"></use>
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+
+
   - id: actionbar
     name: Flexible
     description: Flexible Action Bars fit the width of their content.

--- a/components/actionbar/metadata/actionbar.yml
+++ b/components/actionbar/metadata/actionbar.yml
@@ -28,27 +28,24 @@ examples:
     markup: |
       <div class="spectrum-ActionBar is-open">
         <div class="spectrum-Popover spectrum-ActionBar-popover is-open">
-          <div class="spectrum-Popover-content">
+          <button class="spectrum-CloseButton spectrum-CloseButton--sizeM">
+            <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Cross100" />
+            </svg>
+          </button>
 
-            <button class="spectrum-CloseButton spectrum-CloseButton--sizeM">
-              <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
-                <use xlink:href="#spectrum-css-icon-Cross100" />
-              </svg>
+          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
+
+          <div class="spectrum-ActionGroup">
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+              <span class="spectrum-ActionButton-label">Edit</span>
             </button>
-
-            <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
-
-            <div class="spectrum-ActionGroup">
-              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-                <span class="spectrum-ActionButton-label">Edit</span>
-              </button>
-              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-                <span class="spectrum-ActionButton-label">Copy</span>
-              </button>
-              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-                <span class="spectrum-ActionButton-label">Delete</span>
-              </button>
-            </div>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+              <span class="spectrum-ActionButton-label">Copy</span>
+            </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+              <span class="spectrum-ActionButton-label">Delete</span>
+            </button>
           </div>
         </div>
       </div>
@@ -56,36 +53,33 @@ examples:
 
       <div class="spectrum-ActionBar is-open">
         <div class="spectrum-Popover spectrum-ActionBar-popover is-open">
-          <div class="spectrum-Popover-content">
+          <button class="spectrum-CloseButton spectrum-CloseButton--sizeM">
+            <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Cross100" />
+            </svg>
+          </button>
 
-            <button class="spectrum-CloseButton spectrum-CloseButton--sizeM">
-              <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
-                <use xlink:href="#spectrum-css-icon-Cross100" />
+          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
+
+          <div class="spectrum-ActionGroup">
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit"></use>
               </svg>
+              <span class="spectrum-ActionButton-label">Edit</span>
             </button>
-
-            <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
-
-            <div class="spectrum-ActionGroup">
-              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-                <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Edit">
-                  <use xlink:href="#spectrum-icon-18-Edit"></use>
-                </svg>
-                <span class="spectrum-ActionButton-label">Edit</span>
-              </button>
-              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-                <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Copy">
-                  <use xlink:href="#spectrum-icon-18-Copy"></use>
-                </svg>
-                <span class="spectrum-ActionButton-label">Copy</span>
-              </button>
-              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-                <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Delete">
-                  <use xlink:href="#spectrum-icon-18-Delete"></use>
-                </svg>
-                <span class="spectrum-ActionButton-label">Delete</span>
-              </button>
-            </div>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Copy">
+                <use xlink:href="#spectrum-icon-18-Copy"></use>
+              </svg>
+              <span class="spectrum-ActionButton-label">Copy</span>
+            </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Delete">
+                <use xlink:href="#spectrum-icon-18-Delete"></use>
+              </svg>
+              <span class="spectrum-ActionButton-label">Delete</span>
+            </button>
           </div>
         </div>
       </div>
@@ -93,32 +87,30 @@ examples:
 
       <div class="spectrum-ActionBar is-open">
         <div class="spectrum-Popover spectrum-ActionBar-popover is-open">
-          <div class="spectrum-Popover-content">
-            <button class="spectrum-CloseButton spectrum-CloseButton--sizeM">
-              <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
-                <use xlink:href="#spectrum-css-icon-Cross100" />
+          <button class="spectrum-CloseButton spectrum-CloseButton--sizeM">
+            <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Cross100" />
+            </svg>
+          </button>
+
+          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
+
+          <div class="spectrum-ActionGroup">
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit"></use>
               </svg>
             </button>
-
-            <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
-
-            <div class="spectrum-ActionGroup">
-              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-                <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Edit">
-                  <use xlink:href="#spectrum-icon-18-Edit"></use>
-                </svg>
-              </button>
-              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-                <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Copy">
-                  <use xlink:href="#spectrum-icon-18-Copy"></use>
-                </svg>
-              </button>
-              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-                <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Delete">
-                  <use xlink:href="#spectrum-icon-18-Delete"></use>
-                </svg>
-              </button>
-            </div>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Copy">
+                <use xlink:href="#spectrum-icon-18-Copy"></use>
+              </svg>
+            </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Delete">
+                <use xlink:href="#spectrum-icon-18-Delete"></use>
+              </svg>
+            </button>
           </div>
         </div>
       </div>
@@ -130,26 +122,24 @@ examples:
     markup: |
       <div class="spectrum-ActionBar spectrum-ActionBar--emphasized is-open">
         <div class="spectrum-Popover spectrum-ActionBar-popover is-open">
-          <div class="spectrum-Popover-content">
-            <button class="spectrum-CloseButton spectrum-CloseButton--sizeM">
-              <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
-                <use xlink:href="#spectrum-css-icon-Cross100" />
-              </svg>
+          <button class="spectrum-CloseButton spectrum-CloseButton--sizeM">
+            <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Cross100" />
+            </svg>
+          </button>
+
+          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
+
+          <div class="spectrum-ActionGroup">
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+              <span class="spectrum-ActionButton-label">Edit</span>
             </button>
-
-            <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
-
-            <div class="spectrum-ActionGroup">
-              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-                <span class="spectrum-ActionButton-label">Edit</span>
-              </button>
-              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-                <span class="spectrum-ActionButton-label">Copy</span>
-              </button>
-              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-                <span class="spectrum-ActionButton-label">Delete</span>
-              </button>
-            </div>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+              <span class="spectrum-ActionButton-label">Copy</span>
+            </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+              <span class="spectrum-ActionButton-label">Delete</span>
+            </button>
           </div>
         </div>
       </div>
@@ -157,35 +147,33 @@ examples:
 
       <div class="spectrum-ActionBar spectrum-ActionBar--emphasized is-open">
         <div class="spectrum-Popover spectrum-ActionBar-popover is-open">
-          <div class="spectrum-Popover-content">
-            <button class="spectrum-CloseButton spectrum-CloseButton--sizeM">
-              <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
-                <use xlink:href="#spectrum-css-icon-Cross100" />
+          <button class="spectrum-CloseButton spectrum-CloseButton--sizeM">
+            <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Cross100" />
+            </svg>
+          </button>
+
+          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
+
+          <div class="spectrum-ActionGroup">
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit"></use>
               </svg>
+              <span class="spectrum-ActionButton-label">Edit</span>
             </button>
-
-            <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
-
-            <div class="spectrum-ActionGroup">
-              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-                <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Edit">
-                  <use xlink:href="#spectrum-icon-18-Edit"></use>
-                </svg>
-                <span class="spectrum-ActionButton-label">Edit</span>
-              </button>
-              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-                <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Copy">
-                  <use xlink:href="#spectrum-icon-18-Copy"></use>
-                </svg>
-                <span class="spectrum-ActionButton-label">Copy</span>
-              </button>
-              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-                <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Delete">
-                  <use xlink:href="#spectrum-icon-18-Delete"></use>
-                </svg>
-                <span class="spectrum-ActionButton-label">Delete</span>
-              </button>
-            </div>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Copy">
+                <use xlink:href="#spectrum-icon-18-Copy"></use>
+              </svg>
+              <span class="spectrum-ActionButton-label">Copy</span>
+            </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Delete">
+                <use xlink:href="#spectrum-icon-18-Delete"></use>
+              </svg>
+              <span class="spectrum-ActionButton-label">Delete</span>
+            </button>
           </div>
         </div>
       </div>
@@ -193,33 +181,32 @@ examples:
 
       <div class="spectrum-ActionBar spectrum-ActionBar--emphasized is-open">
         <div class="spectrum-Popover spectrum-ActionBar-popover is-open">
-          <div class="spectrum-Popover-content">
-            <button class="spectrum-CloseButton spectrum-CloseButton--sizeM">
-              <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
-                <use xlink:href="#spectrum-css-icon-Cross100" />
+          <button class="spectrum-CloseButton spectrum-CloseButton--sizeM">
+            <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Cross100" />
+            </svg>
+          </button>
+
+          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
+
+          <div class="spectrum-ActionGroup">
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit"></use>
               </svg>
             </button>
-
-            <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
-
-            <div class="spectrum-ActionGroup">
-              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-                <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Edit">
-                  <use xlink:href="#spectrum-icon-18-Edit"></use>
-                </svg>
-              </button>
-              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-                <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Copy">
-                  <use xlink:href="#spectrum-icon-18-Copy"></use>
-                </svg>
-              </button>
-              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-                <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Delete">
-                  <use xlink:href="#spectrum-icon-18-Delete"></use>
-                </svg>
-              </button>
-            </div>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Copy">
+                <use xlink:href="#spectrum-icon-18-Copy"></use>
+              </svg>
+            </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Delete">
+                <use xlink:href="#spectrum-icon-18-Delete"></use>
+              </svg>
+            </button>
           </div>
+        </div>
         </div>
       </div>
 
@@ -230,27 +217,25 @@ examples:
     markup: |
       <div class="spectrum-ActionBar spectrum-ActionBar--flexible is-open">
         <div class="spectrum-Popover spectrum-ActionBar-popover is-open">
-          <div class="spectrum-Popover-content">
-            <button class="spectrum-CloseButton spectrum-CloseButton--sizeM">
-              <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
-                <use xlink:href="#spectrum-css-icon-Cross100" />
+          <button class="spectrum-CloseButton spectrum-CloseButton--sizeM">
+            <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Cross100" />
+            </svg>
+          </button>
+
+          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
+
+          <div class="spectrum-ActionGroup">
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit"></use>
               </svg>
             </button>
-
-            <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
-
-            <div class="spectrum-ActionGroup">
-              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-                <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Edit">
-                  <use xlink:href="#spectrum-icon-18-Edit"></use>
-                </svg>
-              </button>
-              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-                <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="More">
-                  <use xlink:href="#spectrum-icon-18-More"></use>
-                </svg>
-              </button>
-            </div>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="More">
+                <use xlink:href="#spectrum-icon-18-More"></use>
+              </svg>
+            </button>
           </div>
         </div>
       </div>
@@ -428,38 +413,35 @@ examples:
 
           <div class="spectrum-ActionBar spectrum-ActionBar--sticky is-open">
             <div class="spectrum-Popover spectrum-ActionBar-popover is-open">
-              <div class="spectrum-Popover-content">
-                <button class="spectrum-CloseButton spectrum-CloseButton--sizeM">
-                  <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
-                    <use xlink:href="#spectrum-css-icon-Cross100" />
+              <button class="spectrum-CloseButton spectrum-CloseButton--sizeM">
+                <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
+                  <use xlink:href="#spectrum-css-icon-Cross100" />
+                </svg>
+              </button>
+
+              <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
+
+              <div class="spectrum-ActionGroup">
+                <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+                  <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Edit">
+                    <use xlink:href="#spectrum-icon-18-Edit"></use>
                   </svg>
+                  <span class="spectrum-ActionButton-label">Edit</span>
                 </button>
-
-                <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
-
-                    <div class="spectrum-ActionGroup">
-                      <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-                        <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Edit">
-                          <use xlink:href="#spectrum-icon-18-Edit"></use>
-                        </svg>
-                        <span class="spectrum-ActionButton-label">Edit</span>
-                      </button>
-                      <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-                        <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Copy">
-                          <use xlink:href="#spectrum-icon-18-Copy"></use>
-                        </svg>
-                        <span class="spectrum-ActionButton-label">Copy</span>
-                      </button>
-                      <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-                        <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Delete">
-                          <use xlink:href="#spectrum-icon-18-Delete"></use>
-                        </svg>
-                        <span class="spectrum-ActionButton-label">Delete</span>
-                      </button>
-                    </div>
-                  </div>
-                </div>
+                <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+                  <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Copy">
+                    <use xlink:href="#spectrum-icon-18-Copy"></use>
+                  </svg>
+                  <span class="spectrum-ActionButton-label">Copy</span>
+                </button>
+                <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+                  <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Delete">
+                    <use xlink:href="#spectrum-icon-18-Delete"></use>
+                  </svg>
+                  <span class="spectrum-ActionButton-label">Delete</span>
+                </button>
               </div>
-
+            </div>
+          </div>
         </div>
       </div>

--- a/components/actionbar/metadata/actionbar.yml
+++ b/components/actionbar/metadata/actionbar.yml
@@ -207,7 +207,6 @@ examples:
             </button>
           </div>
         </div>
-        </div>
       </div>
 
 

--- a/components/actionbar/metadata/actionbar.yml
+++ b/components/actionbar/metadata/actionbar.yml
@@ -124,7 +124,7 @@ examples:
     markup: |
       <div class="spectrum-ActionBar spectrum-ActionBar--emphasized is-open">
         <div class="spectrum-Popover spectrum-ActionBar-popover is-open">
-          <button class="spectrum-CloseButton spectrum-CloseButton--sizeM">
+          <button class="spectrum-CloseButton spectrum-CloseButton--sizeM spectrum-CloseButton--staticWhite">
             <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
               <use xlink:href="#spectrum-css-icon-Cross100" />
             </svg>
@@ -149,7 +149,7 @@ examples:
 
       <div class="spectrum-ActionBar spectrum-ActionBar--emphasized is-open">
         <div class="spectrum-Popover spectrum-ActionBar-popover is-open">
-          <button class="spectrum-CloseButton spectrum-CloseButton--sizeM">
+          <button class="spectrum-CloseButton spectrum-CloseButton--sizeM spectrum-CloseButton--staticWhite">
             <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
               <use xlink:href="#spectrum-css-icon-Cross100" />
             </svg>
@@ -183,7 +183,7 @@ examples:
 
       <div class="spectrum-ActionBar spectrum-ActionBar--emphasized is-open">
         <div class="spectrum-Popover spectrum-ActionBar-popover is-open">
-          <button class="spectrum-CloseButton spectrum-CloseButton--sizeM">
+          <button class="spectrum-CloseButton spectrum-CloseButton--sizeM spectrum-CloseButton--staticWhite">
             <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
               <use xlink:href="#spectrum-css-icon-Cross100" />
             </svg>

--- a/components/actionbar/metadata/actionbar.yml
+++ b/components/actionbar/metadata/actionbar.yml
@@ -15,6 +15,8 @@ sections:
       ### New Action Button markup
       Action Button requires `.spectrum-ActionButton-icon` class on icons nested inside of Action Button.
 
+      Emphasized Action Bar requires `.spectrum-ActionButton-staticWhite` class on Action Button.
+
       ### New ActionGroup markup
       Action Bar now uses the new ActionGroup markup. Replace `.spectrum-ButtonGroup` with `.spectrum-ActionGroup` and apply `.spectrum-ActionGroup-item` to each action button. See the [Action Group](actiongroup.html) for more information.
 
@@ -131,13 +133,13 @@ examples:
           <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
 
           <div class="spectrum-ActionGroup">
-            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionButton--staticWhite spectrum-ActionGroup-item">
               <span class="spectrum-ActionButton-label">Edit</span>
             </button>
-            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionButton--staticWhite spectrum-ActionGroup-item">
               <span class="spectrum-ActionButton-label">Copy</span>
             </button>
-            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionButton--staticWhite spectrum-ActionGroup-item">
               <span class="spectrum-ActionButton-label">Delete</span>
             </button>
           </div>
@@ -156,19 +158,19 @@ examples:
           <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
 
           <div class="spectrum-ActionGroup">
-            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionButton--staticWhite spectrum-ActionGroup-item">
               <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Edit">
                 <use xlink:href="#spectrum-icon-18-Edit"></use>
               </svg>
               <span class="spectrum-ActionButton-label">Edit</span>
             </button>
-            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionButton--staticWhite spectrum-ActionGroup-item">
               <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Copy">
                 <use xlink:href="#spectrum-icon-18-Copy"></use>
               </svg>
               <span class="spectrum-ActionButton-label">Copy</span>
             </button>
-            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionButton--staticWhite spectrum-ActionGroup-item">
               <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Delete">
                 <use xlink:href="#spectrum-icon-18-Delete"></use>
               </svg>
@@ -190,17 +192,17 @@ examples:
           <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
 
           <div class="spectrum-ActionGroup">
-            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionButton--staticWhite spectrum-ActionGroup-item">
               <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Edit">
                 <use xlink:href="#spectrum-icon-18-Edit"></use>
               </svg>
             </button>
-            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionButton--staticWhite spectrum-ActionGroup-item">
               <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Copy">
                 <use xlink:href="#spectrum-icon-18-Copy"></use>
               </svg>
             </button>
-            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionButton--staticWhite spectrum-ActionGroup-item">
               <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Delete">
                 <use xlink:href="#spectrum-icon-18-Delete"></use>
               </svg>

--- a/components/actionbar/metadata/actionbar.yml
+++ b/components/actionbar/metadata/actionbar.yml
@@ -38,7 +38,7 @@ examples:
 
           <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
 
-          <div class="spectrum-ActionGroup">
+          <div class="spectrum-ActionGroup spectrum-ActionGroup--sizeM">
             <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
               <span class="spectrum-ActionButton-label">Edit</span>
             </button>
@@ -63,7 +63,7 @@ examples:
 
           <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
 
-          <div class="spectrum-ActionGroup">
+          <div class="spectrum-ActionGroup spectrum-ActionGroup--sizeM">
             <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
               <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Edit">
                 <use xlink:href="#spectrum-icon-18-Edit"></use>
@@ -97,7 +97,7 @@ examples:
 
           <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
 
-          <div class="spectrum-ActionGroup">
+          <div class="spectrum-ActionGroup spectrum-ActionGroup--sizeM">
             <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
               <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Edit">
                 <use xlink:href="#spectrum-icon-18-Edit"></use>
@@ -132,7 +132,7 @@ examples:
 
           <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
 
-          <div class="spectrum-ActionGroup">
+          <div class="spectrum-ActionGroup spectrum-ActionGroup--sizeM">
             <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionButton--staticWhite spectrum-ActionGroup-item">
               <span class="spectrum-ActionButton-label">Edit</span>
             </button>
@@ -157,7 +157,7 @@ examples:
 
           <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
 
-          <div class="spectrum-ActionGroup">
+          <div class="spectrum-ActionGroup spectrum-ActionGroup--sizeM">
             <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionButton--staticWhite spectrum-ActionGroup-item">
               <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Edit">
                 <use xlink:href="#spectrum-icon-18-Edit"></use>
@@ -191,7 +191,7 @@ examples:
 
           <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
 
-          <div class="spectrum-ActionGroup">
+          <div class="spectrum-ActionGroup spectrum-ActionGroup--sizeM">
             <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionButton--staticWhite spectrum-ActionGroup-item">
               <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Edit">
                 <use xlink:href="#spectrum-icon-18-Edit"></use>
@@ -226,7 +226,7 @@ examples:
 
           <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">2 Selected</label>
 
-          <div class="spectrum-ActionGroup">
+          <div class="spectrum-ActionGroup spectrum-ActionGroup--sizeM">
             <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
               <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true" aria-label="Edit">
                 <use xlink:href="#spectrum-icon-18-Edit"></use>

--- a/components/actionbar/package.json
+++ b/components/actionbar/package.json
@@ -21,17 +21,17 @@
     "@spectrum-css/checkbox": "^3.1.1",
     "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/popover": "^5.0.0",
-    "@spectrum-css/vars": "^8.0.0"
+    "@spectrum-css/tokens": "^1.0.4"
   },
   "devDependencies": {
     "@spectrum-css/actionbutton": "^1.1.14",
     "@spectrum-css/actiongroup": "^2.0.0",
     "@spectrum-css/checkbox": "^3.1.3",
-    "@spectrum-css/component-builder": "^3.2.0",
+    "@spectrum-css/component-builder-simple": "^1.0.0-beta.0",
     "@spectrum-css/icon": "^3.0.23",
     "@spectrum-css/popover": "^5.0.18",
     "@spectrum-css/table": "^4.0.19",
-    "@spectrum-css/vars": "^8.0.0",
+    "@spectrum-css/tokens": "^1.0.4",
     "gulp": "^4.0.0"
   },
   "publishConfig": {

--- a/components/actionbar/package.json
+++ b/components/actionbar/package.json
@@ -17,23 +17,23 @@
   },
   "peerDependencies": {
     "@spectrum-css/actionbutton": "^2.1.3",
-    "@spectrum-css/actiongroup": "3.0.0-beta.0",
+    "@spectrum-css/actiongroup": "^3.0.0-beta.0",
     "@spectrum-css/closebutton": "^2.0.2",
     "@spectrum-css/fieldlabel": "^4.0.29",
     "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/popover": "^5.0.0",
-    "@spectrum-css/tokens": "^1.0.4"
+    "@spectrum-css/tokens": "^1.0.7"
   },
   "devDependencies": {
     "@spectrum-css/actionbutton": "^2.1.3",
-    "@spectrum-css/actiongroup": "3.0.0-beta.0",
+    "@spectrum-css/actiongroup": "^3.0.0-beta.0",
     "@spectrum-css/closebutton": "^2.0.2",
     "@spectrum-css/fieldlabel": "^4.0.29",
     "@spectrum-css/component-builder-simple": "^1.0.0-beta.0",
     "@spectrum-css/icon": "^3.0.23",
     "@spectrum-css/popover": "^5.0.18",
     "@spectrum-css/table": "^4.0.19",
-    "@spectrum-css/tokens": "^1.0.4",
+    "@spectrum-css/tokens": "^1.0.7",
     "gulp": "^4.0.0"
   },
   "publishConfig": {

--- a/components/actionbar/package.json
+++ b/components/actionbar/package.json
@@ -16,17 +16,19 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/actionbutton": "^1.1.13",
-    "@spectrum-css/actiongroup": "^2.0.0",
-    "@spectrum-css/checkbox": "^3.1.1",
+    "@spectrum-css/actionbutton": "^2.1.3",
+    "@spectrum-css/actiongroup": "3.0.0-beta.0",
+    "@spectrum-css/closebutton": "^2.0.2",
+    "@spectrum-css/fieldlabel": "^4.0.29",
     "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/popover": "^5.0.0",
     "@spectrum-css/tokens": "^1.0.4"
   },
   "devDependencies": {
-    "@spectrum-css/actionbutton": "^1.1.14",
-    "@spectrum-css/actiongroup": "^2.0.0",
-    "@spectrum-css/checkbox": "^3.1.3",
+    "@spectrum-css/actionbutton": "^2.1.3",
+    "@spectrum-css/actiongroup": "3.0.0-beta.0",
+    "@spectrum-css/closebutton": "^2.0.2",
+    "@spectrum-css/fieldlabel": "^4.0.29",
     "@spectrum-css/component-builder-simple": "^1.0.0-beta.0",
     "@spectrum-css/icon": "^3.0.23",
     "@spectrum-css/popover": "^5.0.18",

--- a/components/actionbar/package.json
+++ b/components/actionbar/package.json
@@ -17,7 +17,7 @@
   },
   "peerDependencies": {
     "@spectrum-css/actionbutton": "^2.1.3",
-    "@spectrum-css/actiongroup": "^3.0.0-beta.0",
+    "@spectrum-css/actiongroup": "^3.0.0",
     "@spectrum-css/closebutton": "^2.0.2",
     "@spectrum-css/fieldlabel": "^4.0.29",
     "@spectrum-css/icon": "^3.0.21",
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@spectrum-css/actionbutton": "^2.1.3",
-    "@spectrum-css/actiongroup": "^3.0.0-beta.0",
+    "@spectrum-css/actiongroup": "^3.0.0",
     "@spectrum-css/closebutton": "^2.0.2",
     "@spectrum-css/fieldlabel": "^4.0.29",
     "@spectrum-css/component-builder-simple": "^1.0.0-beta.0",

--- a/components/actionbar/package.json
+++ b/components/actionbar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spectrum-css/actionbar",
-  "version": "5.0.0-beta.1",
+  "version": "5.0.0-beta.2",
   "description": "The Spectrum CSS actionbar component",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",

--- a/components/actionbar/package.json
+++ b/components/actionbar/package.json
@@ -22,7 +22,7 @@
     "@spectrum-css/fieldlabel": "^4.0.29",
     "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/popover": "^5.0.0",
-    "@spectrum-css/tokens": "^1.0.7"
+    "@spectrum-css/tokens": "^3.0.0"
   },
   "devDependencies": {
     "@spectrum-css/actionbutton": "^2.1.3",
@@ -33,7 +33,7 @@
     "@spectrum-css/icon": "^3.0.23",
     "@spectrum-css/popover": "^5.0.18",
     "@spectrum-css/table": "^4.0.19",
-    "@spectrum-css/tokens": "^1.0.7",
+    "@spectrum-css/tokens": "^3.0.0",
     "gulp": "^4.0.0"
   },
   "publishConfig": {

--- a/components/actionbar/package.json
+++ b/components/actionbar/package.json
@@ -18,7 +18,7 @@
   "peerDependencies": {
     "@spectrum-css/actionbutton": "^2.1.3",
     "@spectrum-css/actiongroup": "^3.0.0",
-    "@spectrum-css/closebutton": "^2.0.2",
+    "@spectrum-css/closebutton": "^3.0.0",
     "@spectrum-css/fieldlabel": "^4.0.29",
     "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/popover": "^5.0.0",
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@spectrum-css/actionbutton": "^2.1.3",
     "@spectrum-css/actiongroup": "^3.0.0",
-    "@spectrum-css/closebutton": "^2.0.2",
+    "@spectrum-css/closebutton": "^3.0.0",
     "@spectrum-css/fieldlabel": "^4.0.29",
     "@spectrum-css/component-builder-simple": "^1.0.0-beta.0",
     "@spectrum-css/icon": "^3.0.23",

--- a/components/actionbar/package.json
+++ b/components/actionbar/package.json
@@ -22,7 +22,7 @@
     "@spectrum-css/fieldlabel": "^4.0.29",
     "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/popover": "^5.0.0",
-    "@spectrum-css/tokens": "^3.0.0"
+    "@spectrum-css/tokens": "^4.0.0"
   },
   "devDependencies": {
     "@spectrum-css/actionbutton": "^2.1.3",
@@ -33,7 +33,7 @@
     "@spectrum-css/icon": "^3.0.23",
     "@spectrum-css/popover": "^5.0.18",
     "@spectrum-css/table": "^4.0.19",
-    "@spectrum-css/tokens": "^3.0.0",
+    "@spectrum-css/tokens": "^4.0.0",
     "gulp": "^4.0.0"
   },
   "publishConfig": {

--- a/components/actionbar/package.json
+++ b/components/actionbar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spectrum-css/actionbar",
-  "version": "4.0.1",
+  "version": "5.0.0-beta.0",
   "description": "The Spectrum CSS actionbar component",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",

--- a/components/actionbar/package.json
+++ b/components/actionbar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spectrum-css/actionbar",
-  "version": "5.0.0-beta.0",
+  "version": "5.0.0-beta.1",
   "description": "The Spectrum CSS actionbar component",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",

--- a/components/actionbar/package.json
+++ b/components/actionbar/package.json
@@ -16,20 +16,20 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/actionbutton": "^2.1.3",
-    "@spectrum-css/actiongroup": "^3.0.0",
+    "@spectrum-css/actionbutton": "^3.0.0",
+    "@spectrum-css/actiongroup": "^3.0.1",
     "@spectrum-css/closebutton": "^3.0.0",
-    "@spectrum-css/fieldlabel": "^4.0.29",
+    "@spectrum-css/fieldlabel": "^5.0.2",
     "@spectrum-css/icon": "^3.0.21",
     "@spectrum-css/popover": "^5.0.0",
     "@spectrum-css/tokens": "^4.0.0"
   },
   "devDependencies": {
-    "@spectrum-css/actionbutton": "^2.1.3",
-    "@spectrum-css/actiongroup": "^3.0.0",
+    "@spectrum-css/actionbutton": "^3.0.0",
+    "@spectrum-css/actiongroup": "^3.0.1",
     "@spectrum-css/closebutton": "^3.0.0",
-    "@spectrum-css/fieldlabel": "^4.0.29",
-    "@spectrum-css/component-builder-simple": "^1.0.0-beta.0",
+    "@spectrum-css/fieldlabel": "^5.0.2",
+    "@spectrum-css/component-builder-simple": "^2.0.0",
     "@spectrum-css/icon": "^3.0.23",
     "@spectrum-css/popover": "^5.0.18",
     "@spectrum-css/table": "^4.0.19",

--- a/components/actionbar/themes/express.css
+++ b/components/actionbar/themes/express.css
@@ -1,0 +1,15 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+@container (--system: express) {
+
+}

--- a/components/actionbar/themes/spectrum.css
+++ b/components/actionbar/themes/spectrum.css
@@ -1,0 +1,15 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+@container (--system: spectrum) {
+
+}


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
BREAKING CHANGE: This migrates the ActionBar component to core tokens.
- Jira issue CSS-121 https://jira.corp.adobe.com/browse/CSS-121

## How and where has this been tested?
 - Chrome 103 for macOS
 - Firefox 102 for macOS
 - Safari 15.5 for macOS
 - **How this was tested:** comparing local build of http://localhost:3000/docs/actionbar.html with XD redline components batch 2 and with https://spectrum.adobe.com/page/actionbar

## Screenshots
Standard:
<img width="838" alt="Screen Shot 2022-09-07 at 2 56 45 PM" src="https://user-images.githubusercontent.com/25614178/188956368-a9f87aa9-69d5-4220-8123-bba141353a4d.png">

Emphasized:
<img width="840" alt="Screen Shot 2022-09-07 at 2 56 49 PM" src="https://user-images.githubusercontent.com/25614178/188956394-f63b11ca-6acd-4d07-8016-12d56953d4d8.png">

Flexible width:
<img width="1223" alt="Screen Shot 2022-09-07 at 2 57 10 PM" src="https://user-images.githubusercontent.com/25614178/188956395-04bb898b-5037-413c-a017-6b744cba43b4.png">

Sticky:
<img width="1216" alt="Screen Shot 2022-09-07 at 2 57 19 PM" src="https://user-images.githubusercontent.com/25614178/188956396-c254e922-8f90-44a1-8534-5954ddfe6c68.png">

## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
