### PR TITLE
fix(fieldlabel): add missing color token

### DIFF
--- a/components/fieldlabel/index.css
+++ b/components/fieldlabel/index.css
@@ -10,6 +10,9 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+.spectrum-FieldLabel {
+  --spectrum-fieldlabel-color: var(--spectrum-neutral-subdued-content-color-default);
+}
 
 /* Component level tokens currently missing in core-tokens as of July 2022 or are simply incorrect */
 .spectrum--medium {
@@ -95,6 +98,8 @@ governing permissions and limitations under the License.
   -webkit-font-smoothing: subpixel-antialiased;
   -moz-osx-font-smoothing: auto;
   font-smoothing: subpixel-antialiased;
+
+  color: var(--spectrum-fieldlabel-color);
 }
 
 /* international lang support */


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
This adds the missing text color token to field label.
- Jira issue CSS-347 https://jira.corp.adobe.com/browse/CSS-347

## How and where has this been tested?
 - Chrome 108 for macOS
 - Firefox 107 for macOS
 - Safari 16 for macOS
 - **How this was tested:** comparing local build of http://localhost:3000/docs/fieldlabel.html with XD redline components Batch 1

## Screenshots

**Prior to this change, field label color was inherited from the body, seen here overridden in the browser with red:**

<img width="458" alt="Screen Shot 2022-12-13 at 12 17 01 PM" src="https://user-images.githubusercontent.com/25614178/207413948-8503ea20-f38a-442e-b8fb-72c0160bc66f.png">

**Adding the missing color token allows field label to self-manage its color:**

<img width="461" alt="Screen Shot 2022-12-13 at 12 17 21 PM" src="https://user-images.githubusercontent.com/25614178/207413958-9e793510-e9de-4b51-8f01-ce644bef9fed.png">


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.