### PR TITLE
chore: Validate pathing to the component pages looks right and is loading from navigation with a single click

### DIFF
--- a/tools/documentation/_includes/example.njk
+++ b/tools/documentation/_includes/example.njk
@@ -2,9 +2,9 @@
   {% if example.name != component.name %}
     <h3 id="{{ example.name | slugify }}" class="spectrum-CSSExample-heading spectrum-Heading spectrum-Heading--sizeS">
       <a href="#{{ example.name | slugify }}" class="spectrum-CSSComponent-link">{{example.name}}</a>
-      {% if example.status -%}
-        <span class="spectrum-StatusLight spectrum-StatusLight--sizeM spectrum-CSSExample-status spectrum-StatusLight--{{ example.status | statusLightVariant }}">
-          {{ example.status }}
+      {% if component.status -%}
+        <span class="spectrum-StatusLight spectrum-StatusLight--sizeM spectrum-CSSExample-status spectrum-StatusLight--{{ component.status | statusLightVariant }}">
+          {{ component.status }}
         </span>
       {%- endif %}
     </h3>

--- a/tools/documentation/_includes/example.njk
+++ b/tools/documentation/_includes/example.njk
@@ -2,9 +2,9 @@
   {% if example.name != component.name %}
     <h3 id="{{ example.name | slugify }}" class="spectrum-CSSExample-heading spectrum-Heading spectrum-Heading--sizeS">
       <a href="#{{ example.name | slugify }}" class="spectrum-CSSComponent-link">{{example.name}}</a>
-      {% if component.status -%}
-        <span class="spectrum-StatusLight spectrum-StatusLight--sizeM spectrum-CSSExample-status spectrum-StatusLight--{{ component.status | statusLightVariant }}">
-          {{ component.status }}
+      {% if example.status -%}
+        <span class="spectrum-StatusLight spectrum-StatusLight--sizeM spectrum-CSSExample-status spectrum-StatusLight--{{ example.status | statusLightVariant }}">
+          {{ example.status }}
         </span>
       {%- endif %}
     </h3>

--- a/tools/documentation/_includes/link-cards.njk
+++ b/tools/documentation/_includes/link-cards.njk
@@ -1,6 +1,6 @@
 <a class="spectrum-Card spectrum-Card--sizeS spectrum-Card--horizontal" href="{{ card.href }}">
     <div class="spectrum-Card-preview spectrum-CSSComponent-resource--{{ card.type | slugify }}">
-        {{ card.logo }}
+        {{ card.svg | safe }}
     </div>
     <div class="spectrum-Card-body">
         <div class="spectrum-Card-header">

--- a/tools/documentation/_includes/sidenav.njk
+++ b/tools/documentation/_includes/sidenav.njk
@@ -1,6 +1,6 @@
 {% macro renderNavListItem(entry) -%}
-  <li class="spectrum-SideNav-item">
-    <a href="{{ entry.url }}" class="spectrum-SideNav-itemLink {{ 'is-selected' if entry.url == page.url }}">{{ entry.title }}</a>
+  <li class="spectrum-SideNav-item {{ 'is-selected' if entry.url == page.url }}">
+    <a href="{{ entry.url }}" class="spectrum-SideNav-itemLink">{{ entry.title }}</a>
     {%- if entry.children.length -%}
     <ul class="spectrum-SideNav spectrum-SideNav--multiLevel">
         {%- for child in entry.children %}{{ renderNavListItem(child) }}{% endfor -%}

--- a/tools/documentation/_layouts/pages.njk
+++ b/tools/documentation/_layouts/pages.njk
@@ -15,9 +15,7 @@ layout: layout.njk
         {% include "sidenav.njk" %}
         <div class="spectrum-Site-mainContent">
             <div class="spectrum-Site-mainContainer">
-                <div class="spectrum-Site-page spectrum-Typography">
-                    {{ content | safe }}
-                </div>
+                {{ content | safe }}
             </div>
             {% if not process.env.VRT -%}
                 <div class="spectrum-Site-footerContainer">

