### PR TITLE
fix(button): add icon only variant

### DIFF
--- a/components/button/index.css
+++ b/components/button/index.css
@@ -20,11 +20,9 @@ governing permissions and limitations under the License.
 
   --spectrum-button-focus-ring-gap: var(--spectrum-focus-indicator-gap);
   --spectrum-button-focus-ring-border-radius: calc(var(--spectrum-button-border-radius) + var(--spectrum-button-focus-ring-gap));
-
   --spectrum-button-focus-ring-gap: var(--spectrum-focus-indicator-gap);
   --spectrum-button-focus-ring-thickness: var(--spectrum-focus-indicator-thickness);
   --spectrum-button-focus-indicator-color: var(--spectrum-focus-indicator-color);
-  --spectrum-button-focus-ring-border-radius: calc(var(--spectrum-button-border-radius) + var(--spectrum-button-focus-ring-gap));
 }
 
 
@@ -138,6 +136,10 @@ governing permissions and limitations under the License.
 
     .spectrum-Icon {
       margin-inline-start: 0;
+    }
+
+    &:after {
+      border-radius: 50%;
     }
   }
 }

--- a/components/button/index.css
+++ b/components/button/index.css
@@ -103,7 +103,6 @@ governing permissions and limitations under the License.
   font-size: var(--mod-button-font-size, var(--spectrum-button-font-size));
   font-weight: var(--mod-bold-font-weight, var(--spectrum-bold-font-weight));
   gap: var(--mod-button-padding-label-to-icon, var(--spectrum-button-padding-label-to-icon));
-  height: var(--mod-button-height, var(--spectrum-button-height));
   min-inline-size: var(--mod-button-min-width, var(--spectrum-button-min-width));
   min-block-size: var(--mod-button-height, var(--spectrum-button-height));
   /* Start with text-only padding */
@@ -132,9 +131,14 @@ governing permissions and limitations under the License.
     border-radius: calc(var(--mod-button-border-radius, var(--spectrum-button-border-radius)) + var(--mod-focus-indicator-gap, var(--spectrum-focus-indicator-gap)));
   }
 
-  &.spectrum-Button--hideLabel {
+  &.spectrum-Button--iconOnly {
     min-inline-size: unset;
-    padding-inline: var(--mod-button-edge-to-visual-only, var(--spectrum-button-edge-to-visual-only));
+    padding: var(--mod-button-edge-to-visual-only, var(--spectrum-button-edge-to-visual-only));
+    border-radius: 50%;
+
+    .spectrum-Icon {
+      margin-inline-start: 0;
+    }
   }
 }
 

--- a/components/button/index.css
+++ b/components/button/index.css
@@ -37,6 +37,7 @@ governing permissions and limitations under the License.
   --spectrum-button-font-size: var(--spectrum-font-size-75);
 
   --spectrum-button-edge-to-visual: calc(var(--spectrum-component-pill-edge-to-visual-75) - var(--spectrum-button-border-width));
+  --spectrum-button-edge-to-visual-only: var(--spectrum-component-pill-edge-to-visual-only-75);
   --spectrum-button-edge-to-text: calc(var(--spectrum-component-pill-edge-to-text-75) - var(--spectrum-button-border-width));
   --spectrum-button-padding-label-to-icon: var(--spectrum-text-to-visual-75);
   --spectrum-button-padding-label-top: var(--spectrum-component-top-to-text-75);
@@ -52,6 +53,7 @@ governing permissions and limitations under the License.
   --spectrum-button-font-size: var(--spectrum-font-size-100);
   
   --spectrum-button-edge-to-visual: calc(var(--spectrum-component-pill-edge-to-visual-100) - var(--spectrum-button-border-width));
+  --spectrum-button-edge-to-visual-only: var(--spectrum-component-pill-edge-to-visual-only-100);
   --spectrum-button-edge-to-text: calc(var(--spectrum-component-pill-edge-to-text-100) - var(--spectrum-button-border-width));
   --spectrum-button-padding-label-to-icon: var(--spectrum-text-to-visual-100);
   --spectrum-button-padding-label-top: var(--spectrum-component-top-to-text-100);
@@ -67,6 +69,7 @@ governing permissions and limitations under the License.
   --spectrum-button-font-size: var(--spectrum-font-size-200);
 
   --spectrum-button-edge-to-visual: calc(var(--spectrum-component-pill-edge-to-visual-200) - var(--spectrum-button-border-width));
+  --spectrum-button-edge-to-visual-only: var(--spectrum-component-pill-edge-to-visual-only-200);
   --spectrum-button-edge-to-text: calc(var(--spectrum-component-pill-edge-to-text-200) - var(--spectrum-button-border-width));
   --spectrum-button-padding-label-to-icon: var(--spectrum-text-to-visual-200);
   --spectrum-button-padding-label-top: var(--spectrum-component-top-to-text-200);
@@ -82,6 +85,7 @@ governing permissions and limitations under the License.
   --spectrum-button-font-size: var(--spectrum-font-size-300);
 
   --spectrum-button-edge-to-visual: calc(var(--spectrum-component-pill-edge-to-visual-300) - var(--spectrum-button-border-width));
+  --spectrum-button-edge-to-visual-only: var(--spectrum-component-pill-edge-to-visual-only-300);
   --spectrum-button-edge-to-text: calc(var(--spectrum-component-pill-edge-to-text-300) - var(--spectrum-button-border-width));
   --spectrum-button-padding-label-to-icon: var(--spectrum-text-to-visual-300);
   --spectrum-button-padding-label-top: var(--spectrum-component-top-to-text-300);
@@ -126,6 +130,11 @@ governing permissions and limitations under the License.
   /* correct focus-ring radius for t-shirt sizing */
   &:after {
     border-radius: calc(var(--mod-button-border-radius, var(--spectrum-button-border-radius)) + var(--mod-focus-indicator-gap, var(--spectrum-focus-indicator-gap)));
+  }
+
+  &.spectrum-Button--hideLabel {
+    min-inline-size: unset;
+    padding-inline: var(--mod-button-edge-to-visual-only, var(--spectrum-button-edge-to-visual-only));
   }
 }
 

--- a/components/button/metadata/button-accent.yml
+++ b/components/button/metadata/button-accent.yml
@@ -34,6 +34,12 @@ examples:
             </svg>
             <span class="spectrum-Button-label">Edit</span>
           </button>
