### PR TITLE
fix(dialog): adjust padding and margins to avoid focus indicator clip

### DIFF
--- a/components/dialog/index.css
+++ b/components/dialog/index.css
@@ -151,6 +151,11 @@ governing permissions and limitations under the License.
   margin-bottom: var(--spectrum-dialog-confirm-divider-margin-bottom);
 }
 
+/* remove top vertical padding of spectrum-Dialog-content from bottom margin of first divider after heading */
+.spectrum-Dialog--fullscreen .spectrum-Dialog-heading + .spectrum-Dialog-divider {
+  margin-bottom: calc(var(--spectrum-dialog-confirm-divider-margin-bottom) - (var(--spectrum-dialog-confirm-description-padding) * 2));
+}
+
 .spectrum-Dialog--noDivider {
   .spectrum-Dialog-divider {
     display: none;
@@ -182,7 +187,7 @@ governing permissions and limitations under the License.
   line-height: var(--spectrum-dialog-confirm-description-text-line-height);
 
   /* this is kinda dumb, but needed for the keyboard focus rings so they don't get clipped. is there a better way to treat this */
-  padding: 0 var(--spectrum-dialog-confirm-description-padding);
+  padding: calc(var(--spectrum-dialog-confirm-description-padding) * 2);
   margin: 0 var(--spectrum-dialog-confirm-description-margin);
 }
 


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
This mitigates the clipping of focus indicators of components within Dialog Fullscreen's content area. 
- Jira issue CSS-79 https://jira.corp.adobe.com/browse/CSS-79


## How and where has this been tested?
 - Chrome 109 for macOS
 - Firefox 109 for macOS
 - Safari 16.2 for macOS
 - **How this was tested:** Temporarily added Close Button and Button components to the top of the content area (spectrum-Dialog-content) of the fullscreen dialog in the YML for dialog on local build http://localhost:3000/docs/dialog.html. Viewed the error and the correction on the local build. 

## Screenshots
The error is present in the following screenshot. A pink "16px" bar has been added to show spacing. 16px is the correct spacing for the margin below the HR (horizontal rule) on medium screens, medium HR. We need to maintain this spacing while preventing the focus indicators from being clipped as they are in this screenshot.
Closebutton and Button are focused here.
![dialog focus clip](https://user-images.githubusercontent.com/25614178/214172464-327aa552-55d4-4ef6-82f0-afebae3756b1.png)


Adding padding to the content area to allow for the focus indicator and focus indicator gaps resolves the clipping issue, but adds space below the HR which we then need to remove.
![dialog focus clip 2](https://user-images.githubusercontent.com/25614178/214172513-758a413f-65be-4cc5-a9b1-d514a97d7a36.png)


The extra space is removed from the bottom margin of the first HR after the dialog's heading.
![dialog focus clip 3](https://user-images.githubusercontent.com/25614178/214174051-11716bbc-c217-4b01-a5d4-2f278ce55137.png)


Added an additional HR and additional components within the content area to test that the change does not impact any subsequent HR components. 
![dialog focus clip 4](https://user-images.githubusercontent.com/25614178/214172782-7d9ad823-6b17-404f-a0f8-114db7d3d2df.png)



## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] I have tested these changes in Windows High Contrast mode.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
