### PR TITLE
fix(tabs): selection indicator scroll overflow border

### DIFF
--- a/components/tabs/index.css
+++ b/components/tabs/index.css
@@ -163,8 +163,6 @@ governing permissions and limitations under the License.
 .spectrum-Tabs--horizontal {
   align-items: center;
 
-  border-block-end: var(--spectrum-tabs-quiet-textonly-divider-size) solid;
-
   .spectrum-Tabs-item {
     vertical-align: top;
 
@@ -178,8 +176,6 @@ governing permissions and limitations under the License.
     position: absolute;
     inset-block-end: 0;
     block-size: var(--spectrum-tabs-quiet-textonly-divider-size);
-
-    inset-block-end: calc(-1 * var(--spectrum-tabs-quiet-textonly-divider-size));
   }
 
 
@@ -200,7 +196,6 @@ governing permissions and limitations under the License.
   display: inline-flex;
   flex-direction: column;
   padding: 0;
-  border-inline-start: var(--spectrum-tabs-quiet-textonly-divider-size) solid;
 
   .spectrum-Tabs-item {
     block-size: var(--spectrum-tabs-vertical-textonly-tabitem-height);
@@ -240,7 +235,5 @@ governing permissions and limitations under the License.
     position: absolute;
     inset-inline-start: 0px;
     inline-size: var(--spectrum-tabs-quiet-textonly-divider-size);
-
-    inset-inline-start: calc(-1 * var(--spectrum-tabs-quiet-textonly-divider-size));
   }
 }

--- a/components/tabs/skin.css
+++ b/components/tabs/skin.css
@@ -11,11 +11,27 @@ governing permissions and limitations under the License.
 */
 
 .spectrum-Tabs {
-  border-block-end-color: var(--spectrum-tabs-textonly-divider-background-color);
+  --spectrum-tabs-list-background-direction: top;
+
+  background: linear-gradient(
+    to var(--spectrum-tabs-list-background-direction),
+    var(--spectrum-tabs-textonly-divider-background-color) 0 var(--spectrum-tabs-quiet-textonly-divider-size),
+    transparent var(--spectrum-tabs-quiet-textonly-divider-size)
+  );
 }
 
 .spectrum-Tabs--vertical {
-  border-inline-start-color: var(--spectrum-tabs-vertical-textonly-divider-background-color);
+  --spectrum-tabs-list-background-direction: right;
+}
+
+.spectrum-Tabs--quiet,
+.spectrum-Tabs--quiet.spectrum-Tabs--compact,
+.spectrum-Tabs--vertical.spectrum-Tabs--compact {
+  --spectrum-tabs-textonly-divider-background-color: var(--spectrum-tabs-quiet-textonly-divider-background-color);
+}
+
+.spectrum-Tabs--vertical.spectrum-Tabs--emphasized {
+  --spectrum-tabs-textonly-divider-background-color: var(--spectrum-tabs-emphasized-textonly-divider-background-color);
 }
 
 .spectrum-Tabs-selectionIndicator {
@@ -101,15 +117,12 @@ governing permissions and limitations under the License.
 .spectrum-Tabs--vertical {
   &.spectrum-Tabs--quiet,
   &.spectrum-Tabs--compact {
-    border-inline-start-color: var(--spectrum-tabs-vertical-quiet-textonly-divider-background-color);
-
     .spectrum-Tabs-selectionIndicator {
       background-color: var(--spectrum-tabs-vertical-textonly-tabitem-selection-indicator-background-color-selected);
     }
   }
 
   &.spectrum-Tabs--emphasized {
-    border-inline-start-color: var(--spectrum-tabs-emphasized-textonly-divider-background-color);
     .spectrum-Tabs-selectionIndicator {
       background-color: var(--spectrum-tabs-emphasized-texticon-tabitem-selection-indicator-background-color-selected);
     }


### PR DESCRIPTION
## Description

Resolves an issue with the selection indicator border when there is scrollable overflow.

Updated with the recommended solution using the background linear gradient rather than background-color.

## How and where has this been tested?
 
Set `.spectrum-Tabs` width to less than the widths of its `.spectrum-Tab-item` children combined e.g. `200px`. Set `.spectrum-Tabs` to `overflow: auto`.  See examples of the bug and fix below.

#### Bug
https://user-images.githubusercontent.com/16216104/194005007-e61b01ee-3f0d-4563-b2c4-a127217171a0.mp4

#### Fixed

https://user-images.githubusercontent.com/16216104/194003987-77d9c0f5-9aad-49f2-b57a-229ef2226e51.mp4

## Screenshots

## To-do list
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] This pull request is ready to merge.
