### PR TITLE
fix(link): correct highcontrast custom properties

### DIFF
--- a/components/link/index.css
+++ b/components/link/index.css
@@ -33,31 +33,18 @@ governing permissions and limitations under the License.
 /* Windows high contrast mode */
 @media (forced-colors: active) {
   .spectrum-Link {
-      --highcontrast-link-focus-color: CanvasText;
-  }
+    --highcontrast-link-text-color-primary-default: LinkText;
+    --highcontrast-link-text-color-primary-hover: LinkText;
+    --highcontrast-link-text-color-primary-active: LinkText;
+    --highcontrast-link-text-color-primary-focus: LinkText;
 
-  .spectrum-Link--secondary {
-    color: LinkText;
+    --highcontrast-link-text-color-secondary-default: LinkText;
+    --highcontrast-link-text-color-secondary-hover: LinkText;
+    --highcontrast-link-text-color-secondary-active: LinkText;
+    --highcontrast-link-text-color-secondary-focus: LinkText;
 
-    &:hover {
-      color: LinkText;
-    }
-
-    &:active {
-      color: LinkText;
-    }
-
-    &:focus {
-      color: LinkText;
-    }
-  }
-
-  &--staticBlack {
-    --highcontrast-link-text-color-black: ButtonText;
-  }
-
-  &--staticWhite {
-    --highcontrast-link-text-color-white: ButtonText;
+    --highcontrast-link-text-color-white: LinkText;
+    --highcontrast-link-text-color-black: LinkText;
   }
 }
 
@@ -71,18 +58,18 @@ governing permissions and limitations under the License.
   outline: none;
   cursor: pointer;
 
-  color: var(--mod-link-text-color-primary-default, var(--spectrum-link-text-color-primary-default));
+  color: var(--highcontrast-link-text-color-primary-default, var(--mod-link-text-color-primary-default, var(--spectrum-link-text-color-primary-default)));
 
   &:hover {
-    color: var(--mod-link-text-color-primary-hover, var(--spectrum-link-text-color-primary-hover));
+    color: var(--highcontrast-link-text-color-primary-hover, var(--mod-link-text-color-primary-hover, var(--spectrum-link-text-color-primary-hover)));
   }
 
   &:active {
-    color: var(--mod-link-text-color-primary-active, var(--spectrum-link-text-color-primary-active));
+    color: var(--highcontrast-link-text-color-primary-active, var(--mod-link-text-color-primary-active, var(--spectrum-link-text-color-primary-active)));
   }
 
   &:focus-visible {
-    color: var(--mod-link-text-color-primary-focus, var(--spectrum-link-text-color-primary-focus));
+    color: var(--highcontrast-link-text-color-primary-focus, var(--mod-link-text-color-primary-focus, var(--spectrum-link-text-color-primary-focus)));
     text-decoration: underline;
     text-decoration-style: double;
     text-decoration-color: var(--highcontrast-link-focus-color, inherit);
@@ -90,18 +77,18 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Link--secondary {
-  color: var(--mod-link-text-color-secondary-default, var(--spectrum-link-text-color-secondary-default));
+  color: var(--highcontrast-link-text-color-secondary-default, var(--mod-link-text-color-secondary-default, var(--spectrum-link-text-color-secondary-default)));
 
   &:hover {
-    color: var(--mod-link-text-color-secondary-hover, var(--spectrum-link-text-color-secondary-hover));
+    color: var(--highcontrast-link-text-color-secondary-hover, var(--mod-link-text-color-secondary-hover, var(--spectrum-link-text-color-secondary-hover)));
   }
 
   &:active {
-    color: var(--mod-link-text-color-secondary-active, var(--spectrum-link-text-color-secondary-active));
+    color: var(--highcontrast-link-text-color-secondary-active, var(--mod-link-text-color-secondary-active, var(--spectrum-link-text-color-secondary-active)));
   }
 
   &:focus {
-    color: var(--mod-link-text-color-secondary-focus, var(--spectrum-link-text-color-secondary-focus));
+    color: var(--highcontrast-link-text-color-secondary-focus, var(--mod-link-text-color-secondary-focus, var(--spectrum-link-text-color-secondary-focus)));
   }
 }
 


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
This corrects link colors in Windows High Contrast mode.

- Jira issue CSS-333 https://jira.corp.adobe.com/browse/CSS-333

## How and where has this been tested?
 - Using Chrome emulation of WHCM + dark mode. You can replicate this test by opening the rendering drawer in Chrome dev tools (Command + P, search "rendering", open the rendering drawer) and activating prefers-color-scheme: dark and forced-colors: active.

 -  Chrome 108 for macOS

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->

<img width="760" alt="Screen Shot 2022-12-12 at 3 53 41 PM" src="https://user-images.githubusercontent.com/25614178/207152437-5b4ea3d4-6534-44d3-b1a4-6a646537dd29.png">
<img width="732" alt="Screen Shot 2022-12-12 at 3 53 45 PM" src="https://user-images.githubusercontent.com/25614178/207152452-993575d9-aeff-4176-97e5-4a4587e3b974.png">
<img width="755" alt="Screen Shot 2022-12-12 at 3 53 50 PM" src="https://user-images.githubusercontent.com/25614178/207152467-023822df-e73d-497f-818b-8f65e7c00026.png">
<img width="762" alt="Screen Shot 2022-12-12 at 3 53 59 PM" src="https://user-images.githubusercontent.com/25614178/207152477-3879bbe5-9fbc-4613-9dce-3b512baf7913.png">
<img width="765" alt="Screen Shot 2022-12-12 at 3 54 07 PM" src="https://user-images.githubusercontent.com/25614178/207152493-e160295d-5ff7-448c-a443-6f81a3368eae.png">

**Primary keyboard focus:**
<img width="783" alt="Screen Shot 2022-12-12 at 3 55 18 PM" src="https://user-images.githubusercontent.com/25614178/207152667-50026952-e92e-4e4c-8089-8e90279a554d.png">

## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] I have tested these changes in Windows High Contrast mode.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
