### PR TITLE
chore: fix dependabot ignore error

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,8 +13,8 @@ updates:
     rebase-strategy: "auto"
     versioning-strategy: "increase"
     ignore:
-      - "@spectrum-css/*"
-      
+      - dependency-name: "@spectrum-css/*"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Dependabot ignore was expecting an object and not an array. https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore


## To-do list
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] This pull request is ready to merge.
