### PR TITLE
fix(progressbar): typo in --mod-progressbar-label-and-value-white variable

### DIFF
--- a/components/progressbar/index.css
+++ b/components/progressbar/index.css
@@ -150,7 +150,7 @@ governing permissions and limitations under the License.
 
     background: var(--highcontrast-progressbar-track-color, var(--mod-progressbar-track-color, var(--spectrum-progressbar-track-color)));
   }
-  
+
   /* Fill variants */
   &.is-positive {
     .spectrum-ProgressBar-fill {
@@ -192,13 +192,13 @@ governing permissions and limitations under the License.
     .spectrum-ProgressBar-track {
       flex: 1 1 var(--mod-progressbar-size-default, var(--spectrum-progressbar-size-default));
     }
-  
+
     .spectrum-ProgressBar-label {
       flex-grow: 0;
       margin-inline-end: var(--mod-progressbar-spacing-label-to-text, var(--spectrum-progressbar-spacing-label-to-text));
       margin-block-end: 0;
     }
-  
+
     .spectrum-ProgressBar-percentage {
       order: 3;
       text-align: end;
@@ -216,7 +216,7 @@ governing permissions and limitations under the License.
 
     .spectrum-ProgressBar-label,
     .spectrum-ProgressBar-percentage {
-      color: var(--mode-progressbar-label-and-value-white, var(--spectrum-progressbar-label-and-value-white));
+      color: var(--mod-progressbar-label-and-value-white, var(--spectrum-progressbar-label-and-value-white));
     }
 
     .spectrum-ProgressBar-track {


### PR DESCRIPTION
## Description

Small typo in the name of the mod variable for inline alert:

`--mode-progressbar-label-and-value-white` corrected to -> `--mod-progressbar-label-and-value-white`


## How and where has this been tested?
 - **How this was tested:**
   - Empty var but should communicate this out in the next release.

## To-do list
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] This pull request is ready to merge.
