### PR TITLE
fix: resolve always black text in docs site

### DIFF
--- a/site/templates/siteComponent.pug
+++ b/site/templates/siteComponent.pug
@@ -145,14 +145,14 @@ html(lang='en-US' dir="ltr").spectrum.spectrum--light.spectrum--medium
                   a(href=`#${component.slug}`).spectrum-BigSubtleLink #{component.name}
 
               table.spectrum-CSSComponent-detailsTable
-                tr
+                tr.spectrum-Body
                   th.spectrum-Body--secondary Component status
                   td
                     div(class=`spectrum-StatusLight spectrum-StatusLight--sizeM spectrum-CSSComponent-status spectrum-StatusLight--${util.getStatusLightVariant(component.dnaStatus)}`)= status
-                tr
+                tr.spectrum-Body
                   th.spectrum-Body--secondary Last released
                   td= releaseDate
-                tr
+                tr.spectrum-Body
                   th.spectrum-Body--secondary Current version
                   td
                     bdo(dir="ltr") #{pkg.name}@#{pkg.version}


### PR DESCRIPTION
Fixes an issue where the "details table" section of each component wasn't properly switching text color along with theme changes.

before:
<img width="347" alt="Screen Shot 2023-04-26 at 11 03 41 AM" src="https://user-images.githubusercontent.com/360251/234618435-ae92e1d7-0330-4572-944d-bc7220e52f63.png">


after:
<img width="333" alt="Screen Shot 2023-04-26 at 11 03 22 AM" src="https://user-images.githubusercontent.com/360251/234618496-99cfa433-c8aa-4e7b-b193-af42ee3aef5f.png">


<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->


## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] I have updated any relevant storybook stories and templates. 
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
