### PR TITLE
chore: fix handlebars template error

### DIFF
--- a/tools/generator/templates/stories/template.js.hbs
+++ b/tools/generator/templates/stories/template.js.hbs
@@ -15,7 +15,7 @@ export const Template = ({ rootClass, size }) => {
 
   return html`{{#if example}}
     <!-- Example markup -->
-    {{{ example }}}{{#else}}
+    {{{ example }}}{{else}}
     <!-- Component mark-up goes here -->
     <div class=${classMap(classList)}></div>{{/if}}
   `;


### PR DESCRIPTION
## Description

During demo we uncovered a syntax error in one of the handlebars templates for the generator. This PR resolves that syntax issue.

## How and where has this been tested?
 - **How this was tested:**
   - [x] `yarn new`, answers: component, Bar chart; expect no errors thrown.

## To-do list
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] This pull request is ready to merge.
