### PR TITLE
refactor(buttongroup)!: migrate to core tokens

### DIFF
--- a/components/buttongroup/gulpfile.js
+++ b/components/buttongroup/gulpfile.js
@@ -1,1 +1,1 @@
-module.exports = require('@spectrum-css/component-builder');
+module.exports = require('@spectrum-css/component-builder-simple');

--- a/components/buttongroup/index.css
+++ b/components/buttongroup/index.css
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Adobe. All rights reserved.
+Copyright 2022 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -11,7 +11,28 @@ governing permissions and limitations under the License.
 */
 
 .spectrum-ButtonGroup {
-  --spectrum-buttongroup-button-gap-reset: 0;
+  --spectrum-buttongroup-spacing-horizontal: var(--spectrum-spacing-300);
+  --spectrum-buttongroup-spacing-vertical: var(--spectrum-spacing-300);
+}
+
+.spectrum-ButtonGroup--sizeS {
+  --spectrum-buttongroup-spacing-horizontal: var(--spectrum-spacing-200);
+  --spectrum-buttongroup-spacing-vertical: var(--spectrum-spacing-200);
+}
+
+.spectrum-ButtonGroup--sizeM {
+  --spectrum-buttongroup-spacing-horizontal: var(--spectrum-spacing-300);
+  --spectrum-buttongroup-spacing-vertical: var(--spectrum-spacing-300);
+}
+
+.spectrum-ButtonGroup--sizeL {
+  --spectrum-buttongroup-spacing-horizontal: var(--spectrum-spacing-300);
+  --spectrum-buttongroup-spacing-vertical: var(--spectrum-spacing-300);
+}
+
+.spectrum-ButtonGroup--sizeXL {
+  --spectrum-buttongroup-spacing-horizontal: var(--spectrum-spacing-300);
+  --spectrum-buttongroup-spacing-vertical: var(--spectrum-spacing-300);
 }
 
 .spectrum-ButtonGroup {
@@ -22,7 +43,7 @@ governing permissions and limitations under the License.
   }
 
   .spectrum-ButtonGroup-item + .spectrum-ButtonGroup-item {
-    margin-inline-start: var(--spectrum-buttongroup-button-gap-x);
+    margin-inline-start: var(--mod-buttongroup-spacing-horizontal, var(--spectrum-buttongroup-spacing-horizontal));
   }
 }
 
@@ -31,7 +52,7 @@ governing permissions and limitations under the License.
   flex-direction: column;
 
   .spectrum-ButtonGroup-item + .spectrum-ButtonGroup-item {
-    margin-block-start: var(--spectrum-buttongroup-button-gap-y);
-    margin-inline-start: var(--spectrum-buttongroup-button-gap-reset);
+    margin-block-start: var(--mod-buttongroup-spacing-vertical, var(--spectrum-buttongroup-spacing-vertical));
+    margin-inline-start: 0;
   }
 }

--- a/components/buttongroup/index.css
+++ b/components/buttongroup/index.css
@@ -37,22 +37,16 @@ governing permissions and limitations under the License.
 
 .spectrum-ButtonGroup {
   display: flex;
+  flex-wrap: wrap;
+  gap: var(--mod-buttongroup-spacing-horizontal, var(--spectrum-buttongroup-spacing-horizontal));
 
   .spectrum-ButtonGroup-item {
     flex-shrink: 0;
-  }
-
-  .spectrum-ButtonGroup-item + .spectrum-ButtonGroup-item {
-    margin-inline-start: var(--mod-buttongroup-spacing-horizontal, var(--spectrum-buttongroup-spacing-horizontal));
   }
 }
 
 .spectrum-ButtonGroup--vertical {
   display: inline-flex;
   flex-direction: column;
-
-  .spectrum-ButtonGroup-item + .spectrum-ButtonGroup-item {
-    margin-block-start: var(--mod-buttongroup-spacing-vertical, var(--spectrum-buttongroup-spacing-vertical));
-    margin-inline-start: 0;
-  }
+  gap: var(--mod-buttongroup-spacing-vertical, var(--spectrum-buttongroup-spacing-vertical));
 }

