### PR TITLE
refactor(button): combinator free layout rules

### DIFF
--- a/components/actionbutton/index.css
+++ b/components/actionbutton/index.css
@@ -137,10 +137,11 @@ governing permissions and limitations under the License.
 
   border-radius: var(--mod-actionbutton-border-radius, var(--spectrum-actionbutton-border-radius));
   border-width: var(--mod-actionbutton-border-width, var(--spectrum-actionbutton-border-width));
+  
+  gap: calc(var(--spectrum-actionbutton-text-to-visual) + (var(--spectrum-actionbutton-edge-to-text) - var(--spectrum-actionbutton-edge-to-visual-only)));
 
   /* Start with text-only padding */
-  padding-inline-start: var(--mod-actionbutton-edge-to-text, var(--spectrum-actionbutton-edge-to-text));
-  padding-inline-end: var(--mod-actionbutton-edge-to-text, var(--spectrum-actionbutton-edge-to-text));
+  padding-inline: var(--mod-actionbutton-edge-to-text, var(--spectrum-actionbutton-edge-to-text));
 
   background-color: var(--highcontrast-actionbutton-background-color-default, var(--mod-actionbutton-background-color-default, var(--spectrum-actionbutton-background-color-default)));
   border-color: var(--highcontrast-actionbutton-border-color-default, var(--mod-actionbutton-border-color-default, var(--spectrum-actionbutton-border-color-default)));
