### PR TITLE
feat(contextualhelp): create contextual help component

### DIFF
--- a/components/contextualhelp/README.md
+++ b/components/contextualhelp/README.md
@@ -1,0 +1,7 @@
+# @spectrum-css/contextualhelp
+
+> The Spectrum CSS Contextual Help component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/contextualhelp).

--- a/components/contextualhelp/gulpfile.js
+++ b/components/contextualhelp/gulpfile.js
@@ -1,0 +1,1 @@
+module.exports = require('@spectrum-css/component-builder-simple');

--- a/components/contextualhelp/index.css
+++ b/components/contextualhelp/index.css
@@ -11,9 +11,21 @@ governing permissions and limitations under the License.
 */
 
 .spectrum-ContextualHelp {
-  /* Variables defined here */
-  /* --spectrum-contextualhelp-... */
+  /* Layout Variables */
   --spectrum-contextual-help-minimum-width: var(--spectrum-contextual-help-minimum-width);
+  --spectrum-contextual-help-padding: var(--spectrum-spacing-400);
+  --spectrum-contextual-help-content-spacing: var(--spectrum-spacing-100);
+  --spectrum-contextual-help-link-spacing: var(--spectrum-spacing-300);
+
+  /* Typography Variables */
+  --spectrum-contextual-help-title-size: var(--spectrum-contextual-help-title-size);
+
+
+
+  /* Mobile styling */
+  @media screen and (max-width: 700px) {
+    --spectrum-contextual-help-content-spacing: var(--spectrum-spacing-200);
+  }
 
 }
 
@@ -31,6 +43,32 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-ContextualHelp {
-  /* Properties defined here */
+  position: relative;
   min-inline-size: var(--mod-spectrum-contextual-help-minimum-width, var(--spectrum-contextual-help-minimum-width));
 }
+
+.spectrum-ContextualHelp-button {
+  display: block;
+}
+
+.spectrum-ContextualHelp-popover {
+  padding-block: var(--mod-spectrum-contextual-help-padding, var(--spectrum-contextual-help-padding));
+  padding-inline: var(--mod-spectrum-contextual-help-padding, var(--spectrum-contextual-help-padding));
+  font-size: var(--mod-spectrum-contextual-help-body-size, var(--spectrum-contextual-help-body-size));
+
+
+  h2, p {
+    margin: 0;
+  }
+
+  h2 {
+    margin-block-end: var(--mod-spectrum-contextual-help-content-spacing, var(--spectrum-contextual-help-content-spacing));
+    font-size: var(--mod-spectrum-contextual-help-title-size, var(--spectrum-contextual-help-title-size));
+  }
+}
+
+.spectrum-ContextualHelp-link {
+  margin-block-start: var(--mod-spectrum-contextual-help-link-spacing, var(--spectrum-contextual-help-link-spacing));
+}
+
+

--- a/components/contextualhelp/index.css
+++ b/components/contextualhelp/index.css
@@ -13,12 +13,8 @@ governing permissions and limitations under the License.
 .spectrum-ContextualHelp {
   /* Variables defined here */
   /* --spectrum-contextualhelp-... */
+  --spectrum-contextual-help-minimum-width: var(--spectrum-contextual-help-minimum-width);
 
-  &:lang(ja),
-  &:lang(zh),
-  &:lang(ko) {
-    --spectrum-contextualhelp-line-height-cjk: var(--spectrum-cjk-line-height-100);
-  }
 }
 
 .spectrum-ContextualHelp--sizeS {}
