### PR TITLE
fix(card): increase content area height when necessary

### DIFF
--- a/components/card/index.css
+++ b/components/card/index.css
@@ -131,7 +131,7 @@ governing permissions and limitations under the License.
 
 .spectrum-Card-content {
   display: flex;
-  block-size: var(--spectrum-card-body-content-min-height);
+  min-block-size: var(--spectrum-card-body-content-min-height);
   margin-block-start: var(--spectrum-card-body-content-margin-top);
 }
 


### PR DESCRIPTION
## Description

The height of the content area of the Card (within `spectrum-Card-content`) won't grow when the actual content becomes tall. To fix it, I have changed the property name `block-size` to `min-block-size` under `.spectrum-Card-content`.

See #1521.

## How and where has this been tested?

 - **How this was tested:** Using steps in issue #1521
 - **Browser(s) and OS(s) this was tested with:** Chrome 105.0.5195.125 on macOS 12.6

## Screenshots

Before:

<img width="367" alt="截屏2022-09-27 11 56 58" src="https://user-images.githubusercontent.com/91254072/192429516-6ee25d7a-b593-4a25-85f8-fdc36c39e301.png">

After:

<img width="364" alt="截屏2022-09-27 12 06 10" src="https://user-images.githubusercontent.com/91254072/192429528-3d756fac-6901-451b-916c-8c16b5409e70.png">

## To-do list

- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] I have tested these changes in Windows High Contrast mode.
- [x] This pull request is ready to merge.