+
+          <button class="spectrum-Button spectrum-Button--fill spectrum-Button--accent spectrum-Button--sizeS spectrum-Button--iconOnly">
+            <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Edit">
+              <use xlink:href="#spectrum-icon-18-Edit" />
+            </svg>
+          </button>
         </div>
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">M (default)</h4>
@@ -47,6 +53,12 @@ examples:
               <use xlink:href="#spectrum-icon-18-Edit" />
             </svg>
             <span class="spectrum-Button-label">Edit</span>
+          </button>
+
+          <button class="spectrum-Button spectrum-Button--fill spectrum-Button--accent spectrum-Button--sizeM spectrum-Button--iconOnly">
+            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+              <use xlink:href="#spectrum-icon-18-Edit" />
+            </svg>
           </button>
         </div>
 
@@ -63,6 +75,12 @@ examples:
             </svg>
             <span class="spectrum-Button-label">Edit</span>
           </button>
+
+          <button class="spectrum-Button spectrum-Button--fill spectrum-Button--accent spectrum-Button--sizeL spectrum-Button--iconOnly">
+            <svg class="spectrum-Icon spectrum-Icon--sizeL" focusable="false" aria-hidden="true" aria-label="Edit">
+              <use xlink:href="#spectrum-icon-18-Edit" />
+            </svg>
+          </button>
         </div>
 
         <div class="spectrum-Examples-item">
@@ -78,15 +96,38 @@ examples:
             </svg>
             <span class="spectrum-Button-label">Edit</span>
           </button>
+
+          <button class="spectrum-Button spectrum-Button--fill spectrum-Button--accent spectrum-Button--sizeXL spectrum-Button--iconOnly">
+            <svg class="spectrum-Icon spectrum-Icon--sizeXL" focusable="false" aria-hidden="true" aria-label="Edit">
+              <use xlink:href="#spectrum-icon-18-Edit" />
+            </svg>
+          </button>
         </div>
       </div>
 
   - id: button-accent-disabled
     name: Disabled
     markup: |
-      <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--fill spectrum-Button--accent" disabled>
-        <span class="spectrum-Button-label">Button</span>
-      </button>
+      <div class="spectrum-Examples">
+        <div class="spectrum-Examples-item">
+          <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--fill spectrum-Button--accent" disabled>
+            <span class="spectrum-Button-label">Button</span>
+          </button>
+
+          <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--fill spectrum-Button--accent" disabled>
+            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+              <use xlink:href="#spectrum-icon-18-Edit" />
+            </svg>
+            <span class="spectrum-Button-label">Edit</span>
+          </button>
+
+          <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--fill spectrum-Button--accent spectrum-Button--iconOnly" disabled>
+            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+              <use xlink:href="#spectrum-icon-18-Edit" />
+            </svg>
+          </button>
+        </div>
+      </div>
 
   - id: button-accent-outline
     name: Outline
@@ -105,6 +146,12 @@ examples:
             </svg>
             <span class="spectrum-Button-label">Edit</span>
           </button>
+
+          <button class="spectrum-Button spectrum-Button--outline spectrum-Button--accent spectrum-Button--sizeS spectrum-Button--iconOnly">
+            <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Edit">
+              <use xlink:href="#spectrum-icon-18-Edit" />
+            </svg>
+          </button>
         </div>
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">M (default)</h4>
@@ -118,6 +165,12 @@ examples:
               <use xlink:href="#spectrum-icon-18-Edit" />
             </svg>
             <span class="spectrum-Button-label">Edit</span>
+          </button>
+
+          <button class="spectrum-Button spectrum-Button--outline spectrum-Button--accent spectrum-Button--sizeM spectrum-Button--iconOnly">
+            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+              <use xlink:href="#spectrum-icon-18-Edit" />
+            </svg>
           </button>
         </div>
 
@@ -134,6 +187,12 @@ examples:
             </svg>
             <span class="spectrum-Button-label">Edit</span>
           </button>
+
+          <button class="spectrum-Button spectrum-Button--outline spectrum-Button--accent spectrum-Button--sizeL spectrum-Button--iconOnly">
+            <svg class="spectrum-Icon spectrum-Icon--sizeL" focusable="false" aria-hidden="true" aria-label="Edit">
+              <use xlink:href="#spectrum-icon-18-Edit" />
+            </svg>
+          </button>
         </div>
 
         <div class="spectrum-Examples-item">
@@ -149,12 +208,35 @@ examples:
             </svg>
             <span class="spectrum-Button-label">Edit</span>
           </button>
+
+          <button class="spectrum-Button spectrum-Button--outline spectrum-Button--accent spectrum-Button--sizeXL spectrum-Button--iconOnly">
+            <svg class="spectrum-Icon spectrum-Icon--sizeXL" focusable="false" aria-hidden="true" aria-label="Edit">
+              <use xlink:href="#spectrum-icon-18-Edit" />
+            </svg>
+          </button>
         </div>
       </div>
 
   - id: button-accent-outline-disabled
     name: Outline- Disabled
     markup: |
-      <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--outline spectrum-Button--accent" disabled>
-        <span class="spectrum-Button-label">Button</span>
-      </button>
+      <div class="spectrum-Examples">
+        <div class="spectrum-Examples-item">
+          <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--outline spectrum-Button--accent" disabled>
+            <span class="spectrum-Button-label">Button</span>
+          </button>
+
+          <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--outline spectrum-Button--accent" disabled>
+            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+              <use xlink:href="#spectrum-icon-18-Edit" />
+            </svg>
+            <span class="spectrum-Button-label">Edit</span>
+          </button>
+
+          <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--outline spectrum-Button--accent spectrum-Button--iconOnly" disabled>
+            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+              <use xlink:href="#spectrum-icon-18-Edit" />
+            </svg>
+          </button>
+        </div>
+      </div>

--- a/components/button/metadata/button-negative.yml
+++ b/components/button/metadata/button-negative.yml
@@ -48,6 +48,12 @@ examples:
             </svg>
             <span class="spectrum-Button-label">Delete</span>
           </button>
+
+          <button class="spectrum-Button spectrum-Button--fill spectrum-Button--negative spectrum-Button--sizeS spectrum-Button--iconOnly">
+            <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Delete">
+              <use xlink:href="#spectrum-icon-18-Delete" />
+            </svg>
+          </button>
         </div>
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">M (default)</h4>
@@ -61,6 +67,12 @@ examples:
               <use xlink:href="#spectrum-icon-18-Delete" />
             </svg>
             <span class="spectrum-Button-label">Delete</span>
