### PR TITLE
chore(splitview): write storybook story + configure template

### DIFF
--- a/components/splitview/stories/splitview.stories.js
+++ b/components/splitview/stories/splitview.stories.js
@@ -6,20 +6,68 @@ export default {
   description: "The Splitview component is...",
   component: "Splitview",
   argTypes: {
-    size: {
-      name: "Size",
-      type: { name: "string", required: true },
+    orientation: {
+      name: "Orientation",
+      type: { name: "string" },
       table: {
         type: { summary: "string" },
         category: "Component",
+        disable: true
       },
-      options: ["s", "m", "l", "xl"],
-      control: "select"
     },
+    isResizable: {
+      name: "Resizable",
+      type: "boolean",
+      table: {
+        type: { summary: "boolean" },
+        category: "Component",
+        disable: true
+      },
+      control: "boolean"
+    },
+    isCollapsible: {
+      name: "Collapsible",
+      type: "boolean",
+      table: {
+        type: { summary: "boolean" },
+        category: "Component",
+        disable: true
+      },
+    },
+    collapsePosition: {
+      name: "Collapse position",
+      type: "string",
+      table: {
+        type: { summary: "string" },
+        category: "Component",
+        disable: true
+      },
+      control: "select",
+      options: ["left", "right", "top", "bottom"],
+      if: {
+        arg: 'isCollapsible',
+        truthy: true,
+      }
+    },
+    panelLabels: {
+      name: "Panel labels",
+      type: "string",
+      table: { disable: true },
+    },
+    panelStyles: {
+      name: "Panel labels",
+      type: "string",
+      table: { disable: true },
+    },
+    componentHeight: {
+      name: "Component height",
+      table: { disable: true }
+    }
   },
   args: {
-    rootClass: "spectrum-",
-    size: "m",
+    rootClass: "spectrum-SplitView",
+    isResizable: false,
+    componentHeight: "200px",
   },
   parameters: {
     actions: {
@@ -31,5 +79,78 @@ export default {
   }
 };
 
-export const Default = Template.bind({});
-Default.args = {};
+export const Horizontal = Template.bind({});
+Horizontal.args = {
+  orientation: "horizontal",
+  isResizable: false,
+  isCollapsible: false,
+  panelLabels: ["Left", "Right"],
+  panelStyles: ["width: 304px;", "flex: 1;"]
+};
+
+export const HorizontallyResizable = Template.bind({});
+HorizontallyResizable.args = {
+  orientation: "horizontal",
+  isResizable: true,
+  isCollapsible: false,
+  panelLabels: ["Left", "Right"],
+  panelStyles: ["width: 304px;", "flex: 1;"]
+};
+
+export const HorizontalCollapsedLeft = Template.bind({});
+HorizontalCollapsedLeft.args = {
+  orientation: "horizontal",
+  isResizable: true,
+  isCollapsible: true,
+  collapsePosition: "left",
+  panelLabels: ["Left", "Right"],
+  panelStyles: ["width: 0;", "flex: 1;"]
+};
+
+export const HorizontalCollapsedRight = Template.bind({});
+HorizontalCollapsedRight.args = {
+  orientation: "horizontal",
+  isResizable: true,
+  isCollapsible: true,
+  collapsePosition: "right",
+  panelLabels: ["Left", "Right"],
+  panelStyles: ["flex: 1;", "width: 0;"]
+};
+
+export const Vertical = Template.bind({});
+Vertical.args = {
+  orientation: "vertical",
+  isResizable: false,
+  isCollapsible: false,
+  panelLabels: ["Top", "Bottom"],
+  panelStyles: ["height: 50px;", "flex: 1;"]
+};
+
+export const VerticallyResizable = Template.bind({});
+VerticallyResizable.args = {
+  orientation: "vertical",
+  isResizable: true,
+  isCollapsible: false,
+  panelLabels: ["Top", "Bottom"],
+  panelStyles: ["height: 50px;", "flex: 1;"]
+};
+
+export const VerticalCollapsedTop = Template.bind({});
+VerticalCollapsedTop.args = {
+  orientation: "vertical",
+  isResizable: true,
+  isCollapsible: true,
+  collapsePosition: "top",
+  panelLabels: ["Top", "Bottom"],
+  panelStyles: ["height: 0;", "flex: 1;"]
+};
+
+export const VerticalCollapsedBottom = Template.bind({});
+VerticalCollapsedBottom.args = {
+  orientation: "vertical",
+  isResizable: true,
+  isCollapsible: true,
+  collapsePosition: "bottom",
+  panelLabels: ["Top", "Bottom"],
+  panelStyles: ["flex: 1;", "height: 0;"]
+};

--- a/components/splitview/stories/template.js
+++ b/components/splitview/stories/template.js
@@ -1,5 +1,6 @@
 import { html } from 'lit-html';
 import { classMap } from 'lit-html/directives/class-map.js';
+import { when } from "lit-html/directives/when.js";
 // import { ifDefined } from 'lit-html/directives/if-defined.js';
 
 import "../index.css";
@@ -8,14 +9,38 @@ import "../skin.css";
 export const Template = ({
   rootClass = "spectrum-SplitView",
   customClasses = [],
-  size = "m",
+  orientation = "horizontal",
+  isResizable = false,
+  isCollapsible = false,
+  collapsePosition,
+  panelLabels = [],
+  panelStyles = [],
+  componentHeight = "200px",
   // ...globals
 }) => {
+
+  const collapsible = isCollapsible;
+  const collapsibleStart = typeof collapsePosition !== "undefined" && collapsePosition === "left" || collapsePosition === "top";
+  const collapsibleEnd = typeof collapsePosition !== "undefined" && collapsePosition === "right" || collapsePosition === "bottom";
+  const collapsibleClassName = collapsible && collapsibleStart ? 'start' : collapsible && collapsibleEnd ? 'end' : '';
+
   return html`
-    <div class=${classMap({
+    <div
+      style="height: ${componentHeight};"
+      class=${classMap({
       [rootClass]: true,
-      [`${rootClass}--size${size?.toUpperCase()}`]: typeof size !== "undefined",
+      [`${rootClass}--${orientation}`]: orientation,
       ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
-  })}></div>
+    })}>
+      <div class="spectrum-SplitView-pane" style="${panelStyles[0]}">${panelLabels[0]}</div>
+      <div class=${classMap({
+        [`${rootClass}-splitter`]: true,
+        ['is-draggable']: isResizable,
+        [`is-collapsed-${collapsibleClassName}`]: isCollapsible,
+      })}>
+        ${when(isResizable, () => html`<div class="spectrum-SplitView-gripper"></div>`)}
+      </div>
+      <div class="spectrum-SplitView-pane" style="${panelStyles[1]}">${panelLabels[1]}</div>
+    </div>
   `;
 }


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
Adds Storybook stories + template for Split View.


## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
