### PR TITLE
fix(checkbox): rename misspelled mod and add missing mods

### DIFF
--- a/components/checkbox/index.css
+++ b/components/checkbox/index.css
@@ -111,7 +111,7 @@ governing permissions and limitations under the License.
 
   position: relative;
 
-  min-block-size: var(--mod-checkox-height, var(--spectrum-checkbox-height));
+  min-block-size: var(--mod-checkbox-height, var(--spectrum-checkbox-height));
   max-inline-size: 100%;
 
   vertical-align: top;
@@ -462,7 +462,7 @@ governing permissions and limitations under the License.
   block-size: var(--mod-checkbox-control-size, var(--spectrum-checkbox-control-size));
 
   /* Fix vertical alignment when not wrapping since we're flex-start */
-  --spectrum-checkbox-spacing: calc(var(--spectrum-checkbox-height) - var(--spectrum-checkbox-control-size));
+  --spectrum-checkbox-spacing: calc(var(--mod-checkbox-height, var(--spectrum-checkbox-height)) - var(--mod-checkbox-control-size, var(--spectrum-checkbox-control-size)));
   margin: calc(var(--mod-checkbox-spacing, var(--spectrum-checkbox-spacing)) / 2) 0;
 
   flex-grow: 0;
@@ -481,7 +481,7 @@ governing permissions and limitations under the License.
     width: var(--mod-checkbox-control-size, var(--spectrum-checkbox-control-size));
     height: var(--mod-checkbox-control-size, var(--spectrum-checkbox-control-size));
 
-    border-radius: var(--spectrum-checkbox-control-corner-radius);
+    border-radius: var(--mod-checkbox-control-corner-radius, var(--spectrum-checkbox-control-corner-radius));
     border-width: var(--mod-checkbox-border-width, var(--spectrum-checkbox-border-width));
     border-style: solid;
 
@@ -491,7 +491,7 @@ governing permissions and limitations under the License.
   }
 
   &:after {
-    border-radius: calc(var(--spectrum-checkbox-control-corner-radius) + var(--spectrum-checkbox-focus-indicator-gap));
+    border-radius: calc(var(--mod-checkbox-control-corner-radius, var(--spectrum-checkbox-control-corner-radius)) + var(--mod-checkbox-focus-indicator-gap, var(--spectrum-checkbox-focus-indicator-gap)));
     content: '';
     display: block;
     position: absolute;

--- a/components/checkbox/metadata/mods.md
+++ b/components/checkbox/metadata/mods.md
@@ -13,6 +13,7 @@
 | `--mod-checkbox-control-color-down` |
 | `--mod-checkbox-control-color-focus` |
 | `--mod-checkbox-control-color-hover` |
+| `--mod-checkbox-control-corner-radius` |
 | `--mod-checkbox-control-invalid-color-down` |
 | `--mod-checkbox-control-selected-color-default` |
 | `--mod-checkbox-control-selected-color-down` |
@@ -26,6 +27,7 @@
 | `--mod-checkbox-focus-indicator-gap` |
 | `--mod-checkbox-focus-indicator-thinkness` |
 | `--mod-checkbox-font-size` |
+| `--mod-checkbox-height` |
 | `--mod-checkbox-invalid-color-default` |
 | `--mod-checkbox-invalid-color-focus` |
 | `--mod-checkbox-invalid-color-hover` |
@@ -35,5 +37,4 @@
 | `--mod-checkbox-spacing` |
 | `--mod-checkbox-text-to-control` |
 | `--mod-checkbox-top-to-text` |
-| `--mod-checkox-height` |
 | `--mod-focus-indicator-thickness` |


### PR DESCRIPTION
## Description

**Checkbox**
- Rename misspelled custom property mod `--mod-checkox-height` to `--mod-checkbox-height`
- Also adds mods to a few usages of var() that were missing them.

## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] I have updated any relevant storybook stories and templates. 
- [ ] If my change(s) include visual change(s), a designer has reviewed and approved those changes.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
