### PR TITLE
chore: add storybook to publish task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -173,11 +173,19 @@ function prepareSite_docs() {
     .pipe(gulp.dest('dist-site/'));
 }
 
+function prepareSite_storybook() {
+  return gulp.src('dist/preview/**/*', {
+    base: 'dist'
+  })
+    .pipe(gulp.dest('dist-site/'));
+}
+
 const prepareSite = gulp.series(
   prepareSite_clean,
   gulp.parallel(
     prepareSite_docs,
-    prepareSite_components
+    prepareSite_components,
+    prepareSite_storybook,
   )
 );
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,16 +10,12 @@
 # this remaps this to our /preview/ path.
 # Why? Using preview decouples us from the tool.
 [[redirects]]
-  from = "/storybook/"
-  to = "/preview/"
+  from = "/storybook/*"
+  to = "/preview/:splat"
 
 [[redirects]]
-  from = "/preview"
-  to = "/preview/"
-
-[[redirects]]
-  from = "/docs/*"
-  to = "/docs/:splat.html"
+  from = "/docs/preview/*"
+  to = "/preview/:splat"
 
 # If skip_processing = true, all other settings are ignored
 [build.processing]
@@ -37,5 +33,5 @@
 
 # Skip all post processing in deploy previews,
 # ignoring any other settings
-[context.deploy-preview.processing]
-  skip_processing = true
+# [context.deploy-preview.processing]
+#  skip_processing = true

--- a/site/includes/nav.pug
+++ b/site/includes/nav.pug
@@ -21,4 +21,4 @@
       li.spectrum-SideNav-item
         a.spectrum-SideNav-itemLink(href='https://spectrum.adobe.com', target='_blank', rel='noopener') Spectrum
       li.spectrum-SideNav-item
-        a.spectrum-SideNav-itemLink(href='/preview', rel='noopener') Component preview
+        a.spectrum-SideNav-itemLink(href='preview/', rel='noopener') Component preview


### PR DESCRIPTION
## Description

This update adds a small step to copy the preview folder from dist into dist-site and updates the nav link to be relative instead of absolute as the site is published to `spectrum-css` folder on the open source site.

- https://opensource.adobe.com/spectrum-css/preview/index.html


## To-do list
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] This pull request is ready to merge.