@@ -28,7 +24,7 @@ governing permissions and limitations under the License.
 
 @media (forced-colors: active) {
   .spectrum-ContextualHelp {
-    --highcontrast-contextualhelp-content-color-default: CanvasText;
+    //--highcontrast-contextualhelp-content-color-default: CanvasText;
 
     forced-color-adjust: none;
   }
@@ -36,5 +32,5 @@ governing permissions and limitations under the License.
 
 .spectrum-ContextualHelp {
   /* Properties defined here */
-  color: var(--highcontrast-contextualhelp-content-color-default, var(--mod-contextualhelp-content-color-default, var(--spectrum-contextualhelp-content-color-default)));
+  min-inline-size: var(--mod-spectrum-contextual-help-minimum-width, var(--spectrum-contextual-help-minimum-width));
 }

--- a/components/contextualhelp/index.css
+++ b/components/contextualhelp/index.css
@@ -1,0 +1,40 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+.spectrum-ContextualHelp {
+  /* Variables defined here */
+  /* --spectrum-contextualhelp-... */
+
+  &:lang(ja),
+  &:lang(zh),
+  &:lang(ko) {
+    --spectrum-contextualhelp-line-height-cjk: var(--spectrum-cjk-line-height-100);
+  }
+}
+
+.spectrum-ContextualHelp--sizeS {}
+.spectrum-ContextualHelp--sizeM {}
+.spectrum-ContextualHelp--sizeL {}
+.spectrum-ContextualHelp--sizeXL {}
+
+@media (forced-colors: active) {
+  .spectrum-ContextualHelp {
+    --highcontrast-contextualhelp-content-color-default: CanvasText;
+
+    forced-color-adjust: none;
+  }
+}
+
+.spectrum-ContextualHelp {
+  /* Properties defined here */
+  color: var(--highcontrast-contextualhelp-content-color-default, var(--mod-contextualhelp-content-color-default, var(--spectrum-contextualhelp-content-color-default)));
+}

--- a/components/contextualhelp/index.css
+++ b/components/contextualhelp/index.css
@@ -18,7 +18,9 @@ governing permissions and limitations under the License.
   --spectrum-contextual-help-link-spacing: var(--spectrum-spacing-300);
 
   /* Typography Variables */
-  --spectrum-contextual-help-title-size: var(--spectrum-contextual-help-title-size);
+  /* TODO: these need to be changed to the contextual-help tokens when available */
+  --spectrum-contextual-help-title-size: var(--spectrum-heading-size-xs);
+  --spectrum-contextual-help-body-size: var(--spectrum-body-size-s);
 
 
 

--- a/components/contextualhelp/metadata/contextualhelp.yml
+++ b/components/contextualhelp/metadata/contextualhelp.yml
@@ -1,9 +1,13 @@
 name: Contextual Help
 status: Verified
 SpectrumSiteSlug: https://spectrum.adobe.com/page/contextual-help/
+sections: 
+- name: Custom Properties API
+  description: |
+    This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/popover/metadata/mods.md">here</a>.
 examples:
   - id: contextualhelp-variants
-    name: Variants
+    name: Info Icon
     markup: |
       <div class="spectrum-Examples">
         <div class="spectrum-Examples-item">
@@ -13,14 +17,43 @@ examples:
                 <use xlink:href="#spectrum-icon-18-Info" />
               </svg>
             </button>
-            <div class="spectrum-Popover spectrum-Popover--top is-open" role="presentation">
-              <section class="spectrum-Dialog spectrum-Dialog--small" role="dialog" tabindex="-1" aria-modal="true">
-                <div class="spectrum-Dialog-grid" style="display: grid;">
-                  <h2 class="spectrum-Dialog-heading spectrum-Dialog-heading--noHeader">Popover Title</h2>
-                  <hr class="spectrum-Divider spectrum-Divider--sizeM spectrum-Divider--horizontal spectrum-Dialog-divider">
-                  <section class="spectrum-Dialog-content">Cupcake ipsum dolor sit amet jelly beans. Chocolate jelly caramels. Icing soufflé chupa chups donut cheesecake. Jelly-o chocolate cake sweet roll cake danish candy biscuit halvah.</section>
-                </div>
-              </section>
+            <div class="spectrum-Popover is-open spectrum-Popover--bottom-start spectrum-ContextualHelp-popover" role="presentation">
+              <h2 class="spectrum-ContextualHelp-heading">Permission required</h2>
+              <p class="spectrum-ContextualHelp-body">Cupcake ipsum dolor sit amet jelly beans. Chocolate jelly caramels. Icing soufflé chupa chups donut cheesecake. Jelly-o chocolate cake sweet roll cake danish candy biscuit halvah.</p>
+            </div>
+            <div class="dummy-spacing" style="position: relative; height: 248px; min-width: 400px; max-width: 50%;"></div>
+          </div>
+        </div>
+        <div class="spectrum-Examples-item">
+          <div class="spectrum-ContextualHelp">
+            <div class="spectrum-Popover is-open spectrum-Popover--top spectrum-ContextualHelp-popover" role="presentation">
+              <h2 class="spectrum-ContextualHelp-heading">Permission required</h2>
+              <p class="spectrum-ContextualHelp-body">Cupcake ipsum dolor sit amet jelly beans. Chocolate jelly caramels. Icing soufflé chupa chups donut cheesecake. Jelly-o chocolate cake sweet roll cake danish candy biscuit halvah.</p>
+            </div>
+            <div class="dummy-spacing" style="position: relative; height: 132px; min-width: 400px; max-width: 50%;"></div>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeXS spectrum-ContextualHelp-button">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-icon-18-Info" />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+  - id: contextualhelp-variants
+    name: Help Icon
+    markup: |
+      <div class="spectrum-Examples">
+        <div class="spectrum-Examples-item">
+          <div class="spectrum-ContextualHelp">
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeXS spectrum-ContextualHelp-button">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-icon-18-Help" />
+              </svg>
+            </button>
+            <div class="spectrum-Popover is-open spectrum-Popover--bottom-start spectrum-ContextualHelp-popover" role="presentation">
+              <h2 class="spectrum-ContextualHelp-heading">Permission required</h2>
+              <p class="spectrum-ContextualHelp-body">Cupcake ipsum dolor sit amet jelly beans. Chocolate jelly caramels. Icing soufflé chupa chups donut cheesecake. Jelly-o chocolate cake sweet roll cake danish candy biscuit halvah.</p>
+              <a class="spectrum-Link spectrum-ContextualHelp-link" href="#">Learn about permissions</a>
             </div>
             <div class="dummy-spacing" style="position: relative; height: 248px; min-width: 400px; max-width: 50%;"></div>
           </div>

--- a/components/contextualhelp/metadata/contextualhelp.yml
+++ b/components/contextualhelp/metadata/contextualhelp.yml
@@ -1,0 +1,25 @@
+name: Contextual Help
+status: Verified
+SpectrumSiteSlug: https://spectrum.adobe.com/page/contextual-help/
+examples:
+  - id: contextualhelp-sizing
+    name: Sizing
+    markup: |
+      <div class="spectrum-Examples">
+        <div class="spectrum-Examples-item">
+          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">S</h4>
+          <!-- Component mark-up goes here -->
+        </div>
+        <div class="spectrum-Examples-item">
+          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">M</h4>
+          <!-- Component mark-up goes here -->
+        </div>
+        <div class="spectrum-Examples-item">
+          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">L</h4>
+          <!-- Component mark-up goes here -->
+        </div>
+        <div class="spectrum-Examples-item">
+          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">XL</h4>
+          <!-- Component mark-up goes here -->
+        </div>
+      </div>

--- a/components/contextualhelp/metadata/contextualhelp.yml
+++ b/components/contextualhelp/metadata/contextualhelp.yml
@@ -2,24 +2,27 @@ name: Contextual Help
 status: Verified
 SpectrumSiteSlug: https://spectrum.adobe.com/page/contextual-help/
 examples:
-  - id: contextualhelp-sizing
-    name: Sizing
+  - id: contextualhelp-variants
+    name: Variants
     markup: |
       <div class="spectrum-Examples">
         <div class="spectrum-Examples-item">
-          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">S</h4>
-          <!-- Component mark-up goes here -->
-        </div>
-        <div class="spectrum-Examples-item">
-          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">M</h4>
-          <!-- Component mark-up goes here -->
-        </div>
-        <div class="spectrum-Examples-item">
-          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">L</h4>
-          <!-- Component mark-up goes here -->
-        </div>
-        <div class="spectrum-Examples-item">
-          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">XL</h4>
-          <!-- Component mark-up goes here -->
+          <div class="spectrum-ContextualHelp">
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeXS spectrum-ContextualHelp-button">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-icon-18-Info" />
+              </svg>
+            </button>
+            <div class="spectrum-Popover spectrum-Popover--top is-open" role="presentation">
+              <section class="spectrum-Dialog spectrum-Dialog--small" role="dialog" tabindex="-1" aria-modal="true">
+                <div class="spectrum-Dialog-grid" style="display: grid;">
+                  <h2 class="spectrum-Dialog-heading spectrum-Dialog-heading--noHeader">Popover Title</h2>
+                  <hr class="spectrum-Divider spectrum-Divider--sizeM spectrum-Divider--horizontal spectrum-Dialog-divider">
+                  <section class="spectrum-Dialog-content">Cupcake ipsum dolor sit amet jelly beans. Chocolate jelly caramels. Icing soufflé chupa chups donut cheesecake. Jelly-o chocolate cake sweet roll cake danish candy biscuit halvah.</section>
+                </div>
+              </section>
+            </div>
+            <div class="dummy-spacing" style="position: relative; height: 248px; min-width: 400px; max-width: 50%;"></div>
+          </div>
         </div>
       </div>

--- a/components/contextualhelp/package.json
+++ b/components/contextualhelp/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@spectrum-css/contextualhelp",
+  "version": "1.0.0-alpha.0",
+  "description": "The Spectrum CSS contextualhelp component",
+  "license": "Apache-2.0",
+  "author": "Adobe",
+  "contributors": [],
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/contextualhelp"
+  },
+  "bugs": {
+    "url": "https://github.com/adobe/spectrum-css/issues"
+  },
+  "main": "dist/index-vars.css",
+  "scripts": {
+    "build": "gulp",
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "watch": "gulp watch"
+  },
+  "peerDependencies": {
+    "@spectrum-css/tokens": ">= 7"
+  },
+  "devDependencies": {
+    "@spectrum-css/component-builder-simple": "^2.0.6",
+    "@spectrum-css/tokens": "^7.5.1",
+    "gulp": "^4.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/components/contextualhelp/stories/contextualhelp.stories.js
+++ b/components/contextualhelp/stories/contextualhelp.stories.js
@@ -2,8 +2,7 @@
 import { Template } from "./template";
 import { html } from "lit-html";
 
-import { default as IconStories } from "@spectrum-css/icon/stories/icon.stories.js";
-import { Default as Dialog } from "@spectrum-css/dialog/stories/dialog.stories.js";
+import { default as ActionButtonStories } from "@spectrum-css/actionbutton/stories/actionbutton.stories.js";
 
 // More on default export: https://storybook.js.org/docs/web-components/writing-stories/introduction#default-export
 export default {
@@ -39,16 +38,20 @@ export default {
       options: ["Info", "Help"],
       control: "select"
     },
+    popoverPlacement: { table: { disable: true }},
+    link: { table: { disable: true }}
   },
   // More on args: https://storybook.js.org/docs/web-components/writing-stories/args
   args: {
     rootClass: "spectrum-ContextualHelp",
-    size: "xs",
-    iconName: "Info"
+    iconName: "Info",
+    popoverPlacement: "bottom-start"
   },
   parameters: {
     actions: {
-      handles: []
+      handles: [
+        ...ActionButtonStories?.parameters?.actions?.handles ?? [],
+      ]
     },
     status: {
       type: process.env.MIGRATED_PACKAGES.includes('contextualhelp') ? 'migrated' : undefined

--- a/components/contextualhelp/stories/contextualhelp.stories.js
+++ b/components/contextualhelp/stories/contextualhelp.stories.js
@@ -21,6 +21,22 @@ export default {
       options: ["s", "m", "l", "xl"],
       control: "select"
     },
+    title: {
+      name: "Title",
+      type: { name: "string", required: true },
+      table: {
+        type: { summary: "string" },
+        category: "Content",
+      },
+    },
+    body: {
+      name: "Body",
+      type: { name: "string", required: true },
+      table: {
+        type: { summary: "string" },
+        category: "Content",
+      },
+    },
     iconName: {
       ...IconStories?.argTypes?.iconName ?? {},
       if: false,
@@ -43,4 +59,7 @@ export default {
 };
 
 export const Default = Template.bind({});
-Default.args = {};
+Default.args = {
+  title: "Permission required",
+  body: "Your admin must grant you permission before you can create a segment."
+};

--- a/components/contextualhelp/stories/contextualhelp.stories.js
+++ b/components/contextualhelp/stories/contextualhelp.stories.js
@@ -1,6 +1,8 @@
 // Import the component markup template
 import { Template } from "./template";
 
+import { default as IconStories } from "@spectrum-css/icon/stories/icon.stories.js";
+
 // More on default export: https://storybook.js.org/docs/web-components/writing-stories/introduction#default-export
 export default {
   title: "Contextual Help",
@@ -19,11 +21,16 @@ export default {
       options: ["s", "m", "l", "xl"],
       control: "select"
     },
+    iconName: {
+      ...IconStories?.argTypes?.iconName ?? {},
+      if: false,
+    },
   },
   // More on args: https://storybook.js.org/docs/web-components/writing-stories/args
   args: {
     rootClass: "spectrum-ContextualHelp",
-    size: "m",
+    size: "xs",
+    iconName: "Info"
   },
   parameters: {
     actions: {

--- a/components/contextualhelp/stories/contextualhelp.stories.js
+++ b/components/contextualhelp/stories/contextualhelp.stories.js
@@ -1,7 +1,9 @@
 // Import the component markup template
 import { Template } from "./template";
+import { html } from "lit-html";
 
 import { default as IconStories } from "@spectrum-css/icon/stories/icon.stories.js";
+import { Default as Dialog } from "@spectrum-css/dialog/stories/dialog.stories.js";
 
 // More on default export: https://storybook.js.org/docs/web-components/writing-stories/introduction#default-export
 export default {
@@ -9,18 +11,6 @@ export default {
   description: "The Contextual Help component is...",
   component: "ContextualHelp",
   argTypes: {
-    size: {
-      name: "Size",
-      type: { name: "string", required: true },
-      defaultValue: "m",
-      table: {
-        type: { summary: "string" },
-        category: "Component",
-        defaultValue: { summary: "m" }
-      },
-      options: ["s", "m", "l", "xl"],
-      control: "select"
-    },
     title: {
       name: "Title",
       type: { name: "string", required: true },
@@ -38,8 +28,16 @@ export default {
       },
     },
     iconName: {
-      ...IconStories?.argTypes?.iconName ?? {},
-      if: false,
+      name: "Icon",
+      type: { name: "string", required: true },
+      defaultValue: "Info",
+      table: {
+        type: { summary: "string" },
+        category: "Component",
+        defaultValue: { summary: "Info" }
+      },
+      options: ["Info", "Help"],
+      control: "select"
     },
   },
   // More on args: https://storybook.js.org/docs/web-components/writing-stories/args
@@ -61,5 +59,15 @@ export default {
 export const Default = Template.bind({});
 Default.args = {
   title: "Permission required",
-  body: "Your admin must grant you permission before you can create a segment."
+  body: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+};
+
+export const WithLink = Template.bind({});
+WithLink.args = {
+  title: "Permission required",
+  body: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+  link: {
+    text: "Learn about permissions",
+    url: "#",
+  }
 };

--- a/components/contextualhelp/stories/contextualhelp.stories.js
+++ b/components/contextualhelp/stories/contextualhelp.stories.js
@@ -1,0 +1,39 @@
+// Import the component markup template
+import { Template } from "./template";
+
+// More on default export: https://storybook.js.org/docs/web-components/writing-stories/introduction#default-export
+export default {
+  title: "Contextual Help",
+  description: "The Contextual Help component is...",
+  component: "ContextualHelp",
+  argTypes: {
+    size: {
+      name: "Size",
+      type: { name: "string", required: true },
+      defaultValue: "m",
+      table: {
+        type: { summary: "string" },
+        category: "Component",
+        defaultValue: { summary: "m" }
+      },
+      options: ["s", "m", "l", "xl"],
+      control: "select"
+    },
+  },
+  // More on args: https://storybook.js.org/docs/web-components/writing-stories/args
+  args: {
+    rootClass: "spectrum-ContextualHelp",
+    size: "m",
+  },
+  parameters: {
+    actions: {
+      handles: []
+    },
+    status: {
+      type: process.env.MIGRATED_PACKAGES.includes('contextualhelp') ? 'migrated' : undefined
+    }
+  }
+};
+
+export const Default = Template.bind({});
+Default.args = {};

--- a/components/contextualhelp/stories/template.js
+++ b/components/contextualhelp/stories/template.js
@@ -1,0 +1,24 @@
+import { html } from 'lit-html';
+import { classMap } from 'lit-html/directives/class-map.js';
+import { ifDefined } from 'lit-html/directives/if-defined.js';
+
+import "../index.css";
+
+// More on component templates: https://storybook.js.org/docs/web-components/writing-stories/introduction#using-args
+export const Template = ({
+  rootClass = "spectrum-ContextualHelp",
+  size,
+  id,
+  customClasses = [],
+  ...globals
+}) => {
+  return html`
+    <div class=${classMap({
+      [rootClass]: true,
+      [`${rootClass}--size${size.toUpperCase()}`]: true,
+      ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
+    })} id=${ifDefined(id)}>
+      <!-- Component mark-up goes here -->
+    </div>
+  `;
+}

--- a/components/contextualhelp/stories/template.js
+++ b/components/contextualhelp/stories/template.js
@@ -3,6 +3,7 @@ import { classMap } from 'lit-html/directives/class-map.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 
 import { Template as ActionButton } from "@spectrum-css/actionbutton/stories/template.js";
+import { Template as Popover } from "@spectrum-css/popover/stories/template.js";
 
 import "../index.css";
 
@@ -12,6 +13,8 @@ export const Template = ({
   size,
   id,
   iconName,
+  title,
+  body,
   customClasses = [],
   ...globals
 }) => {
@@ -25,6 +28,13 @@ export const Template = ({
         ...globals,
         size,
         iconName
+      })}
+      ${Popover({
+        content: [
+          html`<div class='${rootClass}--Heading'>${title}</div>`,
+          html`<div class='${rootClass}--Body'>${body}</div>`
+        ]
+
       })}
     </div>
   `;

--- a/components/contextualhelp/stories/template.js
+++ b/components/contextualhelp/stories/template.js
@@ -4,6 +4,8 @@ import { ifDefined } from 'lit-html/directives/if-defined.js';
 
 import { Template as ActionButton } from "@spectrum-css/actionbutton/stories/template.js";
 import { Template as Popover } from "@spectrum-css/popover/stories/template.js";
+import { Template as Link } from "@spectrum-css/link/stories/template.js";
+
 
 import "../index.css";
 
@@ -15,6 +17,7 @@ export const Template = ({
   iconName,
   title,
   body,
+  link,
   customClasses = [],
   ...globals
 }) => {
@@ -27,14 +30,16 @@ export const Template = ({
       ${ActionButton({
         ...globals,
         size,
-        iconName
+        iconName,
+        customClasses: [`${rootClass}-button`]
       })}
       ${Popover({
         content: [
-          html`<div class='${rootClass}--Heading'>${title}</div>`,
-          html`<div class='${rootClass}--Body'>${body}</div>`
-        ]
-
+          title ? html`<h2 class="${rootClass}-Heading">${title}</h2>` : "",
+          body ? html`<p class="${rootClass}-Body">${body}</p>` : "",
+          link ? Link({ text: link.text, url: link.url }) : ""
+        ],
+        customClasses: [`${rootClass}-popover`]
       })}
     </div>
   `;

--- a/components/contextualhelp/stories/template.js
+++ b/components/contextualhelp/stories/template.js
@@ -12,24 +12,23 @@ import "../index.css";
 // More on component templates: https://storybook.js.org/docs/web-components/writing-stories/introduction#using-args
 export const Template = ({
   rootClass = "spectrum-ContextualHelp",
-  size,
   id,
   iconName,
   title,
   body,
   link,
+  popoverPlacement,
   customClasses = [],
   ...globals
 }) => {
   return html`
     <div class=${classMap({
       [rootClass]: true,
-      [`${rootClass}--size${size.toUpperCase()}`]: true,
       ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
     })} id=${ifDefined(id)}>
       ${ActionButton({
         ...globals,
-        size,
+        size: "xs",
         iconName,
         customClasses: [`${rootClass}-button`]
       })}
@@ -37,9 +36,9 @@ export const Template = ({
         content: [
           title ? html`<h2 class="${rootClass}-Heading">${title}</h2>` : "",
           body ? html`<p class="${rootClass}-Body">${body}</p>` : "",
-          link ? Link({ text: link.text, url: link.url }) : ""
+          link ? Link({ text: link.text, url: link.url, customClasses: [`${rootClass}-link`]}) : ""
         ],
-        customClasses: [`${rootClass}-popover`]
+        customClasses: [`spectrum-Popover--${popoverPlacement}`, `${rootClass}-popover`]
       })}
     </div>
   `;

--- a/components/contextualhelp/stories/template.js
+++ b/components/contextualhelp/stories/template.js
@@ -2,6 +2,8 @@ import { html } from 'lit-html';
 import { classMap } from 'lit-html/directives/class-map.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 
+import { Template as ActionButton } from "@spectrum-css/actionbutton/stories/template.js";
+
 import "../index.css";
 
 // More on component templates: https://storybook.js.org/docs/web-components/writing-stories/introduction#using-args
@@ -9,6 +11,7 @@ export const Template = ({
   rootClass = "spectrum-ContextualHelp",
   size,
   id,
+  iconName,
   customClasses = [],
   ...globals
 }) => {
@@ -18,7 +21,11 @@ export const Template = ({
       [`${rootClass}--size${size.toUpperCase()}`]: true,
       ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
     })} id=${ifDefined(id)}>
-      <!-- Component mark-up goes here -->
+      ${ActionButton({
+        ...globals,
+        size,
+        iconName
+      })}
     </div>
   `;
 }

--- a/components/contextualhelp/themes/express.css
+++ b/components/contextualhelp/themes/express.css
@@ -1,0 +1,13 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+@container (--system: express) {}

--- a/components/contextualhelp/themes/spectrum.css
+++ b/components/contextualhelp/themes/spectrum.css
@@ -1,0 +1,13 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+@container (--system: spectrum) {}


### PR DESCRIPTION
## Description

This PR creates the Contextual Help component which previous did not exist in Spectrum CSS (and also does not currently exist in Spectrum Web Components). It utilizes two already migrated components: Popover and ActionButton. Because of this, there weren't many changes needed for ContextualHelp other than to render those two components.


## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