@@ -183,26 +184,25 @@ a.spectrum-ActionButton {
   height: var(--mod-actionbutton-icon-size, var(--spectrum-actionbutton-icon-size));
 
   /* adjust icon positioning to match UI kit */
-  margin-inline-start: calc(-1 * (var(--mod-actionbutton-edge-to-text, var(--spectrum-actionbutton-edge-to-text)) - var(--mod-actionbutton-edge-to-visual, var(--spectrum-actionbutton-edge-to-visual))));
+  margin-inline-start: calc(
+    var(--mod-actionbutton-edge-to-visual, var(--spectrum-actionbutton-edge-to-visual)) -
+        var(--mod-actionbutton-edge-to-text, var(--spectrum-actionbutton-edge-to-text))
+  );
+  margin-inline-end: calc(
+      var(--mod-actionbutton-edge-to-visual-only, var(--spectrum-actionbutton-edge-to-visual-only)) -
+          var(--mod-actionbutton-edge-to-text, var(--spectrum-actionbutton-edge-to-text))
+  );
 
   color: inherit;
-
-  & + .spectrum-ActionButton-label {
-    /* Have gap on on the left */
-    padding-inline-start: var(--mod-actionbutton-text-to-visual, var(--spectrum-actionbutton-text-to-visual));
-
-    /* Have no padding on the right (it's built into the element) */
-    padding-inline-end: 0;
-  }
-
-  padding-inline-start: calc(-1 * (var(--mod-actionbutton-edge-to-text, var(--spectrum-actionbutton-edge-to-text)) - var(--mod-actionbutton-edge-to-visual, var(--spectrum-actionbutton-edge-to-visual))));
 }
 
 .spectrum-ActionButton-hold + .spectrum-ActionButton-icon,
 .spectrum-ActionButton-icon:only-child {
-  /* Use icon-only padding, subtracted from the default text-only padding */
-  margin-inline-start: calc(-1 * (var(--mod-actionbutton-edge-to-text, var(--spectrum-actionbutton-edge-to-text)) - var(--mod-actionbutton-edge-to-visual-only, var(--spectrum-actionbutton-edge-to-visual-only))));
-  margin-inline-end: calc(-1 * (var(--mod-actionbutton-edge-to-text, var(--spectrum-actionbutton-edge-to-text)) - var(--mod-actionbutton-edge-to-visual-only, var(--spectrum-actionbutton-edge-to-visual-only))));
+  /* Augment the margin correction for the icon only scenario */
+  margin-inline-start: calc(
+      var(--spectrum-actionbutton-edge-to-visual-only, var(--spectrum-actionbutton-edge-to-visual-only)) -
+          var(--spectrum-actionbutton-edge-to-text, var(--spectrum-actionbutton-edge-to-text))
+  );
 }
 
 .spectrum-ActionButton-label {

--- a/components/actionbutton/index.css
+++ b/components/actionbutton/index.css
@@ -138,7 +138,7 @@ governing permissions and limitations under the License.
   border-radius: var(--mod-actionbutton-border-radius, var(--spectrum-actionbutton-border-radius));
   border-width: var(--mod-actionbutton-border-width, var(--spectrum-actionbutton-border-width));
   
-  gap: calc(var(--spectrum-actionbutton-text-to-visual) + (var(--spectrum-actionbutton-edge-to-text) - var(--spectrum-actionbutton-edge-to-visual-only)));
+  gap: calc(var(--mod-actionbutton-text-to-visual, var(--spectrum-actionbutton-text-to-visual)) + (var(--mod-actionbutton-edge-to-text, var(--spectrum-actionbutton-edge-to-text)) - var(--mod-actionbutton-edge-to-visual-only, var(--spectrum-actionbutton-edge-to-visual-only))));
 
   /* Start with text-only padding */
   padding-inline: var(--mod-actionbutton-edge-to-text, var(--spectrum-actionbutton-edge-to-text));
@@ -200,8 +200,8 @@ a.spectrum-ActionButton {
 .spectrum-ActionButton-icon:only-child {
   /* Augment the margin correction for the icon only scenario */
   margin-inline-start: calc(
-      var(--spectrum-actionbutton-edge-to-visual-only, var(--spectrum-actionbutton-edge-to-visual-only)) -
-          var(--spectrum-actionbutton-edge-to-text, var(--spectrum-actionbutton-edge-to-text))
+      var(--mod-actionbutton-edge-to-visual-only, var(--spectrum-actionbutton-edge-to-visual-only)) -
+          var(--mod-actionbutton-edge-to-text, var(--spectrum-actionbutton-edge-to-text))
   );
 }
 

--- a/components/actionbutton/metadata/mods.md
+++ b/components/actionbutton/metadata/mods.md
@@ -4,7 +4,9 @@
 |`--mod-actionbutton-height`|
 |`--mod-actionbutton-border-radius`|
 |`--mod-actionbutton-border-width`|
+|`--mod-actionbutton-text-to-visual`|
 |`--mod-actionbutton-edge-to-text`|
+|`--mod-actionbutton-edge-to-visual-only`|
 |`--mod-actionbutton-background-color-default`|
 |`--mod-actionbutton-border-color-default`|
 |`--mod-actionbutton-content-color-default`|
@@ -22,8 +24,6 @@
 |`--mod-actionbutton-content-color-disabled`|
 |`--mod-actionbutton-icon-size`|
 |`--mod-actionbutton-edge-to-visual`|
-|`--mod-actionbutton-text-to-visual`|
-|`--mod-actionbutton-edge-to-visual-only`|
 |`--mod-actionbutton-font-size`|
 |`--mod-actionbutton-edge-to-hold-icon`|
 |`--mod-actionbutton-animation-duration`|

--- a/components/button/index.css
+++ b/components/button/index.css
@@ -50,9 +50,7 @@ governing permissions and limitations under the License.
   --spectrum-button-height: var(--spectrum-component-height-100);
 
   --spectrum-button-font-size: var(--spectrum-font-size-100);
-
-
-
+  
   --spectrum-button-edge-to-visual: calc(var(--spectrum-component-pill-edge-to-visual-100) - var(--spectrum-button-border-width));
   --spectrum-button-edge-to-text: calc(var(--spectrum-component-pill-edge-to-text-100) - var(--spectrum-button-border-width));
   --spectrum-button-padding-label-to-icon: var(--spectrum-text-to-visual-100);
@@ -91,67 +89,38 @@ governing permissions and limitations under the License.
 
 }
 
-
 .spectrum-Button {
   @inherit: %spectrum-BaseButton;
   @inherit: %spectrum-ButtonWithFocusRing;
 
-
   border-radius: var(--mod-button-border-radius, var(--spectrum-button-border-radius));
   border-width: var(--mod-button-border-width, var(--spectrum-button-border-width));
   border-style: solid;
-  block-size: auto;
-  height: var(--mod-button-height, var(--spectrum-button-height));
-
-  min-width: var(--mod-button-min-width, var(--spectrum-button-min-width));
-  min-block-size: var(--mod-button-min-width, var(--spectrum-button-min-width));
-  position: relative;
-
-
-  padding-block-start: 0;
-  padding-block-end: 0;
-
-  position: relative;
-
-  min-inline-size: var(--mod-button-min-width, var(--spectrum-button-min-width));
-  min-block-size: var(--mod-spectrum-button-height, var(--spectrum-button-height));
-
-  height: var(--mod-button-height, var(--spectrum-button-height));
-  border-radius: var(--mod-button-border-radius, var(--spectrum-button-border-radius));
-  border-width: var(--mod-button-border-width, var(--spectrum-button-border-width));
-  /* Start with text-only padding */
-  padding-inline-start: var(--mod-button-edge-to-visual, var(--spectrum-button-edge-to-visual));
-  padding-inline-end: var(--mod-button-edge-to-text, var(--spectrum-button-edge-to-text));
-
-
   font-size: var(--mod-button-font-size, var(--spectrum-button-font-size));
   font-weight: var(--mod-bold-font-weight, var(--spectrum-bold-font-weight));
+  gap: var(--spectrum-button-padding-label-to-icon);
+  height: var(--mod-button-height, var(--spectrum-button-height));
+  min-inline-size: var(--mod-button-min-width, var(--spectrum-button-min-width));
+  min-block-size: var(--mod-spectrum-button-height, var(--spectrum-button-height));
+  /* Start with text-only padding */
+  padding-inline: var(--mod-button-edge-to-text, var(--spectrum-button-edge-to-text));
+  position: relative;
+  
+  /* let staticColor variants inherit their color */
+  color: inherit;
 
   &:hover,
   &:active {
     box-shadow: none;
   }
 
-  /* let staticColor variants inherit their color */
-  color: inherit;
-
   .spectrum-Icon {
-    inset-inline-end: calc(var(--mod-spectrum-button-edge-to-visual, var(--spectrum-button-edge-to-visual)) - var(--mod-button-border-width, var(--spectrum-button-border-width)));
-    inset-block-end: calc(var(--mod-spectrum-button-edge-to-visual, var(--spectrum-button-edge-to-visual)) - var(--mod-button-border-width, var(--spectrum-button-border-width)));
+    margin-inline-start: calc(
+        var(--spectrum-button-edge-to-visual) - 
+        var(--spectrum-button-edge-to-text)
+    );
     color: inherit;
   }
-
-  .spectrum-Icon+.spectrum-Button-label {
-    /* Have gap on on the left */
-    padding-inline-start: var(--mod-button-padding-label-to-icon, var(--spectrum-button-padding-label-to-icon));
-
-    /*
-      Have no padding on the right (it's built into the element)
-      This will fail if --spectrum-button-primary-fill-textonly-padding-right !== --spectrum-button-padding-right
-    */
-    padding-inline-end: 0;
-  }
-
 
   /* correct focus-ring radius for t-shirt sizing */
   &:after {
@@ -167,10 +136,15 @@ a.spectrum-Button {
   @inherit: %spectrum-ButtonLabel;
   padding-block-start: var(--mod-button-padding-label-top, var(--spectrum-button-padding-label-top));
   padding-block-end: var(--mod-button-padding-label-bottom, var(--spectrum-button-padding-label-bottom));
+  white-space: nowrap;
+  line-height: calc(
+      var(--mod-button-height, var(--spectrum-button-height)) -
+      var(--mod-button-padding-label-top, var(--spectrum-button-padding-label-top)) - 
+      var(--mod-button-padding-label-bottom, var(--spectrum-button-padding-label-bottom))
+  );
 }
 
 .spectrum-Button {
-
   &:focus-ring,
   &.is-focused {
     &:after {

--- a/components/button/index.css
+++ b/components/button/index.css
@@ -103,6 +103,7 @@ governing permissions and limitations under the License.
   min-inline-size: var(--mod-button-min-width, var(--spectrum-button-min-width));
   min-block-size: var(--mod-spectrum-button-height, var(--spectrum-button-height));
   /* Start with text-only padding */
+  padding-block: 0;
   padding-inline: var(--mod-button-edge-to-text, var(--spectrum-button-edge-to-text));
   position: relative;
   

--- a/components/button/index.css
+++ b/components/button/index.css
@@ -98,10 +98,10 @@ governing permissions and limitations under the License.
   border-style: solid;
   font-size: var(--mod-button-font-size, var(--spectrum-button-font-size));
   font-weight: var(--mod-bold-font-weight, var(--spectrum-bold-font-weight));
-  gap: var(--spectrum-button-padding-label-to-icon);
+  gap: var(--mod-button-padding-label-to-icon, var(--spectrum-button-padding-label-to-icon));
   height: var(--mod-button-height, var(--spectrum-button-height));
   min-inline-size: var(--mod-button-min-width, var(--spectrum-button-min-width));
-  min-block-size: var(--mod-spectrum-button-height, var(--spectrum-button-height));
+  min-block-size: var(--mod-button-height, var(--spectrum-button-height));
   /* Start with text-only padding */
   padding-block: 0;
   padding-inline: var(--mod-button-edge-to-text, var(--spectrum-button-edge-to-text));
@@ -117,8 +117,8 @@ governing permissions and limitations under the License.
 
   .spectrum-Icon {
     margin-inline-start: calc(
-        var(--spectrum-button-edge-to-visual) - 
-        var(--spectrum-button-edge-to-text)
+      var(--mod-button-edge-to-visual, var(--spectrum-button-edge-to-visual)) - 
+      var(--mod-button-edge-to-text, var(--spectrum-button-edge-to-text))
     );
     color: inherit;
   }
@@ -150,7 +150,6 @@ a.spectrum-Button {
     }
   }
 }
-
 
 /* special cases for focus-ring */
 .spectrum-Button {
@@ -223,7 +222,7 @@ a.spectrum-Button {
     &:focus-ring {
       &:after {
         forced-color-adjust: none;
-        box-shadow: 0 0 0 var(--mod-button-focus-ring-thickness, var(--spectrum-button-focus-ring-thickness)) ButtonTExt;
+        box-shadow: 0 0 0 var(--mod-button-focus-ring-thickness, var(--spectrum-button-focus-ring-thickness)) ButtonText;
       }
     }
 

--- a/components/button/index.css
+++ b/components/button/index.css
@@ -135,14 +135,11 @@ a.spectrum-Button {
 
 .spectrum-Button-label {
   @inherit: %spectrum-ButtonLabel;
-  padding-block-start: var(--mod-button-padding-label-top, var(--spectrum-button-padding-label-top));
-  padding-block-end: var(--mod-button-padding-label-bottom, var(--spectrum-button-padding-label-bottom));
+  padding-block-start: calc(var(--mod-button-padding-label-top, var(--spectrum-button-padding-label-top)) - var(--mod-button-border-width, var(--spectrum-button-border-width)));
+  padding-block-end: calc(var(--mod-button-padding-label-bottom, var(--spectrum-button-padding-label-bottom)) - var(--mod-button-border-width, var(--spectrum-button-border-width)));
   white-space: nowrap;
-  line-height: calc(
-      var(--mod-button-height, var(--spectrum-button-height)) -
-      var(--mod-button-padding-label-top, var(--spectrum-button-padding-label-top)) - 
-      var(--mod-button-padding-label-bottom, var(--spectrum-button-padding-label-bottom))
-  );
+  line-height: var(--spectrum-line-height-100);
+  align-self: start;
 }
 
 .spectrum-Button {

--- a/components/button/metadata/mods.md
+++ b/components/button/metadata/mods.md
@@ -2,15 +2,13 @@
 | --- |
 |`--mod-button-border-radius`|
 |`--mod-button-border-width`|
-|`--mod-button-height`|
-|`--mod-button-min-width`|
-|`--mod-spectrum-button-height`|
-|`--mod-button-edge-to-visual`|
-|`--mod-button-edge-to-text`|
 |`--mod-button-font-size`|
 |`--mod-bold-font-weight`|
-|`--mod-spectrum-button-edge-to-visual`|
 |`--mod-button-padding-label-to-icon`|
+|`--mod-button-height`|
+|`--mod-button-min-width`|
+|`--mod-button-edge-to-text`|
+|`--mod-button-edge-to-visual`|
 |`--mod-focus-indicator-gap`|
 |`--mod-button-padding-label-top`|
 |`--mod-button-padding-label-bottom`|


### PR DESCRIPTION
## Description
The use of the `+` combinator to style icon/label layout in the Button requires SWC to leverage content observers in order to mimic the relationship across the slots leveraged to accept these two pieces of content. More heavily leveraging `display: inline-flex` and some alternate padding/margin applications should allow the same layout without requiring the use of a combinator.

**_Works best for SWC when the same can be done for Action Button (which used the `+` AND `:only-child`), will investigate further._**

## Screenshots
TK baring preview site build

## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
