### PR TITLE
chore(rating): update storybook with functionality

### DIFF
--- a/components/rating/stories/rating.stories.js
+++ b/components/rating/stories/rating.stories.js
@@ -7,9 +7,59 @@ export default {
     "A rating element is used to display or collect a user's rating of an item as represented by a number of stars.",
   component: "Rating",
   argTypes: {
+    isFocused: {
+      name: "Focused",
+      type: { name: "boolean" },
+      table: {
+        type: { summary: "boolean" },
+        category: "State",
+        disable: true,
+      },
+      control: "boolean"
+    },
+    isDisabled: {
+      name: "Disabled",
+      type: { name: "boolean" },
+      table: {
+        type: { summary: "boolean" },
+        category: "State",
+      },
+      control: "boolean",
+    },
+    isReadOnly: {
+      name: "Read only",
+      type: { name: "boolean" },
+      table: {
+        type: { summary: "boolean" },
+        category: "Component",
+      },
+      control: "boolean",
+    },
+    max: {
+      name: "Maximum value",
+      type: { name: "number" },
+      table: {
+        type: { summary: "number" },
+        category: "Content",
+      },
+      control: { type: "number" },
+    },
+    value: {
+      name: "Value",
+      type: { name: "number" },
+      table: {
+        type: { summary: "number" },
+        category: "Content",
+        disable: true,
+      },
+      control: { type: "number" },
+    },
   },
   args: {
     rootClass: "spectrum-Rating",
+    isDisabled: false,
+    max: 5,
+    value: 3
   },
   parameters: {
     actions: {

--- a/components/rating/stories/template.js
+++ b/components/rating/stories/template.js
@@ -35,10 +35,10 @@ export const Template = ({
       })}
       id=${ifDefined(id)}
       @focusin=${() => {
-        updateArgs({ isFocused: !isFocused });
+        updateArgs({ isFocused: true });
       }}
       @focusout=${() => {
-        updateArgs({ isFocused: !isFocused });
+        updateArgs({ isFocused: false });
       }}
     >
       <input
@@ -71,7 +71,7 @@ export const Template = ({
               'is-currentValue': !isDisabled && !isReadOnly && idx === value - 1,
             })}
             @click=${(e) => {
-              updateArgs({ value: idx +1 });
+              updateArgs({ value: idx + 1, isFocused: true });
             }}
           >
             ${Icon({

--- a/components/rating/stories/template.js
+++ b/components/rating/stories/template.js
@@ -3,6 +3,8 @@ import { classMap } from "lit-html/directives/class-map.js";
 import { repeat } from "lit-html/directives/repeat.js";
 import { ifDefined } from "lit-html/directives/if-defined.js";
 
+import { useArgs } from "@storybook/client-api";
+
 // Uncomment if you plan to include an icon
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 
@@ -13,30 +15,65 @@ export const Template = ({
   rootClass = "spectrum-Rating",
   size = "m",
   max = 5,
+  value = 0,
+  isReadOnly = false,
+  isFocused = false,
+  isDisabled = true,
   customClasses = [],
   id,
   ...globals
 }) => {
+  const [, updateArgs] = useArgs();
+
   return html`
     <div
       class=${classMap({
         [rootClass]: true,
-        [`${rootClass}--size${size?.toUpperCase()}`]: typeof size !== "undefined",
+        'is-disabled': isDisabled,
+        'is-readOnly': isReadOnly,
         ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
       })}
-      id=${ifDefined(id)}>
+      id=${ifDefined(id)}
+      @focusin=${() => {
+        updateArgs({ isFocused: !isFocused });
+      }}
+      @focusout=${() => {
+        updateArgs({ isFocused: !isFocused });
+      }}
+    >
       <input
         class="${rootClass}-input"
         type="range"
         min="0"
         max=${max}
-        value="0"
+        value=${value}
         aria-label="Rating"
+        ?readonly=${isReadOnly}
+        ?disabled=${isDisabled}
+        @change=${(e) => {
+          const rating = e.target.closest(`.${rootClass}`);
+          if (!rating) return;
+
+          const input = rating.closest(`.${rootClass}-input`);
+          if (!input) return;
+          if (!isReadOnly && !isDisabled) {
+            updateArgs({ value: parseInt(input.value, 10) });
+          }
+        }}
       />
       ${repeat(
         Array(max).fill(0),
-        () => html`
-          <span class="${rootClass}-icon">
+        (_, idx) => html`
+          <span
+            class=${classMap({
+              [`${rootClass}-icon`]: true,
+              'is-selected': !isDisabled && idx <= value - 1,
+              'is-currentValue': !isDisabled && !isReadOnly && idx === value - 1,
+            })}
+            @click=${(e) => {
+              updateArgs({ value: idx +1 });
+            }}
+          >
             ${Icon({
               ...globals,
               iconName: "Star",


### PR DESCRIPTION
## Description

Bring in some of the functionality to the rating storybook that exists for the site.


## How and where has this been tested?
 - **How this was tested:**
 - [ ] Open storybook instance, move focus into the rating: expect `is-focused` class to be added
 - [x] Open storybook, click one of the icons: expect the input value to change


## To-do list
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] I have updated any relevant storybook stories and templates. 
- [x] This pull request is ready to merge.
