### PR TITLE
feat: add stylelint

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,33 @@
+name: Linting
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    paths:
+      - "**.css"
+
+jobs:
+  styles:
+    name: Lint CSS
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Use Node LTS version
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: Install dependencies
+        run: yarn install
+      - name: Compile assets
+        run: yarn build
+      - name: Lint assets using stylelint
+        uses: reviewdog/action-stylelint@v1
+        with:
+          reporter: github-pr-review
+          fail_on_error: true

--- a/.prettierignore
+++ b/.prettierignore
@@ -7,6 +7,7 @@ components/*/dist
 components/expressvars/css/**/*.css
 components/vars/css/**/*.css
 components/tokens/custom-*/*.css
+tools/preview/storybook-static/**
 dist
 template.hbs
 

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,6 @@
+components/**/*-generated.css
+components/tokens/*
+components/vars/*
+components/express/*
+components/expressvars/*
+components/site/*

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,37 @@
+{
+	"extends": ["stylelint-config-standard"],
+	"plugins": [
+		"stylelint-use-logical",
+		"stylelint-no-missing-parenthesis",
+		"stylelint-no-missing-var",
+		"stylelint-suit-naming-pattern"
+	],
+	"rules": {
+		"rule-empty-line-before": null,
+		"block-no-empty": null,
+		"at-rule-empty-line-before": null,
+		"at-rule-no-unknown": null,
+		"no-descending-specificity": null,
+		"selector-class-pattern": null,
+		"declaration-empty-line-before": null,
+		"custom-property-empty-line-before": null,
+		"comment-whitespace-inside": null,
+		"comment-empty-line-before": null,
+		"no-duplicate-selectors": null,
+		"property-no-vendor-prefix": null,
+		"max-nesting-depth": 2,
+		"csstools/use-logical": true,
+		"custom-rule/no-missing-parenthesis": true,
+		"custom-rule/no-missing-var": true,
+		"custom-rule/suit-naming-pattern": true,
+		"custom-property-pattern": "^[a-zA-Z0-9]+(-[a-z0-9]([a-zA-Z0-9]+)?)+$",
+		"alpha-value-notation": null,
+		"color-function-notation": null,
+		"import-notation": null,
+		"no-empty-source": null,
+		"property-no-unknown": true,
+		"declaration-property-value-no-unknown": true,
+		"value-keyword-case": null,
+		"selector-not-notation": null
+	}
+}

--- a/components/checkbox/index.css
+++ b/components/checkbox/index.css
@@ -962,8 +962,6 @@ governing permissions and limitations under the License.
 
 		--highcontrast-checkbox-disabled-color-default: GrayText;
 
-		--highcontrast-checkbox-focus-indicator-color: ButtonText;
-
 		--highcontrast-checkbox-highlight-color-focus: Highlight;
 		--highcontrast-checkbox-focus-indicator-color: FieldText;
 		--highcontrast-checkbox-color-focus: FieldText;

--- a/components/switch/index.css
+++ b/components/switch/index.css
@@ -738,8 +738,6 @@ governing permissions and limitations under the License.
 		--highcontrast-switch-handle-background-color: ButtonFace;
 
 		--highcontrast-switch-handle-border-color-default: ButtonText;
-		--highcontrast-switch-handle-border-color-hover: Highlight;
-		--highcontrast-switch-handle-border-color-down: Highlight;
 		--highcontrast-switch-handle-border-color-focus: Highlight;
 		--highcontrast-switch-handle-border-color-disabled: Highlight;
 

--- a/package.json
+++ b/package.json
@@ -1,109 +1,118 @@
 {
-	"private": true,
-	"name": "spectrum-css-monorepo",
-	"version": "0.0.0",
-	"license": "Apache-2.0",
-	"author": "Adobe",
-	"contributors": [
-		"Cassondra Roberts <castastrophe@users.noreply.github.com> (https://allons-y.llc)",
-		"Garth Braithwaite <garthdb@gmail.com> (https://garthdb.com)",
-		"Larry Davis <lazdnet@gmail.com>",
-		"Patrick Fulton <pfulton@users.noreply.github.com>",
-		"Steve Gill <stevengill97@gmail.com>"
-	],
-	"homepage": "https://opensource.adobe.com/spectrum-css/",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/adobe/spectrum-css.git"
-	},
-	"bugs": {
-		"url": "https://github.com/adobe/spectrum-css/issues"
-	},
-	"scripts": {
-		"build": "yarn build:components",
-		"build:all": "run-s build:components build:site build:preview",
-		"postbuild:all": "yarn mv:preview",
-		"build:clean": "run-s clean build",
-		"build:components": "lerna run --scope \"${SCOPE:-@spectrum-css/*}\" --ignore \"@spectrum-css/{*-builder*,preview,generator}\" build",
-		"postbuild:components": "yarn docs:mod",
-		"build:preview": "nx build @spectrum-css/preview",
-		"build:site": "gulp buildDocs -LLL",
-		"cache:clean": "nx reset",
-		"ci": "yarn build:all",
-		"ci:storybook": "nx storybook @spectrum-css/preview",
-		"clean": "yarn cache:clean && run-p clean:*",
-		"clean:components": "lerna exec --scope \"${SCOPE:-@spectrum-css/*}\" --ignore \"@spectrum-css/{*-builder*,preview,generator}\" -- rimraf dist",
-		"clean:docs": "rimraf dist",
-		"clean:preview": "nx clean @spectrum-css/preview",
-		"predev": "yarn build:components",
-		"dev": "NODE_ENV=development BROWSERSYNC_OPEN=true gulp dev",
-		"docs:mod": "node tasks/mod-extractor.js",
-		"lint:components": "node ./tasks/packageLint.js",
-		"mv:preview": "rimraf dist/preview && mv -f tools/preview/storybook-static dist/preview",
-		"new": "nx run @spectrum-css/generator:new",
-		"precommit": "lint-staged",
-		"prepare": "husky install",
-		"prepare:site": "run-s clean:docs build:all",
-		"prerelease": "yarn version:build",
-		"release": "lerna publish",
-		"release:beta-from-package": "yarn release from-package --conventional-prerelease --preid beta --pre-dist-tag beta --no-private",
-		"prerelease:site": "yarn prepare:site",
-		"release:site": "gh-pages -d dist/ -f -e .",
-		"prestart": "yarn build:components",
-		"start": "NODE_ENV=development yarn workspace @spectrum-css/preview start",
-		"test": "nx test @spectrum-css/preview",
-		"test:scope": "nx test:scope @spectrum-css/preview",
-		"version:build": "lerna run --since origin/main build",
-		"watch": "gulp watch"
-	},
-	"workspaces": [
-		"components/*",
-		"tools/*"
-	],
-	"devDependencies": {
-		"@adobe/focus-ring-polyfill": "^0.1.5",
-		"@commitlint/cli": "^17.6.3",
-		"@commitlint/config-conventional": "^17.6.3",
-		"gh-pages": "^5.0.0",
-		"gulp": "^4.0.0",
-		"gulp-replace": "^1.0.0",
-		"gulplog": "^1.0.0",
-		"husky": "^8.0.3",
-		"lerna": "^6.6.2",
-		"lint-staged": "^13.2.2",
-		"loadicons": "^1.0.0",
-		"lunr": "^2.3.6",
-		"markdown-it": "^12.3.2",
-		"npm-run-all": "^4.1.5",
-		"nx": "^16.2.2",
-		"prettier": "^2.8.8",
-		"prettier-package-json": "^2.8.0",
-		"prismjs": "^1.23.0",
-		"rimraf": "^5.0.1",
-		"semver": "^7.5.1",
-		"through2": "^3.0.1",
-		"yargs": "^17.7.2"
-	},
-	"engines": {
-		"node": ">=14.0.0 <18"
-	},
-	"browserslist": [
-		"last 2 Edge versions",
-		"last 2 Chrome versions",
-		"last 2 Firefox versions",
-		"last 2 Safari versions",
-		"last 2 iOS versions"
-	],
-	"lint-staged": {
-		"*.{md,js,css,yml,hbs}": [
-			"prettier --write"
-		],
-		"components/*/package.json": [
-			"yarn lint:components",
-			"prettier-package-json --write"
-		],
-		"package.json": [
-			"prettier-package-json --write"
-		]
-	}
+  "private": true,
+  "name": "spectrum-css-monorepo",
+  "version": "0.0.0",
+  "license": "Apache-2.0",
+  "author": "Adobe",
+  "contributors": [
+    "Cassondra Roberts <castastrophe@users.noreply.github.com> (https://allons-y.llc)",
+    "Garth Braithwaite <garthdb@gmail.com> (https://garthdb.com)",
+    "Larry Davis <lazdnet@gmail.com>",
+    "Patrick Fulton <pfulton@users.noreply.github.com>",
+    "Steve Gill <stevengill97@gmail.com>"
+  ],
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/adobe/spectrum-css.git"
+  },
+  "bugs": {
+    "url": "https://github.com/adobe/spectrum-css/issues"
+  },
+  "scripts": {
+    "build": "yarn build:components",
+    "build:all": "run-s build:components build:site build:preview",
+    "postbuild:all": "yarn mv:preview",
+    "build:clean": "run-s clean build",
+    "build:components": "lerna run --scope \"${SCOPE:-@spectrum-css/*}\" --ignore \"@spectrum-css/{*-builder*,preview,generator}\" build",
+    "postbuild:components": "yarn docs:mod",
+    "build:preview": "nx build @spectrum-css/preview",
+    "build:site": "gulp buildDocs -LLL",
+    "cache:clean": "nx reset",
+    "ci": "yarn build:all",
+    "ci:storybook": "nx storybook @spectrum-css/preview",
+    "clean": "yarn cache:clean && run-p clean:*",
+    "clean:components": "lerna exec --scope \"${SCOPE:-@spectrum-css/*}\" --ignore \"@spectrum-css/{*-builder*,preview,generator}\" -- rimraf dist",
+    "clean:docs": "rimraf dist",
+    "clean:preview": "nx clean @spectrum-css/preview",
+    "predev": "yarn build:components",
+    "dev": "NODE_ENV=development BROWSERSYNC_OPEN=true gulp dev",
+    "docs:mod": "node tasks/mod-extractor.js",
+    "postdocs:mod": "prettier --cache --write components/*/metadata/*.md > /dev/null",
+    "lint:components": "node ./tasks/packageLint.js",
+    "lint:styles": "stylelint",
+    "mv:preview": "rimraf dist/preview && mv tools/preview/storybook-static dist/preview",
+    "new": "nx run @spectrum-css/generator:new",
+    "precommit": "lint-staged",
+    "prepare": "husky install",
+    "prepare:site": "run-s clean:docs build:all",
+    "prerelease": "yarn version:build",
+    "release": "lerna publish",
+    "release:beta-from-package": "yarn release from-package --conventional-prerelease --preid beta --pre-dist-tag beta --no-private",
+    "prerelease:site": "yarn prepare:site",
+    "release:site": "gh-pages -d dist/ -f -e .",
+    "prestart": "yarn build:components",
+    "start": "NODE_ENV=development yarn workspace @spectrum-css/preview start",
+    "test": "nx test @spectrum-css/preview",
+    "test:scope": "nx test:scope @spectrum-css/preview",
+    "version:build": "lerna run --since origin/main build",
+    "watch": "gulp watch"
+  },
+  "workspaces": [
+    "components/*",
+    "tools/*",
+    "plugins/*"
+  ],
+  "devDependencies": {
+    "@adobe/focus-ring-polyfill": "^0.1.5",
+    "@commitlint/cli": "^17.6.3",
+    "@commitlint/config-conventional": "^17.6.3",
+    "gh-pages": "^5.0.0",
+    "gulp": "^4.0.0",
+    "gulp-replace": "^1.0.0",
+    "gulplog": "^1.0.0",
+    "husky": "^8.0.3",
+    "lerna": "^6.6.2",
+    "lint-staged": "^13.2.2",
+    "loadicons": "^1.0.0",
+    "lunr": "^2.3.6",
+    "markdown-it": "^12.3.2",
+    "npm-run-all": "^4.1.5",
+    "nx": "^16.2.2",
+    "prettier": "^2.8.8",
+    "prettier-package-json": "^2.8.0",
+    "prismjs": "^1.23.0",
+    "rimraf": "^5.0.1",
+    "semver": "^7.5.1",
+    "stylelint": "^15.5.0",
+    "stylelint-config-standard": "^33.0.0",
+    "stylelint-use-logical": "^2.1.0",
+    "through2": "^3.0.1",
+    "yargs": "^17.7.2"
+  },
+  "engines": {
+    "node": ">=14.0.0 <18"
+  },
+  "browserslist": [
+    "last 2 Edge versions",
+    "last 2 Chrome versions",
+    "last 2 Firefox versions",
+    "last 2 Safari versions",
+    "last 2 iOS versions"
+  ],
+  "lint-staged": {
+    "*.{md,js,css,yml,hbs}": [
+      "prettier --write --cache"
+    ],
+    "components/*/*.css": [
+      "stylelint --write"
+    ],
+    "components/*/package.json": [
+      "yarn lint:components",
+      "prettier-package-json --write"
+    ],
+    "package.json": [
+      "prettier-package-json --write"
+    ]
+  }
 }

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,0 +1,66 @@
+# Stylelint for Adobe Spectrum CSS
+
+Design tokens are supported by linting rules, which warn you if a token is deprecated, missing, missing vars or using deprecated formatting. Design token lint rules are provided by the Adobe Design System Stylelint plugins.
+
+If you are an Adobe employee, you must configure the lint rule in your repository and keep it up-to-date. If you are a partner developer, we strongly recommend you to use it as well.
+
+## Installation (Custom Plugins)
+
+```
+yarn add stylelint-no-missing-var
+yarn add stylelint-suit-naming-pattern
+yarn add stylelint-no-missing-parenthesis
+```
+
+## Configuration
+
+Add the plugins to your Stylelint configuration file.
+
+```js
+// .stylelintrc.js
+
+module.exports = {
+	extends: ["stylelint-config-standard"],
+	plugins: [
+		"stylelint-use-logical",
+		+"stylelint-no-missing-parenthesis",
+		+"stylelint-suit-naming-pattern",
+		+"stylelint-no-missing-var",
+	],
+};
+```
+
+Enable any desired rules. The rules and options shown below are strongly recommended
+
+```json
+module.exports = {
+    "rules" : {
+        "rule-empty-line-before": null,
+        "block-no-empty": null,
+        "at-rule-empty-line-before": null,
+        "at-rule-no-unknown": null,
+        "no-descending-specificity": null,
+        "selector-class-pattern": null,
+        "declaration-empty-line-before": null,
+        "custom-property-empty-line-before": null,
+        "comment-whitespace-inside": null,
+        "comment-empty-line-before": null,
+        "no-duplicate-selectors": null,
+        "property-no-vendor-prefix": null,
+        "max-nesting-depth": 2,
+        "csstools/use-logical": true,
+        "custom-rule/no-missing-parenthesis": true,
+        "custom-rule/no-missing-var": true,
+        "custom-rule/suit-naming-pattern": true,
+        "custom-property-pattern": "^[a-zA-Z0-9]+(-[a-z0-9]([a-zA-Z0-9]+)?)+$",
+        "alpha-value-notation": null,
+        "color-function-notation": null,
+        "import-notation": null,
+        "no-empty-source": null,
+        "property-no-unknown": true,
+        "declaration-property-value-no-unknown": true,
+        "value-keyword-case":null,
+        "selector-not-notation":null
+    }
+}
+```

