### PR TITLE
feat: field label storybook

### DIFF
--- a/components/fieldlabel/stories/fieldlabel.stories.js
+++ b/components/fieldlabel/stories/fieldlabel.stories.js
@@ -27,7 +27,7 @@ export default {
     },
     alignment: {
       name: "Alignment",
-      type: { name: "string", required: true },
+      type: { name: "string" },
       table: {
         type: { summary: "string" },
         category: "Component",

--- a/components/fieldlabel/stories/fieldlabel.stories.js
+++ b/components/fieldlabel/stories/fieldlabel.stories.js
@@ -75,3 +75,10 @@ export const Default = Template.bind({});
 Default.args = {
   label: "Label",
 };
+
+export const RightAligned = Template.bind({});
+RightAligned.args = {
+  label: "Label",
+  alignment: "right",
+  style: "width: 72px;"
+};

--- a/components/fieldlabel/stories/fieldlabel.stories.js
+++ b/components/fieldlabel/stories/fieldlabel.stories.js
@@ -80,5 +80,5 @@ export const RightAligned = Template.bind({});
 RightAligned.args = {
   label: "Label",
   alignment: "right",
-  style: "width: 72px;"
+  style: { width: "72px" }
 };

--- a/components/fieldlabel/stories/fieldlabel.stories.js
+++ b/components/fieldlabel/stories/fieldlabel.stories.js
@@ -3,7 +3,7 @@ import { Template } from "./template";
 
 export default {
   title: "Field label",
-  description: "The Field label component is...",
+  description: "The Field label component is used along with inputs to display a label for that input.",
   component: "Fieldlabel",
   argTypes: {
     size: {
@@ -25,10 +25,41 @@ export default {
       },
       control: { type: "text" },
     },
+    alignment: {
+      name: "Alignment",
+      type: { name: "string", required: true },
+      table: {
+        type: { summary: "string" },
+        category: "Component",
+      },
+      options: ["left", "right"],
+      control: "select"
+    },
+    isDisabled: {
+      name: "Disabled",
+      type: { name: "boolean" },
+      table: {
+        type: { summary: "boolean" },
+        category: "State",
+      },
+      control: "boolean",
+    },
+    isRequired: {
+      name: "Required",
+      type: { name: "boolean" },
+      table: {
+        type: { summary: "boolean" },
+        category: "State",
+      },
+      control: "boolean",
+    },
   },
   args: {
     rootClass: "spectrum-FieldLabel",
     size: "m",
+    alignment: "left",
+    isDisabled: false,
+    isRequired: false
   },
   parameters: {
     actions: {

--- a/components/fieldlabel/stories/template.js
+++ b/components/fieldlabel/stories/template.js
@@ -15,7 +15,7 @@ export const Template = ({
   alignment = "left",
   isDisabled,
   isRequired,
-  style = { width: "72px" },
+  style = {},
   ...globals
 }) => {
   if (!label) {
@@ -40,7 +40,7 @@ export const Template = ({
       "is-disabled": isDisabled,
       ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
     })}
-      style=${ifDefined(style)}
+      style=${ifDefined(styleMap(style))}
     >
       ${label}
       ${isRequired ?

--- a/components/fieldlabel/stories/template.js
+++ b/components/fieldlabel/stories/template.js
@@ -1,5 +1,7 @@
 import { html } from 'lit-html';
 import { classMap } from 'lit-html/directives/class-map.js';
+import { styleMap } from 'lit-html/directives/style-map.js';
+import { ifDefined } from "lit-html/directives/if-defined.js";
 
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 
@@ -13,6 +15,7 @@ export const Template = ({
   alignment = "left",
   isDisabled,
   isRequired,
+  style = { width: "72px" },
   ...globals
 }) => {
   if (!label) {
@@ -37,7 +40,7 @@ export const Template = ({
       "is-disabled": isDisabled,
       ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
     })}
-      style="width: 72px;"
+      style=${ifDefined(style)}
     >
       ${label}
       ${isRequired ?

--- a/components/fieldlabel/stories/template.js
+++ b/components/fieldlabel/stories/template.js
@@ -1,6 +1,7 @@
 import { html } from 'lit-html';
 import { classMap } from 'lit-html/directives/class-map.js';
-// import { ifDefined } from 'lit-html/directives/if-defined.js';
+
+import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 
 import "../index.css";
 
@@ -9,6 +10,9 @@ export const Template = ({
   customClasses = [],
   size = "m",
   label,
+  alignment,
+  isDisabled,
+  isRequired,
   ...globals
 }) => {
   if (!label) {
@@ -29,9 +33,18 @@ export const Template = ({
     <label class=${classMap({
       [rootClass]: true,
       [`${rootClass}--size${size?.toUpperCase()}`]: typeof size !== "undefined",
+      [`${rootClass}--${alignment}`]: typeof align !== "undefined",
+      "is-disabled": isDisabled,
       ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
   })}>
     ${label}
+    ${isRequired ?
+      Icon({
+        ...globals,
+        iconName: "Asterisk100",
+        customClasses: [`${rootClass}-UIIcon`],
+      })
+    : ""}
   </label>
   `;
 }

--- a/components/fieldlabel/stories/template.js
+++ b/components/fieldlabel/stories/template.js
@@ -10,7 +10,7 @@ export const Template = ({
   customClasses = [],
   size = "m",
   label,
-  alignment,
+  alignment = "left",
   isDisabled,
   isRequired,
   ...globals

--- a/components/fieldlabel/stories/template.js
+++ b/components/fieldlabel/stories/template.js
@@ -33,18 +33,20 @@ export const Template = ({
     <label class=${classMap({
       [rootClass]: true,
       [`${rootClass}--size${size?.toUpperCase()}`]: typeof size !== "undefined",
-      [`${rootClass}--${alignment}`]: typeof align !== "undefined",
+      [`${rootClass}--${alignment}`]: typeof alignment !== "undefined",
       "is-disabled": isDisabled,
       ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
-  })}>
-    ${label}
-    ${isRequired ?
-      Icon({
-        ...globals,
-        iconName: "Asterisk100",
-        customClasses: [`${rootClass}-UIIcon`],
-      })
-    : ""}
-  </label>
+    })}
+      style="width: 72px;"
+    >
+      ${label}
+      ${isRequired ?
+        Icon({
+          ...globals,
+          iconName: "Asterisk100",
+          customClasses: [`${rootClass}-UIIcon`],
+        })
+      : ""}
+    </label>
   `;
 }


### PR DESCRIPTION
## Description

This adds a storybook instance for the Field Label component.

[Jira CSS-405](https://jira.corp.adobe.com/browse/CSS-405)

**Note: This does have a width style attribute hard coded and this is in order to demonstrate the alignment options, like how they do on [the docs site](https://opensource.adobe.com/spectrum-css/fieldlabel.html#left)**

