### PR TITLE
feat(tokens): use v12.8.0 of @adobe/spectrum-tokens

### DIFF
--- a/components/tokens/package.json
+++ b/components/tokens/package.json
@@ -27,7 +27,7 @@
     "format:results": "prettier --no-config --no-error-on-unmatched-pattern --ignore-unknown --loglevel silent --write dist/"
   },
   "devDependencies": {
-    "@adobe/spectrum-tokens": "12.7.0",
+    "@adobe/spectrum-tokens": "12.8.0",
     "concat-cli": "^4.0.0",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,10 +22,10 @@
   resolved "https://registry.yarnpkg.com/@adobe/spectrum-tokens-deprecated/-/spectrum-tokens-deprecated-11.8.0.tgz#7edf6f7b7e3c22581e0732c8de97fa0a68ed66b9"
   integrity sha512-LW2SA/8VhW868tEcgIcugx7xdtgFG3KiUoEz+4s2nHTdmKj0h2A9pnTNplVTNAMq2uPSfp6wKKvQNNnMSIXqCg==
 
-"@adobe/spectrum-tokens@12.7.0":
-  version "12.7.0"
-  resolved "https://registry.yarnpkg.com/@adobe/spectrum-tokens/-/spectrum-tokens-12.7.0.tgz#43079fc5ef3d90e5b33cfb878205ce8e29d9d501"
-  integrity sha512-iJ/DttvhDq6x0S7Av42uq61fZMnKQ7N4q8lXlcsAY0T+Bzp4RNpVagaBoStW8QB5vwzFBgfXHr4OK7AzyUBsVw==
+"@adobe/spectrum-tokens@12.8.0":
+  version "12.8.0"
+  resolved "https://registry.yarnpkg.com/@adobe/spectrum-tokens/-/spectrum-tokens-12.8.0.tgz#eec3b755d9d6f61e12c0fd35feec441477c41ca6"
+  integrity sha512-XK1j8zkXLOwetH99+D7woihQ1NYHVYCaM+WREoU9bkA/sZ8kUy1lnXdyYwxWfWaoEHODNjLAtSaDYEJdDluTLQ==
 
 "@ampproject/remapping@^2.2.0":
   version "2.2.0"


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
Updates to `@adobe/spectrum-tokens@12.8.0`, which contains 2 token value updates for color handle to remove express specific values. Full details in the [release notes](https://github.com/adobe/spectrum-tokens/releases/tag/%40adobe/spectrum-tokens%4012.8.0).


## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] I have updated any relevant storybook stories and templates. 
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
