### PR TITLE
fix(tooltip): update inline padding

### DIFF
--- a/components/tooltip/index.css
+++ b/components/tooltip/index.css
@@ -34,14 +34,14 @@ governing permissions and limitations under the License.
   --spectrum-tooltip-font-weight: var(--spectrum-font-weight-regular); /* TODO - check is still 400 */
 
   /* horizontal spacing */
-  --spectrum-tooltip-spacing-inline-start: var(--spectrum-component-edge-to-visual-75);
-  --spectrum-tooltip-spacing-inline-end: var(--spectrum-component-edge-to-text-75);
+  --spectrum-tooltip-spacing-inline: var(--spectrum-component-edge-to-text-75);
 
   /* vertical spacing */
   --spectrum-tooltip-spacing-block-start: var(--spectrum-component-top-to-text-75);
   --spectrum-tooltip-spacing-block-end: var(--spectrum-component-bottom-to-text-75);
 
   /* icon spacing */
+  --spectrum-tooltip-icon-spacing-inline-start: var(--spectrum-text-to-visual-75);
   --spectrum-tooltip-icon-spacing-inline-end: var(--spectrum-text-to-visual-75);
   --spectrum-tooltip-icon-spacing-block-start: var(--spectrum-component-top-to-workflow-icon-75);
 
@@ -91,8 +91,7 @@ governing permissions and limitations under the License.
   vertical-align: top;
 
   width: auto;
-  padding-inline-start: var(--mod-tooltip-spacing-inline-start, var(--spectrum-tooltip-spacing-inline-start));
-  padding-inline-end: var(--mod-tooltip-spacing-inline-end, var(--spectrum-tooltip-spacing-inline-end));
+  padding-inline: var(--mod-tooltip-spacing-inline, var(--spectrum-tooltip-spacing-inline));
 
   border-radius: var(--mod-tooltip-border-radius, var(--spectrum-tooltip-border-radius));
 
@@ -340,6 +339,9 @@ governing permissions and limitations under the License.
 
 /****** Icon ******/
 .spectrum-Tooltip-typeIcon {
+  /* subtract tooltip padding from icon start margin */
+  margin-inline-start: calc(var(--mod-tooltip-icon-spacing-inline-start, var(--spectrum-tooltip-icon-spacing-inline-start))
+                            - var(--mod-tooltip-spacing-inline, var(--spectrum-tooltip-spacing-inline)));
   margin-inline-end: var(--mod-tooltip-icon-spacing-inline-end, var(--spectrum-tooltip-icon-spacing-inline-end));
   margin-block-start: var(--mod-tooltip-icon-spacing-block-start, var(--spectrum-tooltip-icon-spacing-block-start));
   width: var(--mod-tooltip-icon-width, var(--spectrum-tooltip-icon-width));


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
This updates Tooltip to have identical inline padding for start and end when no icon is present. Previously, start padding was equal to the margin from the icon to the label.

- Jira issue CSS-350 https://jira.corp.adobe.com/browse/CSS-350

**Revised XD redline:**
<img width="700" alt="image-1" src="https://user-images.githubusercontent.com/25614178/206783022-c8139a64-71be-4665-a805-5e609599eba8.png">

**Illustration of difference:**
<img width="400" alt="Screen Shot 2022-12-09 at 2 20 33 PM" src="https://user-images.githubusercontent.com/25614178/206783056-1a4e93d8-b9da-4122-95c1-baf1188c2ec9.png">
Pixel numbers in the above illustration represent medium/large.

## How and where has this been tested?
 - Chrome 108 for macOS
 - Firefox 107 for macOS
 - Safari 16 for macOS
 - **How this was tested:** comparing local build of http://localhost:3000/docs/tooltip.html with revised XD redline component.

## Screenshots
<img width="498" alt="Screen Shot 2022-12-09 at 2 33 49 PM" src="https://user-images.githubusercontent.com/25614178/206783131-9f33967c-eb8a-4267-b29a-98a5ac17430e.png">


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] I have tested these changes in Windows High Contrast mode.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.

