### PR TITLE
feat(tokens)!: apply CSSOpenTypeTransform for font transforms

### DIFF
--- a/components/tokens/config.js
+++ b/components/tokens/config.js
@@ -15,6 +15,7 @@ const StyleDictionary = require('style-dictionary');
 const CSSSetsFormatter = require('style-dictionary-sets').CSSSetsFormatter;
 const NameKebabTransfom = require('style-dictionary-sets').NameKebabTransfom;
 const AttributeSetsTransform = require('style-dictionary-sets').AttributeSetsTransform;
+const CSSOpenTypeTransform = require('style-dictionary-sets').CSSOpenTypeTransform;
 
 /**
  * @note This references the package.json because we want the root folder and
@@ -27,6 +28,7 @@ const tokensDir = path.dirname(tokensPath);
 StyleDictionary.registerTransform(NameKebabTransfom);
 StyleDictionary.registerTransform(AttributeSetsTransform);
 StyleDictionary.registerFormat(CSSSetsFormatter);
+StyleDictionary.registerTransform(CSSOpenTypeTransform);
 
 const systemNames = ['express', 'spectrum', 'wireframe'];
 
@@ -139,7 +141,7 @@ module.exports = {
   platforms: {
     CSS: {
       buildPath: 'dist/css/',
-      transforms: [AttributeSetsTransform.name, NameKebabTransfom.name],
+      transforms: [AttributeSetsTransform.name, NameKebabTransfom.name, CSSOpenTypeTransform.name],
       prefix: 'spectrum',
       files: [
         {

--- a/components/tokens/package.json
+++ b/components/tokens/package.json
@@ -25,7 +25,7 @@
     "gulp-concat": "^2.6.1",
     "rimraf": "^4.1.1",
     "style-dictionary": "^3.7.0",
-    "style-dictionary-sets": "^2.0.2"
+    "style-dictionary-sets": "^2.1.1"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16096,10 +16096,10 @@ strong-log-transformer@^2.1.0:
     minimist "^1.2.0"
     through "^2.3.4"
 
-style-dictionary-sets@^2.0.2:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/style-dictionary-sets/-/style-dictionary-sets-2.0.5.tgz#11d7cc85f603d0bbe76e46679ef9598c825916be"
-  integrity sha512-BeL+3GbtLRvkn21vjQN+si9RjVHbj+SJ208P9jexqM1ga+qzaZ7ofc6rgmG8zHTRdSjUXc+QbVLmDoMY68Pd7g==
+style-dictionary-sets@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/style-dictionary-sets/-/style-dictionary-sets-2.1.1.tgz#98ec8e2dc8c74b93d9d64963dc271f0543f5997f"
+  integrity sha512-pvm1Y6jdXi2IlsWgglnNK7YCi63jCy6VkaANuXQOC0XhxXDsdzo52PzJzEeAdfDZoiZ5DosGAWNpnZ0Yp4gqbQ==
   dependencies:
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
BREAKING CHANGE: alters the values associated with font-weights by changing them into valid CSS values.

<!-- Summarize your changes in the Title field -->

## Description
* Brings in the latest version of `style-dictionary-sets`, which includes `CSSOpenTypeTransform`. This allows Spectrum CSS to consume font-specific tokens and transform them into valid CSS values.


## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
