### PR TITLE
fix(actionbutton): fix variable used in documentation

### DIFF
--- a/components/actionbutton/metadata/actionbutton.yml
+++ b/components/actionbutton/metadata/actionbutton.yml
@@ -5,7 +5,7 @@ description: |
   - For Action Buttons that only contain an icon with no label, do not include the element with the `.spectrum-ActionButton-label` class in the markup
   - If an icon and a label are both used, ensure that the element with the `.spectrum-ActionButton-label` class comes after the `.spectrum-Icon` element.
   - If the hold icon is used, ensure that the element with the `.spectrum-ActionButton-hold` class comes before the `.spectrum-Icon` element.
-  - When using `.spectrum-ActionButton--staticWhite` or `.spectrum-ActionButton--staticblack`, use the `--mod-actionbutton-static-content-color` custom property to set the text color when selected.
+  - When using `.spectrum-ActionButton--staticWhite` or `.spectrum-ActionButton--staticblack`, use the `--mod-actionbutton-content-color-default` custom property to set the text color when selected.
 sections:
   - name: Migration Guide
     description: |
@@ -733,10 +733,10 @@ examples:
   - id: actionbutton-staticwhite
     name: Static White
     markup: |
-      <div style="background-color: rgb(15, 121, 125); --mod-actionbutton-static-content-color: rgb(15, 121, 125); padding: 15px 20px;">
+      <div style="--spectrum-alias-background-color-default: rgb(15, 121, 125); --spectrum-alias-heading-text-color: white; background-color: var(--spectrum-alias-background-color-default); color: var(--spectrum-alias-heading-text-color); padding: 15px 20px; border-radius: var(--spectrum-cssexample-border-radius);">
         <div class="spectrum-Examples">
           <div class="spectrum-Examples-item">
-            <h4 style="color: white" class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Default</h4>
+            <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Default</h4>
 
             <div class="spectrum-Examples-itemGroup">
               <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticWhite">
@@ -766,8 +766,8 @@ examples:
               </button>
             </div>
           </div>
-          <div class="spectrum-Examples-item">
-            <h4 style="color: white" class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Selected</h4>
+          <div class="spectrum-Examples-item" style="--mod-actionbutton-content-color-default: var(--spectrum-alias-background-color-default);">
+            <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Selected</h4>
 
             <div class="spectrum-Examples-itemGroup">
               <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticWhite is-selected">
@@ -798,7 +798,7 @@ examples:
             </div>
           </div>
           <div class="spectrum-Examples-item">
-            <h4 style="color: white" class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Disabled</h4>
+            <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Disabled</h4>
 
             <div class="spectrum-Examples-itemGroup">
               <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticWhite" disabled>
@@ -829,7 +829,7 @@ examples:
             </div>
           </div>
           <div class="spectrum-Examples-item">
-            <h4 style="color: white" class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Selected + Disabled</h4>
+            <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Selected + Disabled</h4>
 
             <div class="spectrum-Examples-itemGroup">
               <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticWhite is-selected" disabled>
@@ -865,7 +865,7 @@ examples:
   - id: actionbutton-staticblack
     name: Static Black
     markup: |
-      <div style="background-color: rgb(181, 209, 211); --mod-actionbutton-static-content-color: rgb(181, 209, 211); padding: 15px 20px;">
+      <div style="--spectrum-alias-background-color-default: rgb(181, 209, 211); background-color: var(--spectrum-alias-background-color-default); padding: 15px 20px; border-radius: var(--spectrum-cssexample-border-radius);">
         <div class="spectrum-Examples">
           <div class="spectrum-Examples-item">
             <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Default</h4>
@@ -898,7 +898,7 @@ examples:
               </button>
             </div>
           </div>
-          <div class="spectrum-Examples-item">
+          <div class="spectrum-Examples-item" style="--mod-actionbutton-content-color-default: var(--spectrum-alias-background-color-default);">
             <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Selected</h4>
 
             <div class="spectrum-Examples-itemGroup">
@@ -998,10 +998,10 @@ examples:
   - id: actionbutton-staticwhite-quiet
     name: Static White (quiet)
     markup: |
-      <div style="background-color: rgb(15, 121, 125); --mod-actionbutton-static-content-color: rgb(15, 121, 125); padding: 15px 20px;">
+      <div style="--spectrum-alias-background-color-default: rgb(15, 121, 125); --spectrum-alias-heading-text-color: white; background-color: var(--spectrum-alias-background-color-default); color: var(--spectrum-alias-heading-text-color); padding: 15px 20px; border-radius: var(--spectrum-cssexample-border-radius);">
         <div class="spectrum-Examples">
           <div class="spectrum-Examples-item">
-            <h4 style="color: white" class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Default</h4>
+            <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Default</h4>
 
             <div class="spectrum-Examples-itemGroup">
               <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticWhite spectrum-ActionButton--quiet">
@@ -1031,8 +1031,8 @@ examples:
               </button>
             </div>
           </div>
-          <div class="spectrum-Examples-item">
-            <h4 style="color: white" class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Selected</h4>
+          <div class="spectrum-Examples-item" style="--mod-actionbutton-content-color-default: var(--spectrum-alias-background-color-default)">
+            <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Selected</h4>
 
             <div class="spectrum-Examples-itemGroup">
               <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticWhite spectrum-ActionButton--quiet is-selected">
@@ -1063,7 +1063,7 @@ examples:
             </div>
           </div>
           <div class="spectrum-Examples-item">
-            <h4 style="color: white" class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Disabled</h4>
+            <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Disabled</h4>
 
             <div class="spectrum-Examples-itemGroup">
               <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticWhite spectrum-ActionButton--quiet" disabled>
@@ -1094,7 +1094,7 @@ examples:
             </div>
           </div>
           <div class="spectrum-Examples-item">
-            <h4 style="color: white" class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Selected + Disabled</h4>
+            <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Selected + Disabled</h4>
 
             <div class="spectrum-Examples-itemGroup">
               <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--staticWhite spectrum-ActionButton--quiet is-selected" disabled>
@@ -1130,7 +1130,7 @@ examples:
   - id: actionbutton-staticblack-quiet
     name: Static Black (quiet)
     markup: |
-      <div style="background-color: rgb(181, 209, 211); --mod-actionbutton-static-content-color: rgb(181, 209, 211); padding: 15px 20px;">
+      <div style="--spectrum-alias-background-color-default: rgb(181, 209, 211); background-color: var(--spectrum-alias-background-color-default); padding: 15px 20px; border-radius: var(--spectrum-cssexample-border-radius);">
         <div class="spectrum-Examples">
           <div class="spectrum-Examples-item">
             <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Default</h4>
@@ -1163,7 +1163,7 @@ examples:
               </button>
             </div>
           </div>
-          <div class="spectrum-Examples-item">
+          <div class="spectrum-Examples-item" style="--mod-actionbutton-content-color-default: var(--spectrum-alias-background-color-default)">
             <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Selected</h4>
 
             <div class="spectrum-Examples-itemGroup">


### PR DESCRIPTION
## Before

<img width="594" alt="Screenshot 2023-02-21 at 4 42 12 PM" src="https://user-images.githubusercontent.com/1840295/220465127-c3cba250-916a-4ab1-966e-c664cfe0c43d.png">

## After

<img width="1137" alt="Screenshot 2023-02-21 at 5 13 06 PM" src="https://user-images.githubusercontent.com/1840295/220470517-b257035d-90b8-4e4a-b094-ae68a365eb9c.png">

## To-do list
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] This pull request is ready to merge.