--- a/plugins/stylelint-no-missing-parenthesis/CHANGELOG.md
+++ b/plugins/stylelint-no-missing-parenthesis/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/plugins/stylelint-no-missing-parenthesis/README.md
+++ b/plugins/stylelint-no-missing-parenthesis/README.md
@@ -1,0 +1,60 @@
+# stylelint-no-missing-parenthesis
+
+> Validates classnames for any missing parenthesis mostly in calc() method with multiple vars
+
+## Description
+
+This stylelint plugin will validate against all css properties and check to be sure that all () are properly closed.especially in places where we do larger calc() operations along with var(). This is an example of one of those places.
+
+For e.g:
+
+```css
+.spectrum-ActionButton-hold {
+	inset-inline-end: calc(
+		var(
+				--mod-actionbutton-edge-to-hold-icon,
+				var(--spectrum-actionbutton-edge-to-hold-icon)
+			) - var(--mod-actionbutton-border-width, var(--spectrum-actionbutton-border-width))
+	);
+}
+```
+
+## Installation
+
+```
+npm install stylelint-no-missing-parenthesis
+
+yarn add stylelint-no-missing-parenthesis
+```
+
+## How to use
+
+In your stylelintrc.json add stylelint-no-missing-parenthesis to your plugins array and to your rules array like this:
+
+```js
+plugins: ['stylelint-no-missing-parenthesis'],
+rules: {
+  "custom-rule/no-missing-parenthesis": true,
+}
+```
+
+## Usage
+
+Wrong: Throws a lint error here
+
+```css
+.spectrum-Well-Component {
+  background-color : calc(var(--prefix-component-background-color), var(--prefix-component-background-color);
+}
+```
+
+Correct:
+
+```css
+.spectrum-Well-Component {
+	background-color: calc(
+		var(--prefix-component-background-color),
+		var(--prefix-component-background-color)
+	);
+}
+```

