### PR TITLE
fix(floatingactionbutton): update token dependency

### DIFF
--- a/components/floatingactionbutton/package.json
+++ b/components/floatingactionbutton/package.json
@@ -21,11 +21,11 @@
     "watch": "gulp watch"
   },
   "peerDependencies": {
-    "@spectrum-css/tokens": ">= 8"
+    "@spectrum-css/tokens": ">=10.0.0"
   },
   "devDependencies": {
     "@spectrum-css/component-builder-simple": "^2.0.7",
-    "@spectrum-css/tokens": "^8.1.0",
+    "@spectrum-css/tokens": "^10.0.0",
     "gulp": "^4.0.0"
   },
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2168,11 +2168,6 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/thumbnail/-/thumbnail-2.0.34.tgz#b10c6474490ca1ae88992cbecf752ae12b3e986f"
   integrity sha512-DjDpD+bbp8ef9LN1GvaS/88ajVoQ9CsvkiYh/tW9kCQhuGqMujRfg3HAbVBfZLrKHF/0+FspRB9U2xz6pBHCwA==
 
-"@spectrum-css/tokens@^8.1.0":
-  version "8.1.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/tokens/-/tokens-8.1.1.tgz#cf23ef126622faaac537006a0df448b361aadd4a"
-  integrity sha512-uYXChRvQ9LS0tiUNzIJfBnkGZj6M+DixACa4AxyRYzO8zbfoS9H/XB6EzgKeVzNAutw43cr/ZtaK2FhQ727Nlg==
-
 "@storybook/addon-a11y@^6.5.15":
   version "6.5.16"
   resolved "https://registry.yarnpkg.com/@storybook/addon-a11y/-/addon-a11y-6.5.16.tgz#9288a6c1d111fa4ec501d213100ffff91757d3fc"


### PR DESCRIPTION
## Description

A fresh install was breaking the build due to the token dependency for Floating Action Button not being high enough. This bumps the dev dependency up to the latest version and increases the peer dependency to 9, as that is needed for all of the tokens to be included. 

## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
