### PR TITLE
feat(tokens): adds colorwheel custom express tokens

### DIFF
--- a/components/tokens/custom-express/custom-large-vars.css
+++ b/components/tokens/custom-express/custom-large-vars.css
@@ -13,5 +13,6 @@ governing permissions and limitations under the License.
 /* This file contains overrides and additions to core tokens */
 
 .spectrum--express.spectrum--large {
-  /*  */
+  --spectrum-colorwheel-path: "M 118 118 m -118 0 a 118 118 0 1 0 236 0 a 118 118 0 1 0 -236 0.2 M 118 118 m -92 0 a 92 92 0 1 0 184 0 a 92 92 0 1 0 -184 0";
+  --spectrum-colorwheel-path-borders: "M 120 120 m -120 0 a 120 120 0 1 0 240 0 a 120 120 0 1 0 -240 0.2 M 120 120 m -90 0 a 90 90 0 1 0 180 0 a 90 90 0 1 0 -180 0";
 }

--- a/components/tokens/custom-express/custom-medium-vars.css
+++ b/components/tokens/custom-express/custom-medium-vars.css
@@ -13,5 +13,6 @@ governing permissions and limitations under the License.
 /* This file contains overrides and additions to core tokens */
 
 .spectrum--express.spectrum--medium {
-  /*  */
+  --spectrum-colorwheel-path: "M 94 94 m -94 0 a 94 94 0 1 0 188 0 a 94 94 0 1 0 -188 0.2 M 94 94 m -74 0 a 74 74 0 1 0 148 0 a 74 74 0 1 0 -148 0";
+  --spectrum-colorwheel-path-borders: "M 96 96 m -96 0 a 96 96 0 1 0 192 0 a 96 96 0 1 0 -192 0.2 M 96 96 m -72 0 a 72 72 0 1 0 144 0 a 72 72 0 1 0 -144 0";
 }


### PR DESCRIPTION
## Description
Adds ColorWheel clip path custom tokens for express. The border property applied to the ColorWheel increase from 1px to 2px when viewed in express. The clip paths also need to adjust accordingly. 


## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots



## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
