### PR TITLE
Minor content update to main and get-started pages.

### DIFF
--- a/site/get-started.pug
+++ b/site/get-started.pug
@@ -1,7 +1,7 @@
 doctype html
 html(lang='en-US' dir="ltr").spectrum.spectrum--light.spectrum--medium
   head
-    title Getting Started - Spectrum CSS
+    title Getting started - Spectrum CSS
 
     include includes/dependencies.pug
 
@@ -19,7 +19,7 @@ html(lang='en-US' dir="ltr").spectrum.spectrum--light.spectrum--medium
 
           .spectrum-Site-mainContainer
             .spectrum-Site-page.spectrum-Typography
-              h1.spectrum-Heading.spectrum-Heading--sizeXXL.spectrum-Heading--serif Get Started with Spectrum CSS
+              h1.spectrum-Heading.spectrum-Heading--sizeXXL.spectrum-Heading--serif Get started with Spectrum CSS
 
               p.spectrum-Body.spectrum-Body--sizeL We have a number of resources that outline how to set up Spectrum CSS for your project, as well as an introductory tutorial that’s a hands-on way to understand how our implementation works.
 

--- a/site/index.pug
+++ b/site/index.pug
@@ -21,7 +21,7 @@ html(lang='en-US' dir="ltr").spectrum.spectrum--light.spectrum--medium
             .spectrum-Site-page.spectrum-Typography
               .spectrum-Site-hero
                 .spectrum-Site-heroHeading
-                  h1.spectrum-Heading.spectrum-Heading--sizeXXXL.spectrum-Heading--serif Meet Spectrum CSS
+                  h1.spectrum-Heading.spectrum-Heading--sizeXXXL.spectrum-Heading--serif Spectrum CSS
                 p.spectrum-Body.spectrum-Body--sizeXL Spectrum CSS is an open-source implementation of Spectrum, Adobe’s design system. It includes components and resources to make applications more cohesive.
                 img(alt="Spectrum CSS Hero image" src="img/spectrum-css_illustration_desktop@2x.png?w=976&amp;h=446" srcset="img/spectrum-css_illustration_desktop@2x.png 2x").spectrum-Site-heroImage
 


### PR DESCRIPTION
docs: update content on main page and get-started to match content strategy recommendations

<!-- Summarize your changes in the Title field -->

## Description

From content strategy:

> Please edit the following two strings on the Spectrum CSS homepage:
> 1) Change the headline of "Meet Spectrum CSS" to just:
> **Spectrum CSS**
> (This is so the site can be more evergreen; it's in line with the content strategy we're going to have for all Spectrum implementations)
> 2) In the "Flexible" content block, please make the link sentence case, to follow content standards:
> **Get started**
> (not: Get Started)

## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
