### PR TITLE
refactor(progressbar): prefer global animation vars to component-defined

### DIFF
--- a/components/progressbar/index.css
+++ b/components/progressbar/index.css
@@ -12,8 +12,8 @@ governing permissions and limitations under the License.
 
 .spectrum-ProgressBar {
   /* Static tokens */
-  --spectrum-progressbar-animation-ease-in-out-indeterminate: cubic-bezier(.45, 0, .40, 1);
-  --spectrum-progressbar-animation-duration-indeterminate: 1000ms;
+  --spectrum-progressbar-animation-ease-in-out-indeterminate: var(--spectrum-animation-ease-in-out);
+  --spectrum-progressbar-animation-duration-indeterminate: var(--spectrum-animation-duration-2000);
   --spectrum-progressbar-corner-radius: var(--spectrum-corner-radius-100);
 
   --spectrum-progressbar-fill-size-indeterminate: 70%;

--- a/components/progressbar/package.json
+++ b/components/progressbar/package.json
@@ -17,8 +17,8 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/fieldlabel": "^5.0.3",
-    "@spectrum-css/tokens": "^6.2.0"
+    "@spectrum-css/fieldlabel": "^6.0.0",
+    "@spectrum-css/tokens": "^7.0.0"
   },
   "devDependencies": {
     "@spectrum-css/component-builder-simple": "^2.0.3",

--- a/components/progressbar/package.json
+++ b/components/progressbar/package.json
@@ -18,7 +18,7 @@
   },
   "peerDependencies": {
     "@spectrum-css/fieldlabel": "^5.0.3",
-    "@spectrum-css/tokens": "^6.0.0"
+    "@spectrum-css/tokens": "^6.2.0"
   },
   "devDependencies": {
     "@spectrum-css/component-builder-simple": "^2.0.3",


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
Uses global animation vars from `@spectrum-css/tokens` instead of defining its own vars. As described in [this PR comment](https://github.com/adobe/spectrum-web-components/pull/2585#pullrequestreview-1180051361), this has a number of benefits to what we're shipping, but it allows for consumers to more easily alter motion settings (where reduced motion is preferred).


## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
