### PR TITLE
refactor(textfield): migrate spectrum tokens

### DIFF
--- a/components/inputgroup/CHANGELOG.md
+++ b/components/inputgroup/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="5.0.15-beta.0"></a>
+## 5.0.15-beta.0
+🗓 2023-03-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inputgroup@5.0.14...@spectrum-css/inputgroup@5.0.15-beta.0)
+
+**Note:** Version bump only for package @spectrum-css/inputgroup
+
+
+
+
+
 <a name="5.0.14"></a>
 ## 5.0.14
 🗓 2023-03-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inputgroup@5.0.13...@spectrum-css/inputgroup@5.0.14)

--- a/components/inputgroup/package.json
+++ b/components/inputgroup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spectrum-css/inputgroup",
-  "version": "5.0.14",
+  "version": "5.0.15-beta.0",
   "description": "The Spectrum CSS inputgroup component",
   "license": "Apache-2.0",
   "author": "Adobe",
@@ -26,7 +26,7 @@
     "@spectrum-css/component-builder": "^4.0.3",
     "@spectrum-css/icon": "^3.0.35",
     "@spectrum-css/menu": "^4.0.16",
-    "@spectrum-css/pickerbutton": "^2.0.12",
+    "@spectrum-css/pickerbutton": "^2.0.13-beta.0",
     "@spectrum-css/popover": "^5.0.18",
     "@spectrum-css/textfield": "^3.2.16",
     "@spectrum-css/vars": "^8.0.5",

--- a/components/pickerbutton/CHANGELOG.md
+++ b/components/pickerbutton/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.0.13-beta.0"></a>
+## 2.0.13-beta.0
+🗓 2023-03-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@2.0.12...@spectrum-css/pickerbutton@2.0.13-beta.0)
+
+### 🐛 Bug fixes
+
+* **textfield:** remove zero margin from pickerbutton ([42a81b5](https://github.com/adobe/spectrum-css/commit/42a81b5))
+
+
+
+
+
 <a name="2.0.12"></a>
 ## 2.0.12
 🗓 2023-03-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@2.0.11...@spectrum-css/pickerbutton@2.0.12)

--- a/components/pickerbutton/index.css
+++ b/components/pickerbutton/index.css
@@ -63,7 +63,4 @@ governing permissions and limitations under the License.
 .spectrum-PickerButton-icon {
   /* don't be small, ever */
   flex-shrink: 0;
-
-  /* remove margin used for centering */
-  margin: 0 !important;
 }

--- a/components/pickerbutton/package.json
+++ b/components/pickerbutton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spectrum-css/pickerbutton",
-  "version": "2.0.12",
+  "version": "2.0.13-beta.0",
   "description": "The Spectrum CSS picker button component",
   "license": "Apache-2.0",
   "author": "Adobe",

--- a/components/stepper/CHANGELOG.md
+++ b/components/stepper/CHANGELOG.md
@@ -3,6 +3,33 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="4.0.0-beta.4"></a>
+# 4.0.0-beta.4
+🗓 2023-03-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@3.0.39...@spectrum-css/stepper@4.0.0-beta.4)
+
+### ✨ Features
+
+* **stepper:** add hideStepper control to fix border styling issue ([ba2f078](https://github.com/adobe/spectrum-css/commit/ba2f078))
+* **stepper:** adjustment to quiet focus and placeholder tokens ([05a95ae](https://github.com/adobe/spectrum-css/commit/05a95ae))
+* **stepper:** colors for variants and states ([699bc5e](https://github.com/adobe/spectrum-css/commit/699bc5e))
+* **stepper:** design revisions ([b31d264](https://github.com/adobe/spectrum-css/commit/b31d264))
+* **stepper:** refactor for readability and variant cascade ([a5cfd00](https://github.com/adobe/spectrum-css/commit/a5cfd00))
+* **stepper:** windows high contrast mode overrides ([290fa58](https://github.com/adobe/spectrum-css/commit/290fa58))
+
+
+### 🐛 Bug fixes
+
+* **stepper, textfield:** revert use of has ([c26c64f](https://github.com/adobe/spectrum-css/commit/c26c64f))
+* **stepper:** button border radii correction ([be2e210](https://github.com/adobe/spectrum-css/commit/be2e210))
+* **stepper:** correct button width for SWC VRTs ([94f2fd4](https://github.com/adobe/spectrum-css/commit/94f2fd4))
+* **stepper:** fix quiet stepper button width ([1d06567](https://github.com/adobe/spectrum-css/commit/1d06567))
+* **stepper:** quiet hover background ([920b500](https://github.com/adobe/spectrum-css/commit/920b500))
+* **stepper:** refactor button border radii and inset ([df24935](https://github.com/adobe/spectrum-css/commit/df24935))
+
+
+
+
+
 <a name="3.0.39"></a>
 ## 3.0.39
 🗓 2023-03-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@3.0.38...@spectrum-css/stepper@3.0.39)

--- a/components/stepper/gulpfile.js
+++ b/components/stepper/gulpfile.js
@@ -1,1 +1,1 @@
-module.exports = require('@spectrum-css/component-builder');
+module.exports = require('@spectrum-css/component-builder-simple');

--- a/components/stepper/index.css
+++ b/components/stepper/index.css
@@ -12,25 +12,38 @@ governing permissions and limitations under the License.
 
 
 .spectrum-Stepper {
+   /**** TODO - ask Design to evaluate these widths ****/
+  --spectrum-stepper-width-medium: 72px; /* replaces --spectrum-global-dimension-size-900 */
+  --spectrum-stepper-width-large: 90px; /* replaces --spectrum-global-dimension-size-900 */
+  --spectrum-stepper-icon-width-medium: 10px; /* placeholder for --spectrum-alias-ui-icon-chevron-size-75 */
+  --spectrum-stepper-icon-width-large: 12px; /* placeholder for --spectrum-alias-ui-icon-chevron-size-75 */
 
-  /* TODO - ask Design to evaluate these widths */
+  /* set defaults */
+  --spectrum-stepper-width: var(--spectrum-stepper-width-medium);
+  --spectrum-stepper-icon-width: var(--spectrum-stepper-icon-width-medium);
+
+  /* override per size */
+  /* this is necessary to mimmic the size-responsive tokens which were already present */
   .spectrum--medium {
     & {
-      --spectrum-stepper-width: 72px; /* replaces --spectrum-global-dimension-size-900 */
-      --spectrum-stepper-icon-width: 10px; /* placeholder for --spectrum-alias-ui-icon-chevron-size-75 */
+      --spectrum-stepper-width: var(--spectrum-stepper-width-medium);
+      --spectrum-stepper-icon-width: var(--spectrum-stepper-icon-width-medium);
     }
   }
 
   .spectrum--large {
     & {
-      --spectrum-stepper-width: 90px; /* replaces --spectrum-global-dimension-size-900 */
-      --spectrum-stepper-icon-width: 12px; /* placeholder for --spectrum-alias-ui-icon-chevron-size-75 */
+      --spectrum-stepper-width: var(--spectrum-stepper-width-large);
+      --spectrum-stepper-icon-width: var(--spectrum-stepper-icon-width-large);
     }
   }
-
-  --spectrum-stepper-button-offset: calc(var(--spectrum-stepper-button-width) / 2 - var(--spectrum-stepper-icon-width) / 2); /* TODO - reevaluate when icons are migrated */
+  /**** end TODO ****/
 
   --spectrum-stepper-button-width: var(--spectrum-component-height-75); /* this height token matches the previous width token */
+
+ /* quiet variant */
+  --spectrum-stepper-quiet-width: var(--spectrum-component-height-300); /* matches previous width token */
+  --spectrum-stepper-quiet-button-width: calc(var(--spectrum-stepper-button-width) - var(--spectrum-stepper-button-offset));
 
   --spectrum-stepper-button-padding: var(--spectrum-component-edge-to-visual-50); /* 6px md + 7px lg - previously 6px md + 7.5px lg */
 
@@ -45,23 +58,27 @@ governing permissions and limitations under the License.
   /* was var(--spectrum-global-dimension-size-25); */
   /* was 2px */
 
-  --spectrum-stepper-quiet-width: var(--spectrum-component-height-300); /* matches previous width token */
 
-  --spectrum-stepper-quiet-button-width: calc(var(--spectrum-stepper-button-width) - var(--spectrum-stepper-button-offset));
+  /* this is for the :after hit area element */
+  --spectrum-stepper-button-offset: calc(var(--spectrum-stepper-button-width) / 2 - var(--spectrum-stepper-icon-width) / 2); /* TODO - reevaluate when icons are migrated */
+    /* chevron = --spectrum-global-dimension-static-size-125 and --spectrum-global-dimension-static-size-150 = 10px and 12px */
+  /* button width of 23px / 29px divided by 2 = 11.5px and 14.5px */
+  /* chevron size of 10px and 12px divided by 2 = 5px and 6px */
+  /* 11.5px minus 5px = 6.5px */
+  /* 14.5px minus 6px = 8.5px */
 
 
-  /* New tokens */
+  /* New tokens - to match textfield */
   --spectrum-stepper-animation-duration: var(--spectrum-animation-duration-100);
-  --spectrum-stepper-border-radius: var(--spectrum-corner-radius-100); /* was 6px 8px */
-  --spectrum-stepper-buttons-height: var(--spectrum-component-height-100);
+  --spectrum-stepper-border-radius: var(--spectrum-corner-radius-100);
+  --spectrum-stepper-buttons-height: var(--spectrum-component-height-100); /* from textfield height */
 
   /* focus indicator */
   --spectrum-stepper-focus-indicator-width: var(--spectrum-focus-indicator-thickness);
   --spectrum-stepper-focus-indicator-gap: var(--spectrum-focus-indicator-gap);
 
-  /* new colors */
-    /* Disabled Colors */
-  --spectrum-stepper-border-color-disabled: var(--spectrum-disabled-border-color);
+  /* Disabled Colors */
+  --spectrum-stepper-border-color-quiet-disabled: var(--spectrum-disabled-border-color);
 
   /* Invalid Colors */
   --spectrum-stepper-border-color-invalid-default: var(--spectrum-negative-border-color-default);
@@ -348,7 +365,7 @@ governing permissions and limitations under the License.
   &.is-disabled {
     .spectrum-Stepper-stepUp,
     .spectrum-Stepper-stepDown {
-      border-color: var(--spectrum-stepper-border-color-disabled);
+      border-color: transparent;
     }
   }
 }
@@ -357,7 +374,7 @@ governing permissions and limitations under the License.
 .spectrum-Stepper-stepDown {
 
   &:disabled {
-    border-color: var(--spectrum-stepper-border-color-disabled);
+    border-color: transparent;
   }
 }
 
@@ -365,7 +382,7 @@ governing permissions and limitations under the License.
   &.is-disabled {
     .spectrum-Stepper-stepUp,
     .spectrum-Stepper-stepDown {
-      border-color: var(--spectrum-stepper-border-color-disabled);
+      border-color: var(--spectrum-stepper-border-color-quiet-disabled);
     }
   }
 
@@ -374,7 +391,7 @@ governing permissions and limitations under the License.
     border-color: var(--spectrum-stepper-border-color);
 
     &:disabled {
-      border-color: var(--spectrum-stepper-border-color-disabled);
+      border-color: var(--spectrum-stepper-border-color-quiet-disabled);
     }
   }
 
@@ -417,7 +434,7 @@ governing permissions and limitations under the License.
     &::after {
       border-width: 0 0 var(--mod-stepper-focus-indicator-width, var(--spectrum-stepper-focus-indicator-width)) 0;
       border-radius: 0;
-      inline-size: var(--mod-stepper-width, var(--spectrum-stepper-width));
+      inline-size: 100%;
       block-size: calc(100% + var(--mod-stepper-focus-indicator-gap, var(--spectrum-stepper-focus-indicator-gap)));
       margin-inline-start: 0;
       margin-block-start: 0;

--- a/components/stepper/index.css
+++ b/components/stepper/index.css
@@ -41,17 +41,9 @@ governing permissions and limitations under the License.
   }
   /**** END placeholder widths ****/
 
-
-  --spectrum-stepper-button-width: var(--spectrum-component-height-75); /* this height token matches the previous WIDTH token */
-
-  --spectrum-stepper-button-padding: var(--spectrum-component-edge-to-visual-50); /* 6px md + 7px lg - previously 6px md + 7.5px lg */
-
-  --spectrum-stepper-border-radius-reset: 0;
-
   /*** Button Icons - appears to adjust position ***/
   --spectrum-stepper-icon-nudge-start: 1px; /* placeholder - was var(--spectrum-global-dimension-size-10) - 1px */
   --spectrum-stepper-icon-nudge-end: 2px; /* placeholder -was var(--spectrum-global-dimension-size-25) - 2px */
-
 
  /*** :AFTER - this is for the :after element labeled below as hit area, but used as focus indicator in ActionButton ***/
   --spectrum-stepper-button-offset: calc(var(--spectrum-stepper-button-width) / 2 - var(--spectrum-stepper-icon-width) / 2);
@@ -64,8 +56,14 @@ governing permissions and limitations under the License.
 
   /*** New added tokens begin here - chosen to match textfield - reevaluate when fully migrating Stepper ***/
   --spectrum-stepper-animation-duration: var(--spectrum-animation-duration-100);
-  --spectrum-stepper-border-radius: var(--spectrum-corner-radius-100);
   --spectrum-stepper-buttons-height: var(--spectrum-component-height-100); /* from textfield height */
+  --spectrum-stepper-border-radius: var(--spectrum-corner-radius-100);
+
+  /*** Buttons ***/
+  --spectrum-stepper-button-width: var(--spectrum-component-height-75); /* this height token matches the previous WIDTH token */
+  --spectrum-stepper-button-padding: var(--spectrum-component-edge-to-visual-50); /* 6px md + 7px lg - previously 6px md + 7.5px lg */
+  --spectrum-stepper-button-gap: var(--spectrum-stepper-button-gap-reset);
+  --spectrum-stepper-button-border-radius: var(--spectrum-stepper-button-border-radius-reset);
 
   /* background same as textfield */
   --spectrum-stepper-background-color: var(--spectrum-gray-50);
@@ -74,7 +72,6 @@ governing permissions and limitations under the License.
  /*** Quiet Variant ***/
   --spectrum-stepper-quiet-width: var(--spectrum-component-height-300); /* matches previous width token */
   --spectrum-stepper-quiet-button-width: calc(var(--spectrum-stepper-button-width) - var(--spectrum-stepper-button-offset));
-
 
   /*** Disabled Colors ***/
   --spectrum-stepper-border-color-disabled: var(--spectrum-disabled-background-color);
@@ -122,6 +119,9 @@ governing permissions and limitations under the License.
     --highcontrast-stepper-focus-indicator-color: CanvasText;
   }
 }
+.x {
+ border-radius: var(--spectrum-stepper-button-border-radius-reset);
+}
 
 .spectrum-Stepper {
   position: relative;
@@ -132,7 +132,6 @@ governing permissions and limitations under the License.
   inline-size: var(--mod-stepper-width, var(--spectrum-stepper-width));
   line-height: 0;
   border-radius: var(--mod-stepper-border-radius, var(--spectrum-stepper-border-radius)); /* --spectrum-global-dimension-size-75 = 6px 8px */
-  transition: border-color var(--mod-stepper-animation-duration, var(--spectrum-stepper-animation-duration)) ease-in-out;
 
   /*** Focus Indicator - Unfocused Base Styles ***/
   &::after {
@@ -313,11 +312,11 @@ governing permissions and limitations under the License.
   /*** Quiet ***/
   &--quiet {
     /* quiet corners not rounded */
-    border-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
+    border-radius: 0;
     inline-size: var(--mod-stepper-quiet-width, var(--spectrum-stepper-quiet-width));
 
     .spectrum-Stepper-buttons {
-      border-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
+      border-radius: 0;
       border-width: 0 0 var(--mod-stepper-border-width, var(--spectrum-stepper-border-width)) 0;
     }
 
@@ -328,7 +327,7 @@ governing permissions and limitations under the License.
 
       border-block-start: none;
       border-inline-start: none;
-      border-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
+      border-radius: 0;
 
       padding-inline-end: 0;
       justify-content: flex-end;
@@ -461,18 +460,21 @@ governing permissions and limitations under the License.
   display: flex;
   flex-direction: column;
   justify-content: center;
+  align-itmes: flex-end;
   /* allow express buttons to have a gap the size of the stepper border */
-  gap: var(--mod-stepper-button-gap, var(--spectrum-stepper-button-gap));
+  row-gap: var(--mod-stepper-button-gap, var(--spectrum-stepper-button-gap));
 
-  /* allow express buttons to have space around the size of the stepper border */
-  /* padding: var(--mod-stepper-button-gap, var(--spectrum-stepper-button-gap)); */
+  overflow: hidden;
+
+  block-size: var(--mod-stepper-buttons-height, var(--spectrum-stepper-buttons-height));
+
+  inline-size: var(--mod-stepper-button-width, var(--spectrum-stepper-button-width));
 
   box-sizing: border-box;
   border-start-start-radius: 0;
-  border-start-end-radius: var(--mod-stepper-border-radius, var(--spectrum-stepper-border-radius)); /* --spectrum-global-dimension-size-75  = 6px 8px */
+  border-start-end-radius: var(--mod-stepper-border-radius, var(--spectrum-stepper-border-radius));
   border-end-end-radius: var(--mod-stepper-border-radius, var(--spectrum-stepper-border-radius));
   border-end-start-radius: 0;
-  block-size: var(--mod-stepper-buttons-height, var(--spectrum-stepper-buttons-height));
 
   border-style: solid;
   border-width: var(--mod-stepper-border-width, var(--spectrum-stepper-border-width))
@@ -482,37 +484,33 @@ governing permissions and limitations under the License.
 
   border-color: var(--highcontrast-stepper-border-color, var(--mod-stepper-border-color, var(--spectrum-stepper-border-color)));
   background-color: var(--highcontrast-stepper-background-color, var(--mod-stepper-background-color, var(--spectrum-stepper-background-color)));
+
+  transition: border-color var(--mod-stepper-animation-duration, var(--spectrum-stepper-animation-duration)) ease-in-out;
 }
 
 .spectrum-Stepper-stepUp,
 .spectrum-Stepper-stepDown {
   position: relative;
   display: flex;
-
+  flex-direction: row;
+  justify-content: center;
   box-sizing: border-box;
   block-size: calc((var(--mod-stepper-buttons-height, var(--spectrum-stepper-buttons-height)) / 2)
-                  - (var(--spectrum-stepper-button-gap) * 2.5));
+                  - (var(--mod-stepper-button-gap, var(--spectrum-stepper-button-gap)) * 2.5));
 
-  /* remove left border width from button width */
-  inline-size: calc(var(--mod-stepper-button-width, var(--spectrum-stepper-button-width))
-                    - (var(--mod-stepper-border-width, var(--spectrum-stepper-border-width)) * 2));
+  inline-size: calc(100% - var(--mod-stepper-button-gap, var(--spectrum-stepper-button-gap)));
+
+  margin-inline-end: var(--mod-stepper-button-gap, var(--spectrum-stepper-button-gap));
 
   min-inline-size: 0;
 
-  padding-inline-start: var(--mod-stepper-button-padding, var(--spectrum-stepper-button-padding));
-  padding-inline-end: var(--mod-stepper-button-padding, var(--spectrum-stepper-button-padding));
+  padding-inline: var(--mod-stepper-button-padding, var(--spectrum-stepper-button-padding));
 
   /* Avoid margin added by adjacent buttons */
   margin: 0;
 
-  inset-inline-end: var(--mod-stepper-button-gap, var(--spectrum-stepper-button-gap));
-
   border-color: var(--highcontrast-stepper-border-color, var(--mod-stepper-border-color, var(--spectrum-stepper-border-color)));
   border-width: 0;
-
-  /* set border radius of buttons proportionately to border */
-  border-radius: calc(var(--mod-stepper-border-radius, var(--spectrum-stepper-border-radius))
-                      - var(--mod-stepper-button-gap, var(--spectrum-stepper-button-gap)) * 1.5);
 
   background-color: var(--highcontrast-stepper-button-background-color-default, var(--mod-stepper-button-background-color-default, var(--spectrum-stepper-button-background-color-default)));
 
@@ -533,16 +531,22 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Stepper-stepUp {
-  border-end-end-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
-  border-end-start-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
   padding-block-start: var(--mod-stepper-icon-nudge-start, var(--spectrum-stepper-icon-nudge-start));
+
+  border-start-start-radius: var(--mod-stepper-button-border-radius, var(--spectrum-stepper-button-border-radius));
+  border-start-end-radius: var(--mod-stepper-button-border-radius, var(--spectrum-stepper-button-border-radius));
+  border-end-start-radius: 0;
+  border-end-end-radius: 0;
 }
 
 .spectrum-Stepper-stepDown {
   border-block-start-width: var(--mod-stepper-button-middle-border-width, var(--spectrum-stepper-button-middle-border-width));
-  border-start-end-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
-  border-start-start-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
   padding-block-end: var(--mod-stepper-icon-nudge-end, var(--spectrum-stepper-icon-nudge-end));
+
+  border-start-start-radius: 0;
+  border-start-end-radius: 0;
+  border-end-start-radius: var(--mod-stepper-button-border-radius, var(--spectrum-stepper-button-border-radius));
+  border-end-end-radius: var(--mod-stepper-button-border-radius, var(--spectrum-stepper-button-border-radius));
 }
 
 .spectrum-Stepper-textfield {
@@ -558,7 +562,7 @@ governing permissions and limitations under the License.
 
 .spectrum-Stepper-input {
   min-inline-size: 0;
-  border-start-end-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
-  border-end-end-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
+  border-start-end-radius: 0;
+  border-end-end-radius: 0;
   border-inline-end-width: 0;
 }

--- a/components/stepper/index.css
+++ b/components/stepper/index.css
@@ -10,6 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+
 .spectrum-Stepper {
 
   /* TODO - ask Design to evaluate these widths */
@@ -54,8 +55,31 @@ governing permissions and limitations under the License.
   --spectrum-stepper-border-radius: var(--spectrum-corner-radius-100); /* was 6px 8px */
   --spectrum-stepper-buttons-height: var(--spectrum-component-height-100);
 
+  /* focus indicator */
+  --spectrum-stepper-focus-indicator-width: var(--spectrum-focus-indicator-thickness);
+  --spectrum-stepper-focus-indicator-gap: var(--spectrum-focus-indicator-gap);
+
   /* new colors */
-  --spectrum-stepper-border-color: var(--spectrum-stepper-border-color-default);
+    /* Disabled Colors */
+  --spectrum-stepper-border-color-disabled: var(--spectrum-disabled-border-color);
+
+  /* Invalid Colors */
+  --spectrum-stepper-border-color-invalid-default: var(--spectrum-negative-border-color-default);
+  --spectrum-stepper-border-color-invalid-hover: var(--spectrum-negative-border-color-hover);
+  --spectrum-stepper-border-color-invalid-focus: var(--spectrum-negative-border-color-focus);
+  --spectrum-stepper-border-color-invalid-focus-hover: var(--spectrum-negative-border-color-focus-hover);
+  --spectrum-stepper-border-color-invalid-keyboard-focus: var(--spectrum-negative-border-color-key-focus);
+
+  /* Focus Indicator Color */
+  --spectrum-stepper-focus-indicator-color: var(--spectrum-focus-indicator-color);
+}
+
+
+/********* WHCM *********/
+@media (forced-colors: active) {
+  .spectrum-Stepper {
+    --highcontrast-stepper-focus-indicator-color: CanvasText;
+  }
 }
 
 .spectrum-Stepper {
@@ -66,8 +90,7 @@ governing permissions and limitations under the License.
   inline-size: var(--spectrum-stepper-width);
   line-height: 0;
   border-radius: var(--spectrum-stepper-border-radius); /* --spectrum-global-dimension-size-75 = 6px 8px */
-  transition: border-color var(--spectrum-stepper-animation-duration) ease-in-out, box-shadow var(--spectrum-stepper-animation-duration) ease-in-out;
-  /* 130ms */
+  transition: border-color var(--spectrum-stepper-animation-duration) ease-in-out;
 }
 .spectrum-Stepper::before {
   content: '';
@@ -80,7 +103,6 @@ governing permissions and limitations under the License.
   border-start-end-radius: var(--spectrum-stepper-border-radius); /* --spectrum-global-dimension-size-75  = 6px 8px */
   border-end-end-radius: var(--spectrum-stepper-border-radius);
   border-end-start-radius: 0;
-  transition: box-shadow var(--spectrum-stepper-animation-duration) ease-in-out;
   block-size: var(--spectrum-stepper-buttons-height);
 }
 
@@ -91,14 +113,14 @@ governing permissions and limitations under the License.
   box-sizing: border-box;
 
   /* remove middle border from button height */
-  block-size: calc((var(--spectrum-stepper-buttons-height) / 2)) - var(--spectrum-stepper-border-size));
-  block-size: calc((var(--spectrum-stepper-buttons-height) - var(--spectrum-stepper-border-size)) / 2);
+  block-size: calc((var(--spectrum-stepper-buttons-height) / 2)) - var(--spectrum-stepper-border-width));
+  block-size: calc((var(--spectrum-stepper-buttons-height) - var(--spectrum-stepper-border-width)) / 2);
 
-  block-size: calc((var(--spectrum-stepper-buttons-height) / 2) - (var(--spectrum-stepper-border-size) / 2));
+  block-size: calc((var(--spectrum-stepper-buttons-height) / 2) - (var(--spectrum-stepper-border-width) / 2));
   block-size: calc(var(--spectrum-stepper-buttons-height) / 2);
 
   /* remove left border width from button width */
-  inline-size: calc(var(--spectrum-stepper-button-width) - var(--spectrum-stepper-border-size));
+  inline-size: calc(var(--spectrum-stepper-button-width) - var(--spectrum-stepper-border-width));
 
   min-inline-size: 0;
 
@@ -106,18 +128,17 @@ governing permissions and limitations under the License.
   padding-inline-end: var(--spectrum-stepper-button-padding);
 
   /* Avoid margin added by adjacent buttons */
-  margin: 0 !important;
+  margin: 0;
 
   border-color: var(--spectrum-stepper-border-color);
 
-  border-width: var(--spectrum-stepper-border-size);
+  border-width: var(--spectrum-stepper-border-width);
   border-inline-start-width: var(--spectrum-stepper-border-size-reset);
 
   border-start-start-radius: var(--spectrum-stepper-border-radius-reset);
   border-end-start-radius: var(--spectrum-stepper-border-radius-reset);
 
   .spectrum-Icon {
-    margin: 0 !important;
     opacity: 1;
   }
 }
@@ -183,68 +204,103 @@ governing permissions and limitations under the License.
 }
 
 
-
 /* Variant colors - WIP placeholders - bring in colors from textfield */
 
 .spectrum-Stepper {
+  position: relative;
+
+  /* remove textfield focus indicator so we don't have two of them */
+  .spectrum-Stepper-textfield::after {
+    display: none;
+  }
+
+    /*** Focus Indicator - Unfocused Base Styles ***/
+  &::after {
+    block-size: calc(100% + (var(--mod-stepper-focus-indicator-gap, var(--spectrum-stepper-focus-indicator-gap)) * 2));
+    inline-size: calc(100% + (var(--mod-stepper-focus-indicator-gap, var(--spectrum-stepper-focus-indicator-gap)) * 2));
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    pointer-events: none;
+    content: '';
+    border-style: solid;
+    border-color: transparent;
+    border-width: 0;
+    border-radius: calc(var(--mod-stepper-border-radius, var(--spectrum-stepper-border-radius))
+                        + var(--mod-stepper-border-width, var(--spectrum-stepper-border-width))
+                        + var(--mod-stepper-focus-indicator-gap, var(--spectrum-stepper-focus-indicator-gap)));
+
+    margin-block-start: calc((var(--mod-stepper-focus-indicator-gap, var(--spectrum-stepper-focus-indicator-gap))
+                              + var(--mod-stepper-focus-indicator-width, var(--spectrum-stepper-focus-indicator-width)))
+                              * -1);
+    margin-inline-start: calc((var(--mod-stepper-focus-indicator-gap, var(--spectrum-stepper-focus-indicator-gap))
+                              + var(--mod-stepper-focus-indicator-width, var(--spectrum-stepper-focus-indicator-width)))
+                              * -1);
+  }
+
   &:hover:not(.is-disabled):not(.is-invalid):not(.is-focused):not(.is-keyboardFocused) {
     .spectrum-Stepper-stepUp,
     .spectrum-Stepper-stepDown,
     .spectrum-Stepper-input {
-      border-color: var(--spectrum-stepper-border-color);
+      border-color: var(--spectrum-stepper-border-color-hover);
     }
   }
 
   &.is-focused {
-    border-color: cyan; /* WIP placeholder */
+    border-color: var(--spectrum-stepper-border-color-focus);
 
     .spectrum-Stepper-stepUp,
     .spectrum-Stepper-stepDown {
-      border-color:  cyan; /* WIP placeholder */
+      border-color: var(--spectrum-stepper-border-color-focus);
     }
 
     .spectrum-Stepper-input {
-      border-color:  cyan; /* WIP placeholder */
-      box-shadow: none;
+      border-color: var(--spectrum-stepper-border-color-focus);
     }
 
-    &.is-invalid {
-      border-color: red;
+    &:hover {
+      border-color: var(--spectrum-stepper-border-color-focus-hover);
 
       .spectrum-Stepper-stepUp,
       .spectrum-Stepper-stepDown {
-        border-color: red;
+        border-color: var(--spectrum-stepper-border-color-focus-hover);
+      }
+    }
+
+    &.is-invalid {
+      border-color: var(--spectrum-stepper-border-color-invalid-focus);
+
+      .spectrum-Stepper-stepUp,
+      .spectrum-Stepper-stepDown {
+        border-color: var(--spectrum-stepper-border-color-invalid-focus);
       }
 
       .spectrum-Stepper-input {
-        border-color: red;
+        border-color: var(--spectrum-stepper-border-color-invalid-focus);
       }
     }
   }
 
   &.is-keyboardFocused {
-    box-shadow: 0 0 0 1px magenta;
 
-    .spectrum-Stepper-input,
-    .spectrum-Stepper-buttons {
-      box-shadow: 0 0 0 1px magenta;
+    /* focus indicator is visible */
+    &::after {
+      border-color: var(--highcontrast-stepper-focus-indicator-color, var(--mod-stepper-focus-indicator-color, var(--spectrum-stepper-focus-indicator-color)));
+      border-width: var(--mod-stepper-focus-indicator-width, var(--spectrum-stepper-focus-indicator-width));
     }
 
     .spectrum-Stepper-input,
     .spectrum-Stepper-stepUp,
     .spectrum-Stepper-stepDown {
-      border-color: magenta;
+      border-color: var(--spectrum-stepper-border-color-keyboard-focus);
     }
 
     &.is-invalid {
-      box-shadow: 0 0 0 1px magenta;
 
       .spectrum-Stepper-stepUp,
       .spectrum-Stepper-stepDown {
-        border-color: magenta;
-      }
-      .spectrum-Stepper-buttons {
-        box-shadow: 0 0 0 1px magenta;
+        border-color: var(--spectrum-stepper-border-color-invalid-keyboard-focus);
       }
     }
   }
@@ -252,21 +308,39 @@ governing permissions and limitations under the License.
   &.is-invalid {
     .spectrum-Stepper-stepUp,
     .spectrum-Stepper-stepDown {
-      border-color: red;
+      border-color: var(--spectrum-stepper-border-color-invalid-default);
     }
 
     .spectrum-Stepper-input {
-      border-color: red;
+      border-color: var(--spectrum-stepper-border-color-invalid-default);
+    }
+
+    &:hover {
+      border-color: var(--spectrum-stepper-border-color-invalid-hover);
+
+      .spectrum-Stepper-stepUp,
+      .spectrum-Stepper-stepDown {
+        border-color: var(--spectrum-stepper-border-color-invalid-hover);
+      }
+    }
+
+    &.is-focused {
+      .spectrum-Stepper-stepUp,
+      .spectrum-Stepper-stepDown {
+        border-color: var(--spectrum-stepper-border-color-invalid-focus);
+      }
+
+      &:hover {
+        .spectrum-Stepper-stepUp,
+        .spectrum-Stepper-stepDown {
+          border-color: var(--spectrum-stepper-border-color-invalid-focus-hover);
+        }
+      }
     }
 
     &.is-keyboardFocused {
       .spectrum-Stepper-input {
-        border-color: red;
-        box-shadow: 0 0 0 1px red;
-      }
-
-      .spectrum-Stepper-buttons {
-        box-shadow: 0 0 0 1px red;
+        border-color: var(--spectrum-stepper-border-color-invalid-keyboard-focus);
       }
     }
   }
@@ -274,7 +348,7 @@ governing permissions and limitations under the License.
   &.is-disabled {
     .spectrum-Stepper-stepUp,
     .spectrum-Stepper-stepDown {
-      border-color: gray;
+      border-color: var(--spectrum-stepper-border-color-disabled);
     }
   }
 }
@@ -283,7 +357,7 @@ governing permissions and limitations under the License.
 .spectrum-Stepper-stepDown {
 
   &:disabled {
-    border-color: gray;
+    border-color: var(--spectrum-stepper-border-color-disabled);
   }
 }
 
@@ -291,60 +365,75 @@ governing permissions and limitations under the License.
   &.is-disabled {
     .spectrum-Stepper-stepUp,
     .spectrum-Stepper-stepDown {
-      border-color: pink;
+      border-color: var(--spectrum-stepper-border-color-disabled);
     }
   }
 
   .spectrum-Stepper-stepUp,
   .spectrum-Stepper-stepDown {
-    border-color: pink;
+    border-color: var(--spectrum-stepper-border-color);
 
     &:disabled {
-      border-color: pink;
+      border-color: var(--spectrum-stepper-border-color-disabled);
     }
-  }
-
-  .spectrum-Stepper-input {
-    box-shadow: none;
   }
 
   &.is-invalid {
     .spectrum-Stepper-input {
-      border-color: red;
+      border-color: var(--spectrum-stepper-border-color-invalid-default);
     }
 
     .spectrum-Stepper-stepDown {
-      border-color: red;
+      border-color: var(--spectrum-stepper-border-color-invalid-default);
     }
   }
 
-  &.is-keyboardFocused,
   &.is-focused {
-    box-shadow: none;
-
-    .spectrum-Stepper-buttons,
-    .spectrum-Stepper-input {
-      box-shadow: 0 1px 0 0 purple;;
+    .spectrum-Stepper-stepDown {
+      border-color: var(--spectrum-stepper-border-color-focus);
     }
 
-    .spectrum-Stepper-stepDown {
-      border-color: purple;
+    &:hover {
+      border-color: var(--spectrum-stepper-border-color-focus-hover);
+
+      .spectrum-Stepper-stepUp,
+      .spectrum-Stepper-stepDown {
+        border-color: var(--spectrum-stepper-border-color-focus-hover);
+      }
     }
 
     &.is-invalid {
-      box-shadow: none;
-
-      .spectrum-Stepper-input,
-      .spectrum-Stepper-buttons {
-        box-shadow: 0 1px 0 0 purple;;
-      }
-
       .spectrum-Stepper-input {
-        border-color: purple;
+        border-color: var(--spectrum-stepper-border-color-focus);
       }
 
       .spectrum-Stepper-stepDown {
-        border-color: purple;
+        border-color: var(--spectrum-stepper-border-color-focus);
+      }
+    }
+  }
+
+  &.is-keyboardFocused {
+    &::after {
+      border-width: 0 0 var(--mod-stepper-focus-indicator-width, var(--spectrum-stepper-focus-indicator-width)) 0;
+      border-radius: 0;
+      inline-size: var(--mod-stepper-width, var(--spectrum-stepper-width));
+      block-size: calc(100% + var(--mod-stepper-focus-indicator-gap, var(--spectrum-stepper-focus-indicator-gap)));
+      margin-inline-start: 0;
+      margin-block-start: 0;
+    }
+
+    .spectrum-Stepper-stepDown {
+      border-color: var(--spectrum-stepper-border-color-keyboard-focus);
+    }
+
+    &.is-invalid {
+      .spectrum-Stepper-input {
+        border-color: var(--spectrum-stepper-border-color-invalid-keyboard-focus);
+      }
+
+      .spectrum-Stepper-stepDown {
+        border-color: var(--spectrum-stepper-border-color-invalid-keyboard-focus);
       }
     }
   }

--- a/components/stepper/index.css
+++ b/components/stepper/index.css
@@ -10,19 +10,21 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+/*** TODO - Stepper was migrated using placeholder tokens, reevaluate when complete design specs are available ***/
+/*** This migration combines existing Stepper styles with minimal new design instructions ***/
 
 .spectrum-Stepper {
-   /**** TODO - ask Design to evaluate these widths ****/
-  --spectrum-stepper-width-medium: 72px; /* replaces --spectrum-global-dimension-size-900 */
-  --spectrum-stepper-width-large: 90px; /* replaces --spectrum-global-dimension-size-900 */
+   /**** TODO - this section contains placeholder widths ****/
+  --spectrum-stepper-width-medium: 72px; /* placeholder for --spectrum-global-dimension-size-900 */
+  --spectrum-stepper-width-large: 90px; /* placeholder for --spectrum-global-dimension-size-900 */
   --spectrum-stepper-icon-width-medium: 10px; /* placeholder for --spectrum-alias-ui-icon-chevron-size-75 */
   --spectrum-stepper-icon-width-large: 12px; /* placeholder for --spectrum-alias-ui-icon-chevron-size-75 */
 
-  /* set defaults */
+  /* set defaults to medium theme */
   --spectrum-stepper-width: var(--spectrum-stepper-width-medium);
   --spectrum-stepper-icon-width: var(--spectrum-stepper-icon-width-medium);
 
-  /* override per size */
+  /* override per theme size to match old token --spectrum-global-dimension-size-900 */
   /* this is necessary to mimmic the size-responsive tokens which were already present */
   .spectrum--medium {
     & {
@@ -37,30 +39,23 @@ governing permissions and limitations under the License.
       --spectrum-stepper-icon-width: var(--spectrum-stepper-icon-width-large);
     }
   }
-  /**** end TODO ****/
+  /**** END placeholder widths ****/
 
-  --spectrum-stepper-button-width: var(--spectrum-component-height-75); /* this height token matches the previous width token */
 
- /* quiet variant */
-  --spectrum-stepper-quiet-width: var(--spectrum-component-height-300); /* matches previous width token */
-  --spectrum-stepper-quiet-button-width: calc(var(--spectrum-stepper-button-width) - var(--spectrum-stepper-button-offset));
+  --spectrum-stepper-button-width: var(--spectrum-component-height-75); /* this height token matches the previous WIDTH token */
 
   --spectrum-stepper-button-padding: var(--spectrum-component-edge-to-visual-50); /* 6px md + 7px lg - previously 6px md + 7.5px lg */
 
   --spectrum-stepper-border-radius-reset: 0;
   --spectrum-stepper-border-size-reset: 0;
 
-  --spectrum-stepper-icon-nudge-start: 1px; /* 1px - could this be == the component border width? Check Express */
-  /* was var(--spectrum-global-dimension-size-10); */
-  /* was 1px */
-
-  --spectrum-stepper-icon-nudge-end: 2px; /* 2px - could this be == the component border width? Check Express */
-  /* was var(--spectrum-global-dimension-size-25); */
-  /* was 2px */
+  /*** Button Icons - appears to adjust position ***/
+  --spectrum-stepper-icon-nudge-start: 1px; /* placeholder - was var(--spectrum-global-dimension-size-10) - 1px */
+  --spectrum-stepper-icon-nudge-end: 2px; /* placeholder -was var(--spectrum-global-dimension-size-25) - 2px */
 
 
-  /* this is for the :after hit area element */
-  --spectrum-stepper-button-offset: calc(var(--spectrum-stepper-button-width) / 2 - var(--spectrum-stepper-icon-width) / 2); /* TODO - reevaluate when icons are migrated */
+ /*** :AFTER - this is for the :after element labeled below as hit area, but used as focus indicator in ActionButton ***/
+  --spectrum-stepper-button-offset: calc(var(--spectrum-stepper-button-width) / 2 - var(--spectrum-stepper-icon-width) / 2);
     /* chevron = --spectrum-global-dimension-static-size-125 and --spectrum-global-dimension-static-size-150 = 10px and 12px */
   /* button width of 23px / 29px divided by 2 = 11.5px and 14.5px */
   /* chevron size of 10px and 12px divided by 2 = 5px and 6px */
@@ -68,26 +63,30 @@ governing permissions and limitations under the License.
   /* 14.5px minus 6px = 8.5px */
 
 
-  /* New tokens - to match textfield */
+  /*** New added tokens begin here - chosen to match textfield - reevaluate when fully migrating Stepper ***/
   --spectrum-stepper-animation-duration: var(--spectrum-animation-duration-100);
   --spectrum-stepper-border-radius: var(--spectrum-corner-radius-100);
   --spectrum-stepper-buttons-height: var(--spectrum-component-height-100); /* from textfield height */
 
-  /* focus indicator */
-  --spectrum-stepper-focus-indicator-width: var(--spectrum-focus-indicator-thickness);
-  --spectrum-stepper-focus-indicator-gap: var(--spectrum-focus-indicator-gap);
+ /*** Quiet Variant ***/
+  --spectrum-stepper-quiet-width: var(--spectrum-component-height-300); /* matches previous width token */
+  --spectrum-stepper-quiet-button-width: calc(var(--spectrum-stepper-button-width) - var(--spectrum-stepper-button-offset));
 
-  /* Disabled Colors */
+  /*** Disabled Colors ***/
   --spectrum-stepper-border-color-quiet-disabled: var(--spectrum-disabled-border-color);
 
-  /* Invalid Colors */
+  /*** Invalid Colors ***/
   --spectrum-stepper-border-color-invalid-default: var(--spectrum-negative-border-color-default);
   --spectrum-stepper-border-color-invalid-hover: var(--spectrum-negative-border-color-hover);
   --spectrum-stepper-border-color-invalid-focus: var(--spectrum-negative-border-color-focus);
   --spectrum-stepper-border-color-invalid-focus-hover: var(--spectrum-negative-border-color-focus-hover);
   --spectrum-stepper-border-color-invalid-keyboard-focus: var(--spectrum-negative-border-color-key-focus);
 
-  /* Focus Indicator Color */
+  /*** Focus Indicator ***/
+  --spectrum-stepper-focus-indicator-width: var(--spectrum-focus-indicator-thickness);
+  --spectrum-stepper-focus-indicator-gap: var(--spectrum-focus-indicator-gap);
+
+  /*** Focus Indicator Color ***/
   --spectrum-stepper-focus-indicator-color: var(--spectrum-focus-indicator-color);
 }
 
@@ -95,6 +94,22 @@ governing permissions and limitations under the License.
 /********* WHCM *********/
 @media (forced-colors: active) {
   .spectrum-Stepper {
+    --highcontrast-stepper-border-color: CanvasText;
+    --highcontrast-stepper-border-color-hover: Highlight;
+    --highcontrast-stepper-border-color-focus: Highlight;
+    --highcontrast-stepper-border-color-focus-hover: Highlight;
+    --highcontrast-stepper-border-color-keyboard-focus: Highlight;
+
+    /*** Disabled Colors ***/
+    --highcontrast-stepper-border-color-quiet-disabled: GrayText;
+
+    /*** Invalid Colors ***/
+    --highcontrast-stepper-border-color-invalid-default: Highlight;
+    --highcontrast-stepper-border-color-invalid-hover: Highlight;
+    --highcontrast-stepper-border-color-invalid-focus: Highlight;
+    --highcontrast-stepper-border-color-invalid-focus-hover: Highlight;
+    --highcontrast-stepper-border-color-invalid-keyboard-focus: Highlight;
+
     --highcontrast-stepper-focus-indicator-color: CanvasText;
   }
 }
@@ -104,10 +119,10 @@ governing permissions and limitations under the License.
   flex-direction: row;
   flex-wrap: nowrap;
 
-  inline-size: var(--spectrum-stepper-width);
+  inline-size: var(--mod-stepper-width, var(--spectrum-stepper-width));
   line-height: 0;
-  border-radius: var(--spectrum-stepper-border-radius); /* --spectrum-global-dimension-size-75 = 6px 8px */
-  transition: border-color var(--spectrum-stepper-animation-duration) ease-in-out;
+  border-radius: var(--mod-stepper-border-radius, var(--spectrum-stepper-border-radius)); /* --spectrum-global-dimension-size-75 = 6px 8px */
+  transition: border-color var(--mod-stepper-animation-duration, var(--spectrum-stepper-animation-duration)) ease-in-out;
 }
 .spectrum-Stepper::before {
   content: '';
@@ -117,10 +132,10 @@ governing permissions and limitations under the License.
   display: block;
   box-sizing: border-box;
   border-start-start-radius: 0;
-  border-start-end-radius: var(--spectrum-stepper-border-radius); /* --spectrum-global-dimension-size-75  = 6px 8px */
-  border-end-end-radius: var(--spectrum-stepper-border-radius);
+  border-start-end-radius: var(--mod-stepper-border-radius, var(--spectrum-stepper-border-radius)); /* --spectrum-global-dimension-size-75  = 6px 8px */
+  border-end-end-radius: var(--mod-stepper-border-radius, var(--spectrum-stepper-border-radius));
   border-end-start-radius: 0;
-  block-size: var(--spectrum-stepper-buttons-height);
+  block-size: var(--mod-stepper-buttons-height, var(--spectrum-stepper-buttons-height));
 }
 
 .spectrum-Stepper-stepUp,
@@ -130,30 +145,30 @@ governing permissions and limitations under the License.
   box-sizing: border-box;
 
   /* remove middle border from button height */
-  block-size: calc((var(--spectrum-stepper-buttons-height) / 2)) - var(--spectrum-stepper-border-width));
-  block-size: calc((var(--spectrum-stepper-buttons-height) - var(--spectrum-stepper-border-width)) / 2);
+  block-size: calc((var(--mod-stepper-buttons-height, var(--spectrum-stepper-buttons-height)) / 2)) - var(--mod-stepper-border-width, var(--spectrum-stepper-border-width)));
+  block-size: calc((var(--mod-stepper-buttons-height, var(--spectrum-stepper-buttons-height)) - var(--mod-stepper-border-width, var(--spectrum-stepper-border-width))) / 2);
 
-  block-size: calc((var(--spectrum-stepper-buttons-height) / 2) - (var(--spectrum-stepper-border-width) / 2));
-  block-size: calc(var(--spectrum-stepper-buttons-height) / 2);
+  block-size: calc((var(--mod-stepper-buttons-height, var(--spectrum-stepper-buttons-height)) / 2) - (var(--mod-stepper-border-width, var(--spectrum-stepper-border-width)) / 2));
+  block-size: calc(var(--mod-stepper-buttons-height, var(--spectrum-stepper-buttons-height)) / 2);
 
   /* remove left border width from button width */
-  inline-size: calc(var(--spectrum-stepper-button-width) - var(--spectrum-stepper-border-width));
+  inline-size: calc(var(--mod-stepper-button-width, var(--spectrum-stepper-button-width)) - var(--mod-stepper-border-width, var(--spectrum-stepper-border-width)));
 
   min-inline-size: 0;
 
-  padding-inline-start: var(--spectrum-stepper-button-padding);
-  padding-inline-end: var(--spectrum-stepper-button-padding);
+  padding-inline-start: var(--mod-stepper-button-padding, var(--spectrum-stepper-button-padding));
+  padding-inline-end: var(--mod-stepper-button-padding, var(--spectrum-stepper-button-padding));
 
   /* Avoid margin added by adjacent buttons */
   margin: 0;
 
-  border-color: var(--spectrum-stepper-border-color);
+  border-color: var(--highcontrast-stepper-border-color, var(--mod-stepper-border-color, var(--spectrum-stepper-border-color)));
 
-  border-width: var(--spectrum-stepper-border-width);
-  border-inline-start-width: var(--spectrum-stepper-border-size-reset);
+  border-width: var(--mod-stepper-border-width, var(--spectrum-stepper-border-width));
+  border-inline-start-width: var(--mod-stepper-border-size-reset, var(--spectrum-stepper-border-size-reset));
 
-  border-start-start-radius: var(--spectrum-stepper-border-radius-reset);
-  border-end-start-radius: var(--spectrum-stepper-border-radius-reset);
+  border-start-start-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
+  border-end-start-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
 
   .spectrum-Icon {
     opacity: 1;
@@ -162,15 +177,15 @@ governing permissions and limitations under the License.
 
 .spectrum-Stepper-stepUp {
   border-block-end: none;
-  border-end-end-radius: var(--spectrum-stepper-border-radius-reset);
+  border-end-end-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
 
-  padding-block-start: var(--spectrum-stepper-icon-nudge-start);
+  padding-block-start: var(--mod-stepper-icon-nudge-start, var(--spectrum-stepper-icon-nudge-start));
 }
 
 .spectrum-Stepper-stepDown {
-  border-start-end-radius: var(--spectrum-stepper-border-radius-reset);
+  border-start-end-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
 
-  padding-block-end: var(--spectrum-stepper-icon-nudge-end);
+  padding-block-end: var(--mod-stepper-icon-nudge-end, var(--spectrum-stepper-icon-nudge-end));
 }
 
 .spectrum-Stepper-textfield {
@@ -180,8 +195,8 @@ governing permissions and limitations under the License.
 
 .spectrum-Stepper-input {
   min-inline-size: 0;
-  border-start-end-radius: var(--spectrum-stepper-border-radius-reset);
-  border-end-end-radius: var(--spectrum-stepper-border-radius-reset);
+  border-start-end-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
+  border-end-end-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
 }
 
 .spectrum-Stepper-textfield {
@@ -189,22 +204,22 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Stepper--quiet {
-  border-radius: var(--spectrum-stepper-border-radius-reset);
-  inline-size: var(--spectrum-stepper-quiet-width);
+  border-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
+  inline-size: var(--mod-stepper-quiet-width, var(--spectrum-stepper-quiet-width));
 
   .spectrum-Stepper-buttons {
-    border-radius: var(--spectrum-stepper-border-radius-reset);
+    border-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
   }
 
   .spectrum-Stepper-stepUp,
   .spectrum-Stepper-stepDown {
-    inline-size: var(--spectrum-stepper-quiet-button-width);
+    inline-size: var(--mod-stepper-quiet-button-width, var(--spectrum-stepper-quiet-button-width));
     min-inline-size: 0;
 
-    border-inline-end-width: var(--spectrum-stepper-border-size-reset);
+    border-inline-end-width: var(--mod-stepper-border-size-reset, var(--spectrum-stepper-border-size-reset));
     border-block-start: none;
     border-inline-start: none;
-    border-radius: var(--spectrum-stepper-border-radius-reset);
+    border-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
 
     padding-inline-end: 0;
     justify-content: flex-end;
@@ -214,8 +229,8 @@ governing permissions and limitations under the License.
       content: '';
       position: absolute;
       block-size: 100%;
-      inline-size: var(--spectrum-stepper-button-offset);
-      inset-inline-end: calc(var(--spectrum-stepper-button-offset) * -1);
+      inline-size: var(--mod-stepper-button-offset, var(--spectrum-stepper-button-offset));
+      inset-inline-end: calc(var(--mod-stepper-button-offset, var(--spectrum-stepper-button-offset)) * -1);
     }
   }
 }
@@ -260,41 +275,41 @@ governing permissions and limitations under the License.
     .spectrum-Stepper-stepUp,
     .spectrum-Stepper-stepDown,
     .spectrum-Stepper-input {
-      border-color: var(--spectrum-stepper-border-color-hover);
+      border-color: var(--highcontrast-stepper-border-color-hover, var(--mod-stepper-border-color-hover, var(--spectrum-stepper-border-color-hover)));
     }
   }
 
   &.is-focused {
-    border-color: var(--spectrum-stepper-border-color-focus);
+    border-color: var(--highcontrast-stepper-border-color-focus, var(--mod-stepper-border-color-focus, var(--spectrum-stepper-border-color-focus)));
 
     .spectrum-Stepper-stepUp,
     .spectrum-Stepper-stepDown {
-      border-color: var(--spectrum-stepper-border-color-focus);
+      border-color: var(--highcontrast-stepper-border-color-focus, var(--mod-stepper-border-color-focus, var(--spectrum-stepper-border-color-focus)));
     }
 
     .spectrum-Stepper-input {
-      border-color: var(--spectrum-stepper-border-color-focus);
+      border-color: var(--highcontrast-stepper-border-color-focus, var(--mod-stepper-border-color-focus, var(--spectrum-stepper-border-color-focus)));
     }
 
     &:hover {
-      border-color: var(--spectrum-stepper-border-color-focus-hover);
+      border-color: var(--highcontrast-stepper-border-color-focus-hover, var(--mod-stepper-border-color-focus-hover, var(--spectrum-stepper-border-color-focus-hover)));
 
       .spectrum-Stepper-stepUp,
       .spectrum-Stepper-stepDown {
-        border-color: var(--spectrum-stepper-border-color-focus-hover);
+        border-color: var(--highcontrast-stepper-border-color-focus-hover, var(--mod-stepper-border-color-focus-hover, var(--spectrum-stepper-border-color-focus-hover)));
       }
     }
 
     &.is-invalid {
-      border-color: var(--spectrum-stepper-border-color-invalid-focus);
+      border-color: var(--highcontrast-stepper-border-color-invalid-focus, var(--mod-stepper-border-color-invalid-focus, var(--spectrum-stepper-border-color-invalid-focus)));
 
       .spectrum-Stepper-stepUp,
       .spectrum-Stepper-stepDown {
-        border-color: var(--spectrum-stepper-border-color-invalid-focus);
+        border-color: var(--highcontrast-stepper-border-color-invalid-focus, var(--mod-stepper-border-color-invalid-focus, var(--spectrum-stepper-border-color-invalid-focus)));
       }
 
       .spectrum-Stepper-input {
-        border-color: var(--spectrum-stepper-border-color-invalid-focus);
+        border-color: var(--highcontrast-stepper-border-color-invalid-focus, var(--mod-stepper-border-color-invalid-focus, var(--spectrum-stepper-border-color-invalid-focus)));
       }
     }
   }
@@ -310,14 +325,14 @@ governing permissions and limitations under the License.
     .spectrum-Stepper-input,
     .spectrum-Stepper-stepUp,
     .spectrum-Stepper-stepDown {
-      border-color: var(--spectrum-stepper-border-color-keyboard-focus);
+      border-color: var(--highcontrast-stepper-border-color-keyboard-focus, var(--mod-stepper-border-color-keyboard-focus, var(--spectrum-stepper-border-color-keyboard-focus)));
     }
 
     &.is-invalid {
 
       .spectrum-Stepper-stepUp,
       .spectrum-Stepper-stepDown {
-        border-color: var(--spectrum-stepper-border-color-invalid-keyboard-focus);
+        border-color: var(--highcontrast-stepper-border-color-invalid-keyboard-focus, var(--mod-stepper-border-color-invalid-keyboard-focus, var(--spectrum-stepper-border-color-invalid-keyboard-focus)));
       }
     }
   }
@@ -325,39 +340,39 @@ governing permissions and limitations under the License.
   &.is-invalid {
     .spectrum-Stepper-stepUp,
     .spectrum-Stepper-stepDown {
-      border-color: var(--spectrum-stepper-border-color-invalid-default);
+      border-color: var(--highcontrast-stepper-border-color-invalid-default, var(--mod-stepper-border-color-invalid-default, var(--spectrum-stepper-border-color-invalid-default)));
     }
 
     .spectrum-Stepper-input {
-      border-color: var(--spectrum-stepper-border-color-invalid-default);
+      border-color: var(--highcontrast-stepper-border-color-invalid-default, var(--mod-stepper-border-color-invalid-default, var(--spectrum-stepper-border-color-invalid-default)));
     }
 
     &:hover {
-      border-color: var(--spectrum-stepper-border-color-invalid-hover);
+      border-color: var(--highcontrast-stepper-border-color-invalid-hover, var(--mod-stepper-border-color-invalid-hover, var(--spectrum-stepper-border-color-invalid-hover)));
 
       .spectrum-Stepper-stepUp,
       .spectrum-Stepper-stepDown {
-        border-color: var(--spectrum-stepper-border-color-invalid-hover);
+        border-color: var(--highcontrast-stepper-border-color-invalid-hover, var(--mod-stepper-border-color-invalid-hover, var(--spectrum-stepper-border-color-invalid-hover)));
       }
     }
 
     &.is-focused {
       .spectrum-Stepper-stepUp,
       .spectrum-Stepper-stepDown {
-        border-color: var(--spectrum-stepper-border-color-invalid-focus);
+        border-color: var(--highcontrast-stepper-border-color-invalid-focus, var(--mod-stepper-border-color-invalid-focus, var(--spectrum-stepper-border-color-invalid-focus)));
       }
 
       &:hover {
         .spectrum-Stepper-stepUp,
         .spectrum-Stepper-stepDown {
-          border-color: var(--spectrum-stepper-border-color-invalid-focus-hover);
+          border-color: var(--highcontrast-stepper-border-color-invalid-focus-hover, var(--mod-stepper-border-color-invalid-focus-hover, var(--spectrum-stepper-border-color-invalid-focus-hover)));
         }
       }
     }
 
     &.is-keyboardFocused {
       .spectrum-Stepper-input {
-        border-color: var(--spectrum-stepper-border-color-invalid-keyboard-focus);
+        border-color: var(--highcontrast-stepper-border-color-invalid-keyboard-focus, var(--mod-stepper-border-color-invalid-keyboard-focus, var(--spectrum-stepper-border-color-invalid-keyboard-focus)));
       }
     }
   }
@@ -382,50 +397,50 @@ governing permissions and limitations under the License.
   &.is-disabled {
     .spectrum-Stepper-stepUp,
     .spectrum-Stepper-stepDown {
-      border-color: var(--spectrum-stepper-border-color-quiet-disabled);
+      border-color: var(--highcontrast-stepper-border-color-quiet-disabled, var(--mod-stepper-border-color-quiet-disabled, var(--spectrum-stepper-border-color-quiet-disabled)));
     }
   }
 
   .spectrum-Stepper-stepUp,
   .spectrum-Stepper-stepDown {
-    border-color: var(--spectrum-stepper-border-color);
+    border-color: var(--highcontrast-stepper-border-color, var(--mod-stepper-border-color, var(--spectrum-stepper-border-color)));
 
     &:disabled {
-      border-color: var(--spectrum-stepper-border-color-quiet-disabled);
+      border-color: var(--highcontrast-stepper-border-color-quiet-disabled, var(--mod-stepper-border-color-quiet-disabled, var(--spectrum-stepper-border-color-quiet-disabled)));
     }
   }
 
   &.is-invalid {
     .spectrum-Stepper-input {
-      border-color: var(--spectrum-stepper-border-color-invalid-default);
+      border-color: var(--highcontrast-stepper-border-color-invalid-default, var(--mod-stepper-border-color-invalid-default, var(--spectrum-stepper-border-color-invalid-default)));
     }
 
     .spectrum-Stepper-stepDown {
-      border-color: var(--spectrum-stepper-border-color-invalid-default);
+      border-color: var(--highcontrast-stepper-border-color-invalid-default, var(--mod-stepper-border-color-invalid-default, var(--spectrum-stepper-border-color-invalid-default)));
     }
   }
 
   &.is-focused {
     .spectrum-Stepper-stepDown {
-      border-color: var(--spectrum-stepper-border-color-focus);
+      border-color: var(--highcontrast-stepper-border-color-focus, var(--mod-stepper-border-color-focus, var(--spectrum-stepper-border-color-focus)));
     }
 
     &:hover {
-      border-color: var(--spectrum-stepper-border-color-focus-hover);
+      border-color: var(--highcontrast-stepper-border-color-focus-hover, var(--mod-stepper-border-color-focus-hover, var(--spectrum-stepper-border-color-focus-hover)));
 
       .spectrum-Stepper-stepUp,
       .spectrum-Stepper-stepDown {
-        border-color: var(--spectrum-stepper-border-color-focus-hover);
+        border-color: var(--highcontrast-stepper-border-color-focus-hover, var(--mod-stepper-border-color-focus-hover, var(--spectrum-stepper-border-color-focus-hover)));
       }
     }
 
     &.is-invalid {
       .spectrum-Stepper-input {
-        border-color: var(--spectrum-stepper-border-color-focus);
+        border-color: var(--highcontrast-stepper-border-color-focus, var(--mod-stepper-border-color-focus, var(--spectrum-stepper-border-color-focus)));
       }
 
       .spectrum-Stepper-stepDown {
-        border-color: var(--spectrum-stepper-border-color-focus);
+        border-color: var(--highcontrast-stepper-border-color-focus, var(--mod-stepper-border-color-focus, var(--spectrum-stepper-border-color-focus)));
       }
     }
   }
@@ -441,16 +456,16 @@ governing permissions and limitations under the License.
     }
 
     .spectrum-Stepper-stepDown {
-      border-color: var(--spectrum-stepper-border-color-keyboard-focus);
+      border-color: var(--highcontrast-stepper-border-color-keyboard-focus, var(--mod-stepper-border-color-keyboard-focus, var(--spectrum-stepper-border-color-keyboard-focus)));
     }
 
     &.is-invalid {
       .spectrum-Stepper-input {
-        border-color: var(--spectrum-stepper-border-color-invalid-keyboard-focus);
+        border-color: var(--highcontrast-stepper-border-color-invalid-keyboard-focus, var(--mod-stepper-border-color-invalid-keyboard-focus, var(--spectrum-stepper-border-color-invalid-keyboard-focus)));
       }
 
       .spectrum-Stepper-stepDown {
-        border-color: var(--spectrum-stepper-border-color-invalid-keyboard-focus);
+        border-color: var(--highcontrast-stepper-border-color-invalid-keyboard-focus, var(--mod-stepper-border-color-invalid-keyboard-focus, var(--spectrum-stepper-border-color-invalid-keyboard-focus)));
       }
     }
   }

--- a/components/stepper/index.css
+++ b/components/stepper/index.css
@@ -110,6 +110,11 @@ governing permissions and limitations under the License.
     --highcontrast-stepper-border-color-invalid-focus-hover: Highlight;
     --highcontrast-stepper-border-color-invalid-keyboard-focus: Highlight;
 
+    --highcontrast-stepper-background-color-default: Canvas;
+    --highcontrast-stepper-background-color-hover: Canvas;
+    --highcontrast-stepper-background-color-active: Canvas;
+    --highcontrast-stepper-background-color-keyboard-focus: Canvas;
+
     --highcontrast-stepper-focus-indicator-color: CanvasText;
   }
 }
@@ -129,13 +134,23 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Stepper-buttons {
-  display: block;
+  display: flex;
+  flex-direction: column;
+  gap: var(--mod-stepper-button-gap, var(--spectrum-stepper-button-gap));
   box-sizing: border-box;
   border-start-start-radius: 0;
   border-start-end-radius: var(--mod-stepper-border-radius, var(--spectrum-stepper-border-radius)); /* --spectrum-global-dimension-size-75  = 6px 8px */
   border-end-end-radius: var(--mod-stepper-border-radius, var(--spectrum-stepper-border-radius));
   border-end-start-radius: 0;
   block-size: var(--mod-stepper-buttons-height, var(--spectrum-stepper-buttons-height));
+
+  border-style: solid;
+  border-width: var(--mod-stepper-border-width, var(--spectrum-stepper-border-width))
+                var(--mod-stepper-border-width, var(--spectrum-stepper-border-width))
+                var(--mod-stepper-border-width, var(--spectrum-stepper-border-width))
+                var(--mod-stepper-border-size-reset, var(--spectrum-stepper-border-size-reset));
+
+  border-color: var(--highcontrast-stepper-border-color, var(--mod-stepper-border-color, var(--spectrum-stepper-border-color)));
 }
 
 .spectrum-Stepper-stepUp,
@@ -163,12 +178,11 @@ governing permissions and limitations under the License.
   margin: 0;
 
   border-color: var(--highcontrast-stepper-border-color, var(--mod-stepper-border-color, var(--spectrum-stepper-border-color)));
-
-  border-width: var(--mod-stepper-border-width, var(--spectrum-stepper-border-width));
-  border-inline-start-width: var(--mod-stepper-border-size-reset, var(--spectrum-stepper-border-size-reset));
-
+  border-width: 0;
   border-start-start-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
   border-end-start-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
+
+  background-color: var(--highcontrast-stepper-background-color-default, var(--mod-stepper-background-color-default, var(--spectrum-stepper-background-color-default)));
 
   .spectrum-Icon {
     opacity: 1;
@@ -176,13 +190,13 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Stepper-stepUp {
-  border-block-end: none;
   border-end-end-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
 
   padding-block-start: var(--mod-stepper-icon-nudge-start, var(--spectrum-stepper-icon-nudge-start));
 }
 
 .spectrum-Stepper-stepDown {
+  border-block-start-width: var(--mod-stepper-middle-border-width, var(--spectrum-stepper-middle-border-width));
   border-start-end-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
 
   padding-block-end: var(--mod-stepper-icon-nudge-end, var(--spectrum-stepper-icon-nudge-end));
@@ -197,6 +211,7 @@ governing permissions and limitations under the License.
   min-inline-size: 0;
   border-start-end-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
   border-end-end-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
+  border-inline-end-width: 0;
 }
 
 .spectrum-Stepper-textfield {
@@ -216,7 +231,6 @@ governing permissions and limitations under the License.
     inline-size: var(--mod-stepper-quiet-button-width, var(--spectrum-stepper-quiet-button-width));
     min-inline-size: 0;
 
-    border-inline-end-width: var(--mod-stepper-border-size-reset, var(--spectrum-stepper-border-size-reset));
     border-block-start: none;
     border-inline-start: none;
     border-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
@@ -246,7 +260,7 @@ governing permissions and limitations under the License.
     display: none;
   }
 
-    /*** Focus Indicator - Unfocused Base Styles ***/
+  /*** Focus Indicator - Unfocused Base Styles ***/
   &::after {
     block-size: calc(100% + (var(--mod-stepper-focus-indicator-gap, var(--spectrum-stepper-focus-indicator-gap)) * 2));
     inline-size: calc(100% + (var(--mod-stepper-focus-indicator-gap, var(--spectrum-stepper-focus-indicator-gap)) * 2));
@@ -272,19 +286,31 @@ governing permissions and limitations under the License.
   }
 
   &:hover:not(.is-disabled):not(.is-invalid):not(.is-focused):not(.is-keyboardFocused) {
+    .spectrum-Stepper-buttons,
     .spectrum-Stepper-stepUp,
     .spectrum-Stepper-stepDown,
     .spectrum-Stepper-input {
       border-color: var(--highcontrast-stepper-border-color-hover, var(--mod-stepper-border-color-hover, var(--spectrum-stepper-border-color-hover)));
+    }
+
+    .spectrum-Stepper-stepUp,
+    .spectrum-Stepper-stepDown {
+      background-color: var(--highcontrast-stepper-background-color-hover), var(--mod-stepper-background-color-hover), var(--spectrum-stepper-background-color-hover)));
     }
   }
 
   &.is-focused {
     border-color: var(--highcontrast-stepper-border-color-focus, var(--mod-stepper-border-color-focus, var(--spectrum-stepper-border-color-focus)));
 
+    .spectrum-Stepper-buttons,
     .spectrum-Stepper-stepUp,
     .spectrum-Stepper-stepDown {
       border-color: var(--highcontrast-stepper-border-color-focus, var(--mod-stepper-border-color-focus, var(--spectrum-stepper-border-color-focus)));
+    }
+
+    .spectrum-Stepper-stepUp,
+    .spectrum-Stepper-stepDown {
+      background-color: var(--highcontrast-stepper-background-color-active, var(--mod-stepper-background-color-active, var(--spectrum-stepper-background-color-active))); /* is this right? */
     }
 
     .spectrum-Stepper-input {
@@ -294,15 +320,22 @@ governing permissions and limitations under the License.
     &:hover {
       border-color: var(--highcontrast-stepper-border-color-focus-hover, var(--mod-stepper-border-color-focus-hover, var(--spectrum-stepper-border-color-focus-hover)));
 
+      .spectrum-Stepper-buttons,
       .spectrum-Stepper-stepUp,
       .spectrum-Stepper-stepDown {
         border-color: var(--highcontrast-stepper-border-color-focus-hover, var(--mod-stepper-border-color-focus-hover, var(--spectrum-stepper-border-color-focus-hover)));
+      }
+
+      .spectrum-Stepper-stepUp,
+      .spectrum-Stepper-stepDown {
+        background-color: var(--highcontrast-stepper-background-color-hover), var(--mod-stepper-background-color-hover), var(--spectrum-stepper-background-color-hover))); /* is this right? */
       }
     }
 
     &.is-invalid {
       border-color: var(--highcontrast-stepper-border-color-invalid-focus, var(--mod-stepper-border-color-invalid-focus, var(--spectrum-stepper-border-color-invalid-focus)));
 
+      .spectrum-Stepper-buttons,
       .spectrum-Stepper-stepUp,
       .spectrum-Stepper-stepDown {
         border-color: var(--highcontrast-stepper-border-color-invalid-focus, var(--mod-stepper-border-color-invalid-focus, var(--spectrum-stepper-border-color-invalid-focus)));
@@ -323,13 +356,19 @@ governing permissions and limitations under the License.
     }
 
     .spectrum-Stepper-input,
+    .spectrum-Stepper-buttons,
     .spectrum-Stepper-stepUp,
     .spectrum-Stepper-stepDown {
       border-color: var(--highcontrast-stepper-border-color-keyboard-focus, var(--mod-stepper-border-color-keyboard-focus, var(--spectrum-stepper-border-color-keyboard-focus)));
     }
 
-    &.is-invalid {
+    .spectrum-Stepper-stepUp,
+    .spectrum-Stepper-stepDown {
+      background-color: var(--highcontrast-stepper-background-color-keyboard-focus, var(--mod-stepper-background-color-keyboard-focus, var(--spectrum-stepper-background-color-keyboard-focus)));
+    }
 
+    &.is-invalid {
+      .spectrum-Stepper-buttons,
       .spectrum-Stepper-stepUp,
       .spectrum-Stepper-stepDown {
         border-color: var(--highcontrast-stepper-border-color-invalid-keyboard-focus, var(--mod-stepper-border-color-invalid-keyboard-focus, var(--spectrum-stepper-border-color-invalid-keyboard-focus)));
@@ -338,6 +377,7 @@ governing permissions and limitations under the License.
   }
 
   &.is-invalid {
+    .spectrum-Stepper-buttons,
     .spectrum-Stepper-stepUp,
     .spectrum-Stepper-stepDown {
       border-color: var(--highcontrast-stepper-border-color-invalid-default, var(--mod-stepper-border-color-invalid-default, var(--spectrum-stepper-border-color-invalid-default)));
@@ -350,6 +390,7 @@ governing permissions and limitations under the License.
     &:hover {
       border-color: var(--highcontrast-stepper-border-color-invalid-hover, var(--mod-stepper-border-color-invalid-hover, var(--spectrum-stepper-border-color-invalid-hover)));
 
+      .spectrum-Stepper-buttons,
       .spectrum-Stepper-stepUp,
       .spectrum-Stepper-stepDown {
         border-color: var(--highcontrast-stepper-border-color-invalid-hover, var(--mod-stepper-border-color-invalid-hover, var(--spectrum-stepper-border-color-invalid-hover)));
@@ -357,12 +398,14 @@ governing permissions and limitations under the License.
     }
 
     &.is-focused {
+      .spectrum-Stepper-buttons,
       .spectrum-Stepper-stepUp,
       .spectrum-Stepper-stepDown {
         border-color: var(--highcontrast-stepper-border-color-invalid-focus, var(--mod-stepper-border-color-invalid-focus, var(--spectrum-stepper-border-color-invalid-focus)));
       }
 
       &:hover {
+        .spectrum-Stepper-buttons,
         .spectrum-Stepper-stepUp,
         .spectrum-Stepper-stepDown {
           border-color: var(--highcontrast-stepper-border-color-invalid-focus-hover, var(--mod-stepper-border-color-invalid-focus-hover, var(--spectrum-stepper-border-color-invalid-focus-hover)));
@@ -378,6 +421,7 @@ governing permissions and limitations under the License.
   }
 
   &.is-disabled {
+    .spectrum-Stepper-buttons,
     .spectrum-Stepper-stepUp,
     .spectrum-Stepper-stepDown {
       border-color: transparent;
@@ -385,28 +429,44 @@ governing permissions and limitations under the License.
   }
 }
 
+.spectrum-Stepper-buttons,
 .spectrum-Stepper-stepUp,
 .spectrum-Stepper-stepDown {
-
   &:disabled {
     border-color: transparent;
   }
 }
 
 .spectrum-Stepper--quiet {
+
+ .spectrum-Stepper-buttons {
+   border-width: 0 0 var(--mod-stepper-border-width, var(--spectrum-stepper-border-width)) 0;
+ }
+
+  .spectrum-Stepper-buttons,
+  .spectrum-Stepper-stepUp,
+  .spectrum-Stepper-stepDown {
+    background-color: transparent;
+  }
+
   &.is-disabled {
+    .spectrum-Stepper-buttons,
     .spectrum-Stepper-stepUp,
     .spectrum-Stepper-stepDown {
       border-color: var(--highcontrast-stepper-border-color-quiet-disabled, var(--mod-stepper-border-color-quiet-disabled, var(--spectrum-stepper-border-color-quiet-disabled)));
+      background-color: transparent;
     }
   }
 
+  .spectrum-Stepper-buttons,
   .spectrum-Stepper-stepUp,
   .spectrum-Stepper-stepDown {
     border-color: var(--highcontrast-stepper-border-color, var(--mod-stepper-border-color, var(--spectrum-stepper-border-color)));
+    background-color: transparent;
 
     &:disabled {
       border-color: var(--highcontrast-stepper-border-color-quiet-disabled, var(--mod-stepper-border-color-quiet-disabled, var(--spectrum-stepper-border-color-quiet-disabled)));
+      background-color: transparent;
     }
   }
 
@@ -415,19 +475,32 @@ governing permissions and limitations under the License.
       border-color: var(--highcontrast-stepper-border-color-invalid-default, var(--mod-stepper-border-color-invalid-default, var(--spectrum-stepper-border-color-invalid-default)));
     }
 
+    .spectrum-Stepper-buttons,
     .spectrum-Stepper-stepDown {
       border-color: var(--highcontrast-stepper-border-color-invalid-default, var(--mod-stepper-border-color-invalid-default, var(--spectrum-stepper-border-color-invalid-default)));
+    }
+
+    .spectrum-Stepper-stepUp,
+    .spectrum-Stepper-stepDown {
+      background-color: transparent;
     }
   }
 
   &.is-focused {
+    .spectrum-Stepper-buttons,
     .spectrum-Stepper-stepDown {
       border-color: var(--highcontrast-stepper-border-color-focus, var(--mod-stepper-border-color-focus, var(--spectrum-stepper-border-color-focus)));
+    }
+
+    .spectrum-Stepper-stepUp,
+    .spectrum-Stepper-stepDown {
+      background-color: transparent;
     }
 
     &:hover {
       border-color: var(--highcontrast-stepper-border-color-focus-hover, var(--mod-stepper-border-color-focus-hover, var(--spectrum-stepper-border-color-focus-hover)));
 
+      .spectrum-Stepper-buttons,
       .spectrum-Stepper-stepUp,
       .spectrum-Stepper-stepDown {
         border-color: var(--highcontrast-stepper-border-color-focus-hover, var(--mod-stepper-border-color-focus-hover, var(--spectrum-stepper-border-color-focus-hover)));
@@ -439,6 +512,7 @@ governing permissions and limitations under the License.
         border-color: var(--highcontrast-stepper-border-color-focus, var(--mod-stepper-border-color-focus, var(--spectrum-stepper-border-color-focus)));
       }
 
+      .spectrum-Stepper-buttons,
       .spectrum-Stepper-stepDown {
         border-color: var(--highcontrast-stepper-border-color-focus, var(--mod-stepper-border-color-focus, var(--spectrum-stepper-border-color-focus)));
       }
@@ -455,6 +529,12 @@ governing permissions and limitations under the License.
       margin-block-start: 0;
     }
 
+    .spectrum-Stepper-stepUp,
+    .spectrum-Stepper-stepDown {
+      background-color: transparent;
+    }
+
+    .spectrum-Stepper-buttons,
     .spectrum-Stepper-stepDown {
       border-color: var(--highcontrast-stepper-border-color-keyboard-focus, var(--mod-stepper-border-color-keyboard-focus, var(--spectrum-stepper-border-color-keyboard-focus)));
     }
@@ -464,6 +544,7 @@ governing permissions and limitations under the License.
         border-color: var(--highcontrast-stepper-border-color-invalid-keyboard-focus, var(--mod-stepper-border-color-invalid-keyboard-focus, var(--spectrum-stepper-border-color-invalid-keyboard-focus)));
       }
 
+      .spectrum-Stepper-buttons,
       .spectrum-Stepper-stepDown {
         border-color: var(--highcontrast-stepper-border-color-invalid-keyboard-focus, var(--mod-stepper-border-color-invalid-keyboard-focus, var(--spectrum-stepper-border-color-invalid-keyboard-focus)));
       }

--- a/components/stepper/index.css
+++ b/components/stepper/index.css
@@ -350,6 +350,15 @@ governing permissions and limitations under the License.
       background-color: transparent;
     }
 
+    /* quiet hover */
+    &:hover {
+      .spectrum-Stepper-buttons,
+      .spectrum-Stepper-stepUp,
+      .spectrum-Stepper-stepDown {
+        background-color: transparent;
+      }
+    }
+
     /* quiet disabled */
     &.is-disabled {
       .spectrum-Stepper-input,

--- a/components/stepper/index.css
+++ b/components/stepper/index.css
@@ -490,10 +490,12 @@ governing permissions and limitations under the License.
   display: flex;
 
   box-sizing: border-box;
-  block-size: calc((var(--mod-stepper-buttons-height, var(--spectrum-stepper-buttons-height)) / 2) - (var(--spectrum-stepper-button-gap) * 2.5));
+  block-size: calc((var(--mod-stepper-buttons-height, var(--spectrum-stepper-buttons-height)) / 2)
+                  - (var(--spectrum-stepper-button-gap) * 2.5));
 
   /* remove left border width from button width */
-  inline-size: calc(var(--mod-stepper-button-width, var(--spectrum-stepper-button-width)) - var(--mod-stepper-border-width, var(--spectrum-stepper-border-width)));
+  inline-size: calc(var(--mod-stepper-button-width, var(--spectrum-stepper-button-width))
+                    - (var(--mod-stepper-border-width, var(--spectrum-stepper-border-width)) * 2));
 
   min-inline-size: 0;
 

--- a/components/stepper/index.css
+++ b/components/stepper/index.css
@@ -514,9 +514,6 @@ governing permissions and limitations under the License.
   border-radius: calc(var(--mod-stepper-border-radius, var(--spectrum-stepper-border-radius))
                       - var(--mod-stepper-button-gap, var(--spectrum-stepper-button-gap)) * 1.5);
 
-  border-start-start-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
-  border-end-start-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
-
   background-color: var(--highcontrast-stepper-button-background-color-default, var(--mod-stepper-button-background-color-default, var(--spectrum-stepper-button-background-color-default)));
 
   .spectrum-Icon {
@@ -537,15 +534,15 @@ governing permissions and limitations under the License.
 
 .spectrum-Stepper-stepUp {
   border-end-end-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
+  border-end-start-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
   padding-block-start: var(--mod-stepper-icon-nudge-start, var(--spectrum-stepper-icon-nudge-start));
-  /* inset-block-start: var(--mod-stepper-button-gap, var(--spectrum-stepper-button-gap)); */
 }
 
 .spectrum-Stepper-stepDown {
   border-block-start-width: var(--mod-stepper-button-middle-border-width, var(--spectrum-stepper-button-middle-border-width));
   border-start-end-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
+  border-start-start-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
   padding-block-end: var(--mod-stepper-icon-nudge-end, var(--spectrum-stepper-icon-nudge-end));
-  /* inset-block-end: var(--mod-stepper-button-gap, var(--spectrum-stepper-button-gap)); */
 }
 
 .spectrum-Stepper-textfield {

--- a/components/stepper/index.css
+++ b/components/stepper/index.css
@@ -47,7 +47,6 @@ governing permissions and limitations under the License.
   --spectrum-stepper-button-padding: var(--spectrum-component-edge-to-visual-50); /* 6px md + 7px lg - previously 6px md + 7.5px lg */
 
   --spectrum-stepper-border-radius-reset: 0;
-  --spectrum-stepper-border-size-reset: 0;
 
   /*** Button Icons - appears to adjust position ***/
   --spectrum-stepper-icon-nudge-start: 1px; /* placeholder - was var(--spectrum-global-dimension-size-10) - 1px */
@@ -68,11 +67,17 @@ governing permissions and limitations under the License.
   --spectrum-stepper-border-radius: var(--spectrum-corner-radius-100);
   --spectrum-stepper-buttons-height: var(--spectrum-component-height-100); /* from textfield height */
 
+  /* background same as textfield */
+  --spectrum-stepper-background-color: var(--spectrum-gray-50);
+  --spectrum-stepper-background-color-disabled: var(--spectrum-disabled-background-color);
+
  /*** Quiet Variant ***/
   --spectrum-stepper-quiet-width: var(--spectrum-component-height-300); /* matches previous width token */
   --spectrum-stepper-quiet-button-width: calc(var(--spectrum-stepper-button-width) - var(--spectrum-stepper-button-offset));
 
+
   /*** Disabled Colors ***/
+  --spectrum-stepper-border-color-disabled: var(--spectrum-disabled-background-color);
   --spectrum-stepper-border-color-quiet-disabled: var(--spectrum-disabled-border-color);
 
   /*** Invalid Colors ***/
@@ -100,26 +105,26 @@ governing permissions and limitations under the License.
     --highcontrast-stepper-border-color-focus-hover: Highlight;
     --highcontrast-stepper-border-color-keyboard-focus: Highlight;
 
-    /*** Disabled Colors ***/
+    --highcontrast-stepper-border-color-disabled: GrayText;
     --highcontrast-stepper-border-color-quiet-disabled: GrayText;
 
-    /*** Invalid Colors ***/
     --highcontrast-stepper-border-color-invalid-default: Highlight;
     --highcontrast-stepper-border-color-invalid-hover: Highlight;
     --highcontrast-stepper-border-color-invalid-focus: Highlight;
     --highcontrast-stepper-border-color-invalid-focus-hover: Highlight;
     --highcontrast-stepper-border-color-invalid-keyboard-focus: Highlight;
 
-    --highcontrast-stepper-background-color-default: Canvas;
-    --highcontrast-stepper-background-color-hover: Canvas;
-    --highcontrast-stepper-background-color-active: Canvas;
-    --highcontrast-stepper-background-color-keyboard-focus: Canvas;
+    --highcontrast-stepper-button-background-color-default: Canvas;
+    --highcontrast-stepper-button-background-color-hover: Canvas;
+    --highcontrast-stepper-button-background-color-focus: Canvas;
+    --highcontrast-stepper-button-background-color-keyboard-focus: Canvas;
 
     --highcontrast-stepper-focus-indicator-color: CanvasText;
   }
 }
 
 .spectrum-Stepper {
+  position: relative;
   display: inline-flex;
   flex-direction: row;
   flex-wrap: nowrap;
@@ -128,137 +133,6 @@ governing permissions and limitations under the License.
   line-height: 0;
   border-radius: var(--mod-stepper-border-radius, var(--spectrum-stepper-border-radius)); /* --spectrum-global-dimension-size-75 = 6px 8px */
   transition: border-color var(--mod-stepper-animation-duration, var(--spectrum-stepper-animation-duration)) ease-in-out;
-}
-.spectrum-Stepper::before {
-  content: '';
-}
-
-.spectrum-Stepper-buttons {
-  display: flex;
-  flex-direction: column;
-  gap: var(--mod-stepper-button-gap, var(--spectrum-stepper-button-gap));
-  box-sizing: border-box;
-  border-start-start-radius: 0;
-  border-start-end-radius: var(--mod-stepper-border-radius, var(--spectrum-stepper-border-radius)); /* --spectrum-global-dimension-size-75  = 6px 8px */
-  border-end-end-radius: var(--mod-stepper-border-radius, var(--spectrum-stepper-border-radius));
-  border-end-start-radius: 0;
-  block-size: var(--mod-stepper-buttons-height, var(--spectrum-stepper-buttons-height));
-
-  border-style: solid;
-  border-width: var(--mod-stepper-border-width, var(--spectrum-stepper-border-width))
-                var(--mod-stepper-border-width, var(--spectrum-stepper-border-width))
-                var(--mod-stepper-border-width, var(--spectrum-stepper-border-width))
-                var(--mod-stepper-border-size-reset, var(--spectrum-stepper-border-size-reset));
-
-  border-color: var(--highcontrast-stepper-border-color, var(--mod-stepper-border-color, var(--spectrum-stepper-border-color)));
-}
-
-.spectrum-Stepper-stepUp,
-.spectrum-Stepper-stepDown {
-  position: relative;
-  display: flex;
-  box-sizing: border-box;
-
-  /* remove middle border from button height */
-  block-size: calc((var(--mod-stepper-buttons-height, var(--spectrum-stepper-buttons-height)) / 2)) - var(--mod-stepper-border-width, var(--spectrum-stepper-border-width)));
-  block-size: calc((var(--mod-stepper-buttons-height, var(--spectrum-stepper-buttons-height)) - var(--mod-stepper-border-width, var(--spectrum-stepper-border-width))) / 2);
-
-  block-size: calc((var(--mod-stepper-buttons-height, var(--spectrum-stepper-buttons-height)) / 2) - (var(--mod-stepper-border-width, var(--spectrum-stepper-border-width)) / 2));
-  block-size: calc(var(--mod-stepper-buttons-height, var(--spectrum-stepper-buttons-height)) / 2);
-
-  /* remove left border width from button width */
-  inline-size: calc(var(--mod-stepper-button-width, var(--spectrum-stepper-button-width)) - var(--mod-stepper-border-width, var(--spectrum-stepper-border-width)));
-
-  min-inline-size: 0;
-
-  padding-inline-start: var(--mod-stepper-button-padding, var(--spectrum-stepper-button-padding));
-  padding-inline-end: var(--mod-stepper-button-padding, var(--spectrum-stepper-button-padding));
-
-  /* Avoid margin added by adjacent buttons */
-  margin: 0;
-
-  border-color: var(--highcontrast-stepper-border-color, var(--mod-stepper-border-color, var(--spectrum-stepper-border-color)));
-  border-width: 0;
-  border-start-start-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
-  border-end-start-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
-
-  background-color: var(--highcontrast-stepper-background-color-default, var(--mod-stepper-background-color-default, var(--spectrum-stepper-background-color-default)));
-
-  .spectrum-Icon {
-    opacity: 1;
-  }
-}
-
-.spectrum-Stepper-stepUp {
-  border-end-end-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
-
-  padding-block-start: var(--mod-stepper-icon-nudge-start, var(--spectrum-stepper-icon-nudge-start));
-}
-
-.spectrum-Stepper-stepDown {
-  border-block-start-width: var(--mod-stepper-middle-border-width, var(--spectrum-stepper-middle-border-width));
-  border-start-end-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
-
-  padding-block-end: var(--mod-stepper-icon-nudge-end, var(--spectrum-stepper-icon-nudge-end));
-}
-
-.spectrum-Stepper-textfield {
-  flex: 1;
-  inline-size: auto;
-}
-
-.spectrum-Stepper-input {
-  min-inline-size: 0;
-  border-start-end-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
-  border-end-end-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
-  border-inline-end-width: 0;
-}
-
-.spectrum-Stepper-textfield {
-  min-inline-size: 0;
-}
-
-.spectrum-Stepper--quiet {
-  border-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
-  inline-size: var(--mod-stepper-quiet-width, var(--spectrum-stepper-quiet-width));
-
-  .spectrum-Stepper-buttons {
-    border-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
-  }
-
-  .spectrum-Stepper-stepUp,
-  .spectrum-Stepper-stepDown {
-    inline-size: var(--mod-stepper-quiet-button-width, var(--spectrum-stepper-quiet-button-width));
-    min-inline-size: 0;
-
-    border-block-start: none;
-    border-inline-start: none;
-    border-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
-
-    padding-inline-end: 0;
-    justify-content: flex-end;
-
-    /* More hitarea */
-    &::after {
-      content: '';
-      position: absolute;
-      block-size: 100%;
-      inline-size: var(--mod-stepper-button-offset, var(--spectrum-stepper-button-offset));
-      inset-inline-end: calc(var(--mod-stepper-button-offset, var(--spectrum-stepper-button-offset)) * -1);
-    }
-  }
-}
-
-
-/* Variant colors - WIP placeholders - bring in colors from textfield */
-
-.spectrum-Stepper {
-  position: relative;
-
-  /* remove textfield focus indicator so we don't have two of them */
-  .spectrum-Stepper-textfield::after {
-    display: none;
-  }
 
   /*** Focus Indicator - Unfocused Base Styles ***/
   &::after {
@@ -285,6 +159,7 @@ governing permissions and limitations under the License.
                               * -1);
   }
 
+  /*** Hover ***/
   &:hover:not(.is-disabled):not(.is-invalid):not(.is-focused):not(.is-keyboardFocused) {
     .spectrum-Stepper-buttons,
     .spectrum-Stepper-stepUp,
@@ -292,16 +167,12 @@ governing permissions and limitations under the License.
     .spectrum-Stepper-input {
       border-color: var(--highcontrast-stepper-border-color-hover, var(--mod-stepper-border-color-hover, var(--spectrum-stepper-border-color-hover)));
     }
-
-    .spectrum-Stepper-stepUp,
-    .spectrum-Stepper-stepDown {
-      background-color: var(--highcontrast-stepper-background-color-hover), var(--mod-stepper-background-color-hover), var(--spectrum-stepper-background-color-hover)));
-    }
   }
 
-  &.is-focused {
-    border-color: var(--highcontrast-stepper-border-color-focus, var(--mod-stepper-border-color-focus, var(--spectrum-stepper-border-color-focus)));
 
+  /*** Focused ***/
+  &.is-focused {
+    .spectrum-Stepper-input,
     .spectrum-Stepper-buttons,
     .spectrum-Stepper-stepUp,
     .spectrum-Stepper-stepDown {
@@ -310,46 +181,35 @@ governing permissions and limitations under the License.
 
     .spectrum-Stepper-stepUp,
     .spectrum-Stepper-stepDown {
-      background-color: var(--highcontrast-stepper-background-color-active, var(--mod-stepper-background-color-active, var(--spectrum-stepper-background-color-active))); /* is this right? */
+      background-color: var(--highcontrast-stepper-button-background-color-focus, var(--mod-stepper-button-background-color-focus, var(--spectrum-stepper-button-background-color-focus)));
     }
 
-    .spectrum-Stepper-input {
-      border-color: var(--highcontrast-stepper-border-color-focus, var(--mod-stepper-border-color-focus, var(--spectrum-stepper-border-color-focus)));
-    }
-
+    /* focused hover */
     &:hover {
-      border-color: var(--highcontrast-stepper-border-color-focus-hover, var(--mod-stepper-border-color-focus-hover, var(--spectrum-stepper-border-color-focus-hover)));
-
+      .spectrum-Stepper-input,
       .spectrum-Stepper-buttons,
       .spectrum-Stepper-stepUp,
       .spectrum-Stepper-stepDown {
         border-color: var(--highcontrast-stepper-border-color-focus-hover, var(--mod-stepper-border-color-focus-hover, var(--spectrum-stepper-border-color-focus-hover)));
       }
-
-      .spectrum-Stepper-stepUp,
-      .spectrum-Stepper-stepDown {
-        background-color: var(--highcontrast-stepper-background-color-hover), var(--mod-stepper-background-color-hover), var(--spectrum-stepper-background-color-hover))); /* is this right? */
-      }
     }
 
+    /* focused invalid */
     &.is-invalid {
-      border-color: var(--highcontrast-stepper-border-color-invalid-focus, var(--mod-stepper-border-color-invalid-focus, var(--spectrum-stepper-border-color-invalid-focus)));
-
+      .spectrum-Stepper-input,
       .spectrum-Stepper-buttons,
       .spectrum-Stepper-stepUp,
       .spectrum-Stepper-stepDown {
         border-color: var(--highcontrast-stepper-border-color-invalid-focus, var(--mod-stepper-border-color-invalid-focus, var(--spectrum-stepper-border-color-invalid-focus)));
       }
-
-      .spectrum-Stepper-input {
-        border-color: var(--highcontrast-stepper-border-color-invalid-focus, var(--mod-stepper-border-color-invalid-focus, var(--spectrum-stepper-border-color-invalid-focus)));
-      }
     }
   }
 
+
+  /*** Keyboard Focused ***/
   &.is-keyboardFocused {
 
-    /* focus indicator is visible */
+    /* keyboard focus indicator is visible */
     &::after {
       border-color: var(--highcontrast-stepper-focus-indicator-color, var(--mod-stepper-focus-indicator-color, var(--spectrum-stepper-focus-indicator-color)));
       border-width: var(--mod-stepper-focus-indicator-width, var(--spectrum-stepper-focus-indicator-width));
@@ -364,10 +224,12 @@ governing permissions and limitations under the License.
 
     .spectrum-Stepper-stepUp,
     .spectrum-Stepper-stepDown {
-      background-color: var(--highcontrast-stepper-background-color-keyboard-focus, var(--mod-stepper-background-color-keyboard-focus, var(--spectrum-stepper-background-color-keyboard-focus)));
+      background-color: var(--highcontrast-stepper-button-background-color-keyboard-focus, var(--mod-stepper-button-background-color-keyboard-focus, var(--spectrum-stepper-button-background-color-keyboard-focus)));
     }
 
+    /* keyboard focused invalid */
     &.is-invalid {
+      .spectrum-Stepper-input,
       .spectrum-Stepper-buttons,
       .spectrum-Stepper-stepUp,
       .spectrum-Stepper-stepDown {
@@ -376,20 +238,19 @@ governing permissions and limitations under the License.
     }
   }
 
+
+  /*** Invalid ***/
   &.is-invalid {
+    .spectrum-Stepper-input,
     .spectrum-Stepper-buttons,
     .spectrum-Stepper-stepUp,
     .spectrum-Stepper-stepDown {
       border-color: var(--highcontrast-stepper-border-color-invalid-default, var(--mod-stepper-border-color-invalid-default, var(--spectrum-stepper-border-color-invalid-default)));
     }
 
-    .spectrum-Stepper-input {
-      border-color: var(--highcontrast-stepper-border-color-invalid-default, var(--mod-stepper-border-color-invalid-default, var(--spectrum-stepper-border-color-invalid-default)));
-    }
-
+    /* invalid hover */
     &:hover {
-      border-color: var(--highcontrast-stepper-border-color-invalid-hover, var(--mod-stepper-border-color-invalid-hover, var(--spectrum-stepper-border-color-invalid-hover)));
-
+      .spectrum-Stepper-input,
       .spectrum-Stepper-buttons,
       .spectrum-Stepper-stepUp,
       .spectrum-Stepper-stepDown {
@@ -397,14 +258,18 @@ governing permissions and limitations under the License.
       }
     }
 
+    /* invalid focused */
     &.is-focused {
+      .spectrum-Stepper-input,
       .spectrum-Stepper-buttons,
       .spectrum-Stepper-stepUp,
       .spectrum-Stepper-stepDown {
         border-color: var(--highcontrast-stepper-border-color-invalid-focus, var(--mod-stepper-border-color-invalid-focus, var(--spectrum-stepper-border-color-invalid-focus)));
       }
 
+      /* invalid focused hover */
       &:hover {
+        .spectrum-Stepper-input,
         .spectrum-Stepper-buttons,
         .spectrum-Stepper-stepUp,
         .spectrum-Stepper-stepDown {
@@ -413,141 +278,279 @@ governing permissions and limitations under the License.
       }
     }
 
+    /* invalid keyboard focused */
     &.is-keyboardFocused {
-      .spectrum-Stepper-input {
+      .spectrum-Stepper-input,
+      .spectrum-Stepper-buttons,
+      .spectrum-Stepper-stepUp,
+      .spectrum-Stepper-stepDown {
         border-color: var(--highcontrast-stepper-border-color-invalid-keyboard-focus, var(--mod-stepper-border-color-invalid-keyboard-focus, var(--spectrum-stepper-border-color-invalid-keyboard-focus)));
       }
     }
   }
 
+
+  /*** Disabled ***/
   &.is-disabled {
+    .spectrum-Stepper-input,
     .spectrum-Stepper-buttons,
     .spectrum-Stepper-stepUp,
     .spectrum-Stepper-stepDown {
-      border-color: transparent;
+      border-color: var(--highcontrast-stepper-border-color-disabled, var(--mod-stepper-border-color-disabled, var(--spectrum-stepper-border-color-disabled)));
+    }
+
+    .spectrum-Stepper-stepUp,
+    .spectrum-Stepper-stepDown {
+      background-color: transparent;
+    }
+
+    .spectrum-Stepper-buttons {
+      background-color: var(--spectrum-stepper-background-color-disabled);
+    }
+  }
+
+
+  /*** Quiet ***/
+  &--quiet {
+    /* quiet corners not rounded */
+    border-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
+    inline-size: var(--mod-stepper-quiet-width, var(--spectrum-stepper-quiet-width));
+
+    .spectrum-Stepper-buttons {
+      border-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
+      border-width: 0 0 var(--mod-stepper-border-width, var(--spectrum-stepper-border-width)) 0;
+    }
+
+    .spectrum-Stepper-stepUp,
+    .spectrum-Stepper-stepDown {
+      inline-size: var(--mod-stepper-quiet-button-width, var(--spectrum-stepper-quiet-button-width));
+      min-inline-size: 0;
+
+      border-block-start: none;
+      border-inline-start: none;
+      border-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
+
+      padding-inline-end: 0;
+      justify-content: flex-end;
+
+      /* More hitarea */
+      &::after {
+        content: '';
+        position: absolute;
+        block-size: 100%;
+        inline-size: var(--mod-stepper-button-offset, var(--spectrum-stepper-button-offset));
+        inset-inline-end: calc(var(--mod-stepper-button-offset, var(--spectrum-stepper-button-offset)) * -1);
+      }
+    }
+
+    .spectrum-Stepper-input,
+    .spectrum-Stepper-buttons,
+    .spectrum-Stepper-stepUp,
+    .spectrum-Stepper-stepDown {
+      background-color: transparent;
+    }
+
+    /* quiet disabled */
+    &.is-disabled {
+      .spectrum-Stepper-input,
+      .spectrum-Stepper-buttons,
+      .spectrum-Stepper-stepUp,
+      .spectrum-Stepper-stepDown {
+        border-color: var(--highcontrast-stepper-border-color-quiet-disabled, var(--mod-stepper-border-color-quiet-disabled, var(--spectrum-stepper-border-color-quiet-disabled)));
+        background-color: transparent;
+      }
+    }
+
+    /* quiet invalid */
+    &.is-invalid {
+      .spectrum-Stepper-input,
+      .spectrum-Stepper-buttons,
+      .spectrum-Stepper-stepDown {
+        border-color: var(--highcontrast-stepper-border-color-invalid-default, var(--mod-stepper-border-color-invalid-default, var(--spectrum-stepper-border-color-invalid-default)));
+      }
+
+      .spectrum-Stepper-stepUp,
+      .spectrum-Stepper-stepDown {
+        background-color: transparent;
+      }
+    }
+
+    /* quiet focused */
+    &.is-focused {
+      .spectrum-Stepper-input,
+      .spectrum-Stepper-buttons,
+      .spectrum-Stepper-stepDown {
+        border-color: var(--highcontrast-stepper-border-color-focus, var(--mod-stepper-border-color-focus, var(--spectrum-stepper-border-color-focus)));
+      }
+
+      .spectrum-Stepper-stepUp,
+      .spectrum-Stepper-stepDown {
+        background-color: transparent;
+      }
+
+      /* quiet focused hover */
+      &:hover {
+        .spectrum-Stepper-input,
+        .spectrum-Stepper-buttons,
+        .spectrum-Stepper-stepUp,
+        .spectrum-Stepper-stepDown {
+          border-color: var(--highcontrast-stepper-border-color-focus-hover, var(--mod-stepper-border-color-focus-hover, var(--spectrum-stepper-border-color-focus-hover)));
+        }
+      }
+
+      /* quiet invalid */
+      &.is-invalid {
+        .spectrum-Stepper-input,
+        .spectrum-Stepper-buttons,
+        .spectrum-Stepper-stepDown {
+          border-color: var(--highcontrast-stepper-border-color-invalid-focus, var(--mod-stepper-border-color-invalid-focus, var(--spectrum-stepper-border-color-invalid-focus)));
+        }
+      }
+    }
+
+    /* quiet keyboard focused */
+    &.is-keyboardFocused {
+
+      /* quiet focus indicator only on bottom border */
+      &::after {
+        border-width: 0 0 var(--mod-stepper-focus-indicator-width, var(--spectrum-stepper-focus-indicator-width)) 0;
+        border-radius: 0;
+        inline-size: 100%;
+        block-size: calc(100% + var(--mod-stepper-focus-indicator-gap, var(--spectrum-stepper-focus-indicator-gap)));
+        margin-inline-start: 0;
+        margin-block-start: 0;
+      }
+
+      .spectrum-Stepper-stepUp,
+      .spectrum-Stepper-stepDown {
+        background-color: transparent;
+      }
+
+      .spectrum-Stepper-buttons,
+      .spectrum-Stepper-stepDown {
+        border-color: var(--highcontrast-stepper-border-color-keyboard-focus, var(--mod-stepper-border-color-keyboard-focus, var(--spectrum-stepper-border-color-keyboard-focus)));
+      }
+
+      /* quiet keyboard focused invalid */
+      &.is-invalid {
+        .spectrum-Stepper-input,
+        .spectrum-Stepper-buttons,
+        .spectrum-Stepper-stepDown {
+          border-color: var(--highcontrast-stepper-border-color-invalid-keyboard-focus, var(--mod-stepper-border-color-invalid-keyboard-focus, var(--spectrum-stepper-border-color-invalid-keyboard-focus)));
+        }
+      }
     }
   }
 }
 
-.spectrum-Stepper-buttons,
+.spectrum-Stepper::before {
+  content: '';
+}
+
+/* container for stepUp and stepDown buttons */
+.spectrum-Stepper-buttons {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  /* allow express buttons to have a gap the size of the stepper border */
+  gap: var(--mod-stepper-button-gap, var(--spectrum-stepper-button-gap));
+
+  /* allow express buttons to have space around the size of the stepper border */
+  /* padding: var(--mod-stepper-button-gap, var(--spectrum-stepper-button-gap)); */
+
+  box-sizing: border-box;
+  border-start-start-radius: 0;
+  border-start-end-radius: var(--mod-stepper-border-radius, var(--spectrum-stepper-border-radius)); /* --spectrum-global-dimension-size-75  = 6px 8px */
+  border-end-end-radius: var(--mod-stepper-border-radius, var(--spectrum-stepper-border-radius));
+  border-end-start-radius: 0;
+  block-size: var(--mod-stepper-buttons-height, var(--spectrum-stepper-buttons-height));
+
+  border-style: solid;
+  border-width: var(--mod-stepper-border-width, var(--spectrum-stepper-border-width))
+                var(--mod-stepper-border-width, var(--spectrum-stepper-border-width))
+                var(--mod-stepper-border-width, var(--spectrum-stepper-border-width))
+                var(--mod-stepper-border-size-reset, var(--spectrum-stepper-border-size-reset));
+
+  border-color: var(--highcontrast-stepper-border-color, var(--mod-stepper-border-color, var(--spectrum-stepper-border-color)));
+  background-color: var(--highcontrast-stepper-background-color, var(--mod-stepper-background-color, var(--spectrum-stepper-background-color)));
+}
+
 .spectrum-Stepper-stepUp,
 .spectrum-Stepper-stepDown {
+  position: relative;
+  display: flex;
+
+  box-sizing: border-box;
+  block-size: calc((var(--mod-stepper-buttons-height, var(--spectrum-stepper-buttons-height)) / 2) - (var(--spectrum-stepper-button-gap) * 2.5));
+
+  /* remove left border width from button width */
+  inline-size: calc(var(--mod-stepper-button-width, var(--spectrum-stepper-button-width)) - var(--mod-stepper-border-width, var(--spectrum-stepper-border-width)));
+
+  min-inline-size: 0;
+
+  padding-inline-start: var(--mod-stepper-button-padding, var(--spectrum-stepper-button-padding));
+  padding-inline-end: var(--mod-stepper-button-padding, var(--spectrum-stepper-button-padding));
+
+  /* Avoid margin added by adjacent buttons */
+  margin: 0;
+
+  inset-inline-end: var(--mod-stepper-button-gap, var(--spectrum-stepper-button-gap));
+
+  border-color: var(--highcontrast-stepper-border-color, var(--mod-stepper-border-color, var(--spectrum-stepper-border-color)));
+  border-width: 0;
+
+  /* set border radius of buttons proportionately to border */
+  border-radius: calc(var(--mod-stepper-border-radius, var(--spectrum-stepper-border-radius))
+                      - var(--mod-stepper-button-gap, var(--spectrum-stepper-button-gap)) * 1.5);
+
+  border-start-start-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
+  border-end-start-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
+
+  background-color: var(--highcontrast-stepper-button-background-color-default, var(--mod-stepper-button-background-color-default, var(--spectrum-stepper-button-background-color-default)));
+
+  .spectrum-Icon {
+    opacity: 1;
+  }
+
+  /*** Action Buttons Hover ***/
+  &:hover {
+    background-color: var(--highcontrast-stepper-button-background-color-hover, var(--mod-stepper-button-background-color-hover, var(--spectrum-stepper-button-background-color-hover)));
+  }
+
+  /*** Action Buttons Disabled **/
   &:disabled {
+    border-color: var(--highcontrast-stepper-border-color-quiet-disabled, var(--mod-stepper-border-color-quiet-disabled, var(--spectrum-stepper-border-color-quiet-disabled)));
     border-color: transparent;
   }
 }
 
-.spectrum-Stepper--quiet {
+.spectrum-Stepper-stepUp {
+  border-end-end-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
+  padding-block-start: var(--mod-stepper-icon-nudge-start, var(--spectrum-stepper-icon-nudge-start));
+  /* inset-block-start: var(--mod-stepper-button-gap, var(--spectrum-stepper-button-gap)); */
+}
 
- .spectrum-Stepper-buttons {
-   border-width: 0 0 var(--mod-stepper-border-width, var(--spectrum-stepper-border-width)) 0;
- }
+.spectrum-Stepper-stepDown {
+  border-block-start-width: var(--mod-stepper-button-middle-border-width, var(--spectrum-stepper-button-middle-border-width));
+  border-start-end-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
+  padding-block-end: var(--mod-stepper-icon-nudge-end, var(--spectrum-stepper-icon-nudge-end));
+  /* inset-block-end: var(--mod-stepper-button-gap, var(--spectrum-stepper-button-gap)); */
+}
 
-  .spectrum-Stepper-buttons,
-  .spectrum-Stepper-stepUp,
-  .spectrum-Stepper-stepDown {
-    background-color: transparent;
+.spectrum-Stepper-textfield {
+  flex: 1;
+  inline-size: auto;
+  min-inline-size: 0;
+
+  /* remove textfield focus indicator so we don't have two of them */
+  &::after {
+    display: none;
   }
+}
 
-  &.is-disabled {
-    .spectrum-Stepper-buttons,
-    .spectrum-Stepper-stepUp,
-    .spectrum-Stepper-stepDown {
-      border-color: var(--highcontrast-stepper-border-color-quiet-disabled, var(--mod-stepper-border-color-quiet-disabled, var(--spectrum-stepper-border-color-quiet-disabled)));
-      background-color: transparent;
-    }
-  }
-
-  .spectrum-Stepper-buttons,
-  .spectrum-Stepper-stepUp,
-  .spectrum-Stepper-stepDown {
-    border-color: var(--highcontrast-stepper-border-color, var(--mod-stepper-border-color, var(--spectrum-stepper-border-color)));
-    background-color: transparent;
-
-    &:disabled {
-      border-color: var(--highcontrast-stepper-border-color-quiet-disabled, var(--mod-stepper-border-color-quiet-disabled, var(--spectrum-stepper-border-color-quiet-disabled)));
-      background-color: transparent;
-    }
-  }
-
-  &.is-invalid {
-    .spectrum-Stepper-input {
-      border-color: var(--highcontrast-stepper-border-color-invalid-default, var(--mod-stepper-border-color-invalid-default, var(--spectrum-stepper-border-color-invalid-default)));
-    }
-
-    .spectrum-Stepper-buttons,
-    .spectrum-Stepper-stepDown {
-      border-color: var(--highcontrast-stepper-border-color-invalid-default, var(--mod-stepper-border-color-invalid-default, var(--spectrum-stepper-border-color-invalid-default)));
-    }
-
-    .spectrum-Stepper-stepUp,
-    .spectrum-Stepper-stepDown {
-      background-color: transparent;
-    }
-  }
-
-  &.is-focused {
-    .spectrum-Stepper-buttons,
-    .spectrum-Stepper-stepDown {
-      border-color: var(--highcontrast-stepper-border-color-focus, var(--mod-stepper-border-color-focus, var(--spectrum-stepper-border-color-focus)));
-    }
-
-    .spectrum-Stepper-stepUp,
-    .spectrum-Stepper-stepDown {
-      background-color: transparent;
-    }
-
-    &:hover {
-      border-color: var(--highcontrast-stepper-border-color-focus-hover, var(--mod-stepper-border-color-focus-hover, var(--spectrum-stepper-border-color-focus-hover)));
-
-      .spectrum-Stepper-buttons,
-      .spectrum-Stepper-stepUp,
-      .spectrum-Stepper-stepDown {
-        border-color: var(--highcontrast-stepper-border-color-focus-hover, var(--mod-stepper-border-color-focus-hover, var(--spectrum-stepper-border-color-focus-hover)));
-      }
-    }
-
-    &.is-invalid {
-      .spectrum-Stepper-input {
-        border-color: var(--highcontrast-stepper-border-color-focus, var(--mod-stepper-border-color-focus, var(--spectrum-stepper-border-color-focus)));
-      }
-
-      .spectrum-Stepper-buttons,
-      .spectrum-Stepper-stepDown {
-        border-color: var(--highcontrast-stepper-border-color-focus, var(--mod-stepper-border-color-focus, var(--spectrum-stepper-border-color-focus)));
-      }
-    }
-  }
-
-  &.is-keyboardFocused {
-    &::after {
-      border-width: 0 0 var(--mod-stepper-focus-indicator-width, var(--spectrum-stepper-focus-indicator-width)) 0;
-      border-radius: 0;
-      inline-size: 100%;
-      block-size: calc(100% + var(--mod-stepper-focus-indicator-gap, var(--spectrum-stepper-focus-indicator-gap)));
-      margin-inline-start: 0;
-      margin-block-start: 0;
-    }
-
-    .spectrum-Stepper-stepUp,
-    .spectrum-Stepper-stepDown {
-      background-color: transparent;
-    }
-
-    .spectrum-Stepper-buttons,
-    .spectrum-Stepper-stepDown {
-      border-color: var(--highcontrast-stepper-border-color-keyboard-focus, var(--mod-stepper-border-color-keyboard-focus, var(--spectrum-stepper-border-color-keyboard-focus)));
-    }
-
-    &.is-invalid {
-      .spectrum-Stepper-input {
-        border-color: var(--highcontrast-stepper-border-color-invalid-keyboard-focus, var(--mod-stepper-border-color-invalid-keyboard-focus, var(--spectrum-stepper-border-color-invalid-keyboard-focus)));
-      }
-
-      .spectrum-Stepper-buttons,
-      .spectrum-Stepper-stepDown {
-        border-color: var(--highcontrast-stepper-border-color-invalid-keyboard-focus, var(--mod-stepper-border-color-invalid-keyboard-focus, var(--spectrum-stepper-border-color-invalid-keyboard-focus)));
-      }
-    }
-  }
+.spectrum-Stepper-input {
+  min-inline-size: 0;
+  border-start-end-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
+  border-end-end-radius: var(--mod-stepper-border-radius-reset, var(--spectrum-stepper-border-radius-reset));
+  border-inline-end-width: 0;
 }

--- a/components/stepper/index.css
+++ b/components/stepper/index.css
@@ -170,8 +170,7 @@ governing permissions and limitations under the License.
 
 
   /*** Focused ***/
-  &.is-focused,
-  &:has(input:focus) {
+  &.is-focused {
     .spectrum-Stepper-input,
     .spectrum-Stepper-buttons,
     .spectrum-Stepper-stepUp,
@@ -229,8 +228,7 @@ governing permissions and limitations under the License.
     }
 
     /* keyboard focused invalid */
-    &.is-invalid,
-    &:has(input:invalid) {
+    &.is-invalid {
       .spectrum-Stepper-input,
       .spectrum-Stepper-buttons,
       .spectrum-Stepper-stepUp,
@@ -242,8 +240,7 @@ governing permissions and limitations under the License.
 
 
   /*** Invalid ***/
-  &.is-invalid,
-  &:has(input:invalid) {
+  &.is-invalid {
     .spectrum-Stepper-input,
     .spectrum-Stepper-buttons,
     .spectrum-Stepper-stepUp,
@@ -294,8 +291,7 @@ governing permissions and limitations under the License.
 
 
   /*** Disabled ***/
-  &.is-disabled,
-  &:has(input:disabled) {
+  &.is-disabled {
     .spectrum-Stepper-input,
     .spectrum-Stepper-buttons,
     .spectrum-Stepper-stepUp,

--- a/components/stepper/index.css
+++ b/components/stepper/index.css
@@ -170,7 +170,8 @@ governing permissions and limitations under the License.
 
 
   /*** Focused ***/
-  &.is-focused {
+  &.is-focused,
+  &:has(input:focus) {
     .spectrum-Stepper-input,
     .spectrum-Stepper-buttons,
     .spectrum-Stepper-stepUp,
@@ -206,7 +207,8 @@ governing permissions and limitations under the License.
 
 
   /*** Keyboard Focused ***/
-  &.is-keyboardFocused {
+  &.is-keyboardFocused,
+  &:focus-visible {
 
     /* keyboard focus indicator is visible */
     &::after {
@@ -239,7 +241,8 @@ governing permissions and limitations under the License.
 
 
   /*** Invalid ***/
-  &.is-invalid {
+  &.is-invalid,
+  &:has(input:invalid) {
     .spectrum-Stepper-input,
     .spectrum-Stepper-buttons,
     .spectrum-Stepper-stepUp,
@@ -290,7 +293,8 @@ governing permissions and limitations under the License.
 
 
   /*** Disabled ***/
-  &.is-disabled {
+  &.is-disabled,
+  &:has(input:disabled) {
     .spectrum-Stepper-input,
     .spectrum-Stepper-buttons,
     .spectrum-Stepper-stepUp,

--- a/components/stepper/index.css
+++ b/components/stepper/index.css
@@ -71,7 +71,7 @@ governing permissions and limitations under the License.
 
  /*** Quiet Variant ***/
   --spectrum-stepper-quiet-width: var(--spectrum-component-height-300); /* matches previous width token */
-  --spectrum-stepper-quiet-button-width: calc(var(--spectrum-stepper-button-width) - var(--spectrum-stepper-button-offset));
+  --spectrum-stepper-quiet-button-width: var(--spectrum-stepper-button-width);
 
   /*** Disabled Colors ***/
   --spectrum-stepper-border-color-disabled: var(--spectrum-disabled-background-color);

--- a/components/stepper/index.css
+++ b/components/stepper/index.css
@@ -12,22 +12,50 @@ governing permissions and limitations under the License.
 
 .spectrum-Stepper {
 
-  --spectrum-stepper-width: var(--spectrum-global-dimension-size-900);
-  --spectrum-stepper-border-size: var(--spectrum-alias-border-size-thin);
+  /* TODO - ask Design to evaluate these widths */
+  .spectrum--medium {
+    & {
+      --spectrum-stepper-width: 72px; /* replaces --spectrum-global-dimension-size-900 */
+      --spectrum-stepper-icon-width: 10px; /* placeholder for --spectrum-alias-ui-icon-chevron-size-75 */
+    }
+  }
 
-  --spectrum-stepper-button-height: calc(var(--spectrum-alias-single-line-height) / 2);
-  --spectrum-stepper-button-width: calc(var(--spectrum-global-dimension-size-300) - var(--spectrum-stepper-border-size));
+  .spectrum--large {
+    & {
+      --spectrum-stepper-width: 90px; /* replaces --spectrum-global-dimension-size-900 */
+      --spectrum-stepper-icon-width: 12px; /* placeholder for --spectrum-alias-ui-icon-chevron-size-75 */
+    }
+  }
 
-  --spectrum-stepper-button-padding: calc(var(--spectrum-global-dimension-size-150) / 2);
+  --spectrum-stepper-button-offset: calc(var(--spectrum-stepper-button-width) / 2 - var(--spectrum-stepper-icon-width) / 2); /* TODO - reevaluate when icons are migrated */
+
+  --spectrum-stepper-button-width: var(--spectrum-component-height-75); /* this height token matches the previous width token */
+
+  --spectrum-stepper-button-padding: var(--spectrum-component-edge-to-visual-50); /* 6px md + 7px lg - previously 6px md + 7.5px lg */
+
   --spectrum-stepper-border-radius-reset: 0;
   --spectrum-stepper-border-size-reset: 0;
 
-  --spectrum-stepper-icon-nudge-top: var(--spectrum-global-dimension-size-10);
-  --spectrum-stepper-icon-nudge: var(--spectrum-global-dimension-size-25);
+  --spectrum-stepper-icon-nudge-start: 1px; /* 1px - could this be == the component border width? Check Express */
+  /* was var(--spectrum-global-dimension-size-10); */
+  /* was 1px */
 
-  --spectrum-stepper-quiet-width: var(--spectrum-global-dimension-size-600);
-  --spectrum-stepper-button-offset: calc(var(--spectrum-stepper-button-width) / 2 - var(--spectrum-alias-ui-icon-chevron-size-75) / 2);
+  --spectrum-stepper-icon-nudge-end: 2px; /* 2px - could this be == the component border width? Check Express */
+  /* was var(--spectrum-global-dimension-size-25); */
+  /* was 2px */
+
+  --spectrum-stepper-quiet-width: var(--spectrum-component-height-300); /* matches previous width token */
+
   --spectrum-stepper-quiet-button-width: calc(var(--spectrum-stepper-button-width) - var(--spectrum-stepper-button-offset));
+
+
+  /* New tokens */
+  --spectrum-stepper-animation-duration: var(--spectrum-animation-duration-100);
+  --spectrum-stepper-border-radius: var(--spectrum-corner-radius-100); /* was 6px 8px */
+  --spectrum-stepper-buttons-height: var(--spectrum-component-height-100);
+
+  /* new colors */
+  --spectrum-stepper-border-color: var(--spectrum-stepper-border-color-default);
 }
 
 .spectrum-Stepper {
@@ -37,8 +65,9 @@ governing permissions and limitations under the License.
 
   inline-size: var(--spectrum-stepper-width);
   line-height: 0;
-  border-radius: var(--spectrum-alias-border-radius-regular);
-  transition: border-color var(--spectrum-global-animation-duration-100) ease-in-out, box-shadow var(--spectrum-global-animation-duration-100) ease-in-out;
+  border-radius: var(--spectrum-stepper-border-radius); /* --spectrum-global-dimension-size-75 = 6px 8px */
+  transition: border-color var(--spectrum-stepper-animation-duration) ease-in-out, box-shadow var(--spectrum-stepper-animation-duration) ease-in-out;
+  /* 130ms */
 }
 .spectrum-Stepper::before {
   content: '';
@@ -46,11 +75,13 @@ governing permissions and limitations under the License.
 
 .spectrum-Stepper-buttons {
   display: block;
+  box-sizing: border-box;
   border-start-start-radius: 0;
-  border-start-end-radius: var(--spectrum-alias-border-radius-regular);
-  border-end-end-radius: var(--spectrum-alias-border-radius-regular);
+  border-start-end-radius: var(--spectrum-stepper-border-radius); /* --spectrum-global-dimension-size-75  = 6px 8px */
+  border-end-end-radius: var(--spectrum-stepper-border-radius);
   border-end-start-radius: 0;
-  transition: box-shadow var(--spectrum-global-animation-duration-100) ease-in-out;
+  transition: box-shadow var(--spectrum-stepper-animation-duration) ease-in-out;
+  block-size: var(--spectrum-stepper-buttons-height);
 }
 
 .spectrum-Stepper-stepUp,
@@ -59,8 +90,16 @@ governing permissions and limitations under the License.
   display: flex;
   box-sizing: border-box;
 
-  block-size: var(--spectrum-stepper-button-height);
-  inline-size: var(--spectrum-stepper-button-width);
+  /* remove middle border from button height */
+  block-size: calc((var(--spectrum-stepper-buttons-height) / 2)) - var(--spectrum-stepper-border-size));
+  block-size: calc((var(--spectrum-stepper-buttons-height) - var(--spectrum-stepper-border-size)) / 2);
+
+  block-size: calc((var(--spectrum-stepper-buttons-height) / 2) - (var(--spectrum-stepper-border-size) / 2));
+  block-size: calc(var(--spectrum-stepper-buttons-height) / 2);
+
+  /* remove left border width from button width */
+  inline-size: calc(var(--spectrum-stepper-button-width) - var(--spectrum-stepper-border-size));
+
   min-inline-size: 0;
 
   padding-inline-start: var(--spectrum-stepper-button-padding);
@@ -68,6 +107,8 @@ governing permissions and limitations under the License.
 
   /* Avoid margin added by adjacent buttons */
   margin: 0 !important;
+
+  border-color: var(--spectrum-stepper-border-color);
 
   border-width: var(--spectrum-stepper-border-size);
   border-inline-start-width: var(--spectrum-stepper-border-size-reset);
@@ -85,14 +126,13 @@ governing permissions and limitations under the License.
   border-block-end: none;
   border-end-end-radius: var(--spectrum-stepper-border-radius-reset);
 
-  padding-block-start: var(--spectrum-stepper-icon-nudge-top);
+  padding-block-start: var(--spectrum-stepper-icon-nudge-start);
 }
 
 .spectrum-Stepper-stepDown {
-  /*border-block-start: none;*/
   border-start-end-radius: var(--spectrum-stepper-border-radius-reset);
 
-  padding-block-end: var(--spectrum-stepper-icon-nudge);
+  padding-block-end: var(--spectrum-stepper-icon-nudge-end);
 }
 
 .spectrum-Stepper-textfield {
@@ -132,12 +172,180 @@ governing permissions and limitations under the License.
     justify-content: flex-end;
 
     /* More hitarea */
-    &:after {
+    &::after {
       content: '';
       position: absolute;
       block-size: 100%;
       inline-size: var(--spectrum-stepper-button-offset);
       inset-inline-end: calc(var(--spectrum-stepper-button-offset) * -1);
+    }
+  }
+}
+
+
+
+/* Variant colors - WIP placeholders - bring in colors from textfield */
+
+.spectrum-Stepper {
+  &:hover:not(.is-disabled):not(.is-invalid):not(.is-focused):not(.is-keyboardFocused) {
+    .spectrum-Stepper-stepUp,
+    .spectrum-Stepper-stepDown,
+    .spectrum-Stepper-input {
+      border-color: var(--spectrum-stepper-border-color);
+    }
+  }
+
+  &.is-focused {
+    border-color: cyan; /* WIP placeholder */
+
+    .spectrum-Stepper-stepUp,
+    .spectrum-Stepper-stepDown {
+      border-color:  cyan; /* WIP placeholder */
+    }
+
+    .spectrum-Stepper-input {
+      border-color:  cyan; /* WIP placeholder */
+      box-shadow: none;
+    }
+
+    &.is-invalid {
+      border-color: red;
+
+      .spectrum-Stepper-stepUp,
+      .spectrum-Stepper-stepDown {
+        border-color: red;
+      }
+
+      .spectrum-Stepper-input {
+        border-color: red;
+      }
+    }
+  }
+
+  &.is-keyboardFocused {
+    box-shadow: 0 0 0 1px magenta;
+
+    .spectrum-Stepper-input,
+    .spectrum-Stepper-buttons {
+      box-shadow: 0 0 0 1px magenta;
+    }
+
+    .spectrum-Stepper-input,
+    .spectrum-Stepper-stepUp,
+    .spectrum-Stepper-stepDown {
+      border-color: magenta;
+    }
+
+    &.is-invalid {
+      box-shadow: 0 0 0 1px magenta;
+
+      .spectrum-Stepper-stepUp,
+      .spectrum-Stepper-stepDown {
+        border-color: magenta;
+      }
+      .spectrum-Stepper-buttons {
+        box-shadow: 0 0 0 1px magenta;
+      }
+    }
+  }
+
+  &.is-invalid {
+    .spectrum-Stepper-stepUp,
+    .spectrum-Stepper-stepDown {
+      border-color: red;
+    }
+
+    .spectrum-Stepper-input {
+      border-color: red;
+    }
+
+    &.is-keyboardFocused {
+      .spectrum-Stepper-input {
+        border-color: red;
+        box-shadow: 0 0 0 1px red;
+      }
+
+      .spectrum-Stepper-buttons {
+        box-shadow: 0 0 0 1px red;
+      }
+    }
+  }
+
+  &.is-disabled {
+    .spectrum-Stepper-stepUp,
+    .spectrum-Stepper-stepDown {
+      border-color: gray;
+    }
+  }
+}
+
+.spectrum-Stepper-stepUp,
+.spectrum-Stepper-stepDown {
+
+  &:disabled {
+    border-color: gray;
+  }
+}
+
+.spectrum-Stepper--quiet {
+  &.is-disabled {
+    .spectrum-Stepper-stepUp,
+    .spectrum-Stepper-stepDown {
+      border-color: pink;
+    }
+  }
+
+  .spectrum-Stepper-stepUp,
+  .spectrum-Stepper-stepDown {
+    border-color: pink;
+
+    &:disabled {
+      border-color: pink;
+    }
+  }
+
+  .spectrum-Stepper-input {
+    box-shadow: none;
+  }
+
+  &.is-invalid {
+    .spectrum-Stepper-input {
+      border-color: red;
+    }
+
+    .spectrum-Stepper-stepDown {
+      border-color: red;
+    }
+  }
+
+  &.is-keyboardFocused,
+  &.is-focused {
+    box-shadow: none;
+
+    .spectrum-Stepper-buttons,
+    .spectrum-Stepper-input {
+      box-shadow: 0 1px 0 0 purple;;
+    }
+
+    .spectrum-Stepper-stepDown {
+      border-color: purple;
+    }
+
+    &.is-invalid {
+      box-shadow: none;
+
+      .spectrum-Stepper-input,
+      .spectrum-Stepper-buttons {
+        box-shadow: 0 1px 0 0 purple;;
+      }
+
+      .spectrum-Stepper-input {
+        border-color: purple;
+      }
+
+      .spectrum-Stepper-stepDown {
+        border-color: purple;
+      }
     }
   }
 }

--- a/components/stepper/index.css
+++ b/components/stepper/index.css
@@ -560,7 +560,8 @@ governing permissions and limitations under the License.
   }
 }
 
-.spectrum-Stepper-input {
+/* Only remove input border if stepper is visible */
+.spectrum-Stepper:not(.hide-stepper) .spectrum-Stepper-input {
   min-inline-size: 0;
   border-start-end-radius: 0;
   border-end-end-radius: 0;

--- a/components/stepper/index.css
+++ b/components/stepper/index.css
@@ -229,7 +229,8 @@ governing permissions and limitations under the License.
     }
 
     /* keyboard focused invalid */
-    &.is-invalid {
+    &.is-invalid,
+    &:has(input:invalid) {
       .spectrum-Stepper-input,
       .spectrum-Stepper-buttons,
       .spectrum-Stepper-stepUp,

--- a/components/stepper/metadata/stepper.yml
+++ b/components/stepper/metadata/stepper.yml
@@ -32,7 +32,7 @@ examples:
     markup: |
       <div class="spectrum-Stepper">
         <div class="spectrum-Textfield spectrum-Stepper-textfield">
-          <input type="number" class="spectrum-Textfield-input spectrum-Stepper-input" placeholder="100" min="-2" max="2" step="0.5">
+          <input type="number" class="spectrum-Textfield-input spectrum-Stepper-input" min="-2" max="2" step="0.5">
         </div>
         <span class="spectrum-Stepper-buttons">
           <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-Stepper-stepUp" tabindex="-1">
@@ -52,7 +52,7 @@ examples:
     markup: |
       <div class="spectrum-Stepper is-focused">
         <div class="spectrum-Textfield spectrum-Stepper-textfield">
-          <input type="number" class="spectrum-Textfield-input spectrum-Stepper-input" placeholder="100" min="-2" max="2" step="0.5">
+          <input type="number" class="spectrum-Textfield-input spectrum-Stepper-input" min="-2" max="2" step="0.5">
         </div>
         <span class="spectrum-Stepper-buttons">
           <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-Stepper-stepUp" tabindex="-1">
@@ -72,7 +72,7 @@ examples:
     markup: |
       <div class="spectrum-Stepper is-keyboardFocused">
         <div class="spectrum-Textfield spectrum-Stepper-textfield">
-          <input type="number" class="spectrum-Textfield-input spectrum-Stepper-input" placeholder="100" min="-2" max="2" step="0.5">
+          <input type="number" class="spectrum-Textfield-input spectrum-Stepper-input" min="-2" max="2" step="0.5">
         </div>
         <span class="spectrum-Stepper-buttons">
           <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-Stepper-stepUp" tabindex="-1">
@@ -92,7 +92,7 @@ examples:
     markup: |
       <div class="spectrum-Stepper is-invalid">
         <div class="spectrum-Textfield spectrum-Stepper-textfield">
-          <input type="number" class="spectrum-Textfield-input spectrum-Stepper-input" placeholder="100" min="-2" max="2" step="0.5">
+          <input type="number" class="spectrum-Textfield-input spectrum-Stepper-input" min="-2" max="2" step="0.5">
         </div>
         <span class="spectrum-Stepper-buttons">
           <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-Stepper-stepUp" tabindex="-1">
@@ -112,7 +112,7 @@ examples:
     markup: |
       <div class="spectrum-Stepper is-invalid is-focused">
         <div class="spectrum-Textfield spectrum-Stepper-textfield">
-          <input type="number" class="spectrum-Textfield-input spectrum-Stepper-input" placeholder="100" min="-2" max="2" step="0.5">
+          <input type="number" class="spectrum-Textfield-input spectrum-Stepper-input" min="-2" max="2" step="0.5">
         </div>
         <span class="spectrum-Stepper-buttons">
           <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-Stepper-stepUp" tabindex="-1">
@@ -132,7 +132,7 @@ examples:
     markup: |
       <div class="spectrum-Stepper is-invalid is-keyboardFocused">
         <div class="spectrum-Textfield spectrum-Stepper-textfield">
-          <input type="number" class="spectrum-Textfield-input spectrum-Stepper-input" placeholder="100" min="-2" max="2" step="0.5">
+          <input type="number" class="spectrum-Textfield-input spectrum-Stepper-input" min="-2" max="2" step="0.5">
         </div>
         <span class="spectrum-Stepper-buttons">
           <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-Stepper-stepUp" tabindex="-1">
@@ -152,7 +152,7 @@ examples:
     markup: |
       <div class="spectrum-Stepper is-disabled">
         <div class="spectrum-Textfield spectrum-Stepper-textfield is-disabled">
-          <input type="number" class="spectrum-Textfield-input spectrum-Stepper-input" placeholder="100" min="-2" max="2" step="0.5" disabled>
+          <input type="number" class="spectrum-Textfield-input spectrum-Stepper-input" min="-2" max="2" step="0.5" disabled>
         </div>
         <span class="spectrum-Stepper-buttons">
           <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-Stepper-stepUp" tabindex="-1" disabled>
@@ -172,7 +172,7 @@ examples:
     markup: |
       <div class="spectrum-Stepper spectrum-Stepper--quiet">
         <div class="spectrum-Textfield spectrum-Textfield--quiet spectrum-Stepper-textfield">
-          <input type="number" class="spectrum-Textfield-input spectrum-Stepper-input" placeholder="100" min="-2" max="2" step="0.5">
+          <input type="number" class="spectrum-Textfield-input spectrum-Stepper-input" min="-2" max="2" step="0.5">
         </div>
         <span class="spectrum-Stepper-buttons">
           <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-Stepper-stepUp" tabindex="-1">
@@ -192,7 +192,7 @@ examples:
     markup: |
       <div class="spectrum-Stepper spectrum-Stepper--quiet is-focused">
         <div class="spectrum-Textfield spectrum-Textfield--quiet spectrum-Stepper-textfield">
-          <input type="number" class="spectrum-Textfield-input spectrum-Stepper-input" placeholder="100" min="-2" max="2" step="0.5">
+          <input type="number" class="spectrum-Textfield-input spectrum-Stepper-input" min="-2" max="2" step="0.5">
         </div>
         <span class="spectrum-Stepper-buttons">
           <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-Stepper-stepUp" tabindex="-1">
@@ -212,7 +212,7 @@ examples:
     markup: |
       <div class="spectrum-Stepper spectrum-Stepper--quiet is-keyboardFocused">
         <div class="spectrum-Textfield spectrum-Textfield--quiet spectrum-Stepper-textfield">
-          <input type="number" class="spectrum-Textfield-input spectrum-Stepper-input" placeholder="100" min="-2" max="2" step="0.5">
+          <input type="number" class="spectrum-Textfield-input spectrum-Stepper-input" min="-2" max="2" step="0.5">
         </div>
         <span class="spectrum-Stepper-buttons">
           <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-Stepper-stepUp" tabindex="-1">
@@ -232,7 +232,7 @@ examples:
     markup: |
       <div class="spectrum-Stepper spectrum-Stepper--quiet is-invalid">
         <div class="spectrum-Textfield spectrum-Textfield--quiet spectrum-Stepper-textfield">
-          <input type="number" class="spectrum-Textfield-input spectrum-Stepper-input" placeholder="100" min="-2" max="2" step="0.5">
+          <input type="number" class="spectrum-Textfield-input spectrum-Stepper-input" min="-2" max="2" step="0.5">
         </div>
         <span class="spectrum-Stepper-buttons">
           <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-Stepper-stepUp" tabindex="-1">
@@ -252,7 +252,7 @@ examples:
     markup: |
       <div class="spectrum-Stepper spectrum-Stepper--quiet is-invalid is-focused">
         <div class="spectrum-Textfield spectrum-Textfield--quiet spectrum-Stepper-textfield">
-          <input type="number" class="spectrum-Textfield-input spectrum-Stepper-input" placeholder="100" min="-2" max="2" step="0.5">
+          <input type="number" class="spectrum-Textfield-input spectrum-Stepper-input" min="-2" max="2" step="0.5">
         </div>
         <span class="spectrum-Stepper-buttons">
           <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-Stepper-stepUp" tabindex="-1">
@@ -272,7 +272,7 @@ examples:
     markup: |
       <div class="spectrum-Stepper spectrum-Stepper--quiet is-invalid is-keyboardFocused">
         <div class="spectrum-Textfield spectrum-Textfield--quiet spectrum-Stepper-textfield">
-          <input type="number" class="spectrum-Textfield-input spectrum-Stepper-input" placeholder="100" min="-2" max="2" step="0.5">
+          <input type="number" class="spectrum-Textfield-input spectrum-Stepper-input" min="-2" max="2" step="0.5">
         </div>
         <span class="spectrum-Stepper-buttons">
           <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-Stepper-stepUp" tabindex="-1">
@@ -292,7 +292,7 @@ examples:
     markup: |
       <div class="spectrum-Stepper spectrum-Stepper--quiet is-disabled">
         <div class="spectrum-Textfield spectrum-Textfield--quiet spectrum-Stepper-textfield is-disabled">
-          <input type="number" class="spectrum-Textfield-input spectrum-Stepper-input" placeholder="100" min="-2" max="2" step="0.5" disabled>
+          <input type="number" class="spectrum-Textfield-input spectrum-Stepper-input" min="-2" max="2" step="0.5" disabled>
         </div>
         <span class="spectrum-Stepper-buttons">
           <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-Stepper-stepUp" tabindex="-1" disabled>

--- a/components/stepper/package.json
+++ b/components/stepper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spectrum-css/stepper",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-beta.1",
   "description": "The Spectrum CSS stepper component",
   "license": "Apache-2.0",
   "author": "Adobe",

--- a/components/stepper/package.json
+++ b/components/stepper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spectrum-css/stepper",
-  "version": "3.0.39",
+  "version": "4.0.0-beta.0",
   "description": "The Spectrum CSS stepper component",
   "license": "Apache-2.0",
   "author": "Adobe",
@@ -27,7 +27,7 @@
     "@spectrum-css/actionbutton": "^1.1.14",
     "@spectrum-css/component-builder-simple": "^2.0.0",
     "@spectrum-css/icon": "^3.0.27",
-    "@spectrum-css/textfield": "^3.2.8",
+    "@spectrum-css/textfield": "^4.0.0-beta.3",
     "@spectrum-css/tokens": "^7.0.0",
     "gulp": "^4.0.0"
   },

--- a/components/stepper/package.json
+++ b/components/stepper/package.json
@@ -18,16 +18,16 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/actionbutton": "^1.1.13",
-    "@spectrum-css/icon": "^3.0.21",
-    "@spectrum-css/textfield": "^4.0.0-beta.3",
-    "@spectrum-css/tokens": "^6.2.0"
+    "@spectrum-css/actionbutton": "^3.0.13",
+    "@spectrum-css/icon": "^3.0.22",
+    "@spectrum-css/textfield": "^4.0.0-beta.4",
+    "@spectrum-css/tokens": "^7.0.0"
   },
   "devDependencies": {
-    "@spectrum-css/actionbutton": "^1.1.14",
+    "@spectrum-css/actionbutton": "^3.0.13",
     "@spectrum-css/component-builder-simple": "^2.0.0",
-    "@spectrum-css/icon": "^3.0.27",
-    "@spectrum-css/textfield": "^4.0.0-beta.3",
+    "@spectrum-css/icon": "^3.0.22",
+    "@spectrum-css/textfield": "^4.0.0-beta.4",
     "@spectrum-css/tokens": "^7.0.0",
     "gulp": "^4.0.0"
   },

--- a/components/stepper/package.json
+++ b/components/stepper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spectrum-css/stepper",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "description": "The Spectrum CSS stepper component",
   "license": "Apache-2.0",
   "author": "Adobe",
@@ -18,17 +18,17 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/actionbutton": "^3.0.13",
+    "@spectrum-css/actionbutton": "^3.0.20",
     "@spectrum-css/icon": "^3.0.22",
     "@spectrum-css/textfield": "^4.0.0-beta.4",
-    "@spectrum-css/tokens": "^7.0.0"
+    "@spectrum-css/tokens": "^7.5.1"
   },
   "devDependencies": {
-    "@spectrum-css/actionbutton": "^3.0.13",
+    "@spectrum-css/actionbutton": "^3.0.20",
     "@spectrum-css/component-builder-simple": "^2.0.0",
     "@spectrum-css/icon": "^3.0.22",
-    "@spectrum-css/textfield": "^4.0.0-beta.4",
-    "@spectrum-css/tokens": "^7.0.0",
+    "@spectrum-css/textfield": "^4.0.0-beta.5",
+    "@spectrum-css/tokens": "^7.5.1",
     "gulp": "^4.0.0"
   },
   "publishConfig": {

--- a/components/stepper/package.json
+++ b/components/stepper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spectrum-css/stepper",
-  "version": "4.0.0-beta.3",
+  "version": "4.0.0-beta.4",
   "description": "The Spectrum CSS stepper component",
   "license": "Apache-2.0",
   "author": "Adobe",
@@ -27,7 +27,7 @@
     "@spectrum-css/actionbutton": "^3.0.20",
     "@spectrum-css/component-builder-simple": "^2.0.0",
     "@spectrum-css/icon": "^3.0.22",
-    "@spectrum-css/textfield": "^4.0.0-beta.5",
+    "@spectrum-css/textfield": "^4.0.0-beta.7",
     "@spectrum-css/tokens": "^7.5.1",
     "gulp": "^4.0.0"
   },

--- a/components/stepper/package.json
+++ b/components/stepper/package.json
@@ -28,7 +28,7 @@
     "@spectrum-css/component-builder-simple": "^2.0.0",
     "@spectrum-css/icon": "^3.0.27",
     "@spectrum-css/textfield": "^3.2.8",
-    "@spectrum-css/tokens": "^6.2.0",
+    "@spectrum-css/tokens": "^7.0.0",
     "gulp": "^4.0.0"
   },
   "publishConfig": {

--- a/components/stepper/package.json
+++ b/components/stepper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spectrum-css/stepper",
-  "version": "4.0.0-beta.2",
+  "version": "4.0.0-beta.3",
   "description": "The Spectrum CSS stepper component",
   "license": "Apache-2.0",
   "author": "Adobe",

--- a/components/stepper/package.json
+++ b/components/stepper/package.json
@@ -18,17 +18,17 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/actionbutton": "^1.0.0 || ^2.0.0 || ^3.0.0",
-    "@spectrum-css/icon": "^3.0.0",
-    "@spectrum-css/textfield": "^3.0.0",
-    "@spectrum-css/vars": "^8.0.0"
+    "@spectrum-css/actionbutton": "^1.1.13",
+    "@spectrum-css/icon": "^3.0.21",
+    "@spectrum-css/textfield": "^4.0.0-beta.3",
+    "@spectrum-css/tokens": "^6.2.0"
   },
   "devDependencies": {
     "@spectrum-css/actionbutton": "^1.1.14",
-    "@spectrum-css/component-builder": "^4.0.3",
-    "@spectrum-css/icon": "^3.0.35",
-    "@spectrum-css/textfield": "^3.2.16",
-    "@spectrum-css/vars": "^8.0.5",
+    "@spectrum-css/component-builder-simple": "^2.0.0",
+    "@spectrum-css/icon": "^3.0.27",
+    "@spectrum-css/textfield": "^3.2.8",
+    "@spectrum-css/tokens": "^6.2.0",
     "gulp": "^4.0.0"
   },
   "publishConfig": {

--- a/components/stepper/stories/stepper.stories.js
+++ b/components/stepper/stories/stepper.stories.js
@@ -16,6 +16,15 @@ export default {
       },
       control: "boolean",
     },
+    hideStepper: {
+      name: "Hide Stepper",
+      type: { name: "boolean" },
+      table: {
+        type: { summary: "boolean" },
+        category: "State",
+      },
+      control: "boolean",
+    },
     isDisabled: {
       name: "Disabled",
       type: { name: "boolean" },
@@ -74,4 +83,9 @@ export default {
 };
 
 export const Default = Template.bind({});
-Default.args = {};
+Default.args = {}
+
+export const HideStepper = Template.bind({});
+HideStepper.args = {
+  hideStepper: true
+};

--- a/components/stepper/stories/template.js
+++ b/components/stepper/stories/template.js
@@ -16,6 +16,7 @@ export const Template = ({
   isKeyboardFocused = false,
   isInvalid = false,
   isDisabled = false,
+  hideStepper = false,
   customClasses = [],
   id,
   style = {
@@ -31,13 +32,14 @@ export const Template = ({
       'is-keyboardFocused': isKeyboardFocused,
       'is-invalid': isInvalid,
       'is-disabled': isDisabled,
+      'hide-stepper': hideStepper,
       ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
     })} id=${ifDefined(id)}
     style=${ifDefined(styleMap(style))}
     >
       ${Textfield({
         ...globals,
-        placeholder: "100",
+        placeholder: "1",
         min: "-2",
         max: "2",
         step: "0.5",
@@ -46,10 +48,12 @@ export const Template = ({
         customClasses: [`${rootClass}-textfield`],
         customInputClasses: [`${rootClass}-input`],
       })}
-      <span class="${rootClass}-buttons">
+      ${hideStepper ? "" :
+      html`<span class="${rootClass}-buttons">
         ${ActionButton({ ...globals, customClasses: [`${rootClass}-stepUp`], iconName: 'ChevronUp75', isDisabled, isQuiet })}
         ${ActionButton({ ...globals, customClasses: [`${rootClass}-stepDown`], iconName: 'ChevronDown75', isDisabled, isQuiet })}
-      </span>
+      </span>`
+      }
     </div>
   `;
 };

--- a/components/stepper/themes/express.css
+++ b/components/stepper/themes/express.css
@@ -14,8 +14,11 @@ governing permissions and limitations under the License.
   /* @todo remove this when stepper is migrated; this ensures stepper buttons inherit border color and width */
   .spectrum-Stepper {
     --spectrum-stepper-border-width: var(--spectrum-border-width-200);
-    --spectrum-stepper-middle-border-width: 0;
+
+    /* replace middle border with flex row gap */
+    --spectrum-stepper-button-middle-border-width: 0;
     --spectrum-stepper-button-gap: var(--spectrum-border-width-200);
+
     --spectrum-stepper-border-size-reset: 0;
 
     --spectrum-stepper-border-color: var(--spectrum-gray-400);
@@ -24,9 +27,9 @@ governing permissions and limitations under the License.
     --spectrum-stepper-border-color-focus-hover: var(--spectrum-gray-900);
     --spectrum-stepper-border-color-keyboard-focus: var(--spectrum-gray-900);
 
-    --spectrum-stepper-background-color-default: var(--spectrum-gray-200);
-    --spectrum-stepper-background-color-hover: var(--spectrum-gray-300);
-    --spectrum-stepper-background-color-active: var(--spectrum-gray-400);
-    --spectrum-stepper-background-color-keyboard-focus: var(--spectrum-gray-300);
+    --spectrum-stepper-button-background-color-default: var(--spectrum-gray-200);
+    --spectrum-stepper-button-background-color-hover: var(--spectrum-gray-300);
+    --spectrum-stepper-button-background-color-focus: var(--spectrum-gray-400);
+    --spectrum-stepper-button-background-color-keyboard-focus: var(--spectrum-gray-300);
   }
 }

--- a/components/stepper/themes/express.css
+++ b/components/stepper/themes/express.css
@@ -13,11 +13,12 @@ governing permissions and limitations under the License.
 @container (--system: express) {
   /* @todo remove this when stepper is migrated; this ensures stepper buttons inherit border color and width */
   .spectrum-Stepper {
-    --spectrum-stepper-border-color-default: var(--spectrum-gray-400);
+    --spectrum-stepper-border-width: var(--spectrum-border-width-200);
 
-    .spectrum-Stepper-stepUp,
-    .spectrum-Stepper-stepDown {
-      --spectrum-stepper-border-size: var(--spectrum-border-width-200);
-    }
+    --spectrum-stepper-border-color: var(--spectrum-gray-400);
+    --spectrum-stepper-border-color-hover: var(--spectrum-gray-500);
+    --spectrum-stepper-border-color-focus: var(--spectrum-gray-800);
+    --spectrum-stepper-border-color-focus-hover: var(--spectrum-gray-900);
+    --spectrum-stepper-border-color-keyboard-focus: var(--spectrum-gray-900);
   }
 }

--- a/components/stepper/themes/express.css
+++ b/components/stepper/themes/express.css
@@ -10,14 +10,14 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@container (--system: spectrum) {
-  .spectrum-Textfield {
-    --spectrum-textfield-border-color: var(--spectrum-gray-500);
-    --spectrum-textfield-border-color-hover: var(--spectrum-gray-600);
-    --spectrum-textfield-border-color-focus: var(--spectrum-gray-800);
-    --spectrum-textfield-border-color-focus-hover: var(--spectrum-gray-900);
-    --spectrum-textfield-border-color-keyboard-focus: var(--spectrum-gray-900);
+@container (--system: express) {
+  /* @todo remove this when stepper is migrated; this ensures stepper buttons inherit border color and width */
+  .spectrum-Stepper {
+    --spectrum-stepper-border-color-default: var(--spectrum-gray-400);
 
-    --spectrum-textfield-border-width: var(--spectrum-border-width-100);
+    .spectrum-Stepper-stepUp,
+    .spectrum-Stepper-stepDown {
+      --spectrum-stepper-border-size: var(--spectrum-border-width-200);
+    }
   }
 }

--- a/components/stepper/themes/express.css
+++ b/components/stepper/themes/express.css
@@ -13,13 +13,12 @@ governing permissions and limitations under the License.
 @container (--system: express) {
   /* @todo remove this when stepper is migrated; this ensures stepper buttons inherit border color and width */
   .spectrum-Stepper {
-    --spectrum-stepper-border-width: var(--spectrum-border-width-200);
+    --spectrum-stepper-border-width: var(--spectrum-border-width-200); /* express stepper has border */
+    --spectrum-stepper-border-size-reset: 0; /* express buttons have no inline start border */
 
-    /* replace middle border with flex row gap */
-    --spectrum-stepper-button-middle-border-width: 0;
-    --spectrum-stepper-button-gap: var(--spectrum-border-width-200);
-
-    --spectrum-stepper-border-size-reset: 0;
+    --spectrum-stepper-button-middle-border-width: 0; /* express buttons have no middle border */
+    --spectrum-stepper-button-gap-reset: var(--spectrum-border-width-200); /* express buttons have middle gap */
+    --spectrum-stepper-button-border-radius-reset: calc(var(--spectrum-corner-radius-100) - (var(--spectrum-border-width-200) * 2));
 
     --spectrum-stepper-border-color: var(--spectrum-gray-400);
     --spectrum-stepper-border-color-hover: var(--spectrum-gray-500);

--- a/components/stepper/themes/express.css
+++ b/components/stepper/themes/express.css
@@ -14,11 +14,19 @@ governing permissions and limitations under the License.
   /* @todo remove this when stepper is migrated; this ensures stepper buttons inherit border color and width */
   .spectrum-Stepper {
     --spectrum-stepper-border-width: var(--spectrum-border-width-200);
+    --spectrum-stepper-middle-border-width: 0;
+    --spectrum-stepper-button-gap: var(--spectrum-border-width-200);
+    --spectrum-stepper-border-size-reset: 0;
 
     --spectrum-stepper-border-color: var(--spectrum-gray-400);
     --spectrum-stepper-border-color-hover: var(--spectrum-gray-500);
     --spectrum-stepper-border-color-focus: var(--spectrum-gray-800);
     --spectrum-stepper-border-color-focus-hover: var(--spectrum-gray-900);
     --spectrum-stepper-border-color-keyboard-focus: var(--spectrum-gray-900);
+
+    --spectrum-stepper-background-color-default: var(--spectrum-gray-200);
+    --spectrum-stepper-background-color-hover: var(--spectrum-gray-300);
+    --spectrum-stepper-background-color-active: var(--spectrum-gray-400);
+    --spectrum-stepper-background-color-keyboard-focus: var(--spectrum-gray-300);
   }
 }

--- a/components/stepper/themes/spectrum.css
+++ b/components/stepper/themes/spectrum.css
@@ -14,8 +14,8 @@ governing permissions and limitations under the License.
   /* @todo remove this when stepper is migrated; this ensures stepper buttons inherit border color and width */
   .spectrum-Stepper {
     --spectrum-stepper-border-width: var(--spectrum-border-width-100);
-    --spectrum-stepper-middle-border-width: var(--spectrum-border-width-100);
-    --spectrum-stepper-button-gap: none;
+    --spectrum-stepper-button-middle-border-width: var(--spectrum-border-width-100);
+    --spectrum-stepper-button-gap: 0px;
     --spectrum-stepper-border-size-reset: var(--spectrum-border-width-100);
 
     --spectrum-stepper-border-color: var(--spectrum-gray-500);
@@ -24,9 +24,9 @@ governing permissions and limitations under the License.
     --spectrum-stepper-border-color-focus-hover: var(--spectrum-gray-900);
     --spectrum-stepper-border-color-keyboard-focus: var(--spectrum-gray-900);
 
-    --spectrum-stepper-background-color-default: var(--spectrum-gray-75);
-    --spectrum-stepper-background-color-hover: var(--spectrum-gray-200);
-    --spectrum-stepper-background-color-active: var(--spectrum-gray-300);
-    --spectrum-stepper-background-color-keyboard-focus: var(--spectrum-gray-200);
+    --spectrum-stepper-button-background-color-default: var(--spectrum-gray-75);
+    --spectrum-stepper-button-background-color-hover: var(--spectrum-gray-200);
+    --spectrum-stepper-button-background-color-focus: var(--spectrum-gray-300);
+    --spectrum-stepper-button-background-color-keyboard-focus: var(--spectrum-gray-200);
   }
 }

--- a/components/stepper/themes/spectrum.css
+++ b/components/stepper/themes/spectrum.css
@@ -13,10 +13,12 @@ governing permissions and limitations under the License.
 @container (--system: spectrum) {
   /* @todo remove this when stepper is migrated; this ensures stepper buttons inherit border color and width */
   .spectrum-Stepper {
-    --spectrum-stepper-border-width: var(--spectrum-border-width-100);
-    --spectrum-stepper-button-middle-border-width: var(--spectrum-border-width-100);
-    --spectrum-stepper-button-gap: 0px;
-    --spectrum-stepper-border-size-reset: var(--spectrum-border-width-100);
+    --spectrum-stepper-border-width: var(--spectrum-border-width-100); /* spectrum stepper has border */
+    --spectrum-stepper-border-size-reset: var(--spectrum-border-width-100);  /* spectrum buttons have inline start border */
+
+    --spectrum-stepper-button-middle-border-width: var(--spectrum-border-width-100); /* spectrum buttons have middle border */
+    --spectrum-stepper-button-gap-reset: 0px; /* spectrum buttons have no middle gap */
+    --spectrum-stepper-button-border-radius-reset: 0px;
 
     --spectrum-stepper-border-color: var(--spectrum-gray-500);
     --spectrum-stepper-border-color-hover: var(--spectrum-gray-600);

--- a/components/stepper/themes/spectrum.css
+++ b/components/stepper/themes/spectrum.css
@@ -14,11 +14,19 @@ governing permissions and limitations under the License.
   /* @todo remove this when stepper is migrated; this ensures stepper buttons inherit border color and width */
   .spectrum-Stepper {
     --spectrum-stepper-border-width: var(--spectrum-border-width-100);
+    --spectrum-stepper-middle-border-width: var(--spectrum-border-width-100);
+    --spectrum-stepper-button-gap: none;
+    --spectrum-stepper-border-size-reset: var(--spectrum-border-width-100);
 
     --spectrum-stepper-border-color: var(--spectrum-gray-500);
     --spectrum-stepper-border-color-hover: var(--spectrum-gray-600);
     --spectrum-stepper-border-color-focus: var(--spectrum-gray-800);
     --spectrum-stepper-border-color-focus-hover: var(--spectrum-gray-900);
     --spectrum-stepper-border-color-keyboard-focus: var(--spectrum-gray-900);
+
+    --spectrum-stepper-background-color-default: var(--spectrum-gray-75);
+    --spectrum-stepper-background-color-hover: var(--spectrum-gray-200);
+    --spectrum-stepper-background-color-active: var(--spectrum-gray-300);
+    --spectrum-stepper-background-color-keyboard-focus: var(--spectrum-gray-200);
   }
 }

--- a/components/stepper/themes/spectrum.css
+++ b/components/stepper/themes/spectrum.css
@@ -11,13 +11,13 @@ governing permissions and limitations under the License.
 */
 
 @container (--system: spectrum) {
-  .spectrum-Textfield {
-    --spectrum-textfield-border-color: var(--spectrum-gray-500);
-    --spectrum-textfield-border-color-hover: var(--spectrum-gray-600);
-    --spectrum-textfield-border-color-focus: var(--spectrum-gray-800);
-    --spectrum-textfield-border-color-focus-hover: var(--spectrum-gray-900);
-    --spectrum-textfield-border-color-keyboard-focus: var(--spectrum-gray-900);
+  /* @todo remove this when stepper is migrated; this ensures stepper buttons inherit border color and width */
+  .spectrum-Stepper {
+    --spectrum-stepper-border-color-default: var(--spectrum-gray-500);
 
-    --spectrum-textfield-border-width: var(--spectrum-border-width-100);
+    .spectrum-Stepper-stepUp,
+    .spectrum-Stepper-stepDown {
+      --spectrum-stepper-border-size: var(--spectrum-border-width-100);
+    }
   }
 }

--- a/components/stepper/themes/spectrum.css
+++ b/components/stepper/themes/spectrum.css
@@ -13,11 +13,12 @@ governing permissions and limitations under the License.
 @container (--system: spectrum) {
   /* @todo remove this when stepper is migrated; this ensures stepper buttons inherit border color and width */
   .spectrum-Stepper {
-    --spectrum-stepper-border-color-default: var(--spectrum-gray-500);
+    --spectrum-stepper-border-width: var(--spectrum-border-width-100);
 
-    .spectrum-Stepper-stepUp,
-    .spectrum-Stepper-stepDown {
-      --spectrum-stepper-border-size: var(--spectrum-border-width-100);
-    }
+    --spectrum-stepper-border-color: var(--spectrum-gray-500);
+    --spectrum-stepper-border-color-hover: var(--spectrum-gray-600);
+    --spectrum-stepper-border-color-focus: var(--spectrum-gray-800);
+    --spectrum-stepper-border-color-focus-hover: var(--spectrum-gray-900);
+    --spectrum-stepper-border-color-keyboard-focus: var(--spectrum-gray-900);
   }
 }

--- a/components/textfield/CHANGELOG.md
+++ b/components/textfield/CHANGELOG.md
@@ -3,6 +3,98 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="4.0.0-beta.7"></a>
+# 4.0.0-beta.7
+🗓 2023-03-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@3.2.16...@spectrum-css/textfield@4.0.0-beta.7)
+
+### ✨ Features
+
+* add TextArea story and grows control ([c5ba477](https://github.com/adobe/spectrum-css/commit/c5ba477))
+* **textarea:** auto resize solution ([47e4ff6](https://github.com/adobe/spectrum-css/commit/47e4ff6))
+* **textarea:** implemented tokens for text area ([d9cfec0](https://github.com/adobe/spectrum-css/commit/d9cfec0))
+* **textarea:** quiet variant height WIP ([41cf1f6](https://github.com/adobe/spectrum-css/commit/41cf1f6))
+* **textarea:** update text area yml ([882ddfd](https://github.com/adobe/spectrum-css/commit/882ddfd))
+* **textarea:** wip token migration ([4a4ba7a](https://github.com/adobe/spectrum-css/commit/4a4ba7a))
+* **textfield:** add aria markup for character count ([beed486](https://github.com/adobe/spectrum-css/commit/beed486))
+* **textfield:** add default icon alignment for search icon ([e17cca4](https://github.com/adobe/spectrum-css/commit/e17cca4))
+* **textfield:** corrections and markup updates ([c06e899](https://github.com/adobe/spectrum-css/commit/c06e899))
+* **textfield:** final tokens populated ([a1a6d5b](https://github.com/adobe/spectrum-css/commit/a1a6d5b))
+* **textfield:** focus and dependency corrections ([9a5ecab](https://github.com/adobe/spectrum-css/commit/9a5ecab))
+* **textfield:** focus hover state ([ac96ce6](https://github.com/adobe/spectrum-css/commit/ac96ce6))
+* **textfield:** focus indicator ([4c07923](https://github.com/adobe/spectrum-css/commit/4c07923))
+* **textfield:** grid layout ([ba6b689](https://github.com/adobe/spectrum-css/commit/ba6b689))
+* **textfield:** organizing variants ([68f9b5e](https://github.com/adobe/spectrum-css/commit/68f9b5e))
+* **textfield:** refactor for readability of variants ([43014e9](https://github.com/adobe/spectrum-css/commit/43014e9))
+* **textfield:** refinement of focus states ([0cec4c8](https://github.com/adobe/spectrum-css/commit/0cec4c8))
+* **textfield:** reorganizing states and variants ([f440bf5](https://github.com/adobe/spectrum-css/commit/f440bf5))
+* **textfield:** resolving errors ([9f53dc7](https://github.com/adobe/spectrum-css/commit/9f53dc7))
+* **textfield:** rework focus states and nesting ([bca4ac2](https://github.com/adobe/spectrum-css/commit/bca4ac2))
+* **textfield:** rework markup and focus indicator WIP ([142a7f9](https://github.com/adobe/spectrum-css/commit/142a7f9))
+* **textfield:** token migration WIP ([3b67a12](https://github.com/adobe/spectrum-css/commit/3b67a12))
+* **textfield:** WHCM and tidying ([fe3ac52](https://github.com/adobe/spectrum-css/commit/fe3ac52))
+* **textfield:** WHCM setup WIP ([feb62af](https://github.com/adobe/spectrum-css/commit/feb62af))
+* **textfield:** windows high contrast mode ([e30149c](https://github.com/adobe/spectrum-css/commit/e30149c))
+
+
+### 🐛 Bug fixes
+
+* **stepper, textfield:** revert use of has ([c26c64f](https://github.com/adobe/spectrum-css/commit/c26c64f))
+* **textarea:** simplified multiline t-shirt styles and markup ([5e63c63](https://github.com/adobe/spectrum-css/commit/5e63c63))
+* **textfield:** add spacing around label and character count ([65acf5c](https://github.com/adobe/spectrum-css/commit/65acf5c))
+* **textfield:** add style to prevent search icon from breaking ([954125f](https://github.com/adobe/spectrum-css/commit/954125f))
+* **textfield:** add width to input ([56d7c0e](https://github.com/adobe/spectrum-css/commit/56d7c0e))
+* **textfield:** added missing WHCM refs to token stacks ([820ac89](https://github.com/adobe/spectrum-css/commit/820ac89))
+* **textfield:** apply width to parent instead of input wrapper ([645127c](https://github.com/adobe/spectrum-css/commit/645127c))
+* **textfield:** changed icon margins to inset ([957b42e](https://github.com/adobe/spectrum-css/commit/957b42e))
+* **textfield:** cleanup placeholder tokens for clarity ([ee30c04](https://github.com/adobe/spectrum-css/commit/ee30c04))
+* **textfield:** correct input patterns ([38a14cb](https://github.com/adobe/spectrum-css/commit/38a14cb))
+* **textfield:** correct invisible focus indicator ([bbd6f57](https://github.com/adobe/spectrum-css/commit/bbd6f57))
+* **textfield:** correct WHCM focus indicator reference ([ded46d4](https://github.com/adobe/spectrum-css/commit/ded46d4))
+* **textfield:** default placeholder font size ([943d9d0](https://github.com/adobe/spectrum-css/commit/943d9d0))
+* **textfield:** disabled safari value text color ([323f434](https://github.com/adobe/spectrum-css/commit/323f434))
+* **textfield:** ensure long side label does not impact helptext ([fbce894](https://github.com/adobe/spectrum-css/commit/fbce894))
+* **textfield:** ensure placeholder has correct font styles ([39a5ca7](https://github.com/adobe/spectrum-css/commit/39a5ca7))
+* **textfield:** ensure stepper inherits correct border styles ([91b5dfa](https://github.com/adobe/spectrum-css/commit/91b5dfa))
+* **textfield:** establish textfield animation token ([102d6af](https://github.com/adobe/spectrum-css/commit/102d6af))
+* **textfield:** fix focus and grows for textfield and textarea ([6f02a4d](https://github.com/adobe/spectrum-css/commit/6f02a4d))
+* **textfield:** fix issue with readonly styles not working ([740b1b1](https://github.com/adobe/spectrum-css/commit/740b1b1))
+* **textfield:** fix storybook keyboard focused typo ([ba471d3](https://github.com/adobe/spectrum-css/commit/ba471d3))
+* **textfield:** focus border invalid correction ([6ff801d](https://github.com/adobe/spectrum-css/commit/6ff801d))
+* **textfield:** focus hover colors ([ffe9415](https://github.com/adobe/spectrum-css/commit/ffe9415))
+* **textfield:** grid adjustments for label and character count ([1c6cc9e](https://github.com/adobe/spectrum-css/commit/1c6cc9e))
+* **textfield:** icon class name ([3e5bad7](https://github.com/adobe/spectrum-css/commit/3e5bad7))
+* **textfield:** icon color defaults ([3b21957](https://github.com/adobe/spectrum-css/commit/3b21957))
+* **textfield:** mitigate search icon misalignment in swc ([a88e152](https://github.com/adobe/spectrum-css/commit/a88e152))
+* **textfield:** mitigate validation icon within combobox ([d7fb96e](https://github.com/adobe/spectrum-css/commit/d7fb96e))
+* **textfield:** mitigation of search icon alignment issues ([7adb664](https://github.com/adobe/spectrum-css/commit/7adb664))
+* **textfield:** point placeholder font token to existing custom token ([bbc1b2c](https://github.com/adobe/spectrum-css/commit/bbc1b2c))
+* **textfield:** quiet and quiet focus corrections ([c0a6bb8](https://github.com/adobe/spectrum-css/commit/c0a6bb8))
+* **textfield:** quiet focus indicator position correction ([d0fff11](https://github.com/adobe/spectrum-css/commit/d0fff11))
+* **textfield:** quiet textarea no resize ([e2782fa](https://github.com/adobe/spectrum-css/commit/e2782fa))
+* **textfield:** refactor to avoid additional markup ([062019f](https://github.com/adobe/spectrum-css/commit/062019f))
+* **textfield:** remove skin.css import from storyfile ([c268381](https://github.com/adobe/spectrum-css/commit/c268381))
+* **textfield:** restored font placeholder tokens ([f59a3c0](https://github.com/adobe/spectrum-css/commit/f59a3c0))
+* **textfield:** search icon align and text overflow ([f292fc8](https://github.com/adobe/spectrum-css/commit/f292fc8))
+* **textfield:** textarea inherits resize ([86691cb](https://github.com/adobe/spectrum-css/commit/86691cb))
+* **textfield:** tokens and express border ([160452a](https://github.com/adobe/spectrum-css/commit/160452a))
+* **textfield:** update example text to match helptext ([ee9e4d2](https://github.com/adobe/spectrum-css/commit/ee9e4d2))
+* **textfield:** update express border width per design update ([2b726b8](https://github.com/adobe/spectrum-css/commit/2b726b8))
+* **textfield:** WHCM corrections ([df1577f](https://github.com/adobe/spectrum-css/commit/df1577f))
+* **textfield:** WHCM corrections - focus states ([9a1d627](https://github.com/adobe/spectrum-css/commit/9a1d627))
+* **textfield:** whcm decouple input color and placeholder text color ([8e16a5b](https://github.com/adobe/spectrum-css/commit/8e16a5b))
+
+
+* feat(textfield)!: initial migration with placeholder tokens ([b8bb223](https://github.com/adobe/spectrum-css/commit/b8bb223))
+
+
+### 🛑 BREAKING CHANGES
+
+* migrates textfield to spectrum tokens
+
+
+
+
+
 <a name="3.2.16"></a>
 ## 3.2.16
 🗓 2023-03-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@3.2.15...@spectrum-css/textfield@3.2.16)

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -49,6 +49,9 @@ governing permissions and limitations under the License.
   --spectrum-textfield-icon-spacing-inline-end-quiet-valid: var(--spectrum-field-edge-to-validation-icon-quiet);
   --spectrum-textfield-icon-spacing-block-valid: var(--spectrum-field-top-to-validation-icon-medium);
 
+  /* icon end spacing override for combobox */
+  --spectrum-textfield-icon-spacing-inline-end-override: 32px; /* TODO - placeholder - reevaluate after combobox migration */
+
   /* font styles */
   --spectrum-textfield-font-family: var(--spectrum-font-family-base); /* placeholder for --spectrum-font-family-default */
   --spectrum-textfield-font-weight: var(--spectrum-font-weight-regular);
@@ -432,6 +435,11 @@ governing permissions and limitations under the License.
   [dir="rtl"] & {
     left: 0;
     right: auto;
+  }
+
+  /* TODO - reevaluate after combobox is migrated - ensures icon is not under picker button */
+  .spectrum-InputGroup & {
+    margin-inline-end: var(--spectrum-textfield-icon-spacing-inline-end-override);
   }
 
   /****** Validation Icon - Valid ✅ ******/

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -741,6 +741,9 @@ governing permissions and limitations under the License.
   &.spectrum-Textfield--quiet {
     .spectrum-Textfield-input {
       min-block-size: var(--mod-text-area-min-block-size-quiet, var(--spectrum-text-area-min-block-size-quiet));
+      /* Treat all quiet inputs and text areas the same */
+      resize: none;
+      overflow-y: hidden;
     }
   }
 }

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -286,7 +286,7 @@ governing permissions and limitations under the License.
   position: absolute;
   top: 0;
   bottom: 0;
-  margin: auto;
+  margin-block: auto;
   color: var(--highcontrast-textfield-text-color-default, var(--mod-textfield-text-color-default, var(--spectrum-textfield-text-color-default)));
 
   .spectrum-Textfield.is-disabled & {
@@ -493,6 +493,8 @@ governing permissions and limitations under the License.
   /*** ↓ Browser Mitigations for Input ↓ ***/
   /* Remove the margin for input in Firefox and Safari. */
   margin: 0;
+
+  text-overflow: ellipsis;
 
   /* Show the overflow for input in Edge. */
   overflow: visible;

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -235,11 +235,9 @@ governing permissions and limitations under the License.
 
     &.is-focused,
     &.is-keyboardFocused {
-      .spectrum-Textfield-input-wrapper {
-        /* focus indicator is focused state */
-        &::after {
-          forced-color-adjust: none;
-        }
+      /* focus indicator is focused state */
+      &::after {
+        forced-color-adjust: none;
       }
     }
   }

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -210,14 +210,25 @@ governing permissions and limitations under the License.
     --highcontrast-textfield-border-color-invalid-focus: Highlight;
     --highcontrast-textfield-border-color-invalid-keyboard-focus: Highlight;
 
-    --highcontrast-textfield-text-color-default: GrayText;
-    --highcontrast-textfield-text-color-hover: GrayText;
-    --highcontrast-textfield-text-color-keyboard-focus: GrayText;
-    --highcontrast-textfield-text-color-disabled: GrayText;
-    --highcontrast-textfield-text-color-readonly: CanvasText;
-
     --highcontrast-textfield-text-color-valid: CanvasText;
     --highcontrast-textfield-text-color-invalid: CanvasText;
+
+    .spectrum-Textfield-input {
+      --highcontrast-textfield-text-color-default: CanvasText;
+      --highcontrast-textfield-text-color-hover: CanvasText;
+      --highcontrast-textfield-text-color-keyboard-focus: CanvasText;
+      --highcontrast-textfield-text-color-disabled: GrayText;
+      --highcontrast-textfield-text-color-readonly: CanvasText;
+
+      &::placeholder {
+        --highcontrast-textfield-text-color-default: GrayText;
+        --highcontrast-textfield-text-color-hover: GrayText;
+        --highcontrast-textfield-text-color-keyboard-focus: GrayText;
+        --highcontrast-textfield-text-color-disabled: GrayText;
+        --highcontrast-textfield-text-color-readonly: CanvasText;
+      }
+    }
+
 
     &.is-focused,
     &.is-keyboardFocused {

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -593,8 +593,8 @@ governing permissions and limitations under the License.
 
   /* invalid keyboard focus */
   .is-invalid.is-keyboardFocused &,
-  &:focus-ring,
-  &:focus-visible {
+  .is-invalid &:focus-ring,
+  .is-invalid &:focus-visible {
     border-color: var(--highcontrast-textfield-border-color-invalid-keyboard-focus, var(--mod-textfield-border-color-invalid-keyboard-focus, var(--spectrum-textfield-border-color-invalid-keyboard-focus)));
   }
 

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -230,6 +230,9 @@ governing permissions and limitations under the License.
   outline: none;
   margin: auto;
 
+  /* prevent input from expanding to width of helptext */
+  inline-size: var(--mod-textfield-width, var(--spectrum-textfield-width));
+
   /*** ↓ Browser Mitigations for Text Field ↓ ***/
   /* Edge - Use padding instead of text-indent because text-indent does not left align the text  */
   text-indent: 0;
@@ -371,9 +374,6 @@ governing permissions and limitations under the License.
   grid-column: 1 / span 3;
   box-sizing: border-box;
   position: relative;
-
-  /* prevent input from expanding to width of helptext */
-  inline-size: var(--mod-textfield-width, var(--spectrum-textfield-width));
 
   /*** Focus Indicator - Unfocused Base Styles ***/
   &::after {

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -249,13 +249,6 @@ governing permissions and limitations under the License.
   }
 }
 
-
-/* TODO - stepper button border color - remove when stepper is migrated - remove from themes also */
-🤫 {
-  border-color: var(--spectrum-textfield-m-texticon-border-color);
-  border-width: var(--spectrum-stepper-border-size);
-}
-
 /********* TEXT FIELD and TEXT AREA Outer Wrapper *********/
 .spectrum-Textfield {
   position: relative;

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -283,16 +283,77 @@ governing permissions and limitations under the License.
 
   /* Grid layout for child components */
   display: inline-grid;
-  grid-template-columns: auto auto auto;
-  grid-template-rows: auto auto;
+  grid-template-columns: auto auto;
+  grid-template-rows: auto auto auto;
+
+  /*** Focus Indicator - Unfocused Base Styles ***/
+  &::after {
+    block-size: calc(100% + (var(--mod-textfield-focus-indicator-gap, var(--spectrum-textfield-focus-indicator-gap)) * 2));
+    inline-size: calc(100% + (var(--mod-textfield-focus-indicator-gap, var(--spectrum-textfield-focus-indicator-gap)) * 2));
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    margin-block-start: calc((var(--mod-textfield-focus-indicator-gap, var(--spectrum-textfield-focus-indicator-gap))
+                              + var(--mod-textfield-focus-indicator-width, var(--spectrum-textfield-focus-indicator-width)))
+                              * -1);
+    margin-inline-start: calc((var(--mod-textfield-focus-indicator-gap, var(--spectrum-textfield-focus-indicator-gap))
+                              + var(--mod-textfield-focus-indicator-width, var(--spectrum-textfield-focus-indicator-width)))
+                              * -1);
+    pointer-events: none;
+    content: '';
+    border-style: solid;
+    border-color: transparent;
+    border-width: 0;
+    border-radius: calc(var(--mod-textfield-corner-radius, var(--spectrum-textfield-corner-radius))
+                        + var(--mod-textfield-border-width, var(--spectrum-textfield-border-width))
+                        + var(--mod-textfield-focus-indicator-gap, var(--spectrum-textfield-focus-indicator-gap)));
+
+    /* place in same cell: input, focus indicator, and grows sizer */
+    grid-row: 2 / span 1;
+    grid-column: 1 / span 2;
+  }
+
+  .is-keyboardFocused & {
+    /* focus indicator is focused state */
+    &::after {
+      border-color: var(--highcontrast-textfield-focus-indicator-color, var(--mod-textfield-focus-indicator-color, var(--spectrum-textfield-focus-indicator-color)));
+      border-width: var(--mod-textfield-focus-indicator-width, var(--spectrum-textfield-focus-indicator-width));
+    }
+  }
+
+  .is-readOnly & {
+    &::after {
+      border: 0;
+    }
+  }
+
+  &--quiet {
+    &::after {
+      inline-size: 100%;
+      block-size: calc(100% + var(--mod-textfield-focus-indicator-gap, var(--spectrum-textfield-focus-indicator-gap)));
+      margin-inline-start: 0;
+      margin-block-start: 0;
+      border-radius: 0;
+      border-color: var(--highcontrast-textfield-focus-indicator-color, var(--mod-textfield-focus-indicator-color, var(--spectrum-textfield-focus-indicator-color)));
+    }
+  }
+
+  &--quiet.is-keyboardFocused & {
+    &::after {
+      border-width: 0 0 var(--mod-textfield-focus-indicator-width, var(--spectrum-textfield-focus-indicator-width)) 0;
+    }
+  }
 }
+
 
 /* align search icon */
 .spectrum-Textfield-icon {
   position: absolute;
-  top: 0;
-  bottom: 0;
-  margin-block: auto;
+  top: 0; /* TODO - reevaluate block spacing when search field is migrated */
+  bottom: 0; /* TODO - reevaluate block spacing when search field is migrated */
+  margin-block: auto; /* TODO - reevaluate block spacing when search field is migrated */
+
   color: var(--highcontrast-textfield-text-color-default, var(--mod-textfield-text-color-default, var(--spectrum-textfield-text-color-default)));
 
   .spectrum-Textfield.is-disabled & {
@@ -315,9 +376,9 @@ governing permissions and limitations under the License.
 /********* Child Component - Label *********/
 .spectrum-FieldLabel {
   .spectrum-Textfield & {
-    grid-row: 1;
-    grid-column: 1 / span 2;
     margin-block-end: var(--mod-textfield-label-spacing-block, var(--spectrum-textfield-label-spacing-block));
+    grid-row: 1;
+    grid-column: 1 / span 1;
   }
 
   .spectrum-Textfield--quiet & {
@@ -332,16 +393,14 @@ governing permissions and limitations under the License.
 /********* Child Component - Help Text *********/
 .spectrum-HelpText {
   .spectrum-Textfield & {
-    grid-row: 3;
-    grid-column: 1 / span 3;
     margin-block-start: var(--mod-textfield-helptext-spacing-block, var(--spectrum-textfield-helptext-spacing-block));
+    grid-row: 3;
+    grid-column: 1 / span 2;
   }
 }
 
 /********* Child Element - Character Count *********/
 .spectrum-Textfield-character-count {
-  grid-row: 1;
-  grid-column: 3 / span 1;
   display: inline-flex;
   align-items: flex-end;
   justify-content: flex-end;
@@ -352,6 +411,8 @@ governing permissions and limitations under the License.
   font-size: var(--mod-textfield-character-count-font-size, var(--spectrum-textfield-character-count-font-size));
   font-family: var(--mod-textfield-character-count-font-family, var(--spectrum-textfield-character-count-font-family));
   font-weight: var(--mod-textfield-character-count-font-weight, var(--spectrum-textfield-character-count-font-weight));
+  grid-row: 1;
+  grid-column: 2 / span 1;
 
   .spectrum-Textfield--quiet & {
     margin-block-end: var(--mod-textfield-character-count-spacing-block-quiet, var(--spectrum-textfield-character-count-spacing-block-quiet));
@@ -365,6 +426,8 @@ governing permissions and limitations under the License.
   top: 0;
   right: 0;
   margin-inline-start: auto;
+  grid-row: 2;
+  grid-column: 2;
 
   [dir="rtl"] & {
     left: 0;
@@ -410,69 +473,6 @@ governing permissions and limitations under the License.
   }
 }
 
-/********* Child div - Input Wrapper - for alignment of focus indicator *********/
-.spectrum-Textfield-input-wrapper {
-  grid-row: 2;
-  grid-column: 1 / span 3;
-  box-sizing: border-box;
-  position: relative;
-
-  /*** Focus Indicator - Unfocused Base Styles ***/
-  &::after {
-    block-size: calc(100% + (var(--mod-textfield-focus-indicator-gap, var(--spectrum-textfield-focus-indicator-gap)) * 2));
-    inline-size: calc(100% + (var(--mod-textfield-focus-indicator-gap, var(--spectrum-textfield-focus-indicator-gap)) * 2));
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 0;
-    margin-block-start: calc((var(--mod-textfield-focus-indicator-gap, var(--spectrum-textfield-focus-indicator-gap))
-                              + var(--mod-textfield-focus-indicator-width, var(--spectrum-textfield-focus-indicator-width)))
-                              * -1);
-    margin-inline-start: calc((var(--mod-textfield-focus-indicator-gap, var(--spectrum-textfield-focus-indicator-gap))
-                              + var(--mod-textfield-focus-indicator-width, var(--spectrum-textfield-focus-indicator-width)))
-                              * -1);
-    pointer-events: none;
-    content: '';
-    border-color: transparent;
-    border-style: solid;
-    border-width: 0;
-    border-radius: calc(var(--mod-textfield-corner-radius, var(--spectrum-textfield-corner-radius))
-                        + var(--mod-textfield-border-width, var(--spectrum-textfield-border-width))
-                        + var(--mod-textfield-focus-indicator-gap, var(--spectrum-textfield-focus-indicator-gap)));
-  }
-
-  .is-keyboardFocused & {
-    /* focus indicator is focused state */
-    &::after {
-      border-color: var(--highcontrast-textfield-focus-indicator-color, var(--mod-textfield-focus-indicator-color, var(--spectrum-textfield-focus-indicator-color)));
-      border-width: var(--mod-textfield-focus-indicator-width, var(--spectrum-textfield-focus-indicator-width));
-    }
-  }
-
-  .is-readOnly & {
-    &::after {
-      border: 0;
-    }
-  }
-
-  .spectrum-Textfield--quiet & {
-    &::after {
-      inline-size: 100%;
-      block-size: calc(100% + var(--mod-textfield-focus-indicator-gap, var(--spectrum-textfield-focus-indicator-gap)));
-      margin-inline-start: 0;
-      margin-block-start: 0;
-      border-radius: 0;
-      border-color: var(--highcontrast-textfield-focus-indicator-color, var(--mod-textfield-focus-indicator-color, var(--spectrum-textfield-focus-indicator-color)));
-    }
-  }
-
-  .spectrum-Textfield--quiet.is-keyboardFocused & {
-    &::after {
-      border-width: 0 0 var(--mod-textfield-focus-indicator-width, var(--spectrum-textfield-focus-indicator-width)) 0;
-    }
-  }
-}
-
 /********* Child Element - Input *********/
 .spectrum-Textfield-input {
   box-sizing: border-box;
@@ -515,6 +515,10 @@ governing permissions and limitations under the License.
     Details: https://github.com/csstools/normalize.css/blob/main/normalize.css#L297
   */
   -moz-appearance: textfield;
+
+  /* place in same cell: input, focus indicator, and grows sizer */
+  grid-row: 2;
+  grid-column: 1 / span 2;
 
   /* Remove the native clear button in IE */
   /* http://stackoverflow.com/questions/14007655/remove-ie10s-clear-field-x-button-on-certain-inputs */
@@ -713,28 +717,42 @@ governing permissions and limitations under the License.
 
 /*** Layout Variant - Side Label ***/
 .spectrum-Textfield--sidelabel {
-  .spectrum-Textfield-input-wrapper {
-    grid-row: 1;
-    grid-column: 2 / span 1;
+  grid-template-columns: auto auto auto;
+  grid-template-rows: auto auto;
+
+  /*** Focus Indicator ***/
+  &::after {
+    grid-row: 1/span 1;
+    grid-column: 2/span 1;
   }
 
   .spectrum-FieldLabel {
-    grid-row: 1 / span 2;
-    grid-column: 1 / span 1;
     margin-inline-end: var(--mod-textfield-label-spacing-inline-side-label, var(--spectrum-textfield-label-spacing-inline-side-label));
+    grid-row: 1/span 2;
+    grid-column: 1/span 1;
   }
 
   .spectrum-Textfield-character-count {
-    grid-row: 1;
-    grid-column: 3 / span 1;
     align-items: flex-start;
     margin-block-start: var(--mod-textfield-character-count-spacing-block-side, var(--spectrum-textfield-character-count-spacing-block-side));
     margin-inline-start: var(--mod-textfield-character-count-spacing-inline-side, var(--spectrum-textfield-character-count-spacing-inline-side));
+    grid-row: 1;
+    grid-column: 3/span 1;
   }
 
   .spectrum-HelpText {
     grid-row: 2;
-    grid-column: 2 / span 1;
+    grid-column: 2/span 1;
+  }
+
+  .spectrum-Textfield-validationIcon {
+    grid-row: 1/span 1;
+    grid-column: 2/span 1;
+  }
+
+  .spectrum-Textfield-input {
+    grid-row: 1/span 1;
+    grid-column: 2/span 1;
   }
 }
 

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -52,6 +52,12 @@ governing permissions and limitations under the License.
   /* icon end spacing override for combobox */
   --spectrum-textfield-icon-spacing-inline-end-override: 32px; /* TODO - placeholder - reevaluate after combobox migration */
 
+
+  /* TODO - icon spacing override for search - reevaluate after search is migrated */
+  --spectrum-Textfield-workflow-icon-width: 18px;
+  --spectrum-Textfield-workflow-icon-gap: 6px;
+
+
   /* font styles */
   --spectrum-textfield-font-family: var(--spectrum-font-family-base); /* placeholder for --spectrum-font-family-default */
   --spectrum-textfield-font-weight: var(--spectrum-font-weight-regular);
@@ -347,13 +353,14 @@ governing permissions and limitations under the License.
   }
 }
 
-
+/* TODO - reevaluate icon styles when search field is migrated */
 /* align search icon */
 .spectrum-Textfield-icon {
+  display: block;
   position: absolute;
-  top: 0; /* TODO - reevaluate block spacing when search field is migrated */
-  bottom: 0; /* TODO - reevaluate block spacing when search field is migrated */
-  margin-block: auto; /* TODO - reevaluate block spacing when search field is migrated */
+  top: 0;
+  bottom: 0;
+  margin-block: auto;
 
   color: var(--highcontrast-textfield-text-color-default, var(--mod-textfield-text-color-default, var(--spectrum-textfield-text-color-default)));
 
@@ -526,6 +533,12 @@ governing permissions and limitations under the License.
   grid-row: 2;
   grid-column: 1 / span 2;
 
+  /* TODO - quiet search field left padding - reevaluate when search is migrated */
+  .spectrum-Textfield--quiet .spectrum-Textfield-icon ~ & {
+    padding-inline-start: calc(var(--mod--Textfield-workflow-icon-gap, var(--spectrum-Textfield-workflow-icon-gap))
+                              + var(--mod-Textfield-workflow-icon-width, var(--spectrum-Textfield-workflow-icon-width)));
+  }
+
   /* Remove the native clear button in IE */
   /* http://stackoverflow.com/questions/14007655/remove-ie10s-clear-field-x-button-on-certain-inputs */
   &::-ms-clear {
@@ -691,7 +704,7 @@ governing permissions and limitations under the License.
     /* Treat all quiet inputs and text areas the same */
     resize: none;
     overflow-y: hidden;
-   }
+  }
 
   /****** Input - Quiet 🤫 + Disabled 🚫 ******/
   .spectrum-Textfield--quiet.is-disabled &,

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -344,33 +344,90 @@ governing permissions and limitations under the License.
       border-width: 0 0 var(--mod-textfield-focus-indicator-width, var(--spectrum-textfield-focus-indicator-width)) 0;
     }
   }
+
+  /* TODO - reevaluate icon styles when search field is migrated */
+  /* align search icon */
+  .spectrum-Textfield-icon {
+    display: block;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    margin-block: auto;
+
+    color: var(--highcontrast-textfield-text-color-default, var(--mod-textfield-text-color-default, var(--spectrum-textfield-text-color-default)));
+
+    .spectrum-Textfield.is-disabled & {
+      color: var(--highcontrast-textfield-text-color-disabled, var(--mod-textfield-text-color-disabled, var(--spectrum-textfield-text-color-disabled)));
+    }
+
+    .spectrum-Textfield--quiet & {
+      color: var(--highcontrast-textfield-text-color-default, var(--mod-textfield-text-color-default, var(--spectrum-textfield-text-color-default)));
+    }
+
+    .spectrum-Textfield--quiet.is-disabled & {
+      color: var(--highcontrast-textfield-text-color-disabled, var(--mod-textfield-text-color-disabled, var(--spectrum-textfield-text-color-disabled)));
+    }
+
+    .spectrum-Textfield.is-readOnly & {
+      color: var(--highcontrast-textfield-text-color-readonly, var(--mod-textfield-text-color-readonly, var(--spectrum-textfield-text-color-readonly)));
+    }
+  }
 }
 
-/* TODO - reevaluate icon styles when search field is migrated */
-/* align search icon */
-.spectrum-Textfield-icon {
-  display: block;
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  margin-block: auto;
+/********* Child Element - Validation Icons - ⚠️ ✅ *********/
+.spectrum-Textfield-validationIcon {
+  /* specify validation class or web components will apply this to all icons */
+  .spectrum-Textfield.is-valid &,
+  .spectrum-Textfield.is-invalid & {
+    position: absolute;
+    pointer-events: all;
+    top: 0;
+    margin-inline-start: auto;
+    grid-row: 2;
+    grid-column: 2;
+  }
 
-  color: var(--highcontrast-textfield-text-color-default, var(--mod-textfield-text-color-default, var(--spectrum-textfield-text-color-default)));
+  /****** Validation Icon - Valid ✅ ******/
+  .spectrum-Textfield.is-valid & {
+    inset-block-start: var(--mod-textfield-icon-spacing-block-valid, var(--spectrum-textfield-icon-spacing-block-valid));
+    inset-block-end: var(--mod-textfield-icon-spacing-block-valid, var(--spectrum-textfield-icon-spacing-block-valid));
+    inset-inline-start: var(--mod-textfield-icon-spacing-inline-start-valid, var(--spectrum-textfield-icon-spacing-inline-start-valid));
+    inset-inline-end: var(--mod-textfield-icon-spacing-inline-end-valid, var(--spectrum-textfield-icon-spacing-inline-end-valid));
+    color: var(--highcontrast-textfield-icon-color-valid, var(--mod-textfield-icon-color-valid, var(--spectrum-textfield-icon-color-valid)));
+  }
 
-  .spectrum-Textfield.is-disabled & {
-    color: var(--highcontrast-textfield-text-color-disabled, var(--mod-textfield-text-color-disabled, var(--spectrum-textfield-text-color-disabled)));
+  /****** Validation Icon - Invalid ⚠️ ******/
+  .spectrum-Textfield.is-invalid & {
+    block-size: var(--mod-textfield-icon-size-invalid, var(--spectrum-textfield-icon-size-invalid));
+    inline-size: var(--mod-textfield-icon-size-invalid, var(--spectrum-textfield-icon-size-invalid));
+    inset-block-start: var(--mod-textfield-icon-spacing-block-invalid, var(--spectrum-textfield-icon-spacing-block-invalid));
+    inset-block-end: var(--mod-textfield-icon-spacing-block-invalid, var(--spectrum-textfield-icon-spacing-block-invalid));
+    inset-inline-start: var(--mod-textfield-icon-spacing-inline-start-invalid, var(--spectrum-textfield-icon-spacing-inline-start-invalid));
+    inset-inline-end: var(--mod-textfield-icon-spacing-inline-end-invalid, var(--spectrum-textfield-icon-spacing-inline-end-invalid));
+    color: var(--highcontrast-textfield-icon-color-invalid, var(--mod-textfield-icon-color-invalid, var(--spectrum-textfield-icon-color-invalid)));
+  }
+
+  .is-disabled &,
+  .is-readOnly & {
+    /* Disabled validation icons are transparent */
+    color: transparent;
   }
 
   .spectrum-Textfield--quiet & {
-    color: var(--highcontrast-textfield-text-color-default, var(--mod-textfield-text-color-default, var(--spectrum-textfield-text-color-default)));
+    padding-inline-end: 0;
   }
 
-  .spectrum-Textfield--quiet.is-disabled & {
-    color: var(--highcontrast-textfield-text-color-disabled, var(--mod-textfield-text-color-disabled, var(--spectrum-textfield-text-color-disabled)));
+  .spectrum-Textfield--quiet.is-valid & {
+    inset-inline-end: var(--mod-textfield-icon-spacing-inline-end-quiet-valid, var(--spectrum-textfield-icon-spacing-inline-end-quiet-valid));
   }
 
-  .spectrum-Textfield.is-readOnly & {
-    color: var(--highcontrast-textfield-text-color-readonly, var(--mod-textfield-text-color-readonly, var(--spectrum-textfield-text-color-readonly)));
+  .spectrum-Textfield--quiet.is-invalid & {
+    inset-inline-end: var(--mod-textfield-icon-spacing-inline-end-quiet-invalid, var(--spectrum-textfield-icon-spacing-inline-end-quiet-invalid));
+  }
+
+   /* TODO - reevaluate InputGroup override after combobox is migrated - this ensures icon is not hidden under picker button */
+  .spectrum-InputGroup & {
+    margin-inline-end: var(--spectrum-textfield-icon-spacing-inline-end-override);
   }
 }
 
@@ -420,64 +477,7 @@ governing permissions and limitations under the License.
   }
 }
 
-/********* Child Element - Validation Icons - ⚠️ ✅ *********/
-.spectrum-Textfield-validationIcon {
-  position: absolute;
-  pointer-events: all;
-  top: 0;
-  right: 0;
-  margin-inline-start: auto;
-  grid-row: 2;
-  grid-column: 2;
 
-  [dir="rtl"] & {
-    left: 0;
-    right: auto;
-  }
-
-  /* TODO - reevaluate after combobox is migrated - ensures icon is not under picker button */
-  .spectrum-InputGroup & {
-    margin-inline-end: var(--spectrum-textfield-icon-spacing-inline-end-override);
-  }
-
-  /****** Validation Icon - Valid ✅ ******/
-  .is-valid & {
-    inset-block-start: var(--mod-textfield-icon-spacing-block-valid, var(--spectrum-textfield-icon-spacing-block-valid));
-    inset-block-end: var(--mod-textfield-icon-spacing-block-valid, var(--spectrum-textfield-icon-spacing-block-valid));
-    inset-inline-start: var(--mod-textfield-icon-spacing-inline-start-valid, var(--spectrum-textfield-icon-spacing-inline-start-valid));
-    inset-inline-end: var(--mod-textfield-icon-spacing-inline-end-valid, var(--spectrum-textfield-icon-spacing-inline-end-valid));
-    color: var(--highcontrast-textfield-icon-color-valid, var(--mod-textfield-icon-color-valid, var(--spectrum-textfield-icon-color-valid)));
-  }
-
-  /****** Validation Icon - Invalid ⚠️ ******/
-  .is-invalid & {
-    block-size: var(--mod-textfield-icon-size-invalid, var(--spectrum-textfield-icon-size-invalid));
-    inline-size: var(--mod-textfield-icon-size-invalid, var(--spectrum-textfield-icon-size-invalid));
-    inset-block-start: var(--mod-textfield-icon-spacing-block-invalid, var(--spectrum-textfield-icon-spacing-block-invalid));
-    inset-block-end: var(--mod-textfield-icon-spacing-block-invalid, var(--spectrum-textfield-icon-spacing-block-invalid));
-    inset-inline-start: var(--mod-textfield-icon-spacing-inline-start-invalid, var(--spectrum-textfield-icon-spacing-inline-start-invalid));
-    inset-inline-end: var(--mod-textfield-icon-spacing-inline-end-invalid, var(--spectrum-textfield-icon-spacing-inline-end-invalid));
-    color: var(--highcontrast-textfield-icon-color-invalid, var(--mod-textfield-icon-color-invalid, var(--spectrum-textfield-icon-color-invalid)));
-  }
-
-  .is-disabled &,
-  .is-readOnly & {
-    /* Disabled validation icons are transparent */
-    color: transparent;
-  }
-
-  .spectrum-Textfield--quiet & {
-    padding-inline-end: 0;
-  }
-
-  .spectrum-Textfield--quiet.is-valid & {
-    inset-inline-end: var(--mod-textfield-icon-spacing-inline-end-quiet-valid, var(--spectrum-textfield-icon-spacing-inline-end-quiet-valid));
-  }
-
-  .spectrum-Textfield--quiet.is-invalid & {
-    inset-inline-end: var(--mod-textfield-icon-spacing-inline-end-quiet-invalid, var(--spectrum-textfield-icon-spacing-inline-end-quiet-invalid));
-  }
-}
 
 /********* Child Element - Input *********/
 .spectrum-Textfield-input {

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -735,7 +735,7 @@ governing permissions and limitations under the License.
   .spectrum-Textfield-input {
     min-inline-size: var(--mod-text-area-min-inline-size, var(--spectrum-text-area-min-inline-size));
     min-block-size: var(--mod-text-area-min-block-size, var(--spectrum-text-area-min-block-size));
-    resize: none;
+    resize: inherit;
   }
 
   &.spectrum-Textfield--quiet {

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -288,6 +288,23 @@ governing permissions and limitations under the License.
   top: 0;
   bottom: 0;
   margin: auto;
+  color: var(--highcontrast-textfield-text-color-default, var(--mod-textfield-text-color-default, var(--spectrum-textfield-text-color-default)));
+
+  .spectrum-Textfield.is-disabled & {
+    color: var(--highcontrast-textfield-text-color-disabled, var(--mod-textfield-text-color-disabled, var(--spectrum-textfield-text-color-disabled)));
+  }
+
+  .spectrum-Textfield--quiet & {
+    color: var(--highcontrast-textfield-text-color-default, var(--mod-textfield-text-color-default, var(--spectrum-textfield-text-color-default)));
+  }
+
+  .spectrum-Textfield--quiet.is-disabled & {
+    color: var(--highcontrast-textfield-text-color-disabled, var(--mod-textfield-text-color-disabled, var(--spectrum-textfield-text-color-disabled)));
+  }
+
+  .spectrum-Textfield.is-readOnly & {
+    color: var(--highcontrast-textfield-text-color-readonly, var(--mod-textfield-text-color-readonly, var(--spectrum-textfield-text-color-readonly)));
+  }
 }
 
 /********* Child Component - Label *********/

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -317,7 +317,7 @@ governing permissions and limitations under the License.
     grid-column: 1 / span 2;
   }
 
-  .is-keyboardFocused & {
+  &.is-keyboardFocused {
     /* focus indicator is focused state */
     &::after {
       border-color: var(--highcontrast-textfield-focus-indicator-color, var(--mod-textfield-focus-indicator-color, var(--spectrum-textfield-focus-indicator-color)));
@@ -342,7 +342,7 @@ governing permissions and limitations under the License.
     }
   }
 
-  &--quiet.is-keyboardFocused & {
+  &--quiet.is-keyboardFocused {
     &::after {
       border-width: 0 0 var(--mod-textfield-focus-indicator-width, var(--spectrum-textfield-focus-indicator-width)) 0;
     }

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -93,7 +93,10 @@ governing permissions and limitations under the License.
   --spectrum-textfield-border-color-invalid-keyboard-focus: var(--spectrum-negative-border-color-key-focus);
   --spectrum-textfield-icon-color-invalid: var(--spectrum-negative-visual-color);
 
+  --spectrum-textfield-text-color-invalid: var(--spectrum-neutral-content-color-default);
+
    /* Valid Colors */
+  --spectrum-textfield-text-color-valid: var(--spectrum-neutral-content-color-default);
   --spectrum-textfield-icon-color-valid: var(--spectrum-positive-visual-color);
 
    /* Focus Indicator Color */
@@ -197,20 +200,21 @@ governing permissions and limitations under the License.
 /********* WHCM *********/
 @media (forced-colors: active) {
   .spectrum-Textfield {
-    --spectrum-textfield-border-color-hover: Highlight;
-    --spectrum-textfield-border-color-keyboard-focus: Highlight;
+    --highcontrast-textfield-border-color-hover: Highlight;
+    --highcontrast-textfield-border-color-keyboard-focus: Highlight;
 
-    --spectrum-textfield-border-color-invalid-default: Highlight;
-    --spectrum-textfield-border-color-invalid-hover: Highlight;
-    --spectrum-textfield-border-color-invalid-keyboard-focus: Highlight;
+    --highcontrast-textfield-border-color-invalid-default: Highlight;
+    --highcontrast-textfield-border-color-invalid-hover: Highlight;
+    --highcontrast-textfield-border-color-invalid-keyboard-focus: Highlight;
 
-    --spectrum-textfield-text-color-default: GrayText;
-    --spectrum-textfield-text-color-hover: GrayText;
-    --spectrum-textfield-text-color-keyboard-focus: GrayText;
-    --spectrum-textfield-text-color-disabled: GrayText;
-    --spectrum-textfield-text-color-readonly: CanvasText;
+    --highcontrast-textfield-text-color-default: GrayText;
+    --highcontrast-textfield-text-color-hover: GrayText;
+    --highcontrast-textfield-text-color-keyboard-focus: GrayText;
+    --highcontrast-textfield-text-color-disabled: GrayText;
+    --highcontrast-textfield-text-color-readonly: CanvasText;
 
-    --spectrum-textfield-focus-indicator-color: Highlight;
+    --highcontrast-textfield-text-color-valid: CanvasText;
+    --highcontrast-textfield-text-color-invalid: CanvasText;
 
     &.is-focused,
     &.is-keyboardFocused {
@@ -403,7 +407,7 @@ governing permissions and limitations under the License.
   .is-keyboardFocused & {
     /* focus indicator is focused state */
     &::after {
-      border-color: var(--highcontrast-textfield-focus-indicator-color, var(--mod-textfield-focus-indicator-color, var(--spectrum-textfield-focus-indicator-color)));
+      border-color: var(--mod-textfield-focus-indicator-color, var(--spectrum-textfield-focus-indicator-color));
       border-width: var(--mod-textfield-focus-indicator-width, var(--spectrum-textfield-focus-indicator-width));
     }
   }
@@ -568,8 +572,14 @@ governing permissions and limitations under the License.
     }
   }
 
+  /*** Input Valid ✅ ***/
+  .is-valid & {
+    color: var(--highcontrast-textfield-text-color-valid, var(--mod-textfield-text-color-valid, var(--spectrum-textfield-text-color-valid)));
+  }
+
   /*** Input Invalid ⚠️ ***/
   .is-invalid & {
+    color: var(--highcontrast-textfield-text-color-invalid, var(--mod-textfield-text-color-invalid, var(--spectrum-textfield-text-color-invalid)));
     border-color: var(--highcontrast-textfield-border-color-invalid-default, var(--mod-textfield-border-color-invalid-default, var(--spectrum-textfield-border-color-invalid-default)));
   }
 

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -274,7 +274,6 @@ governing permissions and limitations under the License.
 
   /* All browsers - Change the input font styles */
   text-overflow: ellipsis;
-  -webkit-appearance: none;
 
   /* Grid layout for child components */
   display: inline-grid;
@@ -359,6 +358,7 @@ governing permissions and limitations under the License.
   pointer-events: all;
   top: 0;
   right: 0;
+  margin-inline-start: auto;
 
   [dir="rtl"] & {
     left: 0;
@@ -367,10 +367,10 @@ governing permissions and limitations under the License.
 
   /****** Validation Icon - Valid ✅ ******/
   .is-valid & {
-    margin-block-start: var(--mod-textfield-icon-spacing-block-valid, var(--spectrum-textfield-icon-spacing-block-valid));
-    margin-block-end: var(--mod-textfield-icon-spacing-block-valid, var(--spectrum-textfield-icon-spacing-block-valid));
-    margin-inline-start: var(--mod-textfield-icon-spacing-inline-start-valid, var(--spectrum-textfield-icon-spacing-inline-start-valid));
-    margin-inline-end: var(--mod-textfield-icon-spacing-inline-end-valid, var(--spectrum-textfield-icon-spacing-inline-end-valid));
+    inset-block-start: var(--mod-textfield-icon-spacing-block-valid, var(--spectrum-textfield-icon-spacing-block-valid));
+    inset-block-end: var(--mod-textfield-icon-spacing-block-valid, var(--spectrum-textfield-icon-spacing-block-valid));
+    inset-inline-start: var(--mod-textfield-icon-spacing-inline-start-valid, var(--spectrum-textfield-icon-spacing-inline-start-valid));
+    inset-inline-end: var(--mod-textfield-icon-spacing-inline-end-valid, var(--spectrum-textfield-icon-spacing-inline-end-valid));
     color: var(--highcontrast-textfield-icon-color-valid, var(--mod-textfield-icon-color-valid, var(--spectrum-textfield-icon-color-valid)));
   }
 
@@ -378,10 +378,10 @@ governing permissions and limitations under the License.
   .is-invalid & {
     block-size: var(--mod-textfield-icon-size-invalid, var(--spectrum-textfield-icon-size-invalid));
     inline-size: var(--mod-textfield-icon-size-invalid, var(--spectrum-textfield-icon-size-invalid));
-    margin-block-start: var(--mod-textfield-icon-spacing-block-invalid, var(--spectrum-textfield-icon-spacing-block-invalid));
-    margin-block-end: var(--mod-textfield-icon-spacing-block-invalid, var(--spectrum-textfield-icon-spacing-block-invalid));
-    margin-inline-start: var(--mod-textfield-icon-spacing-inline-start-invalid, var(--spectrum-textfield-icon-spacing-inline-start-invalid));
-    margin-inline-end: var(--mod-textfield-icon-spacing-inline-end-invalid, var(--spectrum-textfield-icon-spacing-inline-end-invalid));
+    inset-block-start: var(--mod-textfield-icon-spacing-block-invalid, var(--spectrum-textfield-icon-spacing-block-invalid));
+    inset-block-end: var(--mod-textfield-icon-spacing-block-invalid, var(--spectrum-textfield-icon-spacing-block-invalid));
+    inset-inline-start: var(--mod-textfield-icon-spacing-inline-start-invalid, var(--spectrum-textfield-icon-spacing-inline-start-invalid));
+    inset-inline-end: var(--mod-textfield-icon-spacing-inline-end-invalid, var(--spectrum-textfield-icon-spacing-inline-end-invalid));
     color: var(--highcontrast-textfield-icon-color-invalid, var(--mod-textfield-icon-color-invalid, var(--spectrum-textfield-icon-color-invalid)));
   }
 
@@ -396,11 +396,11 @@ governing permissions and limitations under the License.
   }
 
   .spectrum-Textfield--quiet.is-valid & {
-    margin-inline-end: var(--mod-textfield-icon-spacing-inline-end-quiet-valid, var(--spectrum-textfield-icon-spacing-inline-end-quiet-valid));
+    inset-inline-end: var(--mod-textfield-icon-spacing-inline-end-quiet-valid, var(--spectrum-textfield-icon-spacing-inline-end-quiet-valid));
   }
 
   .spectrum-Textfield--quiet.is-invalid & {
-    margin-inline-end: var(--mod-textfield-icon-spacing-inline-end-quiet-invalid, var(--spectrum-textfield-icon-spacing-inline-end-quiet-invalid));
+    inset-inline-end: var(--mod-textfield-icon-spacing-inline-end-quiet-invalid, var(--spectrum-textfield-icon-spacing-inline-end-quiet-invalid));
   }
 }
 

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -243,6 +243,12 @@ governing permissions and limitations under the License.
 }
 
 
+/* TODO - stepper button border color - remove when stepper is migrated - remove from themes also */
+🤫 {
+  border-color: var(--spectrum-textfield-m-texticon-border-color);
+  border-width: var(--spectrum-stepper-border-size);
+}
+
 /********* TEXT FIELD and TEXT AREA Outer Wrapper *********/
 .spectrum-Textfield {
   position: relative;

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -52,6 +52,7 @@ governing permissions and limitations under the License.
   /* font styles */
   --spectrum-textfield-font-family: var(--spectrum-font-family-base); /* placeholder for --spectrum-font-family-default */
   --spectrum-textfield-font-weight: var(--spectrum-font-weight-regular);
+  --spectrum-textfield-placeholder-font-size: var(--spectrum-font-size-100);
 
   /* character count */
   --spectrum-textfield-character-count-font-family: var(--spectrum-font-family-base); /* placeholder for --spectrum-font-family-default */

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -713,7 +713,7 @@ governing permissions and limitations under the License.
   }
 
   .spectrum-FieldLabel {
-    grid-row: 1;
+    grid-row: 1 / span 2;
     grid-column: 1 / span 1;
     margin-inline-end: var(--mod-textfield-label-spacing-inline-side-label, var(--spectrum-textfield-label-spacing-inline-side-label));
   }

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -59,13 +59,13 @@ governing permissions and limitations under the License.
 
 
   /* font styles */
-  --spectrum-textfield-font-family: var(--spectrum-font-family-base); /* placeholder for --spectrum-font-family-default */
-  --spectrum-textfield-font-weight: var(--spectrum-font-weight-regular);
+  --spectrum-textfield-font-family: var(--spectrum-sans-font-family-stack);
+  --spectrum-textfield-font-weight: var(--spectrum-regular-font-weight);
   --spectrum-textfield-placeholder-font-size: var(--spectrum-font-size-100);
 
   /* character count */
-  --spectrum-textfield-character-count-font-family: var(--spectrum-font-family-base); /* placeholder for --spectrum-font-family-default */
-  --spectrum-textfield-character-count-font-weight: var(--spectrum-font-weight-regular);
+  --spectrum-textfield-character-count-font-family: var(--spectrum-sans-font-family-stack);
+  --spectrum-textfield-character-count-font-weight: var(--spectrum-regular-font-weight);
   --spectrum-textfield-character-count-font-size: var(--spectrum-font-size-75);
   --spectrum-textfield-character-count-spacing-inline: var(--spectrum-spacing-200);
   --spectrum-textfield-character-count-spacing-block: var(--spectrum-component-bottom-to-text-75);

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -201,10 +201,13 @@ governing permissions and limitations under the License.
 @media (forced-colors: active) {
   .spectrum-Textfield {
     --highcontrast-textfield-border-color-hover: Highlight;
+    --highcontrast-textfield-border-color-focus: Highlight;
     --highcontrast-textfield-border-color-keyboard-focus: Highlight;
+    --highcontrast-textfield-focus-indicator-color: CanvasText;
 
     --highcontrast-textfield-border-color-invalid-default: Highlight;
     --highcontrast-textfield-border-color-invalid-hover: Highlight;
+    --highcontrast-textfield-border-color-invalid-focus: Highlight;
     --highcontrast-textfield-border-color-invalid-keyboard-focus: Highlight;
 
     --highcontrast-textfield-text-color-default: GrayText;
@@ -407,7 +410,7 @@ governing permissions and limitations under the License.
   .is-keyboardFocused & {
     /* focus indicator is focused state */
     &::after {
-      border-color: var(--mod-textfield-focus-indicator-color, var(--spectrum-textfield-focus-indicator-color));
+      border-color: var(--highcontrast-textfield-focus-indicator-color, var(--mod-textfield-focus-indicator-color, var(--spectrum-textfield-focus-indicator-color)));
       border-width: var(--mod-textfield-focus-indicator-width, var(--spectrum-textfield-focus-indicator-width));
     }
   }

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -458,7 +458,7 @@ governing permissions and limitations under the License.
 }
 
 /********* Child Element - Character Count *********/
-.spectrum-Textfield-character-count {
+.spectrum-Textfield-characterCount {
   display: inline-flex;
   align-items: flex-end;
   justify-content: flex-end;
@@ -728,7 +728,7 @@ governing permissions and limitations under the License.
 }
 
 /*** Layout Variant - Side Label ***/
-.spectrum-Textfield--sidelabel {
+.spectrum-Textfield--sideLabel {
   grid-template-columns: auto auto auto;
   grid-template-rows: auto auto;
 
@@ -744,7 +744,7 @@ governing permissions and limitations under the License.
     grid-column: 1/span 1;
   }
 
-  .spectrum-Textfield-character-count {
+  .spectrum-Textfield-characterCount {
     align-items: flex-start;
     margin-block-start: var(--mod-textfield-character-count-spacing-block-side, var(--spectrum-textfield-character-count-spacing-block-side));
     margin-inline-start: var(--mod-textfield-character-count-spacing-inline-side, var(--spectrum-textfield-character-count-spacing-inline-side));

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -356,6 +356,10 @@ governing permissions and limitations under the License.
 
     color: var(--highcontrast-textfield-text-color-default, var(--mod-textfield-text-color-default, var(--spectrum-textfield-text-color-default)));
 
+    &.spectrum-Search-icon {
+      right: auto;
+    }
+    
     .spectrum-Textfield.is-disabled & {
       color: var(--highcontrast-textfield-text-color-disabled, var(--mod-textfield-text-color-disabled, var(--spectrum-textfield-text-color-disabled)));
     }

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -776,6 +776,10 @@ governing permissions and limitations under the License.
     resize: inherit;
   }
 
+  &.spectrum-Textfield--grows {
+    grid-row: 1 / auto;
+  }
+
   &.spectrum-Textfield--quiet {
     .spectrum-Textfield-input {
       min-block-size: var(--mod-text-area-min-block-size-quiet, var(--spectrum-text-area-min-block-size-quiet));

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -374,8 +374,7 @@ governing permissions and limitations under the License.
       color: var(--highcontrast-textfield-text-color-disabled, var(--mod-textfield-text-color-disabled, var(--spectrum-textfield-text-color-disabled)));
     }
 
-    .spectrum-Textfield.is-readOnly &,
-    &:has(+ input:read-only) {
+    .spectrum-Textfield.is-readOnly & {
       color: var(--highcontrast-textfield-text-color-readonly, var(--mod-textfield-text-color-readonly, var(--spectrum-textfield-text-color-readonly)));
     }
   }

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -240,7 +240,8 @@ governing permissions and limitations under the License.
 
 
     &.is-focused,
-    &.is-keyboardFocused {
+    &.is-keyboardFocused,
+    &:focus, &:focus-within {
       /* focus indicator is focused state */
       &::after {
         forced-color-adjust: none;
@@ -314,7 +315,8 @@ governing permissions and limitations under the License.
     grid-column: 1 / span 2;
   }
 
-  &.is-keyboardFocused {
+  &.is-keyboardFocused,
+  &:focus-within {
     /* focus indicator is focused state */
     &::after {
       border-color: var(--highcontrast-textfield-focus-indicator-color, var(--mod-textfield-focus-indicator-color, var(--spectrum-textfield-focus-indicator-color)));
@@ -372,7 +374,8 @@ governing permissions and limitations under the License.
       color: var(--highcontrast-textfield-text-color-disabled, var(--mod-textfield-text-color-disabled, var(--spectrum-textfield-text-color-disabled)));
     }
 
-    .spectrum-Textfield.is-readOnly & {
+    .spectrum-Textfield.is-readOnly &,
+    &:has(+ input:read-only) {
       color: var(--highcontrast-textfield-text-color-readonly, var(--mod-textfield-text-color-readonly, var(--spectrum-textfield-text-color-readonly)));
     }
   }
@@ -411,8 +414,8 @@ governing permissions and limitations under the License.
     color: var(--highcontrast-textfield-icon-color-invalid, var(--mod-textfield-icon-color-invalid, var(--spectrum-textfield-icon-color-invalid)));
   }
 
-  .is-disabled &,
-  .is-readOnly & {
+  .spectrum-Textfield.is-disabled &,
+  .spectrum-Textfield.is-readOnly & {
     /* Disabled validation icons are transparent */
     color: transparent;
   }

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -380,6 +380,13 @@ governing permissions and limitations under the License.
   }
 }
 
+.spectrum-Textfield-validationIcon.spectrum-Search-icon {
+  .spectrum-Textfield.is-disabled &,
+  .spectrum-Textfield.is-readOnly & {
+    color: var(--highcontrast-textfield-text-color-disabled, var(--mod-textfield-text-color-disabled, var(--spectrum-textfield-text-color-disabled)));
+  }
+}
+
 /********* Child Element - Validation Icons - ⚠️ ✅ *********/
 .spectrum-Textfield-validationIcon {
   /* specify validation class or web components will apply this to all icons */
@@ -787,7 +794,13 @@ governing permissions and limitations under the License.
   }
 
   &.spectrum-Textfield--grows {
-    grid-row: 1 / auto;
+    .spectrum-Textfield-input {
+      grid-row: 1 / auto;
+    }
+    &::after {
+      grid-area: unset;
+      min-block-size: calc(var(--mod-text-area-min-block-size, var(--spectrum-text-area-min-block-size)) + var(--mod-textfield-focus-indicator-gap, var(--spectrum-textfield-focus-indicator-gap)) * 2);
+    }
   }
 
   &.spectrum-Textfield--quiet {

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -444,6 +444,7 @@ governing permissions and limitations under the License.
     margin-block-end: var(--mod-textfield-label-spacing-block, var(--spectrum-textfield-label-spacing-block));
     grid-row: 1;
     grid-column: 1 / span 1;
+    padding-left: calc(var(--mod-textfield-corner-radius, var(--spectrum-textfield-corner-radius)) / 2);
   }
 
   .spectrum-Textfield--quiet & {
@@ -461,6 +462,7 @@ governing permissions and limitations under the License.
     margin-block-start: var(--mod-textfield-helptext-spacing-block, var(--spectrum-textfield-helptext-spacing-block));
     grid-row: 3;
     grid-column: 1 / span 2;
+    padding-left: calc(var(--mod-textfield-corner-radius, var(--spectrum-textfield-corner-radius)) / 2);
   }
 }
 
@@ -478,6 +480,8 @@ governing permissions and limitations under the License.
   font-weight: var(--mod-textfield-character-count-font-weight, var(--spectrum-textfield-character-count-font-weight));
   grid-row: 1;
   grid-column: 2 / span 1;
+  padding-right: calc(var(--mod-textfield-corner-radius, var(--spectrum-textfield-corner-radius)) / 2);
+
 
   .spectrum-Textfield--quiet & {
     margin-block-end: var(--mod-textfield-character-count-spacing-block-quiet, var(--spectrum-textfield-character-count-spacing-block-quiet));

--- a/components/textfield/metadata/textarea.yml
+++ b/components/textfield/metadata/textarea.yml
@@ -13,9 +13,7 @@ examples:
       <div class="spectrum-Textfield spectrum-Textfield--sizeS spectrum-Textfield--multiline">
         <label for="textfield-sm" class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">Password</label>
         <span id="character-count-1" class="spectrum-Textfield-character-count">50</span>
-        <div class="spectrum-Textfield-input-wrapper">
-          <textarea id="textfield-s" placeholder="Enter Password" name="field" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-1 character-count-1"></textarea>
-        </div>
+        <textarea id="textfield-s" placeholder="Enter Password" name="field" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-1 character-count-1"></textarea>
         <div class="spectrum-HelpText spectrum-HelpText--sizeS spectrum-HelpText--neutral">
           <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
@@ -24,9 +22,7 @@ examples:
       <div class="spectrum-Textfield spectrum-Textfield--sizeM spectrum-Textfield--multiline">
         <label for="textfield-md" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Password</label>
         <span id="character-count-2" class="spectrum-Textfield-character-count">50</span>
-        <div class="spectrum-Textfield-input-wrapper">
-          <textarea id="textfield-m" placeholder="Enter Password" name="field" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-2 character-count-2"></textarea>
-        </div>
+        <textarea id="textfield-m" placeholder="Enter Password" name="field" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-2 character-count-2"></textarea>
         <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--neutral">
           <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
@@ -35,9 +31,7 @@ examples:
       <div class="spectrum-Textfield spectrum-Textfield--sizeL spectrum-Textfield--multiline">
         <label for="textfield-l" class="spectrum-FieldLabel spectrum-FieldLabel--sizeL">Password</label>
         <span id="character-count-3" class="spectrum-Textfield-character-count">50</span>
-        <div class="spectrum-Textfield-input-wrapper">
-          <textarea id="textfield-l" placeholder="Enter Password" name="field" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-3 character-count-3"></textarea>
-        </div>
+        <textarea id="textfield-l" placeholder="Enter Password" name="field" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-3 character-count-3"></textarea>
         <div class="spectrum-HelpText spectrum-HelpText--sizeL spectrum-HelpText--neutral">
           <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
@@ -46,9 +40,7 @@ examples:
       <div class="spectrum-Textfield spectrum-Textfield--sizeXL spectrum-Textfield--multiline">
         <label for="textfield-xl" class="spectrum-FieldLabel spectrum-FieldLabel--sizeXL">Password</label>
         <span id="character-count-4" class="spectrum-Textfield-character-count">50</span>
-        <div class="spectrum-Textfield-input-wrapper">
-          <textarea id="textfield-xl" placeholder="Enter Password" name="field" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-4 character-count-4"></textarea>
-        </div>
+        <textarea id="textfield-xl" placeholder="Enter Password" name="field" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-4 character-count-4"></textarea>
         <div class="spectrum-HelpText spectrum-HelpText--sizeXL spectrum-HelpText--neutral">
           <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
@@ -59,9 +51,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline">
         <label for="textfield-helptext" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Password</label>
-        <div class="spectrum-Textfield-input-wrapper">
-          <textarea id="textfield-helptext" placeholder="Enter Password" name="field" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-5 character-count-5"></textarea>
-        </div>
+        <textarea id="textfield-helptext" placeholder="Enter Password" name="field" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-5 character-count-5"></textarea>
         <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--neutral">
           <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
@@ -73,9 +63,7 @@ examples:
       <div class="spectrum-Textfield spectrum-Textfield--multiline">
         <label for="textfield-character-count" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
         <span id="character-count-5" class="spectrum-Textfield-character-count">50</span>
-        <div class="spectrum-Textfield-input-wrapper">
-          <textarea id="textfield-character-count" placeholder="Lisa Wilson" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-5 character-count-5"></textarea>
-        </div>
+        <textarea id="textfield-character-count" placeholder="Lisa Wilson" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-5 character-count-5"></textarea>
       </div>
 
   - id: textfield-sidelabel
@@ -84,9 +72,7 @@ examples:
       <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--sidelabel">
         <label for="textfield-md-sidelabel" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Password</label>
         <span id="character-count-6" class="spectrum-Textfield-character-count">50</span>
-        <div class="spectrum-Textfield-input-wrapper">
-          <textarea id="textfield-md-sidelabel" placeholder="Enter Password" name="field" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-6 character-count-6"></textarea>
-        </div>
+        <textarea id="textfield-md-sidelabel" placeholder="Enter Password" name="field" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-6 character-count-6"></textarea>
         <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--neutral">
           <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
@@ -97,9 +83,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline is-disabled">
         <label for="textarea-disabled" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <div class="spectrum-Textfield-input-wrapper">
-          <textarea id="textarea-disabled" placeholder="Lisa Wilson" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-7 character-count-7" disabled></textarea>
-        </div>
+        <textarea id="textarea-disabled" placeholder="Lisa Wilson" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-7 character-count-7" disabled></textarea>
       </div>
 
   - id: textfield
@@ -107,12 +91,10 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline is-valid">
         <label for="textarea-valid" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <div class="spectrum-Textfield-input-wrapper">
-          <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Checkmark100" />
-          </svg>
-          <textarea id="textarea-valid" placeholder="Lisa Wilson" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-8 character-count-8" required>A valid input</textarea>
-        </div>
+        <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
+          <use xlink:href="#spectrum-css-icon-Checkmark100" />
+        </svg>
+        <textarea id="textarea-valid" placeholder="Lisa Wilson" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-8 character-count-8" required>A valid input</textarea>
       </div>
 
   - id: textfield
@@ -120,12 +102,10 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline is-valid is-disabled">
         <label for="textarea-valid-disabled" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <div class="spectrum-Textfield-input-wrapper">
-          <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Checkmark100" />
-          </svg>
-          <textarea id="textarea-valid-disabled" placeholder="Lisa Wilson" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-9 character-count-9" required disabled>A valid input</textarea>
-        </div>
+        <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
+          <use xlink:href="#spectrum-css-icon-Checkmark100" />
+        </svg>
+        <textarea id="textarea-valid-disabled" placeholder="Lisa Wilson" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-9 character-count-9" required disabled>A valid input</textarea>
       </div>
 
   - id: textfield
@@ -135,12 +115,10 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline is-invalid">
         <label for="textarea-invalid" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <div class="spectrum-Textfield-input-wrapper">
-          <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-icon-18-Alert" />
-          </svg>
-          <textarea id="textarea--invalid" placeholder="Lisa Wilson" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-10 character-count-10" required>Invalid input</textarea>
-        </div>
+        <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
+          <use xlink:href="#spectrum-icon-18-Alert" />
+        </svg>
+        <textarea id="textarea--invalid" placeholder="Lisa Wilson" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-10 character-count-10" required>Invalid input</textarea>
       </div>
 
   - id: textfield
@@ -148,12 +126,10 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline is-invalid is-disabled">
         <label for="textarea-invalid-disabled" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <div class="spectrum-Textfield-input-wrapper">
-          <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-icon-18-Alert" />
-          </svg>
-          <textarea id="textarea-invalid-disabled" placeholder="Lisa Wilson" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-11 character-count-11" disabled>Invalid input</textarea>
-        </div>
+        <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
+          <use xlink:href="#spectrum-icon-18-Alert" />
+        </svg>
+        <textarea id="textarea-invalid-disabled" placeholder="Lisa Wilson" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-11 character-count-11" disabled>Invalid input</textarea>
       </div>
 
   - id: textfield
@@ -161,9 +137,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline is-focused">
         <label for="textarea-focused" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <div class="spectrum-Textfield-input-wrapper">
-          <textarea id="textarea-focused"placeholder="Lisa Wilson" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-12 character-count-12"></textarea>
-        </div>
+        <textarea id="textarea-focused"placeholder="Lisa Wilson" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-12 character-count-12"></textarea>
       </div>
 
   - id: textfield
@@ -171,9 +145,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline is-keyboardFocused">
         <label for="textarea-keyboard-focused" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <div class="spectrum-Textfield-input-wrapper">
-          <textarea id="textarea-keyboard-focused" placeholder="Lisa Wilson" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-13 character-count-13"></textarea>
-        </div>
+        <textarea id="textarea-keyboard-focused" placeholder="Lisa Wilson" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-13 character-count-13"></textarea>
       </div>
 
   - id: textfield
@@ -183,12 +155,10 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline is-invalid is-focused">
         <label for="textarea-focused-invalid" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <div class="spectrum-Textfield-input-wrapper">
-          <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-icon-18-Alert" />
-          </svg>
-          <textarea id="textarea-focused-invalid" placeholder="Lisa Wilson" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-14 character-count-14" required>Invalid input</textarea>
-        </div>
+        <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
+          <use xlink:href="#spectrum-icon-18-Alert" />
+        </svg>
+        <textarea id="textarea-focused-invalid" placeholder="Lisa Wilson" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-14 character-count-14" required>Invalid input</textarea>
       </div>
 
   - id: textfield
@@ -198,12 +168,10 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline is-invalid is-keyboardFocused">
         <label for="textarea-keyboard-focused-invalid" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <div class="spectrum-Textfield-input-wrapper">
-          <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-icon-18-Alert" />
-          </svg>
-          <textarea id="textarea-keyboard-focused-invalid" placeholder="Lisa Wilson" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-15 character-count-15" required>Invalid input</textarea>
-        </div>
+        <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
+          <use xlink:href="#spectrum-icon-18-Alert" />
+        </svg>
+        <textarea id="textarea-keyboard-focused-invalid" placeholder="Lisa Wilson" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-15 character-count-15" required>Invalid input</textarea>
       </div>
 
   - id: textfield-quiet
@@ -211,9 +179,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--quiet">
         <label for="textarea-quiet" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Text area</label>
-        <div class="spectrum-Textfield-input-wrapper">
-          <textarea id="textarea-quiet" placeholder="Lisa Wilson" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-16 character-count-16"></textarea>
-        </div>
+        <textarea id="textarea-quiet" placeholder="Lisa Wilson" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-16 character-count-16"></textarea>
       </div>
 
   - id: textfield-quiet
@@ -221,9 +187,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--quiet is-disabled">
         <label for="textarea-quiet-disabled" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <div class="spectrum-Textfield-input-wrapper">
-          <textarea id="textarea-quiet-disabled" placeholder="Lisa Wilson" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-17 character-count-17" disabled></textarea>
-        </div>
+        <textarea id="textarea-quiet-disabled" placeholder="Lisa Wilson" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-17 character-count-17" disabled></textarea>
       </div>
 
   - id: textfield-quiet
@@ -233,12 +197,10 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--quiet is-valid">
         <label for="textarea-quiet-valid" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <div class="spectrum-Textfield-input-wrapper">
-          <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Checkmark100" />
-          </svg>
-          <textarea id="textarea-quiet-valid" placeholder="Lisa Wilson" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-18 character-count-18" required>A valid input</textarea>
-        </div>
+        <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
+          <use xlink:href="#spectrum-css-icon-Checkmark100" />
+        </svg>
+        <textarea id="textarea-quiet-valid" placeholder="Lisa Wilson" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-18 character-count-18" required>A valid input</textarea>
       </div>
 
   - id: textfield-quiet
@@ -246,12 +208,10 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--quiet is-valid is-disabled">
         <label for="textarea-valid-disabled" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <div class="spectrum-Textfield-input-wrapper">
-          <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Checkmark100" />
-          </svg>
-          <textarea id="textarea-valid-disabled"placeholder="Lisa Wilson" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-19 character-count-19" required disabled>A valid input</textarea>
-        </div>
+        <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
+          <use xlink:href="#spectrum-css-icon-Checkmark100" />
+        </svg>
+        <textarea id="textarea-valid-disabled"placeholder="Lisa Wilson" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-19 character-count-19" required disabled>A valid input</textarea>
       </div>
 
   - id: textfield-quiet
@@ -261,12 +221,10 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--quiet is-invalid">
         <label for="textarea-quiet-invalid" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <div class="spectrum-Textfield-input-wrapper">
-          <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-icon-18-Alert" />
-          </svg>
-          <textarea id="textarea-quiet-invalid" placeholder="Lisa Wilson" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-20 character-count-20" required>Invalid input</textarea>
-        </div>
+        <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
+          <use xlink:href="#spectrum-icon-18-Alert" />
+        </svg>
+        <textarea id="textarea-quiet-invalid" placeholder="Lisa Wilson" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-20 character-count-20" required>Invalid input</textarea>
       </div>
 
   - id: textfield-quiet
@@ -274,12 +232,10 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--quiet is-invalid is-disabled">
         <label for="textarea-quiet-invalid-disabled" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <div class="spectrum-Textfield-input-wrapper">
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>
-          <textarea id="textarea-quiet-invalid-disabled" placeholder="Lisa Wilson" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-21 character-count-21" disabled>Invalid input</textarea>
-        </div>
+        <textarea id="textarea-quiet-invalid-disabled" placeholder="Lisa Wilson" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-21 character-count-21" disabled>Invalid input</textarea>
       </div>
 
   - id: textfield-quiet
@@ -287,9 +243,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--quiet is-focused">
         <label for="textarea-quiet-focused" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <div class="spectrum-Textfield-input-wrapper">
-          <textarea id="textarea-quiet-focused" placeholder="Lisa Wilson" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-22 character-count-22"></textarea>
-        </div>
+        <textarea id="textarea-quiet-focused" placeholder="Lisa Wilson" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-22 character-count-22"></textarea>
       </div>
 
   - id: textfield-quiet
@@ -297,9 +251,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--quiet is-keyboardFocused">
         <label for="textarea-quiet-keyboard-focused" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <div class="spectrum-Textfield-input-wrapper">
-          <textarea id="textarea-quiet-keyboard-focused" placeholder="Lisa Wilson" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-23 character-count-23"></textarea>
-        </div>
+        <textarea id="textarea-quiet-keyboard-focused" placeholder="Lisa Wilson" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-23 character-count-23"></textarea>
       </div>
 
   - id: textfield-quiet
@@ -309,12 +261,10 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--quiet is-invalid is-focused">
         <label for="textarea-quiet-focused-invalid" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <div class="spectrum-Textfield-input-wrapper">
-          <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-icon-18-Alert" />
-          </svg>
-          <textarea id="textarea-quiet-focused-invalid" placeholder="Lisa Wilson" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-24 character-count-24" required>Invalid input</textarea>
-        </div>
+        <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
+          <use xlink:href="#spectrum-icon-18-Alert" />
+        </svg>
+        <textarea id="textarea-quiet-focused-invalid" placeholder="Lisa Wilson" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-24 character-count-24" required>Invalid input</textarea>
       </div>
 
   - id: textfield-quiet
@@ -324,10 +274,8 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--quiet is-invalid is-keyboardFocused">
         <label for="textarea-quiet-keyboard-focused-invalid" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <div class="spectrum-Textfield-input-wrapper">
-          <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-icon-18-Alert" />
-          </svg>
-          <textarea id="textarea-quiet-keyboard-focused-invalid" placeholder="Lisa Wilson" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-25 character-count-25" required>Invalid input</textarea>
-        </div>
+        <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
+          <use xlink:href="#spectrum-icon-18-Alert" />
+        </svg>
+        <textarea id="textarea-quiet-keyboard-focused-invalid" placeholder="Lisa Wilson" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-25 character-count-25" required>Invalid input</textarea>
       </div>

--- a/components/textfield/metadata/textarea.yml
+++ b/components/textfield/metadata/textarea.yml
@@ -13,7 +13,7 @@ examples:
       <div class="spectrum-Textfield spectrum-Textfield--sizeS spectrum-Textfield--multiline">
         <label for="textfield-sm" class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">Password</label>
         <span id="character-count-1" class="spectrum-Textfield-character-count">50</span>
-        <textarea id="textfield-s" placeholder="Enter Password" name="field" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-1 character-count-1"></textarea>
+        <textarea id="textfield-s" name="field" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-1 character-count-1"></textarea>
         <div class="spectrum-HelpText spectrum-HelpText--sizeS spectrum-HelpText--neutral">
           <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
@@ -22,7 +22,7 @@ examples:
       <div class="spectrum-Textfield spectrum-Textfield--sizeM spectrum-Textfield--multiline">
         <label for="textfield-md" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Password</label>
         <span id="character-count-2" class="spectrum-Textfield-character-count">50</span>
-        <textarea id="textfield-m" placeholder="Enter Password" name="field" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-2 character-count-2"></textarea>
+        <textarea id="textfield-m" name="field" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-2 character-count-2"></textarea>
         <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--neutral">
           <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
@@ -31,7 +31,7 @@ examples:
       <div class="spectrum-Textfield spectrum-Textfield--sizeL spectrum-Textfield--multiline">
         <label for="textfield-l" class="spectrum-FieldLabel spectrum-FieldLabel--sizeL">Password</label>
         <span id="character-count-3" class="spectrum-Textfield-character-count">50</span>
-        <textarea id="textfield-l" placeholder="Enter Password" name="field" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-3 character-count-3"></textarea>
+        <textarea id="textfield-l" name="field" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-3 character-count-3"></textarea>
         <div class="spectrum-HelpText spectrum-HelpText--sizeL spectrum-HelpText--neutral">
           <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
@@ -40,7 +40,7 @@ examples:
       <div class="spectrum-Textfield spectrum-Textfield--sizeXL spectrum-Textfield--multiline">
         <label for="textfield-xl" class="spectrum-FieldLabel spectrum-FieldLabel--sizeXL">Password</label>
         <span id="character-count-4" class="spectrum-Textfield-character-count">50</span>
-        <textarea id="textfield-xl" placeholder="Enter Password" name="field" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-4 character-count-4"></textarea>
+        <textarea id="textfield-xl" name="field" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-4 character-count-4"></textarea>
         <div class="spectrum-HelpText spectrum-HelpText--sizeXL spectrum-HelpText--neutral">
           <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
@@ -51,7 +51,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline">
         <label for="textfield-helptext" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Password</label>
-        <textarea id="textfield-helptext" placeholder="Enter Password" name="field" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-5 character-count-5"></textarea>
+        <textarea id="textfield-helptext" name="field" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-5 character-count-5"></textarea>
         <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--neutral">
           <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
@@ -63,7 +63,7 @@ examples:
       <div class="spectrum-Textfield spectrum-Textfield--multiline">
         <label for="textfield-character-count" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
         <span id="character-count-5" class="spectrum-Textfield-character-count">50</span>
-        <textarea id="textfield-character-count" placeholder="Lisa Wilson" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-5 character-count-5"></textarea>
+        <textarea id="textfield-character-count" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-5 character-count-5"></textarea>
       </div>
 
   - id: textfield-sidelabel
@@ -72,7 +72,7 @@ examples:
       <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--sidelabel">
         <label for="textfield-md-sidelabel" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Password</label>
         <span id="character-count-6" class="spectrum-Textfield-character-count">50</span>
-        <textarea id="textfield-md-sidelabel" placeholder="Enter Password" name="field" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-6 character-count-6"></textarea>
+        <textarea id="textfield-md-sidelabel" name="field" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-6 character-count-6"></textarea>
         <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--neutral">
           <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
@@ -83,7 +83,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline is-disabled">
         <label for="textarea-disabled" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <textarea id="textarea-disabled" placeholder="Lisa Wilson" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-7 character-count-7" disabled></textarea>
+        <textarea id="textarea-disabled" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-7 character-count-7" disabled></textarea>
       </div>
 
   - id: textfield
@@ -94,7 +94,7 @@ examples:
         <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-css-icon-Checkmark100" />
         </svg>
-        <textarea id="textarea-valid" placeholder="Lisa Wilson" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-8 character-count-8" required>A valid input</textarea>
+        <textarea id="textarea-valid" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-8 character-count-8" required>A valid input</textarea>
       </div>
 
   - id: textfield
@@ -105,7 +105,7 @@ examples:
         <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-css-icon-Checkmark100" />
         </svg>
-        <textarea id="textarea-valid-disabled" placeholder="Lisa Wilson" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-9 character-count-9" required disabled>A valid input</textarea>
+        <textarea id="textarea-valid-disabled" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-9 character-count-9" required disabled>A valid input</textarea>
       </div>
 
   - id: textfield
@@ -118,7 +118,7 @@ examples:
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>
-        <textarea id="textarea--invalid" placeholder="Lisa Wilson" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-10 character-count-10" required>Invalid input</textarea>
+        <textarea id="textarea--invalid" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-10 character-count-10" required>Invalid input</textarea>
       </div>
 
   - id: textfield
@@ -129,7 +129,7 @@ examples:
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>
-        <textarea id="textarea-invalid-disabled" placeholder="Lisa Wilson" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-11 character-count-11" disabled>Invalid input</textarea>
+        <textarea id="textarea-invalid-disabled" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-11 character-count-11" disabled>Invalid input</textarea>
       </div>
 
   - id: textfield
@@ -137,7 +137,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline is-focused">
         <label for="textarea-focused" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <textarea id="textarea-focused"placeholder="Lisa Wilson" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-12 character-count-12"></textarea>
+        <textarea id="textarea-focused" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-12 character-count-12"></textarea>
       </div>
 
   - id: textfield
@@ -145,7 +145,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline is-keyboardFocused">
         <label for="textarea-keyboard-focused" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <textarea id="textarea-keyboard-focused" placeholder="Lisa Wilson" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-13 character-count-13"></textarea>
+        <textarea id="textarea-keyboard-focused" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-13 character-count-13"></textarea>
       </div>
 
   - id: textfield
@@ -158,7 +158,7 @@ examples:
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>
-        <textarea id="textarea-focused-invalid" placeholder="Lisa Wilson" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-14 character-count-14" required>Invalid input</textarea>
+        <textarea id="textarea-focused-invalid" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-14 character-count-14" required>Invalid input</textarea>
       </div>
 
   - id: textfield
@@ -171,7 +171,7 @@ examples:
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>
-        <textarea id="textarea-keyboard-focused-invalid" placeholder="Lisa Wilson" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-15 character-count-15" required>Invalid input</textarea>
+        <textarea id="textarea-keyboard-focused-invalid" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-15 character-count-15" required>Invalid input</textarea>
       </div>
 
   - id: textfield-quiet
@@ -179,7 +179,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--quiet">
         <label for="textarea-quiet" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Text area</label>
-        <textarea id="textarea-quiet" placeholder="Lisa Wilson" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-16 character-count-16"></textarea>
+        <textarea id="textarea-quiet" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-16 character-count-16"></textarea>
       </div>
 
   - id: textfield-quiet
@@ -187,7 +187,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--quiet is-disabled">
         <label for="textarea-quiet-disabled" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <textarea id="textarea-quiet-disabled" placeholder="Lisa Wilson" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-17 character-count-17" disabled></textarea>
+        <textarea id="textarea-quiet-disabled" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-17 character-count-17" disabled></textarea>
       </div>
 
   - id: textfield-quiet
@@ -200,7 +200,7 @@ examples:
         <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-css-icon-Checkmark100" />
         </svg>
-        <textarea id="textarea-quiet-valid" placeholder="Lisa Wilson" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-18 character-count-18" required>A valid input</textarea>
+        <textarea id="textarea-quiet-valid" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-18 character-count-18" required>A valid input</textarea>
       </div>
 
   - id: textfield-quiet
@@ -211,7 +211,7 @@ examples:
         <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-css-icon-Checkmark100" />
         </svg>
-        <textarea id="textarea-valid-disabled"placeholder="Lisa Wilson" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-19 character-count-19" required disabled>A valid input</textarea>
+        <textarea id="textarea-valid-disabled" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-19 character-count-19" required disabled>A valid input</textarea>
       </div>
 
   - id: textfield-quiet
@@ -224,7 +224,7 @@ examples:
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>
-        <textarea id="textarea-quiet-invalid" placeholder="Lisa Wilson" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-20 character-count-20" required>Invalid input</textarea>
+        <textarea id="textarea-quiet-invalid" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-20 character-count-20" required>Invalid input</textarea>
       </div>
 
   - id: textfield-quiet
@@ -235,7 +235,7 @@ examples:
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>
-        <textarea id="textarea-quiet-invalid-disabled" placeholder="Lisa Wilson" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-21 character-count-21" disabled>Invalid input</textarea>
+        <textarea id="textarea-quiet-invalid-disabled" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-21 character-count-21" disabled>Invalid input</textarea>
       </div>
 
   - id: textfield-quiet
@@ -243,7 +243,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--quiet is-focused">
         <label for="textarea-quiet-focused" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <textarea id="textarea-quiet-focused" placeholder="Lisa Wilson" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-22 character-count-22"></textarea>
+        <textarea id="textarea-quiet-focused" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-22 character-count-22"></textarea>
       </div>
 
   - id: textfield-quiet
@@ -251,7 +251,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--quiet is-keyboardFocused">
         <label for="textarea-quiet-keyboard-focused" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <textarea id="textarea-quiet-keyboard-focused" placeholder="Lisa Wilson" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-23 character-count-23"></textarea>
+        <textarea id="textarea-quiet-keyboard-focused" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-23 character-count-23"></textarea>
       </div>
 
   - id: textfield-quiet
@@ -264,7 +264,7 @@ examples:
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>
-        <textarea id="textarea-quiet-focused-invalid" placeholder="Lisa Wilson" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-24 character-count-24" required>Invalid input</textarea>
+        <textarea id="textarea-quiet-focused-invalid" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-24 character-count-24" required>Invalid input</textarea>
       </div>
 
   - id: textfield-quiet
@@ -277,5 +277,5 @@ examples:
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>
-        <textarea id="textarea-quiet-keyboard-focused-invalid" placeholder="Lisa Wilson" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-25 character-count-25" required>Invalid input</textarea>
+        <textarea id="textarea-quiet-keyboard-focused-invalid" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-25 character-count-25" required>Invalid input</textarea>
       </div>

--- a/components/textfield/metadata/textarea.yml
+++ b/components/textfield/metadata/textarea.yml
@@ -11,38 +11,38 @@ examples:
     name: Standard Sizes
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--sizeS spectrum-Textfield--multiline">
-        <label for="textfield-sm" class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">Password</label>
+        <label for="textfield-s" class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">Password</label>
         <span id="character-count-1" class="spectrum-Textfield-characterCount">50</span>
-        <textarea id="textfield-s" name="field" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-1 character-count-1"></textarea>
+        <textarea id="textfield-s" name="field" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-1 character-count-1"></textarea>
         <div class="spectrum-HelpText spectrum-HelpText--sizeS spectrum-HelpText--neutral">
-          <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
+          <div id="helptext-1" class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
       </div>
 
       <div class="spectrum-Textfield spectrum-Textfield--sizeM spectrum-Textfield--multiline">
-        <label for="textfield-md" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Password</label>
+        <label for="textfield-m" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Password</label>
         <span id="character-count-2" class="spectrum-Textfield-characterCount">50</span>
-        <textarea id="textfield-m" name="field" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-2 character-count-2"></textarea>
+        <textarea id="textfield-m" name="field" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-2 character-count-2"></textarea>
         <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--neutral">
-          <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
+          <div id="helptext-2" class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
       </div>
 
       <div class="spectrum-Textfield spectrum-Textfield--sizeL spectrum-Textfield--multiline">
         <label for="textfield-l" class="spectrum-FieldLabel spectrum-FieldLabel--sizeL">Password</label>
         <span id="character-count-3" class="spectrum-Textfield-characterCount">50</span>
-        <textarea id="textfield-l" name="field" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-3 character-count-3"></textarea>
+        <textarea id="textfield-l" name="field" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-3 character-count-3"></textarea>
         <div class="spectrum-HelpText spectrum-HelpText--sizeL spectrum-HelpText--neutral">
-          <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
+          <div id="helptext-3" class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
       </div>
 
       <div class="spectrum-Textfield spectrum-Textfield--sizeXL spectrum-Textfield--multiline">
         <label for="textfield-xl" class="spectrum-FieldLabel spectrum-FieldLabel--sizeXL">Password</label>
         <span id="character-count-4" class="spectrum-Textfield-characterCount">50</span>
-        <textarea id="textfield-xl" name="field" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-4 character-count-4"></textarea>
+        <textarea id="textfield-xl" name="field" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-4 character-count-4"></textarea>
         <div class="spectrum-HelpText spectrum-HelpText--sizeXL spectrum-HelpText--neutral">
-          <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
+          <div id="helptext-4" class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
       </div>
 
@@ -51,9 +51,9 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline">
         <label for="textfield-helptext" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Password</label>
-        <textarea id="textfield-helptext" name="field" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-5 character-count-5"></textarea>
+        <textarea id="textfield-helptext" name="field" class="spectrum-Textfield-input" aria-describedby="helptext-5"></textarea>
         <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--neutral">
-          <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
+          <div id="helptext-5" class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
       </div>
 
@@ -63,18 +63,18 @@ examples:
       <div class="spectrum-Textfield spectrum-Textfield--multiline">
         <label for="textfield-character-count" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
         <span id="character-count-5" class="spectrum-Textfield-characterCount">50</span>
-        <textarea id="textfield-character-count" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-5 character-count-5"></textarea>
+        <textarea id="textfield-character-count" name="field" class="spectrum-Textfield-input" aria-describedby="character-count-5"></textarea>
       </div>
 
   - id: textfield-sidelabel
     name: Textfield with Side Label
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--sideLabel">
-        <label for="textfield-md-sidelabel" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Password</label>
+        <label for="textfield-m-sidelabel" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Password</label>
         <span id="character-count-6" class="spectrum-Textfield-characterCount">50</span>
-        <textarea id="textfield-md-sidelabel" name="field" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-6 character-count-6"></textarea>
+        <textarea id="textfield-m-sidelabel" name="field" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-6 character-count-6"></textarea>
         <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--neutral">
-          <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
+          <div id="helptext-6" class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
       </div>
 
@@ -94,7 +94,7 @@ examples:
         <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-css-icon-Checkmark100" />
         </svg>
-        <textarea id="textarea-valid" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-8 character-count-8" required>A valid input</textarea>
+        <textarea id="textarea-valid" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" required>A valid input</textarea>
       </div>
 
   - id: textfield
@@ -105,7 +105,7 @@ examples:
         <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-css-icon-Checkmark100" />
         </svg>
-        <textarea id="textarea-valid-disabled" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-9 character-count-9" required disabled>A valid input</textarea>
+        <textarea id="textarea-valid-disabled" name="field"  class="spectrum-Textfield-input" required disabled>A valid input</textarea>
       </div>
 
   - id: textfield
@@ -118,7 +118,7 @@ examples:
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>
-        <textarea id="textarea--invalid" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-10 character-count-10" required>Invalid input</textarea>
+        <textarea id="textarea--invalid" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" required>Invalid input</textarea>
       </div>
 
   - id: textfield
@@ -129,7 +129,7 @@ examples:
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>
-        <textarea id="textarea-invalid-disabled" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-11 character-count-11" disabled>Invalid input</textarea>
+        <textarea id="textarea-invalid-disabled" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" disabled>Invalid input</textarea>
       </div>
 
   - id: textfield
@@ -137,7 +137,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline is-focused">
         <label for="textarea-focused" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <textarea id="textarea-focused" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-12 character-count-12"></textarea>
+        <textarea id="textarea-focused" name="field" class="spectrum-Textfield-input"></textarea>
       </div>
 
   - id: textfield
@@ -145,7 +145,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline is-keyboardFocused">
         <label for="textarea-keyboard-focused" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <textarea id="textarea-keyboard-focused" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-13 character-count-13"></textarea>
+        <textarea id="textarea-keyboard-focused" name="field" class="spectrum-Textfield-input"></textarea>
       </div>
 
   - id: textfield
@@ -158,7 +158,7 @@ examples:
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>
-        <textarea id="textarea-focused-invalid" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-14 character-count-14" required>Invalid input</textarea>
+        <textarea id="textarea-focused-invalid" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" required>Invalid input</textarea>
       </div>
 
   - id: textfield
@@ -171,7 +171,7 @@ examples:
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>
-        <textarea id="textarea-keyboard-focused-invalid" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-15 character-count-15" required>Invalid input</textarea>
+        <textarea id="textarea-keyboard-focused-invalid" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" required>Invalid input</textarea>
       </div>
 
   - id: textfield-quiet
@@ -179,7 +179,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--quiet">
         <label for="textarea-quiet" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Text area</label>
-        <textarea id="textarea-quiet" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-16 character-count-16"></textarea>
+        <textarea id="textarea-quiet" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+"></textarea>
       </div>
 
   - id: textfield-quiet
@@ -187,7 +187,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--quiet is-disabled">
         <label for="textarea-quiet-disabled" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <textarea id="textarea-quiet-disabled" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-17 character-count-17" disabled></textarea>
+        <textarea id="textarea-quiet-disabled" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+" disabled></textarea>
       </div>
 
   - id: textfield-quiet
@@ -200,7 +200,7 @@ examples:
         <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-css-icon-Checkmark100" />
         </svg>
-        <textarea id="textarea-quiet-valid" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-18 character-count-18" required>A valid input</textarea>
+        <textarea id="textarea-quiet-valid" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" required>A valid input</textarea>
       </div>
 
   - id: textfield-quiet
@@ -211,7 +211,7 @@ examples:
         <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-css-icon-Checkmark100" />
         </svg>
-        <textarea id="textarea-valid-disabled" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-19 character-count-19" required disabled>A valid input</textarea>
+        <textarea id="textarea-valid-disabled" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" required disabled>A valid input</textarea>
       </div>
 
   - id: textfield-quiet
@@ -224,7 +224,7 @@ examples:
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>
-        <textarea id="textarea-quiet-invalid" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-20 character-count-20" required>Invalid input</textarea>
+        <textarea id="textarea-quiet-invalid" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" required>Invalid input</textarea>
       </div>
 
   - id: textfield-quiet
@@ -235,7 +235,7 @@ examples:
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>
-        <textarea id="textarea-quiet-invalid-disabled" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-21 character-count-21" disabled>Invalid input</textarea>
+        <textarea id="textarea-quiet-invalid-disabled" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" disabled>Invalid input</textarea>
       </div>
 
   - id: textfield-quiet
@@ -243,7 +243,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--quiet is-focused">
         <label for="textarea-quiet-focused" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <textarea id="textarea-quiet-focused" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-22 character-count-22"></textarea>
+        <textarea id="textarea-quiet-focused" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+"></textarea>
       </div>
 
   - id: textfield-quiet
@@ -251,7 +251,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--quiet is-keyboardFocused">
         <label for="textarea-quiet-keyboard-focused" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <textarea id="textarea-quiet-keyboard-focused" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-23 character-count-23"></textarea>
+        <textarea id="textarea-quiet-keyboard-focused" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+"></textarea>
       </div>
 
   - id: textfield-quiet
@@ -264,7 +264,7 @@ examples:
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>
-        <textarea id="textarea-quiet-focused-invalid" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-24 character-count-24" required>Invalid input</textarea>
+        <textarea id="textarea-quiet-focused-invalid" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" required>Invalid input</textarea>
       </div>
 
   - id: textfield-quiet
@@ -277,5 +277,5 @@ examples:
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>
-        <textarea id="textarea-quiet-keyboard-focused-invalid" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-25 character-count-25" required>Invalid input</textarea>
+        <textarea id="textarea-quiet-keyboard-focused-invalid" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" required>Invalid input</textarea>
       </div>

--- a/components/textfield/metadata/textarea.yml
+++ b/components/textfield/metadata/textarea.yml
@@ -12,7 +12,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--sizeS spectrum-Textfield--multiline">
         <label for="textfield-sm" class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">Password</label>
-        <span id="character-count-1" class="spectrum-Textfield-character-count">50</span>
+        <span id="character-count-1" class="spectrum-Textfield-characterCount">50</span>
         <textarea id="textfield-s" name="field" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-1 character-count-1"></textarea>
         <div class="spectrum-HelpText spectrum-HelpText--sizeS spectrum-HelpText--neutral">
           <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
@@ -21,7 +21,7 @@ examples:
 
       <div class="spectrum-Textfield spectrum-Textfield--sizeM spectrum-Textfield--multiline">
         <label for="textfield-md" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Password</label>
-        <span id="character-count-2" class="spectrum-Textfield-character-count">50</span>
+        <span id="character-count-2" class="spectrum-Textfield-characterCount">50</span>
         <textarea id="textfield-m" name="field" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-2 character-count-2"></textarea>
         <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--neutral">
           <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
@@ -30,7 +30,7 @@ examples:
 
       <div class="spectrum-Textfield spectrum-Textfield--sizeL spectrum-Textfield--multiline">
         <label for="textfield-l" class="spectrum-FieldLabel spectrum-FieldLabel--sizeL">Password</label>
-        <span id="character-count-3" class="spectrum-Textfield-character-count">50</span>
+        <span id="character-count-3" class="spectrum-Textfield-characterCount">50</span>
         <textarea id="textfield-l" name="field" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-3 character-count-3"></textarea>
         <div class="spectrum-HelpText spectrum-HelpText--sizeL spectrum-HelpText--neutral">
           <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
@@ -39,7 +39,7 @@ examples:
 
       <div class="spectrum-Textfield spectrum-Textfield--sizeXL spectrum-Textfield--multiline">
         <label for="textfield-xl" class="spectrum-FieldLabel spectrum-FieldLabel--sizeXL">Password</label>
-        <span id="character-count-4" class="spectrum-Textfield-character-count">50</span>
+        <span id="character-count-4" class="spectrum-Textfield-characterCount">50</span>
         <textarea id="textfield-xl" name="field" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-4 character-count-4"></textarea>
         <div class="spectrum-HelpText spectrum-HelpText--sizeXL spectrum-HelpText--neutral">
           <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
@@ -62,16 +62,16 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline">
         <label for="textfield-character-count" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <span id="character-count-5" class="spectrum-Textfield-character-count">50</span>
+        <span id="character-count-5" class="spectrum-Textfield-characterCount">50</span>
         <textarea id="textfield-character-count" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-5 character-count-5"></textarea>
       </div>
 
   - id: textfield-sidelabel
     name: Textfield with Side Label
     markup: |
-      <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--sidelabel">
+      <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--sideLabel">
         <label for="textfield-md-sidelabel" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Password</label>
-        <span id="character-count-6" class="spectrum-Textfield-character-count">50</span>
+        <span id="character-count-6" class="spectrum-Textfield-characterCount">50</span>
         <textarea id="textfield-md-sidelabel" name="field" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-6 character-count-6"></textarea>
         <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--neutral">
           <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
@@ -83,7 +83,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline is-disabled">
         <label for="textarea-disabled" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <textarea id="textarea-disabled" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-7 character-count-7" disabled></textarea>
+        <textarea id="textarea-disabled" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+" disabled></textarea>
       </div>
 
   - id: textfield

--- a/components/textfield/metadata/textfield.yml
+++ b/components/textfield/metadata/textfield.yml
@@ -83,9 +83,7 @@ examples:
       <div class="spectrum-Textfield spectrum-Textfield--sizeS">
         <label for="textfield-sm" class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">Password</label>
         <span id="character-count-1" class="spectrum-Textfield-character-count">50</span>
-        <div class="spectrum-Textfield-input-wrapper">
-          <input id="textfield-sm" type="text" placeholder="Enter Password" name="field" value="" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-1 character-count-1">
-        </div>
+        <input id="textfield-sm" type="text" placeholder="Enter Password" name="field" value="" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-1 character-count-1">
         <div class="spectrum-HelpText spectrum-HelpText--sizeS spectrum-HelpText--neutral">
           <div id="helptext-size-small" class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
@@ -94,9 +92,7 @@ examples:
       <div class="spectrum-Textfield spectrum-Textfield--sizeM">
         <label for="textfield-md" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Password</label>
         <span id="character-count-2" class="spectrum-Textfield-character-count">50</span>
-        <div class="spectrum-Textfield-input-wrapper">
-          <input id="textfield-m" type="text" placeholder="Enter Password" name="field" value="" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-2 character-count-2">
-        </div>
+        <input id="textfield-m" type="text" placeholder="Enter Password" name="field" value="" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-2 character-count-2">
         <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--neutral">
           <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
@@ -105,9 +101,7 @@ examples:
       <div class="spectrum-Textfield spectrum-Textfield--sizeL">
         <label for="textfield-l" class="spectrum-FieldLabel spectrum-FieldLabel--sizeL">Password</label>
         <span id="character-count-3" class="spectrum-Textfield-character-count">50</span>
-        <div class="spectrum-Textfield-input-wrapper">
-          <input id="textfield-l" type="text" placeholder="Enter Password" name="field" value="" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-3 character-count-3">
-        </div>
+        <input id="textfield-l" type="text" placeholder="Enter Password" name="field" value="" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-3 character-count-3">
         <div class="spectrum-HelpText spectrum-HelpText--sizeL spectrum-HelpText--neutral">
           <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
@@ -116,9 +110,7 @@ examples:
       <div class="spectrum-Textfield spectrum-Textfield--sizeXL">
         <label for="textfield-xl" class="spectrum-FieldLabel spectrum-FieldLabel--sizeXL">Password</label>
         <span id="character-count-4" class="spectrum-Textfield-character-count">50</span>
-        <div class="spectrum-Textfield-input-wrapper">
-          <input id="textfield-xl" type="text" placeholder="Enter Password" name="field" value="" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-4 character-count-4">
-        </div>
+        <input id="textfield-xl" type="text" placeholder="Enter Password" name="field" value="" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-4 character-count-4">
          <div class="spectrum-HelpText spectrum-HelpText--sizeXL spectrum-HelpText--neutral">
           <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
@@ -129,9 +121,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield">
         <label for="textfield-helptext" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Password</label>
-        <div class="spectrum-Textfield-input-wrapper">
-          <input id="textfield-helptext" type="text" placeholder="Enter Password" name="field" value="" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-5 character-count-5">
-        </div>
+        <input id="textfield-helptext" type="text" placeholder="Enter Password" name="field" value="" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-5 character-count-5">
         <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--neutral">
           <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
@@ -143,9 +133,7 @@ examples:
       <div class="spectrum-Textfield">
         <label for="textfield-1" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
         <span id="character-count-6" class="spectrum-Textfield-character-count">50</span>
-        <div class="spectrum-Textfield-input-wrapper">
-          <input id="textfield-1" type="text" placeholder="Lisa Wilson" name="field" value="" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-6 character-count-6">
-        </div>
+        <input id="textfield-1" type="text" placeholder="Lisa Wilson" name="field" value="" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-6 character-count-6">
       </div>
 
   - id: textfield-sidelabel
@@ -154,9 +142,7 @@ examples:
       <div class="spectrum-Textfield spectrum-Textfield--sidelabel">
         <label for="textfield-md-sidelabel" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Password</label>
         <span id="character-count-7" class="spectrum-Textfield-character-count">50</span>
-        <div class="spectrum-Textfield-input-wrapper">
-          <input id="textfield-md-sidelabel" type="text" placeholder="Enter Password" name="field" value="" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-7 character-count-7">
-        </div>
+        <input id="textfield-md-sidelabel" type="text" placeholder="Enter Password" name="field" value="" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-7 character-count-7">
         <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--neutral">
           <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
@@ -167,9 +153,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield is-disabled">
         <label for="textfield-disabled" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <div class="spectrum-Textfield-input-wrapper">
-          <input id="textfield-disabled" type="text"  placeholder="Lisa Wilson" name="field" value="" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-8 character-count-8" disabled>
-        </div>
+        <input id="textfield-disabled" type="text"  placeholder="Lisa Wilson" name="field" value="" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-8 character-count-8" disabled>
       </div>
 
   - id: textfield-readonly
@@ -177,9 +161,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield is-readOnly">
       <label for="textfield-readonly" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <div class="spectrum-Textfield-input-wrapper">
-          <input id="textfield-readonly" type="text"  placeholder="Lisa Wilson" name="field" value="This text is read-only" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-9 character-count-9" readonly="readonly" aria-describedby="helptext-7 character-count-7">
-        </div>
+        <input id="textfield-readonly" type="text"  placeholder="Lisa Wilson" name="field" value="This text is read-only" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-9 character-count-9" readonly="readonly" aria-describedby="helptext-7 character-count-7">
       </div>
 
   - id: textfield
@@ -189,42 +171,34 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--sizeS is-valid">
         <label for="textfield-sm-valid" class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">Enter your name</label>
-        <div class="spectrum-Textfield-input-wrapper">
           <svg class="spectrum-Icon spectrum-UIIcon-Checkmark75 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
             <use xlink:href="#spectrum-css-icon-Checkmark75" />
           </svg>
           <input id="textfield-sm-valid" type="text" placeholder="Lisa Wilson" name="field" value="A valid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-10 character-count-10" required>
-        </div>
       </div>
 
       <div class="spectrum-Textfield spectrum-Textfield--sizeM is-valid">
         <label for="textfield-m-valid" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <div class="spectrum-Textfield-input-wrapper">
-          <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Checkmark100" />
-          </svg>
-          <input id="textfield-m-valid" type="text" placeholder="Lisa Wilson" name="field" value="A valid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-11 character-count-11" required>
+        <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
+          <use xlink:href="#spectrum-css-icon-Checkmark100" />
+        </svg>
+        <input id="textfield-m-valid" type="text" placeholder="Lisa Wilson" name="field" value="A valid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-11 character-count-11" required>
         </div>
-      </div>
 
       <div class="spectrum-Textfield spectrum-Textfield--sizeL is-valid">
         <label for="textfield-l-valid" class="spectrum-FieldLabel spectrum-FieldLabel--sizeL">Enter your name</label>
-        <div class="spectrum-Textfield-input-wrapper">
-          <svg class="spectrum-Icon spectrum-UIIcon-Checkmark200 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Checkmark200" />
-          </svg>
-          <input id="textfield-l-valid" type="text" placeholder="Lisa Wilson" name="field" value="A valid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-12 character-count-12" required>
-        </div>
+        <svg class="spectrum-Icon spectrum-UIIcon-Checkmark200 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
+          <use xlink:href="#spectrum-css-icon-Checkmark200" />
+        </svg>
+        <input id="textfield-l-valid" type="text" placeholder="Lisa Wilson" name="field" value="A valid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-12 character-count-12" required>
       </div>
 
       <div class="spectrum-Textfield spectrum-Textfield--sizeXL is-valid">
         <label for="textfield-xl-valid" class="spectrum-FieldLabel spectrum-FieldLabel--sizeXL">Enter your name</label>
-        <div class="spectrum-Textfield-input-wrapper">
-          <svg class="spectrum-Icon spectrum-UIIcon-Checkmark300 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Checkmark300" />
-          </svg>
-          <input id="textfield-xl-valid" type="text" placeholder="Lisa Wilson" name="field" value="A valid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-13 character-count-13" required>
-        </div>
+        <svg class="spectrum-Icon spectrum-UIIcon-Checkmark300 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
+          <use xlink:href="#spectrum-css-icon-Checkmark300" />
+        </svg>
+        <input id="textfield-xl-valid" type="text" placeholder="Lisa Wilson" name="field" value="A valid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-13 character-count-13" required>
       </div>
 
   - id: textfield
@@ -232,12 +206,10 @@ examples:
     markup: |
       <div class="spectrum-Textfield is-valid is-disabled">
       <label for="textfield-valid-disabled" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-      <div class="spectrum-Textfield-input-wrapper">
-        <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
-          <use xlink:href="#spectrum-css-icon-Checkmark100" />
-        </svg>
-          <input id="textfield-valid-disabled" type="text" placeholder="Lisa Wilson" name="field" value="A valid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-14 character-count-14" required disabled>
-        </div>
+      <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
+        <use xlink:href="#spectrum-css-icon-Checkmark100" />
+      </svg>
+        <input id="textfield-valid-disabled" type="text" placeholder="Lisa Wilson" name="field" value="A valid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-14 character-count-14" required disabled>
       </div>
 
   - id: textfield
@@ -247,12 +219,10 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--sizeS is-invalid">
         <label for="textfield-sm-invalid" class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">Password</label>
-        <div class="spectrum-Textfield-input-wrapper">
-          <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-icon-18-Alert" />
-          </svg>
-          <input id="textfield-sm-invalid" type="text" placeholder="Enter Password" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-15 character-count-15" required>
-        </div>
+        <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
+          <use xlink:href="#spectrum-icon-18-Alert" />
+        </svg>
+        <input id="textfield-sm-invalid" type="text" placeholder="Enter Password" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-15 character-count-15" required>
         <div class="spectrum-HelpText spectrum-HelpText--sizeS spectrum-HelpText--negative">
           <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
@@ -260,12 +230,10 @@ examples:
 
       <div class="spectrum-Textfield spectrum-Textfield--sizeM is-invalid">
         <label for="textfield-md-invalid" class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">Password</label>
-        <div class="spectrum-Textfield-input-wrapper">
-          <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-icon-18-Alert" />
-          </svg>
-          <input id="textfield-md-invalid" type="text" placeholder="Enter Password" name="field" value="Invalid input" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-16 character-count-16" required>
-        </div>
+        <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
+          <use xlink:href="#spectrum-icon-18-Alert" />
+        </svg>
+        <input id="textfield-md-invalid" type="text" placeholder="Enter Password" name="field" value="Invalid input" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-16 character-count-16" required>
         <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--negative">
           <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
@@ -273,12 +241,10 @@ examples:
 
       <div class="spectrum-Textfield spectrum-Textfield--sizeL is-invalid">
         <label for="textfield-l-invalid" class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">Password</label>
-        <div class="spectrum-Textfield-input-wrapper">
-          <svg class="spectrum-Icon spectrum-Icon--sizeL spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-icon-18-Alert" />
-          </svg>
-          <input id="textfield-l-invalid" type="text" placeholder="Enter Password" name="field" value="Invalid input" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-17 character-count-17" required>
-        </div>
+        <svg class="spectrum-Icon spectrum-Icon--sizeL spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
+          <use xlink:href="#spectrum-icon-18-Alert" />
+        </svg>
+        <input id="textfield-l-invalid" type="text" placeholder="Enter Password" name="field" value="Invalid input" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-17 character-count-17" required>
         <div class="spectrum-HelpText spectrum-HelpText--sizeL spectrum-HelpText--negative">
           <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
@@ -286,12 +252,10 @@ examples:
 
       <div class="spectrum-Textfield spectrum-Textfield--sizeXL is-invalid">
         <label for="textfield-xl-invalid" class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">Password</label>
-        <div class="spectrum-Textfield-input-wrapper">
-          <svg class="spectrum-Icon spectrum-Icon--sizeXL spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-icon-18-Alert" />
-          </svg>
-          <input id="textfield-xl-invalid" type="text" placeholder="Enter Password" name="field" value="Invalid input" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-18 character-count-18" required>
-        </div>
+        <svg class="spectrum-Icon spectrum-Icon--sizeXL spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
+          <use xlink:href="#spectrum-icon-18-Alert" />
+        </svg>
+        <input id="textfield-xl-invalid" type="text" placeholder="Enter Password" name="field" value="Invalid input" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-18 character-count-18" required>
         <div class="spectrum-HelpText spectrum-HelpText--sizeXL spectrum-HelpText--negative">
           <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
@@ -301,13 +265,11 @@ examples:
     name: Invalid (disabled)
     markup: |
       <div class="spectrum-Textfield is-invalid is-disabled">
-      <label for="textfield-invalid-disabled" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <div class="spectrum-Textfield-input-wrapper">
-          <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-icon-18-Alert" />
-          </svg>
-          <input id="textfield-invalid-disabled" type="text" placeholder="Lisa Wilson" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-19 character-count-19" disabled>
-        </div>
+        <label for="textfield-invalid-disabled" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
+        <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
+          <use xlink:href="#spectrum-icon-18-Alert" />
+        </svg>
+        <input id="textfield-invalid-disabled" type="text" placeholder="Lisa Wilson" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-19 character-count-19" disabled>
       </div>
 
   - id: textfield
@@ -315,9 +277,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield is-focused">
         <label for="textfield-focused" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <div class="spectrum-Textfield-input-wrapper">
-          <input id="textfield-focused" type="text" placeholder="Lisa Wilson" name="field" value="" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-20 character-count-20">
-        </div>
+        <input id="textfield-focused" type="text" placeholder="Lisa Wilson" name="field" value="" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-20 character-count-20">
       </div>
 
   - id: textfield
@@ -325,9 +285,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield is-keyboardFocused">
         <label for="textfield-keyboard-focused" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <div class="spectrum-Textfield-input-wrapper">
-          <input id="textfield-keyboard-focused" type="text" placeholder="Lisa Wilson" name="field" value="" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-21 character-count-21">
-        </div>
+        <input id="textfield-keyboard-focused" type="text" placeholder="Lisa Wilson" name="field" value="" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-21 character-count-21">
       </div>
 
   - id: textfield
@@ -337,12 +295,10 @@ examples:
     markup: |
       <div class="spectrum-Textfield is-invalid is-focused">
         <label for="textfield-focused-invalid" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <div class="spectrum-Textfield-input-wrapper">
-          <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-icon-18-Alert" />
-          </svg>
-          <input id="textfield-focused-invalid" type="text" placeholder="Lisa Wilson" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-22 character-count-22" required>
-      </div>
+        <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
+          <use xlink:href="#spectrum-icon-18-Alert" />
+        </svg>
+        <input id="textfield-focused-invalid" type="text" placeholder="Lisa Wilson" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-22 character-count-22" required>
       </div>
 
   - id: textfield
@@ -352,12 +308,10 @@ examples:
     markup: |
       <div class="spectrum-Textfield is-invalid is-keyboardFocused">
         <label for="textfield-keyboard-focused-invalid" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <div class="spectrum-Textfield-input-wrapper">
-          <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-icon-18-Alert" />
-          </svg>
-          <input id="textfield-keyboard-focused-invalid" type="text" placeholder="Lisa Wilson" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-23 character-count-23" required>
-        </div>
+        <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
+          <use xlink:href="#spectrum-icon-18-Alert" />
+        </svg>
+        <input id="textfield-keyboard-focused-invalid" type="text" placeholder="Lisa Wilson" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-23 character-count-23" required>
       </div>
 
   - id: textfield-quiet
@@ -365,9 +319,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--quiet">
         <label for="textfield-quiet" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <div class="spectrum-Textfield-input-wrapper">
-          <input id="textfield-quiet" type="text" placeholder="Lisa Wilson" name="field" value="" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-24 character-count-24">
-        </div>
+        <input id="textfield-quiet" type="text" placeholder="Lisa Wilson" name="field" value="" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-24 character-count-24">
       </div>
 
   - id: textfield-quiet
@@ -375,9 +327,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--quiet is-disabled">
         <label for="textfield-quiet-disabled" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <div class="spectrum-Textfield-input-wrapper">
-          <input id="textfield-quiet-disabled" type="text" placeholder="Lisa Wilson" name="field" value="" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-25 character-count-25" disabled>
-        </div>
+        <input id="textfield-quiet-disabled" type="text" placeholder="Lisa Wilson" name="field" value="" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-25 character-count-25" disabled>
       </div>
 
   - id: textfield-quiet
@@ -385,12 +335,10 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--quiet is-valid">
         <label for="textfield-quiet-valid" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <div class="spectrum-Textfield-input-wrapper">
-          <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Checkmark100" />
-          </svg>
-          <input id="textfield-quiet-valid" type="text" placeholder="Lisa Wilson" name="field" value="A valid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-26 character-count-26" required>
-        </div>
+        <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
+          <use xlink:href="#spectrum-css-icon-Checkmark100" />
+        </svg>
+        <input id="textfield-quiet-valid" type="text" placeholder="Lisa Wilson" name="field" value="A valid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-26 character-count-26" required>
       </div>
 
   - id: textfield-quiet
@@ -398,12 +346,10 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--quiet is-valid is-disabled">
         <label for="textfield-quiet-valid-disabled" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <div class="spectrum-Textfield-input-wrapper">
-          <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Checkmark100" />
-          </svg>
-          <input id="textfield-quiet-valid-disabled" type="text" placeholder="Lisa Wilson" name="field" value="A valid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-27 character-count-27" required disabled>
-        </div>
+        <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
+          <use xlink:href="#spectrum-css-icon-Checkmark100" />
+        </svg>
+        <input id="textfield-quiet-valid-disabled" type="text" placeholder="Lisa Wilson" name="field" value="A valid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-27 character-count-27" required disabled>
       </div>
 
   - id: textfield-quiet-invalid
@@ -413,12 +359,10 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--quiet is-invalid">
         <label for="textfield-quiet-invalid" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <div class="spectrum-Textfield-input-wrapper">
-          <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-icon-18-Alert" />
-          </svg>
-          <input id="textfield-quiet-invalid" type="text" placeholder="Lisa Wilson" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-28 character-count-28" required>
-        </div>
+        <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
+          <use xlink:href="#spectrum-icon-18-Alert" />
+        </svg>
+        <input id="textfield-quiet-invalid" type="text" placeholder="Lisa Wilson" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-28 character-count-28" required>
       </div>
 
   - id: textfield-quiet-invalid-disabled
@@ -428,12 +372,10 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--quiet is-invalid is-disabled">
         <label for="textfield-quiet-invalid-disabled" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <div class="spectrum-Textfield-input-wrapper">
-          <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-icon-18-Alert" />
-          </svg>
-          <input id="textfield-quiet-invalid-disabled" type="text" placeholder="Lisa Wilson" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-29 character-count-29" disabled>
-        </div>
+        <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
+          <use xlink:href="#spectrum-icon-18-Alert" />
+        </svg>
+        <input id="textfield-quiet-invalid-disabled" type="text" placeholder="Lisa Wilson" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-29 character-count-29" disabled>
       </div>
 
   - id: textfield-quiet-focused
@@ -441,9 +383,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--quiet is-focused">
         <label for="textfield-quiet-focused" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <div class="spectrum-Textfield-input-wrapper">
-          <input id="textfield-quiet-focused" type="text" placeholder="Lisa Wilson" name="field" value="" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-30 character-count-30">
-        </div>
+        <input id="textfield-quiet-focused" type="text" placeholder="Lisa Wilson" name="field" value="" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-30 character-count-30">
       </div>
 
   - id: textfield-quiet
@@ -451,9 +391,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--quiet is-keyboardFocused">
         <label for="textfield-quiet-keyboard-focused" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <div class="spectrum-Textfield-input-wrapper">
-          <input id="textfield-quiet-keyboard-focused" type="text" placeholder="Lisa Wilson" name="field" value="" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-31 character-count-31">
-        </div>
+        <input id="textfield-quiet-keyboard-focused" type="text" placeholder="Lisa Wilson" name="field" value="" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-31 character-count-31">
       </div>
 
   - id: textfield-focused-invalid
@@ -463,12 +401,10 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--quiet is-invalid is-focused">
         <label for="textfield-focused-invalid" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <div class="spectrum-Textfield-input-wrapper">
-          <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-icon-18-Alert" />
-          </svg>
-          <input id="textfield-focused-invalid" type="text" placeholder="Lisa Wilson" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-32 character-count-32" required>
-        </div>
+        <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
+          <use xlink:href="#spectrum-icon-18-Alert" />
+        </svg>
+        <input id="textfield-focused-invalid" type="text" placeholder="Lisa Wilson" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-32 character-count-32" required>
       </div>
 
   - id: textfield-keyboard-focused-invalid
@@ -478,10 +414,8 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--quiet is-invalid is-keyboardFocused">
         <label for="textfield-keyboard-focused-invalid" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <div class="spectrum-Textfield-input-wrapper">
-          <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-icon-18-Alert" />
-          </svg>
-          <input id="textfield-keyboard-focused-invalid" type="text" placeholder="Lisa Wilson" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-33 character-count-33" required>
-        </div>
+        <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
+          <use xlink:href="#spectrum-icon-18-Alert" />
+        </svg>
+        <input id="textfield-keyboard-focused-invalid" type="text" placeholder="Lisa Wilson" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-33 character-count-33" required>
       </div>

--- a/components/textfield/metadata/textfield.yml
+++ b/components/textfield/metadata/textfield.yml
@@ -23,7 +23,9 @@ sections:
 
       That is, the outer element `div.spectrum-Textfield` contains a `input.spectrum-Textfield-input`.
 
-      As of spectrum tokens migration, Textfield contains an additional nested div wrapping the input. The outer element `div.spectrum-Textfield` contains the child components (label, character count, and help text) as well as the additional `div.spectrum-Textfield-input-wrapper` which contains `input.spectrum-Textfield-input`. The additional nested div is necessary to ensure the focus indicator aligns with the input.
+      As of spectrum tokens migration, Textfield uses grid to align the label, character count, helptext, and focus indicator in both the default and sidelabel layouts.
+
+      Any application using Textarea Grows (Textarea input which automatically resizes vertically to accommodate content that is entered) will need to place the sizer element within the same grid area as the input and focus indicator.
 
       ### Icons
       Icons are now added as SVGs, with `svg.spectrum-Textfield-icon` for workflow icons, and `svg.spectrum-Textfield-validationIcon` for UI icons.

--- a/components/textfield/metadata/textfield.yml
+++ b/components/textfield/metadata/textfield.yml
@@ -85,20 +85,20 @@ examples:
     name: Standard Sizes
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--sizeS">
-        <label for="textfield-sm" class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">Password</label>
+        <label for="textfield-s" class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">Password</label>
         <span id="character-count-1" class="spectrum-Textfield-characterCount">50</span>
-        <input id="textfield-sm" type="text" name="field" value="" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-1 character-count-1">
+        <input id="textfield-s" type="text" name="field" value="" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-1 character-count-1">
         <div class="spectrum-HelpText spectrum-HelpText--sizeS spectrum-HelpText--neutral">
-          <div id="helptext-size-small" class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
+          <div id="helptext-1" class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
       </div>
 
       <div class="spectrum-Textfield spectrum-Textfield--sizeM">
-        <label for="textfield-md" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Password</label>
+        <label for="textfield-m" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Password</label>
         <span id="character-count-2" class="spectrum-Textfield-characterCount">50</span>
         <input id="textfield-m" type="text" name="field" value="" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-2 character-count-2">
         <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--neutral">
-          <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
+          <div id="helptext-2" class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
       </div>
 
@@ -107,7 +107,7 @@ examples:
         <span id="character-count-3" class="spectrum-Textfield-characterCount">50</span>
         <input id="textfield-l" type="text" name="field" value="" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-3 character-count-3">
         <div class="spectrum-HelpText spectrum-HelpText--sizeL spectrum-HelpText--neutral">
-          <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
+          <div id="helptext-3" class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
       </div>
 
@@ -116,7 +116,7 @@ examples:
         <span id="character-count-4" class="spectrum-Textfield-characterCount">50</span>
         <input id="textfield-xl" type="text" name="field" value="" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-4 character-count-4">
          <div class="spectrum-HelpText spectrum-HelpText--sizeXL spectrum-HelpText--neutral">
-          <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
+          <div id="helptext-4" class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
       </div>
 
@@ -125,9 +125,9 @@ examples:
     markup: |
       <div class="spectrum-Textfield">
         <label for="textfield-helptext" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Password</label>
-        <input id="textfield-helptext" type="text" name="field" value="" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-5 character-count-5">
+        <input id="textfield-helptext" type="text" name="field" value="" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-5">
         <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--neutral">
-          <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
+          <div id="helptext-5" class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
       </div>
 
@@ -137,18 +137,18 @@ examples:
       <div class="spectrum-Textfield">
         <label for="textfield-1" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
         <span id="character-count-6" class="spectrum-Textfield-characterCount">50</span>
-        <input id="textfield-1" type="text" name="field" value="Lisa Wilson" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-6 character-count-6">
+        <input id="textfield-1" type="text" name="field" value="Lisa Wilson" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="character-count-6">
       </div>
 
   - id: textfield-sidelabel
     name: Textfield with Side Label
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--sideLabel">
-        <label for="textfield-md-sidelabel" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Password</label>
+        <label for="textfield-sidelabel" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Password</label>
         <span id="character-count-7" class="spectrum-Textfield-characterCount">50</span>
-        <input id="textfield-md-sidelabel" type="text" name="field" value="" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-7 character-count-7">
+        <input id="textfield-sidelabel" type="text" name="field" value="" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-7 character-count-7">
         <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--neutral">
-          <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
+          <div id="helptext-7" class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
       </div>
 
@@ -157,7 +157,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield is-disabled">
         <label for="textfield-disabled" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <input id="textfield-disabled" type="text" name="field" value="" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-8 character-count-8" disabled>
+        <input id="textfield-disabled" type="text" name="field" value="" class="spectrum-Textfield-input" pattern="[\w\s]+" disabled>
       </div>
 
   - id: textfield-readonly
@@ -165,7 +165,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield is-readOnly">
       <label for="textfield-readonly" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <input id="textfield-readonly" type="text" name="field" value="This text is read-only" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-9 character-count-9" readonly="readonly" aria-describedby="helptext-7 character-count-7">
+        <input id="textfield-readonly" type="text" name="field" value="This text is read-only" class="spectrum-Textfield-input" pattern="[\w\s]+" readonly="readonly">
       </div>
 
   - id: textfield
@@ -174,11 +174,11 @@ examples:
       *Spectrum for Adobe Express uses a different icon. Use the `SX_Alert_18_N.svg` icon in the Express workflow icon set.*
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--sizeS is-valid">
-        <label for="textfield-sm-valid" class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">Enter your name</label>
+        <label for="textfield-s-valid" class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">Enter your name</label>
           <svg class="spectrum-Icon spectrum-UIIcon-Checkmark75 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
             <use xlink:href="#spectrum-css-icon-Checkmark75" />
           </svg>
-          <input id="textfield-sm-valid" type="text" name="field" value="A valid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-10 character-count-10" required>
+          <input id="textfield-s-valid" type="text" name="field" value="A valid input" class="spectrum-Textfield-input" pattern="[\w\s]+" required>
       </div>
 
       <div class="spectrum-Textfield spectrum-Textfield--sizeM is-valid">
@@ -186,7 +186,7 @@ examples:
         <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-css-icon-Checkmark100" />
         </svg>
-        <input id="textfield-m-valid" type="text" name="field" value="A valid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-11 character-count-11" required>
+        <input id="textfield-m-valid" type="text" name="field" value="A valid input" class="spectrum-Textfield-input" pattern="[\w\s]+" required>
         </div>
 
       <div class="spectrum-Textfield spectrum-Textfield--sizeL is-valid">
@@ -194,7 +194,7 @@ examples:
         <svg class="spectrum-Icon spectrum-UIIcon-Checkmark200 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-css-icon-Checkmark200" />
         </svg>
-        <input id="textfield-l-valid" type="text" name="field" value="A valid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-12 character-count-12" required>
+        <input id="textfield-l-valid" type="text" name="field" value="A valid input" class="spectrum-Textfield-input" pattern="[\w\s]+" required>
       </div>
 
       <div class="spectrum-Textfield spectrum-Textfield--sizeXL is-valid">
@@ -202,18 +202,18 @@ examples:
         <svg class="spectrum-Icon spectrum-UIIcon-Checkmark300 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-css-icon-Checkmark300" />
         </svg>
-        <input id="textfield-xl-valid" type="text" name="field" value="A valid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-13 character-count-13" required>
+        <input id="textfield-xl-valid" type="text" name="field" value="A valid input" class="spectrum-Textfield-input" pattern="[\w\s]+" required>
       </div>
 
   - id: textfield
     name: Valid (disabled)
     markup: |
       <div class="spectrum-Textfield is-valid is-disabled">
-      <label for="textfield-valid-disabled" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-      <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
-        <use xlink:href="#spectrum-css-icon-Checkmark100" />
-      </svg>
-        <input id="textfield-valid-disabled" type="text" name="field" value="A valid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-14 character-count-14" required disabled>
+        <label for="textfield-valid-disabled" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
+        <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
+          <use xlink:href="#spectrum-css-icon-Checkmark100" />
+        </svg>
+        <input id="textfield-valid-disabled" type="text" name="field" value="A valid input" class="spectrum-Textfield-input" pattern="[\w\s]+" required disabled>
       </div>
 
   - id: textfield
@@ -222,24 +222,24 @@ examples:
       *Spectrum for Adobe Express uses a different icon. Use the `SX_Alert_18_N.svg` icon in the Express workflow icon set.*
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--sizeS is-invalid">
-        <label for="textfield-sm-invalid" class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">Password</label>
+        <label for="textfield-s-invalid" class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">Password</label>
         <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>
-        <input id="textfield-sm-invalid" type="text" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-15 character-count-15" required>
+        <input id="textfield-s-invalid" type="text" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-15" required>
         <div class="spectrum-HelpText spectrum-HelpText--sizeS spectrum-HelpText--negative">
-          <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
+          <div id="helptext-15" class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
       </div>
 
       <div class="spectrum-Textfield spectrum-Textfield--sizeM is-invalid">
-        <label for="textfield-md-invalid" class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">Password</label>
+        <label for="textfield-m-invalid" class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">Password</label>
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>
-        <input id="textfield-md-invalid" type="text" name="field" value="Invalid input" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-16 character-count-16" required>
+        <input id="textfield-m-invalid" type="text" name="field" value="Invalid input" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-16" required>
         <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--negative">
-          <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
+          <div id="helptext-16" class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
       </div>
 
@@ -248,9 +248,9 @@ examples:
         <svg class="spectrum-Icon spectrum-Icon--sizeL spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>
-        <input id="textfield-l-invalid" type="text" name="field" value="Invalid input" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-17 character-count-17" required>
+        <input id="textfield-l-invalid" type="text" name="field" value="Invalid input" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-17" required>
         <div class="spectrum-HelpText spectrum-HelpText--sizeL spectrum-HelpText--negative">
-          <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
+          <div id="helptext-17" class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
       </div>
 
@@ -259,9 +259,9 @@ examples:
         <svg class="spectrum-Icon spectrum-Icon--sizeXL spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>
-        <input id="textfield-xl-invalid" type="text" name="field" value="Invalid input" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-18 character-count-18" required>
+        <input id="textfield-xl-invalid" type="text" name="field" value="Invalid input" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-18" required>
         <div class="spectrum-HelpText spectrum-HelpText--sizeXL spectrum-HelpText--negative">
-          <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
+          <div id="helptext-18" class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
       </div>
 
@@ -273,7 +273,7 @@ examples:
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>
-        <input id="textfield-invalid-disabled" type="text" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-19 character-count-19" disabled>
+        <input id="textfield-invalid-disabled" type="text" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern="[\w\s]+" disabled>
       </div>
 
   - id: textfield
@@ -281,7 +281,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield is-focused">
         <label for="textfield-focused" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <input id="textfield-focused" type="text" name="field" value="" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-20 character-count-20">
+        <input id="textfield-focused" type="text" name="field" value="" class="spectrum-Textfield-input">
       </div>
 
   - id: textfield
@@ -289,7 +289,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield is-keyboardFocused">
         <label for="textfield-keyboard-focused" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <input id="textfield-keyboard-focused" type="text" name="field" value="" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-21 character-count-21">
+        <input id="textfield-keyboard-focused" type="text" name="field" value="" class="spectrum-Textfield-input">
       </div>
 
   - id: textfield
@@ -302,7 +302,7 @@ examples:
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>
-        <input id="textfield-focused-invalid" type="text" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-22 character-count-22" required>
+        <input id="textfield-focused-invalid" type="text" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern="[\w\s]+" required>
       </div>
 
   - id: textfield
@@ -315,7 +315,7 @@ examples:
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>
-        <input id="textfield-keyboard-focused-invalid" type="text" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-23 character-count-23" required>
+        <input id="textfield-keyboard-focused-invalid" type="text" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern="[\w\s]+" required>
       </div>
 
   - id: textfield-quiet
@@ -323,7 +323,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--quiet">
         <label for="textfield-quiet" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <input id="textfield-quiet" type="text" name="field" value="" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-24 character-count-24">
+        <input id="textfield-quiet" type="text" name="field" value="" class="spectrum-Textfield-input">
       </div>
 
   - id: textfield-quiet
@@ -331,7 +331,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--quiet is-disabled">
         <label for="textfield-quiet-disabled" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <input id="textfield-quiet-disabled" type="text" name="field" value="" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-25 character-count-25" disabled>
+        <input id="textfield-quiet-disabled" type="text" name="field" value="" class="spectrum-Textfield-input" disabled>
       </div>
 
   - id: textfield-quiet
@@ -342,7 +342,7 @@ examples:
         <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-css-icon-Checkmark100" />
         </svg>
-        <input id="textfield-quiet-valid" type="text" name="field" value="A valid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-26 character-count-26" required>
+        <input id="textfield-quiet-valid" type="text" name="field" value="A valid input" class="spectrum-Textfield-input" required>
       </div>
 
   - id: textfield-quiet
@@ -353,7 +353,7 @@ examples:
         <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-css-icon-Checkmark100" />
         </svg>
-        <input id="textfield-quiet-valid-disabled" type="text" name="field" value="A valid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-27 character-count-27" required disabled>
+        <input id="textfield-quiet-valid-disabled" type="text" name="field" value="A valid input" class="spectrum-Textfield-input" required disabled>
       </div>
 
   - id: textfield-quiet-invalid
@@ -366,7 +366,7 @@ examples:
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>
-        <input id="textfield-quiet-invalid" type="text" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-28 character-count-28" required>
+        <input id="textfield-quiet-invalid" type="text" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern="[\w\s]+" required>
       </div>
 
   - id: textfield-quiet-invalid-disabled
@@ -379,7 +379,7 @@ examples:
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>
-        <input id="textfield-quiet-invalid-disabled" type="text" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-29 character-count-29" disabled>
+        <input id="textfield-quiet-invalid-disabled" type="text" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern="[\w\s]+" disabled>
       </div>
 
   - id: textfield-quiet-focused
@@ -387,7 +387,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--quiet is-focused">
         <label for="textfield-quiet-focused" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <input id="textfield-quiet-focused" type="text" name="field" value="" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-30 character-count-30">
+        <input id="textfield-quiet-focused" type="text" name="field" value="" class="spectrum-Textfield-input">
       </div>
 
   - id: textfield-quiet
@@ -395,7 +395,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--quiet is-keyboardFocused">
         <label for="textfield-quiet-keyboard-focused" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <input id="textfield-quiet-keyboard-focused" type="text" name="field" value="" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-31 character-count-31">
+        <input id="textfield-quiet-keyboard-focused" type="text" name="field" value="" class="spectrum-Textfield-input">
       </div>
 
   - id: textfield-focused-invalid
@@ -408,7 +408,7 @@ examples:
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>
-        <input id="textfield-focused-invalid" type="text" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-32 character-count-32" required>
+        <input id="textfield-focused-invalid" type="text" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern="[\w\s]+" required>
       </div>
 
   - id: textfield-keyboard-focused-invalid
@@ -421,5 +421,5 @@ examples:
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>
-        <input id="textfield-keyboard-focused-invalid" type="text" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-33 character-count-33" required>
+        <input id="textfield-keyboard-focused-invalid" type="text" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern="[\w\s]+" required>
       </div>

--- a/components/textfield/metadata/textfield.yml
+++ b/components/textfield/metadata/textfield.yml
@@ -86,7 +86,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--sizeS">
         <label for="textfield-sm" class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">Password</label>
-        <span id="character-count-1" class="spectrum-Textfield-character-count">50</span>
+        <span id="character-count-1" class="spectrum-Textfield-characterCount">50</span>
         <input id="textfield-sm" type="text" name="field" value="" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-1 character-count-1">
         <div class="spectrum-HelpText spectrum-HelpText--sizeS spectrum-HelpText--neutral">
           <div id="helptext-size-small" class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
@@ -95,7 +95,7 @@ examples:
 
       <div class="spectrum-Textfield spectrum-Textfield--sizeM">
         <label for="textfield-md" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Password</label>
-        <span id="character-count-2" class="spectrum-Textfield-character-count">50</span>
+        <span id="character-count-2" class="spectrum-Textfield-characterCount">50</span>
         <input id="textfield-m" type="text" name="field" value="" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-2 character-count-2">
         <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--neutral">
           <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
@@ -104,7 +104,7 @@ examples:
 
       <div class="spectrum-Textfield spectrum-Textfield--sizeL">
         <label for="textfield-l" class="spectrum-FieldLabel spectrum-FieldLabel--sizeL">Password</label>
-        <span id="character-count-3" class="spectrum-Textfield-character-count">50</span>
+        <span id="character-count-3" class="spectrum-Textfield-characterCount">50</span>
         <input id="textfield-l" type="text" name="field" value="" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-3 character-count-3">
         <div class="spectrum-HelpText spectrum-HelpText--sizeL spectrum-HelpText--neutral">
           <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
@@ -113,7 +113,7 @@ examples:
 
       <div class="spectrum-Textfield spectrum-Textfield--sizeXL">
         <label for="textfield-xl" class="spectrum-FieldLabel spectrum-FieldLabel--sizeXL">Password</label>
-        <span id="character-count-4" class="spectrum-Textfield-character-count">50</span>
+        <span id="character-count-4" class="spectrum-Textfield-characterCount">50</span>
         <input id="textfield-xl" type="text" name="field" value="" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-4 character-count-4">
          <div class="spectrum-HelpText spectrum-HelpText--sizeXL spectrum-HelpText--neutral">
           <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
@@ -136,16 +136,16 @@ examples:
     markup: |
       <div class="spectrum-Textfield">
         <label for="textfield-1" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <span id="character-count-6" class="spectrum-Textfield-character-count">50</span>
+        <span id="character-count-6" class="spectrum-Textfield-characterCount">50</span>
         <input id="textfield-1" type="text" name="field" value="Lisa Wilson" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-6 character-count-6">
       </div>
 
   - id: textfield-sidelabel
     name: Textfield with Side Label
     markup: |
-      <div class="spectrum-Textfield spectrum-Textfield--sidelabel">
+      <div class="spectrum-Textfield spectrum-Textfield--sideLabel">
         <label for="textfield-md-sidelabel" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Password</label>
-        <span id="character-count-7" class="spectrum-Textfield-character-count">50</span>
+        <span id="character-count-7" class="spectrum-Textfield-characterCount">50</span>
         <input id="textfield-md-sidelabel" type="text" name="field" value="" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-7 character-count-7">
         <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--neutral">
           <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>

--- a/components/textfield/metadata/textfield.yml
+++ b/components/textfield/metadata/textfield.yml
@@ -70,8 +70,10 @@ sections:
       Extra Large
       `spectrum-Icon spectrum-Icon--sizeXL spectrum-Textfield-validationIcon`
 
-      ### Removal of `:valid` and `:invalid`
+      ### Removal of `:valid`, `:invalid`, and `::placeholder`
       Textfield no longer supports the CSS pseudo selectors [`:invalid`](https://developer.mozilla.org/en-US/docs/Web/CSS/:invalid) and [`:value`](https://developer.mozilla.org/en-US/docs/Web/CSS/:valid).
+
+      The CSS pseudo-element [`::placeholder`](https://developer.mozilla.org/en-US/docs/Web/CSS/::placeholder) has been deprecated due to accessibility. The styling remains for backwards compatibility but it is advised to stop utilizing placeholders moving forward.
 
       Using these selectors is an anti-pattern that complicates form validation techniques by making inputs appear invalid immediately, not after use interaction. Please apply `.is-valid` and `.is-invalid` to the outer `div.spectrum-Textfield` element instead.
 
@@ -85,7 +87,7 @@ examples:
       <div class="spectrum-Textfield spectrum-Textfield--sizeS">
         <label for="textfield-sm" class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">Password</label>
         <span id="character-count-1" class="spectrum-Textfield-character-count">50</span>
-        <input id="textfield-sm" type="text" placeholder="Enter Password" name="field" value="" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-1 character-count-1">
+        <input id="textfield-sm" type="text" name="field" value="" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-1 character-count-1">
         <div class="spectrum-HelpText spectrum-HelpText--sizeS spectrum-HelpText--neutral">
           <div id="helptext-size-small" class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
@@ -94,7 +96,7 @@ examples:
       <div class="spectrum-Textfield spectrum-Textfield--sizeM">
         <label for="textfield-md" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Password</label>
         <span id="character-count-2" class="spectrum-Textfield-character-count">50</span>
-        <input id="textfield-m" type="text" placeholder="Enter Password" name="field" value="" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-2 character-count-2">
+        <input id="textfield-m" type="text" name="field" value="" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-2 character-count-2">
         <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--neutral">
           <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
@@ -103,7 +105,7 @@ examples:
       <div class="spectrum-Textfield spectrum-Textfield--sizeL">
         <label for="textfield-l" class="spectrum-FieldLabel spectrum-FieldLabel--sizeL">Password</label>
         <span id="character-count-3" class="spectrum-Textfield-character-count">50</span>
-        <input id="textfield-l" type="text" placeholder="Enter Password" name="field" value="" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-3 character-count-3">
+        <input id="textfield-l" type="text" name="field" value="" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-3 character-count-3">
         <div class="spectrum-HelpText spectrum-HelpText--sizeL spectrum-HelpText--neutral">
           <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
@@ -112,7 +114,7 @@ examples:
       <div class="spectrum-Textfield spectrum-Textfield--sizeXL">
         <label for="textfield-xl" class="spectrum-FieldLabel spectrum-FieldLabel--sizeXL">Password</label>
         <span id="character-count-4" class="spectrum-Textfield-character-count">50</span>
-        <input id="textfield-xl" type="text" placeholder="Enter Password" name="field" value="" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-4 character-count-4">
+        <input id="textfield-xl" type="text" name="field" value="" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-4 character-count-4">
          <div class="spectrum-HelpText spectrum-HelpText--sizeXL spectrum-HelpText--neutral">
           <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
@@ -123,7 +125,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield">
         <label for="textfield-helptext" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Password</label>
-        <input id="textfield-helptext" type="text" placeholder="Enter Password" name="field" value="" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-5 character-count-5">
+        <input id="textfield-helptext" type="text" name="field" value="" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-5 character-count-5">
         <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--neutral">
           <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
@@ -135,7 +137,7 @@ examples:
       <div class="spectrum-Textfield">
         <label for="textfield-1" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
         <span id="character-count-6" class="spectrum-Textfield-character-count">50</span>
-        <input id="textfield-1" type="text" placeholder="Lisa Wilson" name="field" value="" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-6 character-count-6">
+        <input id="textfield-1" type="text" name="field" value="Lisa Wilson" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-6 character-count-6">
       </div>
 
   - id: textfield-sidelabel
@@ -144,7 +146,7 @@ examples:
       <div class="spectrum-Textfield spectrum-Textfield--sidelabel">
         <label for="textfield-md-sidelabel" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Password</label>
         <span id="character-count-7" class="spectrum-Textfield-character-count">50</span>
-        <input id="textfield-md-sidelabel" type="text" placeholder="Enter Password" name="field" value="" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-7 character-count-7">
+        <input id="textfield-md-sidelabel" type="text" name="field" value="" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-7 character-count-7">
         <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--neutral">
           <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
@@ -155,7 +157,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield is-disabled">
         <label for="textfield-disabled" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <input id="textfield-disabled" type="text"  placeholder="Lisa Wilson" name="field" value="" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-8 character-count-8" disabled>
+        <input id="textfield-disabled" type="text" name="field" value="" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-8 character-count-8" disabled>
       </div>
 
   - id: textfield-readonly
@@ -163,7 +165,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield is-readOnly">
       <label for="textfield-readonly" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <input id="textfield-readonly" type="text"  placeholder="Lisa Wilson" name="field" value="This text is read-only" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-9 character-count-9" readonly="readonly" aria-describedby="helptext-7 character-count-7">
+        <input id="textfield-readonly" type="text" name="field" value="This text is read-only" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-9 character-count-9" readonly="readonly" aria-describedby="helptext-7 character-count-7">
       </div>
 
   - id: textfield
@@ -176,7 +178,7 @@ examples:
           <svg class="spectrum-Icon spectrum-UIIcon-Checkmark75 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
             <use xlink:href="#spectrum-css-icon-Checkmark75" />
           </svg>
-          <input id="textfield-sm-valid" type="text" placeholder="Lisa Wilson" name="field" value="A valid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-10 character-count-10" required>
+          <input id="textfield-sm-valid" type="text" name="field" value="A valid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-10 character-count-10" required>
       </div>
 
       <div class="spectrum-Textfield spectrum-Textfield--sizeM is-valid">
@@ -184,7 +186,7 @@ examples:
         <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-css-icon-Checkmark100" />
         </svg>
-        <input id="textfield-m-valid" type="text" placeholder="Lisa Wilson" name="field" value="A valid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-11 character-count-11" required>
+        <input id="textfield-m-valid" type="text" name="field" value="A valid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-11 character-count-11" required>
         </div>
 
       <div class="spectrum-Textfield spectrum-Textfield--sizeL is-valid">
@@ -192,7 +194,7 @@ examples:
         <svg class="spectrum-Icon spectrum-UIIcon-Checkmark200 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-css-icon-Checkmark200" />
         </svg>
-        <input id="textfield-l-valid" type="text" placeholder="Lisa Wilson" name="field" value="A valid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-12 character-count-12" required>
+        <input id="textfield-l-valid" type="text" name="field" value="A valid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-12 character-count-12" required>
       </div>
 
       <div class="spectrum-Textfield spectrum-Textfield--sizeXL is-valid">
@@ -200,7 +202,7 @@ examples:
         <svg class="spectrum-Icon spectrum-UIIcon-Checkmark300 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-css-icon-Checkmark300" />
         </svg>
-        <input id="textfield-xl-valid" type="text" placeholder="Lisa Wilson" name="field" value="A valid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-13 character-count-13" required>
+        <input id="textfield-xl-valid" type="text" name="field" value="A valid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-13 character-count-13" required>
       </div>
 
   - id: textfield
@@ -211,7 +213,7 @@ examples:
       <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
         <use xlink:href="#spectrum-css-icon-Checkmark100" />
       </svg>
-        <input id="textfield-valid-disabled" type="text" placeholder="Lisa Wilson" name="field" value="A valid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-14 character-count-14" required disabled>
+        <input id="textfield-valid-disabled" type="text" name="field" value="A valid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-14 character-count-14" required disabled>
       </div>
 
   - id: textfield
@@ -224,7 +226,7 @@ examples:
         <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>
-        <input id="textfield-sm-invalid" type="text" placeholder="Enter Password" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-15 character-count-15" required>
+        <input id="textfield-sm-invalid" type="text" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-15 character-count-15" required>
         <div class="spectrum-HelpText spectrum-HelpText--sizeS spectrum-HelpText--negative">
           <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
@@ -235,7 +237,7 @@ examples:
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>
-        <input id="textfield-md-invalid" type="text" placeholder="Enter Password" name="field" value="Invalid input" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-16 character-count-16" required>
+        <input id="textfield-md-invalid" type="text" name="field" value="Invalid input" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-16 character-count-16" required>
         <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--negative">
           <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
@@ -246,7 +248,7 @@ examples:
         <svg class="spectrum-Icon spectrum-Icon--sizeL spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>
-        <input id="textfield-l-invalid" type="text" placeholder="Enter Password" name="field" value="Invalid input" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-17 character-count-17" required>
+        <input id="textfield-l-invalid" type="text" name="field" value="Invalid input" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-17 character-count-17" required>
         <div class="spectrum-HelpText spectrum-HelpText--sizeL spectrum-HelpText--negative">
           <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
@@ -257,7 +259,7 @@ examples:
         <svg class="spectrum-Icon spectrum-Icon--sizeXL spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>
-        <input id="textfield-xl-invalid" type="text" placeholder="Enter Password" name="field" value="Invalid input" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-18 character-count-18" required>
+        <input id="textfield-xl-invalid" type="text" name="field" value="Invalid input" class="spectrum-Textfield-input"  pattern=".{8,}" aria-describedby="helptext-18 character-count-18" required>
         <div class="spectrum-HelpText spectrum-HelpText--sizeXL spectrum-HelpText--negative">
           <div class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
         </div>
@@ -271,7 +273,7 @@ examples:
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>
-        <input id="textfield-invalid-disabled" type="text" placeholder="Lisa Wilson" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-19 character-count-19" disabled>
+        <input id="textfield-invalid-disabled" type="text" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-19 character-count-19" disabled>
       </div>
 
   - id: textfield
@@ -279,7 +281,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield is-focused">
         <label for="textfield-focused" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <input id="textfield-focused" type="text" placeholder="Lisa Wilson" name="field" value="" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-20 character-count-20">
+        <input id="textfield-focused" type="text" name="field" value="" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-20 character-count-20">
       </div>
 
   - id: textfield
@@ -287,7 +289,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield is-keyboardFocused">
         <label for="textfield-keyboard-focused" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <input id="textfield-keyboard-focused" type="text" placeholder="Lisa Wilson" name="field" value="" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-21 character-count-21">
+        <input id="textfield-keyboard-focused" type="text" name="field" value="" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-21 character-count-21">
       </div>
 
   - id: textfield
@@ -300,7 +302,7 @@ examples:
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>
-        <input id="textfield-focused-invalid" type="text" placeholder="Lisa Wilson" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-22 character-count-22" required>
+        <input id="textfield-focused-invalid" type="text" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-22 character-count-22" required>
       </div>
 
   - id: textfield
@@ -313,7 +315,7 @@ examples:
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>
-        <input id="textfield-keyboard-focused-invalid" type="text" placeholder="Lisa Wilson" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-23 character-count-23" required>
+        <input id="textfield-keyboard-focused-invalid" type="text" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-23 character-count-23" required>
       </div>
 
   - id: textfield-quiet
@@ -321,7 +323,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--quiet">
         <label for="textfield-quiet" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <input id="textfield-quiet" type="text" placeholder="Lisa Wilson" name="field" value="" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-24 character-count-24">
+        <input id="textfield-quiet" type="text" name="field" value="" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-24 character-count-24">
       </div>
 
   - id: textfield-quiet
@@ -329,7 +331,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--quiet is-disabled">
         <label for="textfield-quiet-disabled" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <input id="textfield-quiet-disabled" type="text" placeholder="Lisa Wilson" name="field" value="" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-25 character-count-25" disabled>
+        <input id="textfield-quiet-disabled" type="text" name="field" value="" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-25 character-count-25" disabled>
       </div>
 
   - id: textfield-quiet
@@ -340,7 +342,7 @@ examples:
         <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-css-icon-Checkmark100" />
         </svg>
-        <input id="textfield-quiet-valid" type="text" placeholder="Lisa Wilson" name="field" value="A valid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-26 character-count-26" required>
+        <input id="textfield-quiet-valid" type="text" name="field" value="A valid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-26 character-count-26" required>
       </div>
 
   - id: textfield-quiet
@@ -351,7 +353,7 @@ examples:
         <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-css-icon-Checkmark100" />
         </svg>
-        <input id="textfield-quiet-valid-disabled" type="text" placeholder="Lisa Wilson" name="field" value="A valid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-27 character-count-27" required disabled>
+        <input id="textfield-quiet-valid-disabled" type="text" name="field" value="A valid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-27 character-count-27" required disabled>
       </div>
 
   - id: textfield-quiet-invalid
@@ -364,7 +366,7 @@ examples:
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>
-        <input id="textfield-quiet-invalid" type="text" placeholder="Lisa Wilson" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-28 character-count-28" required>
+        <input id="textfield-quiet-invalid" type="text" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-28 character-count-28" required>
       </div>
 
   - id: textfield-quiet-invalid-disabled
@@ -377,7 +379,7 @@ examples:
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>
-        <input id="textfield-quiet-invalid-disabled" type="text" placeholder="Lisa Wilson" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-29 character-count-29" disabled>
+        <input id="textfield-quiet-invalid-disabled" type="text" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-29 character-count-29" disabled>
       </div>
 
   - id: textfield-quiet-focused
@@ -385,7 +387,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--quiet is-focused">
         <label for="textfield-quiet-focused" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <input id="textfield-quiet-focused" type="text" placeholder="Lisa Wilson" name="field" value="" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-30 character-count-30">
+        <input id="textfield-quiet-focused" type="text" name="field" value="" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-30 character-count-30">
       </div>
 
   - id: textfield-quiet
@@ -393,7 +395,7 @@ examples:
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--quiet is-keyboardFocused">
         <label for="textfield-quiet-keyboard-focused" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <input id="textfield-quiet-keyboard-focused" type="text" placeholder="Lisa Wilson" name="field" value="" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-31 character-count-31">
+        <input id="textfield-quiet-keyboard-focused" type="text" name="field" value="" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-31 character-count-31">
       </div>
 
   - id: textfield-focused-invalid
@@ -406,7 +408,7 @@ examples:
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>
-        <input id="textfield-focused-invalid" type="text" placeholder="Lisa Wilson" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-32 character-count-32" required>
+        <input id="textfield-focused-invalid" type="text" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-32 character-count-32" required>
       </div>
 
   - id: textfield-keyboard-focused-invalid
@@ -419,5 +421,5 @@ examples:
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>
-        <input id="textfield-keyboard-focused-invalid" type="text" placeholder="Lisa Wilson" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-33 character-count-33" required>
+        <input id="textfield-keyboard-focused-invalid" type="text" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern="[\w\s]+" aria-describedby="helptext-33 character-count-33" required>
       </div>

--- a/components/textfield/package.json
+++ b/components/textfield/package.json
@@ -18,12 +18,12 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/tokens": "^6.2.0"
+    "@spectrum-css/tokens": "^7.0.0"
   },
   "devDependencies": {
     "@spectrum-css/component-builder-simple": "^2.0.0",
     "@spectrum-css/helptext": "^3.0.0",
-    "@spectrum-css/tokens": "^6.2.0",
+    "@spectrum-css/tokens": "^7.0.0",
     "gulp": "^4.0.0"
   },
   "publishConfig": {

--- a/components/textfield/package.json
+++ b/components/textfield/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spectrum-css/textfield",
-  "version": "4.0.0-beta.3",
+  "version": "4.0.0-beta.4",
   "description": "The Spectrum CSS textfield component",
   "license": "Apache-2.0",
   "author": "Adobe",

--- a/components/textfield/package.json
+++ b/components/textfield/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spectrum-css/textfield",
-  "version": "3.2.16",
+  "version": "4.0.0-beta.0",
   "description": "The Spectrum CSS textfield component",
   "license": "Apache-2.0",
   "author": "Adobe",

--- a/components/textfield/package.json
+++ b/components/textfield/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spectrum-css/textfield",
-  "version": "4.0.0-beta.6",
+  "version": "4.0.0-beta.7",
   "description": "The Spectrum CSS textfield component",
   "license": "Apache-2.0",
   "author": "Adobe",

--- a/components/textfield/package.json
+++ b/components/textfield/package.json
@@ -18,7 +18,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/tokens": "^4.0.0"
+    "@spectrum-css/tokens": "^6.0.0"
   },
   "devDependencies": {
     "@spectrum-css/component-builder-simple": "^2.0.0",

--- a/components/textfield/package.json
+++ b/components/textfield/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spectrum-css/textfield",
-  "version": "4.0.0-beta.2",
+  "version": "4.0.0-beta.3",
   "description": "The Spectrum CSS textfield component",
   "license": "Apache-2.0",
   "author": "Adobe",

--- a/components/textfield/package.json
+++ b/components/textfield/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spectrum-css/textfield",
-  "version": "4.0.0-beta.4",
+  "version": "4.0.0-beta.5",
   "description": "The Spectrum CSS textfield component",
   "license": "Apache-2.0",
   "author": "Adobe",
@@ -18,12 +18,12 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/tokens": "^7.0.0"
+    "@spectrum-css/tokens": "^7.5.1"
   },
   "devDependencies": {
     "@spectrum-css/component-builder-simple": "^2.0.0",
-    "@spectrum-css/helptext": "^3.0.0",
-    "@spectrum-css/tokens": "^7.0.0",
+    "@spectrum-css/helptext": "^4.0.8",
+    "@spectrum-css/tokens": "^7.5.1",
     "gulp": "^4.0.0"
   },
   "publishConfig": {

--- a/components/textfield/package.json
+++ b/components/textfield/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spectrum-css/textfield",
-  "version": "4.0.0-beta.5",
+  "version": "4.0.0-beta.6",
   "description": "The Spectrum CSS textfield component",
   "license": "Apache-2.0",
   "author": "Adobe",

--- a/components/textfield/package.json
+++ b/components/textfield/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@spectrum-css/component-builder-simple": "^2.0.0",
     "@spectrum-css/helptext": "^3.0.0",
-    "@spectrum-css/tokens": "^5.0.0",
+    "@spectrum-css/tokens": "^6.0.0",
     "gulp": "^4.0.0"
   },
   "publishConfig": {

--- a/components/textfield/package.json
+++ b/components/textfield/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spectrum-css/textfield",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-beta.1",
   "description": "The Spectrum CSS textfield component",
   "license": "Apache-2.0",
   "author": "Adobe",

--- a/components/textfield/package.json
+++ b/components/textfield/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spectrum-css/textfield",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "description": "The Spectrum CSS textfield component",
   "license": "Apache-2.0",
   "author": "Adobe",

--- a/components/textfield/package.json
+++ b/components/textfield/package.json
@@ -18,12 +18,12 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/tokens": "^6.0.0"
+    "@spectrum-css/tokens": "^6.2.0"
   },
   "devDependencies": {
     "@spectrum-css/component-builder-simple": "^2.0.0",
     "@spectrum-css/helptext": "^3.0.0",
-    "@spectrum-css/tokens": "^6.0.0",
+    "@spectrum-css/tokens": "^6.2.0",
     "gulp": "^4.0.0"
   },
   "publishConfig": {

--- a/components/textfield/stories/template.js
+++ b/components/textfield/stories/template.js
@@ -5,7 +5,6 @@ import { classMap } from "lit-html/directives/class-map.js";
 import { Template as Icon } from '@spectrum-css/icon/stories/template.js';
 
 import '../index.css';
-import '../skin.css';
 
 export const Template = ({
   rootClass = "spectrum-Textfield",

--- a/components/textfield/stories/template.js
+++ b/components/textfield/stories/template.js
@@ -53,6 +53,7 @@ export const Template = ({
       'is-focused': isFocused,
       'is-keyboardFocused': isKeyboardFocused,
       'is-disabled': isDisabled,
+      'is-readOnly': isReadOnly,
       ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
     })}
       style=${ifDefined(styleMap(styles))}
@@ -75,7 +76,7 @@ export const Template = ({
         autocomplete=${autocomplete ? undefined : "off"}
         ?required=${isRequired}
         ?disabled=${isDisabled}
-        readonly=${ifDefined(isReadOnly ? "readonly" : undefined)}
+        ?readonly=${ifDefined(isReadOnly)}
         pattern=${ifDefined(pattern)}
         class=${classMap({
           [`${rootClass}-input`]: true,

--- a/components/textfield/stories/template.js
+++ b/components/textfield/stories/template.js
@@ -51,7 +51,7 @@ export const Template = ({
       'is-invalid': isInvalid,
       'is-valid': isValid,
       'is-focused': isFocused,
-      'is-keyboardFocused': isFocused,
+      'is-keyboardFocused': isKeyboardFocused,
       'is-disabled': isDisabled,
       ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
     })}

--- a/components/textfield/stories/template.js
+++ b/components/textfield/stories/template.js
@@ -1,6 +1,7 @@
 import { html } from "lit-html";
 import { ifDefined } from "lit-html/directives/if-defined.js";
 import { classMap } from "lit-html/directives/class-map.js";
+import { styleMap } from "lit-html/directives/style-map.js";
 
 import { Template as Icon } from '@spectrum-css/icon/stories/template.js';
 
@@ -15,6 +16,7 @@ export const Template = ({
   isInvalid = false,
   isValid = false,
   multiline = false,
+  grows = false,
   isQuiet = false,
   isFocused = false,
   isDisabled = false,
@@ -29,6 +31,9 @@ export const Template = ({
   type = "text",
   autocomplete = true,
   onclick,
+  styles = {
+    "--spectrum-textfield-border-color": "rgb(0,0,0)"
+  },
   ...globals
 }) => {
 
@@ -40,6 +45,7 @@ export const Template = ({
       [rootClass]: true,
       [`${rootClass}--size${size?.toUpperCase()}`]: typeof size !== "undefined",
       [`${rootClass}--multiline`]: multiline,
+      [`${rootClass}--grows`]: grows,
       [`${rootClass}--quiet`]: isQuiet,
       'is-invalid': isInvalid,
       'is-valid': isValid,
@@ -48,6 +54,7 @@ export const Template = ({
       'is-disabled': isDisabled,
       ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
     })}
+      style=${ifDefined(styleMap(styles))}
       @click=${onclick}>
       ${iconName ? Icon({
         ...globals,
@@ -58,6 +65,25 @@ export const Template = ({
           ...customIconClasses,
         ],
       }) : ""}
+      ${multiline ?
+        html`
+        ${grows ? html`<div id="sizer">${ifDefined(value)}</div>` : ""}
+        <textarea
+        placeholder=${ifDefined(placeholder)}
+        name=${ifDefined(name)}
+        .value=${ifDefined(value)}
+        autocomplete=${autocomplete ? undefined : "off"}
+        ?required=${isRequired}
+        ?disabled=${isDisabled}
+        readonly=${ifDefined(isReadOnly ? "readonly" : undefined)}
+        pattern=${ifDefined(pattern)}
+        class=${classMap({
+          [`${rootClass}-input`]: true,
+          ...customInputClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
+        })}
+        />`
+      :
+      html`
       <input
         type=${ifDefined(type)}
         placeholder=${ifDefined(placeholder)}
@@ -72,7 +98,8 @@ export const Template = ({
           [`${rootClass}-input`]: true,
           ...customInputClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
         })}
-      />
+      />`
+      }
     </div>
   `;
 };

--- a/components/textfield/stories/template.js
+++ b/components/textfield/stories/template.js
@@ -32,7 +32,8 @@ export const Template = ({
   autocomplete = true,
   onclick,
   styles = {
-    "--spectrum-textfield-border-color": "rgb(0,0,0)"
+    "--spectrum-textfield-border-color": "rgb(0,0,0)",
+    "--spectrum-textfield-border-width": "1px"
   },
   ...globals
 }) => {
@@ -67,7 +68,6 @@ export const Template = ({
       }) : ""}
       ${multiline ?
         html`
-        ${grows ? html`<div id="sizer">${ifDefined(value)}</div>` : ""}
         <textarea
         placeholder=${ifDefined(placeholder)}
         name=${ifDefined(name)}

--- a/components/textfield/stories/textfield.stories.js
+++ b/components/textfield/stories/textfield.stories.js
@@ -61,6 +61,16 @@ export default {
       },
       control: "boolean"
     },
+    grows: {
+      name: "Grows",
+      type: { name: "boolean" },
+      table: {
+        type: { summary: "boolean" },
+        category: "Component",
+      },
+      control: "boolean",
+      if: { arg: "multiline", truthy: true }
+    },
     iconName: {
       table: { disable: true },
     },
@@ -112,6 +122,7 @@ export default {
     isFocused: false,
     isKeyboardFocused: false,
     multiline: false,
+    grows: false,
     isQuiet: false,
   },
   parameters: {
@@ -128,3 +139,10 @@ export default {
 
 export const Default = Template.bind({});
 Default.args = {};
+
+export const TextArea = Template.bind({});
+TextArea.args = {
+  multiline: true,
+  grows: true,
+  value: "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt."
+};

--- a/components/textfield/stories/textfield.stories.js
+++ b/components/textfield/stories/textfield.stories.js
@@ -140,6 +140,11 @@ export default {
 export const Default = Template.bind({});
 Default.args = {};
 
+export const WithIcon = Template.bind({});
+WithIcon.args = {
+  iconName: "Magnify"
+};
+
 export const TextArea = Template.bind({});
 TextArea.args = {
   multiline: true,

--- a/components/textfield/themes/express.css
+++ b/components/textfield/themes/express.css
@@ -11,6 +11,16 @@ governing permissions and limitations under the License.
 */
 
 @container (--system: express) {
+  /* @todo remove this when stepper is migrated; this ensures stepper buttons inherit border color and width */
+  .spectrum-Stepper {
+    --spectrum-textfield-m-texticon-border-color: var(--spectrum-gray-400);
+
+    .spectrum-Stepper-stepUp,
+    .spectrum-Stepper-stepDown {
+      --spectrum-stepper-border-size: var(--spectrum-border-width-200);
+    }
+  }
+
   .spectrum-Textfield {
     --spectrum-textfield-border-color: var(--spectrum-gray-400);
     --spectrum-textfield-border-color-hover: var(--spectrum-gray-500);

--- a/components/textfield/themes/express.css
+++ b/components/textfield/themes/express.css
@@ -18,6 +18,6 @@ governing permissions and limitations under the License.
     --spectrum-textfield-border-color-focus-hover: var(--spectrum-gray-900);
     --spectrum-textfield-border-color-keyboard-focus: var(--spectrum-gray-900);
 
-    --spectrum-textfield-border-width: var(--spectrum-border-width-100);
+    --spectrum-textfield-border-width: var(--spectrum-border-width-200);
   }
 }

--- a/components/textfield/themes/express.css
+++ b/components/textfield/themes/express.css
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 Adobe. All rights reserved.
+Copyright 2023 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -11,16 +11,6 @@ governing permissions and limitations under the License.
 */
 
 @container (--system: express) {
-  /* @todo remove this when stepper is migrated; this ensures stepper buttons inherit border color and width */
-  .spectrum-Stepper {
-    --spectrum-textfield-m-texticon-border-color: var(--spectrum-gray-400);
-
-    .spectrum-Stepper-stepUp,
-    .spectrum-Stepper-stepDown {
-      --spectrum-stepper-border-size: var(--spectrum-border-width-200);
-    }
-  }
-
   .spectrum-Textfield {
     --spectrum-textfield-border-color: var(--spectrum-gray-400);
     --spectrum-textfield-border-color-hover: var(--spectrum-gray-500);

--- a/components/textfield/themes/spectrum.css
+++ b/components/textfield/themes/spectrum.css
@@ -11,6 +11,16 @@ governing permissions and limitations under the License.
 */
 
 @container (--system: spectrum) {
+  /* @todo remove this when stepper is migrated; this ensures stepper buttons inherit border color and width */
+  .spectrum-Stepper {
+    --spectrum-textfield-m-texticon-border-color: var(--spectrum-gray-500);
+
+    .spectrum-Stepper-stepUp,
+    .spectrum-Stepper-stepDown {
+      --spectrum-stepper-border-size: var(--spectrum-border-width-100);
+    }
+  }
+
   .spectrum-Textfield {
     --spectrum-textfield-border-color: var(--spectrum-gray-500);
     --spectrum-textfield-border-color-hover: var(--spectrum-gray-600);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2383,6 +2383,26 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/tag/-/tag-3.3.15.tgz#971184fd8cb977b85a529f808313851863123278"
   integrity sha512-pF6Wh61Z7hmAy20twIlpjdDuivYj6UPtWIzK7giyJKr/qcn20BjVN2ChIeFB1N+vBamJdLsuQOewv4AJ3+LZ2Q==
 
+"@spectrum-css/textfield@^3.2.6":
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/textfield/-/textfield-3.2.6.tgz#ad55cc6dd64f006fc659150298d3df463118fa24"
+  integrity sha512-yNTlrteDJcjKJRL7HV7vF2fZ9SLEDaRcLR6Zf2iwe0fdzzY0SXo9LGf0zoVRe47eW3UFrGC1cMyX27y2MMH1ag==
+
+"@spectrum-css/tokens@^1.0.7":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/tokens/-/tokens-1.0.7.tgz#7256ed9383ac4555f7bc0cf43a9ebe4f5e41b117"
+  integrity sha512-KGP78ZBPLVyj1+2uHU4IOVcPrQipqGkO9e9j3p3eQVbb4JuBJ9v9sJ5p5Z+z3nmcJV6wdg/zLpf1ZH0tnjl3hg==
+
+"@spectrum-css/tokens@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/tokens/-/tokens-4.0.0.tgz#581b858225aae05b9b784db1aa0e257c3e9c53cf"
+  integrity sha512-lDUDbc1BocZR5q9pKpLvFicb7v8Owjhm0mxd+JPk+sVHXHC/u37PEZf7R0QBzl3D/13fNqurtV9DhlPjrhDm0g==
+
+"@spectrum-css/tokens@^6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/tokens/-/tokens-6.2.0.tgz#37cf19d07ba7de160be4d3323a1b38e7e27692d7"
+  integrity sha512-Q7VlLsiOtw+5gqPCr120O5KVaE0Kiaibik6PWVy6w6Y3NGV76azWa5ZYqdaROiatWvgkjp0akRhkqt88ZlKSRA==
+
 "@spectrum-css/tooltip@^3.1.20":
   version "3.1.20"
   resolved "https://registry.yarnpkg.com/@spectrum-css/tooltip/-/tooltip-3.1.20.tgz#c3b6cf274be3ed552f86534f1fede7169827dc83"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2388,30 +2388,30 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/popover/-/popover-5.0.18.tgz#4e8d1b15b0f96ff3c19a6642ebae7937e99723a4"
   integrity sha512-MpdlGjj6Y03l65UUiww8ulc6t6xImQFsIAqzDIuvtH+8BPEM4IbizJFGa6LEEvkMhHiwRF1s94LDg3d+q3ZmvA==
 
+"@spectrum-css/spectrum-css-vr-test-assets-essential@^1.0.46":
+  version "1.0.46"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/spectrum-css-vr-test-assets-essential/-/spectrum-css-vr-test-assets-essential-1.0.46.tgz#8a8c9007003f5c7c1501b3a0ecb721f751f9f68b"
+  integrity sha512-09KcehdKIxpVTxmC3bkaCGiLwbxakFNZIirGQlwryu0qnuu1uzst+ELnZdh0s/O2akfmo43PRbaKiIL0x23NQg==
+
+"@spectrum-css/stepper@^3.0.36":
+  version "3.0.36"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/stepper/-/stepper-3.0.36.tgz#53c01728fa397235116dad8761f0d0413c3e57e6"
+  integrity sha512-xFXa2xeZ/S0aGJ81hEkpnC1P808rcvPVaeRtGDi6Zji0+wSvIKTEPS6qHmVU8dZDcjONsJw1qHTDeE9o0g0prA==
+
 "@spectrum-css/tag@^3.3.15":
   version "3.3.15"
   resolved "https://registry.yarnpkg.com/@spectrum-css/tag/-/tag-3.3.15.tgz#971184fd8cb977b85a529f808313851863123278"
   integrity sha512-pF6Wh61Z7hmAy20twIlpjdDuivYj6UPtWIzK7giyJKr/qcn20BjVN2ChIeFB1N+vBamJdLsuQOewv4AJ3+LZ2Q==
 
-"@spectrum-css/textfield@^3.2.12":
-  version "3.2.12"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/textfield/-/textfield-3.2.12.tgz#636e9cd418637b7a12a5f87484225723a3a2599a"
-  integrity sha512-ShkwBqqNZpyGYMeRPu6UojSJwRjygWqrS1pKhZddGqCeL2mZxTm+8kk8EcRSDr2ossGBVBiMYFS5Y+z/UgwORw==
-
-"@spectrum-css/textfield@^3.2.8":
-  version "3.2.8"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/textfield/-/textfield-3.2.8.tgz#0b63fc14e54264aa3870c0034578d5c900702604"
-  integrity sha512-ofjKKRACoYqZCNN9esGes1+/AzWvPQvzTH1EQFCQnIlUnV+Bw32WoYrITvXY13Bheb4cDWk5SjaLFpHQmlDT+A==
+"@spectrum-css/textfield@^3.2.13":
+  version "3.2.13"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/textfield/-/textfield-3.2.13.tgz#01888b0353b934591ec1177e5f4351e34c74b591"
+  integrity sha512-K26LC+rINXbGhS2nF0FJDfA7Qe1qq7QbnQqURxeN/GUV1vaRbdVTPBtezyc2D1tGNwszELHTsDI8dGWWidpcLQ==
 
 "@spectrum-css/tokens@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@spectrum-css/tokens/-/tokens-4.0.0.tgz#581b858225aae05b9b784db1aa0e257c3e9c53cf"
   integrity sha512-lDUDbc1BocZR5q9pKpLvFicb7v8Owjhm0mxd+JPk+sVHXHC/u37PEZf7R0QBzl3D/13fNqurtV9DhlPjrhDm0g==
-
-"@spectrum-css/tokens@^6.2.0":
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/tokens/-/tokens-6.3.0.tgz#79ac1d63d1082ba3fca4e7b7dc711a0d6102b69a"
-  integrity sha512-4dXI3B3YwWEQ2fN42fn4e9XADz81wVfIq0PSJp1mb//WUYd0flCHvhZSIu8vRU+UxYRCw7AZ3x/Pglokpk3KDw==
 
 "@spectrum-css/tooltip@^3.1.20":
   version "3.1.20"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2363,16 +2363,6 @@
   dependencies:
     "@spectrum-css/vars" "^8.0.0"
 
-"@spectrum-css/fieldgroup@^3.1.4":
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/fieldgroup/-/fieldgroup-3.1.4.tgz#aede57bda56c41310d262774a8805eefc89ddf74"
-  integrity sha512-ynqkD1OWicCEW7hgYQWzJUrUih+guJHjDtPbTKYhCbnxPqi6aifKmLstBehCgs4iG4+YfGDdZTppW64A3o5foQ==
-
-"@spectrum-css/helptext@^3.0.0":
-  version "3.0.13"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/helptext/-/helptext-3.0.13.tgz#bb3ef6d2a66a528f9956fd2cef61d3e1ca844159"
-  integrity sha512-DZesxo+DboeljfeSdMxylorfyPKisNiod4hPybHBqbYm0bs+CGuEOsXhayTzK34Xfsh19kkDQieM62rANkhUCQ==
-
 "@spectrum-css/link@^3.1.23":
   version "3.1.23"
   resolved "https://registry.yarnpkg.com/@spectrum-css/link/-/link-3.1.23.tgz#9d9ff64c41366edbfdb19d04a5deec88bf2ea8fd"
@@ -2388,30 +2378,20 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/popover/-/popover-5.0.18.tgz#4e8d1b15b0f96ff3c19a6642ebae7937e99723a4"
   integrity sha512-MpdlGjj6Y03l65UUiww8ulc6t6xImQFsIAqzDIuvtH+8BPEM4IbizJFGa6LEEvkMhHiwRF1s94LDg3d+q3ZmvA==
 
-"@spectrum-css/spectrum-css-vr-test-assets-essential@^1.0.46":
-  version "1.0.46"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/spectrum-css-vr-test-assets-essential/-/spectrum-css-vr-test-assets-essential-1.0.46.tgz#8a8c9007003f5c7c1501b3a0ecb721f751f9f68b"
-  integrity sha512-09KcehdKIxpVTxmC3bkaCGiLwbxakFNZIirGQlwryu0qnuu1uzst+ELnZdh0s/O2akfmo43PRbaKiIL0x23NQg==
-
-"@spectrum-css/stepper@^3.0.36":
-  version "3.0.36"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/stepper/-/stepper-3.0.36.tgz#53c01728fa397235116dad8761f0d0413c3e57e6"
-  integrity sha512-xFXa2xeZ/S0aGJ81hEkpnC1P808rcvPVaeRtGDi6Zji0+wSvIKTEPS6qHmVU8dZDcjONsJw1qHTDeE9o0g0prA==
+"@spectrum-css/stepper@^3.0.39":
+  version "3.0.39"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/stepper/-/stepper-3.0.39.tgz#659f1a0fe34a672167214f58b359b22f3ac1d017"
+  integrity sha512-dvxWwhisutJmqijzWOQczVKcT0gPWHRc6HrSkPxmwYdQlJy/sweM2ZI2d6pjmwRL95gMgPGr2xugxQEDBRsb7g==
 
 "@spectrum-css/tag@^3.3.15":
   version "3.3.15"
   resolved "https://registry.yarnpkg.com/@spectrum-css/tag/-/tag-3.3.15.tgz#971184fd8cb977b85a529f808313851863123278"
   integrity sha512-pF6Wh61Z7hmAy20twIlpjdDuivYj6UPtWIzK7giyJKr/qcn20BjVN2ChIeFB1N+vBamJdLsuQOewv4AJ3+LZ2Q==
 
-"@spectrum-css/textfield@^3.2.13":
-  version "3.2.13"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/textfield/-/textfield-3.2.13.tgz#01888b0353b934591ec1177e5f4351e34c74b591"
-  integrity sha512-K26LC+rINXbGhS2nF0FJDfA7Qe1qq7QbnQqURxeN/GUV1vaRbdVTPBtezyc2D1tGNwszELHTsDI8dGWWidpcLQ==
-
-"@spectrum-css/tokens@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/tokens/-/tokens-4.0.0.tgz#581b858225aae05b9b784db1aa0e257c3e9c53cf"
-  integrity sha512-lDUDbc1BocZR5q9pKpLvFicb7v8Owjhm0mxd+JPk+sVHXHC/u37PEZf7R0QBzl3D/13fNqurtV9DhlPjrhDm0g==
+"@spectrum-css/textfield@^3.2.16":
+  version "3.2.16"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/textfield/-/textfield-3.2.16.tgz#17cc6d41e6540ab3cc28b9ef9aa3dc2e0161264d"
+  integrity sha512-Ohiq+FIjzwxU/q5i8cgtJQn6Y24h7y1zvxA2L1v53ja40cJKzvAJSYjGVjyuOnLSftt//2xKza6AwPyJJmGEiA==
 
 "@spectrum-css/tooltip@^3.1.20":
   version "3.1.20"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2363,6 +2363,16 @@
   dependencies:
     "@spectrum-css/vars" "^8.0.0"
 
+"@spectrum-css/fieldgroup@^3.1.4":
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/fieldgroup/-/fieldgroup-3.1.4.tgz#aede57bda56c41310d262774a8805eefc89ddf74"
+  integrity sha512-ynqkD1OWicCEW7hgYQWzJUrUih+guJHjDtPbTKYhCbnxPqi6aifKmLstBehCgs4iG4+YfGDdZTppW64A3o5foQ==
+
+"@spectrum-css/helptext@^3.0.0":
+  version "3.0.13"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/helptext/-/helptext-3.0.13.tgz#bb3ef6d2a66a528f9956fd2cef61d3e1ca844159"
+  integrity sha512-DZesxo+DboeljfeSdMxylorfyPKisNiod4hPybHBqbYm0bs+CGuEOsXhayTzK34Xfsh19kkDQieM62rANkhUCQ==
+
 "@spectrum-css/link@^3.1.23":
   version "3.1.23"
   resolved "https://registry.yarnpkg.com/@spectrum-css/link/-/link-3.1.23.tgz#9d9ff64c41366edbfdb19d04a5deec88bf2ea8fd"
@@ -2383,20 +2393,25 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/tag/-/tag-3.3.15.tgz#971184fd8cb977b85a529f808313851863123278"
   integrity sha512-pF6Wh61Z7hmAy20twIlpjdDuivYj6UPtWIzK7giyJKr/qcn20BjVN2ChIeFB1N+vBamJdLsuQOewv4AJ3+LZ2Q==
 
+"@spectrum-css/textfield@^3.2.12":
+  version "3.2.12"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/textfield/-/textfield-3.2.12.tgz#636e9cd418637b7a12a5f87484225723a3a2599a"
+  integrity sha512-ShkwBqqNZpyGYMeRPu6UojSJwRjygWqrS1pKhZddGqCeL2mZxTm+8kk8EcRSDr2ossGBVBiMYFS5Y+z/UgwORw==
+
 "@spectrum-css/textfield@^3.2.8":
   version "3.2.8"
   resolved "https://registry.yarnpkg.com/@spectrum-css/textfield/-/textfield-3.2.8.tgz#0b63fc14e54264aa3870c0034578d5c900702604"
   integrity sha512-ofjKKRACoYqZCNN9esGes1+/AzWvPQvzTH1EQFCQnIlUnV+Bw32WoYrITvXY13Bheb4cDWk5SjaLFpHQmlDT+A==
 
-"@spectrum-css/tokens@^1.0.7":
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/tokens/-/tokens-1.0.7.tgz#7256ed9383ac4555f7bc0cf43a9ebe4f5e41b117"
-  integrity sha512-KGP78ZBPLVyj1+2uHU4IOVcPrQipqGkO9e9j3p3eQVbb4JuBJ9v9sJ5p5Z+z3nmcJV6wdg/zLpf1ZH0tnjl3hg==
-
 "@spectrum-css/tokens@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@spectrum-css/tokens/-/tokens-4.0.0.tgz#581b858225aae05b9b784db1aa0e257c3e9c53cf"
   integrity sha512-lDUDbc1BocZR5q9pKpLvFicb7v8Owjhm0mxd+JPk+sVHXHC/u37PEZf7R0QBzl3D/13fNqurtV9DhlPjrhDm0g==
+
+"@spectrum-css/tokens@^6.2.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/tokens/-/tokens-6.3.0.tgz#79ac1d63d1082ba3fca4e7b7dc711a0d6102b69a"
+  integrity sha512-4dXI3B3YwWEQ2fN42fn4e9XADz81wVfIq0PSJp1mb//WUYd0flCHvhZSIu8vRU+UxYRCw7AZ3x/Pglokpk3KDw==
 
 "@spectrum-css/tooltip@^3.1.20":
   version "3.1.20"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2383,10 +2383,10 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/tag/-/tag-3.3.15.tgz#971184fd8cb977b85a529f808313851863123278"
   integrity sha512-pF6Wh61Z7hmAy20twIlpjdDuivYj6UPtWIzK7giyJKr/qcn20BjVN2ChIeFB1N+vBamJdLsuQOewv4AJ3+LZ2Q==
 
-"@spectrum-css/textfield@^3.2.6":
-  version "3.2.6"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/textfield/-/textfield-3.2.6.tgz#ad55cc6dd64f006fc659150298d3df463118fa24"
-  integrity sha512-yNTlrteDJcjKJRL7HV7vF2fZ9SLEDaRcLR6Zf2iwe0fdzzY0SXo9LGf0zoVRe47eW3UFrGC1cMyX27y2MMH1ag==
+"@spectrum-css/textfield@^3.2.8":
+  version "3.2.8"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/textfield/-/textfield-3.2.8.tgz#0b63fc14e54264aa3870c0034578d5c900702604"
+  integrity sha512-ofjKKRACoYqZCNN9esGes1+/AzWvPQvzTH1EQFCQnIlUnV+Bw32WoYrITvXY13Bheb4cDWk5SjaLFpHQmlDT+A==
 
 "@spectrum-css/tokens@^1.0.7":
   version "1.0.7"
@@ -2397,11 +2397,6 @@
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@spectrum-css/tokens/-/tokens-4.0.0.tgz#581b858225aae05b9b784db1aa0e257c3e9c53cf"
   integrity sha512-lDUDbc1BocZR5q9pKpLvFicb7v8Owjhm0mxd+JPk+sVHXHC/u37PEZf7R0QBzl3D/13fNqurtV9DhlPjrhDm0g==
-
-"@spectrum-css/tokens@^6.2.0":
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/tokens/-/tokens-6.2.0.tgz#37cf19d07ba7de160be4d3323a1b38e7e27692d7"
-  integrity sha512-Q7VlLsiOtw+5gqPCr120O5KVaE0Kiaibik6PWVy6w6Y3NGV76azWa5ZYqdaROiatWvgkjp0akRhkqt88ZlKSRA==
 
 "@spectrum-css/tooltip@^3.1.20":
   version "3.1.20"


### PR DESCRIPTION
## Description
BREAKING CHANGE: This migrates the Text field and text area component to core tokens. This also relates the focus indicator border radius for customization.
- Jira issue CSS-153 https://jira.corp.adobe.com/browse/CSS-153
- Jira issue CSS-185 https://jira.corp.adobe.com/browse/CSS-185
- Jira issue CSS-161 https://jira.corp.adobe.com/browse/CSS-161
- Jira issue CSS-388 https://jira.corp.adobe.com/browse/CSS-388

### Stepper Migration
**EDIT:** This PR now includes partial migration of Stepper. It was necessary to migrate Stepper with Textfield in order to overcome VRT failures in Spectrum Web Components. Migration work aims to maintain existing styles of Stepper, making only the updates which Design approves of at this time. Design provided background and border colors as well as new styling for Express. Express stepper buttons feature spacing around the individual buttons. Stepper border colors are to match Textfield border colors.
- Jira issue for Stepper, CSS-388 https://jira.corp.adobe.com/browse/CSS-388

### Things to Note
Text Area is treated in spectrum-css as a variant of Text Field. They share a single index.css file, but each has a separate YML for the documentation site.

Text Field and Text Area have two focus states: mouse focus and keyboard focus. Mouse focus is associated with the class '.is-focused' and keyboard focus is associated with the class '.is-keyboardFocus'. Mouse focus also has tokens specified for :focus:hover.

Text Area is designated by the designs to adjust automatically in height as content is entered into the field. This is out of scope for spectrum-css, as the `<textarea>` HTML element does not allow this behavior. Adding such behavior is likely to require Javascript and cannot be done with CSS alone.

## How and where has this been tested?
 - Chrome 105 for macOS
 - Firefox 105 for macOS
 - Safari 15.5 for macOS
 - **How this was tested:** comparing local build of http://localhost:3000/docs/textield.html and http://localhost:3000/docs/textarea.html with XD redline components for Text field and Text area and with https://spectrum.adobe.com/page/text-field and https://spectrum.adobe.com/page/text-area/

## Screenshots
Text field:
<img width="1114" alt="Screen Shot 2022-11-08 at 3 20 32 PM" src="https://user-images.githubusercontent.com/25614178/200667281-067f7e32-0bd3-440f-a5b3-48e27ace2da8.png">

Text area:
<img width="1113" alt="Screen Shot 2022-11-08 at 3 21 41 PM" src="https://user-images.githubusercontent.com/25614178/200667369-51f878f0-e405-4759-b515-50bc88c81037.png">


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
