### PR TITLE
fix(textfield): quiet - use underline focus indicator on click

### DIFF
--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -337,13 +337,14 @@ governing permissions and limitations under the License.
       margin-inline-start: 0;
       margin-block-start: 0;
       border-radius: 0;
-      border-color: var(--highcontrast-textfield-focus-indicator-color, var(--mod-textfield-focus-indicator-color, var(--spectrum-textfield-focus-indicator-color)));
     }
-  }
 
-  &--quiet.is-keyboardFocused {
-    &::after {
-      border-width: 0 0 var(--mod-textfield-focus-indicator-width, var(--spectrum-textfield-focus-indicator-width)) 0;
+    &.is-keyboardFocused,
+    &:focus-within {
+      &::after {
+        border-width: 0 0 var(--mod-textfield-focus-indicator-width, var(--spectrum-textfield-focus-indicator-width)) 0;
+        border-color: var(--highcontrast-textfield-focus-indicator-color, var(--mod-textfield-focus-indicator-color, var(--spectrum-textfield-focus-indicator-color)));
+      }
     }
   }
 


### PR DESCRIPTION
## Description
On the quiet type of the textfield component, the focus indicator was showing the full ring instead of the single bottom border underline when clicking into the field. The underline was as expected when tabbing into the field and on examples where the indicator shows with a class.

## How and where has this been tested?
Chrome and Firefox, MacOS

## Screenshots

After clicking into a quiet field on the docs page for textfield--
Before:
![Screenshot 2023-03-22 at 5 28 54 PM](https://user-images.githubusercontent.com/965114/227042838-9fa1801e-96c6-47b4-9449-cc95c60df548.png)

After:
![Screenshot 2023-03-22 at 5 23 29 PM](https://user-images.githubusercontent.com/965114/227042222-6e7005f0-a139-4fa1-bc4c-95d1ce896012.png)

## To-do list
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] This pull request is ready to merge.
