### PR TITLE
fix(icon): correct storybook icon sizing substitution

### DIFF
--- a/components/icon/stories/template.js
+++ b/components/icon/stories/template.js
@@ -19,7 +19,7 @@ import "../index.css";
  * @param {string} props.rootClass
  * @param {"s"|"m"|"l"|"xl"} props.size
  * @param {"ui"|"workflow"} props.setName
- * @param {string} props.iconName
+ * @param {string} props.iconName - Icon name with or without the icon scale number appended. Names with the scale (e.g. 75, 100) will replace it based upon the value of 'size'.
  * @param {string} props.fill
  * @param {string} props.id
  * @param {string[]} props.customClasses
@@ -47,13 +47,16 @@ export const Template = ({
   }
 
   let idKey = iconName;
-  /** If a descriptor like Right, Left, Down, or Up is present for the Chevron or the Arrow, use that only for the class and not the icon fetch */
+
+  // If a descriptor like Right, Left, Down, or Up is present for the Chevron or the
+  // Arrow, use that only for the class and not the icon fetch.
   if (uiIcons.some(c => idKey.startsWith(c)) && ['Right', 'Left', 'Down', 'Up'].some(c => idKey.includes(c))) {
     idKey = idKey.replace(/(Right|Left|Down|Up)/, '');
   }
 
-  /** Reformat the icon scale to match the provided sizing */
-  if(uiIcons.includes(idKey) && !idKey.endsWith('Gripper') && idKey.match(/^(?!\d).*\d{2,3}$/)) {
+  // If the icon name includes its scale, reformat it to match the provided sizing.
+  // E.g. with a size of "s", the icon name "Checkmark100" would become "Checkmark75".
+  if (idKey.match(/^(?!\d).*\d{2,3}$/) && uiIcons.includes(idKey.replace(/\d{2,3}$/, '')) && !idKey.endsWith('Gripper')) {
     let sizeVal;
     switch(size) {
       case 'xs':
@@ -76,6 +79,7 @@ export const Template = ({
     iconName = iconName.replace(/\d{2,3}$/, sizeVal);
   }
 
+  // Determine which icon set contains this icon.
   if (workflowIcons.includes(idKey)) {
     setName = "workflow";
   } else if (uiIcons.includes(idKey.replace(/\d{2,3}$/, ''))) {


### PR DESCRIPTION
## Description
Fix issue where use of Icon in other stories would not change its sizing (scale) based on the value of the size arg. The conditional with uiIcons.includes was comparing against the icon name which still contained the sizing number, so was always failing.

Also adds some docs around this.

## How and where has this been tested?
Chrome, Mac. Testing 'Table' in storybook with t-shirt sizes ("small" should now show smaller icon). Tested some of the other components in Storybook that are using Icon to make sure they still look the same: checkbox, closebutton, textfield

## To-do list
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
- [x] I have updated any relevant storybook stories and templates. 
- [x] This pull request is ready to merge.
