### PR TITLE
fix(textfield, stepper) : textfield and stepper accessibility fixes

### DIFF
--- a/components/stepper/index.css
+++ b/components/stepper/index.css
@@ -60,8 +60,8 @@ governing permissions and limitations under the License.
   --spectrum-stepper-border-radius: var(--spectrum-corner-radius-100);
 
   /*** Buttons ***/
-  --spectrum-stepper-button-width: var(--spectrum-component-height-75); /* this height token matches the previous WIDTH token */
-  --spectrum-stepper-button-padding: var(--spectrum-component-edge-to-visual-50); /* 6px md + 7px lg - previously 6px md + 7.5px lg */
+  --spectrum-stepper-button-width: calc(var(--spectrum-spacing-400) - var(--spectrum-stepper-border-width)); /* this matches the previous WIDTH token */
+  --spectrum-stepper-button-padding: calc(var(--spectrum-spacing-200) / 2); /* 6px md + 7px lg - previously 6px md + 7.5px lg */
   --spectrum-stepper-button-gap: var(--spectrum-stepper-button-gap-reset);
   --spectrum-stepper-button-border-radius: var(--spectrum-stepper-button-border-radius-reset);
 
@@ -499,13 +499,14 @@ governing permissions and limitations under the License.
   block-size: calc((var(--mod-stepper-buttons-height, var(--spectrum-stepper-buttons-height)) / 2)
                   - (var(--mod-stepper-button-gap, var(--spectrum-stepper-button-gap)) * 2.5));
 
-  inline-size: calc(100% - var(--mod-stepper-button-gap, var(--spectrum-stepper-button-gap)));
+  inline-size: var(--spectrum-stepper-button-width);
 
   margin-inline-end: var(--mod-stepper-button-gap, var(--spectrum-stepper-button-gap));
 
   min-inline-size: 0;
 
-  padding-inline: var(--mod-stepper-button-padding, var(--spectrum-stepper-button-padding));
+  padding-inline-start: var(--mod-stepper-button-padding, var(--spectrum-stepper-button-padding));
+  padding-inline-end: var(--mod-stepper-button-padding, var(--spectrum-stepper-button-padding));
 
   /* Avoid margin added by adjacent buttons */
   margin: 0;
@@ -517,6 +518,8 @@ governing permissions and limitations under the License.
 
   .spectrum-Icon {
     opacity: 1;
+    margin-inline-end: 0px;
+    margin-inline-start: calc(-1 * var(--spectrum-stepper-border-radius) / 2); /* This should be looked at again when stepper is migrated */
   }
 
   /*** Action Buttons Hover ***/

