### PR TITLE
fix(typography): reset margins

### DIFF
--- a/components/typography/index.css
+++ b/components/typography/index.css
@@ -98,6 +98,8 @@ governing permissions and limitations under the License.
   font-size: var(--mod-heading-font-size, var(--spectrum-heading-font-size));
   color: var(--highcontrast-heading-font-color, var(--mod-heading-font-color, var(--spectrum-heading-font-color)));
   line-height: var(--mod-heading-line-height, var(--spectrum-heading-line-height));
+  margin-block-start: 0;
+  margin-block-end: 0;
 
   strong,
   .spectrum-Heading-strong {
@@ -388,6 +390,8 @@ governing permissions and limitations under the License.
   font-weight: var(--mod-body-sans-serif-font-weight, var(--spectrum-body-sans-serif-font-weight));
   font-size: var(--mod-body-font-size, var(--spectrum-body-font-size));
   color: var(--highcontrast-body-font-color, var(--mod-body-font-color, var(--spectrum-body-font-color)));
+  margin-block-start: 0;
+  margin-block-end: 0;
 
   line-height: var(--mod-body-line-height, var(--spectrum-body-line-height));
 
@@ -513,6 +517,8 @@ governing permissions and limitations under the License.
   font-style: var(--mod-detail-sans-serif-font-style, var(--spectrum-detail-sans-serif-font-style));
   font-weight: var(--mod-detail-sans-serif-font-weight, var(--spectrum-detail-sans-serif-font-weight));
   font-size: var(--mod-detail-font-size, var(--spectrum-detail-font-size));
+  margin-block-start: 0;
+  margin-block-end: 0;
 
   color: var(--highcontrast-detail-font-color, var(--mod-detail-font-color, var(--spectrum-detail-font-color)));
 
@@ -718,6 +724,8 @@ governing permissions and limitations under the License.
   font-style: var(--mod-code-font-style, var(--spectrum-code-font-style));
   font-weight: var(--mod-code-font-weight, var(--spectrum-code-font-weight));
   font-size: var(--mod-code-font-size, var(--spectrum-code-font-size));
+  margin-block-start: 0;
+  margin-block-end: 0;
 
   line-height: var(--mod-code-line-height, var(--spectrum-code-line-height));
 


### PR DESCRIPTION
## Description

This pull request explicitly sets block margins for `.spectrum-Heading`, `.spectrum-Body`, `.spectrum-Detail`, and `.spectrum-Code` to 0 in order to override user agent styles. 

The margin tokens should only be applied when these elements are wrapped in `.spectrum-Typography`

## How and where has this been tested?
 - **How this was tested:** Chrome, Safari, Firefox

## Screenshots
Before:
![Screenshot 2023-04-24 at 1 59 00 PM](https://user-images.githubusercontent.com/99203545/234078312-2782f88e-32fd-43d9-9073-4a7f0acfc351.png)

After: 
![Screenshot 2023-04-24 at 1 59 11 PM](https://user-images.githubusercontent.com/99203545/234078343-9b08b93c-c16f-4a7d-8e34-9036af1c2f50.png)

## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