+          </button>
+
+          <button class="spectrum-Button spectrum-Button--fill spectrum-Button--negative spectrum-Button--sizeM spectrum-Button--iconOnly">
+            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Delete">
+              <use xlink:href="#spectrum-icon-18-Delete" />
+            </svg>
           </button>
         </div>
 
@@ -77,6 +89,12 @@ examples:
             </svg>
             <span class="spectrum-Button-label">Delete</span>
           </button>
+
+          <button class="spectrum-Button spectrum-Button--fill spectrum-Button--negative spectrum-Button--sizeL spectrum-Button--iconOnly">
+            <svg class="spectrum-Icon spectrum-Icon--sizeL" focusable="false" aria-hidden="true" aria-label="Delete">
+              <use xlink:href="#spectrum-icon-18-Delete" />
+            </svg>
+          </button>
         </div>
 
         <div class="spectrum-Examples-item">
@@ -92,21 +110,33 @@ examples:
             </svg>
             <span class="spectrum-Button-label">Delete</span>
           </button>
+
+          <button class="spectrum-Button spectrum-Button--fill spectrum-Button--negative spectrum-Button--sizeXL spectrum-Button--iconOnly">
+            <svg class="spectrum-Icon spectrum-Icon--sizeXL" focusable="false" aria-hidden="true" aria-label="Delete">
+              <use xlink:href="#spectrum-icon-18-Delete" />
+            </svg>
+          </button>
         </div>
       </div>
 
   - id: button-negative-disabled
     name: Disabled
     markup: |
-      <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--outline spectrum-Button--negative" disabled>
+      <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--fill spectrum-Button--negative" disabled>
         <span class="spectrum-Button-label">Delete</span>
       </button>
 
-      <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--outline spectrum-Button--negative" disabled>
+      <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--fill spectrum-Button--negative" disabled>
         <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Delete">
           <use xlink:href="#spectrum-icon-18-Delete" />
         </svg>
         <span class="spectrum-Button-label">Delete</span>
+      </button>
+
+      <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--fill spectrum-Button--negative spectrum-Button--iconOnly" disabled>
+        <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Delete">
+          <use xlink:href="#spectrum-icon-18-Delete" />
+        </svg>
       </button>
 
   - id: button-negative-outline
@@ -126,6 +156,12 @@ examples:
             </svg>
             <span class="spectrum-Button-label">Delete</span>
           </button>
+
+          <button class="spectrum-Button spectrum-Button--outline spectrum-Button--negative spectrum-Button--sizeS spectrum-Button--iconOnly">
+            <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Delete">
+              <use xlink:href="#spectrum-icon-18-Delete" />
+            </svg>
+          </button>
         </div>
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">M (default)</h4>
@@ -139,6 +175,12 @@ examples:
               <use xlink:href="#spectrum-icon-18-Delete" />
             </svg>
             <span class="spectrum-Button-label">Delete</span>
+          </button>
+
+          <button class="spectrum-Button spectrum-Button--outline spectrum-Button--negative spectrum-Button--sizeM spectrum-Button--iconOnly">
+            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Delete">
+              <use xlink:href="#spectrum-icon-18-Delete" />
+            </svg>
           </button>
         </div>
 
@@ -155,6 +197,12 @@ examples:
             </svg>
             <span class="spectrum-Button-label">Delete</span>
           </button>
+
+          <button class="spectrum-Button spectrum-Button--outline spectrum-Button--negative spectrum-Button--sizeL spectrum-Button--iconOnly">
+            <svg class="spectrum-Icon spectrum-Icon--sizeL" focusable="false" aria-hidden="true" aria-label="Delete">
+              <use xlink:href="#spectrum-icon-18-Delete" />
+            </svg>
+          </button>
         </div>
 
         <div class="spectrum-Examples-item">
@@ -169,6 +217,12 @@ examples:
               <use xlink:href="#spectrum-icon-18-Delete" />
             </svg>
             <span class="spectrum-Button-label">Delete</span>
+          </button>
+
+          <button class="spectrum-Button spectrum-Button--outline spectrum-Button--negative spectrum-Button--sizeXL spectrum-Button--iconOnly">
+            <svg class="spectrum-Icon spectrum-Icon--sizeXL" focusable="false" aria-hidden="true" aria-label="Delete">
+              <use xlink:href="#spectrum-icon-18-Delete" />
+            </svg>
           </button>
         </div>
       </div>
@@ -185,4 +239,10 @@ examples:
           <use xlink:href="#spectrum-icon-18-Delete" />
         </svg>
         <span class="spectrum-Button-label">Delete</span>
+      </button>
+
+      <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--outline spectrum-Button--negative spectrum-Button--iconOnly" disabled>
+        <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Delete">
+          <use xlink:href="#spectrum-icon-18-Delete" />
+        </svg>
       </button>

--- a/components/button/metadata/button-primary.yml
+++ b/components/button/metadata/button-primary.yml
@@ -48,6 +48,12 @@ examples:
             </svg>
             <span class="spectrum-Button-label">Edit</span>
           </button>
+
+          <button class="spectrum-Button spectrum-Button--fill spectrum-Button--primary spectrum-Button--sizeS spectrum-Button--iconOnly">
+            <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Edit">
+              <use xlink:href="#spectrum-icon-18-Edit" />
+            </svg>
+          </button>
         </div>
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">M (default)</h4>
@@ -61,6 +67,12 @@ examples:
               <use xlink:href="#spectrum-icon-18-Edit" />
             </svg>
             <span class="spectrum-Button-label">Edit</span>
+          </button>
+
+          <button class="spectrum-Button spectrum-Button--fill spectrum-Button--primary spectrum-Button--sizeM spectrum-Button--iconOnly">
+            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+              <use xlink:href="#spectrum-icon-18-Edit" />
+            </svg>
           </button>
         </div>
 
@@ -77,6 +89,12 @@ examples:
             </svg>
             <span class="spectrum-Button-label">Edit</span>
           </button>
+
+          <button class="spectrum-Button spectrum-Button--fill spectrum-Button--primary spectrum-Button--sizeL spectrum-Button--iconOnly">
+            <svg class="spectrum-Icon spectrum-Icon--sizeL" focusable="false" aria-hidden="true" aria-label="Edit">
+              <use xlink:href="#spectrum-icon-18-Edit" />
+            </svg>
+          </button>
         </div>
 
         <div class="spectrum-Examples-item">
@@ -91,6 +109,12 @@ examples:
               <use xlink:href="#spectrum-icon-18-Edit" />
             </svg>
             <span class="spectrum-Button-label">Edit</span>
