### PR TITLE
chore: add prettier configuration

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,14 @@
+**/.git
+**/.svn
+**/.hg
+**/node_modules
+
+components/*/dist
+dist
+
+.DS_Store*
+ehthumbs.db
+Icon?
+Thumbs.db
+*~
+*.swp

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "tabWidth": 4,
+  "useTabs": true
+}

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "markdown-it": "^12.3.2",
     "npm-run-all": "^4.1.5",
     "nx": "^16.2.2",
+    "prettier": "^2.8.8",
     "prettier-package-json": "^2.8.0",
     "prismjs": "^1.23.0",
     "rimraf": "^5.0.1",
@@ -94,6 +95,9 @@
     "last 2 iOS versions"
   ],
   "lint-staged": {
+    "*.{md,js,css,yml,hbs}": [
+      "prettier --write"
+    ],
     "components/*/package.json": [
       "yarn lint:components",
       "prettier-package-json --write"


### PR DESCRIPTION
## Description

A prettier config was required for a utility being used in the updated 11ty site so I thought we could pull the implementation out into it's own PR and evaluate if we want to add it as a linter during commits.

Implementation options:

- Merge this and let prettier do it's thing as files are updated in PRs
- Merge this and then run it across all our relevant files and commit that in one go


## To-do list
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] This pull request is ready to merge.
