### PR TITLE
feat(tokens): use full v12 release

### DIFF
--- a/components/tokens/package.json
+++ b/components/tokens/package.json
@@ -20,7 +20,7 @@
     "postbuild": "gulp rebuildCustoms"
   },
   "devDependencies": {
-    "@adobe/spectrum-tokens": "12.0.0-beta.67",
+    "@adobe/spectrum-tokens": "12.0.0",
     "gulp": "^4.0.0",
     "gulp-concat": "^2.6.1",
     "rimraf": "^4.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,10 +12,10 @@
   resolved "https://registry.yarnpkg.com/@adobe/spectrum-css-workflow-icons/-/spectrum-css-workflow-icons-1.5.4.tgz#0e09ff519c36139176c3ba3ce617a995c9032f67"
   integrity sha512-sZ19YOLGw5xTZzCEkVXPjf53lXVzo063KmDTJjpSjy/XLVsF+RaX0b436SfSM4hsIUZ7n27+UsbOvzFaFjcYXw==
 
-"@adobe/spectrum-tokens@12.0.0-beta.67":
-  version "12.0.0-beta.67"
-  resolved "https://registry.yarnpkg.com/@adobe/spectrum-tokens/-/spectrum-tokens-12.0.0-beta.67.tgz#2628ea3ed34217be86b9eaa173f872f73b9b238c"
-  integrity sha512-E9nulUu/YSKwdrvUxxKmCZT8KV09vgajWzQac2AXQ4ogwVhjKPPXOWx/FnqzFXEwrdzYd5szSsr3HmcRYqrT6Q==
+"@adobe/spectrum-tokens@12.0.0":
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/@adobe/spectrum-tokens/-/spectrum-tokens-12.0.0.tgz#23b83311f5b49ca1925b0984073d51ea379f5e44"
+  integrity sha512-iOXqCB8JLgPnHxaHJRJn2JEf2E9QijpI6J8UJAo0dOgkYJm3dISBbdPoi+0C5EKpaOqvLS65ksSpb0PPIeBEJQ==
 
 "@ampproject/remapping@^2.1.0":
   version "2.2.0"


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
Uses the "full" v12 release of `@adobe/spectrum-tokens`.

## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
