### PR TITLE
fix(inlinealert): correct spectrum theme capitalization

### DIFF
--- a/components/inlinealert/themes/spectrum.css
+++ b/components/inlinealert/themes/spectrum.css
@@ -10,7 +10,7 @@ governing permissions and limitations under the License.
 */
 
 @container (--system: spectrum) {
-    .spectrum-InlineAlert {
+    .spectrum-InLineAlert {
       --spectrum-inlinealert-border-and-icon-color-info: var(--spectrum-blue-800);
       --spectrum-inlinealert-border-and-icon-color-positive: var(--spectrum-green-800);
       --spectrum-inlinealert-border-and-icon-color-notice: var(--spectrum-orange-600);


### PR DESCRIPTION
## Description

Found that the inline alert customizations for the spectrum theme were using `.spectrum-InlineAlert` instead of `.spectrum-InLineAlert`.

## How and where has this been tested?
 - **How this was tested:**
 - [x] Confirmed the output assets in dist/index-vars.css are deduped
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots

<img width="1205" alt="Screenshot 2023-02-08 at 9 44 46 AM" src="https://user-images.githubusercontent.com/1840295/217568719-8f528633-63f7-49ae-91c4-624c287d106c.png">


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] I have tested these changes in Windows High Contrast mode.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
