### PR TITLE
Lunarfusion/fix  radio focus

### DIFF
--- a/components/radio/index.css
+++ b/components/radio/index.css
@@ -421,6 +421,10 @@ governing permissions and limitations under the License.
         border-color: var(--highcontrast-radio-focus-indicator-color,
                           var(--mod-radio-focus-indicator-color,
                               var(--spectrum-radio-focus-indicator-color)));
+        border-style: solid;
+
+        width: calc(var(--spectrum-radio-button-control-size) + (var(--spectrum-radio-focus-indicator-gap) * 2));
+        height: calc(var(--spectrum-radio-button-control-size) + (var(--spectrum-radio-focus-indicator-gap) * 2));
       }
     }
   }

--- a/components/radio/index.css
+++ b/components/radio/index.css
@@ -413,7 +413,8 @@ governing permissions and limitations under the License.
   }
 
  /* focus ring is focused state */
-  &:focus-ring {
+  &:focus-ring,
+  &:focus-visible {
     + .spectrum-Radio-button {
       &:after {
         border-width: var(--mod-radio-focus-indicator-thickness,


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
Radio was found to lack focus ring visibility when activated through tabbing. This was due to a lack of border style, width, and height on the focus ring element when activated in this way.

## How and where has this been tested?
 - Chrome 105 for macOS
 - Firefox 105 for macOS
- **How this was tested:** comparing local build of http://localhost:3000/docs/radio.html, tabbing through components before and after the change

## Screenshots
Observe the focus-ring class on the input element within radio. Prior to this change, this class was activated through tabbing but did not have the expected visible focus indicator ring. This change adds the necessary styles for the visible focus indicator on tab. This also adds the :focus-visible state to ensure longevity, as :focus-ring is depreciated.

<img width="1228" alt="Screen Shot 2022-10-17 at 3 48 37 PM" src="https://user-images.githubusercontent.com/25614178/196269749-ea29860a-0c2f-44b8-a950-488ded889e9f.png">



## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
