### PR TITLE
fix(contextualhelp): dark mode font color

### DIFF
--- a/components/contextualhelp/index.css
+++ b/components/contextualhelp/index.css
@@ -17,9 +17,8 @@ governing permissions and limitations under the License.
   --spectrum-contextual-help-link-spacing: var(--spectrum-spacing-300);
 
   /* Typography Variables */
-  /* TODO: these need to be changed to the contextual-help tokens when available */
-  --spectrum-contextual-help-heading-size: var(--spectrum-heading-size-xs);
-  --spectrum-contextual-help-body-size: var(--spectrum-body-size-s);
+  --spectrum-contextual-help-heading-size: var(--spectrum-contextual-help-title-size);
+  --spectrum-contextual-help-body-size: var(--spectrum-contextual-help-body-size);
   --spectrum-contextual-help-heading-color: var(--spectrum-heading-color);
   --spectrum-contextual-help-body-color: var(--spectrum-body-color);
 

--- a/components/contextualhelp/index.css
+++ b/components/contextualhelp/index.css
@@ -18,8 +18,10 @@ governing permissions and limitations under the License.
 
   /* Typography Variables */
   /* TODO: these need to be changed to the contextual-help tokens when available */
-  --spectrum-contextual-help-title-size: var(--spectrum-heading-size-xs);
+  --spectrum-contextual-help-heading-size: var(--spectrum-heading-size-xs);
   --spectrum-contextual-help-body-size: var(--spectrum-body-size-s);