+          </button>
+
+          <button class="spectrum-Button spectrum-Button--fill spectrum-Button--primary spectrum-Button--sizeXL spectrum-Button--iconOnly">
+            <svg class="spectrum-Icon spectrum-Icon--sizeXL" focusable="false" aria-hidden="true" aria-label="Edit">
+              <use xlink:href="#spectrum-icon-18-Edit" />
+            </svg>
           </button>
         </div>
       </div>
@@ -107,6 +131,12 @@ examples:
           <use xlink:href="#spectrum-icon-18-Edit" />
         </svg>
         <span class="spectrum-Button-label">Edit</span>
+      </button>
+
+      <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--fill spectrum-Button--primary spectrum-Button--iconOnly" disabled>
+        <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Edit">
+          <use xlink:href="#spectrum-icon-18-Edit" />
+        </svg>
       </button>
 
   - id: button-primary-outline
@@ -126,6 +156,12 @@ examples:
             </svg>
             <span class="spectrum-Button-label">Edit</span>
           </button>
+
+          <button class="spectrum-Button spectrum-Button--outline spectrum-Button--primary spectrum-Button--sizeS spectrum-Button--iconOnly">
+            <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Edit">
+              <use xlink:href="#spectrum-icon-18-Edit" />
+            </svg>
+          </button>
         </div>
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">M (default)</h4>
@@ -139,6 +175,12 @@ examples:
               <use xlink:href="#spectrum-icon-18-Edit" />
             </svg>
             <span class="spectrum-Button-label">Edit</span>
+          </button>
+
+          <button class="spectrum-Button spectrum-Button--outline spectrum-Button--primary spectrum-Button--sizeM spectrum-Button--iconOnly">
+            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+              <use xlink:href="#spectrum-icon-18-Edit" />
+            </svg>
           </button>
         </div>
 
@@ -155,6 +197,12 @@ examples:
             </svg>
             <span class="spectrum-Button-label">Edit</span>
           </button>
+          
+          <button class="spectrum-Button spectrum-Button--outline spectrum-Button--primary spectrum-Button--sizeL spectrum-Button--iconOnly">
+            <svg class="spectrum-Icon spectrum-Icon--sizeL" focusable="false" aria-hidden="true" aria-label="Edit">
+              <use xlink:href="#spectrum-icon-18-Edit" />
+            </svg>
+          </button>
         </div>
 
         <div class="spectrum-Examples-item">
@@ -169,6 +217,12 @@ examples:
               <use xlink:href="#spectrum-icon-18-Edit" />
             </svg>
             <span class="spectrum-Button-label">Edit</span>
+          </button>
+
+          <button class="spectrum-Button spectrum-Button--outline spectrum-Button--primary spectrum-Button--sizeXL spectrum-Button--iconOnly">
+            <svg class="spectrum-Icon spectrum-Icon--sizeXL" focusable="false" aria-hidden="true" aria-label="Edit">
+              <use xlink:href="#spectrum-icon-18-Edit" />
+            </svg>
           </button>
         </div>
       </div>
@@ -185,4 +239,10 @@ examples:
           <use xlink:href="#spectrum-icon-18-Edit" />
         </svg>
         <span class="spectrum-Button-label">Edit</span>
+      </button>
+
+      <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--outline spectrum-Button--primary spectrum-Button--iconOnly" disabled>
+        <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Edit">
+          <use xlink:href="#spectrum-icon-18-Edit" />
+        </svg>
       </button>

--- a/components/button/metadata/button-secondary.yml
+++ b/components/button/metadata/button-secondary.yml
@@ -48,6 +48,12 @@ examples:
             </svg>
             <span class="spectrum-Button-label">Edit</span>
           </button>
+
+          <button class="spectrum-Button spectrum-Button--fill spectrum-Button--secondary spectrum-Button--sizeS spectrum-Button--iconOnly">
+            <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Edit">
+              <use xlink:href="#spectrum-icon-18-Edit" />
+            </svg>
+          </button>
         </div>
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">M (default)</h4>
@@ -61,6 +67,12 @@ examples:
               <use xlink:href="#spectrum-icon-18-Edit" />
             </svg>
             <span class="spectrum-Button-label">Edit</span>
+          </button>
+
+          <button class="spectrum-Button spectrum-Button--fill spectrum-Button--secondary spectrum-Button--sizeM spectrum-Button--iconOnly">
+            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+              <use xlink:href="#spectrum-icon-18-Edit" />
+            </svg>
           </button>
         </div>
 
@@ -77,6 +89,12 @@ examples:
             </svg>
             <span class="spectrum-Button-label">Edit</span>
           </button>
+
+          <button class="spectrum-Button spectrum-Button--fill spectrum-Button--secondary spectrum-Button--sizeL spectrum-Button--iconOnly">
+            <svg class="spectrum-Icon spectrum-Icon--sizeL" focusable="false" aria-hidden="true" aria-label="Edit">
+              <use xlink:href="#spectrum-icon-18-Edit" />
+            </svg>
+          </button>
         </div>
 
         <div class="spectrum-Examples-item">
@@ -91,6 +109,12 @@ examples:
               <use xlink:href="#spectrum-icon-18-Edit" />
             </svg>
             <span class="spectrum-Button-label">Edit</span>
+          </button>
+
+          <button class="spectrum-Button spectrum-Button--fill spectrum-Button--secondary spectrum-Button--sizeXL spectrum-Button--iconOnly">
+            <svg class="spectrum-Icon spectrum-Icon--sizeXL" focusable="false" aria-hidden="true" aria-label="Edit">
+              <use xlink:href="#spectrum-icon-18-Edit" />
+            </svg>
           </button>
         </div>
       </div>
@@ -107,6 +131,12 @@ examples:
           <use xlink:href="#spectrum-icon-18-Edit" />
         </svg>
         <span class="spectrum-Button-label">Edit</span>
+      </button>
+
+      <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--fill spectrum-Button--secondary spectrum-Button--iconOnly" disabled>
+        <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Edit">
+          <use xlink:href="#spectrum-icon-18-Edit" />
+        </svg>
       </button>
 
   - id: button-secondary
@@ -126,6 +156,12 @@ examples:
             </svg>
             <span class="spectrum-Button-label">Edit</span>
           </button>
