### PR TITLE
chore: update color-* component dependencies

### DIFF
--- a/components/colorarea/package.json
+++ b/components/colorarea/package.json
@@ -18,11 +18,11 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/colorhandle": ">=3.0.0",
-    "@spectrum-css/tokens": ">=8.0.0"
+    "@spectrum-css/colorhandle": ">=4",
+    "@spectrum-css/tokens": ">=9"
   },
   "devDependencies": {
-    "@spectrum-css/colorhandle": "^3.0.6",
+    "@spectrum-css/colorhandle": "^4.0.3",
     "@spectrum-css/component-builder-simple": "*",
     "@spectrum-css/tokens": "^9.0.1",
     "gulp": "^4.0.0"

--- a/components/colorhandle/package.json
+++ b/components/colorhandle/package.json
@@ -18,12 +18,12 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/colorloupe": "^3.0.0-beta.1",
-    "@spectrum-css/tokens": ">=9.0.0"
+    "@spectrum-css/colorloupe": ">=3",
+    "@spectrum-css/tokens": ">=9"
   },
   "devDependencies": {
     "@spectrum-css/colorloupe": "^3.0.3",
-    "@spectrum-css/component-builder-simple": "^2.0.0",
+    "@spectrum-css/component-builder-simple": "*",
     "@spectrum-css/tokens": "^9.0.1",
     "gulp": "^4.0.0"
   },

--- a/components/colorloupe/package.json
+++ b/components/colorloupe/package.json
@@ -18,10 +18,10 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/tokens": ">=9.0.0"
+    "@spectrum-css/tokens": ">=9"
   },
   "devDependencies": {
-    "@spectrum-css/component-builder-simple": "^2.0.0",
+    "@spectrum-css/component-builder-simple": "*",
     "@spectrum-css/tokens": "^9.0.1",
     "gulp": "^4.0.0"
   },

--- a/components/colorwheel/package.json
+++ b/components/colorwheel/package.json
@@ -18,12 +18,12 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/colorhandle": "^3.0.0",
-    "@spectrum-css/tokens": ">=8.0.0"
+    "@spectrum-css/colorhandle": ">=4",
+    "@spectrum-css/tokens": ">=9.0.0"
   },
   "devDependencies": {
     "@spectrum-css/colorarea": "^4.0.3",
-    "@spectrum-css/colorhandle": "^3.0.6",
+    "@spectrum-css/colorhandle": "^4.0.3",
     "@spectrum-css/component-builder-simple": "*",
     "@spectrum-css/tokens": "^9.0.1",
     "gulp": "^4.0.0"


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
Lerna didn't handle the graduation for some of the Color-* components. This is a PR to bring several `package.json` files up-to-date with the full releases.


## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] I have updated any relevant storybook stories and templates. 
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