+  --spectrum-contextual-help-heading-color: var(--spectrum-heading-color);
+  --spectrum-contextual-help-body-color: var(--spectrum-body-color);
 
   /* Mobile styling */
   .spectrum--large & {
@@ -40,6 +42,7 @@ governing permissions and limitations under the License.
   padding-block: var(--mod-spectrum-contextual-help-padding, var(--spectrum-contextual-help-padding));
   padding-inline: var(--mod-spectrum-contextual-help-padding, var(--spectrum-contextual-help-padding));
   font-size: var(--mod-spectrum-contextual-help-body-size, var(--spectrum-contextual-help-body-size));
+  color: var(--highcontrast-contextual-help-body-color, var(--mod-contextual-help-body-color, var(--spectrum-contextual-help-body-color)));
 
 
   .spectrum-ContextualHelp-heading, .spectrum-ContextualHelp-body {
@@ -48,10 +51,18 @@ governing permissions and limitations under the License.
 
   .spectrum-ContextualHelp-heading {
     margin-block-end: var(--mod-spectrum-contextual-help-content-spacing, var(--spectrum-contextual-help-content-spacing));
-    font-size: var(--mod-spectrum-contextual-help-title-size, var(--spectrum-contextual-help-title-size));
+    font-size: var(--mod-spectrum-contextual-help-heading-size, var(--spectrum-contextual-help-heading-size));
+    color: var(--highcontrast-contextual-help-heading-color, var(--mod-contextual-help-heading-color, var(--spectrum-contextual-help-heading-color)));
   }
 }
 
 .spectrum-ContextualHelp-link {
   margin-block-start: var(--mod-spectrum-contextual-help-link-spacing, var(--spectrum-contextual-help-link-spacing));
+}
+
+@media (forced-colors: active) {
+  .spectrum-ContextualHelp {
+    --highcontrast-contextual-help-heading-color: CanvasText;
+    --highcontrast-contextual-help-body-color: CanvasText;
+  }
 }

--- a/components/contextualhelp/index.css
+++ b/components/contextualhelp/index.css
@@ -34,7 +34,7 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-ContextualHelp-button {
-  display: block;
+  display: flex;
 }
 
 .spectrum-ContextualHelp-popover {

--- a/components/contextualhelp/metadata/contextualhelp.yml
+++ b/components/contextualhelp/metadata/contextualhelp.yml
@@ -13,7 +13,7 @@ examples:
         <div class="spectrum-Examples-item">
           <div class="spectrum-ContextualHelp">
             <button class="spectrum-ActionButton spectrum-ActionButton--sizeXS spectrum-ContextualHelp-button">
-              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true">
+              <svg class="spectrum-Icon spectrum-Icon--sizeXS spectrum-ActionButton-icon" focusable="false" aria-hidden="true">
                 <use xlink:href="#spectrum-icon-18-Info" />
               </svg>
             </button>
@@ -32,7 +32,7 @@ examples:
             </div>
             <div class="dummy-spacing" style="position: relative; height: 166px; min-width: 400px; max-width: 50%;"></div>
             <button class="spectrum-ActionButton spectrum-ActionButton--sizeXS spectrum-ContextualHelp-button">
-              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true">
+              <svg class="spectrum-Icon spectrum-Icon--sizeXS spectrum-ActionButton-icon" focusable="false" aria-hidden="true">
                 <use xlink:href="#spectrum-icon-18-Info" />
               </svg>
             </button>
@@ -46,7 +46,7 @@ examples:
         <div class="spectrum-Examples-item">
           <div class="spectrum-ContextualHelp">
             <button class="spectrum-ActionButton spectrum-ActionButton--sizeXS spectrum-ContextualHelp-button">
-              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-hidden="true">
+              <svg class="spectrum-Icon spectrum-Icon--sizeXS spectrum-ActionButton-icon" focusable="false" aria-hidden="true">
                 <use xlink:href="#spectrum-icon-18-Help" />
               </svg>
             </button>

--- a/components/contextualhelp/metadata/contextualhelp.yml
+++ b/components/contextualhelp/metadata/contextualhelp.yml
@@ -18,8 +18,8 @@ examples:
               </svg>
             </button>
             <div class="spectrum-Popover is-open spectrum-Popover--bottom-start spectrum-ContextualHelp-popover" role="presentation">
-              <h2 class="spectrum-ContextualHelp-heading">Permission required</h2>
-              <p class="spectrum-ContextualHelp-body">Cupcake ipsum dolor sit amet jelly beans. Chocolate jelly caramels. Icing soufflé chupa chups donut cheesecake. Jelly-o chocolate cake sweet roll cake danish candy biscuit halvah.</p>
+              <h2 class="spectrum-Heading spectrum-Heading--sizeM spectrum-ContextualHelp-heading">Permission required</h2>
+              <p class="spectrum-Body spectrum-ContextualHelp-body">Cupcake ipsum dolor sit amet jelly beans. Chocolate jelly caramels. Icing soufflé chupa chups donut cheesecake. Jelly-o chocolate cake sweet roll cake danish candy biscuit halvah.</p>
             </div>
             <div class="dummy-spacing" style="position: relative; height: 248px; min-width: 400px; max-width: 50%;"></div>
           </div>
@@ -27,8 +27,8 @@ examples:
         <div class="spectrum-Examples-item">
           <div class="spectrum-ContextualHelp">
             <div class="spectrum-Popover is-open spectrum-Popover--top spectrum-ContextualHelp-popover" role="presentation">
-              <h2 class="spectrum-ContextualHelp-heading">Permission required</h2>
-              <p class="spectrum-ContextualHelp-body">Cupcake ipsum dolor sit amet jelly beans. Chocolate jelly caramels. Icing soufflé chupa chups donut cheesecake. Jelly-o chocolate cake sweet roll cake danish candy biscuit halvah.</p>
+              <h2 class="spectrum-Heading spectrum-ContextualHelp-heading">Permission required</h2>
+              <p class="spectrum-Body spectrum-ContextualHelp-body">Cupcake ipsum dolor sit amet jelly beans. Chocolate jelly caramels. Icing soufflé chupa chups donut cheesecake. Jelly-o chocolate cake sweet roll cake danish candy biscuit halvah.</p>
             </div>
             <div class="dummy-spacing" style="position: relative; height: 166px; min-width: 400px; max-width: 50%;"></div>
             <button class="spectrum-ActionButton spectrum-ActionButton--sizeXS spectrum-ContextualHelp-button">
@@ -51,8 +51,8 @@ examples:
               </svg>
             </button>
             <div class="spectrum-Popover is-open spectrum-Popover--bottom-start spectrum-ContextualHelp-popover" role="presentation">
-              <h2 class="spectrum-ContextualHelp-heading">Permission required</h2>
-              <p class="spectrum-ContextualHelp-body">Cupcake ipsum dolor sit amet jelly beans. Chocolate jelly caramels. Icing soufflé chupa chups donut cheesecake. Jelly-o chocolate cake sweet roll cake danish candy biscuit halvah.</p>
+              <h2 class="spectrum-Heading spectrum-ContextualHelp-heading">Permission required</h2>
+              <p class="spectrum-Body spectrum-ContextualHelp-body">Cupcake ipsum dolor sit amet jelly beans. Chocolate jelly caramels. Icing soufflé chupa chups donut cheesecake. Jelly-o chocolate cake sweet roll cake danish candy biscuit halvah.</p>
               <a class="spectrum-Link spectrum-ContextualHelp-link" href="#">Learn about permissions</a>
             </div>
             <div class="dummy-spacing" style="position: relative; height: 248px; min-width: 400px; max-width: 50%;"></div>

--- a/components/contextualhelp/metadata/contextualhelp.yml
+++ b/components/contextualhelp/metadata/contextualhelp.yml
@@ -18,8 +18,8 @@ examples:
               </svg>
             </button>
             <div class="spectrum-Popover is-open spectrum-Popover--bottom-start spectrum-ContextualHelp-popover" role="presentation">
-              <h2 class="spectrum-Heading spectrum-Heading--sizeM spectrum-ContextualHelp-heading">Permission required</h2>
-              <p class="spectrum-Body spectrum-ContextualHelp-body">Cupcake ipsum dolor sit amet jelly beans. Chocolate jelly caramels. Icing soufflé chupa chups donut cheesecake. Jelly-o chocolate cake sweet roll cake danish candy biscuit halvah.</p>
+              <h2 class="spectrum-ContextualHelp-heading">Permission required</h2>
+              <p class="spectrum-ContextualHelp-body">Cupcake ipsum dolor sit amet jelly beans. Chocolate jelly caramels. Icing soufflé chupa chups donut cheesecake. Jelly-o chocolate cake sweet roll cake danish candy biscuit halvah.</p>
             </div>
             <div class="dummy-spacing" style="position: relative; height: 248px; min-width: 400px; max-width: 50%;"></div>
           </div>
@@ -27,8 +27,8 @@ examples:
         <div class="spectrum-Examples-item">
           <div class="spectrum-ContextualHelp">
             <div class="spectrum-Popover is-open spectrum-Popover--top spectrum-ContextualHelp-popover" role="presentation">
-              <h2 class="spectrum-Heading spectrum-ContextualHelp-heading">Permission required</h2>
-              <p class="spectrum-Body spectrum-ContextualHelp-body">Cupcake ipsum dolor sit amet jelly beans. Chocolate jelly caramels. Icing soufflé chupa chups donut cheesecake. Jelly-o chocolate cake sweet roll cake danish candy biscuit halvah.</p>
+              <h2 class="spectrum-ContextualHelp-heading">Permission required</h2>
+              <p class="spectrum-ContextualHelp-body">Cupcake ipsum dolor sit amet jelly beans. Chocolate jelly caramels. Icing soufflé chupa chups donut cheesecake. Jelly-o chocolate cake sweet roll cake danish candy biscuit halvah.</p>
             </div>
             <div class="dummy-spacing" style="position: relative; height: 166px; min-width: 400px; max-width: 50%;"></div>
             <button class="spectrum-ActionButton spectrum-ActionButton--sizeXS spectrum-ContextualHelp-button">
@@ -51,8 +51,8 @@ examples:
               </svg>
             </button>
             <div class="spectrum-Popover is-open spectrum-Popover--bottom-start spectrum-ContextualHelp-popover" role="presentation">
-              <h2 class="spectrum-Heading spectrum-ContextualHelp-heading">Permission required</h2>
-              <p class="spectrum-Body spectrum-ContextualHelp-body">Cupcake ipsum dolor sit amet jelly beans. Chocolate jelly caramels. Icing soufflé chupa chups donut cheesecake. Jelly-o chocolate cake sweet roll cake danish candy biscuit halvah.</p>
+              <h2 class="spectrum-ContextualHelp-heading">Permission required</h2>
+              <p class="spectrum-ContextualHelp-body">Cupcake ipsum dolor sit amet jelly beans. Chocolate jelly caramels. Icing soufflé chupa chups donut cheesecake. Jelly-o chocolate cake sweet roll cake danish candy biscuit halvah.</p>
               <a class="spectrum-Link spectrum-ContextualHelp-link" href="#">Learn about permissions</a>
             </div>
             <div class="dummy-spacing" style="position: relative; height: 248px; min-width: 400px; max-width: 50%;"></div>

--- a/components/contextualhelp/metadata/mods.md
+++ b/components/contextualhelp/metadata/mods.md
@@ -3,6 +3,8 @@
 |`--mod-spectrum-contextual-help-minimum-width`|
 |`--mod-spectrum-contextual-help-padding`|
 |`--mod-spectrum-contextual-help-body-size`|
+|`--mod-contextual-help-body-color`|
 |`--mod-spectrum-contextual-help-content-spacing`|
-|`--mod-spectrum-contextual-help-title-size`|
+|`--mod-spectrum-contextual-help-heading-size`|
+|`--mod-contextual-help-heading-color`|
 |`--mod-spectrum-contextual-help-link-spacing`|

--- a/components/contextualhelp/stories/template.js
+++ b/components/contextualhelp/stories/template.js
@@ -37,8 +37,8 @@ export const Template = ({
       })}
       ${Popover({
         content: [
-          title ? html`<h2 class="spectrum-Heading ${rootClass}-heading">${title}</h2>` : "",
-          body ? html`<p class="spectrum-Body ${rootClass}-body">${body}</p>` : "",
+          title ? html`<h2 class="${rootClass}-heading">${title}</h2>` : "",
+          body ? html`<p class="${rootClass}-body">${body}</p>` : "",
           link ? Link({ text: link.text, url: link.url, customClasses: [`${rootClass}-link`]}) : ""
         ],
         position: popoverPlacement,

--- a/components/contextualhelp/stories/template.js
+++ b/components/contextualhelp/stories/template.js
@@ -37,8 +37,8 @@ export const Template = ({
       })}
       ${Popover({
         content: [
-          title ? html`<h2 class="${rootClass}-heading">${title}</h2>` : "",
-          body ? html`<p class="${rootClass}-body">${body}</p>` : "",
+          title ? html`<h2 class="spectrum-Heading ${rootClass}-heading">${title}</h2>` : "",
+          body ? html`<p class="spectrum-Body ${rootClass}-body">${body}</p>` : "",
           link ? Link({ text: link.text, url: link.url, customClasses: [`${rootClass}-link`]}) : ""
         ],
         position: popoverPlacement,


### PR DESCRIPTION
## Description

Adds `.spectrum-Heading` and `.spectrum-Body` classes to the heading and paragraph tags in order to get the global font colors needed since font color was not a specified token for this component. 

## How and where has this been tested?
 - Latest versions of Chrome, Safari, Firefox

## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] I have tested these changes in Windows High Contrast mode.
- [x] I have updated any relevant storybook stories and templates. 
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
