### PR TITLE
chore: standardize package license and contributors

### DIFF
--- a/bundles/spectrum-css-compat/package.json
+++ b/bundles/spectrum-css-compat/package.json
@@ -2,22 +2,22 @@
   "name": "@adobe/spectrum-css",
   "version": "3.0.0",
   "description": "The Spectrum CSS top-level backwards compatible package",
+  "license": "Apache-2.0",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/adobe/spectrum-css.git"
+  },
+  "bugs": {
+    "url": "https://github.com/adobe/spectrum-css/issues"
+  },
   "scripts": {
     "build": "gulp build",
     "prepack": "gulp prePack",
     "postpublish": "gulp postPublish",
     "release": "gulp release"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
-  },
-  "author": "Adobe",
-  "bugs": {
-    "url": "https://github.com/adobe/spectrum-css/issues"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
-  "license": "Apache-2.0",
   "devDependencies": {
     "@spectrum-css/accordion": "^3.0.0",
     "@spectrum-css/actionbar": "^3.0.0",

--- a/bundles/spectrum-css-compat/package.json
+++ b/bundles/spectrum-css-compat/package.json
@@ -12,11 +12,7 @@
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git"
   },
-  "author": "Larry Davis <lazdnet@gmail.com>",
-  "contributors": [
-    "Garth Braithwaite <garthdb@gmail.com> (https://garthdb.com)",
-    "Steve Gill <stevengill97@gmail.com>"
-  ],
+  "author": "Adobe",
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },

--- a/bundles/spectrum-css/package.json
+++ b/bundles/spectrum-css/package.json
@@ -13,11 +13,7 @@
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git"
   },
-  "author": "Larry Davis <lazdnet@gmail.com>",
-  "contributors": [
-    "Garth Braithwaite <garthdb@gmail.com> (https://garthdb.com)",
-    "Steve Gill <stevengill97@gmail.com>"
-  ],
+  "author": "Adobe",
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },

--- a/bundles/spectrum-css/package.json
+++ b/bundles/spectrum-css/package.json
@@ -2,6 +2,16 @@
   "name": "@spectrum-css/spectrum-css",
   "version": "3.0.0",
   "description": "The Spectrum CSS top-level package",
