### PR TITLE
chore(colorhandle, colorloupe): remove custom tokens 

### DIFF
--- a/components/colorhandle/index.css
+++ b/components/colorhandle/index.css
@@ -9,19 +9,19 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 .spectrum-ColorHandle {
-  --spectrum-colorhandle-size: var(--spectrum-color-handle-size-interim); /* TODO: this uses custom token, replace with updated --spectrum-color-handle-size token */
-  --spectrum-colorhandle-focused-size: var(--spectrum-color-handle-size-key-focus-interim); /* TODO: this uses custom token, replace with updated --spectrum-color-handle-size-key-focus token */
+  --spectrum-colorhandle-size: var(--spectrum-color-handle-size);
+  --spectrum-colorhandle-focused-size: var(--spectrum-color-handle-size-key-focus);
   --spectrum-colorhandle-hitarea-size: var(--spectrum-color-control-track-width);
 
   --spectrum-colorhandle-animation-duration: var(--spectrum-animation-duration-100);
   --spectrum-colorhandle-animation-easing: ease-in-out;
 
   /* outer border as box shadow on the colorhandle */
-  --spectrum-colorhandle-outer-border-color: rgba(var(--spectrum-black-rgb), 0.42); /*TODO replace --spectrum-black-rgb with color-handle-outer-border-color and  color-handle-inner-border-opacity once express value is removed */
+  --spectrum-colorhandle-outer-border-color: rgba(var(--spectrum-black-rgb), var(--spectrum-color-handle-inner-border-opacity)); /*TODO replace --spectrum-black-rgb with color-handle-outer-border-color */
   --spectrum-colorhandle-outer-border-width: var(--spectrum-color-handle-outer-border-width);
 
   /* inner border as inset boxshadow on the colorhandle-inner */
-  --spectrum-colorhandle-inner-border-color: rgba(var(--spectrum-black-rgb), 0.42); /*TODO replace --spectrum-black-rgb with color-handle-inner-border-color and color-handle-inner-border-opacity once express value is removed */
+  --spectrum-colorhandle-inner-border-color: rgba(var(--spectrum-black-rgb), var(--spectrum-color-handle-inner-border-opacity)); /*TODO replace --spectrum-black-rgb with color-handle-inner-border-color */
   --spectrum-colorhandle-inner-border-width: var(--spectrum-color-handle-inner-border-width);
 
   /* primary border on color handle */

--- a/components/colorhandle/index.css
+++ b/components/colorhandle/index.css
@@ -17,11 +17,11 @@ governing permissions and limitations under the License.
   --spectrum-colorhandle-animation-easing: ease-in-out;
 
   /* outer border as box shadow on the colorhandle */
-  --spectrum-colorhandle-outer-border-color: rgba(var(--spectrum-black-rgb), var(--spectrum-color-handle-inner-border-opacity)); /*TODO replace --spectrum-black-rgb with color-handle-outer-border-color */
+  --spectrum-colorhandle-outer-border-color: rgba(var(--spectrum-black-rgb), var(--spectrum-color-handle-outer-border-opacity)); /* TODO replace --spectrum-black-rgb with color-handle-outer-border-color when supported by RGBA */
   --spectrum-colorhandle-outer-border-width: var(--spectrum-color-handle-outer-border-width);
 
   /* inner border as inset boxshadow on the colorhandle-inner */
-  --spectrum-colorhandle-inner-border-color: rgba(var(--spectrum-black-rgb), var(--spectrum-color-handle-inner-border-opacity)); /*TODO replace --spectrum-black-rgb with color-handle-inner-border-color */
+  --spectrum-colorhandle-inner-border-color: rgba(var(--spectrum-black-rgb), var(--spectrum-color-handle-inner-border-opacity)); /* TODO replace --spectrum-black-rgb with color-handle-inner-border-color when supported by RGBA */
   --spectrum-colorhandle-inner-border-width: var(--spectrum-color-handle-inner-border-width);
 
   /* primary border on color handle */

--- a/components/colorloupe/index.css
+++ b/components/colorloupe/index.css
@@ -9,10 +9,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 .spectrum-ColorLoupe {
-  --spectrum-colorloupe-width: 48px; /* TODO replace with new token for var(--spectrum-color-loupe-width); */
-  --spectrum-colorloupe-height: 64px; /* TODO replace with new token for var(--spectrum-color-loupe-height); */
+  --spectrum-colorloupe-width: var(--spectrum-color-loupe-width); /* TODO replace with new token for var(--spectrum-color-loupe-width); */
+  --spectrum-colorloupe-height: var(--spectrum-color-loupe-height); /* TODO replace with new token for var(--spectrum-color-loupe-height); */
 
-  --spectrum-colorloupe-offset: 12px; /* TODO: replace with updated var(--spectrum-color-loupe-bottom-to-color-handle); */
+  --spectrum-colorloupe-offset: var(--spectrum-color-loupe-bottom-to-color-handle); /* TODO: replace with updated var(--spectrum-color-loupe-bottom-to-color-handle); */
   --spectrum-colorloupe-animation-distance: 8px; /* TODO: replace with forthcoming animation token */
 
   --spectrum-colorloupe-drop-shadow-x: var(--spectrum-drop-shadow-x);
@@ -21,7 +21,7 @@ governing permissions and limitations under the License.
   --spectrum-colorloupe-drop-shadow-color: var(--spectrum-color-loupe-drop-shadow-color);
 
   --spectrum-colorloupe-outer-border-width: var(--spectrum-color-loupe-outer-border-width);
-  --spectrum-colorloupe-inner-border-width: 1px; /* TODO: replace with updated token for color-loupe-inner-border-width */
+  --spectrum-colorloupe-inner-border-width: var(--spectrum-color-loupe-inner-border-width); /* TODO: replace with updated token for color-loupe-inner-border-width */
   --spectrum-colorloupe-outer-border-color: var(--spectrum-color-loupe-outer-border);
   --spectrum-colorloupe-inner-border-color: var(--spectrum-color-loupe-inner-border);
 
@@ -37,7 +37,7 @@ governing permissions and limitations under the License.
   transform: translate(0, var(--mod-colorloupe-animation-distance, var(--spectrum-colorloupe-animation-distance)));
   opacity: 0;
   transform-origin: bottom center;
-  inset-block-end: calc((var(--spectrum-color-handle-size-interim) - var(--spectrum-color-handle-outer-border-width)) + var(--mod-colorloupe-offset, var(--spectrum-colorloupe-offset)));
+  inset-block-end: calc((var(--spectrum-color-handle-size) - var(--spectrum-color-handle-outer-border-width)) + var(--mod-colorloupe-offset, var(--spectrum-colorloupe-offset)));
   inset-inline-end: calc(50% - (var(--spectrum-colorloupe-width) / 2) + 1px);
 
   transition: transform 100ms ease-in-out, opacity 125ms ease-in-out;

--- a/components/colorloupe/index.css
+++ b/components/colorloupe/index.css
@@ -9,10 +9,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 .spectrum-ColorLoupe {
-  --spectrum-colorloupe-width: var(--spectrum-color-loupe-width); /* TODO replace with new token for var(--spectrum-color-loupe-width); */
-  --spectrum-colorloupe-height: var(--spectrum-color-loupe-height); /* TODO replace with new token for var(--spectrum-color-loupe-height); */
+  --spectrum-colorloupe-width: var(--spectrum-color-loupe-width);
+  --spectrum-colorloupe-height: var(--spectrum-color-loupe-height);
 
-  --spectrum-colorloupe-offset: var(--spectrum-color-loupe-bottom-to-color-handle); /* TODO: replace with updated var(--spectrum-color-loupe-bottom-to-color-handle); */
+  --spectrum-colorloupe-offset: var(--spectrum-color-loupe-bottom-to-color-handle);
   --spectrum-colorloupe-animation-distance: 8px; /* TODO: replace with forthcoming animation token */
 
   --spectrum-colorloupe-drop-shadow-x: var(--spectrum-drop-shadow-x);
@@ -21,7 +21,7 @@ governing permissions and limitations under the License.
   --spectrum-colorloupe-drop-shadow-color: var(--spectrum-color-loupe-drop-shadow-color);
 
   --spectrum-colorloupe-outer-border-width: var(--spectrum-color-loupe-outer-border-width);
-  --spectrum-colorloupe-inner-border-width: var(--spectrum-color-loupe-inner-border-width); /* TODO: replace with updated token for color-loupe-inner-border-width */
+  --spectrum-colorloupe-inner-border-width: var(--spectrum-color-loupe-inner-border-width);
   --spectrum-colorloupe-outer-border-color: var(--spectrum-color-loupe-outer-border);
   --spectrum-colorloupe-inner-border-color: var(--spectrum-color-loupe-inner-border);
 

--- a/components/tokens/custom-express/custom-large-vars.css
+++ b/components/tokens/custom-express/custom-large-vars.css
@@ -15,9 +15,4 @@ governing permissions and limitations under the License.
 .spectrum--express.spectrum--large {
   --spectrum-colorwheel-path: "M 118 118 m -118 0 a 118 118 0 1 0 236 0 a 118 118 0 1 0 -236 0.2 M 118 118 m -92 0 a 92 92 0 1 0 184 0 a 92 92 0 1 0 -184 0";
   --spectrum-colorwheel-path-borders: "M 120 120 m -120 0 a 120 120 0 1 0 240 0 a 120 120 0 1 0 -240 0.2 M 120 120 m -90 0 a 90 90 0 1 0 180 0 a 90 90 0 1 0 -180 0";
-
-    /* TODO: Remove once new tokens for colorhandle and colorloupe are released */
-    --spectrum-color-handle-outer-border-width: 1px;
-    --spectrum-color-handle-size-interim: 20px;
-    --spectrum-color-handle-size-key-focus-interim: 40px;
 }

--- a/components/tokens/custom-express/custom-medium-vars.css
+++ b/components/tokens/custom-express/custom-medium-vars.css
@@ -15,9 +15,4 @@ governing permissions and limitations under the License.
 .spectrum--express.spectrum--medium {
   --spectrum-colorwheel-path: "M 94 94 m -94 0 a 94 94 0 1 0 188 0 a 94 94 0 1 0 -188 0.2 M 94 94 m -74 0 a 74 74 0 1 0 148 0 a 74 74 0 1 0 -148 0";
   --spectrum-colorwheel-path-borders: "M 96 96 m -96 0 a 96 96 0 1 0 192 0 a 96 96 0 1 0 -192 0.2 M 96 96 m -72 0 a 72 72 0 1 0 144 0 a 72 72 0 1 0 -144 0";
-
-    /* TODO: Remove once new tokens for colorhandle and colorloupe are released */
-    --spectrum-color-handle-outer-border-width: 1px;
-    --spectrum-color-handle-size-interim: 16px;
-    --spectrum-color-handle-size-key-focus-interim: 32px;
 }

--- a/components/tokens/custom-spectrum/custom-large-vars.css
+++ b/components/tokens/custom-spectrum/custom-large-vars.css
@@ -27,9 +27,6 @@ governing permissions and limitations under the License.
   --spectrum-colorwheel-colorarea-container-size: 182px;
 
   --spectrum-colorloupe-checkerboard-fill: url(#checkerboard-secondary);
-  /* TODO: Remove once new tokens for colorhandle and colorloupe are released */
-  --spectrum-color-handle-size-interim: 20px;
-  --spectrum-color-handle-size-key-focus-interim: 40px;
 
   --spectrum-menu-item-selectable-edge-to-text-not-selected-small: 34px;
   --spectrum-menu-item-selectable-edge-to-text-not-selected-medium: 42px;

--- a/components/tokens/custom-spectrum/custom-medium-vars.css
+++ b/components/tokens/custom-spectrum/custom-medium-vars.css
@@ -27,9 +27,6 @@ governing permissions and limitations under the License.
   --spectrum-colorwheel-colorarea-container-size: 144px;
 
   --spectrum-colorloupe-checkerboard-fill: url(#checkerboard-primary);
-  /* TODO: Remove once new tokens for colorhandle and colorloupe are released */
-  --spectrum-color-handle-size-interim: 16px;
-  --spectrum-color-handle-size-key-focus-interim: 32px;
 
   --spectrum-menu-item-selectable-edge-to-text-not-selected-small: 28px;
   --spectrum-menu-item-selectable-edge-to-text-not-selected-medium: 32px;


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->

Follow up to [migration](https://github.com/adobe/spectrum-css/pull/1753) for ColorHandle 

The following tokens were updated after the migration to account for spectrum vs express styling changes: 
 - color-loupe-bottom-to-color-handle
  - color-loupe-height
  - color-loupe-inner-border-width
  - color-loupe-width
  - color-handle-inner-border-opacity
  - color-handle-outer-border-opacity
  - color-handle-size
  - color-handle-size-key-focus

This PR removes hard coded values, custom tokens, and related comments to use the newly updated tokens. 

To test view the ColorHandle and ColorLoupe component as spectrum and express, there should be no styling difference between the 2 themes. 

## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] I have tested these changes in Windows High Contrast mode.
- [x] I have updated any relevant storybook stories and templates. 
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
