### PR TITLE
fix: textfield and combobox fixes, adjust padding calculations 

### DIFF
--- a/components/combobox/index.css
+++ b/components/combobox/index.css
@@ -130,7 +130,10 @@ governing permissions and limitations under the License.
   --spectrum-combobox-spacing-inline-icon-to-button: var(--spectrum-combo-box-visual-to-field-button-quiet);
   --spectrum-combobox-spacing-inline-start-edge-to-text: var(--spectrum-field-edge-to-text-quiet);
   --spectrum-combobox-spacing-label-to-combobox: var(--spectrum-field-label-to-component-quiet-medium);
-  --spectrum-combobox-button-inline-offset: var(--spectrum-spacing-100);
+  --spectrum-combobox-button-inline-offset: calc(
+    (var(--mod-combobox-block-size, var(--spectrum-combobox-block-size)) / 2) - 
+    (var(--mod-combobox-icon-size, var(--spectrum-combobox-icon-size)) / 2)
+  );
 
   --spectrum-combobox-border-color-disabled: var(--spectrum-disabled-border-color);
   --spectrum-combobox-background-color-default: var(--spectrum-transparent-white-100);

--- a/components/combobox/index.css
+++ b/components/combobox/index.css
@@ -135,11 +135,10 @@ governing permissions and limitations under the License.
 
 .spectrum-Combobox--quiet {
   --spectrum-combobox-min-inline-size: calc(var(--spectrum-combo-box-quiet-minimum-width-multiplier) * var(--spectrum-combobox-block-size));
-  --spectrum-combobox-spacing-block-start-to-border: var(--spectrum-field-edge-to-border-quiet);
   --spectrum-combobox-spacing-inline-icon-to-button: var(--spectrum-combo-box-visual-to-field-button-quiet);
-  --spectrum-combobox-spacing-inline-start-to-textfield: var(--spectrum-field-edge-to-text-quiet);
+  --spectrum-combobox-spacing-inline-start-edge-to-text: var(--spectrum-field-edge-to-text-quiet);
   --spectrum-combobox-spacing-label-to-combobox: var(--spectrum-field-label-to-component-quiet-medium);
-  --spectrum-combobox-button-inline-offset: calc(-1 * var(--spectrum-spacing-100));
+  --spectrum-combobox-button-inline-offset: var(--spectrum-spacing-100);
 
   --spectrum-combobox-border-color-disabled: var(--spectrum-disabled-border-color);
   --spectrum-combobox-background-color-default: var(--spectrum-transparent-white-100);
@@ -189,11 +188,9 @@ governing permissions and limitations under the License.
   inline-size: var(--mod-combobox-inline-size, var(--spectrum-combobox-inline-size));
   min-inline-size: var(--mod-combobox-min-inline-size, var(--spectrum-combobox-min-inline-size));
   block-size: var(--mod-combobox-block-size, var(--spectrum-combobox-block-size));
-
   margin-block-start: var(--mod-combobox-spacing-label-to-combobox, var(--spectrum-combobox-spacing-label-to-combobox));
 
   border-radius: var(--mod-combobox-border-radius, var(--spectrum-combobox-border-radius));
-  border-width: var(--mod-combobox-border-width, var(--spectrum-combobox-border-width));
 
   .spectrum-Popover.is-open {
     transform: translateY(var(--mod-combobox-spacing-edge-to-menu, var(--spectrum-combobox-spacing-edge-to-menu)));
@@ -221,10 +218,13 @@ governing permissions and limitations under the License.
 
 /* PICKER BUTTON */
 .spectrum-Combobox-button {
-  /* Be above textfield so box shadow shines through */
   position: absolute;
-  inset-inline-end: var(--mod-combobox-button-inline-offset, var(--spectrum-combobox-button-inline-offset, 0px));
+  inset-inline-end: calc(-1 * var(--mod-combobox-button-inline-offset, var(--spectrum-combobox-button-inline-offset, 0px)));
   color: var(--highcontrast-combobox-font-color, var(--mod-combobox-font-color-default, var(--spectrum-combobox-font-color-default)));
+
+  .spectrum-PickerButton-fill {
+    border-width: var(--mod-combobox-border-width, var(--spectrum-combobox-border-width));
+  }
 
   /* Default */
   &:not(:disabled):not(.is-invalid) {
@@ -340,7 +340,7 @@ governing permissions and limitations under the License.
       border-radius: calc(
         var(--mod-combobox-border-radius, var(--spectrum-combobox-border-radius)) +
         var(--mod-combobox-focus-indicator-gap, var(--spectrum-combobox-focus-indicator-gap)) +
-        var(--mod-combobox-border-width, var(--spectrum-combobox-border-width))
+        var(--mod-combobox-focus-indicator-thickness, var(--spectrum-combobox-focus-indicator-thickness))
       );
     }
   }
@@ -348,13 +348,27 @@ governing permissions and limitations under the License.
 
 /* TEXT INPUT */
 .spectrum-Combobox-input {
-  padding-block-start: var(--mod-combobox-spacing-block-start-edge-to-textfield, var(--spectrum-combobox-spacing-block-start-edge-to-text));
-  padding-block-end: var(--mod-combobox-spacing-block-end-edge-to-textfield, var(--spectrum-combobox-spacing-block-end-edge-to-text));
-  padding-inline-start: var(--mod-combobox-spacing-inline-start-edge-to-textfield, var(--spectrum-combobox-spacing-inline-start-edge-to-text));
-  padding-inline-end: calc(var(--spectrum-combobox-button-width) + var(--spectrum-combobox-spacing-inline-end-edge-to-text));
+  padding-block-start: calc(
+    var(--mod-combobox-spacing-block-start-edge-to-text, var(--spectrum-combobox-spacing-block-start-edge-to-text)) -
+    var(--mod-combobox-border-width, var(--spectrum-combobox-border-width))
+  );
+  padding-block-end: calc(
+    var(--mod-combobox-spacing-block-end-edge-to-text, var(--spectrum-combobox-spacing-block-end-edge-to-text)) -
+    var(--mod-combobox-border-width, var(--spectrum-combobox-border-width))
+  );
+  padding-inline-start: calc(
+    var(--mod-combobox-spacing-inline-start-edge-to-text, var(--spectrum-combobox-spacing-inline-start-edge-to-text)) - 
+    var(--mod-combobox-border-width, var(--spectrum-combobox-border-width))
+  );
+  padding-inline-end: calc(
+    var(--mod-combobox-button-width, var(--spectrum-combobox-button-width)) + 
+    var(--mod-combobox-spacing-inline-end-edge-to-text, var(--spectrum-combobox-spacing-inline-end-edge-to-text)) - 
+    (var(--mod-combobox-border-width, var(--spectrum-combobox-border-width)) * 2)
+  );
 
   background-color: var(--highcontrast-combobox-background-color, var(--mod-combobox-background-color-default, var(--spectrum-combobox-background-color-default)));
   border-color: var(--highcontrast-combobox-border-color, var(--mod-combobox-border-color-default, var(--spectrum-combobox-border-color-default)));
+  border-width: var(--mod-combobox-border-width, var(--spectrum-combobox-border-width));
   backface-visibility: hidden;
 
   font-size: var(--mod-combobox-font-size, var(--spectrum-combobox-font-size));
@@ -416,8 +430,9 @@ governing permissions and limitations under the License.
       var(--mod-combobox-button-width, var(--spectrum-combobox-button-width)) +
       var(--mod-combobox-spacing-inline-icon-to-button, var(--spectrum-combobox-spacing-inline-icon-to-button)) +
       var(--mod-combobox-icon-size, var(--spectrum-combobox-icon-size)) +
-      var(--mod-spectrum-combobox-spacing-inline-end-edge-to-text, var(--spectrum-combobox-spacing-inline-end-edge-to-text)) -
-      var(--mod-combobox-button-inline-offset, var(--spectrum-combobox-button-inline-offset, 0px))
+      var(--mod-combobox-spacing-inline-end-edge-to-text, var(--spectrum-combobox-spacing-inline-end-edge-to-text)) -
+      var(--mod-combobox-button-inline-offset, var(--spectrum-combobox-button-inline-offset, 0px)) - 
+      (var(--mod-combobox-border-width, var(--spectrum-combobox-border-width)) * 2)
     );
   }
 
@@ -506,12 +521,12 @@ governing permissions and limitations under the License.
       /* Focus Indicator (Underline) */
       &::after {
         margin: 0;
-        margin-inline-start: inherit;
-        inline-size: inherit;
+        margin-inline-start: 0;
+        inline-size: 100%;
         block-size: calc(100% + var(--mod-combobox-focus-indicator-gap, var(--spectrum-combobox-focus-indicator-gap)));
         border-width: 0 0 var(--mod-combobox-focus-indicator-thickness, var(--spectrum-combobox-focus-indicator-thickness)) 0;
         border-bottom-color: var(--highcontrast-combobox-focus-indicator-color, var(--mod-combobox-focus-indicator-color, var(--spectrum-combobox-focus-indicator-color)));
-        border-radius: inherit;
+        border-radius: 0;
       }
     }
 
