### PR TITLE
chore: tabs storybook

### DIFF
--- a/components/tabs/stories/tabs.stories.js
+++ b/components/tabs/stories/tabs.stories.js
@@ -7,6 +7,7 @@ export default {
   component: "Tabs",
   argTypes: {
     items: { table: { disable: true }},
+    selectorWidth: { table: { disable: true }},
     size: {
       name: "Size",
       type: { name: "string", required: true },
@@ -25,16 +26,6 @@ export default {
         category: "Component",
       },
       options: ["horizontal", "vertical"],
-      control: "inline-radio",
-    },
-    density: {
-      name: "Density",
-      type: { name: "string" },
-      table: {
-        type: { summary: "string" },
-        category: "Component",
-      },
-      options: ["regular", "compact"],
       control: "inline-radio",
     },
     isQuiet: {
@@ -70,7 +61,6 @@ export default {
     rootClass: "spectrum-Tabs",
     size: "m",
     orientation: "horizontal",
-    density: "regular",
     isQuiet: false,
     isEmphasized: false,
     isCompact: false,
@@ -85,8 +75,11 @@ export default {
   }
 };
 
-export const Default = Template.bind({});
-Default.args = {
+export const Horizontal = Template.bind({});
+Horizontal.args = {
+  selectorStyle: {
+    "width": "35px",
+  },   
   items: [
     {
       id: "tab-1",
@@ -103,3 +96,102 @@ Default.args = {
     }
   ]
 };
+
+export const HorizontalWithIcon = Template.bind({});
+HorizontalWithIcon.args = {
+  selectorStyle: {
+    "width": "60px",
+  },   
+  items: [
+    {
+      id: "tab-1",
+      label: "Tab 1",
+      icon: "Folder",
+      isSelected: true
+    },
+    {
+      id: "tab-2",
+      label: "Tab 2",
+      icon: "Image"
+    },
+    {
+      id: "tab-3",
+      label: "Tab 3",
+      icon: "Document"
+    }
+  ]
+};
+
+export const HorizontalIconOnly = Template.bind({});
+HorizontalIconOnly.args = {
+  selectorStyle: {
+    "width": "20px",
+  }, 
+  items: [
+    {
+      id: "tab-1",
+      icon: "Folder",
+      isSelected: true
+    },
+    {
+      id: "tab-2",
+      icon: "Image"
+    },
+    {
+      id: "tab-3",
+      icon: "Document"
+    }
+  ]
+};
+
+export const Vertical = Template.bind({});
+Vertical.args = {
+  orientation: "vertical",
+  selectorStyle: {
+    "height": "46px",
+    "top": "0"
+  }, 
+  items: [
+    {
+      id: "tab-1",
+      label: "Tab 1",
+      isSelected: true
+    },
+    {
+      id: "tab-2",
+      label: "Tab 2",
+    },
+    {
+      id: "tab-3",
+      label: "Tab 3",
+    }
+  ]
+};
+
+export const VerticalWithIcon = Template.bind({});
+VerticalWithIcon.args = {
+  orientation: "vertical",
+  selectorStyle: {
+    "height": "46px",
+    "top": "0"
+  }, 
+  items: [
+    {
+      id: "tab-1",
+      label: "Tab 1",
+      icon: "Folder",
+      isSelected: true
+    },
+    {
+      id: "tab-2",
+      label: "Tab 2",
+      icon: "Image"
+    },
+    {
+      id: "tab-3",
+      label: "Tab 3",
+      icon: "Document"
+    }
+  ]
+};
+

--- a/components/tabs/stories/tabs.stories.js
+++ b/components/tabs/stories/tabs.stories.js
@@ -7,7 +7,7 @@ export default {
   component: "Tabs",
   argTypes: {
     items: { table: { disable: true }},
-    selectorWidth: { table: { disable: true }},
+    selectorStyle: { table: { disable: true }},
     size: {
       name: "Size",
       type: { name: "string", required: true },

--- a/components/tabs/stories/tabs.stories.js
+++ b/components/tabs/stories/tabs.stories.js
@@ -1,0 +1,105 @@
+// Import the component markup template
+import { Template } from "./template";
+
+export default {
+  title: "Tabs",
+  description: "Tabs organize content into multiple sections and allow users to navigate between them. The content under the set of tabs should be related and form a coherent unit.",
+  component: "Tabs",
+  argTypes: {
+    items: { table: { disable: true }},
+    size: {
+      name: "Size",
+      type: { name: "string", required: true },
+      table: {
+        type: { summary: "string" },
+        category: "Component",
+      },
+      options: ["s", "m", "l", "xl"],
+      control: "select"
+    },
+    orientation: {
+      name: "Orientation",
+      type: { name: "string" },
+      table: {
+        type: { summary: "string" },
+        category: "Component",
+      },
+      options: ["horizontal", "vertical"],
+      control: "inline-radio",
+    },
+    density: {
+      name: "Density",
+      type: { name: "string" },
+      table: {
+        type: { summary: "string" },
+        category: "Component",
+      },
+      options: ["regular", "compact"],
+      control: "inline-radio",
+    },
+    isQuiet: {
+      name: "Quiet",
+      type: { name: "boolean" },
+      table: {
+        type: { summary: "boolean" },
+        category: "State",
+      },
+      control: "boolean",
+    },
+    isEmphasized: {
+      name: "Emphasized",
+      type: { name: "boolean" },
+      table: {
+        type: { summary: "boolean" },
+        category: "State",
+      },
+      control: "boolean",
+    },
+    isCompact: {
+      name: "Compact",
+      type: { name: "boolean" },
+      table: {
+        type: { summary: "boolean" },
+        category: "State",
+      },
+      control: "boolean",
+      if: { arg: 'isQuiet', truthy: true },
+    },
+  },
+  args: {
+    rootClass: "spectrum-Tabs",
+    size: "m",
+    orientation: "horizontal",
+    density: "regular",
+    isQuiet: false,
+    isEmphasized: false,
+    isCompact: false,
+  },
+  parameters: {
+    actions: {
+      handles: []
+    },
+    status: {
+      type: process.env.MIGRATED_PACKAGES.includes('tabs') ? 'migrated' : undefined
+    }
+  }
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  items: [
+    {
+      id: "tab-1",
+      label: "Tab 1",
+      isSelected: true
+    },
+    {
+      id: "tab-2",
+      label: "Tab 2",
+    },
+    {
+      id: "tab-3",
+      label: "Tab 3",
+    }
+  ]
+};

--- a/components/tabs/stories/template.js
+++ b/components/tabs/stories/template.js
@@ -1,0 +1,36 @@
+import { html } from 'lit-html';
+import { classMap } from 'lit-html/directives/class-map.js';
+// import { ifDefined } from 'lit-html/directives/if-defined.js';
+
+import "../index.css";
+import "../skin.css";
+
+export const Template = ({
+  rootClass = "spectrum-Tabs",
+  customClasses = [],
+  size = "m",
+  // ...globals
+}) => {
+  return html`
+    <div class=${classMap({
+      [rootClass]: true,
+      [`${rootClass}--size${size?.toUpperCase()}`]: typeof size !== "undefined",
+      [`${rootClass}--horizontal`]: true,
+      ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
+    })}>
+      <div class="spectrum-Tabs-item is-selected" tabindex="0">
+        <span class="spectrum-Tabs-itemLabel">Tab 1</span>
+      </div>
+      <div class="spectrum-Tabs-item" tabindex="0">
+        <span class="spectrum-Tabs-itemLabel">Tab 2</span>
+      </div>
+      <div class="spectrum-Tabs-item" tabindex="0">
+        <span class="spectrum-Tabs-itemLabel">Tab 3</span>
+      </div>
+      <div class="spectrum-Tabs-item" tabindex="0">
+        <span class="spectrum-Tabs-itemLabel">Tab 4</span>
+      </div>
+      <div class="spectrum-Tabs-selectionIndicator" style="width: 24px; left: 0px;"></div>
+    </div>
+  `;
+}

--- a/components/tabs/stories/template.js
+++ b/components/tabs/stories/template.js
@@ -15,10 +15,13 @@ export const Template = ({
   density,
   isQuiet,
   isEmphasized,
+  isCompact,
   items,
   style = {
     "--spectrum-tabs-textonly-tabitem-selection-indicator-background-color-selected": "#000",
-    "width": "35px"
+    "--spectrum-tabs-quiet-textonly-tabitem-selection-indicator-background-color-selected": "#000",
+    "--spectrum-tabs-emphasized-texticon-tabitem-text-color-selected": "rgb(27,127,245)",
+    "--spectrum-tabs-emphasized-texticon-tabitem-selection-indicator-background-color-selected": "rgb(27,127,245)",
   },
   ...globals
 }) => {
@@ -29,8 +32,10 @@ export const Template = ({
       [`${rootClass}--${orientation}`]: typeof orientation !== "undefined",
       [`${rootClass}--quiet`]: isQuiet,
       [`${rootClass}--emphasized`]: isEmphasized,
+      [`${rootClass}--compact`]: isCompact,
       ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
-    })}>
+    })} 
+    style=${ifDefined(styleMap(style))}>
     ${repeat(items, (item) => item.id, (item) => {
       if (typeof item === "object") {
         return html`
@@ -43,7 +48,7 @@ export const Template = ({
         `
       } else return item;
     })}
-      <div class="${rootClass}-selectionIndicator" style=${ifDefined(styleMap(style))}></div>
+      <div class="${rootClass}-selectionIndicator" style="width: 35px"></div>
     </div>
   `;
 }

--- a/components/tabs/stories/template.js
+++ b/components/tabs/stories/template.js
@@ -1,6 +1,8 @@
 import { html } from 'lit-html';
 import { classMap } from 'lit-html/directives/class-map.js';
-// import { ifDefined } from 'lit-html/directives/if-defined.js';
+import { styleMap } from 'lit-html/directives/style-map.js';
+import { repeat } from 'lit-html/directives/repeat.js';
+import { ifDefined } from 'lit-html/directives/if-defined.js';
 
 import "../index.css";
 import "../skin.css";
@@ -9,28 +11,39 @@ export const Template = ({
   rootClass = "spectrum-Tabs",
   customClasses = [],
   size = "m",
-  // ...globals
+  orientation = "horizontal",
+  density,
+  isQuiet,
+  isEmphasized,
+  items,
+  style = {
+    "--spectrum-tabs-textonly-tabitem-selection-indicator-background-color-selected": "#000",
+    "width": "35px"
+  },
+  ...globals
 }) => {
   return html`
     <div class=${classMap({
       [rootClass]: true,
       [`${rootClass}--size${size?.toUpperCase()}`]: typeof size !== "undefined",
-      [`${rootClass}--horizontal`]: true,
+      [`${rootClass}--${orientation}`]: typeof orientation !== "undefined",
+      [`${rootClass}--quiet`]: isQuiet,
+      [`${rootClass}--emphasized`]: isEmphasized,
       ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
     })}>
-      <div class="spectrum-Tabs-item is-selected" tabindex="0">
-        <span class="spectrum-Tabs-itemLabel">Tab 1</span>
-      </div>
-      <div class="spectrum-Tabs-item" tabindex="0">
-        <span class="spectrum-Tabs-itemLabel">Tab 2</span>
-      </div>
-      <div class="spectrum-Tabs-item" tabindex="0">
-        <span class="spectrum-Tabs-itemLabel">Tab 3</span>
-      </div>
-      <div class="spectrum-Tabs-item" tabindex="0">
-        <span class="spectrum-Tabs-itemLabel">Tab 4</span>
-      </div>
-      <div class="spectrum-Tabs-selectionIndicator" style="width: 24px; left: 0px;"></div>
+    ${repeat(items, (item) => item.id, (item) => {
+      if (typeof item === "object") {
+        return html`
+          <div class=${classMap({
+            [`${rootClass}-item`]: true,
+            "is-selected": item.isSelected
+          })} tabindex="0">
+          <span class="${rootClass}-itemLabel">${item.label}</span>
+          </div>
+        `
+      } else return item;
+    })}
+      <div class="${rootClass}-selectionIndicator" style=${ifDefined(styleMap(style))}></div>
     </div>
   `;
 }

--- a/components/tabs/stories/template.js
+++ b/components/tabs/stories/template.js
@@ -4,6 +4,8 @@ import { styleMap } from 'lit-html/directives/style-map.js';
 import { repeat } from 'lit-html/directives/repeat.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 
+import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
+
 import "../index.css";
 import "../skin.css";
 
@@ -12,16 +14,17 @@ export const Template = ({
   customClasses = [],
   size = "m",
   orientation = "horizontal",
-  density,
   isQuiet,
   isEmphasized,
   isCompact,
   items,
+  selectorStyle,
   style = {
-    "--spectrum-tabs-textonly-tabitem-selection-indicator-background-color-selected": "#000",
-    "--spectrum-tabs-quiet-textonly-tabitem-selection-indicator-background-color-selected": "#000",
+    "--spectrum-tabs-textonly-tabitem-selection-indicator-background-color-selected": "rgb(0,0,0)",
+    "--spectrum-tabs-quiet-textonly-tabitem-selection-indicator-background-color-selected": "rgb(0,0,0)",
     "--spectrum-tabs-emphasized-texticon-tabitem-text-color-selected": "rgb(27,127,245)",
     "--spectrum-tabs-emphasized-texticon-tabitem-selection-indicator-background-color-selected": "rgb(27,127,245)",
+    "--spectrum-tabs-textonly-divider-background-color": "rgba(225,225,225,0.8)"
   },
   ...globals
 }) => {
@@ -43,12 +46,21 @@ export const Template = ({
             [`${rootClass}-item`]: true,
             "is-selected": item.isSelected
           })} tabindex="0">
-          <span class="${rootClass}-itemLabel">${item.label}</span>
+          ${item.icon ? 
+            Icon({
+              ...globals,
+              iconName: item.icon,
+              size
+            })
+          : ""}
+          ${item.label ? 
+            html`<span class="${rootClass}-itemLabel">${item.label}</span>`
+          : ""}
           </div>
         `
       } else return item;
     })}
-      <div class="${rootClass}-selectionIndicator" style="width: 35px"></div>
+      <div class="${rootClass}-selectionIndicator" style=${ifDefined(styleMap(selectorStyle))}></div>
     </div>
   `;
 }


### PR DESCRIPTION
## Description

This PR adds the Tabs storybook instance. 

The only additional options on the documentation site that I did not add were "[Basic Tabs with Overflow](https://opensource.adobe.com/spectrum-css/tabs.html#basictabswithoverflow)". This was really going to muddy up the template in my opinion and it just implemented two additional components that already have their own stories (Picker and Popover). There wasn't anything specific for tabs being passed into the components that I could see. Because of this, I felt that it wasn't needed. I'm happy to add it if others have different opinions.
