### PR TITLE
fix(textfield, stepper): button padding and focus indicator

### DIFF
--- a/components/combobox/index.css
+++ b/components/combobox/index.css
@@ -63,6 +63,11 @@ governing permissions and limitations under the License.
   --spectrum-combobox-border-color-invalid-key-focus: var(--spectrum-negative-border-color-key-focus);
 
   --spectrum-combobox-alert-icon-color: var(--spectrum-negative-visual-color);
+
+  /* Settings for nested Textfield component. */
+  --mod-textfield-focus-indicator-gap: var(--mod-combobox-focus-indicator-gap, var(--spectrum-combobox-focus-indicator-gap));
+  --mod-textfield-focus-indicator-width: var(--mod-combobox-focus-indicator-thickness, var(--spectrum-combobox-focus-indicator-thickness));
+  --mod-textfield-focus-indicator-color: var(--highcontrast-combobox-focus-indicator-color, var(--mod-combobox-focus-indicator-color, var(--spectrum-combobox-focus-indicator-color)));
 }
 
 .spectrum-Combobox--sizeS {
@@ -312,33 +317,6 @@ governing permissions and limitations under the License.
 /* TEXTFIELD (wrapper) */
 .spectrum-Combobox-textfield {
   inline-size: 100%;
-
-  /* Focus Indicator (Ring) */
-  &.is-keyboardFocused,
-  &:focus-within {
-    &::after {
-      block-size: calc(100% + var(--mod-combobox-focus-indicator-gap, var(--spectrum-combobox-focus-indicator-gap)) * 2);
-      inline-size: calc(100% + var(--mod-combobox-focus-indicator-gap, var(--spectrum-combobox-focus-indicator-gap)) * 2);
-      margin-block-start: calc(
-        (var(--mod-combobox-focus-indicator-gap, var(--spectrum-combobox-focus-indicator-gap)) +
-          var(--mod-combobox-focus-indicator-thickness, var(--spectrum-combobox-focus-indicator-thickness)))
-        * -1
-      );
-      margin-inline-start: calc(
-        (var(--mod-combobox-focus-indicator-gap, var(--spectrum-combobox-focus-indicator-gap)) +
-          var(--mod-combobox-focus-indicator-thickness, var(--spectrum-combobox-focus-indicator-thickness)))
-        * -1
-      );
-
-      border-width: var(--mod-combobox-focus-indicator-thickness, var(--spectrum-combobox-focus-indicator-thickness));
-      border-color: var(--highcontrast-combobox-focus-indicator-color, var(--mod-combobox-focus-indicator-color, var(--spectrum-combobox-focus-indicator-color)));
-      border-radius: calc(
-        var(--mod-combobox-border-radius, var(--spectrum-combobox-border-radius)) +
-        var(--mod-combobox-focus-indicator-gap, var(--spectrum-combobox-focus-indicator-gap)) +
-        var(--mod-combobox-focus-indicator-thickness, var(--spectrum-combobox-focus-indicator-thickness))
-      );
-    }
-  }
 }
 
 /* TEXT INPUT */
@@ -511,20 +489,6 @@ governing permissions and limitations under the License.
   }
 
   .spectrum-Combobox-textfield {
-    &.is-keyboardFocused,
-    &:focus-within {
-      /* Focus Indicator (Underline) */
-      &::after {
-        margin: 0;
-        margin-inline-start: 0;
-        inline-size: 100%;
-        block-size: calc(100% + var(--mod-combobox-focus-indicator-gap, var(--spectrum-combobox-focus-indicator-gap)));
-        border-width: 0 0 var(--mod-combobox-focus-indicator-thickness, var(--spectrum-combobox-focus-indicator-thickness)) 0;
-        border-bottom-color: var(--highcontrast-combobox-focus-indicator-color, var(--mod-combobox-focus-indicator-color, var(--spectrum-combobox-focus-indicator-color)));
-        border-radius: 0;
-      }
-    }
-
     &.is-invalid .spectrum-Textfield-validationIcon {
       inset-inline-end: var(--mod-combobox-button-width, var(--spectrum-combobox-button-width));
     }

--- a/components/stepper/index.css
+++ b/components/stepper/index.css
@@ -43,7 +43,6 @@ governing permissions and limitations under the License.
 
   /*** Button Icons - appears to adjust position ***/
   --spectrum-stepper-icon-nudge-start: 1px; /* placeholder - was var(--spectrum-global-dimension-size-10) - 1px */
-  --spectrum-stepper-icon-nudge-end: 2px; /* placeholder -was var(--spectrum-global-dimension-size-25) - 2px */
 
  /*** :AFTER - this is for the :after element labeled below as hit area, but used as focus indicator in ActionButton ***/
   --spectrum-stepper-button-offset: calc(var(--spectrum-stepper-button-width) / 2 - var(--spectrum-stepper-icon-width) / 2);
@@ -60,7 +59,7 @@ governing permissions and limitations under the License.
   --spectrum-stepper-border-radius: var(--spectrum-corner-radius-100);
 
   /*** Buttons ***/
-  --spectrum-stepper-button-width: calc(var(--spectrum-spacing-400) - var(--spectrum-stepper-border-width)); /* this matches the previous WIDTH token */
+  --spectrum-stepper-button-width: calc(var(--spectrum-spacing-400) - var(--spectrum-stepper-border-width) * 2); /* this matches the previous WIDTH token */
   --spectrum-stepper-button-padding: calc(var(--spectrum-spacing-200) / 2); /* 6px md + 7px lg - previously 6px md + 7.5px lg */
   --spectrum-stepper-button-gap: var(--spectrum-stepper-button-gap-reset);
 
@@ -468,6 +467,7 @@ governing permissions and limitations under the License.
   box-sizing: border-box;
 
   block-size: var(--mod-stepper-buttons-height, var(--spectrum-stepper-buttons-height));
+  inline-size: var(--mod-stepper-button-width, var(--spectrum-stepper-button-width));
 
   border-style: solid;
   border-width: var(--mod-stepper-border-width, var(--spectrum-stepper-border-width))
@@ -512,6 +512,7 @@ governing permissions and limitations under the License.
   .spectrum-Icon {
     opacity: 1;
     margin: 0px;
+    margin-inline-start: calc(-1 * var(--spectrum-stepper-border-radius) / 2)
   }
 
   /*** Action Buttons Hover ***/
@@ -530,8 +531,6 @@ governing permissions and limitations under the License.
   padding-block-start: var(--mod-stepper-icon-nudge-start, var(--spectrum-stepper-icon-nudge-start));
   padding-block-end: 0;
 
-  border-block-end-width: var(--spectrum-stepper-button-border-width-reset);
-  border-block-end-color: var(--highcontrast-stepper-border-color, var(--mod-stepper-border-color, var(--spectrum-stepper-border-color)));
  
   border-radius: var(--spectrum-stepper-button-border-radius-reset);
   border-end-start-radius: 0;
@@ -540,12 +539,14 @@ governing permissions and limitations under the License.
 
 .spectrum-Stepper-stepDown {
   border-block-start-width: 0;
-  padding-block-end: var(--mod-stepper-icon-nudge-end, var(--spectrum-stepper-icon-nudge-end));
   padding-block-start: 0;
 
   border-radius: var(--spectrum-stepper-button-border-radius-reset);
   border-start-start-radius: 0;
   border-start-end-radius: 0;
+  border-block-start-width: var(--spectrum-stepper-button-border-width-reset);
+  border-block-start-color: var(--highcontrast-stepper-border-color, var(--mod-stepper-border-color, var(--spectrum-stepper-border-color)));
+ 
 }
 
 .spectrum-Stepper-textfield {

--- a/components/stepper/index.css
+++ b/components/stepper/index.css
@@ -98,7 +98,7 @@ governing permissions and limitations under the License.
     --highcontrast-stepper-border-color-hover: Highlight;
     --highcontrast-stepper-border-color-focus: Highlight;
     --highcontrast-stepper-border-color-focus-hover: Highlight;
-    --highcontrast-stepper-border-color-keyboard-focus: Highlight;
+    --highcontrast-stepper-border-color-keyboard-focus: CanvasText;
 
     --highcontrast-stepper-border-color-disabled: GrayText;
     --highcontrast-stepper-border-color-quiet-disabled: GrayText;
@@ -114,7 +114,7 @@ governing permissions and limitations under the License.
     --highcontrast-stepper-button-background-color-focus: Canvas;
     --highcontrast-stepper-button-background-color-keyboard-focus: Canvas;
 
-    --highcontrast-stepper-focus-indicator-color: CanvasText;
+    --highcontrast-stepper-focus-indicator-color: Highlight;
   }
 }
 .x {

--- a/components/stepper/index.css
+++ b/components/stepper/index.css
@@ -499,7 +499,7 @@ governing permissions and limitations under the License.
   .spectrum-Icon {
     opacity: 1;
     margin: 0px;
-    margin-inline-start: calc(-1 * var(--spectrum-stepper-border-radius) / 2)
+    margin-inline-start: var(--spectrum-stepper-button-icon-nudge);
   }
 
   /*** Action Buttons Hover ***/

--- a/components/stepper/index.css
+++ b/components/stepper/index.css
@@ -298,7 +298,7 @@ governing permissions and limitations under the License.
     &::after {
       content: '';
       position: absolute;
-      bottom: calc(-1 * var(--mod-stepper-focus-indicator-gap, var(--spectrum-stepper-focus-indicator-gap)) * 2);
+      bottom: calc(-1 * (var(--mod-stepper-focus-indicator-gap, var(--spectrum-stepper-focus-indicator-gap)) + var(--mod-stepper-focus-indicator-width, var(--spectrum-stepper-focus-indicator-width))));
       left: 0;
       inline-size: 100%;
       block-size: var(--mod-stepper-focus-indicator-width, var(--spectrum-stepper-focus-indicator-width));

--- a/components/stepper/index.css
+++ b/components/stepper/index.css
@@ -131,31 +131,6 @@ governing permissions and limitations under the License.
   line-height: 0;
   border-radius: var(--mod-stepper-border-radius, var(--spectrum-stepper-border-radius)); /* --spectrum-global-dimension-size-75 = 6px 8px */
 
-  /*** Focus Indicator - Unfocused Base Styles ***/
-  &::after {
-    block-size: calc(100% + (var(--mod-stepper-focus-indicator-gap, var(--spectrum-stepper-focus-indicator-gap)) * 2));
-    inline-size: calc(100% + (var(--mod-stepper-focus-indicator-gap, var(--spectrum-stepper-focus-indicator-gap)) * 2));
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 0;
-    pointer-events: none;
-    content: '';
-    border-style: solid;
-    border-color: transparent;
-    border-width: 0;
-    border-radius: calc(var(--mod-stepper-border-radius, var(--spectrum-stepper-border-radius))
-                        + var(--mod-stepper-border-width, var(--spectrum-stepper-border-width))
-                        + var(--mod-stepper-focus-indicator-gap, var(--spectrum-stepper-focus-indicator-gap)));
-
-    margin-block-start: calc((var(--mod-stepper-focus-indicator-gap, var(--spectrum-stepper-focus-indicator-gap))
-                              + var(--mod-stepper-focus-indicator-width, var(--spectrum-stepper-focus-indicator-width)))
-                              * -1);
-    margin-inline-start: calc((var(--mod-stepper-focus-indicator-gap, var(--spectrum-stepper-focus-indicator-gap))
-                              + var(--mod-stepper-focus-indicator-width, var(--spectrum-stepper-focus-indicator-width)))
-                              * -1);
-  }
-
   /*** Hover ***/
   &:hover:not(.is-disabled):not(.is-invalid):not(.is-focused):not(.is-keyboardFocused) {
     .spectrum-Stepper-buttons,
@@ -169,6 +144,9 @@ governing permissions and limitations under the License.
 
   /*** Focused ***/
   &.is-focused {
+    .spectrum-Stepper-input {
+      outline: none;
+    }
     .spectrum-Stepper-input,
     .spectrum-Stepper-buttons,
     .spectrum-Stepper-stepUp,
@@ -208,11 +186,14 @@ governing permissions and limitations under the License.
   &:focus-visible {
 
     /* keyboard focus indicator is visible */
-    &::after {
-      border-color: var(--highcontrast-stepper-focus-indicator-color, var(--mod-stepper-focus-indicator-color, var(--spectrum-stepper-focus-indicator-color)));
-      border-width: var(--mod-stepper-focus-indicator-width, var(--spectrum-stepper-focus-indicator-width));
-    }
+    outline: var(--mod-stepper-focus-indicator-width, var(--spectrum-stepper-focus-indicator-width)) solid;
+    outline-color: var(--highcontrast-stepper-focus-indicator-color, var(--mod-stepper-focus-indicator-color, var(--spectrum-stepper-focus-indicator-color)));
+    outline-offset: var(--mod-stepper-focus-indicator-gap, var(--spectrum-stepper-focus-indicator-gap));
 
+    .spectrum-Stepper-input {
+      outline: none;
+    }
+    
     .spectrum-Stepper-input,
     .spectrum-Stepper-buttons,
     .spectrum-Stepper-stepUp,
@@ -313,6 +294,15 @@ governing permissions and limitations under the License.
     /* quiet corners not rounded */
     border-radius: 0;
     inline-size: var(--mod-stepper-quiet-width, var(--spectrum-stepper-quiet-width));
+
+    &::after {
+      content: '';
+      position: absolute;
+      bottom: calc(-1 * var(--mod-stepper-focus-indicator-gap, var(--spectrum-stepper-focus-indicator-gap)) * 2);
+      left: 0;
+      inline-size: 100%;
+      block-size: var(--mod-stepper-focus-indicator-width, var(--spectrum-stepper-focus-indicator-width));
+    }
 
     .spectrum-Stepper-buttons {
       border-radius: 0;
@@ -420,14 +410,11 @@ governing permissions and limitations under the License.
     /* quiet keyboard focused */
     &.is-keyboardFocused {
 
+      outline: none;
+
       /* quiet focus indicator only on bottom border */
       &::after {
-        border-width: 0 0 var(--mod-stepper-focus-indicator-width, var(--spectrum-stepper-focus-indicator-width)) 0;
-        border-radius: 0;
-        inline-size: 100%;
-        block-size: calc(100% + var(--mod-stepper-focus-indicator-gap, var(--spectrum-stepper-focus-indicator-gap)));
-        margin-inline-start: 0;
-        margin-block-start: 0;
+        background-color: var(--highcontrast-stepper-focus-indicator-color, var(--mod-stepper-focus-indicator-color, var(--spectrum-stepper-focus-indicator-color)));
       }
 
       .spectrum-Stepper-stepUp,
@@ -553,11 +540,6 @@ governing permissions and limitations under the License.
   flex: 1;
   inline-size: auto;
   min-inline-size: 0;
-
-  /* remove textfield focus indicator so we don't have two of them */
-  &::after {
-    display: none;
-  }
 }
 
 .spectrum-Stepper-input {

--- a/components/stepper/metadata/mods.md
+++ b/components/stepper/metadata/mods.md
@@ -28,7 +28,6 @@
 | `--mod-stepper-focus-indicator-color` |
 | `--mod-stepper-focus-indicator-gap` |
 | `--mod-stepper-focus-indicator-width` |
-| `--mod-stepper-icon-nudge-end` |
 | `--mod-stepper-icon-nudge-start` |
 | `--mod-stepper-quiet-button-width` |
 | `--mod-stepper-quiet-width` |

--- a/components/stepper/themes/express.css
+++ b/components/stepper/themes/express.css
@@ -15,6 +15,7 @@ governing permissions and limitations under the License.
   .spectrum-Stepper {
     --spectrum-stepper-border-width: var(--spectrum-border-width-200); /* express stepper has border */
     --spectrum-stepper-button-border-width-reset: 0; /* express buttons have no inline start border */
+    --spectrum-stepper-button-icon-nudge: calc(-1 * var(--spectrum-border-width-200));
 
     --spectrum-stepper-button-gap-reset: var(--spectrum-border-width-200); /* express buttons have middle gap */
     --spectrum-stepper-button-border-radius-reset: calc(var(--spectrum-corner-radius-100) - (var(--spectrum-border-width-200) * 2));

--- a/components/stepper/themes/spectrum.css
+++ b/components/stepper/themes/spectrum.css
@@ -15,6 +15,7 @@ governing permissions and limitations under the License.
   .spectrum-Stepper {
     --spectrum-stepper-border-width: var(--spectrum-border-width-100); /* spectrum stepper has border */
     --spectrum-stepper-button-border-width-reset: var(--spectrum-border-width-100); /* spectrum stepper has border */
+    --spectrum-stepper-button-icon-nudge: calc(-1 * var(--spectrum-corner-radius-100) / 2);
 
     --spectrum-stepper-button-gap-reset: 0px; /* spectrum buttons have no middle gap */
     --spectrum-stepper-button-border-radius-reset: 0px;

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -246,7 +246,10 @@ governing permissions and limitations under the License.
     &::after {
       content: '';
       position: absolute;
-      bottom: calc(-1 * var(--mod-textfield-focus-indicator-gap, var(--spectrum-textfield-focus-indicator-gap)) * 2);
+      bottom: calc(-1 * (
+        var(--mod-textfield-focus-indicator-gap, var(--spectrum-textfield-focus-indicator-gap)) + 
+        var(--mod-textfield-focus-indicator-width, var(--spectrum-textfield-focus-indicator-width))
+      ));
       left: 0;
       inline-size: 100%;
       block-size: var(--mod-textfield-focus-indicator-width, var(--spectrum-textfield-focus-indicator-width));

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -209,7 +209,6 @@ governing permissions and limitations under the License.
 /********* TEXT FIELD and TEXT AREA Outer Wrapper *********/
 .spectrum-Textfield {
   position: relative;
-  outline: none;
   margin: auto;
 
   /* prevent input from expanding to width of helptext */
@@ -243,65 +242,23 @@ governing permissions and limitations under the License.
   grid-template-columns: auto auto;
   grid-template-rows: auto auto auto;
 
-  /*** Focus Indicator - Unfocused Base Styles ***/
-  &::after {
-    block-size: calc(100% + (var(--mod-textfield-focus-indicator-gap, var(--spectrum-textfield-focus-indicator-gap)) * 2));
-    inline-size: calc(100% + (var(--mod-textfield-focus-indicator-gap, var(--spectrum-textfield-focus-indicator-gap)) * 2));
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 0;
-    margin-block-start: calc((var(--mod-textfield-focus-indicator-gap, var(--spectrum-textfield-focus-indicator-gap))
-                              + var(--mod-textfield-focus-indicator-width, var(--spectrum-textfield-focus-indicator-width)))
-                              * -1);
-    margin-inline-start: calc((var(--mod-textfield-focus-indicator-gap, var(--spectrum-textfield-focus-indicator-gap))
-                              + var(--mod-textfield-focus-indicator-width, var(--spectrum-textfield-focus-indicator-width)))
-                              * -1);
-    pointer-events: none;
-    content: '';
-    border-style: solid;
-    border-color: transparent;
-    border-width: 0;
-    border-radius: calc(
-      var(--mod-textfield-corner-radius, var(--spectrum-textfield-corner-radius)) + 
-      var(--mod-textfield-focus-indicator-gap, var(--spectrum-textfield-focus-indicator-gap)) +
-      var(--mod-textfield-focus-indicator-width, var(--spectrum-textfield-focus-indicator-width))
-    );
-
-    /* place in same cell: input, focus indicator, and grows sizer */
-    grid-row: 2 / span 1;
-    grid-column: 1 / span 2;
-  }
-
-  &.is-keyboardFocused,
-  &:focus-within {
-    /* focus indicator is focused state */
-    &::after {
-      border-color: var(--highcontrast-textfield-focus-indicator-color, var(--mod-textfield-focus-indicator-color, var(--spectrum-textfield-focus-indicator-color)));
-      border-width: var(--mod-textfield-focus-indicator-width, var(--spectrum-textfield-focus-indicator-width));
-    }
-  }
-
-  .is-readOnly & {
-    &::after {
-      border: 0;
-    }
-  }
-
   &.spectrum-Textfield--quiet {
     &::after {
+      content: '';
+      position: absolute;
+      bottom: calc(-1 * var(--mod-textfield-focus-indicator-gap, var(--spectrum-textfield-focus-indicator-gap)) * 2);
+      left: 0;
       inline-size: 100%;
-      block-size: calc(100% + var(--mod-textfield-focus-indicator-gap, var(--spectrum-textfield-focus-indicator-gap)));
-      margin-inline-start: 0;
-      margin-block-start: 0;
-      border-radius: 0;
+      block-size: var(--mod-textfield-focus-indicator-width, var(--spectrum-textfield-focus-indicator-width));
     }
 
     &.is-keyboardFocused,
-    &:focus-within {
+    &:focus-visible {
+      .spectrum-Textfield-input {
+        outline: none;
+      }
       &::after {
-        border-width: 0 0 var(--mod-textfield-focus-indicator-width, var(--spectrum-textfield-focus-indicator-width)) 0;
-        border-color: var(--highcontrast-textfield-focus-indicator-color, var(--mod-textfield-focus-indicator-color, var(--spectrum-textfield-focus-indicator-color)));
+        background-color: var(--highcontrast-textfield-focus-indicator-color, var(--mod-textfield-focus-indicator-color, var(--spectrum-textfield-focus-indicator-color))); 
       }
     }
   }
@@ -593,14 +550,19 @@ governing permissions and limitations under the License.
 
   /* keyboard focus */
   .is-keyboardFocused &,
-  &:focus-ring,
   &:focus-visible {
+
     border-color: var(--highcontrast-textfield-border-color-keyboard-focus, var(--mod-textfield-border-color-keyboard-focus, var(--spectrum-textfield-border-color-keyboard-focus)));
     color: var(--highcontrast-textfield-text-color-keyboard-focus, var(--mod-textfield-text-color-focus, var(--spectrum-textfield-text-color-keyboard-focus)));
 
     &::placeholder {
       color: var(--highcontrast-textfield-text-color-keyboard-focus, var(--mod-textfield-text-color-keyboard-focus, var(--spectrum-textfield-text-color-keyboard-focus)));
     }
+
+    /* focus indicator is focused state */
+    outline: var(--mod-textfield-focus-indicator-width, var(--spectrum-textfield-focus-indicator-width)) solid;
+    outline-color: var(--highcontrast-textfield-focus-indicator-color, var(--mod-textfield-focus-indicator-color, var(--spectrum-textfield-focus-indicator-color))); 
+    outline-offset: var(--mod-textfield-focus-indicator-gap, var(--spectrum-textfield-focus-indicator-gap));
   }
 
   /*** Input Valid ✅ ***/
@@ -634,7 +596,6 @@ governing permissions and limitations under the License.
 
   /* invalid keyboard focus */
   .is-invalid.is-keyboardFocused &,
-  .is-invalid &:focus-ring,
   .is-invalid &:focus-visible {
     border-color: var(--highcontrast-textfield-border-color-invalid-keyboard-focus, var(--mod-textfield-border-color-invalid-keyboard-focus, var(--spectrum-textfield-border-color-invalid-keyboard-focus)));
   }
@@ -698,6 +659,7 @@ governing permissions and limitations under the License.
     background-color: transparent;
     border-color: transparent;
     color: var(--highcontrast-textfield-text-color-readonly, var(--mod-textfield-text-color-readonly, var(--spectrum-textfield-text-color-readonly)));
+    outline: none;
 
     &::placeholder {
       color: var(--highcontrast-textfield-text-color-readonly, var(--mod-textfield-text-color-readonly, var(--spectrum-textfield-text-color-readonly)));
@@ -759,10 +721,6 @@ governing permissions and limitations under the License.
     .spectrum-Textfield-input {
       grid-row: 1 / auto;
     }
-    &::after {
-      grid-area: unset;
-      min-block-size: calc(var(--mod-text-area-min-block-size, var(--spectrum-text-area-min-block-size)) + var(--mod-textfield-focus-indicator-gap, var(--spectrum-textfield-focus-indicator-gap)) * 2);
-    }
   }
 
   &.spectrum-Textfield--quiet {
@@ -805,12 +763,6 @@ governing permissions and limitations under the License.
         --highcontrast-textfield-text-color-disabled: GrayText;
         --highcontrast-textfield-text-color-readonly: CanvasText;
       }
-    }
-  }
-  .spectrum-Textfield--quiet {
-    &::after {
-      block-size: calc(100% - var(--mod-textfield-focus-indicator-width, var(--spectrum-textfield-focus-indicator-width)));
-      inline-size: calc(100% - var(--mod-textfield-focus-indicator-width, var(--spectrum-textfield-focus-indicator-width)));
     }
   }
 }

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -253,10 +253,8 @@ governing permissions and limitations under the License.
     }
 
     &.is-keyboardFocused,
-    &:focus-visible {
-      .spectrum-Textfield-input {
-        outline: none;
-      }
+    &:focus-visible,
+    &:focus-within {
       &::after {
         background-color: var(--highcontrast-textfield-focus-indicator-color, var(--mod-textfield-focus-indicator-color, var(--spectrum-textfield-focus-indicator-color))); 
       }
@@ -624,6 +622,7 @@ governing permissions and limitations under the License.
 
   /****** Input - Quiet 🤫 ******/
   .spectrum-Textfield--quiet & {
+    outline: none;
     border-block-start-width: 0;
     border-inline-width: 0;
   


### PR DESCRIPTION
## Description

- Removes `padding-block-end` to fix the Express version of the Stepper button.
- Switches Textfield and Stepper to use `outline` for the focus indicator rather than an `::after` pseudo element.

### To Review/Test

- [x] Verify button icons are 10x10 and centered on both Spectrum and Express
- [x] Verify that Quiet, Disabled and all other versions still look the way that they should