### PR TITLE
chore: resolve peer dependency errors

### DIFF
--- a/components/accordion/package.json
+++ b/components/accordion/package.json
@@ -17,7 +17,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/icon": "^3.0.21",
+    "@spectrum-css/icon": "^3.0.0",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/actionbar/package.json
+++ b/components/actionbar/package.json
@@ -18,12 +18,12 @@
   },
   "peerDependencies": {
     "@spectrum-css/actionbutton": "^3.0.0",
-    "@spectrum-css/actiongroup": "^3.0.1",
+    "@spectrum-css/actiongroup": "^3.0.0",
     "@spectrum-css/closebutton": "^3.0.0",
-    "@spectrum-css/fieldlabel": "^5.0.2",
-    "@spectrum-css/icon": "^3.0.21",
-    "@spectrum-css/popover": "^5.0.0",
-    "@spectrum-css/tokens": "^6.0.0"
+    "@spectrum-css/fieldlabel": "^5.0.0 || ^6.0.0",
+    "@spectrum-css/icon": "^3.0.0",
+    "@spectrum-css/popover": "^5.0.0 || ^6.0.0",
+    "@spectrum-css/tokens": "^7.0.0"
   },
   "devDependencies": {
     "@spectrum-css/actionbutton": "^3.0.13",

--- a/components/actionbutton/package.json
+++ b/components/actionbutton/package.json
@@ -17,8 +17,8 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/icon": "^3.0.22",
-    "@spectrum-css/tokens": "^6.0.0"
+    "@spectrum-css/icon": "^3.0.0",
+    "@spectrum-css/tokens": "^7.0.0"
   },
   "devDependencies": {
     "@spectrum-css/component-builder-simple": "^2.0.4",

--- a/components/actiongroup/package.json
+++ b/components/actiongroup/package.json
@@ -18,7 +18,7 @@
   },
   "peerDependencies": {
     "@spectrum-css/actionbutton": "^3.0.0",
-    "@spectrum-css/tokens": "^6.0.0"
+    "@spectrum-css/tokens": "^7.0.0"
   },
   "devDependencies": {
     "@spectrum-css/actionbutton": "^3.0.13",

--- a/components/actionmenu/package.json
+++ b/components/actionmenu/package.json
@@ -17,10 +17,10 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/actionbutton": "^1.1.13",
-    "@spectrum-css/icon": "^3.0.21",
+    "@spectrum-css/actionbutton": "^1.0.0 || ^2.0.0 || ^3.0.0",
+    "@spectrum-css/icon": "^3.0.0",
     "@spectrum-css/menu": "^4.0.0",
-    "@spectrum-css/popover": "^5.0.0",
+    "@spectrum-css/popover": "^5.0.0 || ^6.0.0",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/assetcard/package.json
+++ b/components/assetcard/package.json
@@ -17,9 +17,9 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/checkbox": "^3.1.1",
-    "@spectrum-css/icon": "^3.0.21",
-    "@spectrum-css/typography": "^4.0.18",
+    "@spectrum-css/checkbox": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
+    "@spectrum-css/icon": "^3.0.0",
+    "@spectrum-css/typography": "^4.0.0",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/assetlist/package.json
+++ b/components/assetlist/package.json
@@ -17,8 +17,8 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/checkbox": "^3.1.1",
-    "@spectrum-css/icon": "^3.0.21",
+    "@spectrum-css/checkbox": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
+    "@spectrum-css/icon": "^3.0.0",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/badge/package.json
+++ b/components/badge/package.json
@@ -17,7 +17,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/tokens": "^6.0.0"
+    "@spectrum-css/tokens": "^7.0.0"
   },
   "devDependencies": {
     "@spectrum-css/component-builder-simple": "^2.0.4",

--- a/components/breadcrumb/package.json
+++ b/components/breadcrumb/package.json
@@ -19,7 +19,7 @@
   "peerDependencies": {
     "@spectrum-css/actionbutton": "^3.0.9",
     "@spectrum-css/icon": "^3.0.27",
-    "@spectrum-css/tokens": "^6.3.0"
+    "@spectrum-css/tokens": "^7.0.0"
   },
   "devDependencies": {
     "@spectrum-css/actionbutton": "^3.0.13",

--- a/components/button/package.json
+++ b/components/button/package.json
@@ -17,7 +17,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/tokens": "^6.3.0"
+    "@spectrum-css/tokens": "^7.0.0"
   },
   "devDependencies": {
     "@spectrum-css/component-builder-simple": "^2.0.4",

--- a/components/buttongroup/package.json
+++ b/components/buttongroup/package.json
@@ -17,8 +17,8 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/button": "^6.0.0",
-    "@spectrum-css/tokens": "^6.0.0"
+    "@spectrum-css/button": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
+    "@spectrum-css/tokens": "^7.0.0"
   },
   "devDependencies": {
     "@spectrum-css/button": "^6.0.21",

--- a/components/calendar/package.json
+++ b/components/calendar/package.json
@@ -17,8 +17,8 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/actionbutton": "^1.1.13",
-    "@spectrum-css/icon": "^3.0.22",
+    "@spectrum-css/actionbutton": "^1.0.0 || ^2.0.0 || ^3.0.0",
+    "@spectrum-css/icon": "^3.0.0",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/card/package.json
+++ b/components/card/package.json
@@ -17,12 +17,12 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/actionbutton": "^1.1.13",
-    "@spectrum-css/asset": "^3.0.20",
-    "@spectrum-css/checkbox": "^3.1.1",
-    "@spectrum-css/icon": "^3.0.21",
-    "@spectrum-css/quickaction": "^3.0.24",
-    "@spectrum-css/typography": "^4.0.18",
+    "@spectrum-css/actionbutton": "^1.0.0 || ^2.0.0 || ^3.0.0",
+    "@spectrum-css/asset": "^3.0.0",
+    "@spectrum-css/checkbox": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
+    "@spectrum-css/icon": "^3.0.0",
+    "@spectrum-css/quickaction": "^3.0.0",
+    "@spectrum-css/typography": "^4.0.0",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/checkbox/package.json
+++ b/components/checkbox/package.json
@@ -17,8 +17,8 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/icon": "^3.0.23",
-    "@spectrum-css/tokens": "^6.0.0"
+    "@spectrum-css/icon": "^3.0.0",
+    "@spectrum-css/tokens": "^7.0.0"
   },
   "devDependencies": {
     "@spectrum-css/component-builder-simple": "^2.0.4",

--- a/components/closebutton/package.json
+++ b/components/closebutton/package.json
@@ -17,7 +17,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/tokens": "^6.0.0"
+    "@spectrum-css/tokens": "^7.0.0"
   },
   "devDependencies": {
     "@spectrum-css/component-builder-simple": "^2.0.4",

--- a/components/coachmark/package.json
+++ b/components/coachmark/package.json
@@ -17,7 +17,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/button": "^6.0.0",
+    "@spectrum-css/button": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/cyclebutton/package.json
+++ b/components/cyclebutton/package.json
@@ -17,8 +17,8 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/actionbutton": "^1.1.13",
-    "@spectrum-css/icon": "^3.0.21",
+    "@spectrum-css/actionbutton": "^1.0.0 || ^2.0.0 || ^3.0.0",
+    "@spectrum-css/icon": "^3.0.0",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/dial/package.json
+++ b/components/dial/package.json
@@ -17,7 +17,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/icon": "^3.0.21",
+    "@spectrum-css/icon": "^3.0.0",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/dialog/package.json
+++ b/components/dialog/package.json
@@ -17,13 +17,13 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/button": "^6.0.1",
-    "@spectrum-css/buttongroup": "^5.0.1",
-    "@spectrum-css/closebutton": "^1.2.1",
-    "@spectrum-css/divider": "^1.0.14",
-    "@spectrum-css/icon": "^3.0.13",
-    "@spectrum-css/modal": "^3.0.12",
-    "@spectrum-css/underlay": "^2.0.21",
+    "@spectrum-css/button": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
+    "@spectrum-css/buttongroup": "^5.0.0 || ^6.0.0",
+    "@spectrum-css/closebutton": "^1.0.0 || ^2.0.0 || ^3.0.0",
+    "@spectrum-css/divider": "^1.0.0 || ^2.0.0",
+    "@spectrum-css/icon": "^3.0.0",
+    "@spectrum-css/modal": "^3.0.0",
+    "@spectrum-css/underlay": "^2.0.0",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/divider/package.json
+++ b/components/divider/package.json
@@ -17,7 +17,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/tokens": "^6.0.0"
+    "@spectrum-css/tokens": "^7.0.0"
   },
   "devDependencies": {
     "@spectrum-css/actionbutton": "^1.1.14",

--- a/components/dropindicator/package.json
+++ b/components/dropindicator/package.json
@@ -17,7 +17,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/icon": "^3.0.21",
+    "@spectrum-css/icon": "^3.0.0",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/dropzone/package.json
+++ b/components/dropzone/package.json
@@ -18,7 +18,7 @@
   },
   "peerDependencies": {
     "@spectrum-css/illustratedmessage": "^4.0.0",
-    "@spectrum-css/link": "^3.1.21",
+    "@spectrum-css/link": "^3.0.0 || ^4.0.0",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/fieldgroup/package.json
+++ b/components/fieldgroup/package.json
@@ -17,11 +17,11 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/checkbox": "^5.0.0",
-    "@spectrum-css/helptext": "^3.0.0",
-    "@spectrum-css/icon": "^3.0.21",
-    "@spectrum-css/radio": "^6.0.0",
-    "@spectrum-css/tokens": "^6.0.0"
+    "@spectrum-css/checkbox": "^5.0.0 || ^6.0.0",
+    "@spectrum-css/helptext": "^3.0.0 || ^4.0.0",
+    "@spectrum-css/icon": "^3.0.0",
+    "@spectrum-css/radio": "^6.0.0 || ^7.0.0",
+    "@spectrum-css/tokens": "^7.0.0"
   },
   "devDependencies": {
     "@spectrum-css/checkbox": "^6.0.1",

--- a/components/fieldlabel/package.json
+++ b/components/fieldlabel/package.json
@@ -17,15 +17,15 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/icon": "^3.0.21",
-    "@spectrum-css/tokens": "^6.0.0"
+    "@spectrum-css/icon": "^3.0.0",
+    "@spectrum-css/tokens": "^7.0.0"
   },
   "devDependencies": {
-    "@spectrum-css/checkbox": "^3.1.3",
+    "@spectrum-css/checkbox": "^6.0.1",
     "@spectrum-css/component-builder-simple": "^2.0.4",
-    "@spectrum-css/fieldgroup": "^3.1.4",
+    "@spectrum-css/fieldgroup": "^4.0.15",
     "@spectrum-css/icon": "^3.0.32",
-    "@spectrum-css/picker": "^1.2.21",
+    "@spectrum-css/picker": "^2.0.0",
     "@spectrum-css/radio": "^7.0.1",
     "@spectrum-css/stepper": "^3.0.36",
     "@spectrum-css/textfield": "^3.2.13",

--- a/components/helptext/package.json
+++ b/components/helptext/package.json
@@ -17,8 +17,8 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/icon": "^3.0.23",
-    "@spectrum-css/tokens": "^6.0.0"
+    "@spectrum-css/icon": "^3.0.0",
+    "@spectrum-css/tokens": "^7.0.0"
   },
   "devDependencies": {
     "@spectrum-css/component-builder-simple": "^2.0.4",

--- a/components/illustratedmessage/package.json
+++ b/components/illustratedmessage/package.json
@@ -17,7 +17,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/typography": "^4.0.18",
+    "@spectrum-css/typography": "^4.0.0",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/inlinealert/package.json
+++ b/components/inlinealert/package.json
@@ -17,8 +17,8 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/icon": "^3.0.21",
-    "@spectrum-css/tokens": "^6.0.0"
+    "@spectrum-css/icon": "^3.0.0",
+    "@spectrum-css/tokens": "^7.0.0"
   },
   "devDependencies": {
     "@spectrum-css/button": "^6.0.21",

--- a/components/inputgroup/package.json
+++ b/components/inputgroup/package.json
@@ -18,7 +18,7 @@
   },
   "peerDependencies": {
     "@spectrum-css/pickerbutton": "^2.0.0",
-    "@spectrum-css/popover": "^5.0.0",
+    "@spectrum-css/popover": "^5.0.0 || ^6.0.0",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/link/package.json
+++ b/components/link/package.json
@@ -17,7 +17,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/tokens": "^6.0.0"
+    "@spectrum-css/tokens": "^7.0.0"
   },
   "devDependencies": {
     "@spectrum-css/component-builder-simple": "^2.0.4",

--- a/components/menu/package.json
+++ b/components/menu/package.json
@@ -17,8 +17,8 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/divider": "^1.0.23",
-    "@spectrum-css/icon": "^3.0.21",
+    "@spectrum-css/divider": "^1.0.0 || ^2.0.0",
+    "@spectrum-css/icon": "^3.0.0",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/miller/package.json
+++ b/components/miller/package.json
@@ -17,9 +17,9 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/assetlist": "^3.0.22",
-    "@spectrum-css/checkbox": "^3.1.1",
-    "@spectrum-css/icon": "^3.0.21",
+    "@spectrum-css/assetlist": "^3.0.0",
+    "@spectrum-css/checkbox": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
+    "@spectrum-css/icon": "^3.0.0",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/pagination/package.json
+++ b/components/pagination/package.json
@@ -17,11 +17,11 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/actionbutton": "^1.1.13",
-    "@spectrum-css/button": "^6.0.0",
-    "@spectrum-css/icon": "^3.0.21",
+    "@spectrum-css/actionbutton": "^1.0.0 || ^2.0.0 || ^3.0.0",
+    "@spectrum-css/button": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
+    "@spectrum-css/icon": "^3.0.0",
     "@spectrum-css/splitbutton": "^5.0.0",
-    "@spectrum-css/textfield": "^3.2.2",
+    "@spectrum-css/textfield": "^3.0.0",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/picker/package.json
+++ b/components/picker/package.json
@@ -17,9 +17,9 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/icon": "^3.0.21",
+    "@spectrum-css/icon": "^3.0.0",
     "@spectrum-css/menu": "^4.0.0",
-    "@spectrum-css/popover": "^6.0.16",
+    "@spectrum-css/popover": "^6.0.0",
     "@spectrum-css/tokens": "^7.0.0"
   },
   "devDependencies": {

--- a/components/pickerbutton/package.json
+++ b/components/pickerbutton/package.json
@@ -17,9 +17,9 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/icon": "^3.0.21",
+    "@spectrum-css/icon": "^3.0.0",
     "@spectrum-css/menu": "^4.0.0",
-    "@spectrum-css/popover": "^5.0.0",
+    "@spectrum-css/popover": "^5.0.0 || ^6.0.0",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/popover/package.json
+++ b/components/popover/package.json
@@ -17,8 +17,8 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/dialog": "^6.0.15",
-    "@spectrum-css/tokens": "^6.0.0"
+    "@spectrum-css/dialog": "^6.0.0",
+    "@spectrum-css/tokens": "^7.0.0"
   },
   "devDependencies": {
     "@spectrum-css/button": "^6.0.21",

--- a/components/progresscircle/package.json
+++ b/components/progresscircle/package.json
@@ -17,7 +17,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/tokens": "^6.0.0"
+    "@spectrum-css/tokens": "^7.0.0"
   },
   "devDependencies": {
     "@spectrum-css/component-builder-simple": "^2.0.4",

--- a/components/quickaction/package.json
+++ b/components/quickaction/package.json
@@ -17,8 +17,8 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/actionbutton": "^1.1.13",
-    "@spectrum-css/checkbox": "^3.1.1",
+    "@spectrum-css/actionbutton": "^1.0.0 || ^2.0.0 || ^3.0.0",
+    "@spectrum-css/checkbox": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/radio/package.json
+++ b/components/radio/package.json
@@ -17,8 +17,8 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/icon": "^3.0.21",
-    "@spectrum-css/tokens": "^6.0.0"
+    "@spectrum-css/icon": "^3.0.0",
+    "@spectrum-css/tokens": "^7.0.0"
   },
   "devDependencies": {
     "@spectrum-css/component-builder-simple": "^2.0.4",

--- a/components/rating/package.json
+++ b/components/rating/package.json
@@ -17,7 +17,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/icon": "^3.0.21",
+    "@spectrum-css/icon": "^3.0.0",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/search/package.json
+++ b/components/search/package.json
@@ -17,9 +17,9 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/clearbutton": "^1.2.10",
-    "@spectrum-css/icon": "^3.0.21",
-    "@spectrum-css/textfield": "^3.2.2",
+    "@spectrum-css/clearbutton": "^1.0.0",
+    "@spectrum-css/icon": "^3.0.0",
+    "@spectrum-css/textfield": "^3.0.0",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/searchwithin/package.json
+++ b/components/searchwithin/package.json
@@ -17,11 +17,11 @@
     "build": "gulp"
   },
   "dependencies": {
-    "@spectrum-css/clearbutton": "^1.2.19",
-    "@spectrum-css/icon": "^3.0.32",
-    "@spectrum-css/picker": "^1.2.21",
-    "@spectrum-css/textfield": "^3.2.13",
-    "@spectrum-css/vars": "^8.0.3"
+    "@spectrum-css/clearbutton": "^1.0.0",
+    "@spectrum-css/icon": "^3.0.0",
+    "@spectrum-css/picker": "^1.0.0 || ^2.0.0",
+    "@spectrum-css/textfield": "^3.0.0",
+    "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {
     "@spectrum-css/clearbutton": "1.0.0",

--- a/components/splitbutton/package.json
+++ b/components/splitbutton/package.json
@@ -17,7 +17,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/button": "^6.0.0",
+    "@spectrum-css/button": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/statuslight/package.json
+++ b/components/statuslight/package.json
@@ -17,7 +17,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/tokens": "^6.0.0"
+    "@spectrum-css/tokens": "^7.0.0"
   },
   "devDependencies": {
     "@spectrum-css/component-builder": "^4.0.1",

--- a/components/steplist/package.json
+++ b/components/steplist/package.json
@@ -17,7 +17,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/icon": "^3.0.21",
+    "@spectrum-css/icon": "^3.0.0",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/stepper/package.json
+++ b/components/stepper/package.json
@@ -17,9 +17,9 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/actionbutton": "^1.1.13",
-    "@spectrum-css/icon": "^3.0.21",
-    "@spectrum-css/textfield": "^3.2.2",
+    "@spectrum-css/actionbutton": "^1.0.0 || ^2.0.0 || ^3.0.0",
+    "@spectrum-css/icon": "^3.0.0",
+    "@spectrum-css/textfield": "^3.0.0",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/swatch/package.json
+++ b/components/swatch/package.json
@@ -17,7 +17,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/tokens": "^6.0.0"
+    "@spectrum-css/tokens": "^7.0.0"
   },
   "devDependencies": {
     "@spectrum-css/component-builder-simple": "^2.0.4",

--- a/components/swatchgroup/package.json
+++ b/components/swatchgroup/package.json
@@ -18,7 +18,7 @@
   },
   "peerDependencies": {
     "@spectrum-css/swatch": "^3.0.0",
-    "@spectrum-css/tokens": "^6.0.0"
+    "@spectrum-css/tokens": "^7.0.0"
   },
   "devDependencies": {
     "@spectrum-css/component-builder-simple": "^2.0.4",

--- a/components/switch/package.json
+++ b/components/switch/package.json
@@ -17,7 +17,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/tokens": "^6.2.2"
+    "@spectrum-css/tokens": "^7.0.0"
   },
   "devDependencies": {
     "@spectrum-css/component-builder-simple": "^2.0.4",

--- a/components/table/package.json
+++ b/components/table/package.json
@@ -17,7 +17,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/icon": "^3.0.21",
+    "@spectrum-css/icon": "^3.0.0",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/tabs/package.json
+++ b/components/tabs/package.json
@@ -18,7 +18,7 @@
   },
   "peerDependencies": {
     "@spectrum-css/menu": "^4.0.0",
-    "@spectrum-css/picker": "^1.2.7",
+    "@spectrum-css/picker": "^1.0.0 || ^2.0.0",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/tag/package.json
+++ b/components/tag/package.json
@@ -17,8 +17,8 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/clearbutton": "^1.2.13",
-    "@spectrum-css/tokens": "^6.0.0"
+    "@spectrum-css/clearbutton": "^1.0.0",
+    "@spectrum-css/tokens": "^7.0.0"
   },
   "devDependencies": {
     "@spectrum-css/avatar": "^5.0.27",

--- a/components/taggroup/package.json
+++ b/components/taggroup/package.json
@@ -17,8 +17,8 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/clearbutton": "^1.2.10",
-    "@spectrum-css/tag": "^3.3.12",
+    "@spectrum-css/clearbutton": "^1.0.0",
+    "@spectrum-css/tag": "^3.0.0 || ^4.0.0 || ^5.0.0",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/components/toast/package.json
+++ b/components/toast/package.json
@@ -17,10 +17,10 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/button": "^6.0.0",
+    "@spectrum-css/button": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
     "@spectrum-css/closebutton": "^3.0.0",
-    "@spectrum-css/icon": "^3.0.13",
-    "@spectrum-css/tokens": "^6.0.0"
+    "@spectrum-css/icon": "^3.0.0",
+    "@spectrum-css/tokens": "^7.0.0"
   },
   "devDependencies": {
     "@spectrum-css/button": "^6.0.21",

--- a/components/tooltip/package.json
+++ b/components/tooltip/package.json
@@ -17,8 +17,8 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/icon": "^3.0.21",
-    "@spectrum-css/tokens": "^6.0.0"
+    "@spectrum-css/icon": "^3.0.0",
+    "@spectrum-css/tokens": "^7.0.0"
   },
   "devDependencies": {
     "@spectrum-css/component-builder-simple": "^2.0.4",

--- a/components/tray/package.json
+++ b/components/tray/package.json
@@ -17,10 +17,10 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/button": "^6.0.0",
-    "@spectrum-css/icon": "^3.0.21",
-    "@spectrum-css/modal": "^3.0.20",
-    "@spectrum-css/tokens": "^6.0.0"
+    "@spectrum-css/button": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
+    "@spectrum-css/icon": "^3.0.0",
+    "@spectrum-css/modal": "^3.0.0",
+    "@spectrum-css/tokens": "^7.0.0"
   },
   "devDependencies": {
     "@spectrum-css/button": "^6.0.21",

--- a/components/treeview/package.json
+++ b/components/treeview/package.json
@@ -17,7 +17,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/icon": "^3.0.21",
+    "@spectrum-css/icon": "^3.0.0",
     "@spectrum-css/vars": "^8.0.0"
   },
   "devDependencies": {

--- a/tools/component-builder-simple/package.json
+++ b/tools/component-builder-simple/package.json
@@ -35,7 +35,7 @@
     "through2": "^3.0.1"
   },
   "peerDependencies": {
-    "@spectrum-css/tokens": "^3.0.0"
+    "@spectrum-css/tokens": "^7.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/tools/component-builder/package.json
+++ b/tools/component-builder/package.json
@@ -49,7 +49,7 @@
     "through2": "^3.0.1"
   },
   "peerDependencies": {
-    "@spectrum-css/tokens": "^1.0.0-beta",
+    "@spectrum-css/tokens": "^7.0.0",
     "@spectrum-css/vars": "^8.0.0"
   }
 }

