### PR TITLE
feat(colorslider)!: Use new tokens for opacity checkerboard

### DIFF
--- a/components/colorslider/index.css
+++ b/components/colorslider/index.css
@@ -6,6 +6,9 @@
   --spectrum-colorslider-handle-hitarea-height: var(
     --spectrum-global-dimension-size-300
   );
+  --spectrum-colorslider-checkerboard-size: var(--spectrum-opacity-checkerboard-square-size);
+  --spectrum-colorslider-checkerboard-dark-color: var(--spectrum-opacity-checkerboard-square-dark);
+  --spectrum-colorslider-checkerboard-light-color: var(--spectrum-opacity-checkerboard-square-light);
 }
 
 %spectrum-ColorControl-handle--focused {
@@ -77,12 +80,9 @@
 }
 
 .spectrum-ColorSlider-checkerboard {
-  background-size: var(--spectrum-global-dimension-static-size-200)
-    var(--spectrum-global-dimension-static-size-200);
-  background-position: 0 0, 0 var(--spectrum-global-dimension-static-size-100),
-    var(--spectrum-global-dimension-static-size-100)
-      calc(-1 * var(--spectrum-global-dimension-static-size-100)),
-    calc(-1 * var(--spectrum-global-dimension-static-size-100)) 0;
+  background:
+    repeating-conic-gradient(var(--spectrum-colorslider-checkerboard-light-color) 0% 25%, var(--spectrum-colorslider-checkerboard-dark-color) 0% 50%)
+    left top / calc(var(--spectrum-colorslider-checkerboard-size) * 2 ) calc(var(--spectrum-colorslider-checkerboard-size) * 2 );
 
   /* the floating inset box shadow must be a separate element since <canvas> won't take it */
   &:before {

--- a/components/colorslider/skin.css
+++ b/components/colorslider/skin.css
@@ -4,15 +4,6 @@
 }
 
 .spectrum-ColorSlider-checkerboard {
-  background-color: var(--spectrum-colorcontrol-checkerboard-light-color);
-
-  /* Add a half-percent to fix diagonal line issue in Chrome on non-retina displays */
-  background-image:
-    linear-gradient(-45deg, transparent 75.5%, var(--spectrum-colorcontrol-checkerboard-dark-color) 75.5%),
-    linear-gradient(45deg, transparent 75.5%, var(--spectrum-colorcontrol-checkerboard-dark-color) 75.5%),
-    linear-gradient(-45deg, var(--spectrum-colorcontrol-checkerboard-dark-color) 25.5%, transparent 25.5%),
-    linear-gradient(45deg, var(--spectrum-colorcontrol-checkerboard-dark-color) 25.5%, transparent 25.5%);
-
   &:before {
     box-shadow: inset 0 0 0 var(--spectrum-colorslider-border-size) var(--spectrum-colorslider-border-color);
   }

--- a/components/swatch/index.css
+++ b/components/swatch/index.css
@@ -260,30 +260,15 @@ governing permissions and limitations under the License.
 
 
   /* Checkerboard fill */
-  /* Static checkerboard properties */
-  --spectrum-swatch-checkerboard-size: 8px;
-  --spectrum-swatch-checkerboard-background-offset: 0px;
-  --spectrum-swatch-checkerboard-dark-color: rgb(217, 217, 217);
-  --spectrum-swatch-checkerboard-light-color: rgb(255, 255, 255);
+  --spectrum-swatch-checkerboard-size: var(--spectrum-opacity-checkerboard-square-size);
+  --spectrum-swatch-checkerboard-dark-color: var(--spectrum-opacity-checkerboard-square-dark);
+  --spectrum-swatch-checkerboard-light-color: var(--spectrum-opacity-checkerboard-square-light);
 
   background-color: var(--spectrum-swatch-checkerboard-light-color);
 
-  background-size:
-    calc(var(--mod-swatch-checkerboard-size, var(--spectrum-swatch-checkerboard-size)) * 2)
-    calc(var(--mod-swatch-checkerboard-size, var(--spectrum-swatch-checkerboard-size)) * 2);
-
-  background-position:
-    var(--spectrum-swatch-checkerboard-background-offset) var(--spectrum-swatch-checkerboard-background-offset),
-    var(--spectrum-swatch-checkerboard-background-offset) calc(var(--mod-swatch-checkerboard-size, var(--spectrum-swatch-checkerboard-size)) + var(--spectrum-swatch-checkerboard-background-offset)),
-    calc(var(--mod-swatch-checkerboard-size, var(--spectrum-swatch-checkerboard-size)) + var(--spectrum-swatch-checkerboard-background-offset)) calc(-1 * var(--mod-swatch-checkerboard-size, var(--spectrum-swatch-checkerboard-size)) + var(--spectrum-swatch-checkerboard-background-offset)),
-    calc(-1 * var(--mod-swatch-checkerboard-size, var(--spectrum-swatch-checkerboard-size)) + var(--spectrum-swatch-checkerboard-background-offset)) var(--spectrum-swatch-checkerboard-background-offset);
-
-  /* Add a half-percent to fix diagonal line issue in Chrome on non-retina displays */
-  background-image:
-    linear-gradient(-45deg, transparent 75.5%, var(--spectrum-swatch-checkerboard-dark-color) 75.5%),
-    linear-gradient(45deg, transparent 75.5%, var(--spectrum-swatch-checkerboard-dark-color) 75.5%),
-    linear-gradient(-45deg, var(--spectrum-swatch-checkerboard-dark-color) 25.5%, transparent 25.5%),
-    linear-gradient(45deg, var(--spectrum-swatch-checkerboard-dark-color) 25.5%, transparent 25.5%);
+  background:
+    repeating-conic-gradient(var(--spectrum-swatch-checkerboard-light-color) 0% 25%, var(--spectrum-swatch-checkerboard-dark-color) 0% 50%)
+    left top / calc(var(--spectrum-swatch-checkerboard-size) * 2 ) calc(var(--spectrum-swatch-checkerboard-size) * 2 );
 
   /* Swatch fill: Default */
   &:before {

--- a/components/swatch/index.css
+++ b/components/swatch/index.css
@@ -264,8 +264,6 @@ governing permissions and limitations under the License.
   --spectrum-swatch-checkerboard-dark-color: var(--spectrum-opacity-checkerboard-square-dark);
   --spectrum-swatch-checkerboard-light-color: var(--spectrum-opacity-checkerboard-square-light);
 
-  background-color: var(--spectrum-swatch-checkerboard-light-color);
-
   background:
     repeating-conic-gradient(var(--spectrum-swatch-checkerboard-light-color) 0% 25%, var(--spectrum-swatch-checkerboard-dark-color) 0% 50%)
     left top / calc(var(--spectrum-swatch-checkerboard-size) * 2 ) calc(var(--spectrum-swatch-checkerboard-size) * 2 );


### PR DESCRIPTION
## Description
BREAKING CHANGE: This migrates the using opacity checkerboard core tokens. 
Uses new tokens for opacity checkerboard with in ColorSlider and Swatch 
- also refactors checkerboard to use `repeating-conic-gradient` 
- [caniuse for repeating-conic-gradient]( https://caniuse.com/?search=repeating-conic-gradient) 

Does not include ColorHandle, ColorLoupe, or Thumbnail. Each of which will be addressed when component is migrated. 

## How and where has this been tested?
comparing local build with[ figma](https://www.figma.com/file/nchxla8gD4CxWYwt9eiRrz/Token-definition-library?node-id=202-4135&t=evkhgWs0xvGXQfL8-0) for Opacity Checkerboard

Browser(s) and OS(s) this was tested with:
Chrome 109 on macOS
Safari 16.2 on macOS
Firefox 109 on macOS

## Screenshots
### Swatch
![Screenshot 2023-03-28 at 8 25 54 AM](https://user-images.githubusercontent.com/63808889/228270383-4bbcc2cf-f7ed-4577-8980-9e020045b879.png)
### ColorSlider
![Screenshot 2023-03-28 at 8 26 26 AM](https://user-images.githubusercontent.com/63808889/228270552-1566eff2-d413-4c6c-88c6-adf31063a182.png)


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] I have tested these changes in Windows High Contrast mode.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