--- a/components/stepper/stories/template.js
+++ b/components/stepper/stories/template.js
@@ -24,6 +24,15 @@ export const Template = ({
   },
   ...globals
 }) => {
+  const { express } = globals;
+
+  try {
+    if (!express) import(/* webpackPrefetch: true */ "../themes/spectrum.css");
+    else import(/* webpackPrefetch: true */ "../themes/express.css");
+  } catch (e) {
+    console.warn(e);
+  }
+  
   return html`
     <div class=${classMap({
       [rootClass]: true,

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -775,7 +775,7 @@ governing permissions and limitations under the License.
   .spectrum-Textfield {
     --highcontrast-textfield-border-color-hover: Highlight;
     --highcontrast-textfield-border-color-focus: Highlight;
-    --highcontrast-textfield-border-color-keyboard-focus: Highlight;
+    --highcontrast-textfield-border-color-keyboard-focus: CanvasText;
     --highcontrast-textfield-focus-indicator-color: Highlight;
 
     --highcontrast-textfield-border-color-invalid-default: Highlight;
@@ -800,13 +800,6 @@ governing permissions and limitations under the License.
         --highcontrast-textfield-text-color-disabled: GrayText;
         --highcontrast-textfield-text-color-readonly: CanvasText;
       }
-    }
-
-    &::after {
-      block-size: calc(100% - var(--mod-textfield-focus-indicator-width, var(--spectrum-textfield-focus-indicator-width)) * 2);
-      inline-size: calc(100% - var(--mod-textfield-focus-indicator-width, var(--spectrum-textfield-focus-indicator-width)) * 2);
-      margin-block-start: 0;
-      margin-inline-start: 0;
     }
   }
   .spectrum-Textfield--quiet {

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -206,50 +206,6 @@ governing permissions and limitations under the License.
   --spectrum-text-area-min-block-size-quiet: var(--spectrum-component-height-300);
 }
 
-/********* WHCM *********/
-@media (forced-colors: active) {
-  .spectrum-Textfield {
-    --highcontrast-textfield-border-color-hover: Highlight;
-    --highcontrast-textfield-border-color-focus: Highlight;
-    --highcontrast-textfield-border-color-keyboard-focus: Highlight;
-    --highcontrast-textfield-focus-indicator-color: CanvasText;
-
-    --highcontrast-textfield-border-color-invalid-default: Highlight;
-    --highcontrast-textfield-border-color-invalid-hover: Highlight;
-    --highcontrast-textfield-border-color-invalid-focus: Highlight;
-    --highcontrast-textfield-border-color-invalid-keyboard-focus: Highlight;
-
-    --highcontrast-textfield-text-color-valid: CanvasText;
-    --highcontrast-textfield-text-color-invalid: CanvasText;
-
-    .spectrum-Textfield-input {
-      --highcontrast-textfield-text-color-default: CanvasText;
-      --highcontrast-textfield-text-color-hover: CanvasText;
-      --highcontrast-textfield-text-color-keyboard-focus: CanvasText;
-      --highcontrast-textfield-text-color-disabled: GrayText;
-      --highcontrast-textfield-text-color-readonly: CanvasText;
-
-      &::placeholder {
-        --highcontrast-textfield-text-color-default: GrayText;
-        --highcontrast-textfield-text-color-hover: GrayText;
-        --highcontrast-textfield-text-color-keyboard-focus: GrayText;
-        --highcontrast-textfield-text-color-disabled: GrayText;
-        --highcontrast-textfield-text-color-readonly: CanvasText;
-      }
-    }
-
-
-    &.is-focused,
-    &.is-keyboardFocused,
-    &:focus, &:focus-within {
-      /* focus indicator is focused state */
-      &::after {
-        forced-color-adjust: none;
-      }
-    }
-  }
-}
-
 /********* TEXT FIELD and TEXT AREA Outer Wrapper *********/
 .spectrum-Textfield {
   position: relative;
@@ -330,7 +286,7 @@ governing permissions and limitations under the License.
     }
   }
 
-  &--quiet {
+  &.spectrum-Textfield--quiet {
     &::after {
       inline-size: 100%;
       block-size: calc(100% + var(--mod-textfield-focus-indicator-gap, var(--spectrum-textfield-focus-indicator-gap)));
@@ -810,6 +766,53 @@ governing permissions and limitations under the License.
       /* Treat all quiet inputs and text areas the same */
       resize: none;
       overflow-y: hidden;
+    }
+  }
+}
+
+/********* WHCM *********/
+@media (forced-colors: active) {
+  .spectrum-Textfield {
+    --highcontrast-textfield-border-color-hover: Highlight;
+    --highcontrast-textfield-border-color-focus: Highlight;
+    --highcontrast-textfield-border-color-keyboard-focus: Highlight;
+    --highcontrast-textfield-focus-indicator-color: Highlight;
+
+    --highcontrast-textfield-border-color-invalid-default: Highlight;
+    --highcontrast-textfield-border-color-invalid-hover: Highlight;
+    --highcontrast-textfield-border-color-invalid-focus: Highlight;
+    --highcontrast-textfield-border-color-invalid-keyboard-focus: Highlight;
+
+    --highcontrast-textfield-text-color-valid: CanvasText;
+    --highcontrast-textfield-text-color-invalid: CanvasText;
+
+    .spectrum-Textfield-input {
+      --highcontrast-textfield-text-color-default: CanvasText;
+      --highcontrast-textfield-text-color-hover: CanvasText;
+      --highcontrast-textfield-text-color-keyboard-focus: CanvasText;
+      --highcontrast-textfield-text-color-disabled: GrayText;
+      --highcontrast-textfield-text-color-readonly: CanvasText;
+
+      &::placeholder {
+        --highcontrast-textfield-text-color-default: GrayText;
+        --highcontrast-textfield-text-color-hover: GrayText;
+        --highcontrast-textfield-text-color-keyboard-focus: GrayText;
+        --highcontrast-textfield-text-color-disabled: GrayText;
+        --highcontrast-textfield-text-color-readonly: CanvasText;
+      }
+    }
+
+    &::after {
+      block-size: calc(100% - var(--mod-textfield-focus-indicator-width, var(--spectrum-textfield-focus-indicator-width)) * 2);
+      inline-size: calc(100% - var(--mod-textfield-focus-indicator-width, var(--spectrum-textfield-focus-indicator-width)) * 2);
+      margin-block-start: 0;
+      margin-inline-start: 0;
+    }
+  }
+  .spectrum-Textfield--quiet {
+    &::after {
+      block-size: calc(100% - var(--mod-textfield-focus-indicator-width, var(--spectrum-textfield-focus-indicator-width)));
+      inline-size: calc(100% - var(--mod-textfield-focus-indicator-width, var(--spectrum-textfield-focus-indicator-width)));
     }
   }
 }


### PR DESCRIPTION
This PR makes two updates to help with accessibility for the Textfield and Stepper components based on feedback from the SWC team:
- Updates the WHCM color for the focus ring for Textfield in both the default and quiet variants to be `HIghlight`
- Updates the Stepper button width to match the current wider implementation to allow for a larger target size

Previous WHCM Focus
![Screenshot 2023-04-05 at 3 17 41 PM](https://user-images.githubusercontent.com/99203545/230182649-52b15375-5809-41b4-b4cc-1909251eeca8.png)

Updated WHCM Focus
![Screenshot 2023-04-05 at 3 19 45 PM](https://user-images.githubusercontent.com/99203545/230183058-bb859d0b-9353-40c2-a22d-8ff3a85a358e.png)