+  "license": "Apache-2.0",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/adobe/spectrum-css.git"
+  },
+  "bugs": {
+    "url": "https://github.com/adobe/spectrum-css/issues"
+  },
   "scripts": {
     "build": "gulp build",
     "prepack": "gulp prePack",
@@ -9,16 +19,6 @@
     "publishpages": "gulp ghPages",
     "release": "gulp release"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/adobe/spectrum-css.git"
-  },
-  "author": "Adobe",
-  "bugs": {
-    "url": "https://github.com/adobe/spectrum-css/issues"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
-  "license": "Apache-2.0",
   "devDependencies": {
     "@spectrum-css/accordion": "^2.0.0",
     "@spectrum-css/actionbar": "^2.0.0",

--- a/components/accordion/package.json
+++ b/components/accordion/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.26",
   "description": "The Spectrum CSS accordion component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -27,6 +28,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/actionbar/package.json
+++ b/components/actionbar/package.json
@@ -3,7 +3,7 @@
   "version": "5.0.9",
   "description": "The Spectrum CSS actionbar component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -38,6 +39,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/actionbutton/package.json
+++ b/components/actionbutton/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.6",
   "description": "The Spectrum CSS action button component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -27,6 +28,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/actiongroup/package.json
+++ b/components/actiongroup/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.7",
   "description": "The Spectrum CSS actiongroup component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -28,6 +29,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/actionmenu/package.json
+++ b/components/actionmenu/package.json
@@ -3,7 +3,7 @@
   "version": "4.0.3",
   "description": "The Spectrum CSS actionmenu component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -33,6 +34,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/asset/package.json
+++ b/components/asset/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.23",
   "description": "The Spectrum CSS asset component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -25,6 +26,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/assetcard/package.json
+++ b/components/assetcard/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.6",
   "description": "The Spectrum CSS asset card component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -31,6 +32,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/assetlist/package.json
+++ b/components/assetlist/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.26",
   "description": "The Spectrum CSS assetlist component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -29,6 +30,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/avatar/package.json
+++ b/components/avatar/package.json
@@ -3,7 +3,7 @@
   "version": "5.0.20",
   "description": "The Spectrum CSS avatar component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -25,6 +26,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/badge/package.json
+++ b/components/badge/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.4",
   "description": "The Spectrum CSS badge component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -25,6 +26,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/breadcrumb/package.json
+++ b/components/breadcrumb/package.json
@@ -3,7 +3,7 @@
   "version": "5.0.2",
   "description": "The Spectrum CSS breadcrumb component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -29,6 +30,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/button/package.json
+++ b/components/button/package.json
@@ -3,7 +3,7 @@
   "version": "6.0.17",
   "description": "The Spectrum CSS button component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -26,6 +27,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/buttongroup/package.json
+++ b/components/buttongroup/package.json
@@ -3,7 +3,7 @@
   "version": "6.0.9",
   "description": "The Spectrum CSS buttongroup component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -28,6 +29,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/calendar/package.json
+++ b/components/calendar/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.28",
   "description": "The Spectrum CSS calendar component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -29,6 +30,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/card/package.json
+++ b/components/card/package.json
@@ -3,7 +3,7 @@
   "version": "5.0.3",
   "description": "The Spectrum CSS card component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -37,6 +38,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/checkbox/package.json
+++ b/components/checkbox/package.json
@@ -3,7 +3,7 @@
   "version": "5.0.6",
   "description": "The Spectrum CSS checkbox component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -27,6 +28,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/clearbutton/package.json
+++ b/components/clearbutton/package.json
@@ -3,7 +3,7 @@
   "version": "1.2.13",
   "description": "The Spectrum CSS clearbutton component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -25,6 +26,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/closebutton/package.json
+++ b/components/closebutton/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.6",
   "description": "The Spectrum CSS close button component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -26,6 +27,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/coachmark/package.json
+++ b/components/coachmark/package.json
@@ -3,7 +3,7 @@
   "version": "5.0.17",
   "description": "The Spectrum CSS coachmark component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -27,6 +28,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/colorarea/package.json
+++ b/components/colorarea/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.23",
   "description": "The Spectrum CSS Color Area component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -27,6 +28,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/colorhandle/package.json
+++ b/components/colorhandle/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.9",
   "description": "The Spectrum CSS Color Handle component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -27,6 +28,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/colorloupe/package.json
+++ b/components/colorloupe/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.9",
   "description": "The Spectrum CSS Color Loupe component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -25,6 +26,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/colorslider/package.json
+++ b/components/colorslider/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.9",
   "description": "The Spectrum CSS Color Slider component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -27,6 +28,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/colorwheel/package.json
+++ b/components/colorwheel/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.23",
   "description": "The Spectrum CSS Color Area component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -27,6 +28,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/commons/package.json
+++ b/components/commons/package.json
@@ -3,7 +3,7 @@
   "version": "4.0.0",
   "description": "Common mixins for Spectrum CSS components",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,11 +12,11 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "echo 'No build required'"
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/cyclebutton/package.json
+++ b/components/cyclebutton/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.29",
   "description": "The Spectrum CSS cyclebutton component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -29,6 +30,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/dial/package.json
+++ b/components/dial/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.25",
   "description": "The Spectrum CSS dial component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -27,6 +28,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/dialog/package.json
+++ b/components/dialog/package.json
@@ -3,7 +3,7 @@
   "version": "6.0.19",
   "description": "The Spectrum CSS dialog component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -39,6 +40,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/divider/package.json
+++ b/components/divider/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.5",
   "description": "The Spectrum CSS divider component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -27,6 +28,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/dropindicator/package.json
+++ b/components/dropindicator/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.25",
   "description": "The Spectrum CSS dropindicator component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -27,6 +28,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/dropzone/package.json
+++ b/components/dropzone/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.26",
   "description": "The Spectrum CSS dropzone component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -29,6 +30,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/expressvars/package.json
+++ b/components/expressvars/package.json
@@ -3,10 +3,7 @@
   "version": "2.0.1",
   "description": "The Spectrum CSS vars for Express package",
   "license": "Apache-2.0",
-  "main": "dist/spectrum-metadata.json",
-  "scripts": {
-    "update": "gulp update"
-  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -14,6 +11,10 @@
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
+  },
+  "main": "dist/spectrum-metadata.json",
+  "scripts": {
+    "update": "gulp update"
   },
   "devDependencies": {
     "del": "^5.0.0",
@@ -27,6 +28,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/fieldgroup/package.json
+++ b/components/fieldgroup/package.json
@@ -3,7 +3,7 @@
   "version": "4.0.8",
   "description": "The Spectrum CSS fieldgroup component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -33,6 +34,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/fieldlabel/package.json
+++ b/components/fieldlabel/package.json
@@ -3,7 +3,7 @@
   "version": "5.0.10",
   "description": "The Spectrum CSS fieldlabel component",
   "license": "Apache-2.0",
-  "main": "dist/index.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index.css",
   "scripts": {
     "build": "gulp"
   },
@@ -33,6 +34,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/helptext/package.json
+++ b/components/helptext/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.8",
   "description": "The Spectrum CSS helptext component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -27,6 +28,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/icon/package.json
+++ b/components/icon/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.25",
   "description": "The Spectrum CSS icon component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp",
     "update": "gulp updateIcons"
@@ -33,6 +34,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/illustratedmessage/package.json
+++ b/components/illustratedmessage/package.json
@@ -3,7 +3,7 @@
   "version": "4.0.7",
   "description": "The Spectrum CSS illustratedmessage component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -27,6 +28,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/infieldbutton/package.json
+++ b/components/infieldbutton/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.2",
   "description": "The Spectrum CSS infield button component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -26,6 +27,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/inlinealert/package.json
+++ b/components/inlinealert/package.json
@@ -3,7 +3,7 @@
   "version": "5.0.10",
   "description": "The Spectrum CSS in-line alert component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -28,6 +29,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/inputgroup/package.json
+++ b/components/inputgroup/package.json
@@ -3,7 +3,7 @@
   "version": "5.0.4",
   "description": "The Spectrum CSS inputgroup component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -32,6 +33,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/link/package.json
+++ b/components/link/package.json
@@ -3,7 +3,7 @@
   "version": "4.0.6",
   "description": "The Spectrum CSS link component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -25,6 +26,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/logicbutton/package.json
+++ b/components/logicbutton/package.json
@@ -3,7 +3,7 @@
   "version": "1.2.12",
   "description": "The Spectrum CSS logicbutton component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -25,6 +26,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/menu/package.json
+++ b/components/menu/package.json
@@ -3,7 +3,7 @@
   "version": "4.0.6",
   "description": "The Spectrum CSS menu component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -29,6 +30,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/miller/package.json
+++ b/components/miller/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.26",
   "description": "The Spectrum CSS miller component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -31,6 +32,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/modal/package.json
+++ b/components/modal/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.24",
   "description": "The Spectrum CSS modal component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -25,6 +26,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/overlay/package.json
+++ b/components/overlay/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.0",
   "description": "Overlay mixin",
   "license": "Apache-2.0",
-  "main": "index.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,11 +12,11 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "index.css",
   "scripts": {
     "build": "echo 'No build required'"
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/page/package.json
+++ b/components/page/package.json
@@ -3,7 +3,7 @@
   "version": "5.0.12",
   "description": "The Spectrum CSS page component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -25,6 +26,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/pagination/package.json
+++ b/components/pagination/package.json
@@ -3,7 +3,7 @@
   "version": "5.0.19",
   "description": "The Spectrum CSS pagination component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -35,6 +36,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/picker/package.json
+++ b/components/picker/package.json
@@ -3,7 +3,7 @@
   "version": "1.2.14",
   "description": "The Spectrum CSS picker component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -31,6 +32,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/pickerbutton/package.json
+++ b/components/pickerbutton/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.2",
   "description": "The Spectrum CSS picker button component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -31,6 +32,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/popover/package.json
+++ b/components/popover/package.json
@@ -3,7 +3,7 @@
   "version": "6.0.8",
   "description": "The Spectrum CSS popover component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -30,6 +31,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/progressbar/package.json
+++ b/components/progressbar/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.7",
   "description": "The Spectrum CSS progress bar component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -27,6 +28,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/progresscircle/package.json
+++ b/components/progresscircle/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.6",
   "description": "The Spectrum CSS progress circle component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -25,6 +26,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/quickaction/package.json
+++ b/components/quickaction/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.27",
   "description": "The Spectrum CSS quickaction component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -29,6 +30,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/radio/package.json
+++ b/components/radio/package.json
@@ -3,7 +3,7 @@
   "version": "6.0.5",
   "description": "The Spectrum CSS radio component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -27,6 +28,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/rating/package.json
+++ b/components/rating/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.26",
   "description": "The Spectrum CSS rating component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -27,6 +28,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/search/package.json
+++ b/components/search/package.json
@@ -3,7 +3,7 @@
   "version": "4.2.15",
   "description": "The Spectrum CSS search component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -31,6 +32,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/searchwithin/package.json
+++ b/components/searchwithin/package.json
@@ -3,7 +3,7 @@
   "version": "3.4.23",
   "description": "The Spectrum CSS searchwithin component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -33,6 +34,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/sidenav/package.json
+++ b/components/sidenav/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.26",
   "description": "The Spectrum CSS sidenav component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -26,6 +27,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/site/package.json
+++ b/components/site/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.1",
   "description": "The Spectrum CSS Site component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -25,6 +26,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/slider/package.json
+++ b/components/slider/package.json
@@ -3,7 +3,7 @@
   "version": "3.1.8",
   "description": "The Spectrum CSS slider component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -25,6 +26,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/splitbutton/package.json
+++ b/components/splitbutton/package.json
@@ -3,7 +3,7 @@
   "version": "5.0.17",
   "description": "The Spectrum CSS splitbutton component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -28,6 +29,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/splitview/package.json
+++ b/components/splitview/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.23",
   "description": "The Spectrum CSS splitview component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -25,6 +26,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/statuslight/package.json
+++ b/components/statuslight/package.json
@@ -3,7 +3,7 @@
   "version": "5.0.6",
   "description": "The Spectrum CSS statuslight component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -25,6 +26,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/steplist/package.json
+++ b/components/steplist/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.27",
   "description": "The Spectrum CSS steplist component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -28,6 +29,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/stepper/package.json
+++ b/components/stepper/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.29",
   "description": "The Spectrum CSS stepper component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -31,6 +32,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/swatch/package.json
+++ b/components/swatch/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.4",
   "description": "The Spectrum CSS Color swatch component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -25,6 +26,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/swatchgroup/package.json
+++ b/components/swatchgroup/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.5",
   "description": "The Spectrum CSS Color swatch group component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -27,6 +28,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/switch/package.json
+++ b/components/switch/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.0",
   "description": "The Spectrum CSS switch component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -25,6 +26,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/table/package.json
+++ b/components/table/package.json
@@ -3,7 +3,7 @@
   "version": "4.0.21",
   "description": "The Spectrum CSS table component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -28,6 +29,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/tabs/package.json
+++ b/components/tabs/package.json
@@ -3,7 +3,7 @@
   "version": "3.2.22",
   "description": "The Spectrum CSS tabs component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -30,6 +31,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/tag/package.json
+++ b/components/tag/package.json
@@ -3,7 +3,7 @@
   "version": "4.0.4",
   "description": "The Spectrum CSS tags component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -29,6 +30,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/taggroup/package.json
+++ b/components/taggroup/package.json
@@ -3,7 +3,7 @@
   "version": "3.3.16",
   "description": "The Spectrum CSS tags component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -31,6 +32,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/textfield/package.json
+++ b/components/textfield/package.json
@@ -3,7 +3,7 @@
   "version": "3.2.6",
   "description": "The Spectrum CSS textfield component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -25,6 +26,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/thumbnail/package.json
+++ b/components/thumbnail/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.18",
   "description": "The Spectrum CSS thumbnail component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -25,6 +26,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/toast/package.json
+++ b/components/toast/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.10",
   "description": "The Spectrum CSS toast component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -31,6 +32,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/tokens/package.json
+++ b/components/tokens/package.json
@@ -3,10 +3,7 @@
   "version": "6.2.0",
   "description": "The Spectrum CSS tokens package",
   "license": "Apache-2.0",
-  "main": "dist/index.css",
-  "scripts": {
-    "build": "gulp build"
-  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -14,6 +11,10 @@
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
+  },
+  "main": "dist/index.css",
+  "scripts": {
+    "build": "gulp build"
   },
   "devDependencies": {
     "@adobe/spectrum-tokens": "12.0.0-beta.63",
@@ -24,6 +25,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/tooltip/package.json
+++ b/components/tooltip/package.json
@@ -3,7 +3,7 @@
   "version": "4.0.5",
   "description": "The Spectrum CSS tooltip component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -27,6 +28,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/tray/package.json
+++ b/components/tray/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.5",
   "description": "The Spectrum CSS tray component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -33,6 +34,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/treeview/package.json
+++ b/components/treeview/package.json
@@ -3,7 +3,7 @@
   "version": "6.0.22",
   "description": "The Spectrum CSS treeview component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -28,6 +29,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/typography/package.json
+++ b/components/typography/package.json
@@ -3,7 +3,7 @@
   "version": "4.0.21",
   "description": "The Spectrum CSS typography component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -25,6 +26,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/underlay/package.json
+++ b/components/underlay/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.32",
   "description": "The Spectrum CSS underlay component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -25,6 +26,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/vars/package.json
+++ b/components/vars/package.json
@@ -3,10 +3,7 @@
   "version": "8.0.0",
   "description": "The Spectrum CSS vars package",
   "license": "Apache-2.0",
-  "main": "dist/spectrum-metadata.json",
-  "scripts": {
-    "update": "gulp update"
-  },
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -14,6 +11,10 @@
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
+  },
+  "main": "dist/spectrum-metadata.json",
+  "scripts": {
+    "update": "gulp update"
   },
   "devDependencies": {
     "del": "^5.0.0",
@@ -27,6 +28,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/components/well/package.json
+++ b/components/well/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.23",
   "description": "The Spectrum CSS well component",
   "license": "Apache-2.0",
-  "main": "dist/index-vars.css",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
+  "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp"
   },
@@ -25,6 +26,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "homepage": "https://opensource.adobe.com/spectrum-css/"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,82 +1,59 @@
 {
+  "private": true,
   "name": "spectrum-css-monorepo",
   "version": "0.0.0",
-  "private": true,
+  "license": "Apache-2.0",
+  "author": "Adobe",
+  "contributors": [
+    "Cassondra Roberts <castastrophe@users.noreply.github.com> (https://allons-y.llc)",
+    "Garth Braithwaite <garthdb@gmail.com> (https://garthdb.com)",
+    "Larry Davis <lazdnet@gmail.com>",
+    "Patrick Fulton <pfulton@users.noreply.github.com>",
+    "Steve Gill <stevengill97@gmail.com>"
+  ],
   "homepage": "https://opensource.adobe.com/spectrum-css/",
-  "scripts": {
-    "build": "run-s build:site build:preview mv:preview",
-    "build:components": "gulp buildComponents -LLL ",
-    "build:site": "gulp -LL",
-    "build:preview": "yarn workspace @spectrum-css/preview build",
-    "dev": "NODE_ENV=development BROWSERSYNC_OPEN=true gulp dev",
-    "clean": "gulp clean",
-    "new": "yarn workspace @spectrum-css/generator new",
-    "mv:preview": "mv tools/preview/storybook-static dist/preview",
-    "start": "NODE_ENV=development yarn workspace @spectrum-css/preview start",
-    "ci-all": "yarn build",
-    "prerelease": "yarn clean && yarn build",
-    "release": "lerna publish --no-private",
-    "prerelease:beta-from-package": "yarn clean && yarn build",
-    "release:beta-from-package": "lerna publish from-package --conventional-prerelease --preid beta --pre-dist-tag beta --no-private",
-    "release:site": "gulp prepareSite && gh-pages -d dist-site/ -f -e .",
-    "release:bundles": "gulp releaseBundles",
-    "version": "gulp version",
-    "preversion": "yarn build",
-    "backstop:approve": "backstop approve --config=backstop_data/backstop_test.js",
-    "backstop:test": "backstop test --config=backstop_data/backstop_test.js --env=local",
-    "backstop:clean": "rm -rf backstop_data/bitmaps_test backstop_data/html_report",
-    "backstop:docker:test": "wait-on http://127.0.0.1:3000/docs/index.html && gulp test:init && backstop test --docker --config=backstop_data/backstop_test.js --env=local",
-    "backstop:docker:reference": "wait-on http://127.0.0.1:3000/docs/index.html && gulp test:init && backstop reference --docker --config=backstop_data/backstop_test.js --env=local",
-    "backstop:ci:clean": "backstop clean --docker --config=backstop_data/backstop_test.js --env=ci",
-    "backstop:ci:test": "wait-on http://127.0.0.1:3000/docs/index.html && gulp test:init && backstop test --docker --config=backstop_data/backstop_test.js --env=ci",
-    "backstop:ci:reference": "wait-on http://127.0.0.1:3000/docs/index.html && gulp test:init && backstop reference --docker --config=backstop_data/backstop_test.js --env=ci",
-    "backstop:test-all": "backstop test --docker --config=backstop_data/backstop_test.js --env=local themes=light,dark,darkest scales=medium,large",
-    "kill-zombies": "pkill -f \"(chrome)?(--headless)\"",
-    "prepare": "gulp prepare",
-    "watch": "gulp watch"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git"
   },
-  "author": "Adobe",
-  "contributors": [
-    "Larry Davis <lazdnet@gmail.com>",
-    "Garth Braithwaite <garthdb@gmail.com> (https://garthdb.com)",
-    "Patrick Fulton <pfulton@users.noreply.github.com>",
-    "Steve Gill <stevengill97@gmail.com>",
-    "Cassondra Roberts <castastrophe@users.noreply.github.com> (https://allons-y.llc)"
-  ],
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
-  "license": "Apache-2.0",
-  "devDependencies": {
-    "@adobe/focus-ring-polyfill": "^0.1.5",
-    "@adobe/spectrum-css-workflow-icons": "^1.2.1",
-    "@adobe/spectrum-express-tokens-deprecated": "^1.0.0-beta.35",
-    "@adobe/spectrum-tokens-deprecated": "^11.8.0",
-    "@commitlint/cli": "^8.3.3",
-    "@commitlint/config-conventional": "^8.3.3",
-    "@spectrum-css/spectrum-css-vr-test-assets-essential": "^1.0.46",
-    "audit-ci": "^2.0.1",
-    "backstopjs-spectrum": "6.16.0",
-    "del": "^5.1.0",
-    "gh-pages": "^3.0.0",
-    "gulp": "^4.0.0",
-    "gulp-replace": "^1.0.0",
-    "gulplog": "^1.0.0",
-    "husky": "^3.0.5",
-    "lerna": "^4.0.0",
-    "loadicons": "^1.0.0",
-    "lunr": "^2.3.6",
-    "markdown-it": "^12.3.2",
-    "npm-run-all": "^4.1.5",
-    "prismjs": "^1.23.0",
-    "semver": "^6.3.0",
-    "through2": "^3.0.1",
-    "wait-on": "^6.0.1"
+  "scripts": {
+    "backstop:approve": "backstop approve --config=backstop_data/backstop_test.js",
+    "backstop:ci:clean": "backstop clean --docker --config=backstop_data/backstop_test.js --env=ci",
+    "backstop:ci:reference": "wait-on http://127.0.0.1:3000/docs/index.html && gulp test:init && backstop reference --docker --config=backstop_data/backstop_test.js --env=ci",
+    "backstop:ci:test": "wait-on http://127.0.0.1:3000/docs/index.html && gulp test:init && backstop test --docker --config=backstop_data/backstop_test.js --env=ci",
+    "backstop:clean": "rm -rf backstop_data/bitmaps_test backstop_data/html_report",
+    "backstop:docker:reference": "wait-on http://127.0.0.1:3000/docs/index.html && gulp test:init && backstop reference --docker --config=backstop_data/backstop_test.js --env=local",
+    "backstop:docker:test": "wait-on http://127.0.0.1:3000/docs/index.html && gulp test:init && backstop test --docker --config=backstop_data/backstop_test.js --env=local",
+    "backstop:test": "backstop test --config=backstop_data/backstop_test.js --env=local",
+    "backstop:test-all": "backstop test --docker --config=backstop_data/backstop_test.js --env=local themes=light,dark,darkest scales=medium,large",
+    "build": "run-s build:site build:preview mv:preview",
+    "build:components": "gulp buildComponents -LLL ",
+    "build:preview": "yarn workspace @spectrum-css/preview build",
+    "build:site": "gulp -LL",
+    "ci-all": "yarn build",
+    "clean": "gulp clean",
+    "dev": "NODE_ENV=development BROWSERSYNC_OPEN=true gulp dev",
+    "kill-zombies": "pkill -f \"(chrome)?(--headless)\"",
+    "mv:preview": "mv tools/preview/storybook-static dist/preview",
+    "new": "yarn workspace @spectrum-css/generator new",
+    "precommit": "lint-staged",
+    "prepare": "husky install && gulp prepare",
+    "release": "npx lerna publish",
+    "release:beta-from-package": "yarn run clean && yarn run build && npx lerna publish from-package --conventional-prerelease --preid beta --pre-dist-tag beta",
+    "release:bundles": "gulp releaseBundles",
+    "release:site": "gulp prepareSite && gh-pages -d dist-site/ -f -e .",
+    "start": "NODE_ENV=development yarn workspace @spectrum-css/preview start",
+    "preversion": "yarn build",
+    "version": "gulp version",
+    "watch": "gulp watch"
   },
+  "workspaces": [
+    "components/*",
+    "tools/*"
+  ],
   "resolutions": {
     "axios": "^0.21.1",
     "dot-prop": "^5.2.0",
@@ -93,13 +70,43 @@
     "xmlhttprequest-ssl": "^1.6.2",
     "y18n": "^5.0.5"
   },
-  "workspaces": [
-    "components/*",
-    "tools/*"
-  ],
+  "devDependencies": {
+    "@adobe/focus-ring-polyfill": "^0.1.5",
+    "@adobe/spectrum-css-workflow-icons": "^1.2.1",
+    "@adobe/spectrum-express-tokens-deprecated": "^1.0.0-beta.35",
+    "@adobe/spectrum-tokens-deprecated": "^11.8.0",
+    "@commitlint/cli": "^8.3.3",
+    "@commitlint/config-conventional": "^8.3.3",
+    "@spectrum-css/spectrum-css-vr-test-assets-essential": "^1.0.46",
+    "audit-ci": "^2.0.1",
+    "backstopjs-spectrum": "6.16.0",
+    "del": "^5.1.0",
+    "gh-pages": "^3.0.0",
+    "gulp": "^4.0.0",
+    "gulp-replace": "^1.0.0",
+    "gulplog": "^1.0.0",
+    "husky": "^8.0.3",
+    "lerna": "^4.0.0",
+    "lint-staged": "^13.1.0",
+    "loadicons": "^1.0.0",
+    "lunr": "^2.3.6",
+    "markdown-it": "^12.3.2",
+    "npm-run-all": "^4.1.5",
+    "prettier-package-json": "^2.8.0",
+    "prismjs": "^1.23.0",
+    "semver": "^6.3.0",
+    "through2": "^3.0.1",
+    "wait-on": "^6.0.1"
+  },
   "husky": {
     "hooks": {
-      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
+      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
+      "pre-commit": "lint-staged"
     }
+  },
+  "lint-staged": {
+    "package.json": [
+      "prettier-package-json --write"
+    ]
   }
 }

--- a/tools/bundle-builder/package.json
+++ b/tools/bundle-builder/package.json
@@ -7,11 +7,7 @@
     "url": "https://github.com/adobe/spectrum-css.git",
     "directory": "tools/bundle-builder"
   },
-  "author": "Larry Davis <lazdnet@gmail.com>",
-  "contributors": [
-    "Garth Braithwaite <garthdb@gmail.com> (https://garthdb.com)",
-    "Steve Gill <stevengill97@gmail.com>"
-  ],
+  "author": "Adobe",
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },

--- a/tools/bundle-builder/package.json
+++ b/tools/bundle-builder/package.json
@@ -2,16 +2,19 @@
   "name": "@spectrum-css/bundle-builder",
   "version": "3.4.1",
   "description": "The Spectrum CSS top-level builder",
+  "license": "Apache-2.0",
+  "author": "Adobe",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
     "directory": "tools/bundle-builder"
   },
-  "author": "Adobe",
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
-  "license": "Apache-2.0",
+  "dependencies": {
+    "npm-registry-fetch": "^11.0.0"
+  },
   "devDependencies": {
     "browser-sync": "^2.26.14",
     "colors": "^1.3.3",
@@ -29,8 +32,5 @@
     "replace-ext": "^1.0.0",
     "semver": "^6.3.0",
     "through2": "^3.0.1"
-  },
-  "dependencies": {
-    "npm-registry-fetch": "^11.0.0"
   }
 }

--- a/tools/component-builder-simple/package.json
+++ b/tools/component-builder-simple/package.json
@@ -2,6 +2,7 @@
   "name": "@spectrum-css/component-builder-simple",
   "version": "2.0.0",
   "description": "The Spectrum CSS simple component builder",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -9,13 +10,6 @@
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
-  },
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "@spectrum-css/tokens": "^3.0.0"
-  },
-  "publishConfig": {
-    "access": "public"
   },
   "dependencies": {
     "autoprefixer": "^6.5.3",
@@ -39,5 +33,11 @@
     "postcss-splitinator": "^1.0.0-beta.1",
     "postcss-values-parser": "^3.1.1",
     "through2": "^3.0.1"
+  },
+  "peerDependencies": {
+    "@spectrum-css/tokens": "^3.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/tools/component-builder/package.json
+++ b/tools/component-builder/package.json
@@ -2,6 +2,7 @@
   "name": "@spectrum-css/component-builder",
   "version": "3.2.1",
   "description": "The Spectrum CSS component builder",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -9,11 +10,6 @@
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
-  },
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "@spectrum-css/tokens": "^1.0.0-beta",
-    "@spectrum-css/vars": "^8.0.0"
   },
   "dependencies": {
     "autoprefixer": "^6.5.3",
@@ -51,5 +47,9 @@
     "pug": "^3.0.1",
     "replace-ext": "^1.0.0",
     "through2": "^3.0.1"
+  },
+  "peerDependencies": {
+    "@spectrum-css/tokens": "^1.0.0-beta",
+    "@spectrum-css/vars": "^8.0.0"
   }
 }

