### PR TITLE
chore: add modal to storybook

### DIFF
--- a/components/modal/stories/modal.stories.js
+++ b/components/modal/stories/modal.stories.js
@@ -24,7 +24,10 @@ export default {
       control: {
         type: "select",
       }
-    }
+    },
+    content: { 
+      table: { disable: true }
+    },
   },
   args: {
     isOpen: true,
@@ -41,4 +44,8 @@ export default {
 };
 
 export const Default = Template.bind({});
-Default.args = {};
+Default.args = {
+  content: [
+    "This is a modal. Don't use it like this; get yourself a Modal.",
+  ],
+};

--- a/components/modal/stories/template.js
+++ b/components/modal/stories/template.js
@@ -9,6 +9,7 @@ export const Template = ({
   customClasses = [],
   isOpen = true,
   variant,
+  content = [],
   ...globals
 }) => {
   return html`
@@ -18,7 +19,7 @@ export const Template = ({
           [`${rootClass}--${variant}`]: typeof variant !== "undefined",
           'is-open': isOpen,
           ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
-      })}>This is a modal. Don't use it like this; get yourself a Modal.</div>
+      })}>${content}</div>
     </div>
   `;
 }


### PR DESCRIPTION
## Description
Adds a story to Storybook for the **Modal** component, with markup and classes matching the documentation site. Includes controls for `is-open` and its variant classes (e.g. `fullscreenTakeover`).

>**Note**: The different background colors on [the documentation page for modal](https://opensource.adobe.com/spectrum-css/modal.html) comes from `.spectrum-CSSExample-example--overlay`, which is not present in the story.

## Screenshots
![Screenshot 2023-03-03 at 3 54 01 PM](https://user-images.githubusercontent.com/965114/222827486-44c6fdcd-564a-468d-8cf2-70ad189d86ca.png)

## To-do list
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] This pull request is ready to merge.
