### PR TITLE
fix: allow custom property passthroughs

### DIFF
--- a/components/actiongroup/index.css
+++ b/components/actiongroup/index.css
@@ -10,11 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-/* hack: use var so it's not reported as unused */
-.🤫 {
-  border-radius: var(--spectrum-actionbutton-focus-ring-border-radius);
-}
-
 .spectrum-ActionGroup {
   --spectrum-actiongroup-button-spacing-reset: 0;
   --spectrum-actiongroup-border-radius-reset: 0;
@@ -75,24 +70,30 @@ governing permissions and limitations under the License.
       z-index: 0;
 
       &:first-child {
+        /* Action button passthrough styling */
+        --spectrum-actionbutton-focus-ring-border-radius: var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius)) 0px 0px var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius));
+
         border-start-start-radius: var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius));
         border-end-start-radius: var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius));
         margin-inline-start: var(--mod-actiongroup-button-spacing-reset, var(--spectrum-actiongroup-button-spacing-reset));
-        --spectrum-actionbutton-focus-ring-border-radius: var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius)) 0px 0px var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius));
       }
 
       & + .spectrum-ActionGroup-item {
+        /* Action button passthrough styling */
+        --spectrum-actionbutton-focus-ring-border-radius: 0px;
+
         margin-inline-start: var(--mod-actiongroup-horizontal-spacing-compact, var(--spectrum-actiongroup-horizontal-spacing-compact));
         margin-inline-end: var(--mod-actiongroup-horizontal-spacing-compact, var(--spectrum-actiongroup-horizontal-spacing-compact));
-        --spectrum-actionbutton-focus-ring-border-radius: 0px;
       }
 
       &:last-child {
+        /* Action button passthrough styling */
+        --spectrum-actionbutton-focus-ring-border-radius: 0px var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius)) var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius)) 0px;
+
         border-start-end-radius: var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius));
         border-end-end-radius: var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius));
         margin-inline-start: var(--mod-actiongroup-horizontal-spacing-compact, var(--spectrum-actiongroup-horizontal-spacing-compact));
         margin-inline-end: var(--mod-actiongroup-border-radius-reset, var(--spectrum-actiongroup-border-radius-reset));
-        --spectrum-actionbutton-focus-ring-border-radius: 0px var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius)) var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius)) 0px;
       }
 
       &.is-selected {
@@ -121,12 +122,14 @@ governing permissions and limitations under the License.
         border-radius: var(--mod-actiongroup-border-radius-reset, var(--spectrum-actiongroup-border-radius-reset));
 
         &:first-child {
+          /* Action button passthrough styling */
+          --spectrum-actionbutton-focus-ring-border-radius: var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius)) var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius)) 0px 0px;
+
           border-start-start-radius: var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius));
           border-start-end-radius: var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius));
           margin-inline-end: var(--mod-actiongroup-button-spacing-reset, var(--spectrum-actiongroup-button-spacing-reset));
           margin-block-start: var(--mod-actiongroup-vertical-spacing-compact, var(--spectrum-actiongroup-vertical-spacing-compact));
           margin-block-end: var(--mod-actiongroup-vertical-spacing-compact, var(--spectrum-actiongroup-vertical-spacing-compact));
-          --spectrum-actionbutton-focus-ring-border-radius: var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius)) var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius)) 0px 0px;
         }
 
         & + .spectrum-ActionGroup-item {
@@ -137,11 +140,13 @@ governing permissions and limitations under the License.
         }
 
         &:last-child {
+          /* Action button passthrough styling */
+          --spectrum-actionbutton-focus-ring-border-radius: 0px 0px var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius)) var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius));
+
           border-end-start-radius: var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius));
           border-end-end-radius: var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius));
           margin-block-start: var(--mod-actiongroup-vertical-spacing-compact, var(--spectrum-actiongroup-vertical-spacing-compact));
           margin-block-end: var(--mod-actiongroup-button-spacing-reset, var(--spectrum-actiongroup-button-spacing-reset));
