### PR TITLE
chore(dependabot): ignore postcss and gulp until build migration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,10 @@ updates:
       - dependency-name: "@storybook/*"
         versions: ["7.x"]
       - dependency-name: "@spectrum-css/*"
+      # Ignore postcss versions until build migration complete
+      - dependency-name: "postcss*"
+      # Ignore gulp versions until build migration complete
+      - dependency-name: "gulp*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Ignoring postcss & gulp until after the build migration