@@ -521,8 +536,31 @@ governing permissions and limitations under the License.
   }
 
   .spectrum-Combobox-input {
-    padding-block-end: var(--mod-combobox-spacing-block-start-to-border, var(--spectrum-combobox-spacing-block-start-to-border));
-    padding-inline-start: var(--mod-combobox-spacing-inline-start-to-textfield, var(--spectrum-combobox-spacing-inline-start-to-textfield));
+    border-block-end-width: var(--mod-combobox-border-width, var(--spectrum-combobox-border-width));
+
+    padding-block-start: var(--mod-combobox-spacing-block-start-edge-to-text, var(--spectrum-combobox-spacing-block-start-edge-to-text));
+    padding-block-end: calc(
+      var(--mod-combobox-spacing-block-end-edge-to-text, var(--spectrum-combobox-spacing-block-end-edge-to-text)) -
+      var(--mod-combobox-border-width, var(--spectrum-combobox-border-width))
+    );
+
+    padding-inline-start: var(--mod-combobox-spacing-inline-start-edge-to-text, var(--spectrum-combobox-spacing-inline-start-edge-to-text));
+    padding-inline-end: calc(
+      var(--mod-combobox-button-width, var(--spectrum-combobox-button-width)) + 
+      var(--mod-combobox-spacing-inline-end-edge-to-text, var(--spectrum-combobox-spacing-inline-end-edge-to-text)) -
+      var(--mod-combobox-button-inline-offset, var(--spectrum-combobox-button-inline-offset, 0px))
+    );
+  }
+
+  .spectrum-Combobox-textfield.is-invalid .spectrum-Combobox-input,
+  .spectrum-Combobox-textfield.is-loading .spectrum-Combobox-input {
+    padding-inline-end: calc(
+      var(--mod-combobox-button-width, var(--spectrum-combobox-button-width)) +
+      var(--mod-combobox-spacing-inline-icon-to-button, var(--spectrum-combobox-spacing-inline-icon-to-button)) +
+      var(--mod-combobox-icon-size, var(--spectrum-combobox-icon-size)) +
+      var(--mod-combobox-spacing-inline-end-edge-to-text, var(--spectrum-combobox-spacing-inline-end-edge-to-text)) -
+      var(--mod-combobox-button-inline-offset, var(--spectrum-combobox-button-inline-offset, 0px))
+    );
   }
 
   /* Disabled */

