### PR TITLE
Image and JS path fixes

### DIFF
--- a/tools/documentation/assets/js/Search.js
+++ b/tools/documentation/assets/js/Search.js
@@ -122,14 +122,19 @@ function loadJSON(url, callback) {
   req.send();
 }
 
+function isComponentIndex() {
+  return /^\/docs\/[\w-]+\/$/.test(location.pathname);
+}
 Search.prototype.loadStore = function() {
-  loadJSON('./store.json', function(err, object) {
+  var storePath = isComponentIndex() ? '../store.json' : 'store.json';
+  loadJSON(storePath, function(err, object) {
     this.store = object;
   }.bind(this));
 }
 
 Search.prototype.loadIndex = function() {
-  loadJSON('./index.json', function(err, object) {
+  var indexPath = isComponentIndex() ? '../index.json' : 'index.json';
+  loadJSON(indexPath, function(err, object) {
     this.index = lunr.Index.load(object);
   }.bind(this));
 }

--- a/tools/documentation/assets/js/docs.js
+++ b/tools/documentation/assets/js/docs.js
@@ -14,10 +14,10 @@ governing permissions and limitations under the License.
 
 'use strict';
 
-const isComponentIndex = /^\/docs\/[\w-]+\/$/.test(location.pathname);
+const isComponentIndexExist = /^\/docs\/[\w-]+\/$/.test(location.pathname);
 
 loadIcons('../../components/icon/spectrum-css-icons.svg');
-if(isComponentIndex){
+if(isComponentIndexExist){
   loadIcons('../img/spectrum-icons.svg');
 } else {
   loadIcons('img/spectrum-icons.svg');

--- a/tools/documentation/assets/js/docs.js
+++ b/tools/documentation/assets/js/docs.js
@@ -14,8 +14,14 @@ governing permissions and limitations under the License.
 
 'use strict';
 
+const isComponentIndex = /^\/docs\/[\w-]+\/$/.test(location.pathname);
+
 loadIcons('../../components/icon/spectrum-css-icons.svg');
-loadIcons('../img/spectrum-icons.svg');
+if(isComponentIndex){
+  loadIcons('../img/spectrum-icons.svg');
+} else {
+  loadIcons('img/spectrum-icons.svg');
+}
 
 // Show and hide code samples
 function toggleMarkupVisibility(event) {

--- a/tools/documentation/content/get-started.md
+++ b/tools/documentation/content/get-started.md
@@ -100,7 +100,7 @@ eleventyNavigation:
     <img
       class="spectrum-CenteredImage"
       alt="Screenshot of the rendered CTA button in a browser window"
-      src="img/button-screen-shot.png"/>
+      src="../img/button-screen-shot.png"/>
     <header id="contribute">
       <h2 class="spectrum-Heading spectrum-Heading--sizeM">
         <a class="spectrum-BigSubtleLink" href="#contribute">Contribute to Spectrum CSS</a>


### PR DESCRIPTION

## Description
JS path fixes for store.json and index.json on root index.html and index.html under each component whose relative paths are both different to reach img folder also.
Added a regex to check for path and added the relative paths accordingly.


## How and where has this been tested?
Chrome

## Screenshots

<img width="960" alt="Screenshot 2023-04-17 at 2 47 16 PM" src="https://user-images.githubusercontent.com/8790510/232441354-ffd7ce45-a7e9-4ee7-83c1-2206a2bc765a.png">
<img width="983" alt="Screenshot 2023-04-17 at 2 47 21 PM" src="https://user-images.githubusercontent.com/8790510/232441364-e5bddcf0-3541-453f-8f68-bb95bc36fed5.png">
<img width="774" alt="Screenshot 2023-04-17 at 2 47 26 PM" src="https://user-images.githubusercontent.com/8790510/232441371-cc9d7fef-5019-4d1a-ad8c-f8c56108dfc4.png">