--- a/plugins/stylelint-no-missing-parenthesis/index.js
+++ b/plugins/stylelint-no-missing-parenthesis/index.js
@@ -1,0 +1,24 @@
+const stylelint = require("stylelint");
+
+const ruleName = "custom-rule/no-missing-parenthesis";
+
+const plugin = stylelint.createPlugin(ruleName, (enabled, options) => {
+	return (root, result) => {
+		root.walkDecls((decl) => {
+			const value = decl.value;
+			if (value.includes("calc")) {
+				const openParenCount = (value.match(/\(/g) || []).length;
+				const closeParenCount = (value.match(/\)/g) || []).length;
+				if (openParenCount !== closeParenCount) {
+					const message = `Missing or extra parentheses in "${value}"`;
+					const node = decl.raws.value
+						? decl.raws.value.raw.indexOf("calc")
+						: decl.toString().indexOf("calc");
+					stylelint.utils.report({ message, node: decl, result, ruleName });
+				}
+			}
+		});
+	};
+});
+
+module.exports = plugin;

--- a/plugins/stylelint-no-missing-parenthesis/package.json
+++ b/plugins/stylelint-no-missing-parenthesis/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "stylelint-no-missing-parenthesis",
+  "version": "1.0.1",
+  "license": "MIT",
+  "author": "Rajdeep Chandra",
+  "main": "index.js",
+  "scripts": {
+    "lint": "stylelint index.js",
+    "prepublishOnly": "yarn test",
+    "test": "ava"
+  },
+  "peerDependencies": {
+    "stylelint": ">=15"
+  },
+  "devDependencies": {
+    "ava": "^3.9.0",
+    "stylelint": "^15.6.2"
+  }
+}

--- a/plugins/stylelint-no-missing-parenthesis/test.js
+++ b/plugins/stylelint-no-missing-parenthesis/test.js
@@ -1,0 +1,27 @@
+const test = require("ava");
+const stylelint = require("stylelint");
+const plugin = require("./index");
+
+test("should throw an error for missing or extra parentheses in calc values", async (t) => {
+	const code = `
+    .spectrum {
+      width: calc(100px - 10px;
+    }
+  `;
+
+	const { results } = await stylelint.lint({
+		code,
+		config: {
+			plugins: [plugin],
+			rules: {
+				"custom-rule/no-missing-parenthesis": true,
+			},
+		},
+	});
+
+	const warnings = results[0].warnings;
+
+	t.is(warnings.length, 1);
+	t.is(warnings[0].rule, "CssSyntaxError");
+	t.is(warnings[0].text, "Unclosed bracket (CssSyntaxError)");
+});

--- a/plugins/stylelint-no-missing-var/CHANGELOG.md
+++ b/plugins/stylelint-no-missing-var/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/plugins/stylelint-no-missing-var/README.md
+++ b/plugins/stylelint-no-missing-var/README.md
@@ -1,0 +1,44 @@
+# stylelint-no-missing-var
+
+> Validates classnames for any missing var before a custom property
+
+## Description
+
+This stylelint plugin will validate against all custom properties in css and lints when it fails to find var before a custom property. This plugin also works for custom property defined in other sources too.
+
+## Installation
+
+```
+npm install stylelint-no-missing-var
+
+yarn install stylelint-no-missing-var
+```
+
+## How to use
+
+In your stylelintrc.json add stylelint-no-missing-var to your plugins array and to your rules array like this:
+
+```js
+plugins: ['stylelint-no-missing-var'],
+rules: {
+  "custom-rule/no-missing-var": true,
+}
+```
+
+## Usage
+
+Wrong: Throws an error here
+
+```css
+.spectrum-Well-Component {
+	background-color: (--prefix-component-background-color);
+}
+```
+
+Correct:
+
+```css
+.spectrum-Well-Component {
+	background-color: var(--prefix-component-background-color);
+}
+```

--- a/plugins/stylelint-no-missing-var/index.js
+++ b/plugins/stylelint-no-missing-var/index.js
@@ -1,0 +1,20 @@
+const stylelint = require("stylelint");
+
+const ruleName = "custom-rule/no-missing-var";
+
+const plugin = stylelint.createPlugin(ruleName, (enabled, options) => {
+	return (root, result) => {
+		root.walkDecls((decl) => {
+			const value = decl.value.replace(/\s/g, ""); // Remove whitespace
+			const regex = /(?<!var\(\S*)--\S+\b/;
+			if (regex.test(value)) {
+				const message = `Missing 'var' before custom property "${
+					value.match(regex)[0]
+				}"`;
+				stylelint.utils.report({ message, node: decl, result, ruleName });
+			}
+		});
+	};
+});
+
+module.exports = plugin;

--- a/plugins/stylelint-no-missing-var/package.json
+++ b/plugins/stylelint-no-missing-var/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "stylelint-no-missing-var",
+  "version": "1.0.1",
+  "license": "MIT",
+  "author": "Rajdeep Chandra",
+  "main": "index.js",
+  "scripts": {
+    "lint": "stylelint index.js",
+    "prepublishOnly": "yarn test",
+    "test": "ava"
+  },
+  "peerDependencies": {
+    "stylelint": ">=15"
+  },
+  "devDependencies": {
+    "ava": "^3.9.0",
+    "stylelint": "^15.6.2"
+  }
+}