--- a/components/buttongroup/metadata/buttongroup.yml
+++ b/components/buttongroup/metadata/buttongroup.yml
@@ -1,8 +1,10 @@
 name: Button Group
 SpectrumSiteSlug: https://spectrum.adobe.com/page/button/
 examples:
-  - id: buttongroup
+  - id: buttongroup-horizontal
     name: Horizontal
+    description: |
+      Default spacing for Medium, Large, and Extra Large t-shirt sizes.
     markup: |
       <div class="spectrum-ButtonGroup">
         <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--outline spectrum-Button--secondary spectrum-ButtonGroup-item">
@@ -16,8 +18,27 @@ examples:
         </button>
       </div>
 
-  - id: buttongroup
+  - id: buttongroup-horizontal-small
+    name: Horizontal - Small
+    description: |
+      Spacing for the Small t-shirt size.
+    markup: |
+      <div class="spectrum-ButtonGroup spectrum-ButtonGroup--sizeS">
+        <button class="spectrum-Button spectrum-Button--sizeS spectrum-Button--outline spectrum-Button--secondary spectrum-ButtonGroup-item">
+          <span class="spectrum-Button-label">No, thanks</span>
+        </button>
+        <button class="spectrum-Button spectrum-Button--sizeS spectrum-Button--outline spectrum-Button--secondary spectrum-ButtonGroup-item">
+          <span class="spectrum-Button-label">Remind me later</span>
+        </button>
+        <button class="spectrum-Button spectrum-Button--sizeS spectrum-Button--fill spectrum-Button--primary spectrum-ButtonGroup-item">
+          <span class="spectrum-Button-label">Rate now</span>
+        </button>
+      </div>
+
+  - id: buttongroup-vertical
     name: Vertical
+    description: |
+      Default spacing for Medium, Large, and Extra Large t-shirt sizes.
     markup: |
       <div class="spectrum-ButtonGroup spectrum-ButtonGroup--vertical">
         <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--outline spectrum-Button--secondary spectrum-ButtonGroup-item">
@@ -27,6 +48,23 @@ examples:
           <span class="spectrum-Button-label">Remind me later</span>
         </button>
         <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--fill spectrum-Button--primary spectrum-ButtonGroup-item">
+          <span class="spectrum-Button-label">Rate now</span>
+        </button>
+      </div>
+
+  - id: buttongroup-vertical-small
+    name: Vertical - Small
+    description: |
+      Spacing for the Small t-shirt size.
+    markup: |
+      <div class="spectrum-ButtonGroup spectrum-ButtonGroup--sizeS spectrum-ButtonGroup--vertical">
+        <button class="spectrum-Button spectrum-Button--sizeS spectrum-Button--outline spectrum-Button--secondary spectrum-ButtonGroup-item">
+          <span class="spectrum-Button-label">No, thanks</span>
+        </button>
+        <button class="spectrum-Button spectrum-Button--sizeS spectrum-Button--outline spectrum-Button--secondary spectrum-ButtonGroup-item">
+          <span class="spectrum-Button-label">Remind me later</span>
+        </button>
+        <button class="spectrum-Button spectrum-Button--sizeS spectrum-Button--fill spectrum-Button--primary spectrum-ButtonGroup-item">
           <span class="spectrum-Button-label">Rate now</span>
         </button>
       </div>

