### PR TITLE
fix(textfield): storybook valid icon size and rename mod

### DIFF
--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -552,9 +552,8 @@ governing permissions and limitations under the License.
   /* keyboard focus */
   .is-keyboardFocused &,
   &:focus-visible {
-
     border-color: var(--highcontrast-textfield-border-color-keyboard-focus, var(--mod-textfield-border-color-keyboard-focus, var(--spectrum-textfield-border-color-keyboard-focus)));
-    color: var(--highcontrast-textfield-text-color-keyboard-focus, var(--mod-textfield-text-color-focus, var(--spectrum-textfield-text-color-keyboard-focus)));
+    color: var(--highcontrast-textfield-text-color-keyboard-focus, var(--mod-textfield-text-color-keyboard-focus, var(--spectrum-textfield-text-color-keyboard-focus)));
 
     &::placeholder {
       color: var(--highcontrast-textfield-text-color-keyboard-focus, var(--mod-textfield-text-color-keyboard-focus, var(--spectrum-textfield-text-color-keyboard-focus)));

--- a/components/textfield/stories/template.js
+++ b/components/textfield/stories/template.js
@@ -49,7 +49,7 @@ export const Template = ({
   }
 
   if (isInvalid) iconName = "Alert";
-  else if (isValid) iconName = "Checkmark";
+  else if (isValid) iconName = "Checkmark100";
 
   return html`
     <div class=${classMap({


### PR DESCRIPTION
## Description
**fix(textfield): valid in storybook - display correct icon size**
Fixes the 'valid' checkmark icon not displaying as the right size in Storybook. Needed to add the sizing number, which is programattically replaced with the right size based on the t-shirt size passed to the icon.

**fix(textfield): mod name for keyboard focus color**
Mod custom property for one of the keyboard focus styles was using the focus mod instead of the keyboard focus mod.

## How and where has this been tested?
Tested in Storybook, Chrome on Mac

## Screenshots
Storybook valid icon before:
![Screenshot 2023-05-25 at 11 48 20 AM](https://github.com/adobe/spectrum-css/assets/965114/dd904bc4-3dbb-4a2b-ba59-919350096f9a)

Storybook valid icon after:
![Screenshot 2023-05-25 at 11 48 55 AM](https://github.com/adobe/spectrum-css/assets/965114/590e8c98-df1a-4962-9309-942563a3edaf)

## To-do list
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
- [x] I have updated any relevant storybook stories and templates. 
- [ ] If my change(s) include visual change(s), a designer has reviewed and approved those changes.
- [x] This pull request is ready to merge.