--- a/plugins/stylelint-no-missing-var/test.js
+++ b/plugins/stylelint-no-missing-var/test.js
@@ -1,0 +1,56 @@
+const test = require("ava");
+const stylelint = require("stylelint");
+const plugin = require("./index");
+
+const ruleName = "custom-rule/no-missing-var";
+
+test(`should throw an error for missing "var" before custom properties`, async (t) => {
+	const code = `
+    .spectrum-Button {
+        background-color: (--spectrum-well-background-color);
+        border-color: var(--spectrum-well-border-color);
+      }
+    `;
+
+	const { results } = await stylelint.lint({
+		code,
+		config: {
+			plugins: [plugin],
+			rules: {
+				[ruleName]: true,
+			},
+		},
+	});
+
+	const warnings = results[0].warnings;
+
+	t.is(warnings.length, 1);
+	t.is(warnings[0].rule, ruleName);
+	t.is(
+		warnings[0].text,
+		`Missing 'var' before custom property "--spectrum-well-background-color"`
+	);
+});
+
+test(`should not throw an error for "var" usage`, async (t) => {
+	const code = `
+    .spectrum-Button {
+        background-color: var(--spectrum-well-background-color);
+        border-color: var(--spectrum-well-border-color);
+      }
+    `;
+
+	const { results } = await stylelint.lint({
+		code,
+		config: {
+			plugins: [plugin],
+			rules: {
+				[ruleName]: true,
+			},
+		},
+	});
+
+	const warnings = results[0].warnings;
+
+	t.is(warnings.length, 0);
+});

--- a/plugins/stylelint-suit-naming-pattern/CHANGELOG.md
+++ b/plugins/stylelint-suit-naming-pattern/CHANGELOG.md
@@ -1,0 +1,49 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# 1.0.5
+
+Added postcss-selector-parser to parse the css
+
+# 1.0.4
+
+Updated regex to include the below pattern
+
+```css
+.spectrum-ToolTip--size100 {
+}
+.spectrum-Switch-input[disabled] {
+}
+.spectrum:lang(ar) {
+}
+.spectrum-UIIcon-ChevronDown75 {
+}
+```
+
+# 1.0.3
+
+Updated regex to include the below pattern
+
+```css
+.spectrum--express {
+}
+```
+
+# 1.0.2
+
+Updated regex to include the below patterns
+
+```css
+.spectrum-ComponentName.is-selected {
+}
+.spectrum-ComponentName.is-selected.spectrum-ComponentName--emphasized {
+}
+.spectrum-ComponentName.spectrum-ComponentName--descendentName.is-selected {
+}
+.spectrum-ComponentName.is-selected.spectrum-ComponentName--emphasized {
+}
+.spectrum-ComponentName.spectrum-ComponentName--descendentName.is-selected {
+}
+```

--- a/plugins/stylelint-suit-naming-pattern/README.md
+++ b/plugins/stylelint-suit-naming-pattern/README.md
@@ -1,0 +1,77 @@
+# stylelint-suit-naming-pattern
+
+> Validates classnames on SUIT naming pattern
+
+(SUIT Docs)[https://github.com/suitcss/suit/blob/master/doc/naming-conventions.md]
+
+## Description
+
+Let's say you have a classname `.spectrum-Well-Component{}`. This will show a lint error because it expects the classname to follow SUIT naming convention like`.spectrum-Well-component{}`
+
+Valid classnames:
+
+```css
+.spectrum {
+}
+.spectrum-Component {
+}
+.spectrum-Component-newName {
+}
+.spectrum-Component--state {
+}
+.is-focused {
+}
+.spectrum-ComponentName.spectrum-ComponentX {
+}
+.spectrum-ComponentName-descendant1.spectrum-ComponentX-descendant2 {
+}
+.u-camelCase {
+}
+```
+
+Invalid classnames:
+
+```css
+.spectrum-Component-NewName {
+}
+.spectrum-Component--SizeXS {
+}
+```
+
+## Installation
+
+```
+npm install stylelint-suit-naming-pattern
+
+yarn add stylelint-suit-naming-pattern
+
+```
+
+## How to use
+
+In your stylelintrc.json add stylelint-suit-naming-pattern to your plugins array and to your rules array like this:
+
+```js
+plugins: ['stylelint-suit-naming-pattern'],
+rules: {
+  "custom-rule/suit-naming-pattern": true,
+}
+```
+
+## Usage
+
+Wrong: Throws an error here
+
+```css
+.spectrum-Well-Component {
+	background-color: var(--prefix-component-background-color);
+}
+```
+
+Correct:
+
+```css
+.spectrum-Well-component {
+	background-color: var(--prefix-component-background-color);
+}
+```

--- a/plugins/stylelint-suit-naming-pattern/index.js
+++ b/plugins/stylelint-suit-naming-pattern/index.js
@@ -1,0 +1,50 @@
+const stylelint = require("stylelint");
+const parser = require("postcss-selector-parser");
+const ruleName = "custom-rule/suit-naming-pattern";
+
+const messages = stylelint.utils.ruleMessages(ruleName, {
+	wrongCapitalization: (className) =>
+		`Component Class name "${className}" should follow the SUIT-style naming conventions with the ".spectrum" prefix.`,
+	wrongUtilityClassName: (className) =>
+		`Utility Class name "${className}" should follow the SUIT-style naming conventions with the ".u-camelCase" prefix.`,
+});
+const utilityClassPattern = /^u-[a-z]+[a-zA-Z0-9]+/;
+
+const suitClassPattern =
+	/^spectrum(--(?:express|light|lightest|dark|darkest|medium|large))?((-[A-Z][a-zA-Z0-9]+)([-]{1,2}((\S*\d+\S*)[a-zA-Z0-9]+|[a-z][a-zA-Z0-9-]+]*(?!\d)))?(\s|,\s)?)?$/;
+
+module.exports = stylelint.createPlugin(ruleName, () => {
+	return (root, result) => {
+		root.walkRules(async (rule) => {
+			await parser((selectors) => {
+				selectors.walkClasses((selectorNode) => {
+					const selector = selectorNode.value;
+					if (
+						selector.startsWith("spectrum") &&
+						!suitClassPattern.test(selector)
+					) {
+						stylelint.utils.report({
+							message: messages.wrongCapitalization(selector),
+							node: rule,
+							result,
+							ruleName,
+						});
+					} else if (
+						selector.startsWith("u-") &&
+						!utilityClassPattern.test(selector)
+					) {
+						stylelint.utils.report({
+							message: messages.wrongUtilityClassName(selector),
+							node: rule,
+							result,
+							ruleName,
+						});
+					}
+				});
+			}).process(rule.selector);
+		});
+	};
+});
+
+module.exports.ruleName = ruleName;
+module.exports.messages = messages;

--- a/plugins/stylelint-suit-naming-pattern/package.json
+++ b/plugins/stylelint-suit-naming-pattern/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "stylelint-suit-naming-pattern",
+  "version": "1.0.5",
+  "license": "MIT",
+  "main": "index.js",
+  "scripts": {
+    "prepublishOnly": "yarn test",
+    "test": "ava"
+  },
+  "peerDependencies": {
+    "stylelint": ">=15"
+  },
+  "devDependencies": {
+    "ava": "^3.9.0",
+    "postcss-selector-parser": "^6.0.2",
+    "stylelint": "^15.6.2"
+  }
+}

