### PR TITLE
chore: remove duplicate clean tasks from site build

### DIFF
--- a/site/includes/nav.pug
+++ b/site/includes/nav.pug
@@ -20,5 +20,6 @@
     ul.spectrum-SideNav
       li.spectrum-SideNav-item
         a.spectrum-SideNav-itemLink(href='https://spectrum.adobe.com', target='_blank', rel='noopener') Spectrum
-      li.spectrum-SideNav-item
-        a.spectrum-SideNav-itemLink(href='/preview', rel='noopener') Component preview
+      unless process.env.NODE_ENV === 'development'
+        li.spectrum-SideNav-item
+          a.spectrum-SideNav-itemLink(href='preview/', rel='noopener') Component preview

--- a/tools/bundle-builder/dev/index.js
+++ b/tools/bundle-builder/dev/index.js
@@ -35,7 +35,7 @@ function serve() {
   }
 
   browserSync({
-    startPath: 'docs/index.html',
+    startPath: 'index.html',
     server: `${process.cwd()}/dist/`,
     notify: process.env.BROWSERSYNC_NOTIFY === 'true' ? true : false,
     open: process.env.BROWSERSYNC_OPEN === 'true' ? true : false,


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description

- Remove clean task from bundle-builder (duplicated by npm scripts)
  - This command was cleaning out resources that had already been migrated
- Update storybook link to remove absolute pathing & only show the link in non-dev environments
- Update browser sync to remove the docs folder from the startPath


## How and where has this been tested?
 - **How this was tested:** 
 - [x] Localhost view resolves images, css & js assets
 - [ ] Netlify view resolves images, css & js assets

## To-do list
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] This pull request is ready to merge.