+
+          <button class="spectrum-Button spectrum-Button--outline spectrum-Button--secondary spectrum-Button--sizeS spectrum-Button--iconOnly">
+            <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Edit">
+              <use xlink:href="#spectrum-icon-18-Edit" />
+            </svg>
+          </button>
         </div>
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">M (default)</h4>
@@ -139,6 +175,12 @@ examples:
               <use xlink:href="#spectrum-icon-18-Edit" />
             </svg>
             <span class="spectrum-Button-label">Edit</span>
+          </button>
+
+          <button class="spectrum-Button spectrum-Button--outline spectrum-Button--secondary spectrum-Button--sizeM spectrum-Button--iconOnly">
+            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+              <use xlink:href="#spectrum-icon-18-Edit" />
+            </svg>
           </button>
         </div>
 
@@ -155,6 +197,12 @@ examples:
             </svg>
             <span class="spectrum-Button-label">Edit</span>
           </button>
+
+          <button class="spectrum-Button spectrum-Button--outline spectrum-Button--secondary spectrum-Button--sizeL spectrum-Button--iconOnly">
+            <svg class="spectrum-Icon spectrum-Icon--sizeL" focusable="false" aria-hidden="true" aria-label="Edit">
+              <use xlink:href="#spectrum-icon-18-Edit" />
+            </svg>
+          </button>
         </div>
 
         <div class="spectrum-Examples-item">
@@ -169,6 +217,12 @@ examples:
               <use xlink:href="#spectrum-icon-18-Edit" />
             </svg>
             <span class="spectrum-Button-label">Edit</span>
+          </button>
+
+          <button class="spectrum-Button spectrum-Button--outline spectrum-Button--secondary spectrum-Button--sizeXL spectrum-Button--iconOnly">
+            <svg class="spectrum-Icon spectrum-Icon--sizeXL" focusable="false" aria-hidden="true" aria-label="Edit">
+              <use xlink:href="#spectrum-icon-18-Edit" />
+            </svg>
           </button>
         </div>
       </div>
@@ -185,4 +239,10 @@ examples:
           <use xlink:href="#spectrum-icon-18-Edit" />
         </svg>
         <span class="spectrum-Button-label">Edit</span>
+      </button>
+
+      <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--outline spectrum-Button--secondary spectrum-Button--iconOnly" disabled>
+        <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Edit">
+          <use xlink:href="#spectrum-icon-18-Edit" />
+        </svg>
       </button>

--- a/components/button/metadata/button-staticcolor.yml
+++ b/components/button/metadata/button-staticcolor.yml
@@ -49,6 +49,12 @@ examples:
               </svg>
               <span class="spectrum-Button-label">Edit</span>
             </button>
+
+            <button class="spectrum-Button spectrum-Button--fill spectrum-Button--staticWhite spectrum-Button--sizeS spectrum-Button--iconOnly">
+              <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
           </div>
           <div class="spectrum-Examples-item">
             <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">M (default)</h4>
@@ -62,6 +68,12 @@ examples:
                 <use xlink:href="#spectrum-icon-18-Edit" />
               </svg>
               <span class="spectrum-Button-label">Edit</span>
+            </button>
+
+            <button class="spectrum-Button spectrum-Button--fill spectrum-Button--staticWhite spectrum-Button--sizeM spectrum-Button--iconOnly">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
             </button>
           </div>
 
@@ -78,6 +90,12 @@ examples:
               </svg>
               <span class="spectrum-Button-label">Edit</span>
             </button>
+
+            <button class="spectrum-Button spectrum-Button--fill spectrum-Button--staticWhite spectrum-Button--sizeL spectrum-Button--iconOnly">
+              <svg class="spectrum-Icon spectrum-Icon--sizeL" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
           </div>
 
           <div class="spectrum-Examples-item">
@@ -92,6 +110,12 @@ examples:
                 <use xlink:href="#spectrum-icon-18-Edit" />
               </svg>
               <span class="spectrum-Button-label">Edit</span>
+            </button>
+
+            <button class="spectrum-Button spectrum-Button--fill spectrum-Button--staticWhite spectrum-Button--sizeXL spectrum-Button--iconOnly">
+              <svg class="spectrum-Icon spectrum-Icon--sizeXL" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
             </button>
           </div>
         </div>
@@ -111,6 +135,12 @@ examples:
           </svg>
           <span class="spectrum-Button-label">Edit</span>
         </button>
+
+        <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--fill spectrum-Button--staticWhite spectrum-Button--iconOnly" disabled>
+          <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Edit">
+            <use xlink:href="#spectrum-icon-18-Edit" />
+          </svg>
+        </button>
       </div>
 
   - id: button-staticcolor
@@ -126,6 +156,12 @@ examples:
             <use xlink:href="#spectrum-icon-18-Edit" />
           </svg>
           <span class="spectrum-Button-label">Edit</span>
+        </button>
+
+        <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--fill spectrum-Button--staticWhite spectrum-Button--secondary spectrum-Button--iconOnly">
+          <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Edit">
+            <use xlink:href="#spectrum-icon-18-Edit" />
+          </svg>
         </button>
       </div>
 
@@ -147,6 +183,12 @@ examples:
               </svg>
               <span class="spectrum-Button-label">Edit</span>
             </button>
+
+            <button class="spectrum-Button spectrum-Button--fill spectrum-Button--staticBlack spectrum-Button--sizeS spectrum-Button--iconOnly">
+              <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
           </div>
           <div class="spectrum-Examples-item">
             <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">M (default)</h4>
@@ -160,6 +202,12 @@ examples:
                 <use xlink:href="#spectrum-icon-18-Edit" />
               </svg>
               <span class="spectrum-Button-label">Edit</span>
+            </button>
+
+            <button class="spectrum-Button spectrum-Button--fill spectrum-Button--staticBlack spectrum-Button--sizeM spectrum-Button--iconOnly">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
             </button>
           </div>
 
@@ -176,6 +224,12 @@ examples:
               </svg>
               <span class="spectrum-Button-label">Edit</span>
             </button>
+
+            <button class="spectrum-Button spectrum-Button--fill spectrum-Button--staticBlack spectrum-Button--sizeL spectrum-Button--iconOnly">
+              <svg class="spectrum-Icon spectrum-Icon--sizeL" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
           </div>
 
           <div class="spectrum-Examples-item">
@@ -190,6 +244,12 @@ examples:
                 <use xlink:href="#spectrum-icon-18-Edit" />
               </svg>
               <span class="spectrum-Button-label">Edit</span>
