### PR TITLE
chore(swatch): add functionality to storybook

### DIFF
--- a/components/swatch/stories/swatch.stories.js
+++ b/components/swatch/stories/swatch.stories.js
@@ -4,7 +4,7 @@ import { Template } from "./template";
 export default {
 	title: "Components/Swatch",
 	description:
-		"A swatch shows a small sample of a fill—such as a color, gradient, texture, or material—that is intended to be applied to an object.",
+		"A swatch shows a small sample of a fill-such as a color, gradient, texture, or material—that is intended to be applied to an object.",
 	component: "Swatch",
 	argTypes: {
 		size: {
@@ -17,21 +17,40 @@ export default {
 			options: ["xs", "s", "m", "l",],
 			control: "select",
 		},
-		styles: { table: { disable: true } },
-	},
-	args: {
-		rootClass: "spectrum-Swatch",
-	},
-	parameters: {
-		actions: {
-			handles: [],
+		isDisabled: {
+			name: "Disabled",
+			type: { name: "boolean" },
+			table: {
+				type: { summary: "boolean" },
+				category: "State",
+			},
+			control: "boolean",
 		},
-		status: {
-			type: process.env.MIGRATED_PACKAGES.includes("swatch")
-				? "migrated"
-				: undefined,
+		isSelected: {
+			name: "Selected",
+			type: { name: "boolean" },
+			table: {
+				type: { summary: "boolean" },
+				category: "State",
+			},
+			control: "boolean",
 		},
-	},
+  },
+  args: {
+    rootClass: "spectrum-Swatch",
+    isSelected: false,
+    isDisabled: false,
+  },
+  parameters: {
+    actions: {
+      handles: [],
+    },
+    status: {
+      type: process.env.MIGRATED_PACKAGES.includes("swatch")
+        ? "migrated"
+        : "legacy",
+    },
+  },
 };
 
 export const Default = Template.bind({});

--- a/components/swatch/stories/template.js
+++ b/components/swatch/stories/template.js
@@ -2,18 +2,23 @@ import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { styleMap } from "lit/directives/style-map.js";
-import { Template as OpacityCheckerboard } from "@spectrum-css/opacitycheckerboard/stories/template.js";
+
+import { useArgs } from '@storybook/client-api';
+
 import "../index.css";
 
 export const Template = ({
 	rootClass = "spectrum-Swatch",
 	size = "m",
-	customClasses = [],
+  isSelected = false,
+  isDisabled = false,
+  customClasses = [],
 	styles = {"--spectrum-picked-color": "rgb(174, 216, 230)"},
 	id,
 	...globals
 }) => {
 	const { express } = globals;
+  const [_, updateArgs] = useArgs();
 
 	try {
 		if (!express) import(/* webpackPrefetch: true */ "../themes/spectrum.css");
@@ -22,18 +27,28 @@ export const Template = ({
 		console.warn(e);
 	}
 
-	return html`
-		<div
-			class=${classMap({
-				[rootClass]: true,
-				[`${rootClass}--size${size?.toUpperCase()}`]:
-					typeof size !== "undefined",
-				...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
-			})}
-			id=${ifDefined(id)}
+  return html`
+    <div
+      class=${classMap({
+        [rootClass]: true,
+        [`${rootClass}--size${size?.toUpperCase()}`]: typeof size !== "undefined",
+        'is-selected': !isDisabled && isSelected,
+        'is-disabled': isDisabled,
+        ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
+      })}
+      ?disabled=${isDisabled}
+      id=${ifDefined(id)}
 			style=${styleMap(styles)}
 			tabindex="0"
-		>
+      @click=${(e) => {
+        updateArgs({ isSelected: !isSelected });
+      }}
+      @focusout=${() => updateArgs({ isSelected: false })}
+      @keypress=${(e) => {
+        if (e.key !== 'Enter' && e.key !== ' ') return;
+        updateArgs({ isSelected: !isSelected });
+      }}
+    >
 		${OpacityCheckerboard({
 			...globals,
 			componentOnly: true,


### PR DESCRIPTION
## Description

Bring in some of the functionality to the swatch storybook that exists for the site.


## How and where has this been tested?
 - **How this was tested:**
 - [ ] Open storybook instance, click the swatch: expect the is-selected class to be toggled
 - [ ] Open storybook, key press the swatch: expect the is-selected class to be toggled


## To-do list
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] I have updated any relevant storybook stories and templates. 
- [x] This pull request is ready to merge.
