### PR TITLE
chore: migrate component package validation to node script

### DIFF
--- a/components/accordion/package.json
+++ b/components/accordion/package.json
@@ -3,7 +3,8 @@
   "version": "3.0.33",
   "description": "The Spectrum CSS accordion component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/accordion",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/actionbar/package.json
+++ b/components/actionbar/package.json
@@ -3,7 +3,8 @@
   "version": "6.0.1",
   "description": "The Spectrum CSS actionbar component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/actionbar",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/actionbutton/package.json
+++ b/components/actionbutton/package.json
@@ -3,7 +3,8 @@
   "version": "3.0.13",
   "description": "The Spectrum CSS action button component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/actionbutton",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/actiongroup/package.json
+++ b/components/actiongroup/package.json
@@ -3,7 +3,8 @@
   "version": "3.0.14",
   "description": "The Spectrum CSS actiongroup component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/actiongroup",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/actionmenu/package.json
+++ b/components/actionmenu/package.json
@@ -3,7 +3,8 @@
   "version": "4.0.10",
   "description": "The Spectrum CSS actionmenu component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/actionmenu",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/asset/package.json
+++ b/components/asset/package.json
@@ -3,7 +3,8 @@
   "version": "3.0.30",
   "description": "The Spectrum CSS asset component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/asset",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/assetcard/package.json
+++ b/components/assetcard/package.json
@@ -3,11 +3,12 @@
   "version": "1.1.13",
   "description": "The Spectrum CSS asset card component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/assetcard",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
-    "directory": "components/card"
+    "directory": "components/assetcard"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"

--- a/components/assetlist/package.json
+++ b/components/assetlist/package.json
@@ -3,7 +3,8 @@
   "version": "3.0.33",
   "description": "The Spectrum CSS assetlist component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/assetlist",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/avatar/package.json
+++ b/components/avatar/package.json
@@ -3,7 +3,8 @@
   "version": "6.0.0",
   "description": "The Spectrum CSS avatar component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/avatar",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/badge/package.json
+++ b/components/badge/package.json
@@ -3,7 +3,8 @@
   "version": "3.0.1",
   "description": "The Spectrum CSS badge component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/badge",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/breadcrumb/package.json
+++ b/components/breadcrumb/package.json
@@ -3,7 +3,8 @@
   "version": "7.0.1",
   "description": "The Spectrum CSS breadcrumb component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/breadcrumb",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/button/package.json
+++ b/components/button/package.json
@@ -3,7 +3,8 @@
   "version": "9.0.1",
   "description": "The Spectrum CSS button component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/button-accent",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/buttongroup/package.json
+++ b/components/buttongroup/package.json
@@ -3,7 +3,8 @@
   "version": "6.0.16",
   "description": "The Spectrum CSS buttongroup component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/buttongroup",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/calendar/package.json
+++ b/components/calendar/package.json
@@ -3,7 +3,8 @@
   "version": "3.0.35",
   "description": "The Spectrum CSS calendar component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/calendar",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/card/package.json
+++ b/components/card/package.json
@@ -3,7 +3,8 @@
   "version": "5.0.10",
   "description": "The Spectrum CSS card component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/card",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/checkbox/package.json
+++ b/components/checkbox/package.json
@@ -3,7 +3,8 @@
   "version": "6.0.1",
   "description": "The Spectrum CSS checkbox component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/checkbox",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/clearbutton/package.json
+++ b/components/clearbutton/package.json
@@ -3,7 +3,8 @@
   "version": "1.2.19",
   "description": "The Spectrum CSS clearbutton component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/clearbutton",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/closebutton/package.json
+++ b/components/closebutton/package.json
@@ -3,7 +3,8 @@
   "version": "3.0.13",
   "description": "The Spectrum CSS close button component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/closebutton",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/coachmark/package.json
+++ b/components/coachmark/package.json
@@ -3,7 +3,8 @@
   "version": "5.0.23",
   "description": "The Spectrum CSS coachmark component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/coachmark",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/colorarea/package.json
+++ b/components/colorarea/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.29",
   "description": "The Spectrum CSS Color Area component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/colorarea",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/colorhandle/package.json
+++ b/components/colorhandle/package.json
@@ -3,7 +3,8 @@
   "version": "2.0.15",
   "description": "The Spectrum CSS Color Handle component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/colorhandle",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/colorloupe/package.json