--- a/components/combobox/index.css
+++ b/components/combobox/index.css
@@ -78,8 +78,6 @@ governing permissions and limitations under the License.
   --spectrum-combobox-spacing-block-end-edge-to-text: var(--spectrum-component-bottom-to-text-75);
   --spectrum-combobox-spacing-inline-start-edge-to-text: var(--spectrum-component-edge-to-text-75);
   --spectrum-combobox-spacing-inline-end-edge-to-text: var(--spectrum-component-edge-to-text-75);
-
-  --spectrum-combobox-border-radius: var(--spectrum-corner-radius-75);
 }
 
 .spectrum-Combobox--sizeM {
@@ -95,8 +93,6 @@ governing permissions and limitations under the License.
   --spectrum-combobox-spacing-block-end-edge-to-text: var(--spectrum-component-bottom-to-text-100);
   --spectrum-combobox-spacing-inline-start-edge-to-text: var(--spectrum-component-edge-to-text-100);
   --spectrum-combobox-spacing-inline-end-edge-to-text: var(--spectrum-component-edge-to-text-100);
-
-  --spectrum-combobox-border-radius: var(--spectrum-corner-radius-100);
 }
 
 .spectrum-Combobox--sizeL {
@@ -112,8 +108,6 @@ governing permissions and limitations under the License.
   --spectrum-combobox-spacing-block-end-edge-to-text: var(--spectrum-component-bottom-to-text-200);
   --spectrum-combobox-spacing-inline-start-edge-to-text: var(--spectrum-component-edge-to-text-200);
   --spectrum-combobox-spacing-inline-end-edge-to-text: var(--spectrum-component-edge-to-text-200);
-
-  --spectrum-combobox-border-radius: var(--spectrum-corner-radius-100);
 }
 
 .spectrum-Combobox--sizeXL {
@@ -129,8 +123,6 @@ governing permissions and limitations under the License.
   --spectrum-combobox-spacing-block-end-edge-to-text: var(--spectrum-component-bottom-to-text-300);
   --spectrum-combobox-spacing-inline-start-edge-to-text: var(--spectrum-component-edge-to-text-300);
   --spectrum-combobox-spacing-inline-end-edge-to-text: var(--spectrum-component-edge-to-text-300);
-
-  --spectrum-combobox-border-radius: var(--spectrum-corner-radius-200);
 }
 
 .spectrum-Combobox--quiet {

--- a/components/combobox/metadata/mods.md
+++ b/components/combobox/metadata/mods.md
@@ -1,11 +1,11 @@
 | Modifiable Custom Properties |
 | --- |
+|`--mod-combobox-block-size`|
+|`--mod-combobox-icon-size`|
 |`--mod-combobox-inline-size`|
 |`--mod-combobox-min-inline-size`|
-|`--mod-combobox-block-size`|
 |`--mod-combobox-spacing-label-to-combobox`|
 |`--mod-combobox-border-radius`|
-|`--mod-combobox-border-width`|
 |`--mod-combobox-spacing-edge-to-menu`|
 |`--mod-combobox-spacing-inline-icon-to-button`|
 |`--mod-combobox-button-width`|
@@ -13,6 +13,7 @@
 |`--mod-combobox-block-spacing-edge-to-alert`|
 |`--mod-combobox-button-inline-offset`|
 |`--mod-combobox-font-color-default`|
+|`--mod-combobox-border-width`|
 |`--mod-combobox-border-color-default`|
 |`--mod-combobox-font-color-focus`|
 |`--mod-combobox-border-color-focus`|
@@ -32,9 +33,10 @@
 |`--mod-combobox-focus-indicator-gap`|
 |`--mod-combobox-focus-indicator-thickness`|
 |`--mod-combobox-focus-indicator-color`|
-|`--mod-combobox-spacing-block-start-edge-to-textfield`|
-|`--mod-combobox-spacing-block-end-edge-to-textfield`|
-|`--mod-combobox-spacing-inline-start-edge-to-textfield`|
+|`--mod-combobox-spacing-block-start-edge-to-text`|
+|`--mod-combobox-spacing-block-end-edge-to-text`|
+|`--mod-combobox-spacing-inline-start-edge-to-text`|
+|`--mod-combobox-spacing-inline-end-edge-to-text`|
 |`--mod-combobox-background-color-default`|
 |`--mod-combobox-font-size`|
 |`--mod-combobox-font-family`|
@@ -46,9 +48,5 @@
 |`--mod-combobox-background-color-focus`|
 |`--mod-combobox-background-color-focus-hover`|
 |`--mod-combobox-background-color-key-focus`|
-|`--mod-combobox-icon-size`|
-|`--mod-spectrum-combobox-spacing-inline-end-edge-to-text`|
 |`--mod-combobox-alert-icon-color`|
-|`--mod-combobox-spacing-block-start-to-border`|
-|`--mod-combobox-spacing-inline-start-to-textfield`|
 |`--mod-combobox-border-color-disabled`|

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -262,9 +262,11 @@ governing permissions and limitations under the License.
     border-style: solid;
     border-color: transparent;
     border-width: 0;
-    border-radius: calc(var(--mod-textfield-corner-radius, var(--spectrum-textfield-corner-radius))
-                        + var(--mod-textfield-border-width, var(--spectrum-textfield-border-width))
-                        + var(--mod-textfield-focus-indicator-gap, var(--spectrum-textfield-focus-indicator-gap)));
+    border-radius: calc(
+      var(--mod-textfield-corner-radius, var(--spectrum-textfield-corner-radius)) + 
+      var(--mod-textfield-focus-indicator-gap, var(--spectrum-textfield-focus-indicator-gap)) +
+      var(--mod-textfield-focus-indicator-width, var(--spectrum-textfield-focus-indicator-width))
+    );
 
     /* place in same cell: input, focus indicator, and grows sizer */
     grid-row: 2 / span 1;
@@ -459,9 +461,9 @@ governing permissions and limitations under the License.
   inline-size: 100%;
   min-inline-size: var(--mod-textfield-min-width, var(--spectrum-textfield-min-width));
   block-size: var(--mod-textfield-height, var(--spectrum-textfield-height));
-  padding-block-start: var(--mod-textfield-spacing-block-start, var(--spectrum-textfield-spacing-block-start));
-  padding-block-end: var(--mod-textfield-spacing-block-end, var(--spectrum-textfield-spacing-block-end));
-  padding-inline: var(--mod-textfield-spacing-inline, var(--spectrum-textfield-spacing-inline));
+  padding-block-start: calc(var(--mod-textfield-spacing-block-start, var(--spectrum-textfield-spacing-block-start)) - var(--mod-textfield-border-width, var(--spectrum-textfield-border-width)));
+  padding-block-end: calc(var(--mod-textfield-spacing-block-end, var(--spectrum-textfield-spacing-block-end)) - var(--mod-textfield-border-width, var(--spectrum-textfield-border-width)));
+  padding-inline: calc(var(--mod-textfield-spacing-inline, var(--spectrum-textfield-spacing-inline)) - var(--mod-textfield-border-width, var(--spectrum-textfield-border-width)));
   /* Use padding instead of text-indent because text-indent does not left align the text in Edge browser  */
   text-indent: 0;
   vertical-align: top; /* used to align them correctly in forms. */
@@ -663,8 +665,11 @@ governing permissions and limitations under the License.
   .spectrum-Textfield--quiet & {
     border-block-start-width: 0;
     border-inline-width: 0;
+  
     margin-block-end: var(--mod-textfield-spacing-block-quiet, var(--spectrum-textfield-spacing-block-quiet));
+    padding-block-start: var(--mod-textfield-spacing-block-start, var(--spectrum-textfield-spacing-block-start));
     padding-inline: var(--mod-textfield-spacing-inline-quiet, var(--spectrum-textfield-spacing-inline-quiet));
+
     background-color: transparent;
     border-radius: 0;
 

--- a/components/textfield/stories/textfield.stories.js
+++ b/components/textfield/stories/textfield.stories.js
@@ -43,6 +43,16 @@ export default {
       },
       control: "boolean"
     },
+    size: {
+      name: "Size",
+      type: { name: "string", required: true },
+      table: {
+        type: { summary: "string" },
+        category: "Component",
+      },
+      options: ["s", "m", "l", "xl"],
+      control: "select"
+    },
     isQuiet: {
       name: "Quiet styling",
       type: { name: "boolean" },
@@ -137,6 +147,7 @@ export default {
     isFocused: false,
     isKeyboardFocused: false,
     isLoading: false,
+    size: "m",
     multiline: false,
     grows: false,
     isQuiet: false,


### PR DESCRIPTION
## Description

Some fixes for Textfield and Combobox:

- **Textfield** and **Combobox**: Subtract border width from padding calculations because most of the "...to-edge" tokens include the border. The values were previously 1px larger than they should have been.
- **Textfield** and **Combobox**: fix corner radius of focus indicator when using a larger border radius or a larger indicator width (e.g. to test, try setting a  larger `--mod-textfield-border-width` or `--mod-textfield-focus-indicator-width`. Changed the calculation  to add the focus indicator width instead of the border width)
- **Combobox**: adjust styles so custom property for border width is correctly overriding everything from its sub-components. Previously, using `--mod-combobox-border-width` had no effect.
- **Combobox**: simplify/remove some custom properties related to those fixes and quiet variant.
- **Combobox**: border-radius should not increase for t-shirt sizes (per design feedback) 
- **Combobox**: Use a corrected calculation of the x-offset for the picker button on the quiet variant, based on design feedback and using the same method as the 'search' component.
- **Textfield**: Also adds "size" control to stories

## How and where has this been tested?

Firefox and Chrome, Mac

## Screenshots

Padding issue before and after:
![Screenshot 2023-04-24 at 11 03 05 AM](https://user-images.githubusercontent.com/965114/234091979-f452cf84-4900-4ace-9835-34b179d6cedd.png)
![Screenshot 2023-04-24 at 11 08 07 AM](https://user-images.githubusercontent.com/965114/234091968-df4502c3-e6b8-4dd8-a6ee-581c484f3c9b.png)

Issues with corner radius calculation on focus indicator when using a larger border width, or when changing the focus indicator width (now fixed):
![Screenshot 2023-04-24 at 1 00 55 PM](https://user-images.githubusercontent.com/965114/234091992-b8041d24-1b34-4392-9db6-81f287fdc16c.png)
![Screenshot 2023-04-24 at 3 35 52 PM](https://user-images.githubusercontent.com/965114/234098867-58538814-7aec-44a0-9601-64198d3b0039.png)


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
- [x] I have updated any relevant storybook stories and templates. 
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