+            </button>
+
+            <button class="spectrum-Button spectrum-Button--fill spectrum-Button--staticBlack spectrum-Button--sizeXL spectrum-Button--iconOnly">
+              <svg class="spectrum-Icon spectrum-Icon--sizeXL" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
             </button>
           </div>
         </div>
@@ -209,6 +269,12 @@ examples:
           </svg>
           <span class="spectrum-Button-label">Edit</span>
         </button>
+
+        <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--fill spectrum-Button--staticBlack spectrum-Button--iconOnly" disabled>
+          <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Edit">
+            <use xlink:href="#spectrum-icon-18-Edit" />
+          </svg>
+        </button>
       </div>
 
   - id: button-staticcolor
@@ -224,6 +290,12 @@ examples:
             <use xlink:href="#spectrum-icon-18-Edit" />
           </svg>
           <span class="spectrum-Button-label">Edit</span>
+        </button>
+
+        <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--fill spectrum-Button--staticBlack spectrum-Button--secondary spectrum-Button--iconOnly">
+          <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Edit">
+            <use xlink:href="#spectrum-icon-18-Edit" />
+          </svg>
         </button>
       </div>
 
@@ -245,6 +317,12 @@ examples:
               </svg>
               <span class="spectrum-Button-label">Edit</span>
             </button>
+
+            <button class="spectrum-Button spectrum-Button--outline spectrum-Button--staticWhite spectrum-Button--sizeS spectrum-Button--iconOnly">
+              <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
           </div>
           <div class="spectrum-Examples-item">
             <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">M (default)</h4>
@@ -258,6 +336,12 @@ examples:
                 <use xlink:href="#spectrum-icon-18-Edit" />
               </svg>
               <span class="spectrum-Button-label">Edit</span>
+            </button>
+
+            <button class="spectrum-Button spectrum-Button--outline spectrum-Button--staticWhite spectrum-Button--sizeM spectrum-Button--iconOnly">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
             </button>
           </div>
 
@@ -274,6 +358,12 @@ examples:
               </svg>
               <span class="spectrum-Button-label">Edit</span>
             </button>
+
+            <button class="spectrum-Button spectrum-Button--outline spectrum-Button--staticWhite spectrum-Button--sizeL spectrum-Button--iconOnly">
+              <svg class="spectrum-Icon spectrum-Icon--sizeL" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
           </div>
 
           <div class="spectrum-Examples-item">
@@ -288,6 +378,12 @@ examples:
                 <use xlink:href="#spectrum-icon-18-Edit" />
               </svg>
               <span class="spectrum-Button-label">Edit</span>
+            </button>
+
+            <button class="spectrum-Button spectrum-Button--outline spectrum-Button--staticWhite spectrum-Button--sizeXL spectrum-Button--iconOnly">
+              <svg class="spectrum-Icon spectrum-Icon--sizeXL" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
             </button>
           </div>
         </div>
@@ -307,6 +403,12 @@ examples:
           </svg>
           <span class="spectrum-Button-label">Edit</span>
         </button>
+
+        <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--outline spectrum-Button--staticWhite spectrum-Button--iconOnly" disabled>
+          <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Edit">
+            <use xlink:href="#spectrum-icon-18-Edit" />
+          </svg>
+        </button>
       </div>
 
   - id: button-staticcolor
@@ -322,6 +424,12 @@ examples:
             <use xlink:href="#spectrum-icon-18-Edit" />
           </svg>
           <span class="spectrum-Button-label">Edit</span>
+        </button>
+
+        <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--outline spectrum-Button--staticWhite spectrum-Button--secondary spectrum-Button--iconOnly">
+          <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Edit">
+            <use xlink:href="#spectrum-icon-18-Edit" />
+          </svg>
         </button>
       </div>
 
@@ -343,6 +451,12 @@ examples:
               </svg>
               <span class="spectrum-Button-label">Edit</span>
             </button>
+
+            <button class="spectrum-Button spectrum-Button--outline spectrum-Button--staticBlack spectrum-Button--sizeS spectrum-Button--iconOnly">
+              <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
           </div>
           <div class="spectrum-Examples-item">
             <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">M (default)</h4>
@@ -356,6 +470,12 @@ examples:
                 <use xlink:href="#spectrum-icon-18-Edit" />
               </svg>
               <span class="spectrum-Button-label">Edit</span>
+            </button>
+
+            <button class="spectrum-Button spectrum-Button--outline spectrum-Button--staticBlack spectrum-Button--sizeM spectrum-Button--iconOnly">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
             </button>
           </div>
 
@@ -372,6 +492,12 @@ examples:
               </svg>
               <span class="spectrum-Button-label">Edit</span>
             </button>
+
+            <button class="spectrum-Button spectrum-Button--outline spectrum-Button--staticBlack spectrum-Button--sizeL spectrum-Button--iconOnly">
+              <svg class="spectrum-Icon spectrum-Icon--sizeL" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+            </button>
           </div>
 
           <div class="spectrum-Examples-item">
@@ -386,6 +512,12 @@ examples:
                 <use xlink:href="#spectrum-icon-18-Edit" />
               </svg>
               <span class="spectrum-Button-label">Edit</span>
+            </button>
+
+            <button class="spectrum-Button spectrum-Button--outline spectrum-Button--staticBlack spectrum-Button--sizeXL spectrum-Button--iconOnly">
+              <svg class="spectrum-Icon spectrum-Icon--sizeXL" focusable="false" aria-hidden="true" aria-label="Edit">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
             </button>
           </div>
         </div>
@@ -405,6 +537,12 @@ examples:
           </svg>
           <span class="spectrum-Button-label">Edit</span>
         </button>
+
+        <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--outline spectrum-Button--staticBlack spectrum-Button--iconOnly" disabled>
+          <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Edit">
+            <use xlink:href="#spectrum-icon-18-Edit" />
+          </svg>
+        </button>
       </div>
 
   - id: button-staticcolor
@@ -420,5 +558,11 @@ examples:
             <use xlink:href="#spectrum-icon-18-Edit" />
           </svg>
           <span class="spectrum-Button-label">Edit</span>
+        </button>
+
+        <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--outline spectrum-Button--staticBlack spectrum-Button--secondary spectrum-Button--iconOnly">
+          <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="Edit">
+            <use xlink:href="#spectrum-icon-18-Edit" />
+          </svg>
         </button>
       </div>

--- a/components/button/metadata/mods.md
+++ b/components/button/metadata/mods.md
@@ -5,11 +5,12 @@
 |`--mod-button-font-size`|
 |`--mod-bold-font-weight`|
 |`--mod-button-padding-label-to-icon`|
