### PR TITLE
fix(stepper): fix stepper button padding and borders

### DIFF
--- a/components/stepper/index.css
+++ b/components/stepper/index.css
@@ -63,10 +63,8 @@ governing permissions and limitations under the License.
   --spectrum-stepper-button-width: calc(var(--spectrum-spacing-400) - var(--spectrum-stepper-border-width)); /* this matches the previous WIDTH token */
   --spectrum-stepper-button-padding: calc(var(--spectrum-spacing-200) / 2); /* 6px md + 7px lg - previously 6px md + 7.5px lg */
   --spectrum-stepper-button-gap: var(--spectrum-stepper-button-gap-reset);
-  --spectrum-stepper-button-border-radius: var(--spectrum-stepper-button-border-radius-reset);
 
   /* background same as textfield */
-  --spectrum-stepper-background-color: var(--spectrum-gray-50);
   --spectrum-stepper-background-color-disabled: var(--spectrum-disabled-background-color);
 
  /*** Quiet Variant ***/
@@ -160,7 +158,6 @@ governing permissions and limitations under the License.
 
   /*** Hover ***/
   &:hover:not(.is-disabled):not(.is-invalid):not(.is-focused):not(.is-keyboardFocused) {
-    .spectrum-Stepper-buttons,
     .spectrum-Stepper-stepUp,
     .spectrum-Stepper-stepDown,
     .spectrum-Stepper-input {
@@ -328,6 +325,7 @@ governing permissions and limitations under the License.
 
       border-block-start: none;
       border-inline-start: none;
+      border-inline-end: none;
       border-radius: 0;
 
       padding-inline-end: 0;
@@ -458,42 +456,19 @@ governing permissions and limitations under the License.
 
 /* container for stepUp and stepDown buttons */
 .spectrum-Stepper-buttons {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
   /* allow express buttons to have a gap the size of the stepper border */
   row-gap: var(--mod-stepper-button-gap, var(--spectrum-stepper-button-gap));
 
-  overflow: hidden;
-
-  block-size: var(--mod-stepper-buttons-height, var(--spectrum-stepper-buttons-height));
-
-  inline-size: var(--mod-stepper-button-width, var(--spectrum-stepper-button-width));
-
-  box-sizing: border-box;
   border-start-start-radius: 0;
   border-start-end-radius: var(--mod-stepper-border-radius, var(--spectrum-stepper-border-radius));
   border-end-end-radius: var(--mod-stepper-border-radius, var(--spectrum-stepper-border-radius));
   border-end-start-radius: 0;
-
-  border-style: solid;
-  border-width: var(--mod-stepper-border-width, var(--spectrum-stepper-border-width))
-                var(--mod-stepper-border-width, var(--spectrum-stepper-border-width))
-                var(--mod-stepper-border-width, var(--spectrum-stepper-border-width))
-                var(--mod-stepper-border-size-reset, var(--spectrum-stepper-border-size-reset));
-
-  border-color: var(--highcontrast-stepper-border-color, var(--mod-stepper-border-color, var(--spectrum-stepper-border-color)));
-  background-color: var(--highcontrast-stepper-background-color, var(--mod-stepper-background-color, var(--spectrum-stepper-background-color)));
-
-  transition: border-color var(--mod-stepper-animation-duration, var(--spectrum-stepper-animation-duration)) ease-in-out;
 }
 
 .spectrum-Stepper-stepUp,
 .spectrum-Stepper-stepDown {
   position: relative;
   display: flex;
-  flex-direction: row;
-  justify-content: center;
   box-sizing: border-box;
   block-size: calc((var(--mod-stepper-buttons-height, var(--spectrum-stepper-buttons-height)) / 2)
                   - (var(--mod-stepper-button-gap, var(--spectrum-stepper-button-gap)) * 2.5));
@@ -509,16 +484,17 @@ governing permissions and limitations under the License.
 
   /* Avoid margin added by adjacent buttons */
   margin: 0;
-
   border-color: var(--highcontrast-stepper-border-color, var(--mod-stepper-border-color, var(--spectrum-stepper-border-color)));
-  border-width: 0;
+  border-style: solid;
+  border-width: var(--mod-stepper-border-width, var(--spectrum-stepper-border-width));
+  border-inline-start: 0;
 
   background-color: var(--highcontrast-stepper-button-background-color-default, var(--mod-stepper-button-background-color-default, var(--spectrum-stepper-button-background-color-default)));
+  transition: border-color var(--mod-stepper-animation-duration, var(--spectrum-stepper-animation-duration)) ease-in-out;
 
   .spectrum-Icon {
     opacity: 1;
-    margin-inline-end: 0px;
-    margin-inline-start: calc(-1 * var(--spectrum-stepper-border-radius) / 2); /* This should be looked at again when stepper is migrated */
+    margin: 0px;
   }
 
   /*** Action Buttons Hover ***/
@@ -535,21 +511,24 @@ governing permissions and limitations under the License.
 
 .spectrum-Stepper-stepUp {
   padding-block-start: var(--mod-stepper-icon-nudge-start, var(--spectrum-stepper-icon-nudge-start));
+  padding-block-end: 0;
 
-  border-start-start-radius: var(--mod-stepper-button-border-radius, var(--spectrum-stepper-button-border-radius));
-  border-start-end-radius: var(--mod-stepper-button-border-radius, var(--spectrum-stepper-button-border-radius));
-  border-end-start-radius: 0;
-  border-end-end-radius: 0;
+  border-start-start-radius: var(--mod-stepper-button-border-radius-reset, var(--spectrum-stepper-button-border-radius-reset));
+  border-start-end-radius: var(--mod-stepper-border-radius, var(--spectrum-stepper-border-radius));
+  border-end-start-radius: var(--spectrum-stepper-button-border-radius-reset);
+  border-end-end-radius: var(--spectrum-stepper-button-border-radius-reset);
+  border-bottom-width: var(--spectrum-stepper-button-border-radius-reset);
 }
 
 .spectrum-Stepper-stepDown {
   border-block-start-width: var(--mod-stepper-button-middle-border-width, var(--spectrum-stepper-button-middle-border-width));
   padding-block-end: var(--mod-stepper-icon-nudge-end, var(--spectrum-stepper-icon-nudge-end));
+  padding-block-start: 0;
 
-  border-start-start-radius: 0;
-  border-start-end-radius: 0;
-  border-end-start-radius: var(--mod-stepper-button-border-radius, var(--spectrum-stepper-button-border-radius));
-  border-end-end-radius: var(--mod-stepper-button-border-radius, var(--spectrum-stepper-button-border-radius));
+  border-start-start-radius: var(--spectrum-stepper-button-border-radius-reset);
+  border-start-end-radius: var(--spectrum-stepper-button-border-radius-reset);
+  border-end-start-radius: var(--mod-stepper-button-border-radius-reset, var(--spectrum-stepper-button-border-radius-reset));
+  border-end-end-radius: var(--mod-stepper-border-radius, var(--spectrum-stepper-border-radius));
 }
 
 .spectrum-Stepper-textfield {
@@ -563,10 +542,15 @@ governing permissions and limitations under the License.
   }
 }
 
-/* Only remove input border if stepper is visible */
-.spectrum-Stepper:not(.hide-stepper) .spectrum-Stepper-input {
+.spectrum-Stepper-input {
   min-inline-size: 0;
   border-start-end-radius: 0;
   border-end-end-radius: 0;
-  border-inline-end-width: 0;
+}
+
+
+/* Only remove input border if stepper is visible */
+.spectrum-Stepper.hide-stepper .spectrum-Stepper-input {
+  border-start-end-radius: var(--spectrum-stepper-border-radius);
+  border-end-end-radius: var(--spectrum-stepper-border-radius);
 }

--- a/components/stepper/index.css
+++ b/components/stepper/index.css
@@ -158,6 +158,7 @@ governing permissions and limitations under the License.
 
   /*** Hover ***/
   &:hover:not(.is-disabled):not(.is-invalid):not(.is-focused):not(.is-keyboardFocused) {
+    .spectrum-Stepper-buttons,
     .spectrum-Stepper-stepUp,
     .spectrum-Stepper-stepDown,
     .spectrum-Stepper-input {
@@ -469,7 +470,7 @@ governing permissions and limitations under the License.
   border-width: var(--mod-stepper-border-width, var(--spectrum-stepper-border-width))
                 var(--mod-stepper-border-width, var(--spectrum-stepper-border-width))
                 var(--mod-stepper-border-width, var(--spectrum-stepper-border-width))
-                var(--mod-stepper-button-border-width, var(--spectrum-stepper-button-border-width));
+                var(--spectrum-stepper-button-border-width-reset);
   border-color: var(--highcontrast-stepper-border-color, var(--mod-stepper-border-color, var(--spectrum-stepper-border-color)));
 
   border-start-start-radius: 0;
@@ -489,7 +490,7 @@ governing permissions and limitations under the License.
   block-size: calc((var(--mod-stepper-buttons-height, var(--spectrum-stepper-buttons-height)) / 2)
                   - (var(--mod-stepper-button-gap, var(--spectrum-stepper-button-gap)) * 2.5));
 
-  inline-size: var(--spectrum-stepper-button-width);
+  inline-size: var(--mod-stepper-button-width, var(--spectrum-stepper-button-width));
 
   margin-inline-end: var(--mod-stepper-button-gap, var(--spectrum-stepper-button-gap));
 
@@ -501,14 +502,13 @@ governing permissions and limitations under the License.
   /* Avoid margin added by adjacent buttons */
   margin: 0;
 
-  /* border-color: transparent; */
   border-width: 0;
   background-color: var(--highcontrast-stepper-button-background-color-default, var(--mod-stepper-button-background-color-default, var(--spectrum-stepper-button-background-color-default)));
 
   .spectrum-Icon {
     opacity: 1;
     margin: 0px;
-    margin-inline-start: calc(-1 * var(--spectrum-stepper-border-width) / 2); /* This should be looked at again when stepper is migrated */
+    margin-inline-start: calc(-1 * var(--mod-stepper-border-width, var(--spectrum-stepper-border-width)) / 2); /* This should be looked at again when stepper is migrated */
   }
 
   /*** Action Buttons Hover ***/
@@ -527,7 +527,7 @@ governing permissions and limitations under the License.
   padding-block-start: var(--mod-stepper-icon-nudge-start, var(--spectrum-stepper-icon-nudge-start));
   padding-block-end: 0;
 
-  border-block-end-width: var(--spectrum-stepper-button-border-width);
+  border-block-end-width: var(--spectrum-stepper-button-border-width-reset);
   border-block-end-color: var(--highcontrast-stepper-border-color, var(--mod-stepper-border-color, var(--spectrum-stepper-border-color)));
  
   border-start-start-radius: var(--spectrum-stepper-button-border-radius-reset);
@@ -562,12 +562,13 @@ governing permissions and limitations under the License.
   min-inline-size: 0;
   border-start-end-radius: 0;
   border-end-end-radius: 0;
-  border-inline-end: 0;
+  border-inline-end-width: 0;
 }
 
 
 /* Only remove input border if stepper is visible */
 .spectrum-Stepper.hide-stepper .spectrum-Stepper-input {
-  border-start-end-radius: var(--spectrum-stepper-border-radius);
-  border-end-end-radius: var(--spectrum-stepper-border-radius);
+  border-start-end-radius: var(--mod-stepper-border-radius, var(--spectrum-stepper-border-radius));
+  border-end-end-radius: var(--mod-stepper-border-radius, var(--spectrum-stepper-border-radius));
+  border-inline-end-width: var(--mod-stepper-border-width, var(--spectrum-stepper-border-width));
 }

--- a/components/stepper/index.css
+++ b/components/stepper/index.css
@@ -65,6 +65,7 @@ governing permissions and limitations under the License.
   --spectrum-stepper-button-gap: var(--spectrum-stepper-button-gap-reset);
 
   /* background same as textfield */
+  --spectrum-stepper-background-color: var(--spectrum-gray-50);
   --spectrum-stepper-background-color-disabled: var(--spectrum-disabled-background-color);
 
  /*** Quiet Variant ***/
@@ -328,6 +329,7 @@ governing permissions and limitations under the License.
       border-inline-start: none;
       border-inline-end: none;
       border-radius: 0;
+      border-width: 0;
 
       padding-inline-end: 0;
       justify-content: flex-end;
@@ -462,9 +464,10 @@ governing permissions and limitations under the License.
   justify-content: center;
   /* allow express buttons to have a gap the size of the stepper border */
   row-gap: var(--mod-stepper-button-gap, var(--spectrum-stepper-button-gap));
+  overflow: hidden;
+  box-sizing: border-box;
 
   block-size: var(--mod-stepper-buttons-height, var(--spectrum-stepper-buttons-height));
-  box-sizing: border-box;
 
   border-style: solid;
   border-width: var(--mod-stepper-border-width, var(--spectrum-stepper-border-width))
@@ -478,6 +481,7 @@ governing permissions and limitations under the License.
   border-end-end-radius: var(--mod-stepper-border-radius, var(--spectrum-stepper-border-radius));
   border-end-start-radius: 0;
 
+  background-color: var(--highcontrast-stepper-background-color, var(--mod-stepper-background-color, var(--spectrum-stepper-background-color)));
   transition: border-color var(--mod-stepper-animation-duration, var(--spectrum-stepper-animation-duration)) ease-in-out;
 
 }
@@ -508,7 +512,6 @@ governing permissions and limitations under the License.
   .spectrum-Icon {
     opacity: 1;
     margin: 0px;
-    margin-inline-start: calc(-1 * var(--mod-stepper-border-width, var(--spectrum-stepper-border-width)) / 2); /* This should be looked at again when stepper is migrated */
   }
 
   /*** Action Buttons Hover ***/
@@ -530,10 +533,9 @@ governing permissions and limitations under the License.
   border-block-end-width: var(--spectrum-stepper-button-border-width-reset);
   border-block-end-color: var(--highcontrast-stepper-border-color, var(--mod-stepper-border-color, var(--spectrum-stepper-border-color)));
  
-  border-start-start-radius: var(--spectrum-stepper-button-border-radius-reset);
-  border-start-end-radius: var(--mod-stepper-border-radius, var(--spectrum-stepper-border-radius));
-  border-end-start-radius: var(--spectrum-stepper-button-border-radius-reset);
-  border-end-end-radius: var(--spectrum-stepper-button-border-radius-reset);
+  border-radius: var(--spectrum-stepper-button-border-radius-reset);
+  border-end-start-radius: 0;
+  border-end-end-radius: 0;
 }
 
 .spectrum-Stepper-stepDown {
@@ -541,10 +543,9 @@ governing permissions and limitations under the License.
   padding-block-end: var(--mod-stepper-icon-nudge-end, var(--spectrum-stepper-icon-nudge-end));
   padding-block-start: 0;
 
-  border-start-start-radius: var(--spectrum-stepper-button-border-radius-reset);
-  border-start-end-radius: var(--spectrum-stepper-button-border-radius-reset);
-  border-end-start-radius: var(--spectrum-stepper-button-border-radius-reset);
-  border-end-end-radius: var(--mod-stepper-border-radius, var(--spectrum-stepper-border-radius));
+  border-radius: var(--spectrum-stepper-button-border-radius-reset);
+  border-start-start-radius: 0;
+  border-start-end-radius: 0;
 }
 
 .spectrum-Stepper-textfield {

--- a/components/stepper/index.css
+++ b/components/stepper/index.css
@@ -456,13 +456,29 @@ governing permissions and limitations under the License.
 
 /* container for stepUp and stepDown buttons */
 .spectrum-Stepper-buttons {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
   /* allow express buttons to have a gap the size of the stepper border */
   row-gap: var(--mod-stepper-button-gap, var(--spectrum-stepper-button-gap));
+
+  block-size: var(--mod-stepper-buttons-height, var(--spectrum-stepper-buttons-height));
+  box-sizing: border-box;
+
+  border-style: solid;
+  border-width: var(--mod-stepper-border-width, var(--spectrum-stepper-border-width))
+                var(--mod-stepper-border-width, var(--spectrum-stepper-border-width))
+                var(--mod-stepper-border-width, var(--spectrum-stepper-border-width))
+                var(--mod-stepper-button-border-width, var(--spectrum-stepper-button-border-width));
+  border-color: var(--highcontrast-stepper-border-color, var(--mod-stepper-border-color, var(--spectrum-stepper-border-color)));
 
   border-start-start-radius: 0;
   border-start-end-radius: var(--mod-stepper-border-radius, var(--spectrum-stepper-border-radius));
   border-end-end-radius: var(--mod-stepper-border-radius, var(--spectrum-stepper-border-radius));
   border-end-start-radius: 0;
+
+  transition: border-color var(--mod-stepper-animation-duration, var(--spectrum-stepper-animation-duration)) ease-in-out;
+
 }
 
 .spectrum-Stepper-stepUp,
@@ -484,17 +500,15 @@ governing permissions and limitations under the License.
 
   /* Avoid margin added by adjacent buttons */
   margin: 0;
-  border-color: var(--highcontrast-stepper-border-color, var(--mod-stepper-border-color, var(--spectrum-stepper-border-color)));
-  border-style: solid;
-  border-width: var(--mod-stepper-border-width, var(--spectrum-stepper-border-width));
-  border-inline-start: 0;
 
+  /* border-color: transparent; */
+  border-width: 0;
   background-color: var(--highcontrast-stepper-button-background-color-default, var(--mod-stepper-button-background-color-default, var(--spectrum-stepper-button-background-color-default)));
-  transition: border-color var(--mod-stepper-animation-duration, var(--spectrum-stepper-animation-duration)) ease-in-out;
 
   .spectrum-Icon {
     opacity: 1;
     margin: 0px;
+    margin-inline-start: calc(-1 * var(--spectrum-stepper-border-width) / 2); /* This should be looked at again when stepper is migrated */
   }
 
   /*** Action Buttons Hover ***/
@@ -513,15 +527,17 @@ governing permissions and limitations under the License.
   padding-block-start: var(--mod-stepper-icon-nudge-start, var(--spectrum-stepper-icon-nudge-start));
   padding-block-end: 0;
 
+  border-block-end-width: var(--spectrum-stepper-button-border-width);
+  border-block-end-color: var(--highcontrast-stepper-border-color, var(--mod-stepper-border-color, var(--spectrum-stepper-border-color)));
+ 
   border-start-start-radius: var(--spectrum-stepper-button-border-radius-reset);
   border-start-end-radius: var(--mod-stepper-border-radius, var(--spectrum-stepper-border-radius));
   border-end-start-radius: var(--spectrum-stepper-button-border-radius-reset);
   border-end-end-radius: var(--spectrum-stepper-button-border-radius-reset);
-  border-bottom-width: var(--spectrum-stepper-button-border-radius-reset);
 }
 
 .spectrum-Stepper-stepDown {
-  border-block-start-width: var(--mod-stepper-button-middle-border-width, var(--spectrum-stepper-button-middle-border-width));
+  border-block-start-width: 0;
   padding-block-end: var(--mod-stepper-icon-nudge-end, var(--spectrum-stepper-icon-nudge-end));
   padding-block-start: 0;
 
@@ -546,6 +562,7 @@ governing permissions and limitations under the License.
   min-inline-size: 0;
   border-start-end-radius: 0;
   border-end-end-radius: 0;
+  border-inline-end: 0;
 }
 
 

--- a/components/stepper/index.css
+++ b/components/stepper/index.css
@@ -513,7 +513,7 @@ governing permissions and limitations under the License.
   padding-block-start: var(--mod-stepper-icon-nudge-start, var(--spectrum-stepper-icon-nudge-start));
   padding-block-end: 0;
 
-  border-start-start-radius: var(--mod-stepper-button-border-radius-reset, var(--spectrum-stepper-button-border-radius-reset));
+  border-start-start-radius: var(--spectrum-stepper-button-border-radius-reset);
   border-start-end-radius: var(--mod-stepper-border-radius, var(--spectrum-stepper-border-radius));
   border-end-start-radius: var(--spectrum-stepper-button-border-radius-reset);
   border-end-end-radius: var(--spectrum-stepper-button-border-radius-reset);
@@ -527,7 +527,7 @@ governing permissions and limitations under the License.
 
   border-start-start-radius: var(--spectrum-stepper-button-border-radius-reset);
   border-start-end-radius: var(--spectrum-stepper-button-border-radius-reset);
-  border-end-start-radius: var(--mod-stepper-button-border-radius-reset, var(--spectrum-stepper-button-border-radius-reset));
+  border-end-start-radius: var(--spectrum-stepper-button-border-radius-reset);
   border-end-end-radius: var(--mod-stepper-border-radius, var(--spectrum-stepper-border-radius));
 }
 

--- a/components/stepper/metadata/mods.md
+++ b/components/stepper/metadata/mods.md
@@ -1,38 +1,35 @@
 | Modifiable Custom Properties |
 | --- |
-| `--mod-stepper-animation-duration` |
-| `--mod-stepper-background-color` |
-| `--mod-stepper-border-color` |
-| `--mod-stepper-border-color-disabled` |
-| `--mod-stepper-border-color-focus` |
-| `--mod-stepper-border-color-focus-hover` |
-| `--mod-stepper-border-color-hover` |
-| `--mod-stepper-border-color-invalid-default` |
-| `--mod-stepper-border-color-invalid-focus` |
-| `--mod-stepper-border-color-invalid-focus-hover` |
-| `--mod-stepper-border-color-invalid-hover` |
-| `--mod-stepper-border-color-invalid-keyboard-focus` |
-| `--mod-stepper-border-color-keyboard-focus` |
-| `--mod-stepper-border-color-quiet-disabled` |
-| `--mod-stepper-border-radius` |
-| `--mod-stepper-border-size-reset` |
-| `--mod-stepper-border-width` |
-| `--mod-stepper-button-background-color-default` |
-| `--mod-stepper-button-background-color-focus` |
-| `--mod-stepper-button-background-color-hover` |
-| `--mod-stepper-button-background-color-keyboard-focus` |
-| `--mod-stepper-button-border-radius` |
-| `--mod-stepper-button-gap` |
-| `--mod-stepper-button-middle-border-width` |
-| `--mod-stepper-button-offset` |
-| `--mod-stepper-button-padding` |
-| `--mod-stepper-button-width` |
-| `--mod-stepper-buttons-height` |
-| `--mod-stepper-focus-indicator-color` |
-| `--mod-stepper-focus-indicator-gap` |
-| `--mod-stepper-focus-indicator-width` |
-| `--mod-stepper-icon-nudge-end` |
-| `--mod-stepper-icon-nudge-start` |
-| `--mod-stepper-quiet-button-width` |
-| `--mod-stepper-quiet-width` |
-| `--mod-stepper-width` |
+|`--mod-stepper-width`|
+|`--mod-stepper-border-radius`|
+|`--mod-stepper-focus-indicator-gap`|
+|`--mod-stepper-border-width`|
+|`--mod-stepper-focus-indicator-width`|
+|`--mod-stepper-border-color-hover`|
+|`--mod-stepper-border-color-focus`|
+|`--mod-stepper-button-background-color-focus`|
+|`--mod-stepper-border-color-focus-hover`|
+|`--mod-stepper-border-color-invalid-focus`|
+|`--mod-stepper-focus-indicator-color`|
+|`--mod-stepper-border-color-keyboard-focus`|
+|`--mod-stepper-button-background-color-keyboard-focus`|
+|`--mod-stepper-border-color-invalid-keyboard-focus`|
+|`--mod-stepper-border-color-invalid-default`|
+|`--mod-stepper-border-color-invalid-hover`|
+|`--mod-stepper-border-color-invalid-focus-hover`|
+|`--mod-stepper-border-color-disabled`|
+|`--mod-stepper-quiet-width`|
+|`--mod-stepper-quiet-button-width`|
+|`--mod-stepper-button-offset`|
+|`--mod-stepper-border-color-quiet-disabled`|
+|`--mod-stepper-button-gap`|
+|`--mod-stepper-buttons-height`|
+|`--mod-stepper-button-padding`|
+|`--mod-stepper-border-color`|
+|`--mod-stepper-button-background-color-default`|
+|`--mod-stepper-animation-duration`|
+|`--mod-stepper-button-background-color-hover`|
+|`--mod-stepper-icon-nudge-start`|
+|`--mod-stepper-button-border-radius-reset`|
+|`--mod-stepper-button-middle-border-width`|
+|`--mod-stepper-icon-nudge-end`|

--- a/components/stepper/metadata/mods.md
+++ b/components/stepper/metadata/mods.md
@@ -24,11 +24,11 @@
 |`--mod-stepper-border-color-quiet-disabled`|
 |`--mod-stepper-button-gap`|
 |`--mod-stepper-buttons-height`|
-|`--mod-stepper-button-padding`|
 |`--mod-stepper-border-color`|
-|`--mod-stepper-button-background-color-default`|
 |`--mod-stepper-animation-duration`|
+|`--mod-stepper-button-width`|
+|`--mod-stepper-button-padding`|
+|`--mod-stepper-button-background-color-default`|
 |`--mod-stepper-button-background-color-hover`|
 |`--mod-stepper-icon-nudge-start`|
-|`--mod-stepper-button-middle-border-width`|
 |`--mod-stepper-icon-nudge-end`|

--- a/components/stepper/metadata/mods.md
+++ b/components/stepper/metadata/mods.md
@@ -30,6 +30,5 @@
 |`--mod-stepper-animation-duration`|
 |`--mod-stepper-button-background-color-hover`|
 |`--mod-stepper-icon-nudge-start`|
-|`--mod-stepper-button-border-radius-reset`|
 |`--mod-stepper-button-middle-border-width`|
 |`--mod-stepper-icon-nudge-end`|

--- a/components/stepper/metadata/mods.md
+++ b/components/stepper/metadata/mods.md
@@ -1,34 +1,35 @@
 | Modifiable Custom Properties |
 | --- |
-|`--mod-stepper-width`|
-|`--mod-stepper-border-radius`|
-|`--mod-stepper-focus-indicator-gap`|
-|`--mod-stepper-border-width`|
-|`--mod-stepper-focus-indicator-width`|
-|`--mod-stepper-border-color-hover`|
-|`--mod-stepper-border-color-focus`|
-|`--mod-stepper-button-background-color-focus`|
-|`--mod-stepper-border-color-focus-hover`|
-|`--mod-stepper-border-color-invalid-focus`|
-|`--mod-stepper-focus-indicator-color`|
-|`--mod-stepper-border-color-keyboard-focus`|
-|`--mod-stepper-button-background-color-keyboard-focus`|
-|`--mod-stepper-border-color-invalid-keyboard-focus`|
-|`--mod-stepper-border-color-invalid-default`|
-|`--mod-stepper-border-color-invalid-hover`|
-|`--mod-stepper-border-color-invalid-focus-hover`|
-|`--mod-stepper-border-color-disabled`|
-|`--mod-stepper-quiet-width`|
-|`--mod-stepper-quiet-button-width`|
-|`--mod-stepper-button-offset`|
-|`--mod-stepper-border-color-quiet-disabled`|
-|`--mod-stepper-button-gap`|
-|`--mod-stepper-buttons-height`|
-|`--mod-stepper-border-color`|
-|`--mod-stepper-animation-duration`|
-|`--mod-stepper-button-width`|
-|`--mod-stepper-button-padding`|
-|`--mod-stepper-button-background-color-default`|
-|`--mod-stepper-button-background-color-hover`|
-|`--mod-stepper-icon-nudge-start`|
-|`--mod-stepper-icon-nudge-end`|
+| `--mod-stepper-animation-duration` |
+| `--mod-stepper-background-color` |
+| `--mod-stepper-border-color` |
+| `--mod-stepper-border-color-disabled` |
+| `--mod-stepper-border-color-focus` |
+| `--mod-stepper-border-color-focus-hover` |
+| `--mod-stepper-border-color-hover` |
+| `--mod-stepper-border-color-invalid-default` |
+| `--mod-stepper-border-color-invalid-focus` |
+| `--mod-stepper-border-color-invalid-focus-hover` |
+| `--mod-stepper-border-color-invalid-hover` |
+| `--mod-stepper-border-color-invalid-keyboard-focus` |
+| `--mod-stepper-border-color-keyboard-focus` |
+| `--mod-stepper-border-color-quiet-disabled` |
+| `--mod-stepper-border-radius` |
+| `--mod-stepper-border-width` |
+| `--mod-stepper-button-background-color-default` |
+| `--mod-stepper-button-background-color-focus` |
+| `--mod-stepper-button-background-color-hover` |
+| `--mod-stepper-button-background-color-keyboard-focus` |
+| `--mod-stepper-button-gap` |
+| `--mod-stepper-button-offset` |
+| `--mod-stepper-button-padding` |
+| `--mod-stepper-button-width` |
+| `--mod-stepper-buttons-height` |
+| `--mod-stepper-focus-indicator-color` |
+| `--mod-stepper-focus-indicator-gap` |
+| `--mod-stepper-focus-indicator-width` |
+| `--mod-stepper-icon-nudge-end` |
+| `--mod-stepper-icon-nudge-start` |
+| `--mod-stepper-quiet-button-width` |
+| `--mod-stepper-quiet-width` |
+| `--mod-stepper-width` |

--- a/components/stepper/themes/express.css
+++ b/components/stepper/themes/express.css
@@ -14,7 +14,6 @@ governing permissions and limitations under the License.
   /* @todo remove this when stepper is migrated; this ensures stepper buttons inherit border color and width */
   .spectrum-Stepper {
     --spectrum-stepper-border-width: var(--spectrum-border-width-200); /* express stepper has border */
-    --spectrum-stepper-border-size-reset: 0; /* express buttons have no inline start border */
 
     --spectrum-stepper-button-middle-border-width: 0; /* express buttons have no middle border */
     --spectrum-stepper-button-gap-reset: var(--spectrum-border-width-200); /* express buttons have middle gap */

--- a/components/stepper/themes/express.css
+++ b/components/stepper/themes/express.css
@@ -14,8 +14,8 @@ governing permissions and limitations under the License.
   /* @todo remove this when stepper is migrated; this ensures stepper buttons inherit border color and width */
   .spectrum-Stepper {
     --spectrum-stepper-border-width: var(--spectrum-border-width-200); /* express stepper has border */
+    --spectrum-stepper-button-border-width: 0; /* express buttons have no inline start border */
 
-    --spectrum-stepper-button-middle-border-width: 0; /* express buttons have no middle border */
     --spectrum-stepper-button-gap-reset: var(--spectrum-border-width-200); /* express buttons have middle gap */
     --spectrum-stepper-button-border-radius-reset: calc(var(--spectrum-corner-radius-100) - (var(--spectrum-border-width-200) * 2));
 

--- a/components/stepper/themes/express.css
+++ b/components/stepper/themes/express.css
@@ -14,7 +14,7 @@ governing permissions and limitations under the License.
   /* @todo remove this when stepper is migrated; this ensures stepper buttons inherit border color and width */
   .spectrum-Stepper {
     --spectrum-stepper-border-width: var(--spectrum-border-width-200); /* express stepper has border */
-    --spectrum-stepper-button-border-width: 0; /* express buttons have no inline start border */
+    --spectrum-stepper-button-border-width-reset: 0; /* express buttons have no inline start border */
 
     --spectrum-stepper-button-gap-reset: var(--spectrum-border-width-200); /* express buttons have middle gap */
     --spectrum-stepper-button-border-radius-reset: calc(var(--spectrum-corner-radius-100) - (var(--spectrum-border-width-200) * 2));

--- a/components/stepper/themes/spectrum.css
+++ b/components/stepper/themes/spectrum.css
@@ -14,8 +14,8 @@ governing permissions and limitations under the License.
   /* @todo remove this when stepper is migrated; this ensures stepper buttons inherit border color and width */
   .spectrum-Stepper {
     --spectrum-stepper-border-width: var(--spectrum-border-width-100); /* spectrum stepper has border */
+    --spectrum-stepper-button-border-width: var(--spectrum-border-width-100); /* spectrum stepper has border */
 
-    --spectrum-stepper-button-middle-border-width: var(--spectrum-border-width-100); /* spectrum buttons have middle border */
     --spectrum-stepper-button-gap-reset: 0px; /* spectrum buttons have no middle gap */
     --spectrum-stepper-button-border-radius-reset: 0px;
 

--- a/components/stepper/themes/spectrum.css
+++ b/components/stepper/themes/spectrum.css
@@ -14,7 +14,6 @@ governing permissions and limitations under the License.
   /* @todo remove this when stepper is migrated; this ensures stepper buttons inherit border color and width */
   .spectrum-Stepper {
     --spectrum-stepper-border-width: var(--spectrum-border-width-100); /* spectrum stepper has border */
-    --spectrum-stepper-border-size-reset: var(--spectrum-border-width-100);  /* spectrum buttons have inline start border */
 
     --spectrum-stepper-button-middle-border-width: var(--spectrum-border-width-100); /* spectrum buttons have middle border */
     --spectrum-stepper-button-gap-reset: 0px; /* spectrum buttons have no middle gap */

--- a/components/stepper/themes/spectrum.css
+++ b/components/stepper/themes/spectrum.css
@@ -14,7 +14,7 @@ governing permissions and limitations under the License.
   /* @todo remove this when stepper is migrated; this ensures stepper buttons inherit border color and width */
   .spectrum-Stepper {
     --spectrum-stepper-border-width: var(--spectrum-border-width-100); /* spectrum stepper has border */
-    --spectrum-stepper-button-border-width: var(--spectrum-border-width-100); /* spectrum stepper has border */
+    --spectrum-stepper-button-border-width-reset: var(--spectrum-border-width-100); /* spectrum stepper has border */
 
     --spectrum-stepper-button-gap-reset: 0px; /* spectrum buttons have no middle gap */
     --spectrum-stepper-button-border-radius-reset: 0px;

--- a/components/textfield/stories/template.js
+++ b/components/textfield/stories/template.js
@@ -35,13 +35,18 @@ export const Template = ({
   type = "text",
   autocomplete = true,
   onclick,
-  styles = {
-    "--spectrum-textfield-border-color": "rgb(0,0,0)",
-    "--spectrum-textfield-border-width": "1px"
-  },
+  styles = {},
   ...globals
 }) => {
   const [, updateArgs] = useArgs();
+  const { express } = globals;
+
+  try {
+    if (!express) import(/* webpackPrefetch: true */ "../themes/spectrum.css");
+    else import(/* webpackPrefetch: true */ "../themes/express.css");
+  } catch (e) {
+    console.warn(e);
+  }
 
   if (isInvalid) iconName = "Alert";
   else if (isValid) iconName = "Checkmark";


### PR DESCRIPTION
## Description

This PR fixes the appearance of the Stepper buttons. They were slightly off center due to how the padding and borders were being applied. This PR updates the styling to more closely resemble what is currently shown in SWC and what was there previously. 

**NOTE:** The Stepper component is not yet migrated, so these changes are just a band-aid for now. The component was slightly migrated to allow for Textfield to get through.

## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