--- a/components/buttongroup/package.json
+++ b/components/buttongroup/package.json
@@ -17,13 +17,13 @@
   },
   "peerDependencies": {
     "@spectrum-css/button": "^6.0.0",
-    "@spectrum-css/vars": "^8.0.0"
+    "@spectrum-css/tokens": "^1.0.7"
   },
   "devDependencies": {
     "@spectrum-css/button": "^6.0.13",
     "@spectrum-css/component-builder": "^3.2.0",
     "@spectrum-css/icon": "^3.0.23",
-    "@spectrum-css/vars": "^8.0.0",
+    "@spectrum-css/tokens": "^1.0.7",
     "gulp": "^4.0.0"
   },
   "publishConfig": {

--- a/components/buttongroup/package.json
+++ b/components/buttongroup/package.json
@@ -17,13 +17,13 @@
   },
   "peerDependencies": {
     "@spectrum-css/button": "^6.0.0",
-    "@spectrum-css/tokens": "^1.0.7"
+    "@spectrum-css/tokens": "^3.0.0"
   },
   "devDependencies": {
     "@spectrum-css/button": "^6.0.13",
     "@spectrum-css/component-builder": "^3.2.0",
     "@spectrum-css/icon": "^3.0.23",
-    "@spectrum-css/tokens": "^1.0.7",
+    "@spectrum-css/tokens": "^3.0.0",
     "gulp": "^4.0.0"
   },
   "publishConfig": {

--- a/components/buttongroup/package.json
+++ b/components/buttongroup/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@spectrum-css/button": "^6.0.13",
-    "@spectrum-css/component-builder": "^3.2.0",
+    "@spectrum-css/component-builder-simple": "^1.0.0",
     "@spectrum-css/icon": "^3.0.23",
     "@spectrum-css/tokens": "^3.0.0",
     "gulp": "^4.0.0"

--- a/components/buttongroup/package.json
+++ b/components/buttongroup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spectrum-css/buttongroup",
-  "version": "2.0.0-beta.0",
+  "version": "6.0.0-beta.0",
   "description": "The Spectrum CSS buttongroup component",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",

--- a/components/buttongroup/package.json
+++ b/components/buttongroup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spectrum-css/buttongroup",
-  "version": "5.0.13",
+  "version": "2.0.0-beta.0",
   "description": "The Spectrum CSS buttongroup component",
   "license": "Apache-2.0",
   "main": "dist/index-vars.css",

--- a/components/buttongroup/themes/express.css
+++ b/components/buttongroup/themes/express.css
@@ -1,0 +1,15 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+@container (--system: express) {
+    .spectrum-ButtonGroup {
+    }
+}

--- a/components/buttongroup/themes/spectrum.css
+++ b/components/buttongroup/themes/spectrum.css
@@ -1,0 +1,15 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+@container (--system: spectrum) {
+    .spectrum-ButtonGroup {
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1453,6 +1453,11 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/actiongroup/-/actiongroup-2.0.0.tgz#77a27608d3b774ca2f56539c6375adce7a2cd589"
   integrity sha512-mUdEWcGvCAekmaaLAbimqCd3/H7kDasbna3sLJY6u1+eYyJxQzmYkT4MvdjdoqjrvczU0QgFbY9nHlekUPH4RQ==
 
+"@spectrum-css/buttongroup@^5.0.13":
+  version "5.0.13"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/buttongroup/-/buttongroup-5.0.13.tgz#3414927df053ef7c8fbe0331b68d4353a9b63759"
+  integrity sha512-DPPPwngaecxTFVjvGSrg+5yHrZnV1BvbAp0hPZCV5OvVo3S1FJgPpf6+cjoiVcYCrc/6njGjOMpaHVpHUDOHXA==
+
 "@spectrum-css/closebutton@^1.2.13":
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/@spectrum-css/closebutton/-/closebutton-1.2.13.tgz#a02a33e211349138bcde0988cd4317749a7618e4"


### PR DESCRIPTION
## Description

Migrate Button Group to use core tokens.

## How and where has this been tested?
 - Chrome
 - Safari
 - WHCM emulation

## Screenshots
<img width="556" alt="Screen Shot 2022-09-12 at 8 54 14 AM" src="https://user-images.githubusercontent.com/16216104/189672354-820fa98d-53d3-4778-a0e4-dd90102adbc6.png">


## To-do list
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] I have tested these changes in Windows High Contrast mode.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