+++ b/components/colorloupe/package.json
@@ -3,11 +3,12 @@
   "version": "2.0.15",
   "description": "The Spectrum CSS Color Loupe component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/colorloupe",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
-    "directory": "components/colorhandle"
+    "directory": "components/colorloupe"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"

--- a/components/colorslider/package.json
+++ b/components/colorslider/package.json
@@ -3,7 +3,8 @@
   "version": "2.0.15",
   "description": "The Spectrum CSS Color Slider component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/colorslider",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/colorwheel/package.json
+++ b/components/colorwheel/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.29",
   "description": "The Spectrum CSS Color Area component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/colorwheel",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/commons/package.json
+++ b/components/commons/package.json
@@ -3,6 +3,7 @@
   "version": "7.0.0",
   "description": "Common mixins for Spectrum CSS components",
   "license": "Apache-2.0",
+  "author": "Adobe",
   "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",

--- a/components/cyclebutton/package.json
+++ b/components/cyclebutton/package.json
@@ -3,7 +3,8 @@
   "version": "3.0.36",
   "description": "The Spectrum CSS cyclebutton component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/cyclebutton",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/dial/package.json
+++ b/components/dial/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.32",
   "description": "The Spectrum CSS dial component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/dial",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/dialog/package.json
+++ b/components/dialog/package.json
@@ -3,7 +3,8 @@
   "version": "6.0.27",
   "description": "The Spectrum CSS dialog component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/dialog",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/divider/package.json
+++ b/components/divider/package.json
@@ -3,7 +3,8 @@
   "version": "2.0.12",
   "description": "The Spectrum CSS divider component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/divider",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/dropindicator/package.json
+++ b/components/dropindicator/package.json
@@ -3,7 +3,8 @@
   "version": "3.0.32",
   "description": "The Spectrum CSS dropindicator component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/dropindicator",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/dropzone/package.json
+++ b/components/dropzone/package.json
@@ -3,7 +3,8 @@
   "version": "3.0.33",
   "description": "The Spectrum CSS dropzone component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/dropzone",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/expressvars/package.json
+++ b/components/expressvars/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.3",
   "description": "The Spectrum CSS vars for Express package",
   "license": "Apache-2.0",
+  "author": "Adobe",
   "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",

--- a/components/fieldgroup/package.json
+++ b/components/fieldgroup/package.json
@@ -3,7 +3,8 @@
   "version": "4.0.15",
   "description": "The Spectrum CSS fieldgroup component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/fieldgroup",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/fieldlabel/package.json
+++ b/components/fieldlabel/package.json
@@ -3,7 +3,8 @@
   "version": "6.0.1",
   "description": "The Spectrum CSS fieldlabel component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/fieldlabel",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/helptext/package.json
+++ b/components/helptext/package.json
@@ -3,7 +3,8 @@
   "version": "4.0.1",
   "description": "The Spectrum CSS helptext component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/helptext",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/icon/package.json
+++ b/components/icon/package.json
@@ -3,6 +3,7 @@
   "version": "3.0.32",
   "description": "The Spectrum CSS icon component",
   "license": "Apache-2.0",
+  "author": "Adobe",
   "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",

--- a/components/illustratedmessage/package.json
+++ b/components/illustratedmessage/package.json
@@ -3,7 +3,8 @@
   "version": "4.0.13",
   "description": "The Spectrum CSS illustratedmessage component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/illustratedmessage",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/infieldbutton/package.json
+++ b/components/infieldbutton/package.json
@@ -3,7 +3,8 @@
   "version": "2.0.9",
   "description": "The Spectrum CSS infield button component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/infieldbutton",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/inlinealert/package.json
+++ b/components/inlinealert/package.json
@@ -3,7 +3,8 @@
   "version": "6.0.1",
   "description": "The Spectrum CSS in-line alert component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/inlinealert",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/inputgroup/package.json
+++ b/components/inputgroup/package.json
@@ -3,7 +3,8 @@
   "version": "5.0.11",
   "description": "The Spectrum CSS inputgroup component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/inputgroup",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/link/package.json
+++ b/components/link/package.json
@@ -3,7 +3,8 @@
   "version": "4.0.13",
   "description": "The Spectrum CSS link component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/link",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/logicbutton/package.json
+++ b/components/logicbutton/package.json
@@ -3,7 +3,8 @@
   "version": "1.2.18",
   "description": "The Spectrum CSS logicbutton component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/logicbutton",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/menu/package.json