-|`--mod-button-height`|
 |`--mod-button-min-width`|
+|`--mod-button-height`|
 |`--mod-button-edge-to-text`|
 |`--mod-button-edge-to-visual`|
 |`--mod-focus-indicator-gap`|
+|`--mod-button-edge-to-visual-only`|
 |`--mod-button-padding-label-top`|
 |`--mod-button-padding-label-bottom`|
 |`--mod-button-focus-ring-thickness`|

--- a/components/button/stories/button.stories.js
+++ b/components/button/stories/button.stories.js
@@ -34,15 +34,8 @@ export default {
       if: false,
     },
     hideLabel: {
-      name: "Hide label",
-      type: { name: "boolean" },
       table: {
-        type: { summary: "boolean" },
-        category: "Component",
-      },
-      control: {
-        type: "boolean",
-        if: { arg: 'icon', truthy: true }
+        disable: true
       },
     },
     variant: {
@@ -83,16 +76,7 @@ export default {
       },
       options: ["white", "black"],
       control: "select",
-    },
-    justified: {
-      name: "Justified",
-      type: { name: "boolean" },
-      table: {
-        type: { summary: "boolean" },
-        category: "Advanced",
-      },
-      control: "boolean",
-    },
+    }
   },
   args: {
     rootClass: "spectrum-Button",
@@ -114,19 +98,35 @@ export default {
   },
 };
 