--- a/tools/preview/package.json
+++ b/tools/preview/package.json
@@ -14,7 +14,7 @@
     "@adobe/spectrum-css-workflow-icons": "^1.2.1",
     "@spectrum-css/expressvars": "^2.0.3",
     "@spectrum-css/icon": "^3.0.32",
-    "@spectrum-css/tokens": "^4.0.0",
+    "@spectrum-css/tokens": "^7.0.0",
     "@spectrum-css/vars": "^8.0.3"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2453,11 +2453,6 @@
   dependencies:
     "@spectrum-css/vars" "^8.0.0"
 
-"@spectrum-css/fieldgroup@^3.1.4":
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/fieldgroup/-/fieldgroup-3.1.4.tgz#aede57bda56c41310d262774a8805eefc89ddf74"
-  integrity sha512-ynqkD1OWicCEW7hgYQWzJUrUih+guJHjDtPbTKYhCbnxPqi6aifKmLstBehCgs4iG4+YfGDdZTppW64A3o5foQ==
-
 "@spectrum-css/link@^3.1.23":
   version "3.1.23"
   resolved "https://registry.yarnpkg.com/@spectrum-css/link/-/link-3.1.23.tgz#9d9ff64c41366edbfdb19d04a5deec88bf2ea8fd"
@@ -2482,11 +2477,6 @@
   version "3.3.15"
   resolved "https://registry.yarnpkg.com/@spectrum-css/tag/-/tag-3.3.15.tgz#971184fd8cb977b85a529f808313851863123278"
   integrity sha512-pF6Wh61Z7hmAy20twIlpjdDuivYj6UPtWIzK7giyJKr/qcn20BjVN2ChIeFB1N+vBamJdLsuQOewv4AJ3+LZ2Q==
-
-"@spectrum-css/tokens@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/tokens/-/tokens-4.0.0.tgz#581b858225aae05b9b784db1aa0e257c3e9c53cf"
-  integrity sha512-lDUDbc1BocZR5q9pKpLvFicb7v8Owjhm0mxd+JPk+sVHXHC/u37PEZf7R0QBzl3D/13fNqurtV9DhlPjrhDm0g==
 
 "@spectrum-css/tooltip@^3.1.20":
   version "3.1.20"


### PR DESCRIPTION
## Description

Peer dependencies need to be a little bit more permissive. They should represent the minimum version compatible with the component.

Our install warnings before this update:

<img width="1500" alt="Screenshot 2023-02-16 at 6 25 22 PM" src="https://user-images.githubusercontent.com/1840295/219510867-c8bf9047-1801-43ee-86c7-70ed9612f646.png">

Install warnings after this update:

<img width="1505" alt="Screenshot 2023-02-16 at 6 00 57 PM" src="https://user-images.githubusercontent.com/1840295/219510908-4c084129-a156-451f-b312-fbdf0afef40e.png">


## To-do list
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] This pull request is ready to merge.
