### PR TITLE
fix: correct RTL issues with SideNav and ActionButton

### DIFF
--- a/components/sidenav/index.css
+++ b/components/sidenav/index.css
@@ -31,7 +31,7 @@ governing permissions and limitations under the License.
   position: relative;
   display: inline-flex;
   align-items: center;
-  justify-content: left;
+  justify-content: start;
   box-sizing: border-box;
 
   inline-size: 100%;


### PR DESCRIPTION
## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->
Y'all should probably share the code for `postcss-transform-logical` between the two builders, but this quickfix addresses the ActionButton and SideNav issues I saw when I was trying to create a brown bag preso telling folks to use logical directions

## How and where has this been tested?
 - **How this was tested:** Switch to RTL, look at the hold icon on ActionButton, look at text alignment for SideNav
 - **Browser(s) and OS(s) this was tested with:** Chronumenium

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->
Before
![image](https://user-images.githubusercontent.com/201344/216671562-e3148f6e-0d5d-4c37-a100-4b6bf237551a.png)

After
![image](https://user-images.githubusercontent.com/201344/216671588-acea8ed5-d13e-4022-bed9-31082c4477b2.png)


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] I have tested these changes in Windows High Contrast mode.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
