### PR TITLE
fix(textfield): diacritics & descenders cut off in some languages

### DIFF
--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -415,7 +415,7 @@ governing permissions and limitations under the License.
 
 /********* Child Element - Input *********/
 .spectrum-Textfield-input {
-  line-height: calc(var(--spectrum-textfield-height) - var(--spectrum-textfield-border-width));
+  line-height: var(--spectrum-textfield-height);
   box-sizing: border-box;
   inline-size: 100%;
   min-inline-size: var(--mod-textfield-min-width, var(--spectrum-textfield-min-width));


### PR DESCRIPTION
### 🚨 DO NOT MERGE 🚨 
<!-- Summarize your changes in the Title field -->

## Description
Test/fix branch for prototyping `line-height` changes.


## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] I have updated any relevant storybook stories and templates. 
- [ ] If my change(s) include visual change(s), a designer has reviewed and approved those changes.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
