### PR TITLE
build: fix broken lerna scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "start": "NODE_ENV=development yarn workspace @spectrum-css/preview start",
     "test": "VRT=true run-p dev \"test:run {1}\" --",
     "test:run": "yarn workspace @spectrum-css/test run test",
-    "version:build": "SCOPE=$(lerna changed | tr \"\\\\n\" ,) && lerna run --stream --scope \"{${SCOPE%,}}\" --ignore \"@spectrum-css/{*-builder*,preview,generator,site}\" build",
+    "version:build": "SCOPES=($(lerna changed)) && IFS=, SCOPE=\"${SCOPES[*]}\" && [[ \"${#SCOPES[@]}\" -gt 1 ]] && SCOPE=\"{${SCOPE}}\"; lerna run --stream --scope \"${SCOPE}\" --ignore \"@spectrum-css/{*-builder*,preview,generator,site}\" build",
     "watch": "gulp watch"
   },
   "workspaces": [


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
While trying to run a release on a single package change, the command failed.

<img width="1205" alt="Screen Shot 2023-01-30 at 4 30 27 PM" src="https://user-images.githubusercontent.com/360251/215599533-df7c2652-2199-429d-a786-b48bb0d9b7db.png">

`npx lerna changed` shows that a package is ready for publication, but it looks like the filtering may have been too aggressive while building the scope.

## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
