### PR TITLE
chore: update auto-updater to configurable version

### DIFF
--- a/.github/workflows/pr-update.yml
+++ b/.github/workflows/pr-update.yml
@@ -11,9 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+       # README: https://github.com/castastrophe/actions-pr-auto-update#auto-update-pull-requests
       - uses: castastrophe/actions-pr-auto-update@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          # Draft PRs will not be automatically updated by this utility
           include_drafts: false
           limit: 50
           exclude_labels: blocked,wip

--- a/.github/workflows/pr-update.yml
+++ b/.github/workflows/pr-update.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: maxkomarychev/pr-updater-action@v1.0.1
+      - uses: castastrophe/actions-pr-auto-update@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          include_drafts: false
+          limit: 50
+          exclude_labels: blocked,wip

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -11,7 +11,7 @@ jobs:
   vrt:
     name: Visual regression testing
     # Run VRT only if the PR is not a draft and has the label 'run_vrt' and does not have the label 'skip_vrt'
-    if: contains(github.event.pull_request.labels.*.name, 'run_vrt') && !contains(github.event.pull_request.labels.*.name, 'skip_vrt') && github.event.pull_request.draft == false
+    if: contains(github.event.pull_request.labels.*.name, 'run_vrt') && github.event.pull_request.draft == false
 
     runs-on: ubuntu-latest
 
@@ -38,6 +38,8 @@ jobs:
           onlyChanged: true
           traceChanged: true
           diagnostics: true
+          # this lets the VRT pass without running it if the PR has the label 'skip_vrt'
+          skip: ${{ contains(github.event.pull_request.labels.*.name, 'skip_vrt') }}
       - name: Remove labels
         uses: mondeja/remove-labels-gh-action@v1
         with:


### PR DESCRIPTION
## Description

The auto-updater we were using was not configurable to allow us to control what PRs get updated so I'm swapping it for this one that I forked that adds the functionality we need. 

- Filters out draft PRs
- Limits to 50 PRs to update per push
- Excludes PRs with blocked or wip labels

Moved the skip_vrt label to the Chromatic skip input which will pass PRs when the label is present. This will let us put the VRT as a required action.


## To-do list
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] This pull request is ready to merge.
