### PR TITLE
fix(actionbar): remove selectors

### DIFF
--- a/components/actionbar/index.css
+++ b/components/actionbar/index.css
@@ -164,12 +164,8 @@ governing permissions and limitations under the License.
   }
 
   /* ensure text is legible on emphasized background */
-  .spectrum-ActionButton,
-  .spectrum-FieldLabel,
-  .spectrum-CloseButton-UIIcon {
+  .spectrum-FieldLabel {
     color: var(--mod-actionbar-emphasized-item-counter-color, var(--spectrum-actionbar-emphasized-item-counter-color));
-    /* apply fill so SVG icon is the correct color */
-    fill: var(--mod-actionbar-emphasized-item-counter-color, var(--spectrum-actionbar-emphasized-item-counter-color));
   }
 }
 


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
This removes unnecessary selectors from Actionbar.
- Jira issue CSS-360 https://jira.corp.adobe.com/browse/CSS-360


## How and where has this been tested?
 - Chrome 108 for macOS
 - Firefox 107 for macOS
 - Safari 16 for macOS
 - **How this was tested:** viewing local build of http://localhost:3000/docs/actionbar.html.

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.

