### PR TITLE
fix(preview): storybook precompilation task

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "release": "lerna publish",
     "release:beta-from-package": "yarn release from-package --conventional-prerelease --preid beta --pre-dist-tag beta --no-private",
     "release:site": "gulp prepareSite && gh-pages -d dist-site/ -f -e .",
+    "prestart": "lerna run --scope \"${SCOPE:-@spectrum-css/*}\" --ignore \"@spectrum-css/{*-builder*,preview,generator}\" build",
     "start": "NODE_ENV=development yarn workspace @spectrum-css/preview start",
     "test": "yarn workspace @spectrum-css/preview test",
     "test:scope": "yarn workspace @spectrum-css/preview test:scope",

--- a/tools/preview/package.json
+++ b/tools/preview/package.json
@@ -9,8 +9,8 @@
   "scripts": {
     "build": "yarn storybook",
     "new": "yarn workspace @spectrum-css/generator new story",
-    "start": "WATCH_MODE=true start-storybook --config-dir .",
-    "storybook": "build-storybook --config-dir .",
+    "start": "WATCH_MODE=true start-storybook --quiet --config-dir .",
+    "storybook": "build-storybook --quiet --config-dir .",
     "test": "chromatic --build-script-name build --junit-report",
     "test:scope": "yarn test --only-story-names"
   },


### PR DESCRIPTION

## Description

Fix the storybook compilation task to pre-build assets


## How and where has this been tested?
 - [x] `yarn start`


## To-do list
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] This pull request is ready to merge.
