### PR TITLE
feat: docs updates for Express icons (CSS-241)

### DIFF
--- a/components/inlinealert/metadata/inlinealert.yml
+++ b/components/inlinealert/metadata/inlinealert.yml
@@ -10,6 +10,8 @@ examples:
       </div>
   - id: inlinealert-info
     name: Informative
+    description: |
+      *Spectrum for Adobe Express uses a different icon. Use the `SX_Info_18_S.svg` icon in the Express workflow icon set.*
     markup: |
       <div class="spectrum-InLineAlert spectrum-InLineAlert--info">
         <div class="spectrum-InLineAlert-header">
@@ -22,6 +24,8 @@ examples:
       </div>
   - id: inlinealert-positive
     name: Positive
+    description: |
+      *Spectrum for Adobe Express uses a different icon. Use the `SX_CheckmarkCircle_18_S.svg` icon in the Express workflow icon set.*
     markup: |
       <div class="spectrum-InLineAlert spectrum-InLineAlert--positive">
         <div class="spectrum-InLineAlert-header">
@@ -34,6 +38,8 @@ examples:
       </div>
   - id: inlinealert-notice
     name: Notice
+    description: |
+      *Spectrum for Adobe Express uses a different icon. Use the `SX_Alert_18_S.svg` icon in the Express workflow icon set.*
     markup: |
       <div class="spectrum-InLineAlert spectrum-InLineAlert--notice">
         <div class="spectrum-InLineAlert-header">
@@ -46,6 +52,8 @@ examples:
       </div>
   - id: inlinealert-negative
     name: Negative
+    description: |
+      *Spectrum for Adobe Express uses a different icon. Use the `SX_Alert_18_S.svg` icon in the Express workflow icon set.*
     markup: |
       <div class="spectrum-InLineAlert spectrum-InLineAlert--negative">
         <div class="spectrum-InLineAlert-header">
@@ -59,7 +67,10 @@ examples:
   - id: inlinealert-closable
     name: Closable
     dnaStatus: Contribution
-    description: An in-line alert with a close button in the footer. Combine this strategy with any variant.
+    description: |
+      An in-line alert with a close button in the footer. Combine this strategy with any variant.
+      
+      *Spectrum for Adobe Express uses a different icon. Use the `SX_Alert_18_S.svg` icon in the Express workflow icon set.*
     markup: |
       <div class="spectrum-InLineAlert spectrum-InLineAlert--negative">
         <div class="spectrum-InLineAlert-header">Incorrect Payment Information - Error

--- a/components/textfield/metadata/textarea.yml
+++ b/components/textfield/metadata/textarea.yml
@@ -43,6 +43,8 @@ examples:
 
   - id: textfield
     name: Invalid
+    description: |
+      *Spectrum for Adobe Express uses a different icon. Use the `SX_Alert_18_N.svg` icon in the Express workflow icon set.*
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline is-invalid">
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
@@ -77,6 +79,8 @@ examples:
 
   - id: textfield
     name: Focused (invalid)
+    description: |
+      *Spectrum for Adobe Express uses a different icon. Use the `SX_Alert_18_N.svg` icon in the Express workflow icon set.*
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline is-invalid is-focused">
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
@@ -87,6 +91,8 @@ examples:
 
   - id: textfield
     name: Keyboard Focused (invalid)
+    description: |
+      *Spectrum for Adobe Express uses a different icon. Use the `SX_Alert_18_N.svg` icon in the Express workflow icon set.*
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline is-invalid is-keyboardFocused">
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
@@ -111,6 +117,8 @@ examples:
 
   - id: textfield-quiet
     name: Quiet Valid
+    description: |
+      *Spectrum for Adobe Express uses a different icon. Use the `SX_Alert_18_N.svg` icon in the Express workflow icon set.*    
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--quiet is-valid">
         <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
@@ -131,6 +139,8 @@ examples:
 
   - id: textfield-quiet
     name: Quiet Invalid
+    description: |
+      *Spectrum for Adobe Express uses a different icon. Use the `SX_Alert_18_N.svg` icon in the Express workflow icon set.*
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--quiet is-invalid">
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
@@ -165,6 +175,8 @@ examples:
 
   - id: textfield-quiet
     name: Quiet Focused (invalid)
+    description: |
+      *Spectrum for Adobe Express uses a different icon. Use the `SX_Alert_18_N.svg` icon in the Express workflow icon set.*
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--quiet is-invalid is-focused">
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
@@ -175,6 +187,8 @@ examples:
 
   - id: textfield-quiet
     name: Quiet Keyboard Focused (invalid)
+    description: |
+      *Spectrum for Adobe Express uses a different icon. Use the `SX_Alert_18_N.svg` icon in the Express workflow icon set.*
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--quiet is-invalid is-keyboardFocused">
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">

--- a/components/textfield/metadata/textfield.yml
+++ b/components/textfield/metadata/textfield.yml
@@ -57,6 +57,8 @@ examples:
 
   - id: textfield
     name: Valid
+    description: |
+      *Spectrum for Adobe Express uses a different icon. Use the `SX_Alert_18_N.svg` icon in the Express workflow icon set.*    
     markup: |
       <div class="spectrum-Textfield is-valid">
         <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
@@ -77,6 +79,8 @@ examples:
 
   - id: textfield
     name: Invalid
+    description: |
+      *Spectrum for Adobe Express uses a different icon. Use the `SX_Alert_18_N.svg` icon in the Express workflow icon set.*    
     markup: |
       <div class="spectrum-Textfield is-invalid">
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
@@ -111,6 +115,8 @@ examples:
 
   - id: textfield
     name: Focused (invalid)