--- a/plugins/stylelint-suit-naming-pattern/test.js
+++ b/plugins/stylelint-suit-naming-pattern/test.js
@@ -1,0 +1,63 @@
+const test = require("ava");
+const stylelint = require("stylelint");
+const rule = require("./index");
+
+const { ruleName, messages } = rule;
+
+async function runRule(code) {
+	const result = await stylelint.lint({
+		code,
+		config: {
+			plugins: [rule],
+			rules: {
+				[ruleName]: true,
+			},
+		},
+	});
+
+	return result;
+}
+
+test(`should pass valid class names`, async (t) => {
+	const validCode = `
+  .spectrum {}
+  .spectrum-Component {}
+  .spectrum-Component-newName {}
+  .spectrum-Component--sizeXS {}
+  .spectrum-ComponentName--descendant1 {}
+  .spectrum-ComponentX-descendant2 {}
+  .spectrum--lightest {}
+  .spectrum-ToolTip--size100 {}
+  .spectrum-Switch-input {}
+  .spectrum-UIIcon-ChevronDown75 {}
+  .spectrum--express {}
+  .spectrum-Tooltip--top-left {}
+  `;
+
+	const result = await runRule(validCode);
+	t.is(result.results[0].warnings.length, 0);
+});
+
+test(`should fail invalid class names`, async (t) => {
+	const invalidCode = `
+      .spectrum-UIIcon-United {}
+      .spectrum-underlay-Under-lay {}
+      .spectrum-underlay-under-lay {}
+      .spectrum-detail--serif {}
+      .spectrum-Heading--Heavy {}
+      .spectrum-underlay-underlay {}
+      .spectrum-Underlay--Underlay {}
+      .spectrum-Underlay-Abc {}
+      .spectrum-Underlay--Abc {}
+      .spectrum-underlay--abc {}
+      .spectrum-anderlay--Abc {}
+      .spectrum-anderlay--abc {}
+      .spectrum-Underlay--Abc {}
+      .spectrum-code {}
+      .spectrum-code--Abc {}
+  `;
+
+	const result = await runRule(invalidCode);
+
+	t.is(result.results[0].warnings.length, 15);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1335,6 +1335,41 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
+"@csstools/css-parser-algorithms@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.1.0.tgz#c0a605b0218790faeb5911f240964891c6031501"
+  integrity sha512-KP8TicdXpUyeB1NMlbHud/1l39xvLGvqNFWMpG4qC6H1zs9SadGUHe5SO92n/659sDW9aGDvm9AMru0DZkN1Bw==
+
+"@csstools/css-parser-algorithms@^2.1.1":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.2.0.tgz#1268b07196d1118296443aeff41bca27d94b0981"
+  integrity sha512-9BoQ/jSrPq4vv3b9jjLW+PNNv56KlDH5JMx5yASSNrCtvq70FCNZUjXRvbCeR9hYj9ZyhURtqpU/RFIgg6kiOw==
+
+"@csstools/css-tokenizer@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@csstools/css-tokenizer/-/css-tokenizer-2.1.0.tgz#fee4de3d444db3ce9007f3af6474af8ba3e4b930"
+  integrity sha512-dtqFyoJBHUxGi9zPZdpCKP1xk8tq6KPHJ/NY4qWXiYo6IcSGwzk3L8x2XzZbbyOyBs9xQARoGveU2AsgLj6D2A==
+
+"@csstools/css-tokenizer@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@csstools/css-tokenizer/-/css-tokenizer-2.1.1.tgz#07ae11a0a06365d7ec686549db7b729bc036528e"
+  integrity sha512-GbrTj2Z8MCTUv+52GE0RbFGM527xuXZ0Xa5g0Z+YN573uveS4G0qi6WNOMyz3yrFM/jaILTTwJ0+umx81EzqfA==
+
+"@csstools/media-query-list-parser@^2.0.2":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@csstools/media-query-list-parser/-/media-query-list-parser-2.0.4.tgz#466bd254041530dfd1e88bcb1921e8ca4af75b6a"
+  integrity sha512-GyYot6jHgcSDZZ+tLSnrzkR7aJhF2ZW6d+CXH66mjy5WpAQhZD4HDke2OQ36SivGRWlZJpAz7TzbW6OKlEpxAA==
+
+"@csstools/media-query-list-parser@^2.0.4":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.0.tgz#6e1a5e12e0d103cd13b94bddb88b878bd6866103"
+  integrity sha512-MXkR+TeaS2q9IkpyO6jVCdtA/bfpABJxIrfkLswThFN8EZZgI2RfAHhm6sDNDuYV25d5+b8Lj1fpTccIcSLPsQ==
+
+"@csstools/selector-specificity@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@csstools/selector-specificity/-/selector-specificity-2.2.0.tgz#2cbcf822bf3764c9658c4d2e568bd0c0cb748016"
+  integrity sha512-+OJ9konv95ClSTOJCmMZqpd5+YGsB2S+x6w3E1oaM8UuR5j8nTNHYSz8c9BEPGDOCMQYIEEGlVPj/VY64iTbGw==
+
 "@discoveryjs/json-ext@^0.5.3", "@discoveryjs/json-ext@^0.5.7":
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
@@ -3799,7 +3834,7 @@ ajv@^6.1.0, ajv@^6.10.2, ajv@^6.12.2, ajv@^6.12.4, ajv@^6.12.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.11.0:
+ajv@^8.0.1, ajv@^8.11.0:
   version "8.12.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.12.0.tgz#d1a0527323e22f53562c567c00991577dfbe19d1"
   integrity sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==
@@ -4580,6 +4615,11 @@ balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
+
+balanced-match@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-2.0.0.tgz#dc70f920d78db8b858535795867bf48f820633d9"
+  integrity sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==
 
 base64-js@^1.0.2, base64-js@^1.3.1:
   version "1.5.1"
@@ -5794,6 +5834,11 @@ color-support@^1.1.2, color-support@^1.1.3:
   resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
   integrity sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==
 
+colord@^2.9.3:
+  version "2.9.3"
+  resolved "https://registry.yarnpkg.com/colord/-/colord-2.9.3.tgz#4f8ce919de456f1d5c1c368c307fe20f3e59fb43"
+  integrity sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==
+
 colorette@^2.0.19:
   version "2.0.19"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.19.tgz#cdf044f47ad41a0f4b56b3a0d5b4e6e1a2d5a798"
@@ -6354,7 +6399,7 @@ cosmiconfig@^7.0.0:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
-cosmiconfig@^8.0.0:
+cosmiconfig@^8.0.0, cosmiconfig@^8.1.3:
   version "8.1.3"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-8.1.3.tgz#0e614a118fcc2d9e5afc2f87d53cd09931015689"
   integrity sha512-/UkO2JKI18b5jVMJUp0lvKFMpa/Gye+ZgZjKD+DGEN9y7NRcf/nK1A0sp67ONmKtnDCNMS44E6jrk0Yc3bDuUw==
@@ -6467,6 +6512,11 @@ crypto-random-string@^2.0.0:
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
   integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
 
+css-functions-list@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/css-functions-list/-/css-functions-list-3.1.0.tgz#cf5b09f835ad91a00e5959bcfc627cd498e1321b"
+  integrity sha512-/9lCvYZaUbBGvYUgYGFJ4dcYiyqdhSjG7IPVluoV8A1ILjkF7ilmhp1OGUz8n+nmBcu0RNrQAzgD8B6FJbrt2w==
+
 css-loader@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-3.6.0.tgz#2e4b2c7e6e2d27f8c8f28f61bffcd2e6c91ef645"
@@ -6548,6 +6598,14 @@ css-tree@^1.1.2:
   dependencies:
     mdn-data "2.0.14"
     source-map "^0.6.1"
+
+css-tree@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-2.3.1.tgz#10264ce1e5442e8572fc82fbe490644ff54b5c20"
+  integrity sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==
+  dependencies:
+    mdn-data "2.0.30"
+    source-map-js "^1.0.1"
 
 css-unit-converter@^1.1.1:
   version "1.1.2"
@@ -6664,7 +6722,7 @@ decamelize-keys@^1.1.0:
     decamelize "^1.1.0"
     map-obj "^1.0.0"
 
-decamelize@^1.0.0, decamelize@^1.1.0, decamelize@^1.1.1, decamelize@^1.1.2:
+decamelize@^1.0.0, decamelize@^1.1.0, decamelize@^1.1.1, decamelize@^1.1.2, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==
@@ -7790,7 +7848,7 @@ fast-glob@^2.2.6:
     merge2 "^1.2.3"
     micromatch "^3.1.10"
 
-fast-glob@^3.0.3, fast-glob@^3.2.11, fast-glob@^3.2.2, fast-glob@^3.2.9:
+fast-glob@^3.0.3, fast-glob@^3.2.11, fast-glob@^3.2.12, fast-glob@^3.2.2, fast-glob@^3.2.9:
   version "3.2.12"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.12.tgz#7f39ec99c2e6ab030337142da9e0c18f37afae80"
   integrity sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==
@@ -7810,6 +7868,11 @@ fast-levenshtein@^1.0.0:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-1.1.4.tgz#e6a754cc8f15e58987aa9cbd27af66fd6f4e5af9"
   integrity sha512-Ia0sQNrMPXXkqVFt6w6M1n1oKo3NfKs+mvaV811Jwir7vAk9a6PVV9VPYf6X3BU97QiLEmuW3uXH9u87zDFfdw==
+
+fastest-levenshtein@^1.0.16:
+  version "1.0.16"
+  resolved "https://registry.yarnpkg.com/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz#210e61b6ff181de91ea9b3d1b84fdedd47e034e5"
+  integrity sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==
 
 fastq@^1.6.0:
   version "1.15.0"
@@ -7856,6 +7919,13 @@ figures@^5.0.0:
   dependencies:
     escape-string-regexp "^5.0.0"
     is-unicode-supported "^1.2.0"
+
+file-entry-cache@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz#211b2dd9659cb0394b073e7323ac3c933d522027"
+  integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
+  dependencies:
+    flat-cache "^3.0.4"
 
 file-loader@^6.2.0:
   version "6.2.0"
@@ -8065,10 +8135,23 @@ flagged-respawn@^2.0.0:
   resolved "https://registry.yarnpkg.com/flagged-respawn/-/flagged-respawn-2.0.0.tgz#abf39719dcfe1ac06c86c9466081c541c682987b"
   integrity sha512-Gq/a6YCi8zexmGHMuJwahTGzXlAZAOsbCVKduWXC6TlLCjjFRlExMJc4GC2NYPYZ0r/brw9P7CpRgQmlPVeOoA==
 
+flat-cache@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
+  integrity sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==
+  dependencies:
+    flatted "^3.1.0"
+    rimraf "^3.0.2"
+
 flat@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/flat/-/flat-5.0.2.tgz#8ca6fe332069ffa9d324c327198c598259ceb241"
   integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
+
+flatted@^3.1.0:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
+  integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
 flatten@^1.0.2:
   version "1.0.3"
@@ -8667,6 +8750,13 @@ global-modules@^1.0.0:
     is-windows "^1.0.1"
     resolve-dir "^1.0.0"
 
+global-modules@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/global-modules/-/global-modules-2.0.0.tgz#997605ad2345f27f51539bea26574421215c7780"
+  integrity sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==
+  dependencies:
+    global-prefix "^3.0.0"
+
 global-prefix@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-1.0.2.tgz#dbf743c6c14992593c655568cb66ed32c0122ebe"
@@ -8677,6 +8767,15 @@ global-prefix@^1.0.1:
     ini "^1.3.4"
     is-windows "^1.0.1"
     which "^1.2.14"
+
+global-prefix@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-3.0.0.tgz#fc85f73064df69f50421f47f883fe5b913ba9b97"
+  integrity sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==
+  dependencies:
+    ini "^1.3.5"
+    kind-of "^6.0.2"
+    which "^1.3.1"
 
 global@^4.3.2, global@^4.4.0:
   version "4.4.0"
@@ -8698,7 +8797,7 @@ globalthis@^1.0.0, globalthis@^1.0.3:
   dependencies:
     define-properties "^1.1.3"
 
-globby@11.1.0, globby@^11.0.1, globby@^11.0.2:
+globby@11.1.0, globby@^11.0.1, globby@^11.0.2, globby@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
   integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
@@ -8759,6 +8858,11 @@ globby@^9.2.0:
     ignore "^4.0.3"
     pify "^4.0.1"
     slash "^2.0.0"
+
+globjoin@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/globjoin/-/globjoin-0.1.4.tgz#2f4494ac8919e3767c5cbb691e9f463324285d43"
+  integrity sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==
 
 glogg@^1.0.0:
   version "1.0.2"
@@ -9294,6 +9398,11 @@ html-minifier-terser@^5.0.1:
     relateurl "^0.2.7"
     terser "^4.6.3"
 
+html-tags@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-3.3.1.tgz#a04026a18c882e4bba8a01a3d39cfe465d40b5ce"
+  integrity sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==
+
 html-void-elements@^1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/html-void-elements/-/html-void-elements-1.0.5.tgz#ce9159494e86d95e45795b166c2021c2cfca4483"
@@ -9488,7 +9597,7 @@ ignore@^4.0.3:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.0.4, ignore@^5.1.1, ignore@^5.2.0:
+ignore@^5.0.4, ignore@^5.1.1, ignore@^5.2.0, ignore@^5.2.4:
   version "5.2.4"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
@@ -9510,6 +9619,11 @@ import-lazy@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43"
   integrity sha512-m7ZEHgtw69qOGw+jwxXkHlrlIPdTGkyh66zXZ1ajZbxkDBNjSY/LGbmjc7h0s2ELsUDTAhFr55TrPSSqJGPG0A==
+
+import-lazy@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-4.0.0.tgz#e8eb627483a0a43da3c03f3e35548be5cb0cc153"
+  integrity sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==
 
 import-local@^3.0.2:
   version "3.1.0"
@@ -9574,7 +9688,7 @@ ini@2.0.0:
   resolved "https://registry.yarnpkg.com/ini/-/ini-2.0.0.tgz#e5fd556ecdd5726be978fa1001862eacb0a94bc5"
   integrity sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==
 
-ini@^1.3.2, ini@^1.3.4, ini@~1.3.0:
+ini@^1.3.2, ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
@@ -10681,6 +10795,11 @@ klona@^2.0.4:
   resolved "https://registry.yarnpkg.com/klona/-/klona-2.0.6.tgz#85bffbf819c03b2f53270412420a4555ef882e22"
   integrity sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==
 
+known-css-properties@^0.27.0:
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/known-css-properties/-/known-css-properties-0.27.0.tgz#82a9358dda5fe7f7bd12b5e7142c0a205393c0c5"
+  integrity sha512-uMCj6+hZYDoffuvAJjFAPz56E9uoowFHmTkqRtRq5WyC5Q6Cu/fTZKNQpX/RbzChBYLLl3lo8CjFZBAZXq9qFg==
+
 last-run@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/last-run/-/last-run-1.1.1.tgz#45b96942c17b1c79c772198259ba943bebf8ca5b"
@@ -11249,6 +11368,11 @@ lodash.transform@^4.6.0:
   resolved "https://registry.yarnpkg.com/lodash.transform/-/lodash.transform-4.6.0.tgz#12306422f63324aed8483d3f38332b5f670547a0"
   integrity sha512-LO37ZnhmBVx0GvOU/caQuipEh4GN82TcWv3yHlebGDgOxbxiwwzW5Pcx2AcvpIv2WmvmSMoC492yQFNhy/l/UQ==
 
+lodash.truncate@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
+  integrity sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==
+
 lodash.union@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.union/-/lodash.union-4.6.0.tgz#48bb5088409f16f1821666641c44dd1aaae3cd88"
@@ -11539,6 +11663,11 @@ matcher@^3.0.0:
   dependencies:
     escape-string-regexp "^4.0.0"
 
+mathml-tag-names@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz#4ddadd67308e780cf16a47685878ee27b736a0a3"
+  integrity sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==
+
 md5-hex@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/md5-hex/-/md5-hex-3.0.1.tgz#be3741b510591434b2784d79e556eefc2c9a8e5c"
@@ -11592,6 +11721,11 @@ mdn-data@2.0.14:
   version "2.0.14"
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.14.tgz#7113fc4281917d63ce29b43446f701e68c25ba50"
   integrity sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==
+
+mdn-data@2.0.30:
+  version "2.0.30"
+  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.30.tgz#ce4df6f80af6cfbe218ecd5c552ba13c4dfa08cc"
+  integrity sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==
 
 mdn-data@2.0.4:
   version "2.0.4"
@@ -11674,6 +11808,24 @@ meow@^8.0.0:
   dependencies:
     "@types/minimist" "^1.2.0"
     camelcase-keys "^6.2.2"
+    decamelize-keys "^1.1.0"
+    hard-rejection "^2.1.0"
+    minimist-options "4.1.0"
+    normalize-package-data "^3.0.0"
+    read-pkg-up "^7.0.1"
+    redent "^3.0.0"
+    trim-newlines "^3.0.0"
+    type-fest "^0.18.0"
+    yargs-parser "^20.2.3"
+
+meow@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/meow/-/meow-9.0.0.tgz#cd9510bc5cac9dee7d03c73ee1f9ad959f4ea364"
+  integrity sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==
+  dependencies:
+    "@types/minimist" "^1.2.0"
+    camelcase-keys "^6.2.2"
+    decamelize "^1.2.0"
     decamelize-keys "^1.1.0"
     hard-rejection "^2.1.0"
     minimist-options "4.1.0"
@@ -12101,6 +12253,11 @@ nanoid@^3.3.1, nanoid@^3.3.4:
   version "3.3.4"
   resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
   integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
+
+nanoid@^3.3.6:
+  version "3.3.6"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.6.tgz#443380c856d6e9f9824267d960b4236ad583ea4c"
+  integrity sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -13757,6 +13914,11 @@ postcss-logical@^4.0.2:
   dependencies:
     postcss "^7.0.17"
 
+postcss-media-query-parser@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz#27b39c6f4d94f81b1a73b8f76351c609e5cef244"
+  integrity sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig==
+
 postcss-merge-rules@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/postcss-merge-rules/-/postcss-merge-rules-6.0.0.tgz#0d95bc73541156b8b4e763bd0de2c3f9d0ecf013"
@@ -13821,10 +13983,20 @@ postcss-reporter@^7.0.0:
     picocolors "^1.0.0"
     thenby "^1.3.4"
 
+postcss-resolve-nested-selector@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz#29ccbc7c37dedfac304e9fff0bf1596b3f6a0e4e"
+  integrity sha512-HvExULSwLqHLgUy1rl3ANIqCsvMS0WHss2UOsXhXnQaZ9VCc2oBvIpXrl00IUFT5ZDITME0o6oiXeiHr2SAIfw==
+
 postcss-rgb-mapping@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/postcss-rgb-mapping/-/postcss-rgb-mapping-1.0.1.tgz#1eb203e0569c91e82394930924d0368528110728"
   integrity sha512-RzAtZX+kGf1mLvzMCuvRf95wyKhxG608FfFDk1QhLWVri2xM2Vr33KFCLc3UkvpY3ZQd1o4GY3+gfXTbbf262w==
+
+postcss-safe-parser@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz#bb4c29894171a94bc5c996b9a30317ef402adaa1"
+  integrity sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==
 
 postcss-selector-parser@^2.2.2, postcss-selector-parser@^2.2.3:
   version "2.2.3"
@@ -13853,10 +14025,18 @@ postcss-selector-parser@^5.0.0-rc.3:
     indexes-of "^1.0.1"
     uniq "^1.0.1"
 
-postcss-selector-parser@^6.0.0, postcss-selector-parser@^6.0.10, postcss-selector-parser@^6.0.2, postcss-selector-parser@^6.0.4, postcss-selector-parser@^6.0.5:
+postcss-selector-parser@^6.0.0, postcss-selector-parser@^6.0.10, postcss-selector-parser@^6.0.11, postcss-selector-parser@^6.0.2, postcss-selector-parser@^6.0.4, postcss-selector-parser@^6.0.5:
   version "6.0.11"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz#2e41dc39b7ad74046e1615185185cd0b17d0c8dc"
   integrity sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==
+  dependencies:
+    cssesc "^3.0.0"
+    util-deprecate "^1.0.2"
+
+postcss-selector-parser@^6.0.12:
+  version "6.0.13"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz#d05d8d76b1e8e173257ef9d60b706a8e5e99bf1b"
+  integrity sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==
   dependencies:
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"
@@ -13888,7 +14068,7 @@ postcss-value-parser@^3.2.3, postcss-value-parser@^3.3.0:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz#9ff822547e2893213cf1c30efa51ac5fd1ba8281"
   integrity sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==
 
-postcss-value-parser@^4.1.0:
+postcss-value-parser@^4.1.0, postcss-value-parser@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
@@ -13953,6 +14133,15 @@ postcss@^8.4.21:
   integrity sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==
   dependencies:
     nanoid "^3.3.4"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.2"
+
+postcss@^8.4.23:
+  version "8.4.24"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.24.tgz#f714dba9b2284be3cc07dbd2fc57ee4dc972d2df"
+  integrity sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==
+  dependencies:
+    nanoid "^3.3.6"
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
@@ -15898,7 +16087,7 @@ source-list-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
 
-source-map-js@^1.0.2:
+source-map-js@^1.0.1, source-map-js@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
@@ -16419,12 +16608,130 @@ style-loader@^1.3.0:
     loader-utils "^2.0.0"
     schema-utils "^2.7.0"
 
+style-search@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
+  integrity sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg==
+
 style-to-object@0.3.0, style-to-object@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/style-to-object/-/style-to-object-0.3.0.tgz#b1b790d205991cc783801967214979ee19a76e46"
   integrity sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==
   dependencies:
     inline-style-parser "0.1.1"
+
+stylelint-config-recommended@^12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-recommended/-/stylelint-config-recommended-12.0.0.tgz#d0993232fca017065fd5acfcb52dd8a188784ef4"
+  integrity sha512-x6x8QNARrGO2sG6iURkzqL+Dp+4bJorPMMRNPScdvaUK8PsynriOcMW7AFDKqkWAS5wbue/u8fUT/4ynzcmqdQ==
+
+stylelint-config-standard@^33.0.0:
+  version "33.0.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-standard/-/stylelint-config-standard-33.0.0.tgz#1f7bb299153a53874073e93829e37a475842f0f9"
+  integrity sha512-eyxnLWoXImUn77+ODIuW9qXBDNM+ALN68L3wT1lN2oNspZ7D9NVGlNHb2QCUn4xDug6VZLsh0tF8NyoYzkgTzg==
+  dependencies:
+    stylelint-config-recommended "^12.0.0"
+
+stylelint-use-logical@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/stylelint-use-logical/-/stylelint-use-logical-2.1.0.tgz#4d2e58418d1a5d459beb3d51552491fab1ed22ec"
+  integrity sha512-DN1boOPI6IMYTlu2KeQpH5hDEiCODHhd+AtXU0InO37wkWAuELiPwuv59HrTg2m9PYmqGTTO/QWdMBafYVPfew==
+
+stylelint@^15.5.0:
+  version "15.5.0"
+  resolved "https://registry.yarnpkg.com/stylelint/-/stylelint-15.5.0.tgz#f16c238231f3f32e62da8a88969821d237eae8a6"
+  integrity sha512-jyMO3R1QtE5mUS4v40+Gg+sIQBqe7CF1xPslxycDzNVkIBCUD4O+5F1vLPq16VmunUTv4qG9o2rUKLnU5KkVeQ==
+  dependencies:
+    "@csstools/css-parser-algorithms" "^2.1.0"
+    "@csstools/css-tokenizer" "^2.1.0"
+    "@csstools/media-query-list-parser" "^2.0.2"
+    "@csstools/selector-specificity" "^2.2.0"
+    balanced-match "^2.0.0"
+    colord "^2.9.3"
+    cosmiconfig "^8.1.3"
+    css-functions-list "^3.1.0"
+    css-tree "^2.3.1"
+    debug "^4.3.4"
+    fast-glob "^3.2.12"
+    fastest-levenshtein "^1.0.16"
+    file-entry-cache "^6.0.1"
+    global-modules "^2.0.0"
+    globby "^11.1.0"
+    globjoin "^0.1.4"
+    html-tags "^3.3.1"
+    ignore "^5.2.4"
+    import-lazy "^4.0.0"
+    imurmurhash "^0.1.4"
+    is-plain-object "^5.0.0"
+    known-css-properties "^0.27.0"
+    mathml-tag-names "^2.1.3"
+    meow "^9.0.0"
+    micromatch "^4.0.5"
+    normalize-path "^3.0.0"
+    picocolors "^1.0.0"
+    postcss "^8.4.21"
+    postcss-media-query-parser "^0.2.3"
+    postcss-resolve-nested-selector "^0.1.1"
+    postcss-safe-parser "^6.0.0"
+    postcss-selector-parser "^6.0.11"
+    postcss-value-parser "^4.2.0"
+    resolve-from "^5.0.0"
+    string-width "^4.2.3"
+    strip-ansi "^6.0.1"
+    style-search "^0.1.0"
+    supports-hyperlinks "^3.0.0"
+    svg-tags "^1.0.0"
+    table "^6.8.1"
+    v8-compile-cache "^2.3.0"
+    write-file-atomic "^5.0.0"
+
+stylelint@^15.6.2:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/stylelint/-/stylelint-15.6.2.tgz#06d9005b62a83b72887eed623520e9b472af8c15"
+  integrity sha512-fjQWwcdUye4DU+0oIxNGwawIPC5DvG5kdObY5Sg4rc87untze3gC/5g/ikePqVjrAsBUZjwMN+pZsAYbDO6ArQ==
+  dependencies:
+    "@csstools/css-parser-algorithms" "^2.1.1"
+    "@csstools/css-tokenizer" "^2.1.1"
+    "@csstools/media-query-list-parser" "^2.0.4"
+    "@csstools/selector-specificity" "^2.2.0"
+    balanced-match "^2.0.0"
+    colord "^2.9.3"
+    cosmiconfig "^8.1.3"
+    css-functions-list "^3.1.0"
+    css-tree "^2.3.1"
+    debug "^4.3.4"
+    fast-glob "^3.2.12"
+    fastest-levenshtein "^1.0.16"
+    file-entry-cache "^6.0.1"
+    global-modules "^2.0.0"
+    globby "^11.1.0"
+    globjoin "^0.1.4"
+    html-tags "^3.3.1"
+    ignore "^5.2.4"
+    import-lazy "^4.0.0"
+    imurmurhash "^0.1.4"
+    is-plain-object "^5.0.0"
+    known-css-properties "^0.27.0"
+    mathml-tag-names "^2.1.3"
+    meow "^9.0.0"
+    micromatch "^4.0.5"
+    normalize-path "^3.0.0"
+    picocolors "^1.0.0"
+    postcss "^8.4.23"
+    postcss-media-query-parser "^0.2.3"
+    postcss-resolve-nested-selector "^0.1.1"
+    postcss-safe-parser "^6.0.0"
+    postcss-selector-parser "^6.0.12"
+    postcss-value-parser "^4.2.0"
+    resolve-from "^5.0.0"
+    string-width "^4.2.3"
+    strip-ansi "^6.0.1"
+    style-search "^0.1.0"
+    supports-hyperlinks "^3.0.0"
+    svg-tags "^1.0.0"
+    table "^6.8.1"
+    v8-compile-cache "^2.3.0"
+    write-file-atomic "^5.0.1"
 
 supertap@^2.0.0:
   version "2.0.0"
@@ -16463,6 +16770,14 @@ supports-color@^7.0.0, supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
+supports-hyperlinks@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/supports-hyperlinks/-/supports-hyperlinks-3.0.0.tgz#c711352a5c89070779b4dad54c05a2f14b15c94b"
+  integrity sha512-QBDPHyPQDRTy9ku4URNGY5Lah8PAaXs6tAAwp55sL5WCsSW7GIfdf6W5ixfziW+t7wh3GVvHyHHyQ1ESsoRvaA==
+  dependencies:
+    has-flag "^4.0.0"
+    supports-color "^7.0.0"
+
 supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
@@ -16475,6 +16790,11 @@ sver-compat@^1.5.0:
   dependencies:
     es6-iterator "^2.0.1"
     es6-symbol "^3.1.1"
+
+svg-tags@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/svg-tags/-/svg-tags-1.0.0.tgz#58f71cee3bd519b59d4b2a843b6c7de64ac04764"
+  integrity sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==
 
 svgcombiner@^1.0.0:
   version "1.0.1"
@@ -16516,6 +16836,17 @@ synchronous-promise@^2.0.15:
   version "2.0.17"
   resolved "https://registry.yarnpkg.com/synchronous-promise/-/synchronous-promise-2.0.17.tgz#38901319632f946c982152586f2caf8ddc25c032"
   integrity sha512-AsS729u2RHUfEra9xJrE39peJcc2stq2+poBXX8bcM08Y6g9j/i/PUzwNQqkaJde7Ntg1TO7bSREbR5sdosQ+g==
+
+table@^6.8.1:
+  version "6.8.1"
+  resolved "https://registry.yarnpkg.com/table/-/table-6.8.1.tgz#ea2b71359fe03b017a5fbc296204471158080bdf"
+  integrity sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==
+  dependencies:
+    ajv "^8.0.1"
+    lodash.truncate "^4.4.2"
+    slice-ansi "^4.0.0"
+    string-width "^4.2.3"
+    strip-ansi "^6.0.1"
 
 tapable@^1.0.0, tapable@^1.1.3:
   version "1.1.3"
@@ -17523,7 +17854,7 @@ v8-compile-cache-lib@^3.0.1:
   resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
   integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
-v8-compile-cache@2.3.0:
+v8-compile-cache@2.3.0, v8-compile-cache@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
   integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
@@ -17857,7 +18188,7 @@ which-typed-array@^1.1.9:
     has-tostringtag "^1.0.0"
     is-typed-array "^1.1.10"
 
-which@^1.2.14, which@^1.2.9:
+which@^1.2.14, which@^1.2.9, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
@@ -18018,6 +18349,14 @@ write-file-atomic@^5.0.0:
   dependencies:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.7"
+
+write-file-atomic@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-5.0.1.tgz#68df4717c55c6fa4281a7860b4c2ba0a6d2b11e7"
+  integrity sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==
+  dependencies:
+    imurmurhash "^0.1.4"
+    signal-exit "^4.0.1"
 
 write-json-file@^3.2.0:
   version "3.2.0"


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
* Adds Stylelint to the project & borrows from some of the standard config.
* Adds a new `linting` GH Action to allow for linting in CI.

## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 ``` yarn lint:styles ```

 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->
Chrome and in Github workflow

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] I have updated any relevant storybook stories and templates. 
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
