### PR TITLE
chore: update netlify settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 dist
 dist-site
-node_modules
+
+# Recommended update re:https://docs.netlify.com/integrations/frameworks/eleventy/
+**/node_modules/**
+
 temp
 .npmrc*
 .tmp

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,41 @@
+[build]
+  publish = "dist/"
+  command = "yarn build"
+
 [[redirects]]
   from = "/"
   to = "/docs/"
+
+# Other projects use the default /storybook/ pathing;
+# this remaps this to our /preview/ path.
+# Why? Using preview decouples us from the tool.
+[[redirects]]
+  from = "/storybook/"
+  to = "/preview/"
+
+[[redirects]]
+  from = "/preview"
+  to = "/preview/"
+
+[[redirects]]
+  from = "/docs/*"
+  to = "/docs/:splat.html"
+
+# If skip_processing = true, all other settings are ignored
+[build.processing]
+  skip_processing = false
+[build.processing.css]
+  bundle = true
+  minify = true
+[build.processing.js]
+  bundle = true
+  minify = true
+[build.processing.html]
+  pretty_urls = true
+[build.processing.images]
+  compress = true
+
+# Skip all post processing in deploy previews,
+# ignoring any other settings
+[context.deploy-preview.processing]
+  skip_processing = true


### PR DESCRIPTION
## Description

Looking at the netlify documentation for 11ty integration, it suggests updating the .gitignore to use `**/node_modules/**` rather than `node_modules`.

I also updated the netlify config to include:

- Build commands so that if they change locally, we can update them via the repo
- An alias from storybook to preview b/c storybook is a common url pattern
- From a component name as a folder to the component html asset
- Post-processing support for non-deploy preview builds (minification & bundling)


## To-do list
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] This pull request is ready to merge.