--- a/tools/documentation/_layouts/pages.njk
+++ b/tools/documentation/_layouts/pages.njk
@@ -15,7 +15,9 @@ layout: layout.njk
         {% include "sidenav.njk" %}
         <div class="spectrum-Site-mainContent">
             <div class="spectrum-Site-mainContainer">
-                {{ content | safe }}
+                <div class="spectrum-Site-page">
+                    {{ content | safe }}
+                </div>
             </div>
             {% if not process.env.VRT -%}
                 <div class="spectrum-Site-footerContainer">

--- a/tools/documentation/assets/js/Search.js
+++ b/tools/documentation/assets/js/Search.js
@@ -123,13 +123,13 @@ function loadJSON(url, callback) {
 }
 
 Search.prototype.loadStore = function() {
-  loadJSON('../store.json', function(err, object) {
+  loadJSON('./store.json', function(err, object) {
     this.store = object;
   }.bind(this));
 }
 
 Search.prototype.loadIndex = function() {
-  loadJSON('../index.json', function(err, object) {
+  loadJSON('./index.json', function(err, object) {
     this.index = lunr.Index.load(object);
   }.bind(this));
 }

--- a/tools/documentation/assets/js/docs.js
+++ b/tools/documentation/assets/js/docs.js
@@ -15,7 +15,7 @@ governing permissions and limitations under the License.
 'use strict';
 
 loadIcons('../../components/icon/spectrum-css-icons.svg');
-loadIcons('img/spectrum-icons.svg');
+loadIcons('../img/spectrum-icons.svg');
 
 // Show and hide code samples
 function toggleMarkupVisibility(event) {

--- a/tools/documentation/assets/js/docs.js
+++ b/tools/documentation/assets/js/docs.js
@@ -14,7 +14,7 @@ governing permissions and limitations under the License.
 
 'use strict';
 
-loadIcons('../components/icon/spectrum-css-icons.svg');
+loadIcons('../../components/icon/spectrum-css-icons.svg');
 loadIcons('img/spectrum-icons.svg');
 
 // Show and hide code samples

--- a/tools/documentation/content/components.njk
+++ b/tools/documentation/content/components.njk
@@ -22,26 +22,26 @@ eleventyComputed:
             <a href="#{{ component.name | slugify }}" class="spectrum-BigSubtleLink">{% if component.title %}{{ component.title }}{% else %}{{ component.name }}{% endif %}</a>
         </h1>
     </header>
-    <table class="spectrum-Table spectrum-Table--sizeM spectrum-Table--quiet">
+    <table class="spectrum-CSSComponent-detailsTable">
         <tbody>
         {% if component.status -%}
-            <tr class="spectrum-Table-row">
-                <th class="spectrum-Table-headCell">Component status</th>
-                <td class="spectrum-Table-cell">
+            <tr>
+                <th class="spectrum-Body--secondary">Component status</th>
+                <td >
                     <span class="spectrum-StatusLight spectrum-StatusLight--sizeM spectrum-StatusLight--{{ component.status | statusLightVariant }}">{{ component.status }}</span>
                 </td>
             </tr>
         {%- endif %}
         {% if component.releaseDate -%}
-            <tr class="spectrum-Table-row">
-                <th class="spectrum-Table-headCell">Last released</th>
-                <td class="spectrum-Table-cell">{{ component.releaseDate }}</td>
+            <tr>
+                <th class="spectrum-Body--secondary">Last released</th>
+                <td >{{ component.releaseDate }}</td>
             </tr>
         {%- endif %}
         {% if component.version -%}
-            <tr class="spectrum-Table-row">
-                <th class="spectrum-Table-headCell">Current version</th>
-                <td class="spectrum-Table-cell"><bdo dir="ltr">{{ component.packageName }}@{{ component.version }}</bdo></td>
+            <tr>
+                <th class="spectrum-Body--secondary">Current version</th>
+                <td><bdo dir="ltr">{{ component.packageName }}@{{ component.version }}</bdo></td>
             </tr>
         {%- endif %}
         </tbody>
@@ -58,9 +58,9 @@ eleventyComputed:
         </tfoot>
     </table>
     <div class="spectrum-CSSComponent-resources">
-        {% set card = { type: 'GitHub', cta: 'View repository', href: 'https://github.com/adobe/spectrum-css/tree/main/components/{{ component.name }}', svg: '<svg class="spectrum-Icon spectrum-Icon--sizeXXL" focusable="false" aria-hidden="true" aria-label="GitHub" viewBox="0 0 36 36"><path d="M17.988 2a16.291 16.291 0 0 0-5.147 31.747c.814.149 1.111-.354 1.111-.786 0-.386-.014-1.411-.022-2.77-4.531.984-5.487-2.184-5.487-2.184a4.32 4.32 0 0 0-1.809-2.383c-1.479-1.01.112-.99.112-.99a3.42 3.42 0 0 1 2.495 1.679 3.468 3.468 0 0 0 4.741 1.353 3.482 3.482 0 0 1 1.034-2.177C11.4 25.078 7.6 23.68 7.6 17.438a6.3 6.3 0 0 1 1.677-4.371 5.863 5.863 0 0 1 .16-4.311s1.368-.438 4.479 1.67a15.451 15.451 0 0 1 8.157 0c3.109-2.108 4.475-1.67 4.475-1.67a5.857 5.857 0 0 1 .162 4.311 6.286 6.286 0 0 1 1.674 4.371c0 6.258-3.808 7.635-7.437 8.038a3.888 3.888 0 0 1 1.106 3.017c0 2.177-.02 3.934-.02 4.468 0 .436.293.943 1.12.784A16.292 16.292 0 0 0 17.988 2z"></path></svg>' } %}
+        {% set card = { type: 'GitHub', cta: 'View repository', href: "https://github.com/adobe/spectrum-css/tree/main/components/{{ component.name }}", svg: '<svg class="spectrum-Icon spectrum-Icon--sizeXXL" focusable="false" aria-hidden="true" aria-label="GitHub" viewBox="0 0 36 36"><path d="M17.988 2a16.291 16.291 0 0 0-5.147 31.747c.814.149 1.111-.354 1.111-.786 0-.386-.014-1.411-.022-2.77-4.531.984-5.487-2.184-5.487-2.184a4.32 4.32 0 0 0-1.809-2.383c-1.479-1.01.112-.99.112-.99a3.42 3.42 0 0 1 2.495 1.679 3.468 3.468 0 0 0 4.741 1.353 3.482 3.482 0 0 1 1.034-2.177C11.4 25.078 7.6 23.68 7.6 17.438a6.3 6.3 0 0 1 1.677-4.371 5.863 5.863 0 0 1 .16-4.311s1.368-.438 4.479 1.67a15.451 15.451 0 0 1 8.157 0c3.109-2.108 4.475-1.67 4.475-1.67a5.857 5.857 0 0 1 .162 4.311 6.286 6.286 0 0 1 1.674 4.371c0 6.258-3.808 7.635-7.437 8.038a3.888 3.888 0 0 1 1.106 3.017c0 2.177-.02 3.934-.02 4.468 0 .436.293.943 1.12.784A16.292 16.292 0 0 0 17.988 2z"></path></svg>' } %}
         {% include 'link-cards.njk' %}
-        {% set card = { type: 'npm', cta: 'View package', href: 'https://www.npmjs.com/package/@spectrum-css/{{ component.name }}', svg: '<svg class="spectrum-Icon spectrum-Icon--sizeXXL" viewBox="0 0 18 7" focusable="false" aria-hidden="true" aria-label="npm"><path fill="#CB3837" d="M0,0h18v6H9v1H5V6H0V0z M1,5h2V2h1v3h1V1H1V5z M6,1v5h2V5h2V1H6z M8,2h1v2H8V2z M11,1v4h2V2h1v3h1V2h1v3h1V1H11z"></path><polygon fill="#FFFFFF" points="1,5 3,5 3,2 4,2 4,5 5,5 5,1 1,1 "></polygon><path fill="#FFFFFF" d="M6,1v5h2V5h2V1H6z M9,4H8V2h1V4z"></path><polygon fill="#FFFFFF" points="11,1 11,5 13,5 13,2 14,2 14,5 15,5 15,2 16,2 16,5 17,5 17,1 "></polygon></svg>' } %}
+        {% set card = { type: 'npm', cta: 'View package', href: "https://www.npmjs.com/package/@spectrum-css/{{ component.name }}", svg: '<svg class="spectrum-Icon spectrum-Icon--sizeXXL" viewBox="0 0 18 7" focusable="false" aria-hidden="true" aria-label="npm"><path fill="#CB3837" d="M0,0h18v6H9v1H5V6H0V0z M1,5h2V2h1v3h1V1H1V5z M6,1v5h2V5h2V1H6z M8,2h1v2H8V2z M11,1v4h2V2h1v3h1V2h1v3h1V1H11z"></path><polygon fill="#FFFFFF" points="1,5 3,5 3,2 4,2 4,5 5,5 5,1 1,1 "></polygon><path fill="#FFFFFF" d="M6,1v5h2V5h2V1H6z M9,4H8V2h1V4z"></path><polygon fill="#FFFFFF" points="11,1 11,5 13,5 13,2 14,2 14,5 15,5 15,2 16,2 16,5 17,5 17,1 "></polygon></svg>' } %}
         {% include 'link-cards.njk' %}
     </div>
     {% if component.description -%}

--- a/tools/documentation/content/components.njk
+++ b/tools/documentation/content/components.njk
@@ -15,33 +15,33 @@ eleventyComputed:
     parent: "Components"
 ---
 
-<article class="spectrum-CSSComponent">
+<article>
     {% include "context-switcher.njk" %}
     <header id="{{ component.name | slugify }}" class="spectrum-CSSComponent-heading">
         <h1 class="spectrum-CSSComponent-title spectrum-Heading spectrum-Heading--sizeXXXL spectrum-Heading--serif">
             <a href="#{{ component.name | slugify }}" class="spectrum-BigSubtleLink">{% if component.title %}{{ component.title }}{% else %}{{ component.name }}{% endif %}</a>
         </h1>
     </header>
-    <table class="spectrum-CSSComponent-detailsTable">
+    <table class="spectrum-Table spectrum-Table--sizeM spectrum-Table--quiet">
         <tbody>
         {% if component.status -%}
-            <tr>
-                <th class="spectrum-Body--secondary">Component status</th>
-                <td >
+            <tr class="spectrum-Table-row">
+                <th class="spectrum-Table-headCell">Component status</th>
+                <td class="spectrum-Table-cell">
                     <span class="spectrum-StatusLight spectrum-StatusLight--sizeM spectrum-StatusLight--{{ component.status | statusLightVariant }}">{{ component.status }}</span>
                 </td>
             </tr>
         {%- endif %}
         {% if component.releaseDate -%}
-            <tr>
-                <th class="spectrum-Body--secondary">Last released</th>
-                <td >{{ component.releaseDate }}</td>
+            <tr class="spectrum-Table-row">
+                <th class="spectrum-Table-headCell">Last released</th>
+                <td class="spectrum-Table-cell">{{ component.releaseDate }}</td>
             </tr>
         {%- endif %}
         {% if component.version -%}
-            <tr>
-                <th class="spectrum-Body--secondary">Current version</th>
-                <td><bdo dir="ltr">{{ component.packageName }}@{{ component.version }}</bdo></td>
+            <tr class="spectrum-Table-row">
+                <th class="spectrum-Table-headCell">Current version</th>
+                <td class="spectrum-Table-cell"><bdo dir="ltr">{{ component.packageName }}@{{ component.version }}</bdo></td>
             </tr>
         {%- endif %}
         </tbody>

--- a/tools/documentation/content/index.njk
+++ b/tools/documentation/content/index.njk
@@ -3,46 +3,47 @@ layout: pages.njk
 permalink: /docs/index.html
 eleventyExcludeFromCollections: true
 ---
-
-<div class="spectrum-Site-hero">
-    <div class="spectrum-Site-heroHeading">
-        <h1 class="spectrum-Heading spectrum-Heading--sizeXXXL spectrum-Heading--serif">Spectrum CSS</h1>
-    </div>
-    <p class="spectrum-Body spectrum-Body--sizeXL">Spectrum CSS is an open-source implementation of Spectrum, Adobe's design system. It includes components and resources to make applications more cohesive.</p>
-    <img alt="Spectrum CSS Hero image" src="img/spectrum-css_illustration_desktop@2x.png?w=976&amp;h=446" srcset="img/spectrum-css_illustration_desktop@2x.png 2x" class="spectrum-Site-heroImage"/>
-    <div class="spectrum-HomeCards">
-        <div class="spectrum-HomeCard">
-            <img class="spectrum-HomeCard-image" src="img/illustration_documentation.svg" alt="Documentation illustation"/>
-            <div class="spectrum-HomeCard-content">
-                <h4 class="spectrum-Heading spectrum-Heading--sizeS">Robust documentation</h4>
-                <p class="spectrum-Body spectrum-Body--sizeM">Spectrum CSS is designed to be used in partnership with Spectrum's detailed usage guidelines.</p>
-                <p class="spectrum-Body spectrum-Body--sizeM">
-                    <a class="spectrum-Link spectrum-Link--quiet" href="https://spectrum.adobe.com/" target="_blank">View Spectrum guidelines</a>
-                </p>
-            </div>
+<div class="spectrum-Site-page spectrum-Typography">
+    <div class="spectrum-Site-hero">
+        <div class="spectrum-Site-heroHeading">
+            <h1 class="spectrum-Heading spectrum-Heading--sizeXXXL spectrum-Heading--serif">Spectrum CSS</h1>
         </div>
-        <div class="spectrum-HomeCard">
-            <img class="spectrum-HomeCard-image" src="img/illustration_flexible.svg" alt="Flexible illustation"/>
-            <div class="spectrum-HomeCard-content">
-                <h4 class="spectrum-Heading spectrum-Heading--sizeS">Flexible</h4>
-                <p class="spectrum-Body spectrum-Body--sizeM">Our CSS is customizable, powerful, and designed to work with any JavaScript framework.</p>
-                <p class="spectrum-Body spectrum-Body--sizeM">
-                    <a class="spectrum-Link spectrum-Link--quiet" href="get-started.html">Get started</a>
-                </p>
+        <p class="spectrum-Body spectrum-Body--sizeXL">Spectrum CSS is an open-source implementation of Spectrum, Adobe's design system. It includes components and resources to make applications more cohesive.</p>
+        <img alt="Spectrum CSS Hero image" src="img/spectrum-css_illustration_desktop@2x.png?w=976&amp;h=446" srcset="img/spectrum-css_illustration_desktop@2x.png 2x" class="spectrum-Site-heroImage"/>
+        <div class="spectrum-HomeCards">
+            <div class="spectrum-HomeCard">
+                <img class="spectrum-HomeCard-image" src="img/illustration_documentation.svg" alt="Documentation illustation"/>
+                <div class="spectrum-HomeCard-content">
+                    <h4 class="spectrum-Heading spectrum-Heading--sizeS">Robust documentation</h4>
+                    <p class="spectrum-Body spectrum-Body--sizeM">Spectrum CSS is designed to be used in partnership with Spectrum's detailed usage guidelines.</p>
+                    <p class="spectrum-Body spectrum-Body--sizeM">
+                        <a class="spectrum-Link spectrum-Link--quiet" href="https://spectrum.adobe.com/" target="_blank">View Spectrum guidelines</a>
+                    </p>
+                </div>
             </div>
-        </div>
-        <div class="spectrum-HomeCard">
-            <img class="spectrum-HomeCard-image" src="img/illustration_tested.svg" alt="Tested illustation"/>
-            <div class="spectrum-HomeCard-content">
-                <h4 class="spectrum-Heading spectrum-Heading--sizeS">Rigorously tested</h4>
-                <p class="spectrum-Body spectrum-Body--sizeM">These individually-versioned components have been vetted to be accessible and inclusive of global audiences.</p>
+            <div class="spectrum-HomeCard">
+                <img class="spectrum-HomeCard-image" src="img/illustration_flexible.svg" alt="Flexible illustation"/>
+                <div class="spectrum-HomeCard-content">
+                    <h4 class="spectrum-Heading spectrum-Heading--sizeS">Flexible</h4>
+                    <p class="spectrum-Body spectrum-Body--sizeM">Our CSS is customizable, powerful, and designed to work with any JavaScript framework.</p>
+                    <p class="spectrum-Body spectrum-Body--sizeM">
+                        <a class="spectrum-Link spectrum-Link--quiet" href="get-started.html">Get started</a>
+                    </p>
+                </div>
             </div>
-        </div>
-        <div class="spectrum-HomeCard">
-            <img class="spectrum-HomeCard-image" src="img/illustration_responsive.svg" alt="Responsove illustation"/>
-            <div class="spectrum-HomeCard-content">
-                <h4 class="spectrum-Heading spectrum-Heading--sizeS">Multi-platform support</h4>
-                <p class="spectrum-Body spectrum-Body--sizeM">We support evergreen browsers (minus one version) for scalability and flexibility.</p>
+            <div class="spectrum-HomeCard">
+                <img class="spectrum-HomeCard-image" src="img/illustration_tested.svg" alt="Tested illustation"/>
+                <div class="spectrum-HomeCard-content">
+                    <h4 class="spectrum-Heading spectrum-Heading--sizeS">Rigorously tested</h4>
+                    <p class="spectrum-Body spectrum-Body--sizeM">These individually-versioned components have been vetted to be accessible and inclusive of global audiences.</p>
+                </div>
+            </div>
+            <div class="spectrum-HomeCard">
+                <img class="spectrum-HomeCard-image" src="img/illustration_responsive.svg" alt="Responsove illustation"/>
+                <div class="spectrum-HomeCard-content">
+                    <h4 class="spectrum-Heading spectrum-Heading--sizeS">Multi-platform support</h4>
+                    <p class="spectrum-Body spectrum-Body--sizeM">We support evergreen browsers (minus one version) for scalability and flexibility.</p>
+                </div>
             </div>
         </div>
     </div>

--- a/tools/documentation/content/index.njk
+++ b/tools/documentation/content/index.njk
@@ -3,7 +3,7 @@ layout: pages.njk
 permalink: /docs/index.html
 eleventyExcludeFromCollections: true
 ---
-<div class="spectrum-Site-page spectrum-Typography">
+<div class="spectrum-Typography">
     <div class="spectrum-Site-hero">
         <div class="spectrum-Site-heroHeading">
             <h1 class="spectrum-Heading spectrum-Heading--sizeXXXL spectrum-Heading--serif">Spectrum CSS</h1>


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
loadIcons path fixed: loadIcons('../../components/icon/spectrum-css-icons.svg');
html in example.njk, components.njk & sidenav.njk are fixed.
resources in GitHub and npm svg rendering issue fixes


## How and where has this been tested?
Chrome

## Screenshots
<img width="1747" alt="Screenshot 2023-04-13 at 7 18 53 PM" src="https://user-images.githubusercontent.com/8790510/231780127-d32cd702-37bb-40d9-8916-1d013ad0e9ae.png">
