### PR TITLE
chore(steplist): storybook setup

### DIFF
--- a/components/steplist/stories/steplist.stories.js
+++ b/components/steplist/stories/steplist.stories.js
@@ -1,0 +1,81 @@
+// Import the component markup template
+import { Template } from "./template";
+
+export default {
+  title: "Steplist",
+  description:
+    "A step list can communicate the progress of a task or workflow. It can help users understand where they are in a process and what they need to do next.",
+  component: "StepList",
+  argTypes: {
+    isSmall: {
+      name: "Small",
+      description: "Use a smaller steplist that does not have visible labels or tooltips.",
+      type: { name: "boolean" },
+      table: {
+        type: { summary: "boolean" },
+        category: "Component",
+      },
+      control: "boolean",
+    },
+    isInteractive: {
+      name: "Interactive",
+      description: "Whether the steplist items should be interactive. When true, creates a link around the marker and label.",
+      type: { name: "boolean" },
+      table: {
+        type: { summary: "boolean" },
+        category: "Component",
+      },
+      control: "boolean",
+    },
+    withTooltip: {
+      name: "With Tooltip",
+      description: "Use a Tooltip component for each steplist item, instead of label text. Tooltips do not display when \"Small\" is true.",
+      type: { name: "boolean" },
+      table: {
+        type: { summary: "boolean" },
+        category: "Component",
+      },
+      control: "boolean",
+    },
+    items: {
+      table: { disable: true }
+    },
+  },
+  args: {
+    rootClass: "spectrum-Steplist",
+    isSmall: false,
+    isInteractive: false,
+    withTooltip: false,
+  },
+  parameters: {
+    actions: {
+      handles: [],
+    },
+    status: {
+      type: process.env.MIGRATED_PACKAGES.includes("steplist")
+        ? "migrated"
+        : undefined,
+    },
+  },
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  items: [
+    {
+      label: "Step 1",
+      isComplete: true,
+    },
+    {
+      label: "Step 2",
+      isComplete: true,
+    },
+    {
+      label: "Step 3",
+      isSelected: true,
+    },
+    {
+      label: "Step 4",
+    },
+  ],
+};

--- a/components/steplist/stories/template.js
+++ b/components/steplist/stories/template.js
@@ -1,0 +1,117 @@
+import { html, nothing } from "lit-html";
+import { classMap } from "lit-html/directives/class-map.js";
+import { repeat } from "lit-html/directives/repeat.js";
+import { ifDefined } from "lit-html/directives/if-defined.js";
+
+import { Template as Tooltip } from '@spectrum-css/tooltip/stories/template.js';
+
+import "../index.css";
+import "../skin.css";
+
+export const SteplistItem = ({
+  rootClass,
+  isSmall = false,
+  isInteractive = false,
+  withTooltip = false,
+  label,
+  ariaPosInSet = 1,
+  ariaSetSize = 4,
+  isComplete = false,
+  isSelected = false,
+  id,
+  ...globals
+}) => {
+  const labelMarkup = !isSmall && !withTooltip && typeof label !== "undefined"
+    ? html`<span class="spectrum-Steplist-label">${label}</span>`
+    : nothing;
+
+  const markerContainer = html`
+    <span class="${rootClass}-markerContainer">
+      ${ withTooltip && !isSmall && typeof label !== "undefined"
+          ? Tooltip({
+              label,
+              isOpen: false,
+              placement: 'top',
+              showOnHover: true,
+            })
+          : nothing
+      }
+      <span class="${rootClass}-marker"></span>
+    </span>
+  `;
+
+  return html`
+    <div
+      class=${classMap({
+        [`${rootClass}-item`]: true,
+        "is-complete": isComplete,
+        "is-selected": isSelected,
+        'u-tooltip-showOnHover': withTooltip && !isSmall && typeof label != "undefined",
+      })}
+      id=${ifDefined(id)}
+      role="listitem"
+      aria-posinset=${ariaPosInSet}
+      aria-setsize=${ariaSetSize}
+      aria-label=${isSmall && !isInteractive ? ifDefined(label) : nothing}
+    >
+      ${isInteractive
+        ? html`
+          <a
+            class=${classMap({
+              [`${rootClass}-link`]: true,
+              "is-complete": isComplete,
+              "is-selected": isSelected,
+            })} 
+            role="link"
+            aria-label=${isSmall ? ifDefined(label) : nothing}
+            tabindex=${isSelected ? '1' : '-1'}
+          >
+            ${labelMarkup}
+            ${markerContainer}
+          </a>`
+        : html`
+          ${labelMarkup}
+          ${markerContainer}`
+      }
+      <span class="${rootClass}-segment"></span>
+    </div>
+  `;
+} 
+
+export const Template = ({
+  rootClass = "spectrum-Steplist",
+  items,
+  isSmall = false,
+  isInteractive = false,
+  withTooltip = false,
+  id,
+  customClasses = [],
+  ...globals
+}) => {
+  if (!items || !items.length) return html``;
+
+  return html`
+    <div
+      class=${classMap({
+        [rootClass]: true,
+        [`${rootClass}--small`]: isSmall,
+        [`${rootClass}--interactive`]: isInteractive,
+        ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
+      })}
+      id=${ifDefined(id)}
+      role="list"
+    >
+      ${repeat(items, (args, idx) =>
+          SteplistItem({
+            rootClass: `${rootClass}`,
+            isSmall,
+            isInteractive,
+            withTooltip,
+            ...args,
+            ariaPosInSet: idx + 1,
+            ariaSetSize: items.length,
+          })
+      )}
+    </div>
+  `;
+};


### PR DESCRIPTION
## Description
Adds completed Steplist story to Storybook, matching the options and markup on the documentation site for this component. Includes Storybook controls for small, interactive, and tooltip variants.

## Screenshots
![Screenshot 2023-03-08 at 12 23 03 PM](https://user-images.githubusercontent.com/965114/223784979-48f9bc6b-66ba-49c6-bfc2-a69c31a6d06e.png)

## To-do list
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] This pull request is ready to merge.