-          --spectrum-actionbutton-focus-ring-border-radius: 0px 0px var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius)) var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius));
         }
       }
     }

--- a/components/colorhandle/index.css
+++ b/components/colorhandle/index.css
@@ -111,12 +111,8 @@ governing permissions and limitations under the License.
   inline-size: 100%;
   block-size: 100%;
   box-shadow: inset 0 0 0 var(--mod-colorhandle-inner-border-width, var(--spectrum-colorhandle-inner-border-width)) var(--mod-colorhandle-inner-border-color, var(--spectrum-colorhandle-inner-border-color));
+  /* Undefined variable allows custom stylesheet or JS to pass the value to this element */
   background-color: var(--spectrum-picked-color);
-}
-
-/* hack: make sure we don't complain about this color being undefined */
-.🤫 {
-  --spectrum-picked-color: 0;
 }
 
 @media (forced-colors: active) {

--- a/components/colorloupe/index.css
+++ b/components/colorloupe/index.css
@@ -61,6 +61,7 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-ColorLoupe-inner-border {
+  /* Undefined variable allows custom stylesheet or JS to pass the value to this element */
   fill: var(--spectrum-picked-color);
   stroke: var(--mod-colorloupe-inner-border-color, var(--spectrum-colorloupe-inner-border-color));
   stroke-width: var(--mod-colorloupe-inner-border-width, var(--spectrum-colorloupe-inner-border-width));
@@ -85,11 +86,6 @@ governing permissions and limitations under the License.
 
 .spectrum-ColorLoupe-checkerboard-fill {
   fill: var(--spectrum-colorloupe-checkerboard-fill);
-}
-
-/* hack: so it doesn't get flagged as unused, --spectrum-picked-color is a user defined value thus is not defined by styles */
-.🤫 {
-  --spectrum-picked-color: 0;
 }
 
 @media (forced-colors: active) {

--- a/components/colorwheel/index.css
+++ b/components/colorwheel/index.css
@@ -120,12 +120,6 @@ governing permissions and limitations under the License.
   }
 }
 
-/* hack: make sure we don't complain about these variables being unused*/
-.🤫 {
-  width: var(--track-width);
-  border-width: var(--border-width);
-}
-
 .spectrum-ColorWheel-wheel {
   position: absolute;
   background: conic-gradient(from 90deg, red, rgb(255, 128, 0), rgb(255, 255, 0), rgb(128, 255, 0), rgb(0, 255, 0), rgb(0, 255, 128), rgb(0, 255, 255), rgb(0, 128, 255), rgb(0, 0, 255), rgb(128, 0, 255), rgb(255, 0, 255), rgb(255, 0, 128), red);

--- a/components/datepicker/index.css
+++ b/components/datepicker/index.css
@@ -82,12 +82,8 @@ governing permissions and limitations under the License.
   );
 
   /* todo: when we add t-shirt sizing, this will be wrong ❤️ */
+  /* Passthrough textfield styling */
   --spectrum-textfield-icon-inline-end-override: calc(var(--spectrum-alias-infieldbutton-full-height-m) + var(--spectrum-global-dimension-size-100));
-}
-
-/* hack: use var so it doesn't disappear */
-.🤫 {
-  width: var(--spectrum-textfield-icon-inline-end-override);
 }
 
 .spectrum-DatePicker {
@@ -114,10 +110,12 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-DatePicker--quiet {
+  /* todo: when we add t-shirt sizing, this will be wrong ❤️ */
+  /* Passthrough textfield styling */
+  --spectrum-textfield-icon-inline-end-override: var(--spectrum-alias-infieldbutton-full-height-m);
+
   border-radius: var(--spectrum-combobox-quiet-fieldbutton-border-radius);
 
-  /* todo: when we add t-shirt sizing, this will be wrong ❤️ */
-  --spectrum-textfield-icon-inline-end-override: var(--spectrum-alias-infieldbutton-full-height-m);
 
   .spectrum-DatePicker-button {
     inline-size: auto;

--- a/components/swatch/index.css
+++ b/components/swatch/index.css
@@ -10,11 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-.🤫 {
-  /* hack: make sure we don't complain about this color being undefined */
-  --spectrum-picked-color: 0;
-}
-
 /* Swatch tokens */
 .spectrum-Swatch {
   /* Placeholder tokens */
@@ -164,6 +159,7 @@ governing permissions and limitations under the License.
 
   &.is-mixedValue {
     .spectrum-Swatch-fill {
+      /* Undefined variable allows custom stylesheet or JS to pass the value to this element */
       background: var(--spectrum-picked-color, transparent);
     }
 
@@ -176,6 +172,7 @@ governing permissions and limitations under the License.
   /* Swatch fill: Not fill with Slash */
   &.is-nothing {
     .spectrum-Swatch-fill {
+      /* Undefined variable allows custom stylesheet or JS to pass the value to this element */
       background-color: var(--spectrum-picked-color, transparent);
       background-image: none;
 
@@ -275,6 +272,7 @@ governing permissions and limitations under the License.
     inset: 0;
     z-index: 0;
 
+    /* Undefined variable allows custom stylesheet or JS to pass the value to this element */
     background-color: var(--spectrum-picked-color, transparent);
 
     /* Swatch border */
@@ -288,6 +286,7 @@ governing permissions and limitations under the License.
   .spectrum-Swatch-fill {
     &:before {
       box-shadow: none;
+      /* Undefined variable allows custom stylesheet or JS to pass the value to this element */
       background-color: var(--spectrum-picked-color, transparent);
     }
   }
@@ -296,7 +295,7 @@ governing permissions and limitations under the License.
 .spectrum-Swatch-mixedValueIcon {
   visibility: hidden;
   pointer-events: none;
-
+  /* Undefined variable allows custom stylesheet or JS to pass the value to this element */
   color: var(--spectrum-picked-color, transparent);
 }
 

--- a/tools/bundle-builder/package.json
+++ b/tools/bundle-builder/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "browser-sync": "^2.26.14",
-    "colors": "^1.3.3",
+    "colors": "^1.4.0",
     "del": "^5.0.0",
     "dependency-solver": "^1.0.6",
     "gulp": "^4.0.0",

--- a/tools/component-builder-simple/css/index.js
+++ b/tools/component-builder-simple/css/index.js
@@ -11,6 +11,8 @@ governing permissions and limitations under the License.
 */
 
 const gulp = require('gulp');
+const logger = require('gulplog');
+const colors = require('colors');
 const path = require('path');
 const through = require('through2');
 const postcss = require('gulp-postcss');
@@ -173,23 +175,21 @@ function checkCSS(glob) {
       let { usedTokens } = getTokensUsedInCSS(root, coreTokens, componentTokens);
 
       // Make sure the component doesn't use any undefined tokens
-      let errors = [];
       usedTokens.forEach(tokenName => {
         if (!coreTokens[tokenName] && !componentTokens[tokenName] && !tokenName.startsWith('--mod') && !tokenName.startsWith('--highcontrast')) {
-          console.warn(`⚠️ ${pkg.name} uses undefined token ${tokenName}`);
+          tokenName = `${tokenName}`.cyan;
+          logger.warn(`${'◆'.yellow}  ${pkg.name} uses ${'undefined'.underline} token ${tokenName}`);
         }
       });
 
+      // 2023-05-10: Should remove this to allow for more cascading values to influence nested components
       // Make sure all tokens defined in the component are used
       Object.keys(componentTokens).forEach(tokenName => {
         if (!usedTokens.includes(tokenName)) {
-          errors.push(`${pkg.name} defines ${tokenName}, but never uses it`);
+          tokenName = `${tokenName}`.cyan;
+          logger.warn(`${'◆'.yellow}  ${pkg.name} defines ${tokenName}, but does not use it ${'internally'.italic}`);
         }
       });
-
-      if (errors.length) {
-        return cb(new Error(errors.join('\n')), file);
-      }
 
       cb(null);
     }));

--- a/tools/component-builder-simple/css/processors.js
+++ b/tools/component-builder-simple/css/processors.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-function getProcessors(keepUnusedVars = false, splitinatorOptions = {}) {
+function getProcessors(splitinatorOptions = {}) {
   return [
     require('postcss-import'),
     require('postcss-nested'),
@@ -27,12 +27,12 @@ function getProcessors(keepUnusedVars = false, splitinatorOptions = {}) {
     require('./plugins/postcss-transform-logical')(),
     require('./plugins/postcss-custom-properties-passthrough')(),
     require('postcss-calc'),
-    !keepUnusedVars && require('postcss-dropunusedvars'),
+    require('postcss-dropunusedvars')({ fix: false }),
     require('postcss-dropdupedvars'),
     require('postcss-focus-ring'),
     require('postcss-discard-empty'),
     require('postcss-discard-comments')({removeAllButFirst: true}),
-    require('autoprefixer')({}),
+    require('autoprefixer')({})
   ].filter(Boolean);
 }
 

--- a/tools/component-builder-simple/package.json
+++ b/tools/component-builder-simple/package.json
@@ -13,18 +13,20 @@
   },
   "dependencies": {
     "autoprefixer": "^6.5.3",
+    "colors": "^1.4.0",
     "del": "^5.0.0",
     "gulp": "^4.0.0",
     "gulp-concat": "^2.6.1",
     "gulp-postcss": "^7.0.0",
     "gulp-rename": "^1.4.0",
+    "gulplog": "^2.0.1",
     "postcss": "^7.0.36",
     "postcss-calc": "^6.0.0",
     "postcss-combininator": "^1.0.2",
     "postcss-discard-comments": "^4.0.0",
     "postcss-discard-empty": "^4.0.1",
-    "postcss-dropdupedvars": "^1.1.2",
-    "postcss-dropunusedvars": "^1.2.1",
+    "postcss-dropdupedvars": "file:../postcss-dropdupedvars",
+    "postcss-dropunusedvars": "file:../postcss-dropunusedvars",
     "postcss-focus-ring": "^1.0.0",
     "postcss-import": "^10.0.0",
     "postcss-inherit": "^4.0.3",
@@ -35,7 +37,7 @@
     "through2": "^3.0.1"
   },
   "peerDependencies": {
-    "@spectrum-css/tokens": ">=7 <=9"
+    "@spectrum-css/tokens": ">=7 <=10"
   },
   "publishConfig": {
     "access": "public"

--- a/tools/component-builder/css/vars.js
+++ b/tools/component-builder/css/vars.js
@@ -12,25 +12,12 @@ governing permissions and limitations under the License.
 
 const gulp = require('gulp');
 const through = require('through2');
-const postcss = require('postcss');
 const logger = require('gulplog');
+const colors = require('colors');
 const fsp = require('fs').promises;
 const path = require('path');
 
 const varUtils = require('./lib/varUtils');
-
-// Todo: get these values from a common place?
-let colorStops = [
-  'darkest',
-  'dark',
-  'light',
-  'lightest'
-];
-
-let scales = [
-  'medium',
-  'large'
-];
 
 function bakeVars() {
   return gulp.src([
@@ -59,20 +46,17 @@ function bakeVars() {
     let errors = [];
     let usedVars = {};
     variableList.forEach(varName => {
+      varName = `${varName}`.cyan;
       if (varName.indexOf('spectrum-global') !== -1) {
-        logger.warn(`⚠️  ${pkg.name} directly uses global variable ${varName}`);
-      }
-      else if (!allVars[varName] && !varName.startsWith('--mod') && !varName.startsWith('--highcontrast')) {
+        logger.warn(`${'◆'.red}  ${pkg.name} directly uses global variable ${varName}`);
+      } else if (!allVars[varName] && !varName.startsWith('--mod') && !varName.startsWith('--highcontrast')) {
         if (componentVars.indexOf(varName) === -1) {
-          errors.push(`${pkg.name} uses undefined variable ${varName}`);
+          logger.warn(`${'◆'.yellow}  ${pkg.name} uses ${'undefined'.underline} variable ${varName}`);
         }
         else {
-          logger.warn(`🔶 ${pkg.name} uses locally defined variable ${varName}`);
+          logger.warn(`${'◆'.yellow}  ${pkg.name} uses ${'internally'.italic} defined variable ${varName}`);
         }
-      }
-      else {
-        usedVars[varName] = vars[varName];
-      }
+      } else usedVars[varName] = vars[varName];
     });
 
     if (errors.length) {

--- a/tools/component-builder/package.json
+++ b/tools/component-builder/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "autoprefixer": "^6.5.3",
     "browser-sync": "^2.26.14",
+    "colors": "^1.4.0",
     "del": "^5.0.0",
     "gulp": "^4.0.0",
     "gulp-concat": "^2.6.1",
@@ -48,7 +49,7 @@
     "through2": "^3.0.1"
   },
   "peerDependencies": {
-    "@spectrum-css/tokens": ">=7 <=9",
+    "@spectrum-css/tokens": ">=7 <=10",
     "@spectrum-css/vars": ">=8 <=9"
   }
 }

--- a/tools/generator/package.json
+++ b/tools/generator/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "cheerio": "^1.0.0-rc.12",
     "fuzzy": "^0.1.3",
+    "inquirer": "^9.2.2",
     "inquirer-autocomplete-prompt": "^3.0.0",
     "js-yaml": "^4.1.0",
     "plop": "^3.1.1"

--- a/tools/postcss-dropdupedvars/index.js
+++ b/tools/postcss-dropdupedvars/index.js
@@ -1,22 +1,18 @@
 const postcss = require('postcss');
 
-function dropDupes(root, variableList) {
-  root.walkRules((rule, ruleIndex) => {
-    let seen = {};
-    rule.walkDecls((decl) => {
-      if (decl.prop.startsWith('--')) {
+module.exports = postcss.plugin('postcss-dropdupedvars', function() {
+  return (root) => {
+    root.walkRules((rule) => {
+      let seen = {};
+      rule.walkDecls((decl) => {
+        if (!decl.prop.startsWith('--')) return;
         if (seen[decl.prop]) {
+          decl.warn(root.toResult(), `Dropping duplicate variable ${decl.prop}`);
           seen[decl.prop].remove();
         }
 
         seen[decl.prop] = decl;
-      }
+      });
     });
-  });
-}
-
-module.exports = postcss.plugin('postcss-dropdupedvars', function() {
-  return (root, result) => {
-    dropDupes(root);
   }
 });

--- a/tools/preview/postcss.config.js
+++ b/tools/preview/postcss.config.js
@@ -36,7 +36,7 @@ module.exports = (ctx) => {
             plugins.push(...legacyBuilder.processors);
         } else {
             if (ctx.file.split("/").includes("themes")) {
-                plugins.push(...simpleBuilder.getProcessors(true, { noSelectors: false }));
+                plugins.push(...simpleBuilder.getProcessors({ noSelectors: false }));
             } else {
                 plugins.push(...simpleBuilder.getProcessors());
             }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5782,7 +5782,7 @@ colorette@^2.0.19:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.19.tgz#cdf044f47ad41a0f4b56b3a0d5b4e6e1a2d5a798"
   integrity sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==
 
-colors@^1.3.3:
+colors@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
@@ -8741,6 +8741,13 @@ glogg@^1.0.0:
   dependencies:
     sparkles "^1.0.0"
 
+glogg@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/glogg/-/glogg-2.0.0.tgz#5b69c867f8b02a503b0653ed80c37ceba0a69361"
+  integrity sha512-YDtL/QX54MN8+GorvS9tnKI5HtqWrFW9bv5yPRmFBeofi5neWzqQN8X/0HmM5zMkDbB8OYvC3/Pj8UEJUZFeqA==
+  dependencies:
+    sparkles "^2.0.0"
+
 gopd@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.0.1.tgz#29ff76de69dac7489b7c0918a5788e56477c332c"
@@ -8960,6 +8967,13 @@ gulplog@^1.0.0:
   integrity sha512-hm6N8nrm3Y08jXie48jsC55eCZz9mnb4OirAStEk2deqeyhXU3C1otDVh+ccttMuc1sBi6RX6ZJ720hs9RCvgw==
   dependencies:
     glogg "^1.0.0"
+
+gulplog@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/gulplog/-/gulplog-2.0.1.tgz#414e116287087278e1e8e2ef9ff4a1e9063f8428"
+  integrity sha512-11IFA5ZwhFUjXPNYxrk9Z5FWGQIzJzxrBCE4qZC2elFkwt6oamM1ESwZVrhFMLl5IVlhnMwleFEWxiEyuMndIg==
+  dependencies:
+    glogg "^2.0.0"
 
 handlebars@^4.4.3, handlebars@^4.7.7:
   version "4.7.7"
@@ -9610,7 +9624,7 @@ inquirer@^8.2.2, inquirer@^8.2.4:
     through "^2.3.6"
     wrap-ansi "^7.0.0"
 
-inquirer@^9.2.3:
+inquirer@^9.2.2, inquirer@^9.2.3:
   version "9.2.3"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-9.2.3.tgz#48993a6cf832b581a0df0ba0445c435e3d76a69c"
   integrity sha512-/Et0+d28D7hnTYaqeCQkp3FYuD/X5cc2qbM6BzFdC5zs30oByoU5W/pmLc493FVVMwYmAILKjPBEmwRKTtknSQ==
@@ -13593,6 +13607,17 @@ postcss-discard-empty@^6.0.0:
   resolved "https://registry.yarnpkg.com/postcss-discard-empty/-/postcss-discard-empty-6.0.0.tgz#06c1c4fce09e22d2a99e667c8550eb8a3a1b9aee"
   integrity sha512-b+h1S1VT6dNhpcg+LpyiUrdnEZfICF0my7HAKgJixJLW7BnNmpRH34+uw/etf5AhOlIhIAuXApSzzDzMI9K/gQ==
 
+"postcss-dropdupedvars@file:tools/postcss-dropdupedvars":
+  version "1.1.2"
+  dependencies:
+    postcss "^7.0.32"
+
+"postcss-dropunusedvars@file:tools/postcss-dropunusedvars":
+  version "1.2.1"
+  dependencies:
+    postcss "^7.0.32"
+    postcss-value-parser "^4.1.0"
+
 postcss-flexbugs-fixes@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-4.2.1.tgz#9218a65249f30897deab1033aced8578562a6690"
@@ -15893,6 +15918,11 @@ sparkles@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/sparkles/-/sparkles-1.0.1.tgz#008db65edce6c50eec0c5e228e1945061dd0437c"
   integrity sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw==
+
+sparkles@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/sparkles/-/sparkles-2.0.0.tgz#1fcfb7ad687710bbcdd5c655d6ae523952345346"
+  integrity sha512-rqUsosNTLY8KIT6qhuJlXzIUjYJNHTDoHmPnJwfnD7bEvSSvhUOMKuPMCsmLR3vDhyTGi0oAqAbLjgiIXnL2wQ==
 
 spdx-correct@^3.0.0:
   version "3.2.0"


### PR DESCRIPTION
## Description

After discussion, the team has opted to allow custom property passthroughs in css files; this allows design direction to be handed to nested components in a way that is easier for web components to consume and makes better use of the cascadability of custom properties.

To this end, this PR updates build scripts to change the errors to informational so we can continue to ensure no unexpected variables are unused and the PostCSS steps are updated to prevent them from removing unused variables from compiled output. I've also removed the hacks from the css files as they are no longer necessary.

I want to note, some of the warnings that show up in the logs are false because this is running on the css files before resolving any imports. If variables are defined in the imports, this script does not capture them. Once we integrate stylelint, we can convert this logic into a stylelint plugin and that should improve the validity of the results.

## How and where has this been tested?

 - [x] yarn build - no errors or regressions
 - [x] vrt: [Build 90](https://www.chromatic.com/build?appId=63f7908f19912748edc50f0d&number=90)

### Browser(s) and OS(s) this was tested with:

 - [x] latest Chrome
 - [x] latest Safari
 - [ ] latest Edge
 - [ ] iOS


## To-do list
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
- [x] I have updated any relevant storybook stories and templates. 
- [ ] This pull request is ready to merge.