--- a/tools/conventional-changelog-spectrum/package.json
+++ b/tools/conventional-changelog-spectrum/package.json
@@ -28,11 +28,11 @@
     "writer-opts.js",
     "templates"
   ],
-  "author": "Steve Mao",
+  "author": "Adobe",
   "engines": {
     "node": ">=6.9.0"
   },
-  "license": "ISC",
+  "license": "Apache-2.0",
   "homepage": "https://github.com/adobe/spectrum-css/",
   "dependencies": {
     "compare-func": "^1.3.1",

--- a/tools/conventional-changelog-spectrum/package.json
+++ b/tools/conventional-changelog-spectrum/package.json
@@ -1,12 +1,11 @@
 {
+  "private": true,
   "name": "conventional-changelog-spectrum",
   "version": "1.0.1",
-  "private": true,
   "description": "conventional-changelog spectrum preset",
-  "main": "index.js",
-  "scripts": {
-    "test-windows": "mocha --timeout 30000"
-  },
+  "license": "Apache-2.0",
+  "author": "Adobe",
+  "homepage": "https://github.com/adobe/spectrum-css/",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -15,27 +14,27 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
-  "keywords": [
-    "conventional-changelog",
-    "spectrum",
-    "preset"
-  ],
+  "main": "index.js",
   "files": [
     "conventional-changelog.js",
     "conventional-recommended-bump.js",
-    "index.js",
     "parser-opts.js",
-    "writer-opts.js",
-    "templates"
+    "templates",
+    "writer-opts.js"
   ],
-  "author": "Adobe",
-  "engines": {
-    "node": ">=6.9.0"
+  "scripts": {
+    "test-windows": "mocha --timeout 30000"
   },
-  "license": "Apache-2.0",
-  "homepage": "https://github.com/adobe/spectrum-css/",
   "dependencies": {
     "compare-func": "^1.3.1",
     "q": "^1.5.1"
+  },
+  "keywords": [
+    "conventional-changelog",
+    "preset",
+    "spectrum"
+  ],
+  "engines": {
+    "node": ">=6.9.0"
   }
 }

--- a/tools/generator/package.json
+++ b/tools/generator/package.json
@@ -5,9 +5,6 @@
   "description": "A tool to quickly create standardized components",
   "license": "Apache-2.0",
   "author": "Adobe",
-  "contributors": [
-    "Cassondra Roberts <castastrophe@users.noreply.github.com> (https://allons-y.llc)"
-  ],
   "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",

--- a/tools/generator/package.json
+++ b/tools/generator/package.json
@@ -14,8 +14,8 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
-  "main": "plopfile.js",
   "type": "module",
+  "main": "plopfile.js",
   "scripts": {
     "new": "plop",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/tools/postcss-combininator/package.json
+++ b/tools/postcss-combininator/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "test": "ava"
   },
-  "author": "Larry Davis <lazdnet@gmail.com>",
-  "license": "BSD-2-Clause",
+  "author": "Adobe",
+  "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"
   },

--- a/tools/postcss-combininator/package.json
+++ b/tools/postcss-combininator/package.json
@@ -1,18 +1,18 @@
 {
+  "private": true,
   "name": "postcss-combininator",
   "version": "1.0.0-beta.1",
   "description": "Combines multiple blocks of custom properties",
+  "license": "Apache-2.0",
+  "author": "Adobe",
   "main": "index.js",
-  "private": true,
   "scripts": {
     "test": "ava"
   },
-  "author": "Adobe",
-  "license": "Apache-2.0",
-  "publishConfig": {
-    "access": "public"
-  },
   "dependencies": {
     "postcss": "^7.0.32"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/tools/postcss-dropdupedvars/package.json
+++ b/tools/postcss-dropdupedvars/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "test": "ava"
   },
-  "author": "Larry Davis <lazdnet@gmail.com>",
-  "license": "BSD-2-Clause",
+  "author": "Adobe",
+  "license": "Apache-2.0",
   "dependencies": {
     "postcss": "^7.0.32"
   },

--- a/tools/postcss-dropdupedvars/package.json
+++ b/tools/postcss-dropdupedvars/package.json
@@ -1,14 +1,14 @@
 {
+  "private": true,
   "name": "postcss-dropdupedvars",
   "version": "1.1.2",
   "description": "Drop duplicate vars",
+  "license": "Apache-2.0",
+  "author": "Adobe",
   "main": "index.js",
-  "private": true,
   "scripts": {
     "test": "ava"
   },
-  "author": "Adobe",
-  "license": "Apache-2.0",
   "dependencies": {
     "postcss": "^7.0.32"
   },

--- a/tools/postcss-droproot/package.json
+++ b/tools/postcss-droproot/package.json
@@ -1,14 +1,14 @@
 {
+  "private": true,
   "name": "postcss-droproot",
   "version": "1.0.3",
   "description": "Remove :root rules",
+  "license": "Apache-2.0",
+  "author": "Adobe",
   "main": "index.js",
-  "private": true,
   "scripts": {
     "test": "ava"
   },
-  "author": "Adobe",
-  "license": "Apache-2.0",
   "dependencies": {
     "postcss": "^7.0.32"
   }

--- a/tools/postcss-droproot/package.json
+++ b/tools/postcss-droproot/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "test": "ava"
   },
-  "author": "Larry Davis <lazdnet@gmail.com>",
-  "license": "BSD-2-Clause",
+  "author": "Adobe",
+  "license": "Apache-2.0",
   "dependencies": {
     "postcss": "^7.0.32"
   }

--- a/tools/postcss-dropunusedvars/package.json
+++ b/tools/postcss-dropunusedvars/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "test": "ava"
   },
-  "author": "Larry Davis <lazdnet@gmail.com>",
-  "license": "BSD-2-Clause",
+  "author": "Adobe",
+  "license": "Apache-2.0",
   "dependencies": {
     "postcss": "^7.0.32",
     "postcss-value-parser": "^4.1.0"

--- a/tools/postcss-dropunusedvars/package.json
+++ b/tools/postcss-dropunusedvars/package.json
@@ -1,14 +1,14 @@
 {
+  "private": true,
   "name": "postcss-dropunusedvars",
   "version": "1.2.1",
   "description": "Remove unused variable definitions",
+  "license": "Apache-2.0",
+  "author": "Adobe",
   "main": "index.js",
-  "private": true,
   "scripts": {
     "test": "ava"
   },
-  "author": "Adobe",
-  "license": "Apache-2.0",
   "dependencies": {
     "postcss": "^7.0.32",
     "postcss-value-parser": "^4.1.0"

--- a/tools/postcss-remapvars/package.json
+++ b/tools/postcss-remapvars/package.json
@@ -1,14 +1,14 @@
 {
+  "private": true,
   "name": "postcss-remapvars",
   "version": "1.1.0",
   "description": "Remap variables with find and replace",
+  "license": "Apache-2.0",
+  "author": "Adobe",
   "main": "index.js",
-  "private": true,
   "scripts": {
     "test": "ava"
   },
-  "author": "Adobe",
-  "license": "Apache-2.0",
   "dependencies": {
     "postcss": "^7.0.32"
   },

--- a/tools/postcss-remapvars/package.json
+++ b/tools/postcss-remapvars/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "test": "ava"
   },
-  "author": "Larry Davis <lazdnet@gmail.com>",
-  "license": "BSD-2-Clause",
+  "author": "Adobe",
+  "license": "Apache-2.0",
   "dependencies": {
     "postcss": "^7.0.32"
   },

--- a/tools/postcss-splitinator/package.json
+++ b/tools/postcss-splitinator/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "test": "ava"
   },
-  "author": "Larry Davis <lazdnet@gmail.com>",
-  "license": "BSD-2-Clause",
+  "author": "Adobe",
+  "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"
   },

--- a/tools/postcss-splitinator/package.json
+++ b/tools/postcss-splitinator/package.json
@@ -1,18 +1,18 @@
 {
+  "private": true,
   "name": "postcss-splitinator",
   "version": "1.0.0-beta.1",
   "description": "Turn container queryies into the var hack",
+  "license": "Apache-2.0",
+  "author": "Adobe",
   "main": "index.js",
-  "private": true,
   "scripts": {
     "test": "ava"
   },
-  "author": "Adobe",
-  "license": "Apache-2.0",
-  "publishConfig": {
-    "access": "public"
-  },
   "dependencies": {
     "postcss": "^7.0.32"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/tools/postcss-transformselectors/package.json
+++ b/tools/postcss-transformselectors/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "test": "ava"
   },
-  "author": "Larry Davis <lazdnet@gmail.com>",
-  "license": "BSD-2-Clause",
+  "author": "Adobe",
+  "license": "Apache-2.0",
   "dependencies": {
     "postcss": "^7.0.36"
   },

--- a/tools/postcss-transformselectors/package.json
+++ b/tools/postcss-transformselectors/package.json
@@ -1,14 +1,14 @@
 {
+  "private": true,
   "name": "postcss-transformselectors",
   "version": "2.0.1",
   "description": "Re-map and transform selectors",
+  "license": "Apache-2.0",
+  "author": "Adobe",
   "main": "index.js",
-  "private": true,
   "scripts": {
     "test": "ava"
   },
-  "author": "Adobe",
-  "license": "Apache-2.0",
   "dependencies": {
     "postcss": "^7.0.36"
   },

--- a/tools/postcss-varfallback/package.json
+++ b/tools/postcss-varfallback/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "test": "ava"
   },
-  "author": "Larry Davis <lazdnet@gmail.com>",
-  "license": "BSD-2-Clause",
+  "author": "Adobe",
+  "license": "Apache-2.0",
   "dependencies": {
     "postcss": "^7.0.36",
     "postcss-value-parser": "^4.1.0"

--- a/tools/postcss-varfallback/package.json
+++ b/tools/postcss-varfallback/package.json
@@ -1,14 +1,14 @@
 {
+  "private": true,
   "name": "postcss-varfallback",
   "version": "1.1.3",
   "description": "Use the fallback value of any var reference",
+  "license": "Apache-2.0",
+  "author": "Adobe",
   "main": "index.js",
-  "private": true,
   "scripts": {
     "test": "ava"
   },
-  "author": "Adobe",
-  "license": "Apache-2.0",
   "dependencies": {
     "postcss": "^7.0.36",
     "postcss-value-parser": "^4.1.0"

--- a/tools/preview/package.json
+++ b/tools/preview/package.json
@@ -1,14 +1,21 @@
 {
-  "author": "Adobe",
-  "description": "A Spectrum CSS preview",
-  "license": "Apache-2.0",
-  "main": "main.js",
   "name": "@spectrum-css/preview",
   "version": "1.0.4",
+  "description": "A Spectrum CSS preview",
+  "license": "Apache-2.0",
+  "author": "Adobe",
   "homepage": "https://opensource.adobe.com/spectrum-css/preview",
+  "main": "main.js",
   "scripts": {
     "build": "build-storybook --config-dir .",
     "start": "WATCH_MODE=true start-storybook -p 6006 --config-dir ."
+  },
+  "dependencies": {
+    "@adobe/spectrum-css-workflow-icons": "^1.2.1",
+    "@spectrum-css/expressvars": "^2.0.1",
+    "@spectrum-css/icon": "^3.0.25",
+    "@spectrum-css/tokens": "^4.0.0",
+    "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.5",
@@ -39,12 +46,5 @@
     "react-syntax-highlighter": "^15.5.0",
     "source-map-loader": "^1.0.0",
     "webpack": "^4.46.0"
-  },
-  "dependencies": {
-    "@adobe/spectrum-css-workflow-icons": "^1.2.1",
-    "@spectrum-css/expressvars": "^2.0.1",
-    "@spectrum-css/icon": "^3.0.25",
-    "@spectrum-css/tokens": "^4.0.0",
-    "@spectrum-css/vars": "^8.0.0"
   }
 }

--- a/tools/test-builder/package.json
+++ b/tools/test-builder/package.json
@@ -1,8 +1,9 @@
 {
+  "private": true,
   "name": "@spectrum-css/test-builder",
   "version": "1.0.3",
-  "private": true,
   "description": "The Spectrum CSS text builder",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -11,7 +12,6 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"
   },
-  "license": "Apache-2.0",
   "dependencies": {
     "del": "^5.0.0",
     "gulp": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3716,6 +3716,11 @@
   resolved "https://registry.npmjs.org/@types/npmlog/-/npmlog-4.1.4.tgz#30eb872153c7ead3e8688c476054ddca004115f6"
   integrity sha512-WKG4gTr8przEZBiJ5r3s8ZIAoMXNbOgQ+j/d5O4X3x6kZJRLNvyUJuUK/KoG3+8BaOHPhp2m7WC6JKKeovDSzQ==
 
+"@types/parse-author@^2.0.0":
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/@types/parse-author/-/parse-author-2.0.1.tgz#9e441bdbf837085976e2aa798e54dffa1dac3d69"
+  integrity sha512-2RNXvvDY+7ITl/Q3znDpW9DxyAckKgLCXpoiBHN9BeLH1aV7z/W657P2+PK3wVUgGWXtc99ZQy3LkJTGlxLsvA==
+
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
@@ -4185,7 +4190,7 @@ ansi-escapes@^3.2.0:
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
   integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
 
-ansi-escapes@^4.2.1:
+ansi-escapes@^4.2.1, ansi-escapes@^4.3.0:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.2.tgz#6b2291d1db7d98b6521d5f1efa42d0f3a9feb65e"
   integrity sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==
@@ -4266,6 +4271,11 @@ ansi-styles@^5.0.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
+
+ansi-styles@^6.0.0:
+  version "6.2.1"
+  resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz#0e62320cf99c21afff3b3012192546aacbfb05c5"
+  integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
 
 ansi-to-html@^0.6.11:
   version "0.6.15"
@@ -4675,6 +4685,11 @@ audit-ci@^2.0.1:
     readline-transform "0.9.0"
     semver "^6.0.0"
     yargs "12.0.5"
+
+author-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/author-regex/-/author-regex-1.0.0.tgz#d08885be6b9bbf9439fe087c76287245f0a81450"
+  integrity sha512-KbWgR8wOYRAPekEmMXrYYdc7BRyhn2Ftk7KWfMUnQ43hFdojWEFRxhhRUm3/OFEdPa1r0KAvTTg9YQK57xTe0g==
 
 autoprefixer@^6.5.3:
   version "6.7.7"
@@ -5898,6 +5913,14 @@ cli-truncate@^2.1.0:
     slice-ansi "^3.0.0"
     string-width "^4.2.0"
 
+cli-truncate@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/cli-truncate/-/cli-truncate-3.1.0.tgz#3f23ab12535e3d73e839bb43e73c9de487db1389"
+  integrity sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==
+  dependencies:
+    slice-ansi "^5.0.0"
+    string-width "^5.0.0"
+
 cli-width@^2.0.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.1.tgz#b0433d0b4e9c847ef18868a4ef16fd5fc8271c48"
@@ -6077,6 +6100,11 @@ color-support@^1.1.2, color-support@^1.1.3:
   resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
   integrity sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==
 
+colorette@^2.0.19:
+  version "2.0.19"
+  resolved "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz#cdf044f47ad41a0f4b56b3a0d5b4e6e1a2d5a798"
+  integrity sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==
+
 colors@^1.3.3:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
@@ -6107,7 +6135,7 @@ commander@^2.18.0, commander@^2.2.0, commander@^2.20.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
-commander@^4.1.1:
+commander@^4.0.1, commander@^4.1.1:
   version "4.1.1"
   resolved "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
@@ -6121,6 +6149,11 @@ commander@^8.3.0:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
   integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
+
+commander@^9.4.1:
+  version "9.5.0"
+  resolved "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz#bc08d1eb5cedf7ccb797a96199d41c7bc3e60d30"
+  integrity sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==
 
 common-path-prefix@^3.0.0:
   version "3.0.0"
@@ -6581,7 +6614,7 @@ cosmiconfig@^2.1.0, cosmiconfig@^2.1.1:
     parse-json "^2.2.0"
     require-from-string "^1.1.0"
 
-cosmiconfig@^5.2.0, cosmiconfig@^5.2.1:
+cosmiconfig@^5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a"
   integrity sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==
@@ -6893,7 +6926,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@4.3.4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.3, debug@~4.3.1, debug@~4.3.2:
+debug@4, debug@4.3.4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.3, debug@^4.3.4, debug@~4.3.1, debug@~4.3.2:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -7375,6 +7408,11 @@ each-props@^1.3.2:
     is-plain-object "^2.0.1"
     object.defaults "^1.1.0"
 
+eastasianwidth@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
+  integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
+
 easy-extender@^2.3.4:
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/easy-extender/-/easy-extender-2.3.4.tgz#298789b64f9aaba62169c77a2b3b64b4c9589b8f"
@@ -7446,6 +7484,11 @@ emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
+emoji-regex@^9.2.2:
+  version "9.2.2"
+  resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
+  integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
 
 emojis-list@^3.0.0:
   version "3.0.0"
@@ -7858,6 +7901,21 @@ execa@^5.0.0, execa@^5.1.1:
     onetime "^5.1.2"
     signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
+
+execa@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.npmjs.org/execa/-/execa-6.1.0.tgz#cea16dee211ff011246556388effa0818394fb20"
+  integrity sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==
+  dependencies:
+    cross-spawn "^7.0.3"
+    get-stream "^6.0.1"
+    human-signals "^3.0.1"
+    is-stream "^3.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^5.1.0"
+    onetime "^6.0.0"
+    signal-exit "^3.0.7"
+    strip-final-newline "^3.0.0"
 
 exif-parser@^0.1.12:
   version "0.1.12"
@@ -8633,7 +8691,7 @@ get-port@^5.1.1:
   resolved "https://registry.yarnpkg.com/get-port/-/get-port-5.1.1.tgz#0469ed07563479de6efb986baf053dcd7d4e3193"
   integrity sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==
 
-get-stdin@7.0.0, get-stdin@^7.0.0:
+get-stdin@7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-7.0.0.tgz#8d5de98f15171a125c5e516643c7a6d0ea8a96f6"
   integrity sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==
@@ -8657,7 +8715,7 @@ get-stream@^5.1.0:
   dependencies:
     pump "^3.0.0"
 
-get-stream@^6.0.0:
+get-stream@^6.0.0, get-stream@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
@@ -9562,6 +9620,11 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
+human-signals@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.npmjs.org/human-signals/-/human-signals-3.0.1.tgz#c740920859dafa50e5a3222da9d3bf4bb0e5eef5"
+  integrity sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==
+
 humanize-ms@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/humanize-ms/-/humanize-ms-1.2.1.tgz#c46e3159a293f6b896da29316d8b6fe8bb79bbed"
@@ -9569,22 +9632,10 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-husky@^3.0.5:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-3.1.0.tgz#5faad520ab860582ed94f0c1a77f0f04c90b57c0"
-  integrity sha512-FJkPoHHB+6s4a+jwPqBudBDvYZsoQW5/HBuMSehC8qDiCe50kpcxeqFoDSlow+9I6wg47YxBoT3WxaURlrDIIQ==
-  dependencies:
-    chalk "^2.4.2"
-    ci-info "^2.0.0"
-    cosmiconfig "^5.2.1"
-    execa "^1.0.0"
-    get-stdin "^7.0.0"
-    opencollective-postinstall "^2.0.2"
-    pkg-dir "^4.2.0"
-    please-upgrade-node "^3.2.0"
-    read-pkg "^5.2.0"
-    run-node "^1.0.0"
-    slash "^3.0.0"
+husky@^8.0.3:
+  version "8.0.3"
+  resolved "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz#4936d7212e46d1dea28fef29bb3a108872cd9184"
+  integrity sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==
 
 iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
@@ -10122,6 +10173,11 @@ is-fullwidth-code-point@^3.0.0:
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
+is-fullwidth-code-point@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz#fae3167c729e7463f8461ce512b080a49268aa88"
+  integrity sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==
+
 is-function@^1.0.1, is-function@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-function/-/is-function-1.0.2.tgz#4f097f30abf6efadac9833b17ca5dc03f8144e08"
@@ -10315,6 +10371,11 @@ is-stream@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
   integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
+
+is-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz#e6bfd7aa6bef69f4f472ce9bb681e3e57b4319ac"
+  integrity sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==
 
 is-string@^1.0.5, is-string@^1.0.7:
   version "1.0.7"
@@ -10943,6 +11004,11 @@ liftoff@^4.0.0:
     rechoir "^0.8.0"
     resolve "^1.20.0"
 
+lilconfig@2.0.6:
+  version "2.0.6"
+  resolved "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.6.tgz#32a384558bd58af3d4c6e077dd1ad1d397bc69d4"
+  integrity sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==
+
 limiter@^1.0.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/limiter/-/limiter-1.1.5.tgz#8f92a25b3b16c6131293a0cc834b4a838a2aa7c2"
@@ -10959,6 +11025,39 @@ linkify-it@^3.0.1:
   integrity sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==
   dependencies:
     uc.micro "^1.0.1"
+
+lint-staged@^13.1.0:
+  version "13.1.0"
+  resolved "https://registry.npmjs.org/lint-staged/-/lint-staged-13.1.0.tgz#d4c61aec939e789e489fa51987ec5207b50fd37e"
+  integrity sha512-pn/sR8IrcF/T0vpWLilih8jmVouMlxqXxKuAojmbiGX5n/gDnz+abdPptlj0vYnbfE0SQNl3CY/HwtM0+yfOVQ==
+  dependencies:
+    cli-truncate "^3.1.0"
+    colorette "^2.0.19"
+    commander "^9.4.1"
+    debug "^4.3.4"
+    execa "^6.1.0"
+    lilconfig "2.0.6"
+    listr2 "^5.0.5"
+    micromatch "^4.0.5"
+    normalize-path "^3.0.0"
+    object-inspect "^1.12.2"
+    pidtree "^0.6.0"
+    string-argv "^0.3.1"
+    yaml "^2.1.3"
+
+listr2@^5.0.5:
+  version "5.0.6"
+  resolved "https://registry.npmjs.org/listr2/-/listr2-5.0.6.tgz#3c61153383869ffaad08a8908d63edfde481dff8"
+  integrity sha512-u60KxKBy1BR2uLJNTWNptzWQ1ob/gjMzIJPZffAENzpZqbMZ/5PrXXOomDcevIS/+IB7s1mmCEtSlT2qHWMqag==
+  dependencies:
+    cli-truncate "^2.1.0"
+    colorette "^2.0.19"
+    log-update "^4.0.0"
+    p-map "^4.0.0"
+    rfdc "^1.3.0"
+    rxjs "^7.5.7"
+    through "^2.3.8"
+    wrap-ansi "^7.0.0"
 
 lit-html@^2.5.0:
   version "2.5.0"
@@ -11216,6 +11315,16 @@ log-symbols@^5.1.0:
   dependencies:
     chalk "^5.0.0"
     is-unicode-supported "^1.1.0"
+
+log-update@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz#589ecd352471f2a1c0c570287543a64dfd20e0a1"
+  integrity sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==
+  dependencies:
+    ansi-escapes "^4.3.0"
+    cli-cursor "^3.1.0"
+    slice-ansi "^4.0.0"
+    wrap-ansi "^6.2.0"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -11643,7 +11752,7 @@ micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
-micromatch@^4.0.2, micromatch@^4.0.4:
+micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
   integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==
@@ -11700,6 +11809,11 @@ mimic-fn@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-3.1.0.tgz#65755145bbf3e36954b949c16450427451d5ca74"
   integrity sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==
+
+mimic-fn@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz#60a90550d5cb0b239cca65d893b1a53b29871ecc"
+  integrity sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==
 
 mimic-response@^1.0.0, mimic-response@^1.0.1:
   version "1.0.1"
@@ -12296,6 +12410,13 @@ npm-run-path@^4.0.1:
   dependencies:
     path-key "^3.0.0"
 
+npm-run-path@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz#bc62f7f3f6952d9894bd08944ba011a6ee7b7e00"
+  integrity sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==
+  dependencies:
+    path-key "^4.0.0"
+
 npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
@@ -12516,6 +12637,13 @@ onetime@^5.1.0, onetime@^5.1.2:
   dependencies:
     mimic-fn "^2.1.0"
 
+onetime@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz#7c24c18ed1fd2e9bca4bd26806a33613c77d34b4"
+  integrity sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==
+  dependencies:
+    mimic-fn "^4.0.0"
+
 open@^7.0.3:
   version "7.4.2"
   resolved "https://registry.npmjs.org/open/-/open-7.4.2.tgz#b8147e26dcf3e426316c730089fd71edd29c2321"
@@ -12532,11 +12660,6 @@ open@^8.0.2, open@^8.4.0:
     define-lazy-prop "^2.0.0"
     is-docker "^2.1.1"
     is-wsl "^2.2.0"
-
-opencollective-postinstall@^2.0.2:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz#7a0fff978f6dbfa4d006238fbac98ed4198c3259"
-  integrity sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==
 
 openurl@1.1.1:
   version "1.1.1"
@@ -12862,6 +12985,13 @@ parse-asn1@^5.0.0, parse-asn1@^5.1.5:
     pbkdf2 "^3.0.3"
     safe-buffer "^5.1.1"
 
+parse-author@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/parse-author/-/parse-author-2.0.0.tgz#d3460bf1ddd0dfaeed42da754242e65fb684a81f"
+  integrity sha512-yx5DfvkN8JsHL2xk2Os9oTia467qnvRgey4ahSm2X8epehBLx/gWLcy5KI+Y36ful5DzGbCS6RazqZGgy1gHNw==
+  dependencies:
+    author-regex "^1.0.0"
+
 parse-bmfont-ascii@^1.0.3:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/parse-bmfont-ascii/-/parse-bmfont-ascii-1.0.6.tgz#11ac3c3ff58f7c2020ab22769079108d4dfa0285"
@@ -13054,6 +13184,11 @@ path-key@^3.0.0, path-key@^3.1.0:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
+path-key@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz#295588dc3aee64154f877adb9d780b81c554bf18"
+  integrity sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==
+
 path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
@@ -13150,6 +13285,11 @@ pidtree@^0.3.0:
   resolved "https://registry.npmjs.org/pidtree/-/pidtree-0.3.1.tgz#ef09ac2cc0533df1f3250ccf2c4d366b0d12114a"
   integrity sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==
 
+pidtree@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz#90ad7b6d42d5841e69e0a2419ef38f8883aa057c"
+  integrity sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==
+
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
@@ -13234,13 +13374,6 @@ playwright@^1.24.1:
   integrity sha512-WQmEdCgYYe8jOEkhkW9QLcK0PB+w1RZztBLYIT10MEEsENYg251cU0IzebDINreQsUt+HCwwRhtdz4weH9ICcQ==
   dependencies:
     playwright-core "1.26.1"
-
-please-upgrade-node@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz#aeddd3f994c933e4ad98b99d9a556efa0e2fe942"
-  integrity sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==
-  dependencies:
-    semver-compare "^1.0.0"
 
 plop@^3.1.1:
   version "3.1.1"
@@ -13635,6 +13768,21 @@ prepend-http@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==
+
+prettier-package-json@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.npmjs.org/prettier-package-json/-/prettier-package-json-2.8.0.tgz#70aba2b4f7aeb4e294ae2191fb64b7d8fdea0398"
+  integrity sha512-WxtodH/wWavfw3MR7yK/GrS4pASEQ+iSTkdtSxPJWvqzG55ir5nvbLt9rw5AOiEcqqPCRM92WCtR1rk3TG3JSQ==
+  dependencies:
+    "@types/parse-author" "^2.0.0"
+    commander "^4.0.1"
+    cosmiconfig "^7.0.0"
+    fs-extra "^10.0.0"
+    glob "^7.1.6"
+    minimatch "^3.0.4"
+    parse-author "^2.0.0"
+    sort-object-keys "^1.1.3"
+    sort-order "^1.0.1"
 
 "prettier@>=2.2.1 <=2.3.0":
   version "2.3.0"
@@ -14902,6 +15050,11 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
+rfdc@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz#d0b7c441ab2720d05dc4cf26e01c89631d9da08b"
+  integrity sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==
+
 right-align@^0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/right-align/-/right-align-0.1.3.tgz#61339b722fe6a3515689210d24e14c96148613ef"
@@ -14948,11 +15101,6 @@ run-async@^2.2.0, run-async@^2.4.0, run-async@^2.4.1:
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
   integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
 
-run-node@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/run-node/-/run-node-1.0.0.tgz#46b50b946a2aa2d4947ae1d886e9856fd9cabe5e"
-  integrity sha512-kc120TBlQ3mih1LSzdAJXo4xn/GWS2ec0l3S+syHDXP9uRr0JAT8Qd3mdMuyjqCzeZktgP3try92cEgf9Nks8A==
-
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
@@ -14993,7 +15141,7 @@ rxjs@^7.5.4:
   dependencies:
     tslib "^2.1.0"
 
-rxjs@^7.5.5, rxjs@^7.5.6:
+rxjs@^7.5.5, rxjs@^7.5.6, rxjs@^7.5.7:
   version "7.8.0"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.0.tgz#90a938862a82888ff4c7359811a595e14e1e09a4"
   integrity sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==
@@ -15107,11 +15255,6 @@ schema-utils@^3.0.0:
     "@types/json-schema" "^7.0.8"
     ajv "^6.12.5"
     ajv-keywords "^3.5.2"
-
-semver-compare@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
-  integrity sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==
 
 semver-diff@^3.1.1:
   version "3.1.1"
@@ -15349,7 +15492,7 @@ side-channel@^1.0.4:
     get-intrinsic "^1.0.2"
     object-inspect "^1.9.0"
 
-signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3:
+signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
@@ -15387,6 +15530,23 @@ slice-ansi@^3.0.0:
     ansi-styles "^4.0.0"
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
+
+slice-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz#500e8dd0fd55b05815086255b3195adf2a45fe6b"
+  integrity sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==
+  dependencies:
+    ansi-styles "^4.0.0"
+    astral-regex "^2.0.0"
+    is-fullwidth-code-point "^3.0.0"
+
+slice-ansi@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz#b73063c57aa96f9cd881654b15294d95d285c42a"
+  integrity sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==
+  dependencies:
+    ansi-styles "^6.0.0"
+    is-fullwidth-code-point "^4.0.0"
 
 slide@^1.1.6:
   version "1.1.6"
@@ -15510,6 +15670,16 @@ sort-keys@^4.0.0:
   integrity sha512-aUYIEU/UviqPgc8mHR6IW1EGxkAXpeRETYcrzg8cLAvUPZcpAlleSXHV2mY7G12GphSH6Gzv+4MMVSSkbdteHg==
   dependencies:
     is-plain-obj "^2.0.0"
+
+sort-object-keys@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.npmjs.org/sort-object-keys/-/sort-object-keys-1.1.3.tgz#bff833fe85cab147b34742e45863453c1e190b45"
+  integrity sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==
+
+sort-order@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/sort-order/-/sort-order-1.0.1.tgz#d822b8cdb90ea6a9df968c4bd45987cf548199e6"
+  integrity sha512-BiExT7C1IVF4DNd5dttR/dEq3wunGOHpy4phvqFUQA1pY6j2ye8WWEAV8LhRbfdF0EWDX12FfyPPf9P71eT+cA==
 
 source-list-map@^2.0.0:
   version "2.0.1"
@@ -15783,6 +15953,11 @@ strict-uri-encode@^2.0.0:
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
   integrity sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==
 
+string-argv@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
+  integrity sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==
+
 string-width@^1.0.1, string-width@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
@@ -15808,6 +15983,15 @@ string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
+
+string-width@^5.0.0:
+  version "5.1.2"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz#14f8daec6d81e7221d2a357e668cab73bdbca794"
+  integrity sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==
+  dependencies:
+    eastasianwidth "^0.2.0"
+    emoji-regex "^9.2.2"
+    strip-ansi "^7.0.1"
 
 "string.prototype.matchall@^4.0.0 || ^3.0.1":
   version "4.0.8"
@@ -15957,6 +16141,11 @@ strip-final-newline@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
+
+strip-final-newline@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz#52894c313fbff318835280aed60ff71ebf12b8fd"
+  integrity sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==
 
 strip-indent@^1.0.1:
   version "1.0.1"
@@ -17526,6 +17715,15 @@ wrap-ansi@^2.0.0:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
 
+wrap-ansi@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
+  integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
@@ -17688,6 +17886,11 @@ yaml@^1.10.0, yaml@^1.7.2:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
+
+yaml@^2.1.3:
+  version "2.2.1"
+  resolved "https://registry.npmjs.org/yaml/-/yaml-2.2.1.tgz#3014bf0482dcd15147aa8e56109ce8632cd60ce4"
+  integrity sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw==
 
 yargs-parser@20.2.4, yargs-parser@>=5.0.0-security.0, yargs-parser@^10.0.0, yargs-parser@^11.1.1, yargs-parser@^20.2.2, yargs-parser@^20.2.3, yargs-parser@^20.2.7, yargs-parser@^21.0.0, yargs-parser@^5.0.1:
   version "20.2.9"


### PR DESCRIPTION
## Description

- Removes contributors from nested packages and centralizes them at the root. All nested packages will use `Adobe` as the author going forward. Eventually we can automatically generate the contributors list.
- Update all licenses to `Apache-2.0` per Adobe's open source standards guidelines.

Commit: [283054](https://github.com/adobe/spectrum-css/pull/1579/commits/28305498ca0be7281ba61798b4ac072c5f2d1279)

- Add `lint-staged` to maintain the order & format of the package.json assets.
- Add prettier-package-json to automatically format & sort packages (makes finding information in nested packages easier when they use the same format).

Commit: [972d9d](https://github.com/adobe/spectrum-css/pull/1579/commits/972d9d96a064f30afa18eb1db5da0a7ed8a5b0f7)

## To-do list
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] This pull request is ready to merge.
