### PR TITLE
fix(popover): keep nested drop shadows from affecting the other

### DIFF
--- a/components/popover/index.css
+++ b/components/popover/index.css
@@ -49,6 +49,7 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Popover {
+  --spectrum-popover-filter: drop-shadow(var(--mod-popover-shadow-horizontal, var(--spectrum-popover-shadow-horizontal)) var(--mod-popover-shadow-vertical, var(--spectrum-popover-shadow-vertical)) var(--mod-popover-shadow-blur, var(--spectrum-popover-shadow-blur)) var(--mod-popover-shadow-color, var(--spectrum-popover-shadow-color)));
   @inherit: %spectrum-overlay;
 
   box-sizing: border-box;
@@ -67,7 +68,7 @@ governing permissions and limitations under the License.
   border-width: var(--mod-popover-border-width, var(--spectrum-popover-border-width));
 
   background-color: var(--mod-popover-background-color, var(--spectrum-popover-background-color));
-  filter: drop-shadow(var(--mod-popover-shadow-horizontal, var(--spectrum-popover-shadow-horizontal)) var(--mod-popover-shadow-vertical, var(--spectrum-popover-shadow-vertical)) var(--mod-popover-shadow-blur, var(--spectrum-popover-shadow-blur)) var(--mod-popover-shadow-color, var(--spectrum-popover-shadow-color)));
+  filter: var(--mod-popover-filter, var(--spectrum-popover-filter));
 
   /* default opens and animates upward */
   &.is-open {
@@ -87,6 +88,11 @@ governing permissions and limitations under the License.
       }
     }
   }
+}
+
+/* prevent nested popovers from affecting each others drop shadow filters */
+.spectrum-Popover * {
+  --mod-popover-filter: none;
 }
 
 /* position naming - first position term is popover position, second term is source position */

--- a/components/popover/stories/popover.stories.js
+++ b/components/popover/stories/popover.stories.js
@@ -85,3 +85,68 @@ Default.args = {
     }),
   ],
 };
+
+export const WithTip = Template.bind({});
+WithTip.args = {
+  withTip: true,
+  content: [
+    Menu({
+      items: [
+        {
+          iconName: "Edit",
+          label: "Edit",
+        },
+        {
+          iconName: "Copy",
+          label: "Copy",
+        },
+        {
+          iconName: "Move",
+          label: "Move",
+        },
+        {
+          iconName: "Delete",
+          label: "Delete",
+        },
+      ],
+    }),
+  ],
+};
+
+export const Nested = Template.bind({});
+Nested.args = {
+  content: [
+    Menu({
+      items: [
+        {
+          iconName: "Edit",
+          label: "Edit",
+        },
+      ],
+    }),
+    Default({
+      content: [
+        Menu({
+          items: [
+            {
+              iconName: "Edit",
+              label: "Edit",
+            },
+            {
+              iconName: "Copy",
+              label: "Copy",
+            },
+            {
+              iconName: "Move",
+              label: "Move",
+            },
+            {
+              iconName: "Delete",
+              label: "Delete",
+            },
+          ],
+        }),
+      ],
+    })
+  ],
+};


### PR DESCRIPTION
## Description

This is in response to [Issue #1873](https://github.com/adobe/spectrum-css/issues/1837) where the drop-shadows of nested Popovers affected each other due to the use of the `filter` property. 

This PR adds a filter variable to prevent any nested Popovers from doubling down on the filter. 

## How and where has this been tested?
 - **How this was tested:** A Nested story was added to Storybook in order to test nested Popovers

## Screenshots
The difference is subtle but you can see that the drop-shadow is much darker in the original as the filter was being layered
**Current**
<img width="248" alt="Screenshot 2023-05-30 at 3 08 42 PM" src="https://github.com/adobe/spectrum-css/assets/99203545/505da6e4-3675-4f8d-ae14-cf9b471066ae">

**Updated**
<img width="251" alt="Screenshot 2023-05-30 at 3 08 23 PM" src="https://github.com/adobe/spectrum-css/assets/99203545/f2d58c63-9db4-45d8-aea4-28079bd064df">


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] I have tested these changes in Windows High Contrast mode.
- [x] I have updated any relevant storybook stories and templates. 
- [ ] If my change(s) include visual change(s), a designer has reviewed and approved those changes.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
