### PR TITLE
feat(tokens): adds global animation vars

### DIFF
--- a/components/tokens/custom-spectrum/custom-vars.css
+++ b/components/tokens/custom-spectrum/custom-vars.css
@@ -16,9 +16,24 @@ governing permissions and limitations under the License.
 }
 
 .spectrum {
+  --spectrum-animation-linear: cubic-bezier(0, 0, 1, 1);
+  --spectrum-animation-duration-0: 0ms;
   --spectrum-animation-duration-100: 130ms;
   --spectrum-animation-duration-200: 160ms;
+  --spectrum-animation-duration-300: 190ms;
+  --spectrum-animation-duration-400: 220ms;
   --spectrum-animation-duration-500: 250ms;
+  --spectrum-animation-duration-600: 300ms;
+  --spectrum-animation-duration-700: 350ms;
+  --spectrum-animation-duration-800: 400ms;
+  --spectrum-animation-duration-900: 450ms;
+  --spectrum-animation-duration-1000: 500ms;
+  --spectrum-animation-duration-2000: 1000ms;
+  --spectrum-animation-duration-4000: 2000ms;
+  --spectrum-animation-ease-in-out: cubic-bezier(.45, 0, .40, 1);
+  --spectrum-animation-ease-in: cubic-bezier(.50, 0, 1, 1);
+  --spectrum-animation-ease-out: cubic-bezier(0, 0, 0.40, 1);
+  --spectrum-animation-ease-linear: cubic-bezier(0, 0, 1, 1);
 
   --spectrum-font-family-base: adobe-clean, 'Source Sans Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Ubuntu, 'Trebuchet MS', 'Lucida Grande', sans-serif;
   --spectrum-font-family-serif: adobe-clean-serif, 'Source Serif Pro', Georgia, serif;


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
Adds a set of custom properties for animation. These are copied over from the legacy `vars` package.

*Reason for adding:*
These are added as a response to [this PR comment](https://github.com/adobe/spectrum-web-components/pull/2585#pullrequestreview-1180051361), but we've also been discussing adding global animation vars for several months. The time to add these is now!

## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
