### PR TITLE
Ensure that all metadata/*.js assets are being loaded on the site into a bundle

### DIFF
--- a/tools/documentation/_data/component.js
+++ b/tools/documentation/_data/component.js
@@ -100,6 +100,14 @@ module.exports = async (configData) => {
       renderer = await readFile(renderTemplatePath, "utf8").catch(console.warn);
     }
 
+    /** This loop will extract all the contents of js files under metadata folder in each component */
+    let renderScripts = '';
+    for await (const file of fg.stream('metadata/*.js', { cwd: path, onlyFiles: true, absolute: true })) {
+        if (existsSync(file)) {
+            const data = await readFile(file, "utf8").catch(console.warn);
+            renderScripts += data + '\n'; // Append the contents with a newline
+        }
+    }
     /** This loop determines how many pages are published to the site */
     for await (const file of fg.stream('metadata/*.yml', { cwd: path, onlyFiles: true, absolute: true })) {
       const fileName = basename(file, '.yml');
@@ -120,6 +128,7 @@ module.exports = async (configData) => {
         releaseDate: await getReleaseDate(packageName, version),
         ...metadata,
         renderer,
+        renderScripts,
         eleventyNavigation: {
           title: metadata.title,
           key: metadata.name,

--- a/tools/documentation/_includes/meta-info.njk
+++ b/tools/documentation/_includes/meta-info.njk
@@ -63,7 +63,6 @@
 <script src="/docs/js/Search.js"></script>
 <script src="/docs/js/site.js"></script>
 <script src="/docs/js/docs.js"></script>
-<script src="/docs/js/enhancement.js"></script>
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@mdi/font@6.5.95/css/materialdesignicons.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/Primer/19.1.1/tooltips.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />

--- a/tools/documentation/_layouts/pages.njk
+++ b/tools/documentation/_layouts/pages.njk
@@ -29,3 +29,4 @@ layout: layout.njk
     </div>
 </div>
 <div class="spectrum-Underlay" id="spectrum-underlay"></div>
+<script>{{ component.renderScripts | safe }}</script>


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
Added a loop on metadata/*.js and read all the js files and stored it in a variables which is parsed out in pages.njk


## How and where has this been tested?
 After running 
``` yarn dev:docs ```

The following script tags are embedded in Accordion component's index.html

<img width="765" alt="Screenshot 2023-04-12 at 8 43 46 PM" src="https://user-images.githubusercontent.com/8790510/231503855-de0950e3-e666-4206-9a90-55b18dd807b8.png">



## Screenshots
<img width="765" alt="Screenshot 2023-04-12 at 8 43 46 PM" src="https://user-images.githubusercontent.com/8790510/231503935-0f6a6b1b-6fd6-4fe1-a49a-d968eb6a12cb.png">

