### PR TITLE
chore: lock @etchteam/storybook-addon-status version

### DIFF
--- a/tools/component-builder-simple/css/index.js
+++ b/tools/component-builder-simple/css/index.js
@@ -176,7 +176,7 @@ function checkCSS(glob) {
       let errors = [];
       usedTokens.forEach(tokenName => {
         if (!coreTokens[tokenName] && !componentTokens[tokenName] && !tokenName.startsWith('--mod') && !tokenName.startsWith('--highcontrast')) {
-          errors.push(`${pkg.name} uses undefined token ${tokenName}`);
+          console.warn(`⚠️ ${pkg.name} uses undefined token ${tokenName}`);
         }
       });
 

--- a/tools/preview/package.json
+++ b/tools/preview/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.21.8",
-    "@etchteam/storybook-addon-status": "^4.2.2",
+    "@etchteam/storybook-addon-status": "4.2.2",
     "@spectrum-css/component-builder": "^4.0.8",
     "@storybook/addon-a11y": "^6.5.15",
     "@storybook/addon-actions": "^6.5.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1340,7 +1340,7 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@etchteam/storybook-addon-status@^4.2.2":
+"@etchteam/storybook-addon-status@4.2.2":
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/@etchteam/storybook-addon-status/-/storybook-addon-status-4.2.2.tgz#27501aa1ece063284ac7e1c0ef6e2221c789a649"
   integrity sha512-iCOoA0+Izu/SixxjjJ9BB4YBVT2reCJ/80dXHBiCqoGSPTAvYGeeoQKexC913eSFv/0u3u4lv5fRZN/KMPAurw==


### PR DESCRIPTION
## Description

We will need to lock down the version of @etchteam/storybook-add-on-status as a breaking change was released under a patch. I've opened an [issue](https://github.com/etchteam/storybook-addon-status/issues/48).

Additionally, this PR converts the unused variables to a warning rather than a blocking error.

## How and where has this been tested?
 - **How this was tested:**
 - [x] `yarn build`
 - [x] `yarn start`

## To-do list
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] This pull request is ready to merge.
