### PR TITLE
refactor(tokens): pin dependency to specific version

### DIFF
--- a/components/tokens/package.json
+++ b/components/tokens/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
   "devDependencies": {
-    "@adobe/spectrum-tokens": "^12.0.0-beta.47",
+    "@adobe/spectrum-tokens": "12.0.0-beta.47",
     "gulp": "^4.0.0",
     "gulp-concat": "^2.6.1",
     "style-dictionary": "^3.7.0",


### PR DESCRIPTION
This pins `@adobe/spectrum-tokens` to a specific release to mitigate the effects of a breaking change in a later patch version

<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->


## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
