### PR TITLE
chore(tokens): add custom tokens for button text spacing

### DIFF
--- a/components/tokens/custom-spectrum/custom-large-vars.css
+++ b/components/tokens/custom-spectrum/custom-large-vars.css
@@ -47,4 +47,13 @@ governing permissions and limitations under the License.
   --spectrum-menu-item-checkmark-width-extra-large: 16px;
 
   --spectrum-rating-icon-spacing: var(--spectrum-spacing-100);
+
+  --spectrum-button-top-to-text-small: 6px;
+  --spectrum-button-bottom-to-text-small: 5px;
+  --spectrum-button-top-to-text-medium: 9px;
+  --spectrum-button-bottom-to-text-medium: 10px;
+  --spectrum-button-top-to-text-large: 12px;
+  --spectrum-button-bottom-to-text-large: 13px;
+  --spectrum-button-top-to-text-extra-large: 16px;
+  --spectrum-button-bottom-to-text-extra-large: 17px;
 }

--- a/components/tokens/custom-spectrum/custom-medium-vars.css
+++ b/components/tokens/custom-spectrum/custom-medium-vars.css
@@ -47,4 +47,13 @@ governing permissions and limitations under the License.
   --spectrum-menu-item-checkmark-width-extra-large: 14px;
 
   --spectrum-rating-icon-spacing: var(--spectrum-spacing-75);
+
+  --spectrum-button-top-to-text-small: 5px;
+  --spectrum-button-bottom-to-text-small: 4px;
+  --spectrum-button-top-to-text-medium: 7px;
+  --spectrum-button-bottom-to-text-medium: 8px;
+  --spectrum-button-top-to-text-large: 10px;
+  --spectrum-button-bottom-to-text-large: 10px;
+  --spectrum-button-top-to-text-extra-large: 13px;
+  --spectrum-button-bottom-to-text-extra-large: 13px;
 }


### PR DESCRIPTION
## Description

This adds custom tokens for `--spectrum-button-top-to-text-{size}` and `--spectrum-button-bottom-to-text-{size}` to adjust for the new 1.2 line-height that we will be using to keep the heights as round numbers for buttons. Values were added for both medium and large.

## To-do list
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] This pull request is ready to merge.
