### PR TITLE
chore: update color* component dependencies

### DIFF
--- a/components/colorarea/package.json
+++ b/components/colorarea/package.json
@@ -18,11 +18,11 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/colorhandle": ">=3.0.0",
-    "@spectrum-css/tokens": ">=8.0.0"
+    "@spectrum-css/colorhandle": ">=4",
+    "@spectrum-css/tokens": ">=8 <=9"
   },
   "devDependencies": {
-    "@spectrum-css/colorhandle": "^3.0.6",
+    "@spectrum-css/colorhandle": "^4.0.3",
     "@spectrum-css/component-builder-simple": "*",
     "@spectrum-css/tokens": "^9.0.1",
     "gulp": "^4.0.0"

--- a/components/colorhandle/package.json
+++ b/components/colorhandle/package.json
@@ -18,12 +18,12 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/colorloupe": "^3.0.0-beta.1",
-    "@spectrum-css/tokens": ">=9.0.0"
+    "@spectrum-css/colorloupe": ">=3",
+    "@spectrum-css/tokens": ">=8 <=9"
   },
   "devDependencies": {
     "@spectrum-css/colorloupe": "^3.0.3",
-    "@spectrum-css/component-builder-simple": "^2.0.0",
+    "@spectrum-css/component-builder-simple": "*",
     "@spectrum-css/tokens": "^9.0.1",
     "gulp": "^4.0.0"
   },

--- a/components/colorloupe/package.json
+++ b/components/colorloupe/package.json
@@ -18,10 +18,10 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/tokens": ">=9.0.0"
+    "@spectrum-css/tokens": ">=8 <=9"
   },
   "devDependencies": {
-    "@spectrum-css/component-builder-simple": "^2.0.0",
+    "@spectrum-css/component-builder-simple": "*",
     "@spectrum-css/tokens": "^9.0.1",
     "gulp": "^4.0.0"
   },

--- a/components/colorslider/package.json
+++ b/components/colorslider/package.json
@@ -18,11 +18,11 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/colorhandle": ">=3.0.0",
-    "@spectrum-css/vars": ">=9.0.0"
+    "@spectrum-css/colorhandle": ">=3 <=4",
+    "@spectrum-css/tokens": ">=8 <=9"
   },
   "devDependencies": {
-    "@spectrum-css/colorhandle": "^3.0.6",
+    "@spectrum-css/colorhandle": "^4.0.3",
     "@spectrum-css/component-builder": "*",
     "@spectrum-css/vars": "^9.0.2",
     "gulp": "^4.0.0"

--- a/components/colorwheel/package.json
+++ b/components/colorwheel/package.json
@@ -18,12 +18,12 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/colorhandle": "^3.0.0",
-    "@spectrum-css/tokens": ">=8.0.0"
+    "@spectrum-css/colorhandle": ">=4",
+    "@spectrum-css/tokens": ">=8 <=9"
   },
   "devDependencies": {
     "@spectrum-css/colorarea": "^4.0.3",
-    "@spectrum-css/colorhandle": "^3.0.6",
+    "@spectrum-css/colorhandle": "^4.0.3",
     "@spectrum-css/component-builder-simple": "*",
     "@spectrum-css/tokens": "^9.0.1",
     "gulp": "^4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2128,11 +2128,6 @@
   resolved "https://registry.yarnpkg.com/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz#96116f2a912e0c02817345b3c10751069920d553"
   integrity sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==
 
-"@spectrum-css/colorhandle@^3.0.6":
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/colorhandle/-/colorhandle-3.0.6.tgz#92c2380a6454399e21869aeeaaf249cb856312d5"
-  integrity sha512-W7HIUXcMrVbyNSNDc0v9nJ6oL2QUEBcoKWPtScEbap+x/qlGxeyFTas6WNpiP8srmOJqnOAwRCrjbxW51HtQOg==
-
 "@spectrum-css/illustratedmessage@^4.0.19":
   version "4.0.19"
   resolved "https://registry.yarnpkg.com/@spectrum-css/illustratedmessage/-/illustratedmessage-4.0.19.tgz#064bdb0413b55fec65347959598eb0b65fbd6750"


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
Lerna didn't do a great job of handling versions when trying to graduate two components at the same time. This brings the affected packages up-to-date with their correct dependency versions.

## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] I have updated any relevant storybook stories and templates. 
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
