### PR TITLE
fix(divider): WHCM color

### DIFF
--- a/components/divider/index.css
+++ b/components/divider/index.css
@@ -53,7 +53,10 @@ governing permissions and limitations under the License.
 
 /* windows high contrast mode */
 @media (forced-colors: active) {
-  .spectrum-Divider {
+  .spectrum-Divider,
+  .spectrum-Divider--sizeS,
+  .spectrum-Divider--sizeM,
+  .spectrum-Divider--sizeL {
     --spectrum-divider-background-color: CanvasText;
     --spectrum-divider-background-color-small-static-white: CanvasText;
     --spectrum-divider-background-color-medium-static-white: CanvasText;


### PR DESCRIPTION
## Description

The Divider currently does not display in WHCM because the background-color is being overwritten by the size-specific class styling. This makes the WHCM styling more specific so that it applies at the right time. 

## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] I have tested these changes in Windows High Contrast mode.
- [ ] I have updated any relevant storybook stories and templates. 
- [ ] If my change(s) include visual change(s), a designer has reviewed and approved those changes.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