+++ b/components/menu/package.json
@@ -3,7 +3,8 @@
   "version": "4.0.13",
   "description": "The Spectrum CSS menu component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/menu",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/miller/package.json
+++ b/components/miller/package.json
@@ -3,7 +3,8 @@
   "version": "3.0.33",
   "description": "The Spectrum CSS miller component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/miller",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/modal/package.json
+++ b/components/modal/package.json
@@ -3,7 +3,8 @@
   "version": "3.0.30",
   "description": "The Spectrum CSS modal component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/modal",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/overlay/package.json
+++ b/components/overlay/package.json
@@ -3,6 +3,7 @@
   "version": "3.0.2",
   "description": "Overlay mixin",
   "license": "Apache-2.0",
+  "author": "Adobe",
   "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",

--- a/components/page/package.json
+++ b/components/page/package.json
@@ -3,7 +3,8 @@
   "version": "5.0.17",
   "description": "The Spectrum CSS page component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/page",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/pagination/package.json
+++ b/components/pagination/package.json
@@ -3,7 +3,8 @@
   "version": "5.0.26",
   "description": "The Spectrum CSS pagination component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/pagination",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/picker/package.json
+++ b/components/picker/package.json
@@ -3,7 +3,8 @@
   "version": "2.0.0",
   "description": "The Spectrum CSS picker component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/picker",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/pickerbutton/package.json
+++ b/components/pickerbutton/package.json
@@ -3,11 +3,12 @@
   "version": "2.0.9",
   "description": "The Spectrum CSS picker button component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/pickerbutton",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
