### PR TITLE
fix(fieldlabel): use proper tokens & resolve incorrect gap size

### DIFF
--- a/components/fieldlabel/index.css
+++ b/components/fieldlabel/index.css
@@ -12,15 +12,9 @@ governing permissions and limitations under the License.
 
 .spectrum-FieldLabel {
   --spectrum-fieldlabel-color: var(--spectrum-neutral-subdued-content-color-default);
-}
-
-/* Component level tokens currently missing in core-tokens as of July 2022 or are simply incorrect */
-.spectrum--medium {
-  --spectrum-field-label-top-to-asterisk-small: 8px;
-}
-
-.spectrum--large {
-  --spectrum-field-label-top-to-asterisk-small: 11px;
+  
+  --spectrum-field-label-top-to-asterisk: var(--spectrum-field-label-top-to-asterisk-medium);
+  --spectrum-field-label-text-to-asterisk: var(--spectrum-field-label-text-to-asterisk-medium);
 }
 
 .spectrum-FieldLabel--sizeS {
@@ -31,9 +25,10 @@ governing permissions and limitations under the License.
   --spectrum-fieldlabel-line-height: var(--spectrum-line-height-100);
   --spectrum-fieldlabel-line-height-cjk: var(--spectrum-line-height-cjk-100);
 
-  --spectrum-fieldlabel-asterisk-gap: var(--spectrum-field-label-top-to-asterisk-small);
   --spectrum-fieldlabel-side-padding-top: var(--spectrum-component-top-to-text-75);
   --spectrum-fieldlabel-side-padding-right: var(--spectrum-spacing-100);
+
+  --spectrum-field-label-top-to-asterisk: var(--spectrum-field-label-top-to-asterisk-small);
   --spectrum-field-label-text-to-asterisk: var(--spectrum-field-label-text-to-asterisk-small);
 }
 
@@ -45,9 +40,10 @@ governing permissions and limitations under the License.
   --spectrum-fieldlabel-line-height: var(--spectrum-line-height-200);
   --spectrum-fieldlabel-line-height-cjk: var(--spectrum-line-height-cjk-200);
 
-  --spectrum-fieldlabel-asterisk-gap: var(--spectrum-field-label-top-to-asterisk-medium);
   --spectrum-fieldlabel-side-padding-top: var(--spectrum-component-top-to-text-75);
   --spectrum-fieldlabel-side-padding-right: var(--spectrum-spacing-200);
+  
+  --spectrum-field-label-top-to-asterisk: var(--spectrum-field-label-top-to-asterisk-medium);
   --spectrum-field-label-text-to-asterisk: var(--spectrum-field-label-text-to-asterisk-medium);
 }
 
@@ -59,9 +55,10 @@ governing permissions and limitations under the License.
   --spectrum-fieldlabel-line-height: var(--spectrum-line-height-100);
   --spectrum-fieldlabel-line-height-cjk: var(--spectrum-line-height-cjk-100);
 
-  --spectrum-fieldlabel-asterisk-gap: var(--spectrum-field-label-top-to-asterisk-large);
   --spectrum-fieldlabel-side-padding-top: var(--spectrum-component-top-to-text-100);
   --spectrum-fieldlabel-side-padding-right: var(--spectrum-spacing-200);
+  
+  --spectrum-field-label-top-to-asterisk: var(--spectrum-field-label-top-to-asterisk-large);
   --spectrum-field-label-text-to-asterisk: var(--spectrum-field-label-text-to-asterisk-large);
 }
 
@@ -73,10 +70,10 @@ governing permissions and limitations under the License.
   --spectrum-fieldlabel-line-height: var(--spectrum-line-height-200);
   --spectrum-fieldlabel-line-height-cjk: var(--spectrum-line-height-cjk-200);
 
-
-  --spectrum-fieldlabel-asterisk-gap: var(--spectrum-field-label-top-to-asterisk-extra-large);
   --spectrum-fieldlabel-side-padding-top: var(--spectrum-component-top-to-text-200);
   --spectrum-fieldlabel-side-padding-right: var(--spectrum-spacing-200);
+
+  --spectrum-field-label-top-to-asterisk: var(--spectrum-field-label-top-to-asterisk-extra-large);
   --spectrum-field-label-text-to-asterisk: var(--spectrum-field-label-text-to-asterisk-extra-large);
 }
 
@@ -114,8 +111,7 @@ governing permissions and limitations under the License.
 
 .spectrum-FieldLabel-requiredIcon {
   margin-block: 0;
-  /* Previously used this improperly, it doesn't reposition asterisk, just increased top margin on the whole field label var(--spectrum-fieldlabel-asterisk-margin-y) */
-  margin-inline: var(--mod-fieldlabel-asterisk-gap, var(--spectrum-fieldlabel-asterisk-gap)) 0;
+  margin-inline: var(--mod-field-label-text-to-asterisk, var(--spectrum-field-label-text-to-asterisk)) 0;
 }
 
 .spectrum-FieldLabel--left {
@@ -125,7 +121,7 @@ governing permissions and limitations under the License.
 
   & .spectrum-FieldLabel-requiredIcon {
     margin-block: var(--mod-field-label-text-to-asterisk, var(--spectrum-field-label-text-to-asterisk)) 0;
-    margin-inline: var(--mod-fieldlabel-asterisk-gap, var(--spectrum-fieldlabel-asterisk-gap)) 0;
+    margin-inline: var(--mod-field-label-text-to-asterisk, var(--spectrum-field-label-text-to-asterisk)) 0;
   }
 }
 
@@ -184,7 +180,7 @@ governing permissions and limitations under the License.
     flex-direction: column;
 
     &+.spectrum-Form-item {
-      margin-block-start: var(--mod-field-label-top-to-asterisk-small, var(--spectrum-field-label-top-to-asterisk-small));
+      margin-block-start: var(--mod-field-label-top-to-asterisk, var(--spectrum-field-label-top-to-asterisk));
     }
   }
 }


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
Fixes an issue where we were using hard-coded (previously undefined) incorrect values for the spacing between field labels and their asterisks

**Before:**
<img width="350" alt="Field_label_-_Spectrum_CSS" src="https://user-images.githubusercontent.com/360251/216089597-1f5c9b72-a184-4cda-ab57-3ef478888635.png">

**After:**
<img width="346" alt="Field_label_-_Spectrum_CSS--fixed" src="https://user-images.githubusercontent.com/360251/216089654-2bfcc755-f95c-446b-8ced-4f4c58073ca4.png">


## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