-export const Default = Template.bind({});
-Default.args = {};
-
-export const IconOnly = Template.bind({});
-IconOnly.args = {
-  hideLabel: true,
-  iconName: "Edit",
+export const Accent = Template.bind({});
+Accent.args = {
+  variant: "accent"
 };
 
-export const OutlineWithIcon = Template.bind({});
-OutlineWithIcon.args = {
-  treatment: "outline",
-  iconName: "Edit",
+export const Negative = Template.bind({});
+Negative.args = {
+  variant: "negative",
+  iconName: "Delete"
+};
+
+export const Primary = Template.bind({});
+Primary.args = {
+  variant: "primary"
+};
+
+export const Secondary = Template.bind({});
+Secondary.args = {
+  variant: "secondary"
+};
+
+export const StaticColorWhite = Template.bind({});
+StaticColorWhite.args = {
+  staticColor: "white"
+};
+
+export const StaticColorBlack = Template.bind({});
+StaticColorBlack.args = {
+  staticColor: "black"
 };
 
 export const Disabled = Template.bind({});

--- a/components/button/stories/button.stories.js
+++ b/components/button/stories/button.stories.js
@@ -1,6 +1,7 @@
+import { html } from "lit-html";
+
 // Import the component markup template
 import { Template } from "./template";
-
 
 import { default as IconStories } from "@spectrum-css/icon/stories/icon.stories.js";
 
@@ -98,38 +99,59 @@ export default {
   },
 };
 
-export const Accent = Template.bind({});
+const CustomButton = (args) => {
+  return (
+    html`<div>
+      ${Template(args)}
+      ${Template({
+        ...args,
+        treatment: 'outline'
+      })}
+      ${Template({
+        ...args,
+        iconName: args.iconName ?? 'Edit'
+      })}
+      ${Template({
+        ...args,
+        hideLabel: true,
+        iconName: args.iconName ?? 'Edit'
+      })}
+    </div>`
+  )
+}
+
+export const Accent = CustomButton.bind({});
 Accent.args = {
   variant: "accent"
 };
 
-export const Negative = Template.bind({});
+export const Negative = CustomButton.bind({});
 Negative.args = {
   variant: "negative",
   iconName: "Delete"
 };
 
-export const Primary = Template.bind({});
+export const Primary = CustomButton.bind({});
 Primary.args = {
   variant: "primary"
 };
 
-export const Secondary = Template.bind({});
+export const Secondary = CustomButton.bind({});
 Secondary.args = {
   variant: "secondary"
 };
 
-export const StaticColorWhite = Template.bind({});
+export const StaticColorWhite = CustomButton.bind({});
 StaticColorWhite.args = {
   staticColor: "white"
 };
 
-export const StaticColorBlack = Template.bind({});
+export const StaticColorBlack = CustomButton.bind({});
 StaticColorBlack.args = {
   staticColor: "black"
 };
 
-export const Disabled = Template.bind({});
+export const Disabled = CustomButton.bind({});
 Disabled.args = {
   isDisabled: true,
   iconName: "Actions",

--- a/components/button/stories/button.stories.js
+++ b/components/button/stories/button.stories.js
@@ -117,15 +117,20 @@ export default {
 export const Default = Template.bind({});
 Default.args = {};
 
+export const IconOnly = Template.bind({});
+IconOnly.args = {
+  hideLabel: true,
+  iconName: "Edit",
+};
+
 export const OutlineWithIcon = Template.bind({});
 OutlineWithIcon.args = {
   treatment: "outline",
   iconName: "Edit",
 };
 
-export const DisabledIconOnly = Template.bind({});
-DisabledIconOnly.args = {
-  hideLabel: true,
+export const Disabled = Template.bind({});
+Disabled.args = {
   isDisabled: true,
   iconName: "Actions",
 };

--- a/components/button/stories/template.js
+++ b/components/button/stories/template.js
@@ -16,7 +16,7 @@ export const Template = ({
   size = "m",
   label,
   hideLabel = false,
-  iconName,
+  iconName = "Edit",
   variant,
   staticColor,
   treatment,
@@ -40,7 +40,38 @@ export const Template = ({
         [`${rootClass}--size${size?.toUpperCase()}`]: typeof size !== "undefined",
         [`${rootClass}--${variant}`]: typeof variant !== "undefined",
         [`${rootClass}--${treatment}`]: typeof treatment !== "undefined",
-        [`${rootClass}--iconOnly`]: hideLabel,
+        [`${rootClass}--static${capitalize(lowerCase(staticColor))}`]: typeof staticColor !== "undefined",
+        ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
+      })}
+      id=${ifDefined(id)}
+      ?disabled=${isDisabled}>
+      ${when(label && !hideLabel,
+        () => html`<span class=${`${rootClass}-label`}>${label}</span>`
+      )}
+    </button>
+    <button
+      class=${classMap({
+        [rootClass]: true,
+        "is-open": isOpen,
+        [`${rootClass}--outline`]: true,
+        [`${rootClass}--size${size?.toUpperCase()}`]: typeof size !== "undefined",
+        [`${rootClass}--${variant}`]: typeof variant !== "undefined",
+        [`${rootClass}--static${capitalize(lowerCase(staticColor))}`]: typeof staticColor !== "undefined",
+        ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
+      })}
+      id=${ifDefined(id)}
+      ?disabled=${isDisabled}>
+      ${when(label && !hideLabel,
+        () => html`<span class=${`${rootClass}-label`}>${label}</span>`
+      )}
+    </button>
+    <button
+      class=${classMap({
+        [rootClass]: true,
+        "is-open": isOpen,
+        [`${rootClass}--size${size?.toUpperCase()}`]: typeof size !== "undefined",
+        [`${rootClass}--${variant}`]: typeof variant !== "undefined",
+        [`${rootClass}--${treatment}`]: typeof treatment !== "undefined",
         [`${rootClass}--static${capitalize(lowerCase(staticColor))}`]: typeof staticColor !== "undefined",
         ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
       })}
@@ -50,6 +81,21 @@ export const Template = ({
       ${when(label && !hideLabel,
         () => html`<span class=${`${rootClass}-label`}>${label}</span>`
       )}
+    </button>
+    <button
+      class=${classMap({
+        [rootClass]: true,
+        "is-open": isOpen,
+        [`${rootClass}--iconOnly`]: true,
+        [`${rootClass}--size${size?.toUpperCase()}`]: typeof size !== "undefined",
+        [`${rootClass}--${variant}`]: typeof variant !== "undefined",
+        [`${rootClass}--${treatment}`]: typeof treatment !== "undefined",
+        [`${rootClass}--static${capitalize(lowerCase(staticColor))}`]: typeof staticColor !== "undefined",
+        ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
+      })}
+      id=${ifDefined(id)}
+      ?disabled=${isDisabled}>
+      ${when(iconName, () => Icon({ ...globals, iconName, customClasses: [`${rootClass}-UIIcon`] }))}
     </button>
   `;
 };

--- a/components/button/stories/template.js
+++ b/components/button/stories/template.js
@@ -41,38 +41,7 @@ export const Template = ({
         [`${rootClass}--${variant}`]: typeof variant !== "undefined",
         [`${rootClass}--${treatment}`]: typeof treatment !== "undefined",
         [`${rootClass}--static${capitalize(lowerCase(staticColor))}`]: typeof staticColor !== "undefined",
-        ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
-      })}
-      id=${ifDefined(id)}
-      ?disabled=${isDisabled}>
-      ${when(label && !hideLabel,
-        () => html`<span class=${`${rootClass}-label`}>${label}</span>`
-      )}
-    </button>
-    <button
-      class=${classMap({
-        [rootClass]: true,
-        "is-open": isOpen,
-        [`${rootClass}--outline`]: true,
-        [`${rootClass}--size${size?.toUpperCase()}`]: typeof size !== "undefined",
-        [`${rootClass}--${variant}`]: typeof variant !== "undefined",
-        [`${rootClass}--static${capitalize(lowerCase(staticColor))}`]: typeof staticColor !== "undefined",
-        ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
-      })}
-      id=${ifDefined(id)}
-      ?disabled=${isDisabled}>
-      ${when(label && !hideLabel,
-        () => html`<span class=${`${rootClass}-label`}>${label}</span>`
-      )}
-    </button>
-    <button
-      class=${classMap({
-        [rootClass]: true,
-        "is-open": isOpen,
-        [`${rootClass}--size${size?.toUpperCase()}`]: typeof size !== "undefined",
-        [`${rootClass}--${variant}`]: typeof variant !== "undefined",
-        [`${rootClass}--${treatment}`]: typeof treatment !== "undefined",
-        [`${rootClass}--static${capitalize(lowerCase(staticColor))}`]: typeof staticColor !== "undefined",
+        [`${rootClass}--iconOnly`]: hideLabel,
         ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
       })}
       id=${ifDefined(id)}
@@ -81,21 +50,6 @@ export const Template = ({
       ${when(label && !hideLabel,
         () => html`<span class=${`${rootClass}-label`}>${label}</span>`
       )}
-    </button>
-    <button
-      class=${classMap({
-        [rootClass]: true,
-        "is-open": isOpen,
-        [`${rootClass}--iconOnly`]: true,
-        [`${rootClass}--size${size?.toUpperCase()}`]: typeof size !== "undefined",
-        [`${rootClass}--${variant}`]: typeof variant !== "undefined",
-        [`${rootClass}--${treatment}`]: typeof treatment !== "undefined",
-        [`${rootClass}--static${capitalize(lowerCase(staticColor))}`]: typeof staticColor !== "undefined",
-        ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
-      })}
-      id=${ifDefined(id)}
-      ?disabled=${isDisabled}>
-      ${when(iconName, () => Icon({ ...globals, iconName, customClasses: [`${rootClass}-UIIcon`] }))}
     </button>
   `;
 };

--- a/components/button/stories/template.js
+++ b/components/button/stories/template.js
@@ -40,6 +40,7 @@ export const Template = ({
         [`${rootClass}--size${size?.toUpperCase()}`]: typeof size !== "undefined",
         [`${rootClass}--${variant}`]: typeof variant !== "undefined",
         [`${rootClass}--${treatment}`]: typeof treatment !== "undefined",
+        [`${rootClass}--hideLabel`]: hideLabel,
         [`${rootClass}--static${capitalize(lowerCase(staticColor))}`]: typeof staticColor !== "undefined",
         ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
       })}

--- a/components/button/stories/template.js
+++ b/components/button/stories/template.js
@@ -40,7 +40,7 @@ export const Template = ({
         [`${rootClass}--size${size?.toUpperCase()}`]: typeof size !== "undefined",
         [`${rootClass}--${variant}`]: typeof variant !== "undefined",
         [`${rootClass}--${treatment}`]: typeof treatment !== "undefined",
-        [`${rootClass}--hideLabel`]: hideLabel,
+        [`${rootClass}--iconOnly`]: hideLabel,
         [`${rootClass}--static${capitalize(lowerCase(staticColor))}`]: typeof staticColor !== "undefined",
         ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
       })}


### PR DESCRIPTION
## Description

This adds styling for an icon-only variation of Button that results in a circular button and updates the docs to include it.

This PR also removes an unneeded control from Storybook `justified` and fleshes out the stories more to help make VRTs more robust.


## How and where has this been tested?
 - Safari Version 16.4
 - Chrome Version 111.0.5563.146


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] I have tested these changes in Windows High Contrast mode.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