-    "directory": "components/picker"
+    "directory": "components/pickerbutton"
   },
   "bugs": {
     "url": "https://github.com/adobe/spectrum-css/issues"

--- a/components/popover/package.json
+++ b/components/popover/package.json
@@ -3,7 +3,8 @@
   "version": "6.0.16",
   "description": "The Spectrum CSS popover component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/popover",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/progressbar/package.json
+++ b/components/progressbar/package.json
@@ -3,7 +3,8 @@
   "version": "3.0.3",
   "description": "The Spectrum CSS progress bar component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/progressbar",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/progresscircle/package.json
+++ b/components/progresscircle/package.json
@@ -3,7 +3,8 @@
   "version": "2.0.12",
   "description": "The Spectrum CSS progress circle component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/progresscircle",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/quickaction/package.json
+++ b/components/quickaction/package.json
@@ -3,7 +3,8 @@
   "version": "3.0.34",
   "description": "The Spectrum CSS quickaction component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/quickaction",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/radio/package.json
+++ b/components/radio/package.json
@@ -3,7 +3,8 @@
   "version": "7.0.1",
   "description": "The Spectrum CSS radio component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/radio",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/rating/package.json
+++ b/components/rating/package.json
@@ -3,7 +3,8 @@
   "version": "3.0.33",
   "description": "The Spectrum CSS rating component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/rating",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/search/package.json
+++ b/components/search/package.json
@@ -3,7 +3,8 @@
   "version": "4.2.22",
   "description": "The Spectrum CSS search component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/search",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/searchwithin/package.json
+++ b/components/searchwithin/package.json
@@ -3,7 +3,8 @@
   "version": "3.4.30",
   "description": "The Spectrum CSS searchwithin component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/searchwithin",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/sidenav/package.json
+++ b/components/sidenav/package.json
@@ -3,7 +3,8 @@
   "version": "3.0.33",
   "description": "The Spectrum CSS sidenav component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/sidenav",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/site/package.json
+++ b/components/site/package.json
@@ -3,6 +3,7 @@
   "version": "3.0.7",
   "description": "The Spectrum CSS Site component",
   "license": "Apache-2.0",
+  "author": "Adobe",
   "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",

--- a/components/slider/package.json
+++ b/components/slider/package.json
@@ -3,7 +3,8 @@
   "version": "3.1.14",
   "description": "The Spectrum CSS slider component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/slider",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/splitbutton/package.json
+++ b/components/splitbutton/package.json
@@ -3,7 +3,8 @@
   "version": "5.0.24",
   "description": "The Spectrum CSS splitbutton component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/splitbutton",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/splitview/package.json
+++ b/components/splitview/package.json
@@ -3,7 +3,8 @@
   "version": "3.0.29",
   "description": "The Spectrum CSS splitview component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/splitview",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/statuslight/package.json
+++ b/components/statuslight/package.json
@@ -3,7 +3,8 @@
   "version": "6.0.1",
   "description": "The Spectrum CSS statuslight component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/statuslight",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/steplist/package.json
+++ b/components/steplist/package.json
@@ -3,7 +3,8 @@
   "version": "3.0.34",
   "description": "The Spectrum CSS steplist component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/steplist",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/stepper/package.json
+++ b/components/stepper/package.json
@@ -3,7 +3,8 @@
   "version": "3.0.36",
   "description": "The Spectrum CSS stepper component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/stepper",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/swatch/package.json
+++ b/components/swatch/package.json
@@ -3,7 +3,8 @@
   "version": "3.0.11",
   "description": "The Spectrum CSS Color swatch component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/swatch",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/swatchgroup/package.json
+++ b/components/swatchgroup/package.json
@@ -3,7 +3,8 @@
   "version": "2.0.12",
   "description": "The Spectrum CSS Color swatch group component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/swatchgroup",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/switch/package.json
+++ b/components/switch/package.json
@@ -3,7 +3,8 @@
   "version": "3.0.7",
   "description": "The Spectrum CSS switch component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/switch",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/table/package.json
+++ b/components/table/package.json
@@ -3,7 +3,8 @@
   "version": "4.0.28",
   "description": "The Spectrum CSS table component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/table",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/tabs/package.json
+++ b/components/tabs/package.json
@@ -3,7 +3,8 @@
   "version": "3.2.29",
   "description": "The Spectrum CSS tabs component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/tabs",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/tag/package.json
+++ b/components/tag/package.json
@@ -3,7 +3,8 @@
   "version": "5.0.1",
   "description": "The Spectrum CSS tags component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/tag",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/taggroup/package.json
+++ b/components/taggroup/package.json
@@ -3,7 +3,8 @@
   "version": "3.3.23",
   "description": "The Spectrum CSS tags component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/taggroup",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/textfield/package.json
+++ b/components/textfield/package.json
@@ -3,7 +3,8 @@
   "version": "3.2.13",
   "description": "The Spectrum CSS textfield component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/textfield",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/thumbnail/package.json
+++ b/components/thumbnail/package.json
@@ -3,7 +3,8 @@
   "version": "2.0.25",
   "description": "The Spectrum CSS thumbnail component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/thumbnail",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/toast/package.json
+++ b/components/toast/package.json
@@ -3,7 +3,8 @@
   "version": "9.0.1",
   "description": "The Spectrum CSS toast component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/toast",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/tokens/package.json
+++ b/components/tokens/package.json
@@ -3,6 +3,7 @@
   "version": "7.0.0",
   "description": "The Spectrum CSS tokens package",
   "license": "Apache-2.0",
+  "author": "Adobe",
   "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",

--- a/components/tooltip/package.json
+++ b/components/tooltip/package.json
@@ -3,7 +3,8 @@
   "version": "5.0.1",
   "description": "The Spectrum CSS tooltip component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/tooltip",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/tray/package.json
+++ b/components/tray/package.json
@@ -3,7 +3,8 @@
   "version": "2.0.13",
   "description": "The Spectrum CSS tray component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/tray",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/treeview/package.json
+++ b/components/treeview/package.json
@@ -3,7 +3,8 @@
   "version": "6.0.29",
   "description": "The Spectrum CSS treeview component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/treeview",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/typography/package.json
+++ b/components/typography/package.json
@@ -3,7 +3,8 @@
   "version": "4.0.27",
   "description": "The Spectrum CSS typography component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/typography",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/components/underlay/package.json
+++ b/components/underlay/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.38",
   "description": "The Spectrum CSS underlay component",
   "license": "Apache-2.0",
+  "author": "Adobe",
   "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",

--- a/components/vars/package.json
+++ b/components/vars/package.json
@@ -3,6 +3,7 @@
   "version": "8.0.3",
   "description": "The Spectrum CSS vars package",
   "license": "Apache-2.0",
+  "author": "Adobe",
   "homepage": "https://opensource.adobe.com/spectrum-css/",
   "repository": {
     "type": "git",

--- a/components/well/package.json
+++ b/components/well/package.json
@@ -3,7 +3,8 @@
   "version": "3.0.29",
   "description": "The Spectrum CSS well component",
   "license": "Apache-2.0",
-  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/well",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "ci-all": "yarn build",
     "clean": "gulp clean",
     "dev": "NODE_ENV=development BROWSERSYNC_OPEN=true gulp dev",
+    "lint:components": "node ./tasks/packageLint.js",
     "new": "yarn workspace @spectrum-css/generator new",
     "precommit": "lint-staged",
     "prepare": "husky install && gulp prepare",
@@ -67,8 +68,9 @@
     "prettier-package-json": "^2.8.0",
     "prismjs": "^1.23.0",
     "rimraf": "^4.1.1",
-    "semver": "^6.3.0",
-    "through2": "^3.0.1"
+    "semver": "^7.3.8",
+    "through2": "^3.0.1",
+    "yargs": "^17.6.2"
   },
   "husky": {
     "hooks": {
@@ -77,6 +79,10 @@
     }
   },
   "lint-staged": {
+    "components/*/package.json": [
+      "yarn lint:components",
+      "prettier-package-json --write"
+    ],
     "package.json": [
       "prettier-package-json --write"
     ]

--- a/tasks/packageLint.js
+++ b/tasks/packageLint.js
@@ -1,0 +1,187 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const path = require('path');
+const fsp = require('fs').promises;
+
+const fg = require('fast-glob');
+const semver = require('semver');
+
+const yargs = require('yargs');
+const { hideBin } = require('yargs/helpers');
+
+const rootDir = process.cwd();
+
+const rootPkg = require(path.join(rootDir, 'package.json'));
+const expectedHomepage = (name) => `${rootPkg.homepage}${name && !rootPkg.homepage.endsWith('/') ? `/${name}` : name}`;
+
+/**
+ * Validate peer deps for components; escapes before running lerna if they are not valid.
+ **/
+async function main(dirs = [`${path.join(rootDir, 'components')}/*`], verbose = false) {
+    const promises = [];
+    for (const pkg of await fg(dirs.map(d => path.dirname(d)), {
+        onlyDirectories: true,
+    })) {
+        const report = [];
+        let updated = false;
+        const packagePath = path.join(pkg, 'package.json');
+        const packageJSON = await fsp.readFile(packagePath).then(JSON.parse);
+        if (!packageJSON) {
+            console.error(`Unable to read package.json for ${packagePath}`);
+            continue;
+        }
+
+        const { name, license, publishConfig, repository, author, homepage, bugs, main, peerDependencies, devDependencies } = packageJSON;
+        if (!name) {
+            console.error(`Unable to read name for ${packagePath}`);
+            continue;
+        }
+        if (verbose) report.push(`- ${name}`);
+
+        /* Validate expected license */
+        if (!license || license !== rootPkg.license) {
+            packageJSON.license = rootPkg.license;
+            if (verbose) report.push(`    Adding license=${packageJSON.license}`);
+            updated = true;
+        }
+
+        /* Validate expected publish access */
+        if (!publishConfig || publishConfig.access != 'public') {
+            packageJSON.publishConfig = {
+                ...packageJSON.publishConfig,
+                access: 'public',
+            };
+            if (verbose) report.push(`    Adding publishConfig.access=public`);
+            updated = true;
+        }
+
+        /* Validate repository */
+        if (
+            !repository ||
+            !repository.directory ||
+            !repository.type ||
+            !repository.url ||
+            repository.type !== rootPkg.repository?.type ||
+            repository.url !== rootPkg.repository?.url
+        ) {
+            packageJSON.repository = {
+                ...rootPkg.repository,
+                directory: path.relative(rootDir, pkg),
+            };
+            if (verbose) report.push(`    Adding repository details=${JSON.stringify(packageJSON.repository)}`);
+            updated = true;
+        }
+
+        /* Validate author */
+        if (!author || author !== rootPkg.author) {
+            packageJSON.author = rootPkg.author;
+            if (verbose) report.push(`    Adding author=${packageJSON.author}`);
+            updated = true;
+        }
+
+        /* Validate homepage */
+        if (!homepage) {
+            packageJSON.homepage = expectedHomepage(name.split('/').pop());
+            if (verbose) report.push(`    Adding homepage=${packageJSON.homepage}`);
+            updated = true;
+        }
+
+        /* Validate bugs url */
+        if (!bugs || !bugs.url || bugs.url !== rootPkg.bugs?.url) {
+            packageJSON.bugs = rootPkg.bugs;
+            if (verbose) report.push(`    Adding bugs.url=${JSON.stringify(packageJSON.bugs)}`);
+            updated = true;
+        }
+
+        /* Validate main */
+        if (!main) {
+            packageJSON.main = 'dist/index-vars.css';
+            if (verbose) report.push(`    Adding main=dist/index-vars.css`);
+            updated = true;
+        }
+
+        const peerDepsCheck = await checkPeerDependencies(peerDependencies, devDependencies, verbose);
+        if (peerDepsCheck) {
+            ['peerDependencies', 'devDependencies'].forEach((dep) => {
+                if (peerDepsCheck[dep]) {
+                    packageJSON[dep] = peerDepsCheck[dep];
+                    updated = true;
+                }
+            });
+        }
+
+        if (!updated) continue;
+
+        report.map(r => console.log(r));
+        promises.push(fsp.writeFile(packagePath, JSON.stringify(packageJSON, null, 2)));
+    }
+
+    if (promises.length === 0) {
+        console.log(`👍 All package.json metadata validated.`);
+        process.exit(0);
+    }
+
+    return await Promise.all(promises);
+};
+
+
+/**
+ * Validate peer deps for components; escapes before running lerna if they are not valid.
+ **/
+async function checkPeerDependencies(peerDependencies, devDependencies, verbose = false) {
+    if (!peerDependencies) return;
+
+    const report = [];
+    let updated;
+    for (const dependency of Object.keys(peerDependencies)) {
+        if (!devDependencies) continue;
+        const devDepVer = semver.coerce(devDependencies[dependency]?.replace('^', ''));
+        if (devDepVer === null) continue;
+        if (semver.satisfies(devDepVer, peerDependencies[dependency])) continue;
+
+        // Set a new peer dependency or bump the dev dependency to align them
+        const peerDepVer = semver.coerce(peerDependencies[dependency]);
+        if (semver.gt(devDepVer, peerDepVer)) {
+            if (verbose) {
+                report.push(`    ⚠️ Out of date peerDependencies ${dependency}: devDependency ${devDepVer.toString()} is greater than ${peerDepVer.toString()}`);
+            }
+
+            const newPeerDepVer = semver.coerce('^' + devDepVer.toString()?.replace(/-\d+$/, '')?.split('.')?.shift());
+            packageJSON.peerDependencies[dependency] = `>=${newPeerDepVer.toString()}`;
+            updated = true;
+            report.push(`    ✔ Updated ${dependency} to >=${newPeerDepVer.toString()}`);
+        } else {
+            if (verbose) {
+                report.push(`    ⚠️ Out of date peerDependencies ${dependency}: devDependency ${devDepVer.toString()} is less than ${peerDepVer.toString()}`);
+            }
+
+            const newDevDepVer = semver.coerce('^' + peerDepVer.toString().replace(/-\d+$/, ''));
+            packageJSON.devDependencies[dependency] = `^${newDevDepVer.toString()}`;
+            updated = true;
+            report.push(`    ✔ Updated ${dependency} to ^${newDevDepVer}`);
+        }
+    }
+
+    if (!updated) return;
+
+    report.map(r => console.log(r));
+    return { peerDependencies, devDependencies };
+};
+
+const { _, verbose = false } = yargs(hideBin(process.argv))
+    .alias('v', 'verbose')
+    .argv;
+
+main(_, verbose).catch((err) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -14982,7 +14982,7 @@ semver@6.3.0, semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semver
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.0.0, semver@^7.1.1, semver@^7.1.3, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
+semver@^7.0.0, semver@^7.1.1, semver@^7.1.3, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.8:
   version "7.3.8"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
   integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
@@ -17602,7 +17602,7 @@ yargs@^16.2.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
-yargs@^17.3.1:
+yargs@^17.3.1, yargs@^17.6.2:
   version "17.6.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.6.2.tgz#2e23f2944e976339a1ee00f18c77fedee8332541"
   integrity sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==


### PR DESCRIPTION
## Description

Found this great script in the gulpfile at root that lints package.json assets for the components to keep them consistent. I thought it would make a great pre-commit addition and I didn't want it to get lost in the rewrite.

This commit adds it as a node.js script and alias'es the command: d5fe93a946ccf81766e55ce0e1b2fd4125d8a7bc

This commit runs the tool on all existing packages:  1c64c8dd9a6d26b39b4196c8ada86e5404b61952

## How and where has this been tested?
 - **How this was tested:** 
   - [x] `yarn lint:components`: should now return with: 👍 All package.json metadata validated.


## To-do list
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] This pull request is ready to merge.
