### PR TITLE
fix(stepper): fix express button width and spacing

### DIFF
--- a/components/stepper/index.css
+++ b/components/stepper/index.css
@@ -30,6 +30,7 @@ governing permissions and limitations under the License.
     & {
       --spectrum-stepper-width: var(--spectrum-stepper-width-medium);
       --spectrum-stepper-icon-width: var(--spectrum-stepper-icon-width-medium);
+      --spectrum-stepper-button-padding: calc(var(--spectrum-spacing-200) / 2); /* 6px md + 7px lg - previously 6px md + 7.5px lg */
     }
   }
 
@@ -37,6 +38,7 @@ governing permissions and limitations under the License.
     & {
       --spectrum-stepper-width: var(--spectrum-stepper-width-large);
       --spectrum-stepper-icon-width: var(--spectrum-stepper-icon-width-large);
+      --spectrum-stepper-button-padding: calc(var(--spectrum-spacing-100) / 2); /* 6px md + 7px lg - previously 6px md + 7.5px lg */
     }
   }
   /**** END placeholder widths ****/
@@ -60,7 +62,6 @@ governing permissions and limitations under the License.
 
   /*** Buttons ***/
   --spectrum-stepper-button-width: calc(var(--spectrum-spacing-400) - var(--spectrum-stepper-border-width) * 2); /* this matches the previous WIDTH token */
-  --spectrum-stepper-button-padding: calc(var(--spectrum-spacing-200) / 2); /* 6px md + 7px lg - previously 6px md + 7.5px lg */
   --spectrum-stepper-button-gap: var(--spectrum-stepper-button-gap-reset);
 
   /* background same as textfield */
@@ -454,7 +455,8 @@ governing permissions and limitations under the License.
   box-sizing: border-box;
 
   block-size: var(--mod-stepper-buttons-height, var(--spectrum-stepper-buttons-height));
-  inline-size: var(--mod-stepper-button-width, var(--spectrum-stepper-button-width));
+  inline-size: calc(var(--mod-stepper-button-width, var(--spectrum-stepper-button-width)) + var(--mod-stepper-button-gap, var(--spectrum-stepper-button-gap)) * 2);
+  padding-inline-end: var(--spectrum-stepper-button-gap);
 
   border-style: solid;
   border-width: var(--mod-stepper-border-width, var(--spectrum-stepper-border-width))

--- a/components/stepper/themes/express.css
+++ b/components/stepper/themes/express.css
@@ -15,10 +15,10 @@ governing permissions and limitations under the License.
   .spectrum-Stepper {
     --spectrum-stepper-border-width: var(--spectrum-border-width-200); /* express stepper has border */
     --spectrum-stepper-button-border-width-reset: 0; /* express buttons have no inline start border */
-    --spectrum-stepper-button-icon-nudge: calc(-1 * var(--spectrum-border-width-200));
+    --spectrum-stepper-button-border-radius-reset: calc(var(--spectrum-corner-radius-100) - (var(--spectrum-border-width-200) * 2));
+    --spectrum-stepper-button-icon-nudge: calc(-1 * var(--spectrum-stepper-button-border-radius-reset));
 
     --spectrum-stepper-button-gap-reset: var(--spectrum-border-width-200); /* express buttons have middle gap */
-    --spectrum-stepper-button-border-radius-reset: calc(var(--spectrum-corner-radius-100) - (var(--spectrum-border-width-200) * 2));
 
     --spectrum-stepper-border-color: var(--spectrum-gray-400);
     --spectrum-stepper-border-color-hover: var(--spectrum-gray-500);


### PR DESCRIPTION
## Description

This adds margin to the right side of the buttons for the Stepper in Express.

## Screenshots

### Before
![Screenshot 2023-05-22 at 2 47 22 PM](https://github.com/adobe/spectrum-css/assets/99203545/51b60428-62c6-4e90-9c96-c2a08a7680b2)

### After
![Screenshot 2023-05-22 at 2 47 46 PM](https://github.com/adobe/spectrum-css/assets/99203545/84ab232e-846a-4784-9ac9-cc650c1c53b4)


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] I have updated any relevant storybook stories and templates. 
- [x] If my change(s) include visual change(s), a designer has reviewed and approved those changes.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
