### PR TITLE
feat: minor color token change for accent color (CSS-246)

### DIFF
--- a/components/progresscircle/index.css
+++ b/components/progresscircle/index.css
@@ -17,8 +17,8 @@ governing permissions and limitations under the License.
   --spectrum-progress-circle-track-border-color: var(--spectrum-gray-300);
 
   /* circle progress fill border color */
-  --spectrum-progress-circle-fill-border-color: var(--spectrum-blue-900);
-
+  --spectrum-progress-circle-fill-border-color: var(--spectrum-accent-content-color-default);
+  
   /* over background unfilled border color */
   --spectrum-progress-circle-track-border-color-over-background: var(--spectrum-transparent-white-300);
 


### PR DESCRIPTION
Minor color token change for Progress Circle. 
https://jira.corp.adobe.com/browse/CSS-246 Progress Circle - Update token

## Description
simple rename:
looks the same in system Express and Spectrum:

## How and where has this been tested?
 - **How this was tested:**go to http://localhost:3000/docs/progresscircle.html
 - **Browser(s) and OS(s) this was tested with:** Version 110.0.5423.0 (Official Build) canary (x86_64)


## Screenshots

Express:
<img width="331" alt="Screen Shot 2022-11-18 at 13 00 11" src="https://user-images.githubusercontent.com/52184321/202802098-9e1a2803-487c-40fd-81e1-dd348b031b2e.png">


Spectrum:
<img width="325" alt="Screen Shot 2022-11-18 at 13 00 14" src="https://user-images.githubusercontent.com/52184321/202802135-5ec3d22f-28bd-4f91-93eb-915b913d97e9.png">



## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] I have tested these changes in Windows High Contrast mode.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
