### PR TITLE
fix: resolve missing preview destination

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "dev": "NODE_ENV=development BROWSERSYNC_OPEN=true gulp dev",
     "docs:mod": "node tasks/mod-extractor.js",
     "lint:components": "node ./tasks/packageLint.js",
-    "mv:preview": "rimraf dist/preview && mv tools/preview/storybook-static dist/preview",
+    "mv:preview": "rimraf dist/preview && mkdir dist/preview && mv tools/preview/storybook-static dist/preview",
     "new": "nx run @spectrum-css/generator:new",
     "precommit": "lint-staged",
     "prepare": "husky install",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "dev": "NODE_ENV=development BROWSERSYNC_OPEN=true gulp dev",
     "docs:mod": "node tasks/mod-extractor.js",
     "lint:components": "node ./tasks/packageLint.js",
-    "mv:preview": "rimraf dist/preview && mkdir dist/preview && mv tools/preview/storybook-static dist/preview",
+    "mv:preview": "rimraf dist/preview && mv -f tools/preview/storybook-static dist/preview",
     "new": "nx run @spectrum-css/generator:new",
     "precommit": "lint-staged",
     "prepare": "husky install",


### PR DESCRIPTION
Resolves an issue where trying to release a build of the docs site threw an error due to a script trying to move files to a non-existent destination.

<img width="693" alt="Screen Shot 2023-05-04 at 1 05 06 PM" src="https://user-images.githubusercontent.com/360251/236275616-4e5a4cca-62c0-491c-ab75-bb9e801721a1.png">


<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->


## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] I have updated any relevant storybook stories and templates. 
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