+    description: |
+      *Spectrum for Adobe Express uses a different icon. Use the `SX_Alert_18_N.svg` icon in the Express workflow icon set.*    
     markup: |
       <div class="spectrum-Textfield is-invalid is-focused">
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
@@ -121,6 +127,8 @@ examples:
 
   - id: textfield
     name: Keyboard Focused (invalid)
+    description: |
+      *Spectrum for Adobe Express uses a different icon. Use the `SX_Alert_18_N.svg` icon in the Express workflow icon set.*
     markup: |
       <div class="spectrum-Textfield is-invalid is-keyboardFocused">
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
@@ -165,6 +173,8 @@ examples:
 
   - id: textfield-quiet
     name: Quiet Invalid
+    description: |
+      *Spectrum for Adobe Express uses a different icon. Use the `SX_Alert_18_N.svg` icon in the Express workflow icon set.*
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--quiet is-invalid">
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
@@ -175,6 +185,8 @@ examples:
 
   - id: textfield-quiet
     name: Quiet Invalid (disabled)
+    description: |
+      *Spectrum for Adobe Express uses a different icon. Use the `SX_Alert_18_N.svg` icon in the Express workflow icon set.*
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--quiet is-invalid is-disabled">
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
@@ -199,6 +211,8 @@ examples:
 
   - id: textfield-quiet
     name: Quiet Focused (invalid)
+    description: |
+      *Spectrum for Adobe Express uses a different icon. Use the `SX_Alert_18_N.svg` icon in the Express workflow icon set.*
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--quiet is-invalid is-focused">
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
@@ -209,6 +223,8 @@ examples:
 
   - id: textfield-quiet
     name: Quiet Keyboard Focused (invalid)
+    description: |
+      *Spectrum for Adobe Express uses a different icon. Use the `SX_Alert_18_N.svg` icon in the Express workflow icon set.*
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--quiet is-invalid is-keyboardFocused">
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">

--- a/components/toast/metadata/toast.yml
+++ b/components/toast/metadata/toast.yml
@@ -29,6 +29,8 @@ sections:
   - id: toast-info
     name: Info
     status: Verified
+    description: |
+      *Spectrum for Adobe Express uses a different icon. Use the `SX_Info_18_S.svg` icon in the Express workflow icon set.*
     markup: |
       <div class="spectrum-Toast spectrum-Toast--info">
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Toast-typeIcon" focusable="false" aria-hidden="true">
@@ -48,6 +50,8 @@ sections:
   - id: toast-negative
     name: Negative
     status: Verified
+    description: |
+      *Spectrum for Adobe Express uses a different icon. Use the `SX_Alert_18_S.svg` icon in the Express workflow icon set.*
     markup: |
       <div class="spectrum-Toast spectrum-Toast--negative">
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Toast-typeIcon" focusable="false" aria-hidden="true">
@@ -70,6 +74,8 @@ sections:
   - id: toast-positive
     name: Positive
     status: Verified
+    description: |
+      *Spectrum for Adobe Express uses a different icon. Use the `SX_CheckmarkCircle_18_S.svg` icon in the Express workflow icon set.*
     markup: |
       <div class="spectrum-Toast spectrum-Toast--positive">
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Toast-typeIcon" focusable="false" aria-hidden="true">

--- a/components/tooltip/metadata/tooltip.yml
+++ b/components/tooltip/metadata/tooltip.yml
@@ -16,6 +16,8 @@ examples:
   - id: tooltip-info
     name: Informative
     status: Verified
+    description: |
+      *Spectrum for Adobe Express uses a different icon. Use the `SX_Info_14_S.svg` icon in the Express workflow icon set.*
     markup: |
       <span class="spectrum-Tooltip spectrum-Tooltip--top spectrum-Tooltip--info is-open">
         <span class="spectrum-Tooltip-label">Label</span>
@@ -42,6 +44,8 @@ examples:
   - id: tooltip-positive
     name: Positive
     status: Verified
+    description: |
+      *Spectrum for Adobe Express uses a different icon. Use the `SX_CheckmarkCircle_14_S.svg` icon in the Express workflow icon set.*
     markup: |
       <span class="spectrum-Tooltip spectrum-Tooltip--top spectrum-Tooltip--positive is-open">
         <span class="spectrum-Tooltip-label">Label</span>
@@ -68,6 +72,8 @@ examples:
   - id: tooltip-negative
     name: Negative
     status: Verified
+    description: |
+      *Spectrum for Adobe Express uses a different icon. Use the `SX_Alert_14_S.svg` icon in the Express workflow icon set.*
     markup: |
       <span class="spectrum-Tooltip spectrum-Tooltip--top spectrum-Tooltip--negative is-open">
         <span class="spectrum-Tooltip-label">Label</span>
@@ -143,7 +149,10 @@ examples:
     name: Help
     status: Deprecated
     details: Use `info`
-    description: An informative tooltip with a help icon.
+    description: |
+      An informative tooltip with a help icon.
+
+      *Spectrum for Adobe Express uses a different icon. Use the `SX_Help_14_S.svg` icon in the Express workflow icon set.*
     markup: |
       <span class="spectrum-Tooltip spectrum-Tooltip--top spectrum-Tooltip--info is-open">
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Tooltip-typeIcon" focusable="false" aria-hidden="true">


### PR DESCRIPTION
Minor docs update to get around us not featuring the icon-changes for Express

https://jira.corp.adobe.com/browse/CSS-241 Update a few components to use correct Express Alert Icon


## Description
Add this note.
<img width="516" alt="Screen Shot 2022-11-03 at 16 04 17" src="https://user-images.githubusercontent.com/52184321/199845624-5632880c-4fa4-4107-9a10-e0ab0a561fa9.png">



## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
