### PR TITLE
chore: global storyboook styling updates; add new set of stories [CSS-283]

### DIFF
--- a/components/accordion/stories/template.js
+++ b/components/accordion/stories/template.js
@@ -5,10 +5,14 @@ import { ifDefined } from "lit-html/directives/if-defined.js";
 
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 
+import '../index.css';
+import '../skin.css';
+
 export const AccordionItem = ({
   heading,
   content,
   rootClass = "spectrum-Accordion-item",
+  id,
   idx = 0,
   isDisabled = false,
   isOpen = false,
@@ -22,7 +26,7 @@ export const AccordionItem = ({
         "is-open": isOpen,
         "is-disabled": isDisabled,
       })}
-      id=${ifDefined(globals.id)}
+      id=${ifDefined(id)}
       role="presentation"
       @click=${(evt) => {
         if (isDisabled || !evt || !evt.target) return;
@@ -69,18 +73,11 @@ export const AccordionItem = ({
 export const Template = ({
   rootClass = "spectrum-Accordion",
   items,
+  id,
   customClasses = [],
   ...globals
 }) => {
   if (!items || !items.size) return html``;
-
-  try {
-    // Load styles for this component
-    import(/* webpackPrefetch: true */ "../index.css");
-    import(/* webpackPrefetch: true */ "../skin.css");
-  } catch (e) {
-    console.warn(e);
-  }
 
   return html`
     <div
@@ -88,7 +85,7 @@ export const Template = ({
         [rootClass]: true,
         ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
       })}"
-      id=${ifDefined(globals.id)}
+      id=${ifDefined(id)}
       role="region">
       ${repeat(Array.from(items.keys()), (heading, idx) => {
         const item = items.get(heading);

--- a/components/actionbar/stories/actionbar.stories.js
+++ b/components/actionbar/stories/actionbar.stories.js
@@ -1,0 +1,82 @@
+// Import the component markup template
+import { Template } from "./template";
+
+import { default as Popover } from "@spectrum-css/popover/stories/popover.stories.js";
+import { default as CloseButton } from "@spectrum-css/closebutton/stories/closebutton.stories.js";
+import { default as ActionButton } from "@spectrum-css/actionbutton/stories/actionbutton.stories.js";
+
+export default {
+  title: "Action bar",
+  description: "The Action bar component is...",
+  component: "Actionbar",
+  argTypes: {
+    isOpen: {
+      name: "Open",
+      type: { name: "boolean" },
+      table: {
+        type: { summary: "boolean" },
+        category: "State",
+      },
+      control: "boolean",
+    },
+    isEmphasized: {
+      name: "Emphasized styling",
+      type: { name: "boolean" },
+      table: {
+        type: { summary: "boolean" },
+        category: "Component",
+      },
+      control: "boolean",
+    },
+    isSticky: {
+      name: "Sticky",
+      type: { name: "boolean" },
+      table: {
+        type: { summary: "boolean" },
+        category: "Advanced",
+      },
+      control: "boolean",
+    },
+    isFixed: {
+      name: "Fixed position",
+      type: { name: "boolean" },
+      table: {
+        type: { summary: "boolean" },
+        category: "Advanced",
+      },
+      control: "boolean",
+    },
+    isFlexible: {
+      name: "Flexible width",
+      type: { name: "boolean" },
+      table: {
+        type: { summary: "boolean" },
+        category: "Advanced",
+      },
+      control: "boolean",
+    },
+  },
+  args: {
+    rootClass: "spectrum-ActionBar",
+    isOpen: true,
+    isEmphasized: false,
+    isSticky: false,
+    isFixed: false,
+    isFlexible: false,
+  },
+  parameters: {
+    actions: {
+      handles: [
+        ...Popover.parameters.actions.handles,
+        ...CloseButton.parameters.actions.handles,
+        ...ActionButton.parameters.actions.handles,
+      ]
+    },
+    status: {
+      type: process.env.MIGRATED_PACKAGES.includes('actionbar') ? 'migrated' : undefined
+    }
+  }
+};
+
+export const Default = Template.bind({});
+Default.args = {};

--- a/components/actionbar/stories/template.js
+++ b/components/actionbar/stories/template.js
@@ -1,0 +1,77 @@
+import { html } from 'lit-html';
+import { classMap } from 'lit-html/directives/class-map.js';
+// import { ifDefined } from 'lit-html/directives/if-definedjs';
+
+import { Template as Popover } from '@spectrum-css/popover/stories/template.js';
+import { Template as CloseButton } from '@spectrum-css/closebutton/stories/template.js';
+import { Template as FieldLabel } from '@spectrum-css/fieldlabel/stories/template.js';
+import { Template as ActionGroup } from '@spectrum-css/actiongroup/stories/template.js';
+
+import "../index.css";
+
+export const Template = ({
+  rootClass = "spectrum-ActionBar",
+  size = "m",
+  isOpen = true,
+  isEmphasized = false,
+  isSticky = false,
+  isFixed = false,
+  isFlexible = false,
+  customClasses = [],
+  ...globals
+}) => {
+  const { express } = globals;
+
+  try {
+    if (!express) import(/* webpackPrefetch: true */ "../themes/spectrum.css");
+    else import(/* webpackPrefetch: true */ "../themes/express.css");
+  } catch (e) {
+    console.warn(e);
+  }
+
+  return html`
+    <div class=${classMap({
+      [rootClass]: true,
+      [`${rootClass}--size${size?.toUpperCase()}`]: typeof size !== "undefined",
+      [`${rootClass}--emphasized`]: isEmphasized,
+      [`${rootClass}--sticky`]: isSticky,
+      [`${rootClass}--fixed`]: isFixed,
+      [`${rootClass}--flexible`]: isFlexible,
+      'is-open': isOpen,
+        ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
+    })}>
+      ${Popover({
+        ...globals,
+        customClasses: [`${rootClass}-popover`],
+        isOpen,
+        content: [
+          CloseButton({
+            ...globals,
+            staticColor: isEmphasized ? "white" : undefined,
+          }),
+          FieldLabel({
+            ...globals,
+            size: "s",
+            label: "2 Selected"
+          }),
+          ActionGroup({
+            ...globals,
+            size: "m",
+            areQuiet: true,
+            staticColors: isEmphasized ? "white" : undefined,
+            content: [{
+              icon: "Edit",
+              label: "Edit",
+            }, {
+              icon: "Copy",
+              label: "Copy",
+            }, {
+              icon: "Delete",
+              label: "Delete",
+            }]
+          }),
+        ],
+      })}
+    </div>
+  `;
+}

--- a/components/actionbutton/stories/actionbutton.stories.js
+++ b/components/actionbutton/stories/actionbutton.stories.js
@@ -1,6 +1,7 @@
 // Import the component markup template
 import { Template } from "./template";
 
+
 import { default as IconStories } from "@spectrum-css/icon/stories/icon.stories.js";
 
 export default {
@@ -107,7 +108,7 @@ export default {
   },
   parameters: {
     actions: {
-      handles: ['click button:not([disabled])'],
+      handles: ['click .spectrum-ActionButton:not([disabled])'],
     },
     status: {
       type: process.env.MIGRATED_PACKAGES.includes("actionbutton")

--- a/components/actionbutton/stories/template.js
+++ b/components/actionbutton/stories/template.js
@@ -6,6 +6,8 @@ import { lowerCase, capitalize } from "lodash-es";
 
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 
+import "../index.css";
+
 export const Template = ({
   rootClass = "spectrum-ActionButton",
   size = "m",
@@ -27,7 +29,6 @@ export const Template = ({
   const { express } = globals;
 
   try {
-    import(/* webpackPrefetch: true */ "../index.css");
     if (!express) import(/* webpackPrefetch: true */ "../themes/spectrum.css");
     else import(/* webpackPrefetch: true */ "../themes/express.css");
   } catch (e) {

--- a/components/actiongroup/stories/actiongroup.stories.js
+++ b/components/actiongroup/stories/actiongroup.stories.js
@@ -1,0 +1,85 @@
+// Import the component markup template
+import { Template } from "./template";
+
+import { default as ActionButton } from "@spectrum-css/actionbutton/stories/actionbutton.stories.js";
+
+export default {
+  title: "Action group",
+  description: "The Action group component is...",
+  component: "Actiongroup",
+  argTypes: {
+    areQuiet: ActionButton.argTypes.isQuiet,
+    areEmphasized: ActionButton.argTypes.isEmphasized,
+    staticColors: ActionButton.argTypes.staticColor,
+    content: { table: { disable: true } },
+    size: {
+      name: "Size",
+      type: { name: "string", required: true },
+      table: {
+        type: { summary: "string" },
+        category: "Component",
+      },
+      options: ["s", "m", "l", "xl"],
+      control: "select"
+    },
+    vertical: {
+      name: "Vertical layout",
+      type: { name: "boolean" },
+      table: {
+        type: { summary: "boolean" },
+        category: "Component",
+      },
+      control: "boolean"
+    },
+    compact: {
+      name: "Compact layout",
+      type: { name: "boolean" },
+      table: {
+        type: { summary: "boolean" },
+        category: "Component",
+      },
+      control: "boolean"
+    },
+    justified: {
+      name: "Justified",
+      type: { name: "boolean" },
+      table: {
+        type: { summary: "boolean" },
+        category: "Advanced",
+      },
+      control: "boolean",
+    },
+  },
+  args: {
+    rootClass: "spectrum-ActionGroup",
+    size: "m",
+    areQuiet: ActionButton.args.isQuiet,
+    areEmphasized: ActionButton.args.isEmphasized,
+    staticColors: ActionButton.args.staticColor,
+    vertical: false,
+    compact: false,
+    justified: false,
+  },
+  parameters: {
+    actions: {
+      handles: [
+        ...ActionButton.parameters.actions.handles,
+      ]
+    },
+    status: {
+      type: process.env.MIGRATED_PACKAGES.includes('actiongroup') ? 'migrated' : undefined
+    }
+  }
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  content: [{
+    label: "Edit",
+  },{
+    label: "Copy",
+  }, {
+    label: "Delete",
+    isSelected: true,
+  }]
+};

--- a/components/actiongroup/stories/template.js
+++ b/components/actiongroup/stories/template.js
@@ -1,0 +1,56 @@
+import { html } from 'lit-html';
+import { classMap } from 'lit-html/directives/class-map.js';
+import { repeat } from 'lit-html/directives/repeat.js';
+// import { ifDefined } from 'lit-html/directives/if-definedjs';
+
+import { Template as ActionButton } from '@spectrum-css/actionbutton/stories/template.js';
+
+import "../index.css";
+
+export const Template = ({
+  rootClass = "spectrum-ActionGroup",
+  size = "m",
+  areQuiet = false,
+  areEmphasized = false,
+  vertical = false,
+  compact = false,
+  justified = false,
+  staticColors,
+  content,
+  customClasses = [],
+  ...globals
+}) => {
+  const { express } = globals;
+
+  try {
+    if (!express) import(/* webpackPrefetch: true */ "../themes/spectrum.css");
+    else import(/* webpackPrefetch: true */ "../themes/express.css");
+  } catch (e) {
+    console.warn(e);
+  }
+
+  return html`
+    <div class=${classMap({
+      [rootClass]: true,
+      [`${rootClass}--size${size?.toUpperCase()}`]: typeof size !== "undefined",
+      [`${rootClass}--quiet`]: areQuiet,
+      [`${rootClass}--vertical`]: vertical,
+      [`${rootClass}--compact`]: compact,
+      [`${rootClass}--justified`]: justified,
+      ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
+    })}>
+      ${repeat(content, (item) => item.id, (item) => {
+        if (typeof item === "object") {
+          return ActionButton({
+            ...globals,
+            ...item,
+            isQuiet: areQuiet || item.isQuiet,
+            isEmphasized: areEmphasized || item.isEmphasized,
+            staticColor: staticColors || item.staticColor,
+            customClasses: [`${rootClass}-item`],
+          })
+        } else return item;
+      })}
+    </div>
+  `;
+}

--- a/components/actionmenu/stories/actionmenu.stories.js
+++ b/components/actionmenu/stories/actionmenu.stories.js
@@ -1,0 +1,50 @@
+// Import the component markup template
+import { Template } from "./template";
+
+import { default as ActionButton } from "@spectrum-css/actionbutton/stories/actionbutton.stories.js";
+import { default as Menu } from "@spectrum-css/menu/stories/menu.stories.js";
+
+export default {
+  title: "Action menu",
+  description: "The Action menu component is an action button with a Popover.",
+  component: "Action menu",
+  argTypes: {
+    items: { table: { disable: true } },
+    isOpen: {
+      name: "Open",
+      type: { name: "boolean" },
+      table: {
+        type: { summary: "boolean" },
+        category: "State",
+      },
+      control: "boolean",
+    },
+  },
+  args: {
+    isOpen: true,
+  },
+  parameters: {
+    actions: {
+      handles: [
+        ...ActionButton.parameters.actions.handles,
+        ...Menu.parameters.actions.handles,
+      ]
+    },
+    status: {
+      type: process.env.MIGRATED_PACKAGES.includes('actionmenu') ? 'migrated' : undefined
+    }
+  }
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  items: [{
+    label: "Action 1",
+  }, {
+    label: "Action 2",
+  }, {
+    label: "Action 3",
+  }, {
+    label: "Action 4",
+  }],
+};

--- a/components/actionmenu/stories/template.js
+++ b/components/actionmenu/stories/template.js
@@ -1,0 +1,30 @@
+import { html } from 'lit-html';
+
+import { Template as ActionButton } from '@spectrum-css/actionbutton/stories/template.js';
+import { Template as Popover } from '@spectrum-css/popover/stories/template.js';
+import { Template as Menu } from '@spectrum-css/menu/stories/template.js';
+
+import { useArgs } from "@storybook/client-api";
+
+export const Template = ({
+  items = [],
+  isOpen = true,
+  ...globals
+}) => {
+  const [, updateArgs] = useArgs();
+
+  if (!items.length) {
+    console.warn("Action menu requires items be passed in to render.");
+    return html``;
+  }
+
+  return html`
+    ${ActionButton({ ...globals, size: "m", isQuiet: true, isSelected: isOpen, label: "More Actions", icon: "More", onclick: () => {
+      updateArgs({ isOpen: !isOpen });
+    } })}
+    <br/>
+    ${Popover({ ...globals, position: "bottom", isOpen, content: [
+      Menu({ ...globals, items })
+    ] })}
+  `;
+}

--- a/components/asset/stories/asset.stories.js
+++ b/components/asset/stories/asset.stories.js
@@ -1,6 +1,7 @@
 // Import the component markup template
 import { Template } from "./template";
 
+
 import ava from "./example-ava.jpg";
 
 export default {

--- a/components/asset/stories/template.js
+++ b/components/asset/stories/template.js
@@ -2,31 +2,27 @@ import { html, svg } from "lit-html";
 import { classMap } from "lit-html/directives/class-map.js";
 import { ifDefined } from "lit-html/directives/if-defined.js";
 
+import '../index.css';
+import '../skin.css';
+
 export const Template = ({
   rootClass = "spectrum-Asset",
   image,
   preset,
+  id,
   customClasses = [],
-  ...globals
+  // ...globals
 }) => {
-  try {
-    // Load styles for this component
-    import(/* webpackPrefetch: true */ "../index.css");
-    import(/* webpackPrefetch: true */ "../skin.css");
-  } catch (e) {
-    console.warn(e);
-  }
-
   let visual;
   if (preset === "file") {
     visual = svg`
-    <svg viewBox="0 0 128 128" class="${rootClass}-file">
+    <svg viewBox="0 0 128 128" class="${rootClass}-file" width="10">
       <path class="${rootClass}-fileBackground" d="M24,126c-5.5,0-10-4.5-10-10V12c0-5.5,4.5-10,10-10h61.5c2.1,0,4.1,0.8,5.6,2.3l20.5,20.4c1.5,1.5,2.4,3.5,2.4,5.7V116c0,5.5-4.5,10-10,10H24z"></path>
       <path class="${rootClass}-fileOutline" d="M113.1,23.3L92.6,2.9C90.7,1,88.2,0,85.5,0H24c-6.6,0-12,5.4-12,12v104c0,6.6,5.4,12,12,12h80c6.6,0,12-5.4,12-12V30.4C116,27.8,114.9,25.2,113.1,23.3z M90,6l20.1,20H92c-1.1,0-2-0.9-2-2V6z M112,116c0,4.4-3.6,8-8,8H24c-4.4,0-8-3.6-8-8V12c0-4.4,3.6-8,8-8h61.5c0.2,0,0.3,0,0.5,0v20c0,3.3,2.7,6,6,6h20c0,0.1,0,0.3,0,0.4V116z"></path>
     </svg>`;
   } else if (preset === "folder") {
     visual = svg`
-      <svg viewBox="0 0 32 32" class="${rootClass}-folder">
+      <svg viewBox="0 0 32 32" class="${rootClass}-folder" width="10">
         <path class="${rootClass}-folderBackground" d="M3,29.5c-1.4,0-2.5-1.1-2.5-2.5V5c0-1.4,1.1-2.5,2.5-2.5h10.1c0.5,0,1,0.2,1.4,0.6l3.1,3.1c0.2,0.2,0.4,0.3,0.7,0.3H29c1.4,0,2.5,1.1,2.5,2.5v18c0,1.4-1.1,2.5-2.5,2.5H3z"></path>
         <path class="${rootClass}-folderOutline" d="M29,6H18.3c-0.1,0-0.2,0-0.4-0.2l-3.1-3.1C14.4,2.3,13.8,2,13.1,2H3C1.3,2,0,3.3,0,5v22c0,1.6,1.3,3,3,3h26c1.7,0,3-1.4,3-3V9C32,7.3,30.7,6,29,6z M31,27c0,1.1-0.9,2-2,2H3c-1.1,0-2-0.9-2-2V7h28c1.1,0,2,0.9,2,2V27z"></path>
       </svg>`;
@@ -44,7 +40,7 @@ export const Template = ({
         [rootClass]: true,
         ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
       })}
-      id=${ifDefined(globals.id)}
+      id=${ifDefined(id)}
       >
         ${visual}
     </div>`;

--- a/components/avatar/stories/avatar.stories.js
+++ b/components/avatar/stories/avatar.stories.js
@@ -1,6 +1,7 @@
 // Import the component markup template
 import { Template } from "./template";
 
+
 import ava from "./example-ava.jpg";
 
 export default {
@@ -42,7 +43,7 @@ export default {
       type: { name: "boolean" },
       table: {
         type: { summary: "boolean" },
-        category: "Component",
+        category: "State",
       },
       control: "boolean",
     },

--- a/components/avatar/stories/template.js
+++ b/components/avatar/stories/template.js
@@ -4,22 +4,18 @@ import { ifDefined } from "lit-html/directives/if-defined.js";
 
 import ava from "./example-ava.jpg";
 
+import "../index.css";
+
 export const Template = ({
   rootClass = "spectrum-Avatar",
   image = ava,
   altText,
   isDisabled = false,
   size = "700",
+  id,
   customClasses = [],
-  ...globals
+  // ...globals
 }) => {
-  try {
-    // Load styles for this component
-    import(/* webpackPrefetch: true */ "../index.css");
-  } catch (e) {
-    console.warn(e);
-  }
-
   return html`
     <div
       class=${classMap({
@@ -28,7 +24,7 @@ export const Template = ({
         "is-disabled": isDisabled,
         ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
       })}
-      id=${ifDefined(globals.id)}>
+      id=${ifDefined(id)}>
       <img class="${rootClass}-image" src=${image} alt=${ifDefined(altText)} />
     </div>
   `;

--- a/components/badge/stories/badge.stories.js
+++ b/components/badge/stories/badge.stories.js
@@ -1,6 +1,7 @@
 // Import the component markup template
 import { Template } from "./template";
 
+
 import { default as IconStories } from "../../icon/stories/icon.stories.js";
 
 export default {

--- a/components/badge/stories/template.js
+++ b/components/badge/stories/template.js
@@ -4,6 +4,8 @@ import { ifDefined } from "lit-html/directives/if-defined.js";
 
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 
+import "../index.css";
+
 export const Template = ({
   rootClass = "spectrum-Badge",
   size = "m",
@@ -14,13 +16,12 @@ export const Template = ({
   customColor,
   customLayout,
   customClasses = [],
+  id,
   ...globals
 }) => {
   const { express } = globals;
 
   try {
-    // Load styles for this component
-    import(/* webpackPrefetch: true */ "../index.css");
     if (!express) import(/* webpackPrefetch: true */ "../themes/spectrum.css");
     else import(/* webpackPrefetch: true */ "../themes/express.css");
   } catch (e) {
@@ -46,7 +47,7 @@ export const Template = ({
         [`${rootClass}--${customLayout}`]: typeof customLayout !== "undefined",
         ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
       })}
-      id=${ifDefined(globals.id)}>
+      id=${ifDefined(id)}>
       ${iconMarkup}
       ${!hideLabel || (!label && !variant)
         ? html`<div class="${rootClass}-label">${label ?? variant}</div>`

--- a/components/button/stories/button.stories.js
+++ b/components/button/stories/button.stories.js
@@ -1,6 +1,7 @@
 // Import the component markup template
 import { Template } from "./template";
 
+
 import { default as IconStories } from "../../icon/stories/icon.stories.js";
 
 export default {
@@ -41,7 +42,7 @@ export default {
       },
       control: {
         type: "boolean",
-        // if: { arg: 'icon', truthy: true }
+        if: { arg: 'icon', truthy: true }
       },
     },
     variant: {
@@ -69,7 +70,7 @@ export default {
       type: { name: "boolean" },
       table: {
         type: { summary: "boolean" },
-        category: "Component",
+        category: "State",
       },
       control: "boolean",
     },
@@ -103,7 +104,7 @@ export default {
   },
   parameters: {
     actions: {
-      handles: ["click .spectrum-Button", "focus .spectrum-Button"],
+      handles: ["click .spectrum-Button"],
     },
     status: {
       type: process.env.MIGRATED_PACKAGES.includes("button")

--- a/components/button/stories/template.js
+++ b/components/button/stories/template.js
@@ -6,8 +6,11 @@ import { lowerCase, capitalize } from "lodash-es";
 
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 
+import "../index.css";
+
 export const Template = ({
   rootClass = "spectrum-Button",
+  id,
   customClasses = [],
   size = "m",
   label,
@@ -22,9 +25,6 @@ export const Template = ({
 }) => {
   const { express } = globals;
   try {
-    // Load styles for this component
-    import(/* webpackPrefetch: true */ "../index.css");
-
     if (express) import(/* webpackPrefetch: true */ "../themes/express.css");
     else import(/* webpackPrefetch: true */ "../themes/spectrum.css");
   } catch (e) {
@@ -42,7 +42,7 @@ export const Template = ({
         [`${rootClass}--static${capitalize(lowerCase(staticColor))}`]: typeof staticColor !== "undefined",
         ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
       })}
-      id=${ifDefined(globals.id)}
+      id=${ifDefined(id)}
       ?disabled=${isDisabled}>
       ${icon
         ? Icon({

--- a/components/calendar/stories/calendar.stories.js
+++ b/components/calendar/stories/calendar.stories.js
@@ -1,6 +1,7 @@
 // Import the component markup template
 import { Template } from "./template";
 
+
 const today = new Date();
 const months = [...Array(12).keys()].map((key) =>
   new Date(0, key).toLocaleString("en", { month: "long" })

--- a/components/calendar/stories/template.js
+++ b/components/calendar/stories/template.js
@@ -8,6 +8,9 @@ import { action } from "@storybook/addon-actions";
 
 import { Template as ActionButton } from '../../actionbutton/stories/template.js';
 
+import '../index.css';
+import '../skin.css';
+
 export const Template = ({
   rootClass = "spectrum-Calendar",
   month = new Date().toLocaleString("default", { month: "long" }),
@@ -18,18 +21,11 @@ export const Template = ({
   isDisabled = false,
   useDOWAbbrev = false,
   customClasses = [],
+  id,
   ...globals
 }, ctx) => {
   const { lang } = ctx.globals;
   const displayedDate = new Date(`${month} 1, ${year}`);
-
-  try {
-    // Load styles for this component
-    import(/* webpackPrefetch: true */ "../index.css");
-    import(/* webpackPrefetch: true */ "../skin.css");
-  } catch (e) {
-    console.warn(e);
-  }
 
   const [_, updateArgs] = useArgs();
   const DOW = [
@@ -138,7 +134,7 @@ export const Template = ({
         [`${rootClass}--padded`]: padded,
         ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
       })}
-      id=${ifDefined(globals.id)}>
+      id=${ifDefined(id)}>
       <div class="${rootClass}-header">
         <div
           class="${rootClass}-title"
@@ -149,6 +145,7 @@ export const Template = ({
           ${displayedDate.toLocaleString(lang, { month: "long", year: "numeric" })}
         </div>
         ${ActionButton({
+          ...globals,
           label: 'Previous',
           hideLabel: true,
           isQuiet: true,
@@ -163,6 +160,7 @@ export const Template = ({
           }
         })}
         ${ActionButton({
+          ...globals,
           label: 'Next',
           hideLabel: true,
           isQuiet: true,

--- a/components/card/stories/card.stories.js
+++ b/components/card/stories/card.stories.js
@@ -3,6 +3,7 @@ import { html } from "lit-html";
 // Import the component markup template
 import { Template } from "./template";
 
+
 import landscape from "./example-card-landscape.jpeg";
 import portrait from "./example-card-portrait.jpg";
 import square from "./example-card-square.png";

--- a/components/card/stories/template.js
+++ b/components/card/stories/template.js
@@ -10,6 +10,9 @@ import { Template as Checkbox } from "@spectrum-css/checkbox/stories/template.js
 import { Template as Asset } from "@spectrum-css/asset/stories/template.js";
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 
+import '../index.css';
+import '../skin.css';
+
 export const Template = ({
   rootClass = "spectrum-Card",
   size = "m",
@@ -33,13 +36,7 @@ export const Template = ({
   role,
   ...globals
 }) => {
-  try {
-    // Load styles for this component
-    import(/* webpackPrefetch: true */ "../index.css");
-    import(/* webpackPrefetch: true */ "../skin.css");
-  } catch (e) {
-    console.warn(e);
-  }
+  const [_, updateArgs] = useArgs();
 
   return html`
     <div
@@ -109,7 +106,6 @@ export const Template = ({
         }),
       ],
       onclick: () => {
-        const [_, updateArgs] = useArgs();
         updateArgs({ isSelected: !isSelected });
       },
       customClasses: [`${rootClass}-quickActions`],

--- a/components/checkbox/stories/checkbox.stories.js
+++ b/components/checkbox/stories/checkbox.stories.js
@@ -27,11 +27,11 @@ export default {
       control: { type: "text" },
     },
     isChecked: {
-      name: "Is checked",
+      name: "Checked",
       type: { name: "boolean" },
       table: {
         type: { summary: "boolean" },
-        category: "Component",
+        category: "State",
       },
       control: { type: "boolean" },
     },

--- a/components/checkbox/stories/template.js
+++ b/components/checkbox/stories/template.js
@@ -4,6 +4,8 @@ import { ifDefined } from "lit-html/directives/if-defined.js";
 
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 
+import "../index.css";
+
 export const Template = ({
   rootClass = "spectrum-Checkbox",
   size = "m",
@@ -18,8 +20,6 @@ export const Template = ({
   const { express } = globals;
 
   try {
-    // Load styles for this component
-    import(/* webpackPrefetch: true */ "../index.css");
     if (!express) import(/* webpackPrefetch: true */ "../themes/spectrum.css");
     else import(/* webpackPrefetch: true */ "../themes/express.css");
   } catch (e) {
@@ -33,7 +33,7 @@ export const Template = ({
         [`${rootClass}--size${size?.toUpperCase()}`]: typeof size !== "undefined",
         ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
       })}
-      id=${ifDefined(globals.id)}>
+      id=${ifDefined(id)}>
       <input
         type="checkbox"
         class="${rootClass}-input"

--- a/components/clearbutton/stories/clearbutton.stories.js
+++ b/components/clearbutton/stories/clearbutton.stories.js
@@ -1,0 +1,55 @@
+// Import the component markup template
+import { Template } from "./template";
+
+export default {
+  title: "Clear button",
+  description: "The Clear button component is...",
+  component: "Clearbutton",
+  argTypes: {
+    size: {
+      name: "Size",
+      type: { name: "string", required: true },
+      table: {
+        type: { summary: "string" },
+        category: "Component",
+      },
+      options: ["s", "m", "l", "xl"],
+      control: "select"
+    },
+    isDisabled: {
+      name: "Disabled",
+      type: { name: "boolean" },
+      table: {
+        type: { summary: "boolean" },
+        category: "State",
+      },
+      control: "boolean",
+    },
+    variant: {
+      name: "Variant",
+      type: { name: "string" },
+      table: {
+        type: { summary: "string" },
+        category: "Component",
+      },
+      options: ["overBackground"],
+      control: "select"
+    }
+  },
+  args: {
+    rootClass: "spectrum-ClearButton",
+    size: "m",
+    isDisabled: false,
+  },
+  parameters: {
+    actions: {
+      handles: []
+    },
+    status: {
+      type: process.env.MIGRATED_PACKAGES.includes('clearbutton') ? 'migrated' : undefined
+    }
+  }
+};
+
+export const Default = Template.bind({});
+Default.args = {};

--- a/components/clearbutton/stories/template.js
+++ b/components/clearbutton/stories/template.js
@@ -1,0 +1,49 @@
+import { html } from 'lit-html';
+import { classMap } from 'lit-html/directives/class-map.js';
+// import { ifDefined } from 'lit-html/directives/if-definedjs';
+
+import { Template as Icon } from '@spectrum-css/icon/stories/template.js';
+
+import '../index.css';
+
+export const Template = ({
+  rootClass = "spectrum-ClearButton",
+  customClasses = [],
+  isDisabled = false,
+  size = "m",
+  variant,
+  ...globals
+}) => {
+  let iconName = "Cross100";
+  switch (size) {
+    case "s":
+      iconName = "Cross75";
+      break;
+    case "l":
+      iconName = "Cross200";
+      break;
+    case "xl":
+      iconName = "Cross300";
+      break;
+  }
+
+  return html`
+    <button type="reset" class=${classMap({
+      [rootClass]: true,
+      [`${rootClass}--size${size?.toUpperCase()}`]: typeof size !== "undefined",
+      [`${rootClass}--${variant}`]: typeof variant !== "undefined",
+      'is-disabled': isDisabled,
+      ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
+    })}
+      ?disabled=${isDisabled}>
+      <div class="${rootClass}-fill">
+        ${Icon({
+          ...globals,
+          iconName,
+          customClasses: [`${rootClass}-icon`],
+          setName: "ui",
+        })}
+      </div>
+    </button>
+  `;
+}

--- a/components/closebutton/stories/closebutton.stories.js
+++ b/components/closebutton/stories/closebutton.stories.js
@@ -31,7 +31,7 @@ export default {
       type: { name: "boolean" },
       table: {
         type: { summary: "boolean" },
-        category: "Component",
+        category: "State",
       },
       control: "boolean",
     },
@@ -43,7 +43,7 @@ export default {
   },
   parameters: {
     actions: {
-      handles: ["click .spectrum-CloseButton", "focus .spectrum-CloseButton"],
+      handles: ["click .spectrum-CloseButton"],
     },
     status: {
       type: process.env.MIGRATED_PACKAGES.includes("closebutton")

--- a/components/closebutton/stories/template.js
+++ b/components/closebutton/stories/template.js
@@ -6,6 +6,8 @@ import { upperCase, lowerCase, capitalize } from "lodash-es";
 
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 
+import "../index.css";
+
 export const Template = ({
   rootClass = "spectrum-CloseButton",
   size = "m",
@@ -13,13 +15,13 @@ export const Template = ({
   staticColor,
   isDisabled = false,
   customClasses = [],
+  id,
+  onclick,
   ...globals
 }) => {
   const { express } = globals;
 
   try {
-    // Load styles for this component
-    import(/* webpackPrefetch: true */ "../index.css");
     if (!express) import(/* webpackPrefetch: true */ "../themes/spectrum.css");
     else import(/* webpackPrefetch: true */ "../themes/express.css");
   } catch (e) {
@@ -48,12 +50,13 @@ export const Template = ({
           typeof staticColor !== "undefined",
         ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
       })}
-      id=${ifDefined(globals.id)}
+      id=${ifDefined(id)}
       label=${ifDefined(label)}
-      ?disabled=${isDisabled}>
+      ?disabled=${isDisabled}
+      @click=${ifDefined(onclick)}>
       ${Icon({
-        iconName,
         ...globals,
+        iconName,
         customClasses: [`${rootClass}-UIIcon`],
         setName: "ui",
       })}

--- a/components/coachmark/stories/coachmark.stories.js
+++ b/components/coachmark/stories/coachmark.stories.js
@@ -1,0 +1,59 @@
+// Import the component markup template
+import { Template } from "./template";
+
+export default {
+  title: "Coach mark",
+  description: "The coach mark component can be used to bring added attention to specific parts of a page.",
+  component: "CoachMark",
+  argTypes: {
+    withPopover: {
+      name: "With Popover",
+      type: { name: "boolean" },
+      table: {
+        type: { summary: "boolean" },
+        category: "Component",
+      },
+      control: "boolean",
+    },
+    isQuiet: {
+      name: "Quiet styling",
+      type: { name: "boolean" },
+      table: {
+        type: { summary: "boolean" },
+        category: "Component",
+      },
+      control: "boolean",
+    },
+    variant: {
+      name: "Color variants",
+      type: { name: "string" },
+      table: {
+        type: { summary: "string" },
+        category: "Component",
+      },
+      options: ["dark", "light"],
+      control: "inline-radio",
+    },
+  },
+  args: {
+    rootClass: "spectrum-CoachMark",
+    isQuiet: false,
+    withPopover: false,
+  },
+  parameters: {
+    actions: {
+      handles: []
+    },
+    status: {
+      type: process.env.MIGRATED_PACKAGES.includes('coachmark') ? 'migrated' : undefined
+    }
+  }
+};
+
+export const Default = Template.bind({});
+Default.args = {};
+
+export const WithPopover = Template.bind({});
+WithPopover.args = {
+  withPopover: true
+};

--- a/components/coachmark/stories/template.js
+++ b/components/coachmark/stories/template.js
@@ -1,0 +1,45 @@
+import { html } from 'lit-html';
+import { classMap } from 'lit-html/directives/class-map.js';
+// import { ifDefined } from 'lit-html/directives/if-definedjs';
+
+import { Template as Button } from '@spectrum-css/button/stories/template.js';
+
+import '../index.css';
+import '../skin.css';
+
+export const Template = ({
+  rootClass = "spectrum-CoachMark",
+  isQuiet = false,
+  withPopover = false,
+  variant,
+  ...globals
+}) => {
+  return html`
+  <div class=${classMap({
+    [`${rootClass}Indicator`]: true,
+    [`${rootClass}Indicator--quiet`]: isQuiet,
+    [`${rootClass}Indicator--${variant}`]: typeof variant !== 'undefined',
+  })} style="display: inline-block;vertical-align: top;">
+    <div class="${rootClass}Indicator-ring"></div>
+    <div class="${rootClass}Indicator-ring"></div>
+    <div class="${rootClass}Indicator-ring"></div>
+  </div>
+  ${withPopover ? html`<div class="${rootClass}Popover" style="display: inline-block;">
+    <div class="${rootClass}Popover-header">
+      <div class="${rootClass}Popover-title">Zoom in</div>
+    </div>
+    <div class="${rootClass}Popover-content">
+      Switch to the zoom tool then click and drag in the canvas to move your camera forward and backward.
+    </div>
+    <div class="${rootClass}Popover-footer">
+      ${Button({
+        ...globals,
+        size: "m",
+        variant: "primary",
+        label: "Okay",
+        treatment: "outline"
+      })}
+    </div>
+  </div>` : ''}
+  `;
+}

--- a/components/dial/stories/template.js
+++ b/components/dial/stories/template.js
@@ -2,6 +2,9 @@ import { html } from "lit-html";
 import { classMap } from "lit-html/directives/class-map.js";
 import { ifDefined } from "lit-html/directives/if-defined.js";
 
+import '../index.css';
+import '../skin.css';
+
 export const Template = ({
   rootClass = "spectrum-Dial",
   size = "m",
@@ -12,16 +15,9 @@ export const Template = ({
   min = 0,
   max = 100,
   customClasses = [],
-  ...globals
+  id,
+  // ...globals
 }) => {
-  try {
-    // Load styles for this component
-    import(/* webpackPrefetch: true */ "../index.css");
-    import(/* webpackPrefetch: true */ "../skin.css");
-  } catch (e) {
-    console.warn(e);
-  }
-
   return html`
     <div
       class=${classMap({
@@ -32,7 +28,7 @@ export const Template = ({
         "is-disabled": isDisabled,
         ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
       })}
-      id=${ifDefined(globals.id)}
+      id=${ifDefined(id)}
       @mousedown=${() => {
         if (isDisabled) return;
         document.body.classList.add("u-isGrabbing");

--- a/components/dialog/stories/dialog.stories.js
+++ b/components/dialog/stories/dialog.stories.js
@@ -37,11 +37,21 @@ export default {
       },
       control: "boolean",
     },
+    isOpen: {
+      name: "Open",
+      type: { name: "boolean" },
+      table: {
+        type: { summary: "boolean" },
+        category: "State",
+      },
+      control: "boolean",
+    },
   },
   args: {
     rootClass: "spectrum-Dialog",
     isDismissable: true,
     showModal: false,
+    isOpen: true,
   },
   parameters: {
     actions: {

--- a/components/dialog/stories/template.js
+++ b/components/dialog/stories/template.js
@@ -2,30 +2,25 @@ import { html } from "lit-html";
 import { classMap } from "lit-html/directives/class-map.js";
 import { ifDefined } from "lit-html/directives/if-defined.js";
 
-// @todo: import { Template as Modal } from '../../modal/stories/template.js';
+import { Template as Modal } from '@spectrum-css/modal/stories/template.js';
 import { Template as Divider } from "@spectrum-css/divider/stories/template.js";
 import { Template as CloseButton } from "@spectrum-css/closebutton/stories/template.js";
+
+import '../index.css';
+import '../skin.css';
 
 export const Template = ({
   rootClass = "spectrum-Dialog",
   isDismissable = true,
+  isOpen = true,
   showModal = false,
   heading,
   content = [],
   customClasses = [],
+  id,
   ...globals
 }) => {
   const { scale } = globals;
-  try {
-    import(/* webpackPrefetch: true */ "@spectrum-css/modal");
-
-    // Load styles for this component
-    import(/* webpackPrefetch: true */ "../index.css");
-    import(/* webpackPrefetch: true */ "../skin.css");
-  } catch (e) {
-    console.warn(e);
-  }
-
   const Dialog = html`
     <div
       class=${classMap({
@@ -34,7 +29,7 @@ export const Template = ({
         [`${rootClass}--dismissable`]: isDismissable,
         ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
       })}
-      id=${ifDefined(globals.id)}
+      id=${ifDefined(id)}
       role="dialog"
       tabindex="-1"
       aria-modal="true"
@@ -59,15 +54,14 @@ export const Template = ({
           : ""}
       </div>
     </div>
-    ${showModal ? html`</div></div>` : ""}
   `;
 
   if (showModal) {
-    return html`
-      <div class="spectrum-Modal-wrapper">
-        <div class="spectrum-Modal is-open">${Dialog}</div>
-      </div>
-    `;
+    return Modal({
+      ...globals,
+      isOpen,
+      content: Dialog,
+    });
   } else {
     return Dialog;
   }

--- a/components/divider/stories/template.js
+++ b/components/divider/stories/template.js
@@ -1,6 +1,8 @@
 import { html } from "lit-html";
 import { unsafeHTML } from "lit-html/directives/unsafe-html.js";
 
+import "../index.css";
+
 export const Template = ({
   rootClass = "spectrum-Divider",
   size = "m",
@@ -9,8 +11,6 @@ export const Template = ({
   ...globals
 }) => {
   try {
-    // Load styles for this component
-    import(/* webpackPrefetch: true */ "../index.css");
     if (!express) import(/* webpackPrefetch: true */ "../themes/spectrum.css");
     else import(/* webpackPrefetch: true */ "../themes/express.css");
   } catch (e) {

--- a/components/dropzone/stories/template.js
+++ b/components/dropzone/stories/template.js
@@ -2,31 +2,20 @@ import { html } from "lit-html";
 import { classMap } from "lit-html/directives/class-map.js";
 import { ifDefined } from "lit-html/directives/if-defined.js";
 
-// import { Template as IllustratedMessage } from '@spectrum-css/illustratedmessage/stories/template.js';
+import { CTA as IllustratedMessageStories } from "@spectrum-css/illustratedmessage/stories/illustratedmessage.stories.js";
+import { Template as IllustratedMessage } from '@spectrum-css/illustratedmessage/stories/template.js';
 import { Template as Link } from "@spectrum-css/link/stories/template.js";
+
+import '../index.css';
+import '../skin.css';
 
 export const Template = ({
   rootClass = "spectrum-DropZone",
   isDragged = false,
   customClasses = [],
+  id,
   ...globals
 }) => {
-  try {
-    import(/* webpackPrefetch: true */ "@spectrum-css/illustratedmessage");
-
-    // Load styles for this component
-    import(/* webpackPrefetch: true */ "../index.css");
-    import(/* webpackPrefetch: true */ "../skin.css");
-  } catch (e) {
-    console.warn(e);
-  }
-
-  // ${IllustratedMessage({
-  //   variant: 'cta',
-  //   illustration: svg`<svg class="spectrum-IllustratedMessage-illustration" width="199" height="98" viewBox="0 0 199 97.7"><defs><style>.cls-1,.cls-2{fill:none;stroke-linecap:round;stroke-linejoin:round;}.cls-1{stroke-width:3px;}.cls-2{stroke-width:2px;}</style></defs><path class="cls-1" d="M110.53,85.66,100.26,95.89a1.09,1.09,0,0,1-1.52,0L88.47,85.66"></path><line class="cls-1" x1="99.5" y1="95.5" x2="99.5" y2="58.5"></line><path class="cls-1" d="M105.5,73.5h19a2,2,0,0,0,2-2v-43"></path><path class="cls-1" d="M126.5,22.5h-19a2,2,0,0,1-2-2V1.5h-31a2,2,0,0,0-2,2v68a2,2,0,0,0,2,2h19"></path><line class="cls-1" x1="105.5" y1="1.5" x2="126.5" y2="22.5"></line><path class="cls-2" d="M47.93,50.49a5,5,0,1,0-4.83-5A4.93,4.93,0,0,0,47.93,50.49Z"></path><path class="cls-2" d="M36.6,65.93,42.05,60A2.06,2.06,0,0,1,45,60l12.68,13.2"></path><path class="cls-2" d="M3.14,73.23,22.42,53.76a1.65,1.65,0,0,1,2.38,0l19.05,19.7"></path><path class="cls-1" d="M139.5,36.5H196A1.49,1.49,0,0,1,197.5,38V72A1.49,1.49,0,0,1,196,73.5H141A1.49,1.49,0,0,1,139.5,72V32A1.49,1.49,0,0,1,141,30.5H154a2.43,2.43,0,0,1,1.67.66l6,5.66"></path><rect class="cls-1" x="1.5" y="34.5" width="58" height="39" rx="2" ry="2"></rect></svg>`,
-  //   heading: 'Drag and drop your file',
-  //   description: html`${Link({ content: 'Select a file' })} from your computer.`,
-  // })}
   return html`
     <div
       class=${classMap({
@@ -34,82 +23,15 @@ export const Template = ({
         'is-dragged': isDragged,
         ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
       })}
-      id=${ifDefined(globals.id)}
+      id=${ifDefined(id)}
       role="region"
       tabindex="0"
       style="width: 300px;"
     >
-      <div class="spectrum-IllustratedMessage spectrum-IllustratedMessage--cta">
-        <svg
-          class="spectrum-IllustratedMessage-illustration"
-          width="199"
-          height="98"
-          viewBox="0 0 199 97.7"
-        >
-          <defs>
-            <style>
-              .cls-1,
-              .cls-2 {
-                fill: none;
-                stroke-linecap: round;
-                stroke-linejoin: round;
-              }
-              .cls-1 {
-                stroke-width: 3px;
-              }
-              .cls-2 {
-                stroke-width: 2px;
-              }
-            </style>
-          </defs>
-          <path
-            class="cls-1"
-            d="M110.53,85.66,100.26,95.89a1.09,1.09,0,0,1-1.52,0L88.47,85.66"
-          />
-          <line class="cls-1" x1="99.5" y1="95.5" x2="99.5" y2="58.5" />
-          <path class="cls-1" d="M105.5,73.5h19a2,2,0,0,0,2-2v-43" />
-          <path
-            class="cls-1"
-            d="M126.5,22.5h-19a2,2,0,0,1-2-2V1.5h-31a2,2,0,0,0-2,2v68a2,2,0,0,0,2,2h19"
-          />
-          <line class="cls-1" x1="105.5" y1="1.5" x2="126.5" y2="22.5" />
-          <path
-            class="cls-2"
-            d="M47.93,50.49a5,5,0,1,0-4.83-5A4.93,4.93,0,0,0,47.93,50.49Z"
-          />
-          <path
-            class="cls-2"
-            d="M36.6,65.93,42.05,60A2.06,2.06,0,0,1,45,60l12.68,13.2"
-          />
-          <path
-            class="cls-2"
-            d="M3.14,73.23,22.42,53.76a1.65,1.65,0,0,1,2.38,0l19.05,19.7"
-          />
-          <path
-            class="cls-1"
-            d="M139.5,36.5H196A1.49,1.49,0,0,1,197.5,38V72A1.49,1.49,0,0,1,196,73.5H141A1.49,1.49,0,0,1,139.5,72V32A1.49,1.49,0,0,1,141,30.5H154a2.43,2.43,0,0,1,1.67.66l6,5.66"
-          />
-          <rect
-            class="cls-1"
-            x="1.5"
-            y="34.5"
-            width="58"
-            height="39"
-            rx="2"
-            ry="2"
-          />
-        </svg>
-        <h2
-          class="spectrum-Heading spectrum-Heading--sizeM spectrum-Heading--regular spectrum-IllustratedMessage-heading"
-        >
-          Drag and drop your file
-        </h2>
-        <p
-          class="spectrum-Body spectrum-Body--sizeS spectrum-IllustratedMessage-description"
-        >
-          ${Link({ url: "#", text: "Select a file" })} from your computer.
-        </p>
-      </div>
+      ${IllustratedMessage({
+        ...globals,
+        ...IllustratedMessageStories.args,
+      })}
     </div>
   `;
 };

--- a/components/fieldlabel/stories/fieldlabel.stories.js
+++ b/components/fieldlabel/stories/fieldlabel.stories.js
@@ -1,0 +1,46 @@
+// Import the component markup template
+import { Template } from "./template";
+
+export default {
+  title: "Field label",
+  description: "The Field label component is...",
+  component: "Fieldlabel",
+  argTypes: {
+    size: {
+      name: "Size",
+      type: { name: "string", required: true },
+      table: {
+        type: { summary: "string" },
+        category: "Component",
+      },
+      options: ["s", "m", "l", "xl"],
+      control: "select"
+    },
+    label: {
+      name: "Label",
+      type: { name: "string" },
+      table: {
+        type: { summary: "string" },
+        category: "Component",
+      },
+      control: { type: "text" },
+    },
+  },
+  args: {
+    rootClass: "spectrum-FieldLabel",
+    size: "m",
+  },
+  parameters: {
+    actions: {
+      handles: []
+    },
+    status: {
+      type: process.env.MIGRATED_PACKAGES.includes('fieldlabel') ? 'migrated' : undefined
+    }
+  }
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  label: "Label",
+};

--- a/components/fieldlabel/stories/template.js
+++ b/components/fieldlabel/stories/template.js
@@ -1,0 +1,37 @@
+import { html } from 'lit-html';
+import { classMap } from 'lit-html/directives/class-map.js';
+// import { ifDefined } from 'lit-html/directives/if-definedjs';
+
+import "../index.css";
+
+export const Template = ({
+  rootClass = "spectrum-FieldLabel",
+  customClasses = [],
+  size = "m",
+  label,
+  ...globals
+}) => {
+  if (!label) {
+    console.warn("Please provide a label for the field label");
+    return html``;
+  }
+
+  const { express } = globals;
+
+  try {
+    if (!express) import(/* webpackPrefetch: true */ "../themes/spectrum.css");
+    else import(/* webpackPrefetch: true */ "../themes/express.css");
+  } catch (e) {
+    console.warn(e);
+  }
+
+  return html`
+    <label class=${classMap({
+      [rootClass]: true,
+      [`${rootClass}--size${size?.toUpperCase()}`]: typeof size !== "undefined",
+      ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
+  })}>
+    ${label}
+  </label>
+  `;
+}

--- a/components/helptext/stories/helptext.stories.js
+++ b/components/helptext/stories/helptext.stories.js
@@ -43,11 +43,11 @@ export default {
       },
     },
     isDisabled: {
-      name: "IsDisabled",
+      name: "Disabled",
       type: { name: "boolean" },
       table: {
         type: { summary: "boolean" },
-        category: "Advanced",
+        category: "State",
       },
       control: "boolean",
     },

--- a/components/helptext/stories/template.js
+++ b/components/helptext/stories/template.js
@@ -4,6 +4,8 @@ import { ifDefined } from "lit-html/directives/if-defined.js";
 
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 
+import "../index.css";
+
 // More on component templates: https://storybook.js.org/docs/web-components/writing-stories/introduction#using-args
 export const Template = ({
   rootClass = "spectrum-HelpText",
@@ -12,14 +14,13 @@ export const Template = ({
   hideIcon = false,
   text,
   variant,
+  id,
   customClasses = [],
   ...globals
 }) => {
   const { express } = globals;
 
   try {
-    // Load styles for this component
-    import(/* webpackPrefetch: true */ "../index.css");
     if (!express) import(/* webpackPrefetch: true */ "../themes/spectrum.css");
     else import(/* webpackPrefetch: true */ "../themes/express.css");
   } catch (e) {
@@ -35,7 +36,7 @@ export const Template = ({
         [`${rootClass}--${variant}`]: typeof variant !== "undefined",
         ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
       })}
-      id=${ifDefined(globals.id)}>
+      id=${ifDefined(id)}>
       ${!hideIcon
         ? Icon({
             iconName: "Alert",

--- a/components/icon/stories/icon.stories.js
+++ b/components/icon/stories/icon.stories.js
@@ -3,6 +3,7 @@ import path from "path";
 // Import the component markup template
 import { Template } from "./template";
 
+
 // Imports an array of all icon names in the workflow set
 import iconOpts from "@adobe/spectrum-css-workflow-icons";
 // import workflowIcons from '@adobe/spectrum-css-workflow-icons/dist/spectrum-icons.svg';

--- a/components/icon/stories/template.js
+++ b/components/icon/stories/template.js
@@ -5,6 +5,8 @@ import { classMap } from "lit-html/directives/class-map.js";
 
 import { fetchIconSVG } from "./utilities.js";
 
+import "../index.css";
+
 /**
  * @typedef { keyof import("./icon.stories").default.args } IconArgs
  * @typedef { IconArgs & { scale: string, useRef: boolean, setName: 'workflow' | 'ui' } } IconProps
@@ -19,6 +21,7 @@ export const Template = ({
   size = "m",
   iconName,
   fill,
+  id,
   customClasses = [],
   useRef = false,
   setName = "workflow",
@@ -51,12 +54,6 @@ export const Template = ({
 
   if (foundSet) setName = foundSet;
 
-  try {
-    import(/* webpackPrefetch: true */ "../index.css");
-  } catch (e) {
-    console.warn(e);
-  }
-
   const classList = {
     [rootClass]: true,
     [`spectrum-UIIcon-${iconName}`]: !!(setName === "ui"),
@@ -78,7 +75,7 @@ export const Template = ({
           .map(([k]) => k)
           .join(" ")}"${
           inlineStyle ? ` style="${inlineStyle}"` : ""
-        } focusable="false" aria-hidden="true" role="img" $1>`
+        } focusable="false" aria-hidden="true" role="img" width="10" $1>`
       )
     )}`;
   }
@@ -105,7 +102,7 @@ export const Template = ({
 
   return html` <svg
     class=${classMap(classList)}
-    id=${ifDefined(globals.id)}
+    id=${ifDefined(id)}
     style=${ifDefined(inlineStyle)}
     focusable="false"
     aria-hidden="true"

--- a/components/illustratedmessage/stories/illustratedmessage.stories.js
+++ b/components/illustratedmessage/stories/illustratedmessage.stories.js
@@ -1,0 +1,66 @@
+import { html } from 'lit-html';
+
+// Import the component markup template
+import { Template } from "./template";
+import { Template as Link } from "@spectrum-css/link/stories/template.js";
+
+export default {
+  title: "Illustrated message",
+  description: "The illustrated message component is used for status and errors.",
+  component: "IllustratedMessage",
+  argTypes: {
+    heading: {
+      name: "Heading",
+      type: { name: "string" },
+      table: {
+        type: { summary: "string" },
+        category: "Content",
+      },
+      control: "text",
+    },
+    description: {
+      name: "Description",
+      table: {
+        category: "Content",
+        disable: true,
+      },
+    },
+    variant: {
+      name: "Variants",
+      type: { name: "string" },
+      table: {
+        type: { summary: "string" },
+        category: "Component",
+        disable: true,
+      },
+      options: ["cta"],
+      control: "radio",
+    },
+  },
+  args: {
+    rootClass: "spectrum-IllustratedMessage",
+  },
+  parameters: {
+    actions: {
+      handles: []
+    },
+    status: {
+      type: process.env.MIGRATED_PACKAGES.includes('illustratedmessage') ? 'migrated' : undefined
+    }
+  }
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  heading: "Error 404: Page not found",
+  description: "This page isn't available. Try checking the URL or visit a different page.",
+};
+
+export const CTA = Template.bind({});
+CTA.description = "The illustrated message component is used for instruction/call-to-action.";
+CTA.args = {
+  ...Default.args,
+  heading: "Drag and drop your file",
+  description: html`${Link({ url: '#', text: 'Select a file' })} from your computer.`,
+  variant: "cta",
+};

--- a/components/illustratedmessage/stories/illustration.svg
+++ b/components/illustratedmessage/stories/illustration.svg
@@ -1,0 +1,31 @@
+<svg class="spectrum-IllustratedMessage-illustration" width="199" height="98" viewBox="0 0 199 97.7">
+    <defs>
+        <style>
+            .cls-1,
+            .cls-2 {
+                fill: none;
+                stroke-linecap: round;
+                stroke-linejoin: round;
+            }
+
+            .cls-1 {
+                stroke-width: 3px;
+            }
+
+            .cls-2 {
+                stroke-width: 2px;
+            }
+        </style>
+    </defs>
+    <path class="cls-1" d="M110.53,85.66,100.26,95.89a1.09,1.09,0,0,1-1.52,0L88.47,85.66" />
+    <line class="cls-1" x1="99.5" y1="95.5" x2="99.5" y2="58.5" />
+    <path class="cls-1" d="M105.5,73.5h19a2,2,0,0,0,2-2v-43" />
+    <path class="cls-1" d="M126.5,22.5h-19a2,2,0,0,1-2-2V1.5h-31a2,2,0,0,0-2,2v68a2,2,0,0,0,2,2h19" />
+    <line class="cls-1" x1="105.5" y1="1.5" x2="126.5" y2="22.5" />
+    <path class="cls-2" d="M47.93,50.49a5,5,0,1,0-4.83-5A4.93,4.93,0,0,0,47.93,50.49Z" />
+    <path class="cls-2" d="M36.6,65.93,42.05,60A2.06,2.06,0,0,1,45,60l12.68,13.2" />
+    <path class="cls-2" d="M3.14,73.23,22.42,53.76a1.65,1.65,0,0,1,2.38,0l19.05,19.7" />
+    <path class="cls-1"
+        d="M139.5,36.5H196A1.49,1.49,0,0,1,197.5,38V72A1.49,1.49,0,0,1,196,73.5H141A1.49,1.49,0,0,1,139.5,72V32A1.49,1.49,0,0,1,141,30.5H154a2.43,2.43,0,0,1,1.67.66l6,5.66" />
+    <rect class="cls-1" x="1.5" y="34.5" width="58" height="39" rx="2" ry="2" />
+</svg>

--- a/components/illustratedmessage/stories/template.js
+++ b/components/illustratedmessage/stories/template.js
@@ -1,0 +1,30 @@
+import { html } from 'lit-html';
+import { classMap } from 'lit-html/directives/class-map.js';
+import { unsafeSVG } from 'lit-html/directives/unsafe-svg.js';
+// import { ifDefined } from 'lit-html/directives/if-definedjs';
+
+import '../index.css';
+import '../skin.css';
+
+import illustration from '!raw-loader!./illustration.svg';
+
+export const Template = ({
+  rootClass = "spectrum-IllustratedMessage",
+  variant = "cta",
+  heading,
+  description,
+  customClasses = [],
+  // ...globals
+}) => {
+  return html`
+    <div class=${classMap({
+      [rootClass]: true,
+      [`${rootClass}--${variant}`]: typeof variant !== "undefined",
+      ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
+  })}>
+    ${unsafeSVG(illustration)}
+    ${heading ? html`<h2 class="spectrum-Heading spectrum-Heading--sizeM spectrum-Heading--regular ${rootClass}-heading">${heading}</h2>` : ''}
+    ${description ? html`<p class="spectrum-Body spectrum-Body--sizeS ${rootClass}-description">${description}</p>` : ''}
+  </div>
+  `;
+}

--- a/components/link/stories/link.stories.js
+++ b/components/link/stories/link.stories.js
@@ -12,7 +12,7 @@ export default {
       type: { name: "string", required: true },
       table: {
         type: { summary: "string" },
-        category: "Component",
+        category: "Content",
       },
       control: "url",
     },
@@ -21,7 +21,7 @@ export default {
       type: { name: "string", required: true },
       table: {
         type: { summary: "string" },
-        category: "Component",
+        category: "Content",
       },
       control: "text",
     },

--- a/components/link/stories/template.js
+++ b/components/link/stories/template.js
@@ -4,6 +4,8 @@ import { ifDefined } from "lit-html/directives/if-defined.js";
 
 import { lowerCase, capitalize } from "lodash-es";
 
+import "../index.css";
+
 export const Template = ({
   rootClass = "spectrum-Link",
   size = "m",
@@ -12,14 +14,13 @@ export const Template = ({
   variant,
   staticColor,
   isQuiet = false,
+  id,
   customClasses = [],
   ...globals
 }) => {
   const { express } = globals;
 
   try {
-    // Load styles for this component
-    import(/* webpackPrefetch: true */ "../index.css");
     if (!express) import(/* webpackPrefetch: true */ "../themes/spectrum.css");
     else import(/* webpackPrefetch: true */ "../themes/express.css");
   } catch (e) {
@@ -30,15 +31,13 @@ export const Template = ({
     <a
       class=${classMap({
         [rootClass]: true,
-        [`${rootClass}--size${size?.toUpperCase()}`]:
-          typeof size !== "undefined",
         [`${rootClass}--quiet`]: isQuiet,
         [`${rootClass}--${variant}`]: typeof variant !== "undefined",
         [`${rootClass}--static${capitalize(lowerCase(staticColor))}`]:
           typeof staticColor !== "undefined",
         ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
       })}
-      id=${ifDefined(globals.id)}
+      id=${ifDefined(id)}
       href=${ifDefined(url)}
     >
       ${text}

--- a/components/menu/stories/menu.stories.js
+++ b/components/menu/stories/menu.stories.js
@@ -12,7 +12,7 @@ export default {
       type: { name: "boolean" },
       table: {
         type: { summary: "boolean" },
-        category: "Component",
+        category: "State",
       },
       control: "boolean",
     },
@@ -21,7 +21,7 @@ export default {
       type: { name: "boolean" },
       table: {
         type: { summary: "boolean" },
-        category: "Component",
+        category: "State",
       },
       control: "boolean",
     },

--- a/components/menu/stories/template.js
+++ b/components/menu/stories/template.js
@@ -6,6 +6,9 @@ import { repeat } from "lit-html/directives/repeat.js";
 import { Template as Divider } from "@spectrum-css/divider/stories/template.js";
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 
+import "../index.css";
+import "../skin.css";
+
 export const MenuItem = ({
   rootClass,
   label,
@@ -17,6 +20,7 @@ export const MenuItem = ({
   isChecked = false,
   isFocused = false,
   role = "menuitem",
+  id,
   ...globals
 }) => html`
     <li
@@ -28,7 +32,7 @@ export const MenuItem = ({
         "is-selected": isSelected,
         "is-disabled": isDisabled,
       })}
-      id=${ifDefined(globals.id)}
+      id=${ifDefined(id)}
       role=${ifDefined(role)}
       aria-selected=${isSelected ? "true" : "false"}
       aria-disabled=${isDisabled ? "true" : "false"}
@@ -63,7 +67,7 @@ export const MenuGroup = ({
   ...globals
 }) => html`
     <li
-      id=${ifDefined(globals.id)}
+      id=${ifDefined(id)}
       role="presentation">
       ${heading
         ? html`<span
@@ -93,6 +97,7 @@ export const Submenu = ({
   isDisabled = false,
   isFocused = false,
   role = "menuitem",
+  id,
   ...globals
 }) => html`
     <li
@@ -102,7 +107,7 @@ export const Submenu = ({
         "is-disabled": isDisabled,
         "is-focused": isFocused,
       })}
-      id=${ifDefined(globals.id)}
+      id=${ifDefined(id)}
       role=${ifDefined(role)}
       tabindex="0">
       ${label
@@ -133,14 +138,6 @@ export const Template = ({
   id,
   ...globals
 }) => {
-  try {
-    // Load styles for this component
-    import(/* webpackPrefetch: true */ "../index.css");
-    import(/* webpackPrefetch: true */ "../skin.css");
-  } catch (e) {
-    console.warn(e);
-  }
-
   return html`
     <ul
       class=${classMap({

--- a/components/modal/stories/modal.stories.js
+++ b/components/modal/stories/modal.stories.js
@@ -1,0 +1,35 @@
+// Import the component markup template
+import { Template } from "./template";
+
+export default {
+  title: "Modal",
+  description: "The Modal component is...",
+  component: "Modal",
+  argTypes: {
+    size: {
+      name: "Size",
+      type: { name: "string", required: true },
+      table: {
+        type: { summary: "string" },
+        category: "Component",
+      },
+      options: ["s", "m", "l", "xl"],
+      control: "select"
+    },
+  },
+  args: {
+    rootClass: "spectrum-",
+    size: "m",
+  },
+  parameters: {
+    actions: {
+      handles: []
+    },
+    status: {
+      type: process.env.MIGRATED_PACKAGES.includes('modal') ? 'migrated' : undefined
+    }
+  }
+};
+
+export const Default = Template.bind({});
+Default.args = {};

--- a/components/modal/stories/template.js
+++ b/components/modal/stories/template.js
@@ -1,0 +1,22 @@
+import { html } from 'lit-html';
+import { classMap } from 'lit-html/directives/class-map.js';
+// import { ifDefined } from 'lit-html/directives/if-definedjs';
+
+import "../index.css";
+import "../skin.css";
+
+export const Template = ({
+  rootClass = "spectrum-Modal",
+  customClasses = [],
+  size = "m",
+  // ...globals
+}) => {
+  return html`
+    <div class=${classMap({
+      [rootClass]: true,
+      [`${rootClass}--size${size?.toUpperCase()}`]: typeof size !== "undefined",
+      ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
+    'is-open': true,
+  })}>This is a modal. Don't use it like this; get yourself a Modal.</div>
+  `;
+}

--- a/components/picker/stories/picker.stories.js
+++ b/components/picker/stories/picker.stories.js
@@ -1,6 +1,7 @@
 // Import the component markup template
 import { Template } from "./template";
 
+
 import { default as MenuStories } from "@spectrum-css/menu/stories/menu.stories.js";
 
 export default {
@@ -69,7 +70,7 @@ export default {
       type: { name: "boolean" },
       table: {
         type: { summary: "boolean" },
-        category: "Component",
+        category: "State",
       },
       control: "boolean",
     },

--- a/components/picker/stories/template.js
+++ b/components/picker/stories/template.js
@@ -8,6 +8,8 @@ import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 import { Template as Popover } from "@spectrum-css/popover/stories/template.js";
 import { Template as Menu } from "@spectrum-css/menu/stories/template.js";
 
+import "../index.css";
+
 export const Template = ({
   rootClass = "spectrum-Picker",
   size = "m",
@@ -22,12 +24,7 @@ export const Template = ({
   id,
   ...globals
 }) => {
-  try {
-    // Load styles for this component
-    import(/* webpackPrefetch: true */ "../index.css");
-  } catch (e) {
-    console.warn(e);
-  }
+  const [_, updateArgs] = useArgs();
 
   return html`
     <button
@@ -44,7 +41,6 @@ export const Template = ({
       id=${ifDefined(id)}
       aria-haspopup="listbox"
       @click=${() => {
-        const [_, updateArgs] = useArgs();
         updateArgs({ isOpen: !isOpen });
       }}
     >

--- a/components/popover/stories/popover.stories.js
+++ b/components/popover/stories/popover.stories.js
@@ -1,6 +1,7 @@
 // Import the component markup template
 import { Template } from "./template";
 
+
 import { Default as Menu } from "../../menu/stories/menu.stories.js";
 
 export default {
@@ -14,6 +15,7 @@ export default {
       name: "Open",
       type: { name: "boolean" },
       table: {
+        disable: true,
         type: { summary: "boolean" },
         category: "State",
       },
@@ -43,7 +45,7 @@ export default {
   args: {
     rootClass: "spectrum-Popover",
     isOpen: true,
-    withTip: true,
+    withTip: false,
     position: "top",
   },
   parameters: {

--- a/components/popover/stories/template.js
+++ b/components/popover/stories/template.js
@@ -2,11 +2,13 @@ import { html } from "lit-html";
 import { classMap } from "lit-html/directives/class-map.js";
 import { ifDefined } from "lit-html/directives/if-defined.js";
 
+import "../index.css";
+
 export const Template = ({
   rootClass = "spectrum-Popover",
   size = "m",
   isOpen = true,
-  withTip = true,
+  withTip = false,
   position,
   customClasses = [],
   id,
@@ -16,8 +18,6 @@ export const Template = ({
   const { express } = globals;
 
   try {
-    // Load styles for this component
-    import(/* webpackPrefetch: true */ "../index.css");
     if (!express) import(/* webpackPrefetch: true */ "../themes/spectrum.css");
     else import(/* webpackPrefetch: true */ "../themes/express.css");
   } catch (e) {
@@ -39,8 +39,8 @@ export const Template = ({
       ${content}
       ${withTip ?
         position && ['top', 'bottom'].some(e => position.startsWith(e)) ?
-          html`<svg class="${rootClass}-tip" viewBox="0 -0.5 16 9"><path class="${rootClass}-tip-triangle" d="M-1,-1 8,8 17,-1"></svg>` :
-          html`<svg class="${rootClass}-tip" viewBox="0 -0.5 9 16"><path class="${rootClass}-tip-triangle" d="M-1,-1 8,8 -1,17"></svg>` :
+          html`<svg class="${rootClass}-tip" viewBox="0 -0.5 16 9" width="10"><path class="${rootClass}-tip-triangle" d="M-1,-1 8,8 17,-1"></svg>` :
+          html`<svg class="${rootClass}-tip" viewBox="0 -0.5 9 16" width="10"><path class="${rootClass}-tip-triangle" d="M-1,-1 8,8 -1,17"></svg>` :
         ""}
     </div> `;
 };

--- a/components/quickaction/stories/template.js
+++ b/components/quickaction/stories/template.js
@@ -4,6 +4,9 @@ import { ifDefined } from "lit-html/directives/if-defined.js";
 
 import { Template as ActionButton } from "@spectrum-css/actionbutton/stories/template.js";
 
+import "../index.css";
+import "../skin.css";
+
 export const Template = ({
   rootClass = "spectrum-QuickActions",
   size = "m",
@@ -12,19 +15,13 @@ export const Template = ({
   position,
   noOverlay = false,
   content = [],
+  id,
   customClasses = [],
   ...globals
 }) => {
   if (!content.length) {
     console.warn("Quick actions require content be passed in to render.");
     return html``;
-  }
-
-  try {
-    import(/* webpackPrefetch: true */ "../index.css");
-    import(/* webpackPrefetch: true */ "../skin.css");
-  } catch (e) {
-    console.warn(e);
   }
 
   if (!content.some((c) => c.icon)) {
@@ -42,7 +39,7 @@ export const Template = ({
           [`${rootClass}--textOnly`]: textOnly,
           ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
         })}"
-        id=${ifDefined(globals.id)}>
+        id=${ifDefined(id)}>
         ${content.map((c) => {
           if (typeof c === "object" && c.icon || c.label) {
             return ActionButton({ ...globals, ...c, isQuiet: true });

--- a/components/radio/stories/template.js
+++ b/components/radio/stories/template.js
@@ -2,19 +2,20 @@ import { html } from "lit-html";
 import { classMap } from "lit-html/directives/class-map.js";
 import { ifDefined } from "lit-html/directives/if-defined.js";
 
+import "../index.css";
+
 export const Template = ({
   rootClass = "spectrum-Radio",
   size = "m",
   label,
   name,
+  id,
   customClasses = [],
   ...globals
 }) => {
   const { express } = globals;
 
   try {
-    // Load styles for this component
-    import(/* webpackPrefetch: true */ "../index.css");
     if (!express) import(/* webpackPrefetch: true */ "../themes/spectrum.css");
     else import(/* webpackPrefetch: true */ "../themes/express.css");
   } catch (e) {
@@ -28,7 +29,7 @@ export const Template = ({
         [`${rootClass}--size${size?.toUpperCase()}`]: typeof size !== "undefined",
         ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
       })}
-      id=${ifDefined(globals.id)}>
+      id=${ifDefined(id)}>
       <input
         type="radio"
         name=${name}

--- a/components/rating/stories/template.js
+++ b/components/rating/stories/template.js
@@ -6,21 +6,17 @@ import { ifDefined } from "lit-html/directives/if-defined.js";
 // Uncomment if you plan to include an icon
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 
+import "../index.css";
+import "../skin.css";
+
 export const Template = ({
   rootClass = "spectrum-Rating",
   size = "m",
   max = 5,
   customClasses = [],
-  ...globals
+  id,
+  // ...globals
 }) => {
-  try {
-    // Load styles for this component
-    import(/* webpackPrefetch: true */ "../index.css");
-    import(/* webpackPrefetch: true */ "../skin.css");
-  } catch (e) {
-    console.warn(e);
-  }
-
   return html`
     <div
       class=${classMap({
@@ -28,7 +24,7 @@ export const Template = ({
         [`${rootClass}--size${size?.toUpperCase()}`]: typeof size !== "undefined",
         ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
       })}
-      id=${ifDefined(globals.id)}>
+      id=${ifDefined(id)}>
       <input
         class="${rootClass}-input"
         type="range"

--- a/components/search/stories/search.stories.js
+++ b/components/search/stories/search.stories.js
@@ -1,0 +1,43 @@
+import { Template } from './template.js';
+
+export default {
+  title: "Search",
+  description: "The search component delivers a single input field with a \"reset\" button and mangifying glass icon which serves up a search UI.",
+  component: "Search",
+  argTypes: {
+    isQuiet: {
+      name: "Quiet styling",
+      type: { name: "boolean" },
+      table: {
+        type: { summary: "boolean" },
+        category: "Component",
+      },
+      control: "boolean",
+    },
+    isDisabled: {
+      name: "Disabled",
+      type: { name: "boolean" },
+      table: {
+        type: { summary: "boolean" },
+        category: "State",
+      },
+      control: "boolean",
+    },
+  },
+  args: {
+    rootClass: "spectrum-Search",
+    isQuiet: false,
+    isDisabled: false,
+  },
+  parameters: {
+    actions: {
+      handles: ['change .spectrum-Search-input', 'click .spectrum-Search-clearButton', 'click .spectrum-Search-icon']
+    },
+    status: {
+      type: process.env.MIGRATED_PACKAGES.includes('search') ? 'migrated' : undefined
+    }
+  },
+};
+
+export const Default = Template.bind({});
+Default.args = {};

--- a/components/search/stories/template.js
+++ b/components/search/stories/template.js
@@ -1,0 +1,42 @@
+import { html } from 'lit-html';
+import { classMap } from 'lit-html/directives/class-map.js';
+
+import { Template as ClearButton } from '@spectrum-css/clearbutton/stories/template.js';
+import { Template as TextField } from '@spectrum-css/textfield/stories/template.js';
+
+import '../index.css';
+import '../skin.css';
+
+export const Template = ({
+  rootClass = "spectrum-Search",
+  customClasses = [],
+  isDisabled = false,
+  isQuiet = false,
+  ...globals
+}) => {
+  return html`
+    <form class=${classMap({
+      [rootClass]: true,
+      [`${rootClass}--quiet`]: isQuiet,
+      ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
+    })}>
+      ${TextField({
+        ...globals,
+        isDisabled,
+        customClasses: [`${rootClass}-textfield`],
+        icon: "Magnify",
+        type: "search",
+        placeholder: "Search",
+        name: "search",
+        customInputClasses: [`${rootClass}-input`],
+        customIconClasses: [`${rootClass}-icon`],
+        autocomplete: false,
+      })}
+      ${ClearButton({
+        ...globals,
+        isDisabled,
+        customClasses: [`${rootClass}-clearButton`],
+      })}
+    </form>
+  `;
+}

--- a/components/swatch/stories/template.js
+++ b/components/swatch/stories/template.js
@@ -2,17 +2,18 @@ import { html } from "lit-html";
 import { classMap } from "lit-html/directives/class-map.js";
 import { ifDefined } from "lit-html/directives/if-defined.js";
 
+import "../index.css";
+
 export const Template = ({
   rootClass = "spectrum-Swatch",
   size = "m",
   customClasses = [],
+  id,
   ...globals
 }) => {
   const { express } = globals;
 
   try {
-    // Load styles for this component
-    import(/* webpackPrefetch: true */ "../index.css");
     if (!express) import(/* webpackPrefetch: true */ "../themes/spectrum.css");
     else import(/* webpackPrefetch: true */ "../themes/express.css");
   } catch (e) {
@@ -26,7 +27,7 @@ export const Template = ({
         [`${rootClass}--size${size?.toUpperCase()}`]: typeof size !== "undefined",
         ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
       })}
-      id=${ifDefined(globals.id)}
+      id=${ifDefined(id)}
       style="--spectrum-picked-color: rgb(174, 216, 230)"
       tabindex="0"
     >

--- a/components/switch/stories/template.js
+++ b/components/switch/stories/template.js
@@ -2,18 +2,19 @@ import { html } from "lit-html";
 import { classMap } from "lit-html/directives/class-map.js";
 import { ifDefined } from "lit-html/directives/if-defined.js";
 
+import "../index.css";
+
 export const Template = ({
   rootClass = "spectrum-Switch",
   size = "m",
   customClasses = [],
+  id,
   label,
   ...globals
 }) => {
   const { express } = globals;
 
   try {
-    // Load styles for this component
-    import(/* webpackPrefetch: true */ "../index.css");
     if (!express) import(/* webpackPrefetch: true */ "../themes/spectrum.css");
     else import(/* webpackPrefetch: true */ "../themes/express.css");
   } catch (e) {
@@ -27,7 +28,7 @@ export const Template = ({
         [`${rootClass}--size${size?.toUpperCase()}`]: typeof size !== "undefined",
         ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
       })}
-      id=${ifDefined(globals.id)}>
+      id=${ifDefined(id)}>
       <input
         type="checkbox"
         class="${rootClass}-input"

--- a/components/table/stories/template.js
+++ b/components/table/stories/template.js
@@ -4,20 +4,16 @@ import { ifDefined } from "lit-html/directives/if-defined.js";
 
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 
+import "../index.css";
+import "../skin.css";
+
 export const Template = ({
   rootClass = "spectrum-Table",
   size = "m",
   customClasses = [],
-  ...globals
+  id,
+  // ...globals
 }) => {
-  try {
-    // Load styles for this component
-    import(/* webpackPrefetch: true */ "../index.css");
-    import(/* webpackPrefetch: true */ "../skin.css");
-  } catch (e) {
-    console.warn(e);
-  }
-
   return html`
     <table
       class=${classMap({
@@ -25,7 +21,7 @@ export const Template = ({
         [`${rootClass}--size${size?.toUpperCase()}`]: typeof size !== "undefined",
         ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
       })}
-      id=${ifDefined(globals.id)}>
+      id=${ifDefined(id)}>
       <thead class="${rootClass}-head">
         <tr>
           <th

--- a/components/tag/stories/tag.stories.js
+++ b/components/tag/stories/tag.stories.js
@@ -1,6 +1,7 @@
 // Import the component markup template
 import { Template } from "./template";
 
+
 import { default as IconStories } from "@spectrum-css/icon/stories/icon.stories.js";
 
 import avatar from "@spectrum-css/avatar/stories/example-ava.jpg";

--- a/components/tag/stories/template.js
+++ b/components/tag/stories/template.js
@@ -1,28 +1,12 @@
 import { html } from "lit-html";
 import { classMap } from "lit-html/directives/class-map.js";
-// import { ifDefined } from "lit-html/directives/if-defined.js";
+import { ifDefined } from "lit-html/directives/if-defined.js";
 
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 import { Template as Avatar } from "@spectrum-css/avatar/stories/template.js";
-// import { Template as ClearButton } from "@spectrum-css/clearbutton/stories/template.js";
+import { Template as ClearButton } from "@spectrum-css/clearbutton/stories/template.js";
 
-const ClearButton = () => {
-  try {
-    import("@spectrum-css/clearbutton");
-  } catch (e) {
-    console.warn(e);
-  }
-
-  return html`
-    <button type="reset" class="spectrum-ClearButton spectrum-ClearButton--sizeM spectrum-Tag-clearButton" tabindex="-1">
-      <div class="spectrum-ClearButton-fill">
-        ${Icon({
-          iconName: 'Cross75',
-          customClasses: [`spectrum-ClearButton-icon`],
-        })}
-      </div>
-    </button>`;
-};
+import "../index.css";
 
 // More on component templates: https://storybook.js.org/docs/web-components/writing-stories/introduction#using-args
 export const Template = ({
@@ -36,14 +20,13 @@ export const Template = ({
   isDisabled = false,
   isInvalid = false,
   hasClearButton = false,
+  id,
   customClasses = [],
   ...globals
 }) => {
   const { express } = globals;
 
   try {
-    // Load styles for this component
-    import(/* webpackPrefetch: true */ "../index.css");
     if (!express) import(/* webpackPrefetch: true */ "../themes/spectrum.css");
     else import(/* webpackPrefetch: true */ "../themes/express.css");
   } catch (e) {
@@ -51,15 +34,18 @@ export const Template = ({
   }
 
   return html`
-    <div class=${classMap({
-      [rootClass]: true,
-      [`${rootClass}--size${size?.toUpperCase()}`]: typeof size !== "undefined",
-      'is-emphasized': isEmphasized,
-      'is-disabled': isDisabled,
-      'is-invalid': isInvalid,
-      'is-selected': isSelected,
-      ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
-    })} tabindex="0">
+    <div
+      class=${classMap({
+        [rootClass]: true,
+        [`${rootClass}--size${size?.toUpperCase()}`]: typeof size !== "undefined",
+        'is-emphasized': isEmphasized,
+        'is-disabled': isDisabled,
+        'is-invalid': isInvalid,
+        'is-selected': isSelected,
+        ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
+      })}
+      id=${ifDefined(id)}
+      tabindex="0">
       ${avatarUrl && !icon ? Avatar({
         ...globals,
         image: avatarUrl,
@@ -71,7 +57,10 @@ export const Template = ({
         customClasses: [`${rootClass}s-itemIcon`],
       }) : ""}
       <span class="${rootClass}s-itemLabel">${label}</span>
-      ${hasClearButton ? ClearButton() : ""}
+      ${hasClearButton ? ClearButton({
+        ...globals,
+        customClasses: [`${rootClass}-clearButton`],
+      }) : ""}
     </div>
   `;
 };

--- a/components/textfield/stories/template.js
+++ b/components/textfield/stories/template.js
@@ -2,35 +2,43 @@ import { html } from "lit-html";
 import { ifDefined } from "lit-html/directives/if-defined.js";
 import { classMap } from "lit-html/directives/class-map.js";
 
+import { Template as Icon } from '@spectrum-css/icon/stories/template.js';
+
+import '../index.css';
+import '../skin.css';
+
 export const Template = ({
-  rootClass = "spectrum-TextField",
+  rootClass = "spectrum-Textfield",
   size = "m",
   customClasses = [],
   customInputClasses = [],
+  customIconClasses = [],
   placeholder,
   name,
+  icon,
   value,
+  type = "text",
+  autocomplete = true,
   ...globals
 }) => {
-  try {
-    // Load styles for this component
-    import(/* webpackPrefetch: true */ "../index.css");
-    import(/* webpackPrefetch: true */ "../skin.css");
-  } catch (e) {
-    console.warn(e);
-  }
-
   return html`
     <div class=${classMap({
-        [rootClass]: true,
-        [`${rootClass}--size${size?.toUpperCase()}`]: typeof size !== "undefined",
-        ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
-      })}>
+      [rootClass]: true,
+      [`${rootClass}--size${size?.toUpperCase()}`]: typeof size !== "undefined",
+      ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
+    })}>
+      ${icon ? Icon({
+        ...globals,
+        size,
+        iconName: icon,
+        customClasses: [`${rootClass}-icon`, ...customIconClasses],
+      }) : ""}
       <input
-        type="text"
+        type=${ifDefined(type)}
         placeholder=${ifDefined(placeholder)}
         name=${name}
         value=${ifDefined(value)}
+        autocomplete=${autocomplete ? undefined : "off"}
         class=${classMap({
           [`${rootClass}-input`]: true,
           ...customInputClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),

--- a/components/textfield/stories/textfield.stories.js
+++ b/components/textfield/stories/textfield.stories.js
@@ -9,7 +9,7 @@ export default {
   argTypes: {
   },
   args: {
-    rootClass: "spectrum-TextField",
+    rootClass: "spectrum-Textfield",
   },
   parameters: {
     actions: {

--- a/components/thumbnail/stories/template.js
+++ b/components/thumbnail/stories/template.js
@@ -2,6 +2,9 @@ import { html } from "lit-html";
 import { classMap } from "lit-html/directives/class-map.js";
 import { ifDefined } from "lit-html/directives/if-defined.js";
 
+import "../index.css";
+import "../skin.css";
+
 export const Template = ({
   rootClass = "spectrum-Thumbnail",
   size = "m",
@@ -15,14 +18,6 @@ export const Template = ({
   // ...globals
 }) => {
   if (!imageURL && !svg) return html``;
-
-  try {
-    // Load styles for this component
-    import(/* webpackPrefetch: true */ "../index.css");
-    import(/* webpackPrefetch: true */ "../skin.css");
-  } catch (e) {
-    console.warn(e);
-  }
 
   return html`
     <div

--- a/components/thumbnail/stories/thumbnail.stories.js
+++ b/components/thumbnail/stories/thumbnail.stories.js
@@ -1,6 +1,7 @@
 // Import the component markup template
 import { Template } from "./template";
 
+
 import landscape from "./example-card-landscape.jpeg";
 
 export default {

--- a/components/toast/stories/template.js
+++ b/components/toast/stories/template.js
@@ -6,6 +6,8 @@ import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 import { Template as CloseButton } from "@spectrum-css/closebutton/stories/template.js";
 import { Template as Button } from "@spectrum-css/button/stories/template.js";
 
+import "../index.css";
+
 // More on component templates: https://storybook.js.org/docs/web-components/writing-stories/introduction#using-args
 export const Template = ({
   rootClass = "spectrum-Toast",
@@ -21,7 +23,6 @@ export const Template = ({
   const { express } = globals;
 
   try {
-    import(/* webpackPrefetch: true */ "../index.css");
     if (!express) import(/* webpackPrefetch: true */ "../themes/spectrum.css");
     else import(/* webpackPrefetch: true */ "../themes/express.css");
   } catch (e) {

--- a/components/toast/stories/toast.stories.js
+++ b/components/toast/stories/toast.stories.js
@@ -1,4 +1,3 @@
-// More on default export: https://storybook.js.org/docs/web-components/writing-stories/introduction#default-export
 // More on args: https://storybook.js.org/docs/web-components/writing-stories/args
 
 // Uncomment if you plan to include an icon
@@ -36,7 +35,7 @@ export default {
       name: "Hidden",
       type: { name: "boolean" },
       table: {
-        category: "Component",
+        category: "State",
         type: { summary: "boolean" },
       },
       control: "boolean",

--- a/components/tray/stories/template.js
+++ b/components/tray/stories/template.js
@@ -2,20 +2,21 @@ import { html } from "lit-html";
 import { classMap } from "lit-html/directives/class-map.js";
 import { ifDefined } from "lit-html/directives/if-defined.js";
 
+import { Template as Modal } from '@spectrum-css/modal/stories/template.js';
+
+import "../index.css";
+
 export const Template = ({
   rootClass = "spectrum-Tray",
   isOpen = true,
   content = [],
   customClasses = ["spectrum-Modal"],
+  id,
   ...globals
 }) => {
   const { express } = globals;
 
   try {
-    import(/* webpackPrefetch: true */ "@spectrum-css/modal");
-
-    // Load styles for this component
-    import(/* webpackPrefetch: true */ "../index.css");
     if (!express) import(/* webpackPrefetch: true */ "../themes/spectrum.css");
     else import(/* webpackPrefetch: true */ "../themes/express.css");
   } catch (e) {
@@ -30,7 +31,7 @@ export const Template = ({
           "is-open": isOpen,
           ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
         })}
-        id=${ifDefined(globals.id)}>
+        id=${ifDefined(id)}>
         ${content.map((c) => {
           const { template, ...props } = c;
           return template({ ...props, ...globals });

--- a/components/tray/stories/tray.stories.js
+++ b/components/tray/stories/tray.stories.js
@@ -1,6 +1,7 @@
 // Import the component markup template
 import { Template } from "./template";
 
+
 import { Template as Dialog } from "../../dialog/stories/template.js";
 
 export default {


### PR DESCRIPTION
## Description

This PR includes new storybook assets for:

- [x] actionbar
- [x] actiongroup
- [x] actionmenu
- [x] clearbutton
- [x] coachmark
- [x] illustratedmessage
- [x] search
- [x] link
- [x] modal
- [x] field label

Styling updates & minor changes to globals for:

- [x] accordion
- [x] actionbutton
- [x] asset
- [x] avatar
- [x] badge
- [x] button
- [x] calendar
- [x] card
- [x] checkbox
- [x] closebutton
- [x] dial
- [x] dialog
- [x] divider
- [x] dropzone
- [x] helptext
- [x] icon
- [x] link
- [x] menu
- [x] picker
- [x] popover
- [x] quickaction
- [x] radio
- [x] rating
- [x] swatch
- [x] switch
- [x] table
- [x] tag
- [x] textfield
- [x] thumbnail
- [x] toast
- [x] tray

## How and where has this been tested?
 - **How this was tested:** 
   - `yarn start` to preview stories locally

## To-do list
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] This pull request is ready to merge.
