### PR TITLE
feat(floatingactionbutton): add new component

### DIFF
--- a/components/floatingactionbutton/README.md
+++ b/components/floatingactionbutton/README.md
@@ -1,0 +1,7 @@
+# @spectrum-css/floatingactionbutton
+
+> The Spectrum CSS Floating action button component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/floatingactionbutton).

--- a/components/floatingactionbutton/gulpfile.js
+++ b/components/floatingactionbutton/gulpfile.js
@@ -1,0 +1,1 @@
+module.exports = require('@spectrum-css/component-builder-simple');

--- a/components/floatingactionbutton/index.css
+++ b/components/floatingactionbutton/index.css
@@ -101,7 +101,7 @@ governing permissions and limitations under the License.
   }
 }
 
-.spectrum-FloatingActionButton-icon {
+.spectrum-Icon.spectrum-FloatingActionButton-icon {
   block-size: var(--mod-floating-action-button-icon-size, var(--spectrum-floating-action-button-icon-size));
   inline-size: var(--mod-floating-action-button-icon-size, var(--spectrum-floating-action-button-icon-size));
   fill: var(--highcontrast-floating-action-button-icon-color, var(--mod-floating-action-button-icon-color, var(--spectrum-floating-action-button-icon-color)));

--- a/components/floatingactionbutton/index.css
+++ b/components/floatingactionbutton/index.css
@@ -16,8 +16,8 @@ governing permissions and limitations under the License.
   --spectrum-floating-action-button-padding: var(--spectrum-component-pill-edge-to-visual-only-200);
   --spectrum-floating-action-button-margin: var(--spectrum-spacing-200);
   --spectrum-floating-action-button-drop-shadow-x: var(--spectrum-drop-shadow-x);
-  --spectrum-floating-action-button-drop-shadow-y: var(--spectrum-drop-shadow-y);
-  --spectrum-floating-action-button-drop-shadow-color: var(--spectrum-transparent-black-300);
+  --spectrum-floating-action-button-drop-shadow-y: 4px; /* TODO: waiting for token */
+  --spectrum-floating-action-button-drop-shadow-color: var(--spectrum-transparent-black-300); /* TODO: waiting for token */
 
   --spectrum-floating-action-button-focus-ring-width: var(--spectrum-focus-indicator-thickness);
   --spectrum-floating-action-button-focus-ring-gap: var(--spectrum-focus-indicator-gap);

--- a/components/floatingactionbutton/index.css
+++ b/components/floatingactionbutton/index.css
@@ -47,12 +47,6 @@ governing permissions and limitations under the License.
 
 }
 
-@media (forced-colors: active) {
-  .spectrum-FloatingActionButton {
-
-  }
-}
-
 .spectrum-FloatingActionButton {
   cursor: pointer;
   block-size: var(--mod-floating-action-button-size, var(--spectrum-floating-action-button-size));
@@ -63,35 +57,35 @@ governing permissions and limitations under the License.
   margin-inline-end: var(--mod-floating-action-button-margin, var(--spectrum-floating-action-button-margin));
   margin-block-end: var(--mod-floating-action-button-margin, var(--spectrum-floating-action-button-margin));
   border: none;
-  box-shadow: var(--spectrum-floating-action-button-drop-shadow-x) var(--spectrum-floating-action-button-drop-shadow-y) var(--spectrum-floating-action-button-drop-shadow-blur) var(--spectrum-floating-action-button-drop-shadow-color);
+  box-shadow: var(--mod-floating-action-button-drop-shadow-x, var(--spectrum-floating-action-button-drop-shadow-x)) var(--mod-floating-action-button-drop-shadow-y, var(--spectrum-floating-action-button-drop-shadow-y)) var(--mod-floating-action-button-drop-shadow-blur, var(--spectrum-floating-action-button-drop-shadow-blur)) var(--mod-floating-action-button-drop-shadow-color, var(--spectrum-floating-action-button-drop-shadow-color));
   position: relative;
 
   /* default is primary */
-  background-color: var(--spectrum-floating-action-button-background-color);
+  background-color: var(--highcontrast-floating-action-button-background-color, var(--mod-floating-action-button-background-color, var(--spectrum-floating-action-button-background-color)));
 
   &:hover {
-    background-color: var(--spectrum-floating-action-button-background-color-hover);
+    background-color: var(--highcontrast-floating-action-button-background-color-hover, var(--mod-floating-action-button-background-color-hover, var(--spectrum-floating-action-button-background-color-hover)));
 
     .spectrum-FloatingActionButton-icon {
-      fill: var(--spectrum-floating-action-button-icon-color-hover);
+      fill: var(--highcontrast-floating-action-button-icon-color-hover, var(--mod-floating-action-button-icon-color-hover, var(--spectrum-floating-action-button-icon-color-hover)));
     }
   }
 
   &:active {
-    background-color: var(--spectrum-floating-action-button-background-color-down);
+    background-color: var(--highcontrast-floating-action-button-background-color-down, var(--mod-floating-action-button-background-color-down, var(--spectrum-floating-action-button-background-color-down)));
 
     .spectrum-FloatingActionButton-icon {
-      fill: var(--spectrum-floating-action-button-icon-color-down);
+      fill: var(--highcontrast-floating-action-button-icon-color-down, var(--mod-floating-action-button-icon-color-down, var(--spectrum-floating-action-button-icon-color-down)));
     }
   }
 
   &.is-focused,
   &:focus, 
   &:focus-within {
-    background-color: var(--spectrum-floating-action-button-background-color-key-focus);
+    background-color: var(--highcontrast-floating-action-button-background-color-key-focus, var(--mod-floating-action-button-background-color-key-focus, var(--spectrum-floating-action-button-background-color-key-focus)));
 
     .spectrum-FloatingActionButton-icon {
-      fill: var(--spectrum-floating-action-button-icon-color-key-focus);
+      fill: var(--highcontrast-floating-action-button-icon-color-key-focus, var(--mod-floating-action-button-icon-color-key-focus, var(--spectrum-floating-action-button-icon-color-key-focus)));
     }
 
     &:after {
@@ -110,9 +104,28 @@ governing permissions and limitations under the License.
 .spectrum-FloatingActionButton-icon {
   block-size: var(--mod-floating-action-button-icon-size, var(--spectrum-floating-action-button-icon-size));
   inline-size: var(--mod-floating-action-button-icon-size, var(--spectrum-floating-action-button-icon-size));
-  fill: var(--spectrum-floating-action-button-icon-color);
+  fill: var(--highcontrast-floating-action-button-icon-color, var(--mod-floating-action-button-icon-color, var(--spectrum-floating-action-button-icon-color)));
+}
 
-  &:active {
-    background-color: var(--spectrum-floating-action-button-background-color-down);
+
+@media (forced-colors: active) {
+  .spectrum-FloatingActionButton {
+
+    &:after {
+      /* make sure focus-ring renders */
+      forced-color-adjust: none;
+    }
+
+    --highcontrast-floating-action-button-background-color: CanvasText;
+    --highcontrast-floating-action-button-background-color-hover: Highlight;
+    --highcontrast-floating-action-button-background-color-down: Highlight;
+    --highcontrast-floating-action-button-background-color-key-focus: Highlight;
+
+    --highcontrast-floating-action-button-icon-color: ButtonFace;
+    --highcontrast-floating-action-button-icon-color-hover: ButtonFace;
+    --highcontrast-floating-action-button-icon-color-down: ButtonFace;
+    --highcontrast-floating-action-button-icon-color-key-focus: ButtonFace;
+
+
   }
 }

--- a/components/floatingactionbutton/index.css
+++ b/components/floatingactionbutton/index.css
@@ -16,8 +16,7 @@ governing permissions and limitations under the License.
   --spectrum-floating-action-button-padding: var(--spectrum-component-pill-edge-to-visual-only-200);
   --spectrum-floating-action-button-margin: var(--spectrum-spacing-200);
   --spectrum-floating-action-button-drop-shadow-x: var(--spectrum-drop-shadow-x);
-  --spectrum-floating-action-button-drop-shadow-y: 4px; /* TODO: waiting for token */
-  --spectrum-floating-action-button-drop-shadow-color: var(--spectrum-transparent-black-300); /* TODO: waiting for token */
+  --spectrum-floating-action-button-drop-shadow-color: var(--spectrum-floating-action-button-shadow-color); 
 
   --spectrum-floating-action-button-focus-ring-width: var(--spectrum-focus-indicator-thickness);
   --spectrum-floating-action-button-focus-ring-gap: var(--spectrum-focus-indicator-gap);

--- a/components/floatingactionbutton/index.css
+++ b/components/floatingactionbutton/index.css
@@ -44,11 +44,32 @@ governing permissions and limitations under the License.
 
 }
 
+@media (forced-colors: active) {
+  .spectrum-FloatingActionButton {
+
+    &:after {
+      /* make sure focus-ring renders */
+      forced-color-adjust: none;
+    }
+
+    --highcontrast-floating-action-button-background-color: ButtonText;
+    --highcontrast-floating-action-button-background-color-hover: Highlight;
+    --highcontrast-floating-action-button-background-color-down: Highlight;
+    --highcontrast-floating-action-button-background-color-key-focus: Highlight;
+
+    --highcontrast-floating-action-button-icon-color: ButtonFace;
+    --highcontrast-floating-action-button-icon-color-hover: ButtonFace;
+    --highcontrast-floating-action-button-icon-color-down: ButtonFace;
+    --highcontrast-floating-action-button-icon-color-key-focus: ButtonFace;
+
+  }
+}
+
 .spectrum-FloatingActionButton {
   cursor: pointer;
   block-size: var(--mod-floating-action-button-size, var(--spectrum-floating-action-button-size));
   inline-size: var(--mod-floating-action-button-size, var(--spectrum-floating-action-button-size));
-  border-radius: 50%;
+  border-radius: var(--mod-floating-action-button-border-radius, 50%);
   padding-inline: var(--mod-floating-action-button-padding, var(--spectrum-floating-action-button-padding));
   padding-block: var(--mod-floating-action-button-padding, var(--spectrum-floating-action-button-padding));
   margin-inline-end: var(--mod-floating-action-button-margin, var(--spectrum-floating-action-button-margin));
@@ -80,7 +101,8 @@ governing permissions and limitations under the License.
   &:focus, 
   &:focus-within {
     background-color: var(--highcontrast-floating-action-button-background-color-key-focus, var(--mod-floating-action-button-background-color-key-focus, var(--spectrum-floating-action-button-background-color-key-focus)));
-
+    outline: 0;
+    
     .spectrum-FloatingActionButton-icon {
       fill: var(--highcontrast-floating-action-button-icon-color-key-focus, var(--mod-floating-action-button-icon-color-key-focus, var(--spectrum-floating-action-button-icon-color-key-focus)));
     }
@@ -90,7 +112,7 @@ governing permissions and limitations under the License.
       inset: 0;
       margin: calc(-1 * var(--mod-floating-action-button-focus-ring-gap, var(--spectrum-floating-action-button-focus-ring-gap)));
       box-shadow: 0 0 0 var(--mod-floating-action-button-focus-ring-width, var(--spectrum-floating-action-button-focus-ring-width)) var(--highcontrast-floating-action-button-focus-ring-color, var(--mod-afloating-action-button-focus-ring-color, var(--spectrum-floating-action-button-focus-ring-color)));
-      border-radius: 50%;
+      border-radius: var(--mod-floating-action-button-border-radius, 50%);
       pointer-events: none;
       content: '';
     }
@@ -101,25 +123,4 @@ governing permissions and limitations under the License.
   block-size: var(--mod-floating-action-button-icon-size, var(--spectrum-floating-action-button-icon-size));
   inline-size: var(--mod-floating-action-button-icon-size, var(--spectrum-floating-action-button-icon-size));
   fill: var(--highcontrast-floating-action-button-icon-color, var(--mod-floating-action-button-icon-color, var(--spectrum-floating-action-button-icon-color)));
-}
-
-@media (forced-colors: active) {
-  .spectrum-FloatingActionButton {
-
-    &:after {
-      /* make sure focus-ring renders */
-      forced-color-adjust: none;
-    }
-
-    --highcontrast-floating-action-button-background-color: CanvasText;
-    --highcontrast-floating-action-button-background-color-hover: Highlight;
-    --highcontrast-floating-action-button-background-color-down: Highlight;
-    --highcontrast-floating-action-button-background-color-key-focus: Highlight;
-
-    --highcontrast-floating-action-button-icon-color: ButtonFace;
-    --highcontrast-floating-action-button-icon-color-hover: ButtonFace;
-    --highcontrast-floating-action-button-icon-color-down: ButtonFace;
-    --highcontrast-floating-action-button-icon-color-key-focus: ButtonFace;
-
-  }
 }

--- a/components/floatingactionbutton/index.css
+++ b/components/floatingactionbutton/index.css
@@ -1,0 +1,118 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+.spectrum-FloatingActionButton {
+  --spectrum-floating-action-button-size: var(--spectrum-component-height-200);
+  --spectrum-floating-action-button-icon-size: var(--spectrum-workflow-icon-size-200);
+  --spectrum-floating-action-button-padding: var(--spectrum-component-pill-edge-to-visual-only-200);
+  --spectrum-floating-action-button-margin: var(--spectrum-spacing-200);
+  --spectrum-floating-action-button-drop-shadow-x: var(--spectrum-drop-shadow-x);
+  --spectrum-floating-action-button-drop-shadow-y: var(--spectrum-drop-shadow-y);
+  --spectrum-floating-action-button-drop-shadow-color: var(--spectrum-transparent-black-300);
+
+  --spectrum-floating-action-button-focus-ring-width: var(--spectrum-focus-indicator-thickness);
+  --spectrum-floating-action-button-focus-ring-gap: var(--spectrum-focus-indicator-gap);
+  --spectrum-floating-action-button-focus-ring-color: var(--spectrum-focus-indicator-color);
+
+
+  --spectrum-floating-action-button-background-color: var(--spectrum-accent-background-color-default);
+  --spectrum-floating-action-button-background-color-hover: var(--spectrum-accent-background-color-hover);
+  --spectrum-floating-action-button-background-color-down: var(--spectrum-accent-background-color-down);
+  --spectrum-floating-action-button-background-color-key-focus: var(--spectrum-accent-background-color-key-focus);
+  --spectrum-floating-action-button-icon-color: var(--spectrum-white);
+  --spectrum-floating-action-button-icon-color-hover: var(--spectrum-white);
+  --spectrum-floating-action-button-icon-color-down: var(--spectrum-white);
+  --spectrum-floating-action-button-icon-color-key-focus: var(--spectrum-white);
+
+
+  &--secondary {
+    --spectrum-floating-action-button-background-color: var(--spectrum-background-layer-2-color);
+    --spectrum-floating-action-button-background-color-hover: var(--spectrum-background-layer-2-color);
+    --spectrum-floating-action-button-background-color-down: var(--spectrum-background-layer-2-color);
+    --spectrum-floating-action-button-background-color-key-focus: var(--spectrum-background-layer-2-color);
+    --spectrum-floating-action-button-icon-color: var(--spectrum-neutral-subdued-content-color-default);
+    --spectrum-floating-action-button-icon-color-hover: var(--spectrum-neutral-subdued-content-color-hover);
+    --spectrum-floating-action-button-icon-color-down: var(--spectrum-neutral-subdued-content-color-down);
+    --spectrum-floating-action-button-icon-color-key-focus: var(--spectrum-neutral-subdued-content-color-key-focus);
+  }
+
+}
+
+@media (forced-colors: active) {
+  .spectrum-FloatingActionButton {
+
+  }
+}
+
+.spectrum-FloatingActionButton {
+  cursor: pointer;
+  block-size: var(--mod-floating-action-button-size, var(--spectrum-floating-action-button-size));
+  inline-size: var(--mod-floating-action-button-size, var(--spectrum-floating-action-button-size));
+  border-radius: 50%;
+  padding-inline: var(--mod-floating-action-button-padding, var(--spectrum-floating-action-button-padding));
+  padding-block: var(--mod-floating-action-button-padding, var(--spectrum-floating-action-button-padding));
+  margin-inline-end: var(--mod-floating-action-button-margin, var(--spectrum-floating-action-button-margin));
+  margin-block-end: var(--mod-floating-action-button-margin, var(--spectrum-floating-action-button-margin));
+  border: none;
+  box-shadow: var(--spectrum-floating-action-button-drop-shadow-x) var(--spectrum-floating-action-button-drop-shadow-y) var(--spectrum-floating-action-button-drop-shadow-blur) var(--spectrum-floating-action-button-drop-shadow-color);
+  position: relative;
+
+  /* default is primary */
+  background-color: var(--spectrum-floating-action-button-background-color);
+
+  &:hover {
+    background-color: var(--spectrum-floating-action-button-background-color-hover);
+
+    .spectrum-FloatingActionButton-icon {
+      fill: var(--spectrum-floating-action-button-icon-color-hover);
+    }
+  }
+
+  &:active {
+    background-color: var(--spectrum-floating-action-button-background-color-down);
+
+    .spectrum-FloatingActionButton-icon {
+      fill: var(--spectrum-floating-action-button-icon-color-down);
+    }
+  }
+
+  &.is-focused,
+  &:focus, 
+  &:focus-within {
+    background-color: var(--spectrum-floating-action-button-background-color-key-focus);
+
+    .spectrum-FloatingActionButton-icon {
+      fill: var(--spectrum-floating-action-button-icon-color-key-focus);
+    }
+
+    &:after {
+      position: absolute;
+      inset: 0;
+      margin: calc(-1 * var(--mod-floating-action-button-focus-ring-gap, var(--spectrum-floating-action-button-focus-ring-gap)));
+      box-shadow: 0 0 0 var(--mod-floating-action-button-focus-ring-width, var(--spectrum-floating-action-button-focus-ring-width)) var(--highcontrast-floating-action-button-focus-ring-color, var(--mod-afloating-action-button-focus-ring-color, var(--spectrum-floating-action-button-focus-ring-color)));
+
+      border-radius: 50%;
+      pointer-events: none;
+      content: '';
+    }
+  }
+}
+
+.spectrum-FloatingActionButton-icon {
+  block-size: var(--mod-floating-action-button-icon-size, var(--spectrum-floating-action-button-icon-size));
+  inline-size: var(--mod-floating-action-button-icon-size, var(--spectrum-floating-action-button-icon-size));
+  fill: var(--spectrum-floating-action-button-icon-color);
+
+  &:active {
+    background-color: var(--spectrum-floating-action-button-background-color-down);
+  }
+}

--- a/components/floatingactionbutton/index.css
+++ b/components/floatingactionbutton/index.css
@@ -23,7 +23,6 @@ governing permissions and limitations under the License.
   --spectrum-floating-action-button-focus-ring-gap: var(--spectrum-focus-indicator-gap);
   --spectrum-floating-action-button-focus-ring-color: var(--spectrum-focus-indicator-color);
 
-
   --spectrum-floating-action-button-background-color: var(--spectrum-accent-background-color-default);
   --spectrum-floating-action-button-background-color-hover: var(--spectrum-accent-background-color-hover);
   --spectrum-floating-action-button-background-color-down: var(--spectrum-accent-background-color-down);
@@ -32,7 +31,6 @@ governing permissions and limitations under the License.
   --spectrum-floating-action-button-icon-color-hover: var(--spectrum-white);
   --spectrum-floating-action-button-icon-color-down: var(--spectrum-white);
   --spectrum-floating-action-button-icon-color-key-focus: var(--spectrum-white);
-
 
   &--secondary {
     --spectrum-floating-action-button-background-color: var(--spectrum-background-layer-2-color);
@@ -93,7 +91,6 @@ governing permissions and limitations under the License.
       inset: 0;
       margin: calc(-1 * var(--mod-floating-action-button-focus-ring-gap, var(--spectrum-floating-action-button-focus-ring-gap)));
       box-shadow: 0 0 0 var(--mod-floating-action-button-focus-ring-width, var(--spectrum-floating-action-button-focus-ring-width)) var(--highcontrast-floating-action-button-focus-ring-color, var(--mod-afloating-action-button-focus-ring-color, var(--spectrum-floating-action-button-focus-ring-color)));
-
       border-radius: 50%;
       pointer-events: none;
       content: '';
@@ -106,7 +103,6 @@ governing permissions and limitations under the License.
   inline-size: var(--mod-floating-action-button-icon-size, var(--spectrum-floating-action-button-icon-size));
   fill: var(--highcontrast-floating-action-button-icon-color, var(--mod-floating-action-button-icon-color, var(--spectrum-floating-action-button-icon-color)));
 }
-
 
 @media (forced-colors: active) {
   .spectrum-FloatingActionButton {
@@ -125,7 +121,6 @@ governing permissions and limitations under the License.
     --highcontrast-floating-action-button-icon-color-hover: ButtonFace;
     --highcontrast-floating-action-button-icon-color-down: ButtonFace;
     --highcontrast-floating-action-button-icon-color-key-focus: ButtonFace;
-
 
   }
 }

--- a/components/floatingactionbutton/metadata/floatingactionbutton.yml
+++ b/components/floatingactionbutton/metadata/floatingactionbutton.yml
@@ -4,6 +4,10 @@ SpectrumSiteSlug: https://spectrum.adobe.com/page/floating-action-button/
 description: |
   - Floating action button is used to give users a more prominent button for high frequency actions
   - When using Floating Action Button in dark themes, the `background-layer-color-2` will often show up on the base color `gray-50` or `gray-75` or on content, images, etc.
+sections:
+  - name: Custom Properties API
+    description: |
+      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/floatingactionbutton/metadata/mods.md">here</a>.
 examples:
   - id: floatingactionbutton-primary
     name: Primary

--- a/components/floatingactionbutton/metadata/floatingactionbutton.yml
+++ b/components/floatingactionbutton/metadata/floatingactionbutton.yml
@@ -1,0 +1,36 @@
+name: Floating action button
+status: Verified
+SpectrumSiteSlug: https://spectrum.adobe.com/page/floating-action-button/
+examples:
+  - id: floatingactionbutton-primary
+    name: Primary
+    markup: |
+      <button class="spectrum-FloatingActionButton spectrum-FloatingActionButton--primary" aria-label="Add">
+        <svg class="spectrum-Icon spectrum-FloatingActionButton-icon" focusable="false" aria-hidden="true">
+          <use xlink:href="#spectrum-icon-18-AddCircle" />
+        </svg>
+      </button>
+  - id: floatingactionbutton-primary-focused
+    name: Primary (focused)
+    markup: |
+      <button class="spectrum-FloatingActionButton spectrum-FloatingActionButton--primary is-focused" aria-label="Add">
+        <svg class="spectrum-Icon spectrum-FloatingActionButton-icon" focusable="false" aria-hidden="true">
+          <use xlink:href="#spectrum-icon-18-AddCircle" />
+        </svg>
+      </button>
+  - id: floatingactionbutton-secondary
+    name: Secondary
+    markup: |
+      <button class="spectrum-FloatingActionButton spectrum-FloatingActionButton--secondary" aria-label="Add">
+        <svg class="spectrum-Icon spectrum-FloatingActionButton-icon" focusable="false" aria-hidden="true">
+          <use xlink:href="#spectrum-icon-18-AddCircle" />
+        </svg>
+      </button>
+  - id: floatingactionbutton-secondary-focused
+    name: Secondary (focused)
+    markup: |
+      <button class="spectrum-FloatingActionButton spectrum-FloatingActionButton--secondary is-focused" aria-label="Add">
+        <svg class="spectrum-Icon spectrum-FloatingActionButton-icon" focusable="false" aria-hidden="true">
+          <use xlink:href="#spectrum-icon-18-AddCircle" />
+        </svg>
+      </button>

--- a/components/floatingactionbutton/metadata/floatingactionbutton.yml
+++ b/components/floatingactionbutton/metadata/floatingactionbutton.yml
@@ -1,7 +1,9 @@
 name: Floating Action Button
 status: Verified
 SpectrumSiteSlug: https://spectrum.adobe.com/page/floating-action-button/
-description: Floating action button is used to give users a more prominent button for high frequency actions
+description: |
+  - Floating action button is used to give users a more prominent button for high frequency actions
+  - When using Floating Action Button in dark themes, the `background-layer-color-2` will often show up on the base color `gray-50` or `gray-75` or on content, images, etc.
 examples:
   - id: floatingactionbutton-primary
     name: Primary

--- a/components/floatingactionbutton/metadata/floatingactionbutton.yml
+++ b/components/floatingactionbutton/metadata/floatingactionbutton.yml
@@ -1,6 +1,7 @@
-name: Floating action button
+name: Floating Action Button
 status: Verified
 SpectrumSiteSlug: https://spectrum.adobe.com/page/floating-action-button/
+description: Floating action button is used to give users a more prominent button for high frequency actions
 examples:
   - id: floatingactionbutton-primary
     name: Primary

--- a/components/floatingactionbutton/metadata/mods.md
+++ b/components/floatingactionbutton/metadata/mods.md
@@ -1,6 +1,7 @@
 | Modifiable Custom Properties |
 | --- |
 |`--mod-floating-action-button-size`|
+|`--mod-floating-action-button-border-radius`|
 |`--mod-floating-action-button-padding`|
 |`--mod-floating-action-button-margin`|
 |`--mod-floating-action-button-drop-shadow-x`|

--- a/components/floatingactionbutton/metadata/mods.md
+++ b/components/floatingactionbutton/metadata/mods.md
@@ -1,0 +1,21 @@
+| Modifiable Custom Properties |
+| --- |
+|`--mod-floating-action-button-size`|
+|`--mod-floating-action-button-padding`|
+|`--mod-floating-action-button-margin`|
+|`--mod-floating-action-button-drop-shadow-x`|
+|`--mod-floating-action-button-drop-shadow-y`|
+|`--mod-floating-action-button-drop-shadow-blur`|
+|`--mod-floating-action-button-drop-shadow-color`|
+|`--mod-floating-action-button-background-color`|
+|`--mod-floating-action-button-background-color-hover`|
+|`--mod-floating-action-button-icon-color-hover`|
+|`--mod-floating-action-button-background-color-down`|
+|`--mod-floating-action-button-icon-color-down`|
+|`--mod-floating-action-button-background-color-key-focus`|
+|`--mod-floating-action-button-icon-color-key-focus`|
+|`--mod-floating-action-button-focus-ring-gap`|
+|`--mod-floating-action-button-focus-ring-width`|
+|`--mod-afloating-action-button-focus-ring-color`|
+|`--mod-floating-action-button-icon-size`|
+|`--mod-floating-action-button-icon-color`|

--- a/components/floatingactionbutton/package.json
+++ b/components/floatingactionbutton/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@spectrum-css/floatingactionbutton",
+  "version": "1.0.0-alpha.0",
+  "description": "The Spectrum CSS floatingactionbutton component",
+  "license": "Apache-2.0",
+  "author": "Adobe",
+  "contributors": [],
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/floatingactionbutton"
+  },
+  "bugs": {
+    "url": "https://github.com/adobe/spectrum-css/issues"
+  },
+  "main": "dist/index-vars.css",
+  "scripts": {
+    "build": "gulp",
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "watch": "gulp watch"
+  },
+  "peerDependencies": {
+    "@spectrum-css/tokens": ">= 8"
+  },
+  "devDependencies": {
+    "@spectrum-css/component-builder-simple": "^2.0.7",
+    "@spectrum-css/tokens": "^8.1.0",
+    "gulp": "^4.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/components/floatingactionbutton/stories/floatingactionbutton.stories.js
+++ b/components/floatingactionbutton/stories/floatingactionbutton.stories.js
@@ -1,0 +1,39 @@
+// Import the component markup template
+import { Template } from "./template";
+
+// More on default export: https://storybook.js.org/docs/web-components/writing-stories/introduction#default-export
+export default {
+  title: "Floating action button",
+  description: "The Floating action button component is...",
+  component: "FloatingActionButton",
+  argTypes: {
+    size: {
+      name: "Size",
+      type: { name: "string", required: true },
+      defaultValue: "m",
+      table: {
+        type: { summary: "string" },
+        category: "Component",
+        defaultValue: { summary: "m" }
+      },
+      options: ["s", "m", "l", "xl"],
+      control: "select"
+    },
+  },
+  // More on args: https://storybook.js.org/docs/web-components/writing-stories/args
+  args: {
+    rootClass: "spectrum-FloatingActionButton",
+    size: "m",
+  },
+  parameters: {
+    actions: {
+      handles: []
+    },
+    status: {
+      type: process.env.MIGRATED_PACKAGES.includes('floatingactionbutton') ? 'migrated' : undefined
+    }
+  }
+};
+
+export const Default = Template.bind({});
+Default.args = {};

--- a/components/floatingactionbutton/stories/floatingactionbutton.stories.js
+++ b/components/floatingactionbutton/stories/floatingactionbutton.stories.js
@@ -1,29 +1,36 @@
 // Import the component markup template
 import { Template } from "./template";
 
+import { default as IconStories } from "@spectrum-css/icon/stories/icon.stories.js";
+
 // More on default export: https://storybook.js.org/docs/web-components/writing-stories/introduction#default-export
 export default {
   title: "Floating action button",
-  description: "The Floating action button component is...",
+  description: "The Floating action button component is used to give users a more prominent button for high frequency actions",
   component: "FloatingActionButton",
   argTypes: {
-    size: {
-      name: "Size",
+    variant: {
+      name: "Varaint",
       type: { name: "string", required: true },
-      defaultValue: "m",
+      defaultValue: "primary",
       table: {
         type: { summary: "string" },
         category: "Component",
-        defaultValue: { summary: "m" }
+        defaultValue: { summary: "primary" }
       },
-      options: ["s", "m", "l", "xl"],
-      control: "select"
+      options: ["primary", "secondary"],
+      control: "radio"
+    },
+    iconName: {
+      ...IconStories?.argTypes?.iconName ?? {},
+      if: false,
     },
   },
   // More on args: https://storybook.js.org/docs/web-components/writing-stories/args
   args: {
     rootClass: "spectrum-FloatingActionButton",
-    size: "m",
+    variant: "primary",
+    iconName: "AddCircle"
   },
   parameters: {
     actions: {
@@ -37,3 +44,8 @@ export default {
 
 export const Default = Template.bind({});
 Default.args = {};
+
+export const Secondary = Template.bind({});
+Secondary.args = {
+  variant: "secondary"
+};

--- a/components/floatingactionbutton/stories/template.js
+++ b/components/floatingactionbutton/stories/template.js
@@ -1,0 +1,24 @@
+import { html } from 'lit-html';
+import { classMap } from 'lit-html/directives/class-map.js';
+import { ifDefined } from 'lit-html/directives/if-defined.js';
+
+import "../index.css";
+
+// More on component templates: https://storybook.js.org/docs/web-components/writing-stories/introduction#using-args
+export const Template = ({
+  rootClass = "spectrum-FloatingActionButton",
+  size,
+  id,
+  customClasses = [],
+  ...globals
+}) => {
+  return html`
+    <div class=${classMap({
+      [rootClass]: true,
+      [`${rootClass}--size${size.toUpperCase()}`]: true,
+      ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
+    })} id=${ifDefined(id)}>
+      <!-- Component mark-up goes here -->
+    </div>
+  `;
+}

--- a/components/floatingactionbutton/stories/template.js
+++ b/components/floatingactionbutton/stories/template.js
@@ -3,22 +3,30 @@ import { classMap } from 'lit-html/directives/class-map.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 
 import "../index.css";
+import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 
 // More on component templates: https://storybook.js.org/docs/web-components/writing-stories/introduction#using-args
 export const Template = ({
   rootClass = "spectrum-FloatingActionButton",
-  size,
+  variant,
   id,
+  iconName,
   customClasses = [],
   ...globals
 }) => {
   return html`
-    <div class=${classMap({
+    <button class=${classMap({
       [rootClass]: true,
-      [`${rootClass}--size${size.toUpperCase()}`]: true,
+      [`${rootClass}--${variant}`]: variant !== undefined,
       ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
     })} id=${ifDefined(id)}>
-      <!-- Component mark-up goes here -->
-    </div>
+      ${Icon(
+        {
+          ...globals,
+          iconName,
+          customClasses: [`${rootClass}-icon`]
+        }
+      )}
+    </button>
   `;
 }

--- a/components/floatingactionbutton/themes/express.css
+++ b/components/floatingactionbutton/themes/express.css
@@ -1,0 +1,13 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+@container (--system: express) {}

--- a/components/floatingactionbutton/themes/spectrum.css
+++ b/components/floatingactionbutton/themes/spectrum.css
@@ -1,0 +1,13 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+@container (--system: spectrum) {}

--- a/components/textfield/metadata/mods.md
+++ b/components/textfield/metadata/mods.md
@@ -4,7 +4,6 @@
 |`--mod-textfield-focus-indicator-gap`|
 |`--mod-textfield-focus-indicator-width`|
 |`--mod-textfield-corner-radius`|
-|`--mod-textfield-border-width`|
 |`--mod-textfield-focus-indicator-color`|
 |`--mod-textfield-text-color-default`|
 |`--mod-textfield-text-color-disabled`|
@@ -32,6 +31,7 @@
 |`--mod-textfield-min-width`|
 |`--mod-textfield-height`|
 |`--mod-textfield-spacing-block-start`|
+|`--mod-textfield-border-width`|
 |`--mod-textfield-spacing-block-end`|
 |`--mod-textfield-spacing-inline`|
 |`--mod-textfield-background-color`|

--- a/yarn.lock
+++ b/yarn.lock
@@ -2197,6 +2197,11 @@
   resolved "https://registry.yarnpkg.com/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz#96116f2a912e0c02817345b3c10751069920d553"
   integrity sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==
 
+"@spectrum-css/tokens@^8.1.0":
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/tokens/-/tokens-8.1.1.tgz#cf23ef126622faaac537006a0df448b361aadd4a"
+  integrity sha512-uYXChRvQ9LS0tiUNzIJfBnkGZj6M+DixACa4AxyRYzO8zbfoS9H/XB6EzgKeVzNAutw43cr/ZtaK2FhQ727Nlg==
+
 "@storybook/addon-a11y@^6.5.15":
   version "6.5.16"
   resolved "https://registry.yarnpkg.com/@storybook/addon-a11y/-/addon-a11y-6.5.16.tgz#9288a6c1d111fa4ec501d213100ffff91757d3fc"


### PR DESCRIPTION
## Description

This adds a new FloatingActionButton component with two variants: primary and secondary.

This currently contains "hard coded" values for the `--spectrum-floating-action-button-drop-shadow-y` and `--spectrum-floating-action-button-drop-shadow-color` because we are waiting for these tokens to get added per this ticket


## How and where has this been tested?
- Latest versions of Chrome, Firefox, and Safari


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] I have tested these changes in Windows High Contrast mode.
- [x] I have updated any relevant storybook stories and templates. 
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
