### PR TITLE
fix(colorwheel): move custom properties

### DIFF
--- a/components/colorwheel/index.css
+++ b/components/colorwheel/index.css
@@ -53,6 +53,10 @@ governing permissions and limitations under the License.
     }
   }
 
+  /* --track-width and --border-width to be used with JS in calculating the clip-path paths and colorarea-container-size */
+  --track-width: var(--mod-colorwheel-track-width, var(--spectrum-colorwheel-track-width));
+  --border-width: var(--mod-colorwheel-border-width, var(--spectrum-colorwheel-border-width));
+
   &.is-disabled {
     pointer-events: none;
   }
@@ -139,16 +143,12 @@ governing permissions and limitations under the License.
   border-width: var(--border-width);
 }
 
-/* --track-width and --border-width to be used with JS in calculating the clip-path paths and colorarea-container-size */
 .spectrum-ColorWheel-wheel {
   position: absolute;
   background: conic-gradient(from 90deg, red, rgb(255, 128, 0), rgb(255, 255, 0), rgb(128, 255, 0), rgb(0, 255, 0), rgb(0, 255, 128), rgb(0, 255, 255), rgb(0, 128, 255), rgb(0, 0, 255), rgb(128, 0, 255), rgb(255, 0, 255), rgb(255, 0, 128), red);
   inset-block: var(--spectrum-colorwheel-border-width);
   inset-inline: var(--spectrum-colorwheel-border-width);
   clip-path: path(evenodd, var(--mod-colorwheel-path, var(--spectrum-colorwheel-path)));
-
-  --track-width: var(--mod-colorwheel-track-width, var(--spectrum-colorwheel-track-width));
-  --border-width: var(--mod-colorwheel-border-width, var(--spectrum-colorwheel-border-width));
 
   &.is-disabled {
     pointer-events: none;

--- a/components/colorwheel/index.css
+++ b/components/colorwheel/index.css
@@ -124,7 +124,7 @@ governing permissions and limitations under the License.
 
 }
 
-/* clip path set border-width wider than than spectrum-colorwheel-wheel to create appreance of a border*/
+/* a clip-path set border-width wider than than spectrum-colorwheel-wheel to create the appreance of a border*/
 .spectrum-ColorWheel-border {
   position: relative;
   background-color: var(--mod-colorwheel-border-color, var(--spectrum-colorwheel-border-color));


### PR DESCRIPTION
## Description

As a follow up to, #1619 this PR moves the custom properties `--trackWidth` and `--border-width` to `.spectrum-ColorWheel` to make accessing them more straight forward for SWC. 

[See slack convo. ](https://adobedesign.slack.com/archives/CS22GNRU2/p1679587915417799)


## How and where has this been tested?

Ran branch locally, ensured changes did not visually change anything 

## Screenshots
No visual change


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
