### PR TITLE
feat(tokens): add medium, large tokens for rating-icon-spacing

### DIFF
--- a/components/tokens/custom-spectrum/custom-large-vars.css
+++ b/components/tokens/custom-spectrum/custom-large-vars.css
@@ -43,4 +43,6 @@ governing permissions and limitations under the License.
   --spectrum-menu-item-checkmark-width-medium: 14px;
   --spectrum-menu-item-checkmark-width-large: 16px;
   --spectrum-menu-item-checkmark-width-extra-large: 16px;
+
+  --spectrum-rating-icon-spacing: var(--spectrum-spacing-100);
 }

--- a/components/tokens/custom-spectrum/custom-medium-vars.css
+++ b/components/tokens/custom-spectrum/custom-medium-vars.css
@@ -43,4 +43,6 @@ governing permissions and limitations under the License.
   --spectrum-menu-item-checkmark-width-medium: 10px;
   --spectrum-menu-item-checkmark-width-large: 12px;
   --spectrum-menu-item-checkmark-width-extra-large: 14px;
+
+  --spectrum-rating-icon-spacing: var(--spectrum-spacing-75);
 }


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
Adds a new token for `--spectrum-rating-icon-spacing` at both medium and large scales.


## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
