### PR TITLE
refactor(stepper): use explicit border radius properties

### DIFF
--- a/components/stepper/index.css
+++ b/components/stepper/index.css
@@ -521,7 +521,8 @@ governing permissions and limitations under the License.
   padding-block-end: 0;
 
  
-  border-radius: var(--spectrum-stepper-button-border-radius-reset);
+  border-start-start-radius: var(--spectrum-stepper-button-border-radius-reset);
+  border-start-end-radius: var(--spectrum-stepper-button-border-radius-reset);
   border-end-start-radius: 0;
   border-end-end-radius: 0;
 }
@@ -530,7 +531,8 @@ governing permissions and limitations under the License.
   border-block-start-width: 0;
   padding-block-start: 0;
 
-  border-radius: var(--spectrum-stepper-button-border-radius-reset);
+  border-end-end-radius: var(--spectrum-stepper-button-border-radius-reset);
+  border-end-start-radius: var(--spectrum-stepper-button-border-radius-reset);
   border-start-start-radius: 0;
   border-start-end-radius: 0;
   border-block-start-width: var(--spectrum-stepper-button-border-width-reset);


### PR DESCRIPTION
## Description

There was an issue in SWC where the `border-radius` property was overriding some other things due to how they were compiling the CSS. This makes the two instances where `border-radius` is combined with more specific properties utilize the individual properties rather than the all-encompassing `border-radius` to prevent compilation differences. 

## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
