### PR TITLE
feat(opacitycheckerboard)!: new component

### DIFF
--- a/components/colorhandle/index.css
+++ b/components/colorhandle/index.css
@@ -28,13 +28,13 @@ governing permissions and limitations under the License.
   --spectrum-colorhandle-border-width: var(--spectrum-color-handle-border-width);
   --spectrum-colorhandle-border-color: var(--spectrum-white);
 
-  /* for opacity checkerboard background */
-  --spectrum-colorhandle-checkerboard-dark-color: var(--spectrum-opacity-checkerboard-square-dark);
-  --spectrum-colorhandle-checkerboard-light-color: var(--spectrum-opacity-checkerboard-square-light);
-  --spectrum-colorhandle-checkerboard-size: var(--spectrum-opacity-checkerboard-square-size);
-
-  --spectrum-colorhandle-border-color-disabled: var(--spectrum-disabled-content-color);
-  --spectrum-colorhandle-fill-color-disabled: var(--spectrum-disabled-background-color);
+	--spectrum-colorhandle-border-color-disabled: var(
+		--spectrum-disabled-content-color
+	);
+	--spectrum-colorhandle-fill-color-disabled: var(
+		--spectrum-disabled-background-color
+	);
+	--mod-opacity-checkerboard-position: 50%;
 }
 
 .spectrum-ColorHandle {
@@ -57,32 +57,89 @@ governing permissions and limitations under the License.
     var(--mod-colorhandle-outer-border-width, var(--spectrum-colorhandle-outer-border-width))
     var(--mod-colorhandle-outer-border-color, var(--spectrum-colorhandle-outer-border-color));
 
-  background:
-    repeating-conic-gradient(var(--mod-colorhandle-checkerboard-light-color, var(--spectrum-colorhandle-checkerboard-light-color)) 0% 25%, var(--mod-colorhandle-checkerboard-dark-color, var(--spectrum-colorhandle-checkerboard-dark-color)) 0% 50%)
-    50% / calc(var(--mod-colorhandle-checkerboard-size, var(--spectrum-colorhandle-checkerboard-size)) * 2) calc(var(--mod-colorhandle-checkerboard-size, var(--spectrum-colorhandle-checkerboard-size)) * 2);
+	/* Add a half-percent to fix diagonal line issue in Chrome on non-retina displays */
+	transition: inline-size
+			var(
+				--mod-colorhandle-animation-duration,
+				var(--spectrum-colorhandle-animation-duration)
+			)
+			var(
+				--mod-colorhandle-animation-easing,
+				var(--spectrum-colorhandle-animation-easing)
+			),
+		block-size
+			var(
+				--mod-colorhandle-animation-duration,
+				var(--spectrum-colorhandle-animation-duration)
+			)
+			var(
+				--mod-colorhandle-animation-easing,
+				var(--spectrum-colorhandle-animation-easing)
+			),
+		border-width
+			var(
+				--mod-colorhandle-animation-duration,
+				var(--spectrum-colorhandle-animation-duration)
+			)
+			var(
+				--mod-colorhandle-animation-easing,
+				var(--spectrum-colorhandle-animation-easing)
+			),
+		margin-inline
+			var(
+				--mod-colorhandle-animation-duration,
+				var(--spectrum-colorhandle-animation-duration)
+			)
+			var(
+				--mod-colorhandle-animation-easing,
+				var(--spectrum-colorhandle-animation-easing)
+			),
+		margin-block
+			var(
+				--mod-colorhandle-animation-duration,
+				var(--spectrum-colorhandle-animation-duration)
+			)
+			var(
+				--mod-colorhandle-animation-easing,
+				var(--spectrum-colorhandle-animation-easing)
+			);
 
-  /* Add a half-percent to fix diagonal line issue in Chrome on non-retina displays */
-  transition:
-    inline-size var(--mod-colorhandle-animation-duration, var(--spectrum-colorhandle-animation-duration)) var(--mod-colorhandle-animation-easing, var(--spectrum-colorhandle-animation-easing)),
-    block-size var(--mod-colorhandle-animation-duration, var(--spectrum-colorhandle-animation-duration))  var(--mod-colorhandle-animation-easing, var(--spectrum-colorhandle-animation-easing)),
-    border-width var(--mod-colorhandle-animation-duration, var(--spectrum-colorhandle-animation-duration))  var(--mod-colorhandle-animation-easing, var(--spectrum-colorhandle-animation-easing)),
-    margin-inline var(--mod-colorhandle-animation-duration, var(--spectrum-colorhandle-animation-duration))  var(--mod-colorhandle-animation-easing, var(--spectrum-colorhandle-animation-easing)),
-    margin-block var(--mod-colorhandle-animation-duration, var(--spectrum-colorhandle-animation-duration))  var(--mod-colorhandle-animation-easing, var(--spectrum-colorhandle-animation-easing));
+	&,
+	&::after {
+		border-radius: 100%;
+	}
 
-  &,
-  &:after {
-    border-radius: 100%;
-  }
-
-  &:after {
-    content: '';
-    inset-inline: calc(50% - calc(var(--mod-colorhandle-hitarea-size, var(--spectrum-colorhandle-hitarea-size)) / 2));
-    inset-block: calc(50% - calc(var(--mod-colorhandle-hitarea-size, var(--spectrum-colorhandle-hitarea-size)) / 2));
-    position: absolute;
-    display: block;
-    inline-size: var(--mod-colorhandle-hitarea-size, var(--spectrum-colorhandle-hitarea-size));
-    block-size: var(--mod-colorhandle-hitarea-size, var(--spectrum-colorhandle-hitarea-size));
-  }
+	&::after {
+		content: "";
+		inset-inline: calc(
+			50% -
+				calc(
+					var(
+							--mod-colorhandle-hitarea-size,
+							var(--spectrum-colorhandle-hitarea-size)
+						) / 2
+				)
+		);
+		inset-block: calc(
+			50% -
+				calc(
+					var(
+							--mod-colorhandle-hitarea-size,
+							var(--spectrum-colorhandle-hitarea-size)
+						) / 2
+				)
+		);
+		position: absolute;
+		display: block;
+		inline-size: var(
+			--mod-colorhandle-hitarea-size,
+			var(--spectrum-colorhandle-hitarea-size)
+		);
+		block-size: var(
+			--mod-colorhandle-hitarea-size,
+			var(--spectrum-colorhandle-hitarea-size)
+		);
+	}
 
   &.is-focused,
   &.focus-ring {

--- a/components/colorhandle/metadata/colorhandle.yml
+++ b/components/colorhandle/metadata/colorhandle.yml
@@ -9,21 +9,21 @@ examples:
     name: Standard
     demoClassName: spectrum-CSSExample-example--spacious
     markup: |
-      <div class="spectrum-ColorHandle" style="--spectrum-picked-color: rgba(255, 0, 0, 0.5); position: absolute; inset-block: 50%; inset-inline: 50%;">
+      <div class="spectrum-ColorHandle spectrum-OpacityCheckerboard" style="--spectrum-picked-color: rgba(255, 0, 0, 0.5); position: absolute; inset-block: 50%; inset-inline: 50%;">
         <div class="spectrum-ColorHandle-inner"></div>
       </div>
   - id: color-area
     name: Disabled
     demoClassName: spectrum-CSSExample-example--spacious
     markup: |
-      <div class="spectrum-ColorHandle is-disabled" style="--spectrum-picked-color: rgba(255, 0, 0, 0.5); position: absolute; inset-block: 50%; inset-inline: 50%">
+      <div class="spectrum-ColorHandle spectrum-OpacityCheckerboard" is-disabled" style="--spectrum-picked-color: rgba(255, 0, 0, 0.5); position: absolute; inset-block: 50%; inset-inline: 50%">
         <div class="spectrum-ColorHandle-inner"></div>
       </div>
   - id: color-area
     name: Open
     demoClassName: spectrum-CSSExample-example--spacious
     markup: |
-      <div class="spectrum-ColorHandle" style="--spectrum-picked-color: rgba(255, 0, 0, 0.5); position: absolute; inset-block: 75%; inset-inline: 50%">
+      <div class="spectrum-ColorHandle spectrum-OpacityCheckerboard" style="--spectrum-picked-color: rgba(255, 0, 0, 0.5); position: absolute; inset-block: 75%; inset-inline: 50%">
         <div class="spectrum-ColorHandle-inner"></div>
         <svg class="spectrum-ColorLoupe is-open">
           <defs>

--- a/components/colorhandle/metadata/mods.md
+++ b/components/colorhandle/metadata/mods.md
@@ -13,3 +13,4 @@
 | `--mod-colorhandle-outer-border-color`    |
 | `--mod-colorhandle-outer-border-width`    |
 | `--mod-colorhandle-size`                  |
+| `--mod-opacity-checkerboard-position`     |

--- a/components/colorhandle/metadata/mods.md
+++ b/components/colorhandle/metadata/mods.md
@@ -1,18 +1,15 @@
-| Modifiable Custom Properties                 |
-| -------------------------------------------- |
-| `--mod-colorhandle-animation-duration`       |
-| `--mod-colorhandle-animation-easing`         |
-| `--mod-colorhandle-border-color`             |
-| `--mod-colorhandle-border-color-disabled`    |
-| `--mod-colorhandle-border-width`             |
-| `--mod-colorhandle-checkerboard-dark-color`  |
-| `--mod-colorhandle-checkerboard-light-color` |
-| `--mod-colorhandle-checkerboard-size`        |
-| `--mod-colorhandle-fill-color-disabled`      |
-| `--mod-colorhandle-focused-size`             |
-| `--mod-colorhandle-hitarea-size`             |
-| `--mod-colorhandle-inner-border-color`       |
-| `--mod-colorhandle-inner-border-width`       |
-| `--mod-colorhandle-outer-border-color`       |
-| `--mod-colorhandle-outer-border-width`       |
-| `--mod-colorhandle-size`                     |
+| Modifiable Custom Properties              |
+| ----------------------------------------- |
+| `--mod-colorhandle-animation-duration`    |
+| `--mod-colorhandle-animation-easing`      |
+| `--mod-colorhandle-border-color`          |
+| `--mod-colorhandle-border-color-disabled` |
+| `--mod-colorhandle-border-width`          |
+| `--mod-colorhandle-fill-color-disabled`   |
+| `--mod-colorhandle-focused-size`          |
+| `--mod-colorhandle-hitarea-size`          |
+| `--mod-colorhandle-inner-border-color`    |
+| `--mod-colorhandle-inner-border-width`    |
+| `--mod-colorhandle-outer-border-color`    |
+| `--mod-colorhandle-outer-border-width`    |
+| `--mod-colorhandle-size`                  |

--- a/components/colorhandle/package.json
+++ b/components/colorhandle/package.json
@@ -19,11 +19,13 @@
   },
   "peerDependencies": {
     "@spectrum-css/colorloupe": ">=3",
-    "@spectrum-css/tokens": ">=9"
+    "@spectrum-css/opacitycheckerboard": ">=1.0.0-alpha.0",
+    "@spectrum-css/tokens": ">=11"
   },
   "devDependencies": {
     "@spectrum-css/colorloupe": "^4.1.6",
     "@spectrum-css/component-builder-simple": "^2.0.15",
+    "@spectrum-css/opacitycheckerboard": ">=1.0.0-alpha.0",
     "@spectrum-css/tokens": "^11.0.1",
     "gulp": "^4.0.0"
   },

--- a/components/colorslider/index.css
+++ b/components/colorslider/index.css
@@ -69,10 +69,7 @@
 		content: "";
 		z-index: 1;
 		position: absolute;
-		inset-block-start: 0;
-		inset-inline-start: 0;
-		inset-block-end: 0;
-		inset-inline-end: 0;
+		inset: 0;
 		border-radius: var(--spectrum-colorslider-border-radius);
 	}
 }

--- a/components/colorslider/index.css
+++ b/components/colorslider/index.css
@@ -1,33 +1,30 @@
 .spectrum-ColorSlider {
-  --spectrum-colorslider-handle-hitarea-border-radius: 0%;
-  --spectrum-colorslider-handle-hitarea-width: var(
-    --spectrum-global-dimension-size-300
-  );
-  --spectrum-colorslider-handle-hitarea-height: var(
-    --spectrum-global-dimension-size-300
-  );
-  --spectrum-colorslider-checkerboard-size: var(--spectrum-opacity-checkerboard-square-size);
-  --spectrum-colorslider-checkerboard-dark-color: var(--spectrum-opacity-checkerboard-square-dark);
-  --spectrum-colorslider-checkerboard-light-color: var(--spectrum-opacity-checkerboard-square-light);
+	--spectrum-colorslider-handle-hitarea-border-radius: 0%;
+	--spectrum-colorslider-handle-hitarea-width: var(
+		--spectrum-global-dimension-size-300
+	);
+	--spectrum-colorslider-handle-hitarea-height: var(
+		--spectrum-global-dimension-size-300
+	);
 }
 
 %spectrum-ColorControl-hiddenField {
-  opacity: 0;
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  z-index: 0;
-  margin: 0;
-  pointer-events: none;
+	opacity: 0;
+	position: absolute;
+	inset-block-start: 0;
+	inset-inline-start: 0;
+	inline-size: 100%;
+	block-size: 100%;
+	z-index: 0;
+	margin: 0;
+	pointer-events: none;
 }
 
 .spectrum-ColorSlider {
-  position: relative;
-  display: block;
-  width: var(--spectrum-colorslider-default-length);
-  height: var(--spectrum-colorslider-height);
+	position: relative;
+	display: block;
+	inline-size: var(--spectrum-colorslider-default-length);
+	block-size: var(--spectrum-colorslider-height);
 
   /* Otherwise we randomly drag a file icon */
   user-select: none;
@@ -46,49 +43,45 @@
 .spectrum-ColorSlider--vertical {
   display: inline-block;
 
-  width: var(--spectrum-colorslider-vertical-width);
-  height: var(--spectrum-colorslider-vertical-default-length);
+	inline-size: var(--spectrum-colorslider-vertical-width);
+	block-size: var(--spectrum-colorslider-vertical-default-length);
 
-  .spectrum-ColorSlider-handle {
-    left: 50%;
-    top: 0;
-  }
+	.spectrum-ColorSlider-handle {
+		inset-inline-start: 50%;
+		inset-block-start: 0;
+	}
 }
 
 .spectrum-ColorSlider-handle {
-  left: 0;
-  top: 50%;
+	inset-inline-start: 0;
+	inset-block-start: 50%;
 
-  &:after {
-    border-radius: var(--spectrum-colorslider-handle-hitarea-border-radius);
-    width: var(--spectrum-colorslider-handle-hitarea-width);
-    height: var(--spectrum-colorslider-handle-hitarea-height);
-  }
+	&::after {
+		border-radius: var(--spectrum-colorslider-handle-hitarea-border-radius);
+		inline-size: var(--spectrum-colorslider-handle-hitarea-width);
+		block-size: var(--spectrum-colorslider-handle-hitarea-height);
+	}
 }
 
 .spectrum-ColorSlider-checkerboard {
-  background:
-    repeating-conic-gradient(var(--spectrum-colorslider-checkerboard-light-color) 0% 25%, var(--spectrum-colorslider-checkerboard-dark-color) 0% 50%)
-    left top / calc(var(--spectrum-colorslider-checkerboard-size) * 2 ) calc(var(--spectrum-colorslider-checkerboard-size) * 2 );
-
-  /* the floating inset box shadow must be a separate element since <canvas> won't take it */
-  &:before {
-    content: "";
-    z-index: 1;
-    position: absolute;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    right: 0;
-    border-radius: var(--spectrum-colorslider-border-radius);
-  }
+	/* the floating inset box shadow must be a separate element since <canvas> won't take it */
+	&::before {
+		content: "";
+		z-index: 1;
+		position: absolute;
+		inset-block-start: 0;
+		inset-inline-start: 0;
+		inset-block-end: 0;
+		inset-inline-end: 0;
+		border-radius: var(--spectrum-colorslider-border-radius);
+	}
 }
 
 .spectrum-ColorSlider-gradient,
 .spectrum-ColorSlider-checkerboard {
-  width: 100%;
-  height: 100%;
-  border-radius: var(--spectrum-colorslider-border-radius);
+	inline-size: 100%;
+	block-size: 100%;
+	border-radius: var(--spectrum-colorslider-border-radius);
 }
 
 .spectrum-ColorSlider-slider {

--- a/components/colorslider/metadata/colorslider.yml
+++ b/components/colorslider/metadata/colorslider.yml
@@ -184,7 +184,7 @@ examples:
     demoClassName: spectrum-CSSExample-example--spacious
     markup: |
       <div class="spectrum-ColorSlider" style="position: relative; top: 80px;">
-        <div class="spectrum-ColorSlider-checkerboard" role="presentation">
+        <div class="spectrum-OpacityCheckerboard spectrum-ColorSlider-checkerboard" role="presentation">
           <div class="spectrum-ColorSlider-gradient" role="presentation" style="background: linear-gradient(to right, rgba(255, 0, 0, 0.5) 0%, rgba(255, 255, 0, 0.5) 17%, rgba(0, 255, 0, 0.5) 33%, rgba(0, 255, 255, 0.5) 50%, rgba(0, 0, 255, 0.5) 67%, rgba(255, 0, 255, 0.5) 83%, rgba(255, 0, 0, 0.5) 100%);"></div>
         </div>
 

--- a/components/colorslider/metadata/colorslider.yml
+++ b/components/colorslider/metadata/colorslider.yml
@@ -31,7 +31,7 @@ examples:
     name: Alpha
     markup: |
       <div class="spectrum-ColorSlider">
-        <div class="spectrum-ColorSlider-checkerboard spectrum-OpacityCheckerboard" role="presentation">
+        <div class="spectrum-OpacityCheckerboard spectrum-ColorSlider-checkerboard" role="presentation">
           <div class="spectrum-ColorSlider-gradient" role="presentation" style="background: linear-gradient(to right, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, 0) 100%);"></div>
         </div>
 

--- a/components/colorslider/metadata/colorslider.yml
+++ b/components/colorslider/metadata/colorslider.yml
@@ -31,7 +31,7 @@ examples:
     name: Alpha
     markup: |
       <div class="spectrum-ColorSlider">
-        <div class="spectrum-ColorSlider-checkerboard" role="presentation">
+        <div class="spectrum-ColorSlider-checkerboard spectrum-OpacityCheckerboard" role="presentation">
           <div class="spectrum-ColorSlider-gradient" role="presentation" style="background: linear-gradient(to right, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, 0) 100%);"></div>
         </div>
 

--- a/components/colorslider/package.json
+++ b/components/colorslider/package.json
@@ -19,12 +19,14 @@
   },
   "peerDependencies": {
     "@spectrum-css/colorhandle": ">=5.0.0",
+    "@spectrum-css/opacitycheckerboard": ">=1.0.0-alpha.0",
     "@spectrum-css/vars": ">=9"
   },
   "devDependencies": {
     "@spectrum-css/colorhandle": "^5.0.15",
     "@spectrum-css/component-builder": "^4.0.12",
     "@spectrum-css/vars": "^9.0.8",
+    "@spectrum-css/opacitycheckerboard": ">=1.0.0-alpha.0",
     "gulp": "^4.0.0"
   },
   "publishConfig": {

--- a/components/opacitycheckerboard/README.md
+++ b/components/opacitycheckerboard/README.md
@@ -1,0 +1,7 @@
+# @spectrum-css/opacitycheckerboard
+
+> Opacity checkerboard
+
+This package is part of the [Spectrum CSSproject](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSSdocumentation](https://opensource.adobe.com/spectrum-css/opacitycheckerboard).

--- a/components/opacitycheckerboard/README.md
+++ b/components/opacitycheckerboard/README.md
@@ -2,6 +2,6 @@
 
 > Opacity checkerboard
 
-This package is part of the [Spectrum CSSproject](https://github.com/adobe/spectrum-css).
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
 
-See the [Spectrum CSSdocumentation](https://opensource.adobe.com/spectrum-css/opacitycheckerboard).
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/opacitycheckerboard).

--- a/components/opacitycheckerboard/gulpfile.js
+++ b/components/opacitycheckerboard/gulpfile.js
@@ -1,0 +1,1 @@
+module.exports = require("@spectrum-css/component-builder-simple");

--- a/components/opacitycheckerboard/index.css
+++ b/components/opacitycheckerboard/index.css
@@ -17,6 +17,7 @@ permissions and limitations under the License. */
 	--spectrum-opacity-checkerboard-size: var(
 		--spectrum-opacity-checkerboard-square-size
 	);
+	--spectrum-opacity-checkerboard-position: left top;
 }
 
 .spectrum-OpacityCheckerboard {
@@ -26,7 +27,10 @@ permissions and limitations under the License. */
 			var(--spectrum-opacity-checkerboard-light) 0% 25%,
 			var(--spectrum-opacity-checkerboard-dark) 0% 50%
 		)
-		left top / calc(var(--spectrum-opacity-checkerboard-size) * 2)
+		var(
+			--mod-opacity-checkerboard-position,
+			var(--spectrum-opacity-checkerboard-position)
+		) / calc(var(--spectrum-opacity-checkerboard-size) * 2)
 		calc(var(--spectrum-opacity-checkerboard-size) * 2);
 }
 

--- a/components/opacitycheckerboard/index.css
+++ b/components/opacitycheckerboard/index.css
@@ -18,3 +18,19 @@ permissions and limitations under the License. */
 		--spectrum-opacity-checkerboard-square-size
 	);
 }
+
+.spectrum-OpacityCheckerboard {
+	inline-size: 100%;
+	block-size: 100%;
+	background: repeating-conic-gradient(
+			var(--spectrum-opacity-checkerboard-light) 0% 25%,
+			var(--spectrum-opacity-checkerboard-dark) 0% 50%
+		)
+		left top / calc(var(--spectrum-opacity-checkerboard-size) * 2)
+		calc(var(--spectrum-opacity-checkerboard-size) * 2);
+}
+
+.spectrum-OpacityCheckerboard-example {
+	inline-size: 200px;
+	block-size: 200px;
+}

--- a/components/opacitycheckerboard/index.css
+++ b/components/opacitycheckerboard/index.css
@@ -24,19 +24,37 @@ permissions and limitations under the License. */
 	inline-size: 100%;
 	block-size: 100%;
 	background: repeating-conic-gradient(
-			var(--spectrum-opacity-checkerboard-light) 0% 25%,
-			var(--spectrum-opacity-checkerboard-dark) 0% 50%
+			var(
+					--mod-opacity-checkerboard-light,
+					var(--spectrum-opacity-checkerboard-light)
+				)
+				0% 25%,
+			var(
+					--mod-opacity-checkerboard-dark,
+					var(--spectrum-opacity-checkerboard-dark)
+				)
+				0% 50%
 		)
 		var(
 			--mod-opacity-checkerboard-position,
 			var(--spectrum-opacity-checkerboard-position)
-		) / calc(var(--spectrum-opacity-checkerboard-size) * 2)
-		calc(var(--spectrum-opacity-checkerboard-size) * 2);
+		) /
+		calc(
+			var(
+					--mod-opacity-checkerboard-size,
+					var(--spectrum-opacity-checkerboard-size)
+				) * 2
+		)
+		calc(
+			var(
+					--mod-opacity-checkerboard-size,
+					var(--spectrum-opacity-checkerboard-size)
+				) * 2
+		);
 }
 
 @media (forced-colors: active) {
-	.spectrum-OpacityCheckerboard,
-	.spectrum-OpacityCheckerboard-example-color {
+	.spectrum-OpacityCheckerboard {
 		/* Allow checkerboard pattern to be visible. */
 		forced-color-adjust: none;
 	}

--- a/components/opacitycheckerboard/index.css
+++ b/components/opacitycheckerboard/index.css
@@ -42,7 +42,6 @@ permissions and limitations under the License. */
 .spectrum-OpacityCheckerboard-example-color {
 	inline-size: 100%;
 	block-size: 100%;
-	background-color: rgba(255, 0, 0, 0.5);
 	position: relative;
 	inset-block: -100%;
 }

--- a/components/opacitycheckerboard/index.css
+++ b/components/opacitycheckerboard/index.css
@@ -45,3 +45,11 @@ permissions and limitations under the License. */
 	position: relative;
 	inset-block: -100%;
 }
+
+@media (forced-colors: active) {
+	.spectrum-OpacityCheckerboard,
+	.spectrum-OpacityCheckerboard-example-color {
+		/* Allow checkerboard pattern to be visible. */
+		forced-color-adjust: none;
+	}
+}

--- a/components/opacitycheckerboard/index.css
+++ b/components/opacitycheckerboard/index.css
@@ -35,6 +35,14 @@ permissions and limitations under the License. */
 }
 
 .spectrum-OpacityCheckerboard-example {
-	inline-size: 200px;
-	block-size: 200px;
+	inline-size: 100px;
+	block-size: 100px;
+}
+
+.spectrum-OpacityCheckerboard-example-color {
+	inline-size: 100%;
+	block-size: 100%;
+	background-color: rgba(255, 0, 0, 0.5);
+	position: relative;
+	inset-block: -100%;
 }

--- a/components/opacitycheckerboard/index.css
+++ b/components/opacitycheckerboard/index.css
@@ -34,18 +34,6 @@ permissions and limitations under the License. */
 		calc(var(--spectrum-opacity-checkerboard-size) * 2);
 }
 
-.spectrum-OpacityCheckerboard-example {
-	inline-size: 100px;
-	block-size: 100px;
-}
-
-.spectrum-OpacityCheckerboard-example-color {
-	inline-size: 100%;
-	block-size: 100%;
-	position: relative;
-	inset-block: -100%;
-}
-
 @media (forced-colors: active) {
 	.spectrum-OpacityCheckerboard,
 	.spectrum-OpacityCheckerboard-example-color {

--- a/components/opacitycheckerboard/index.css
+++ b/components/opacitycheckerboard/index.css
@@ -1,0 +1,20 @@
+/*! Copyright 2023 Adobe. All rights reserved. This file is licensed to you
+under the Apache License, Version 2.0 (the "License"); you may not use this file
+except in compliance with the License. You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or
+agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, either
+express or implied. See the License for the specific language governing
+permissions and limitations under the License. */
+
+.spectrum-OpacityCheckerboard {
+	--spectrum-opacity-checkerboard-dark: var(
+		--spectrum-opacity-checkerboard-square-dark
+	);
+	--spectrum-opacity-checkerboard-light: var(
+		--spectrum-opacity-checkerboard-square-light
+	);
+	--spectrum-opacity-checkerboard-size: var(
+		--spectrum-opacity-checkerboard-square-size
+	);
+}

--- a/components/opacitycheckerboard/metadata/mods.md
+++ b/components/opacitycheckerboard/metadata/mods.md
@@ -1,3 +1,6 @@
 | Modifiable Custom Properties          |
 | ------------------------------------- |
+| `--mod-opacity-checkerboard-dark`     |
+| `--mod-opacity-checkerboard-light`    |
 | `--mod-opacity-checkerboard-position` |
+| `--mod-opacity-checkerboard-size`     |

--- a/components/opacitycheckerboard/metadata/mods.md
+++ b/components/opacitycheckerboard/metadata/mods.md
@@ -1,3 +1,3 @@
-| Modifiable Custom Properties                      |
-| ------------------------------------------------- |
-| `--mod-opacitycheckerboard-content-color-default` |
+| Modifiable Custom Properties          |
+| ------------------------------------- |
+| `--mod-opacity-checkerboard-position` |

--- a/components/opacitycheckerboard/metadata/mods.md
+++ b/components/opacitycheckerboard/metadata/mods.md
@@ -1,0 +1,3 @@
+| Modifiable Custom Properties                      |
+| ------------------------------------------------- |
+| `--mod-opacitycheckerboard-content-color-default` |

--- a/components/opacitycheckerboard/metadata/opacitycheckerboard.yml
+++ b/components/opacitycheckerboard/metadata/opacitycheckerboard.yml
@@ -2,7 +2,7 @@ name: Opacity Checkerboard
 description: Opacity checkerboard is used with other components to highlight opacity.
 examples:
   - id: opacity-checkerboard
-    name: Opactiy Checkerboard
+    name: Opacity Checkerboard
     markup: |
       <div style="inline-size: 100px; block-size: 100px;">
         <div class="spectrum-OpacityCheckerboard">

--- a/components/opacitycheckerboard/metadata/opacitycheckerboard.yml
+++ b/components/opacitycheckerboard/metadata/opacitycheckerboard.yml
@@ -8,3 +8,10 @@ examples:
         <div class="spectrum-OpacityCheckerboard">
         </div>
       </div>
+  - id: opacity-checkerboard
+    name: Opactiy Checkerboard with transparent color
+    markup: |
+      <div class="spectrum-OpacityCheckerboard-example" >
+        <div class="spectrum-OpacityCheckerboard"></div>
+        <div class="spectrum-OpacityCheckerboard-example-color"></div>
+      </div>

--- a/components/opacitycheckerboard/metadata/opacitycheckerboard.yml
+++ b/components/opacitycheckerboard/metadata/opacitycheckerboard.yml
@@ -9,9 +9,9 @@ examples:
         </div>
       </div>
   - id: opacity-checkerboard
-    name: Opactiy Checkerboard with color overlay
+    name: Opacity Checkerboard with color overlay
     markup: |
-      <div class="spectrum-OpacityCheckerboard-example" >
+      <div class="spectrum-OpacityCheckerboard-example">
         <div class="spectrum-OpacityCheckerboard"></div>
         <div class="spectrum-OpacityCheckerboard-example-color" style="background-color: rgba(255, 0, 0, 0.5);"></div>
       </div>

--- a/components/opacitycheckerboard/metadata/opacitycheckerboard.yml
+++ b/components/opacitycheckerboard/metadata/opacitycheckerboard.yml
@@ -1,0 +1,9 @@
+name: Opacity Checkerboard
+description: Opacity checkerboard is used with other components to highlight opacity.
+examples:
+  - id: opacity-checkerboard
+    name: Opactiy Checkerboard
+    markup: |
+      <div>
+        <p>Content here</p>
+      </div>

--- a/components/opacitycheckerboard/metadata/opacitycheckerboard.yml
+++ b/components/opacitycheckerboard/metadata/opacitycheckerboard.yml
@@ -4,6 +4,7 @@ examples:
   - id: opacity-checkerboard
     name: Opactiy Checkerboard
     markup: |
-      <div>
-        <p>Content here</p>
+      <div class="spectrum-OpacityCheckerboard-example">
+        <div class="spectrum-OpacityCheckerboard">
+        </div>
       </div>

--- a/components/opacitycheckerboard/metadata/opacitycheckerboard.yml
+++ b/components/opacitycheckerboard/metadata/opacitycheckerboard.yml
@@ -9,9 +9,9 @@ examples:
         </div>
       </div>
   - id: opacity-checkerboard
-    name: Opactiy Checkerboard with transparent color
+    name: Opactiy Checkerboard with color overlay
     markup: |
       <div class="spectrum-OpacityCheckerboard-example" >
         <div class="spectrum-OpacityCheckerboard"></div>
-        <div class="spectrum-OpacityCheckerboard-example-color"></div>
+        <div class="spectrum-OpacityCheckerboard-example-color" style="background-color: rgba(255, 0, 0, 0.5);"></div>
       </div>

--- a/components/opacitycheckerboard/metadata/opacitycheckerboard.yml
+++ b/components/opacitycheckerboard/metadata/opacitycheckerboard.yml
@@ -4,14 +4,14 @@ examples:
   - id: opacity-checkerboard
     name: Opactiy Checkerboard
     markup: |
-      <div class="spectrum-OpacityCheckerboard-example">
+      <div style="inline-size: 100px; block-size: 100px;">
         <div class="spectrum-OpacityCheckerboard">
         </div>
       </div>
   - id: opacity-checkerboard
     name: Opacity Checkerboard with color overlay
     markup: |
-      <div class="spectrum-OpacityCheckerboard-example">
+      <div style="inline-size: 100px; block-size: 100px;">
         <div class="spectrum-OpacityCheckerboard"></div>
-        <div class="spectrum-OpacityCheckerboard-example-color" style="background-color: rgba(255, 0, 0, 0.5);"></div>
+        <div style="background-color: rgba(255, 0, 0, 0.5); inline-size: 100%; block-size: 100%; position: relative; inset-block: -100%"></div>
       </div>

--- a/components/opacitycheckerboard/package.json
+++ b/components/opacitycheckerboard/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@spectrum-css/opacitycheckerboard",
+  "version": "1.0.0-alpha.0",
+  "description": "The Spectrum CSS opacitycheckerboard component",
+  "license": "Apache-2.0",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/opacitycheckerboard"
+  },
+  "bugs": {
+    "url": "https://github.com/adobe/spectrum-css/issues"
+  },
+  "main": "dist/index-vars.css",
+  "scripts": {
+    "build": "gulp",
+    "clean": "rimraf dist",
+    "test": "nx test:scope @spectrum-css/previewopacitycheckerboard"
+  },
+  "peerDependencies": {
+    "@spectrum-css/tokens": ">=10"
+  },
+  "devDependencies": {
+    "@spectrum-css/component-builder-simple": "^2.0.14",
+    "@spectrum-css/tokens": "^10.1.2",
+    "gulp": "^4.0.0",
+    "nx": "^16.2.2",
+    "rimraf": "^5.0.1"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/components/opacitycheckerboard/stories/opacitycheckerboard.stories.js
+++ b/components/opacitycheckerboard/stories/opacitycheckerboard.stories.js
@@ -1,8 +1,9 @@
 import { Template } from "./template";
 
 export default {
-	title: "Opacity checkerboard",
-	description: "The Opacity checkerboard component is...",
+	title: "Opacity Checkerboard",
+	description:
+		"Opacity checkerboard is used with other components to highlight opacity.",
 	component: "OpacityCheckerboard",
 	argTypes: {
 		hasColorOverlay: {
@@ -32,7 +33,7 @@ export default {
 				category: "Component",
 			},
 			control: "text",
-			description: "accepts any valid background-position property",
+			description: "Accepts any valid CSS background-position property value",
 		},
 	},
 	args: {

--- a/components/opacitycheckerboard/stories/opacitycheckerboard.stories.js
+++ b/components/opacitycheckerboard/stories/opacitycheckerboard.stories.js
@@ -1,0 +1,35 @@
+export default {
+	title: "Opacity checkerboard",
+	description: "The Opacity checkerboard component is...",
+	component: "OpacityCheckerboard",
+	argTypes: {
+		size: {
+			name: "Size",
+			type: { name: "string", required: true },
+			defaultValue: "m",
+			table: {
+				type: { summary: "string" },
+				category: "Component",
+				defaultValue: { summary: "m" },
+			},
+			options: ["s", "m", "l", "xl"],
+			control: "select",
+		},
+	},
+	args: {
+		rootClass: "spectrum-OpacityCheckerboard",
+		size: "m",
+	},
+	parameters: {
+		actions: {
+			handles: [],
+		},
+		status: {
+			type: process.env.MIGRATED_PACKAGES.includes("opacitycheckerboard")
+				? "migrated"
+				: undefined,
+		},
+	},
+};
+export const Default = Template.bind({});
+Default.args = {};

--- a/components/opacitycheckerboard/stories/opacitycheckerboard.stories.js
+++ b/components/opacitycheckerboard/stories/opacitycheckerboard.stories.js
@@ -1,24 +1,42 @@
+import { Template } from "./template";
+
 export default {
 	title: "Opacity checkerboard",
 	description: "The Opacity checkerboard component is...",
 	component: "OpacityCheckerboard",
 	argTypes: {
-		size: {
-			name: "Size",
-			type: { name: "string", required: true },
-			defaultValue: "m",
+		hasColorOverlay: {
+			name: "Has Color Overlay",
+			type: { name: "boolean" },
+			defaultValue: false,
 			table: {
-				type: { summary: "string" },
 				category: "Component",
-				defaultValue: { summary: "m" },
 			},
-			options: ["s", "m", "l", "xl"],
-			control: "select",
+			control: "boolean",
+		},
+		overlayColor: {
+			name: "Overlay Color",
+			type: { name: "string" },
+			defaultValue: "rgba(255, 0, 0, 0.5)",
+			table: {
+				category: "Component",
+			},
+			control: "text",
+			if: { arg: "hasColorOverlay", truthy: true },
+		},
+		backgroundPosition: {
+			name: "Position",
+			type: { name: "string" },
+			defaultValue: "top left",
+			table: {
+				category: "Component",
+			},
+			control: "text",
+			description: "accepts any valid background-position property",
 		},
 	},
 	args: {
 		rootClass: "spectrum-OpacityCheckerboard",
-		size: "m",
 	},
 	parameters: {
 		actions: {

--- a/components/opacitycheckerboard/stories/template.js
+++ b/components/opacitycheckerboard/stories/template.js
@@ -17,7 +17,7 @@ export const Template = ({
 	...globals
 }) => {
 	return html`
-		<div class="${rootClass}-example">
+		<div style="inline-size: 100px; block-size: 100px;">
 			<div
 				class=${classMap({
 					[rootClass]: true,
@@ -27,8 +27,7 @@ export const Template = ({
 			></div>
 			${when(hasColorOverlay, () => {
 				return html` <div
-					class="${rootClass}-example-color"
-					style="background-color:${overlayColor}"
+					style="background-color:${overlayColor}; inline-size: 100%; block-size: 100%; position: relative; inset-block: -100%"
 				></div>`;
 			})}
 		</div>

--- a/components/opacitycheckerboard/stories/template.js
+++ b/components/opacitycheckerboard/stories/template.js
@@ -1,0 +1,23 @@
+import { html } from "lit-html";
+import { classMap } from "lit-html/directives/class-map.js";
+import { ifDefined } from "lit-html/directives/if-defined.js";
+import "../index.css";
+
+export const Template = ({
+	rootClass = "spectrum-OpacityCheckerboard",
+	size,
+	id,
+	customClasses = [],
+	...globals
+}) => {
+	return html`
+			<div
+				class="${classMap({
+					[rootClass]: true,
+					[`${rootClass}--size${size.toUpperCase()}`]: true,
+					...customClasses.reduce((a, c)({ ...a, [c]: true }), {}),
+				})} id=${ifDefined(id)}>
+				<!-- Component mark-up goes here -->
+			</div>
+			`;
+};

--- a/components/opacitycheckerboard/stories/template.js
+++ b/components/opacitycheckerboard/stories/template.js
@@ -11,24 +11,33 @@ export const Template = ({
 	overlayColor,
 	backgroundPosition,
 	customClasses = [],
-	style = {
+	containerStyles = {
+		"inline-size": "100px",
+		"block-size": "100px",
+	},
+	checkerBoardStyles = {
 		"--mod-opacity-checkerboard-position": backgroundPosition,
+	},
+	colorStyles = {
+		"background-color": overlayColor,
+		"inline-size": "100%",
+		"block-size": "100%",
+		position: "relative",
+		"inset-block": "-100%",
 	},
 	...globals
 }) => {
 	return html`
-		<div style="inline-size: 100px; block-size: 100px;">
+		<div style=${styleMap(containerStyles)}>
 			<div
 				class=${classMap({
 					[rootClass]: true,
 					...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
 				})}
-				style=${styleMap(style)}
+				style=${styleMap(checkerBoardStyles)}
 			></div>
 			${when(hasColorOverlay, () => {
-				return html` <div
-					style="background-color:${overlayColor}; inline-size: 100%; block-size: 100%; position: relative; inset-block: -100%"
-				></div>`;
+				return html` <div style=${styleMap(colorStyles)}></div>`;
 			})}
 		</div>
 	`;

--- a/components/opacitycheckerboard/stories/template.js
+++ b/components/opacitycheckerboard/stories/template.js
@@ -1,23 +1,36 @@
 import { html } from "lit-html";
 import { classMap } from "lit-html/directives/class-map.js";
-import { ifDefined } from "lit-html/directives/if-defined.js";
+import { styleMap } from "lit-html/directives/style-map.js";
+import { when } from "lit-html/directives/when.js";
+
 import "../index.css";
 
 export const Template = ({
 	rootClass = "spectrum-OpacityCheckerboard",
-	size,
-	id,
+	hasColorOverlay,
+	overlayColor,
+	backgroundPosition,
 	customClasses = [],
+	style = {
+		"--mod-opacity-checkerboard-position": backgroundPosition,
+	},
 	...globals
 }) => {
 	return html`
+		<div class="${rootClass}-example">
 			<div
-				class="${classMap({
+				class=${classMap({
 					[rootClass]: true,
-					[`${rootClass}--size${size.toUpperCase()}`]: true,
-					...customClasses.reduce((a, c)({ ...a, [c]: true }), {}),
-				})} id=${ifDefined(id)}>
-				<!-- Component mark-up goes here -->
-			</div>
-			`;
+					...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
+				})}
+				style=${styleMap(style)}
+			></div>
+			${when(hasColorOverlay, () => {
+				return html` <div
+					class="${rootClass}-example-color"
+					style="background-color:${overlayColor}"
+				></div>`;
+			})}
+		</div>
+	`;
 };

--- a/components/opacitycheckerboard/themes/express.css
+++ b/components/opacitycheckerboard/themes/express.css
@@ -1,0 +1,10 @@
+/*! Copyright 2023 Adobe. All rights reserved. This file is licensed to you
+under the Apache License, Version 2.0 (the "License"); you may not use this file
+except in compliance with the License. You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or
+agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, either
+express or implied. See the License for the specific language governing
+permissions and limitations under the License. */
+@container (--system: express) {
+}

--- a/components/opacitycheckerboard/themes/spectrum.css
+++ b/components/opacitycheckerboard/themes/spectrum.css
@@ -1,0 +1,10 @@
+/*! Copyright 2023 Adobe. All rights reserved. This file is licensed to you
+under the Apache License, Version 2.0 (the "License"); you may not use this file
+except in compliance with the License. You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or
+agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, either
+express or implied. See the License for the specific language governing
+permissions and limitations under the License. */
+@container (--system: spectrum) {
+}

--- a/components/swatch/index.css
+++ b/components/swatch/index.css
@@ -93,9 +93,10 @@ governing permissions and limitations under the License.
 }
 
 /* Swatch styles */
+/* stylelint-disable max-nesting-depth */
 .spectrum-Swatch {
-  width: var(--mod-swatch-size, var(--spectrum-swatch-size));
-  height: var(--mod-swatch-size, var(--spectrum-swatch-size));
+	inline-size: var(--mod-swatch-size, var(--spectrum-swatch-size));
+	block-size: var(--mod-swatch-size, var(--spectrum-swatch-size));
 
   display: flex;
   align-items: center;
@@ -109,15 +110,24 @@ governing permissions and limitations under the License.
   /* don't let double clicking select stuff */
   user-select: none;
 
- .spectrum-Swatch-disabledIcon {
-    width: var(--mod-swatch-disabled-icon-size, var(--spectrum-swatch-disabled-icon-size));
-    height: var(--mod-swatch-disabled-icon-size, var(--spectrum-swatch-disabled-icon-size));
-  }
+	.spectrum-Swatch-disabledIcon {
+		inline-size: var(
+			--mod-swatch-disabled-icon-size,
+			var(--spectrum-swatch-disabled-icon-size)
+		);
+		block-size: var(
+			--mod-swatch-disabled-icon-size,
+			var(--spectrum-swatch-disabled-icon-size)
+		);
+	}
 
-  &,
-  &:before {
-    border-radius: var(--mod-swatch-border-radius, var(--spectrum-swatch-border-radius));
-  }
+	&,
+	&::before {
+		border-radius: var(
+			--mod-swatch-border-radius,
+			var(--spectrum-swatch-border-radius)
+		);
+	}
 
   &.is-selected {
     background-color: var(--highcontrast-swatch-background-color-selected, var(--mod-swatch-inner-border-color-selected, var(--spectrum-swatch-inner-border-color-selected)));
@@ -135,16 +145,16 @@ governing permissions and limitations under the License.
       /* no border radius when selected */
       border-radius: 0;
 
-      &:before {
-        border-radius: 0;
-        box-shadow: none;
-      }
-    }
+			&::before {
+				border-radius: 0;
+				box-shadow: none;
+			}
+		}
 
-    &:before {
-      opacity: 1;
-    }
-  }
+		&::before {
+			opacity: 1;
+		}
+	}
 
   /* Swatch fill: Image, Gradient, SVG */
   &.is-image {
@@ -174,24 +184,33 @@ governing permissions and limitations under the License.
       background-color: var(--spectrum-picked-color, transparent);
       background-image: none;
 
-      &:after {
-        height: var(--mod-swatch-slash-thickness, var(--spectrum-swatch-slash-thickness));
-        content: '';
-        position: absolute;
-        transform: rotate(-45deg);
-        width: 200%; /* just needs to be bigger than a swatch */
-        background: var(--highcontrast-swatch-fill-foreground-color, var(--mod-swatch-slash-icon-color, var(--spectrum-swatch-slash-icon-color)));
-      }
-    }
+			&::after {
+				inline-size: var(
+					--mod-swatch-slash-thickness,
+					var(--spectrum-swatch-slash-thickness)
+				);
+				content: "";
+				position: absolute;
+				transform: rotate(-45deg);
+				block-size: 200%; /* just needs to be bigger than a swatch */
+				background: var(
+					--highcontrast-swatch-fill-foreground-color,
+					var(
+						--mod-swatch-slash-icon-color,
+						var(--spectrum-swatch-slash-icon-color)
+					)
+				);
+			}
+		}
 
-    &.spectrum-Swatch--rectangle {
-      .spectrum-Swatch-fill {
-        &:after {
-          transform: rotate(-25deg);
-        }
-      }
-    }
-  }
+		&.spectrum-Swatch--rectangle {
+			.spectrum-Swatch-fill {
+				&::after {
+					transform: rotate(-25deg);
+				}
+			}
+		}
+	}
 
   &[disabled],
   &.is-disabled {
@@ -200,11 +219,11 @@ governing permissions and limitations under the License.
     }
   }
 
-  /* selection indicator */
-  &:before {
-    content: '';
-    position: absolute;
-    inset: 0;
+	/* selection indicator */
+	&::before {
+		content: "";
+		position: absolute;
+		inset: 0;
 
     border-width: var(--mod-swatch-border-thickness-selected, var(--spectrum-swatch-border-thickness-selected));
     border-style: solid;
@@ -215,11 +234,13 @@ governing permissions and limitations under the License.
     pointer-events: none;
   }
 
-  /* focus-ring */
-  &:after {
-    content: '';
-    position: absolute;
-    inset: calc(-2 * var(--mod-swatch-focus-indicator-gap, var(--spectrum-swatch-focus-indicator-gap)));
+	/* focus-ring */
+	&::after {
+		content: "";
+		position: absolute;
+		inset: calc(
+			-2 * var(--mod-swatch-focus-indicator-gap, var(--spectrum-swatch-focus-indicator-gap))
+		);
 
     opacity: 0;
 
@@ -231,21 +252,22 @@ governing permissions and limitations under the License.
     transition: opacity var(--mod-animation-duration-100, var(--spectrum-animation-duration-100)) ease-in-out;
   }
 
-  &:focus-visible {
-    &:after {
-      opacity: 1;
-    }
-  }
+	&:focus-visible {
+		&::after {
+			opacity: 1;
+		}
+	}
 }
+/* stylelint-enable max-nesting-depth */
 
 .spectrum-Swatch-fill {
   display: flex;
   align-items: center;
   justify-content: center;
 
-  width: 100%;
-  height: 100%;
-  box-sizing: border-box;
+	inline-size: 100%;
+	block-size: 100%;
+	box-sizing: border-box;
 
   position: relative;
 
@@ -253,22 +275,12 @@ governing permissions and limitations under the License.
 
   border-radius: var(--mod-swatch-border-radius, var(--spectrum-swatch-border-radius));
 
-
-  /* Checkerboard fill */
-  --spectrum-swatch-checkerboard-size: var(--spectrum-opacity-checkerboard-square-size);
-  --spectrum-swatch-checkerboard-dark-color: var(--spectrum-opacity-checkerboard-square-dark);
-  --spectrum-swatch-checkerboard-light-color: var(--spectrum-opacity-checkerboard-square-light);
-
-  background:
-    repeating-conic-gradient(var(--spectrum-swatch-checkerboard-light-color) 0% 25%, var(--spectrum-swatch-checkerboard-dark-color) 0% 50%)
-    left top / calc(var(--spectrum-swatch-checkerboard-size) * 2 ) calc(var(--spectrum-swatch-checkerboard-size) * 2 );
-
-  /* Swatch fill: Default */
-  &:before {
-    content: '';
-    position: absolute;
-    inset: 0;
-    z-index: 0;
+	/* Swatch fill: Default */
+	&::before {
+		content: "";
+		position: absolute;
+		inset: 0;
+		z-index: 0;
 
     /* Undefined variable allows custom stylesheet or JS to pass the value to this element */
     background-color: var(--spectrum-picked-color, transparent);
@@ -281,13 +293,13 @@ governing permissions and limitations under the License.
 
 /* Variant: No border */
 .spectrum-Swatch--noBorder {
-  .spectrum-Swatch-fill {
-    &:before {
-      box-shadow: none;
-      /* Undefined variable allows custom stylesheet or JS to pass the value to this element */
-      background-color: var(--spectrum-picked-color, transparent);
-    }
-  }
+	.spectrum-Swatch-fill {
+		&::before {
+			box-shadow: none;
+			/* Undefined variable allows custom stylesheet or JS to pass the value to this element */
+			background-color: var(--spectrum-picked-color, transparent);
+		}
+	}
 }
 
 .spectrum-Swatch-mixedValueIcon {
@@ -319,34 +331,34 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Swatch--rectangle {
-  width: calc(var(--mod-swatch-size, var(--spectrum-swatch-size)) * 2);
+	inline-size: calc(var(--mod-swatch-size, var(--spectrum-swatch-size)) * 2);
 }
 
 /* Variant: Rounding - None */
 .spectrum-Swatch--roundingNone {
-  &,
-  &:before,
-  &:after,
-  .spectrum-Swatch-fill,
-  .spectrum-Swatch-fill:before,
-  &.is-selected .spectrum-Swatch-fill,
-  &.is-selected .spectrum-Swatch-fill:before {
-    border-radius: 0;
-  }
+	&,
+	&::before,
+	&::after,
+	.spectrum-Swatch-fill,
+	.spectrum-Swatch-fill::before,
+	&.is-selected .spectrum-Swatch-fill,
+	&.is-selected .spectrum-Swatch-fill::before {
+		border-radius: 0;
+	}
 }
 
 /* Variant: Rounding - Full */
 .spectrum-Swatch--roundingFull {
-  &:not(.spectrum-Swatch--rectangle) {
-    &,
-    &:before,
-    &:after,
-    .spectrum-Swatch-fill,
-    .spectrum-Swatch-fill:before,
-    &.is-selected .spectrum-Swatch-fill,
-    &.is-selected .spectrum-Swatch-fill:before {
-      border-radius: 100%;
-    }
+	&:not(.spectrum-Swatch--rectangle) {
+		&,
+		&::before,
+		&::after,
+		.spectrum-Swatch-fill,
+		.spectrum-Swatch-fill::before,
+		&.is-selected .spectrum-Swatch-fill,
+		&.is-selected .spectrum-Swatch-fill::before {
+			border-radius: 100%;
+		}
 
     &.is-selected .spectrum-Swatch-fill {
       clip-path: circle(calc(50% - (var(--mod-swatch-border-thickness-selected, var(--spectrum-swatch-border-thickness-selected)) * 2)) at 50% 50%);
@@ -357,8 +369,8 @@ governing permissions and limitations under the License.
 .spectrum-Swatch-image {
   object-fit: contain;
 
-  width: 100%;
-  height: 100%;
+	inline-size: 100%;
+	block-size: 100%;
 
   transition: width var(--mod-animation-duration-100, var(--spectrum-animation-duration-100)) ease-in-out,
               height var(--mod-animation-duration-100, var(--spectrum-animation-duration-100)) ease-in-out;

--- a/components/swatch/metadata/swatch.yml
+++ b/components/swatch/metadata/swatch.yml
@@ -20,7 +20,7 @@ examples:
               <div class="spectrum-Swatch-fill"></div>
             </div>
             <div class="spectrum-Swatch spectrum-Swatch--sizeXS" style="--spectrum-picked-color: rgba(174, 216, 230, 0.3)" tabindex="0">
-              <div class="spectrum-Swatch-fill spectrum-OpacityCheckerboard">
+              <div class="spectrum-OpacityCheckerboard spectrum-Swatch-fill">
               </div>
             </div>
           </div>
@@ -33,7 +33,7 @@ examples:
               <div class="spectrum-Swatch-fill"></div>
             </div>
             <div class="spectrum-Swatch spectrum-Swatch--sizeS" style="--spectrum-picked-color: rgba(174, 216, 230, 0.3)" tabindex="0">
-              <div class="spectrum-Swatch-fill spectrum-OpacityCheckerboard">
+              <div class="spectrum-OpacityCheckerboard spectrum-Swatch-fill">
               </div>
             </div>
           </div>
@@ -46,7 +46,7 @@ examples:
               <div class="spectrum-Swatch-fill"></div>
             </div>
             <div class="spectrum-Swatch spectrum-Swatch--sizeM" style="--spectrum-picked-color: rgba(174, 216, 230, 0.3)" tabindex="0">
-              <div class="spectrum-Swatch-fill spectrum-OpacityCheckerboard">
+              <div class="spectrum-OpacityCheckerboard spectrum-Swatch-fill">
               </div>
             </div>
           </div>
@@ -60,7 +60,7 @@ examples:
               <div class="spectrum-Swatch-fill"></div>
             </div>
             <div class="spectrum-Swatch spectrum-Swatch--sizeL" style="--spectrum-picked-color: rgba(174, 216, 230, 0.3)" tabindex="0">
-              <div class="spectrum-Swatch-fill spectrum-OpacityCheckerboard">
+              <div class="spectrum-OpacityCheckerboard spectrum-Swatch-fill">
               </div>
             </div>
           </div>
@@ -71,21 +71,21 @@ examples:
     name: Rounding - None
     markup: |
       <div class="spectrum-Swatch spectrum-Swatch--sizeM spectrum-Swatch--roundingNone" style="--spectrum-picked-color: rgba(174, 216, 230, 0.25)" tabindex="0">
-        <div class="spectrum-Swatch-fill spectrum-OpacityCheckerboard">
+        <div class="spectrum-OpacityCheckerboard spectrum-Swatch-fill">
         </div>
       </div>
   - id: swatch-roundingfull
     name: Rounding - Full
     markup: |
       <div class="spectrum-Swatch spectrum-Swatch--sizeM spectrum-Swatch--roundingFull" style="--spectrum-picked-color: rgba(174, 216, 230, 0.25)" tabindex="0">
-        <div class="spectrum-Swatch-fill spectrum-OpacityCheckerboard">
+        <div class="spectrum-OpacityCheckerboard spectrum-Swatch-fill>
         </div>
       </div>
   - id: swatch-lightborder
     name: Light border
     markup: |
       <div class="spectrum-Swatch spectrum-Swatch--sizeM spectrum-Swatch--lightBorder" style="--spectrum-picked-color: rgba(174, 216, 230, 0.25)" tabindex="0">
-        <div class="spectrum-Swatch-fill spectrum-OpacityCheckerboard">
+        <div class=" spectrum-OpacityCheckerboard spectrum-Swatch-fill">
         </div>
       </div>
   - id: swatch-noborder
@@ -99,7 +99,7 @@ examples:
     name: Shape - Rectangle
     markup: |
       <div class="spectrum-Swatch spectrum-Swatch--sizeM spectrum-Swatch--rectangle" style="--spectrum-picked-color: rgba(174, 216, 230, 0.25)" tabindex="0">
-        <div class="spectrum-Swatch-fill spectrum-OpacityCheckerboard">
+        <div class=" spectrum-OpacityCheckerboard spectrum-Swatch-fill">
         </div>
       </div>
   - id: swatch-image
@@ -114,7 +114,7 @@ examples:
     name: Gradient
     markup: |
       <div class="spectrum-Swatch spectrum-Swatch--sizeM is-image" tabindex="0">
-        <div class="spectrum-Swatch-fill spectrum-OpacityCheckerboard">
+        <div class=" spectrum-OpacityCheckerboard spectrum-Swatch-fill">
           <div class="spectrum-Swatch-image" style="background: linear-gradient(to right, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, 0) 100%);"></div>
         </div>
       </div>

--- a/components/swatch/metadata/swatch.yml
+++ b/components/swatch/metadata/swatch.yml
@@ -20,7 +20,8 @@ examples:
               <div class="spectrum-Swatch-fill"></div>
             </div>
             <div class="spectrum-Swatch spectrum-Swatch--sizeXS" style="--spectrum-picked-color: rgba(174, 216, 230, 0.3)" tabindex="0">
-              <div class="spectrum-Swatch-fill"></div>
+              <div class="spectrum-Swatch-fill spectrum-OpacityCheckerboard">
+              </div>
             </div>
           </div>
         </div>
@@ -32,7 +33,8 @@ examples:
               <div class="spectrum-Swatch-fill"></div>
             </div>
             <div class="spectrum-Swatch spectrum-Swatch--sizeS" style="--spectrum-picked-color: rgba(174, 216, 230, 0.3)" tabindex="0">
-              <div class="spectrum-Swatch-fill"></div>
+              <div class="spectrum-Swatch-fill spectrum-OpacityCheckerboard">
+              </div>
             </div>
           </div>
         </div>
@@ -44,7 +46,8 @@ examples:
               <div class="spectrum-Swatch-fill"></div>
             </div>
             <div class="spectrum-Swatch spectrum-Swatch--sizeM" style="--spectrum-picked-color: rgba(174, 216, 230, 0.3)" tabindex="0">
-              <div class="spectrum-Swatch-fill"></div>
+              <div class="spectrum-Swatch-fill spectrum-OpacityCheckerboard">
+              </div>
             </div>
           </div>
         </div>
@@ -57,7 +60,8 @@ examples:
               <div class="spectrum-Swatch-fill"></div>
             </div>
             <div class="spectrum-Swatch spectrum-Swatch--sizeL" style="--spectrum-picked-color: rgba(174, 216, 230, 0.3)" tabindex="0">
-              <div class="spectrum-Swatch-fill"></div>
+              <div class="spectrum-Swatch-fill spectrum-OpacityCheckerboard">
+              </div>
             </div>
           </div>
         </div>
@@ -67,21 +71,21 @@ examples:
     name: Rounding - None
     markup: |
       <div class="spectrum-Swatch spectrum-Swatch--sizeM spectrum-Swatch--roundingNone" style="--spectrum-picked-color: rgba(174, 216, 230, 0.25)" tabindex="0">
-        <div class="spectrum-Swatch-fill">
+        <div class="spectrum-Swatch-fill spectrum-OpacityCheckerboard">
         </div>
       </div>
   - id: swatch-roundingfull
     name: Rounding - Full
     markup: |
       <div class="spectrum-Swatch spectrum-Swatch--sizeM spectrum-Swatch--roundingFull" style="--spectrum-picked-color: rgba(174, 216, 230, 0.25)" tabindex="0">
-        <div class="spectrum-Swatch-fill">
+        <div class="spectrum-Swatch-fill spectrum-OpacityCheckerboard">
         </div>
       </div>
   - id: swatch-lightborder
     name: Light border
     markup: |
       <div class="spectrum-Swatch spectrum-Swatch--sizeM spectrum-Swatch--lightBorder" style="--spectrum-picked-color: rgba(174, 216, 230, 0.25)" tabindex="0">
-        <div class="spectrum-Swatch-fill">
+        <div class="spectrum-Swatch-fill spectrum-OpacityCheckerboard">
         </div>
       </div>
   - id: swatch-noborder
@@ -95,7 +99,7 @@ examples:
     name: Shape - Rectangle
     markup: |
       <div class="spectrum-Swatch spectrum-Swatch--sizeM spectrum-Swatch--rectangle" style="--spectrum-picked-color: rgba(174, 216, 230, 0.25)" tabindex="0">
-        <div class="spectrum-Swatch-fill">
+        <div class="spectrum-Swatch-fill spectrum-OpacityCheckerboard">
         </div>
       </div>
   - id: swatch-image
@@ -110,7 +114,7 @@ examples:
     name: Gradient
     markup: |
       <div class="spectrum-Swatch spectrum-Swatch--sizeM is-image" tabindex="0">
-        <div class="spectrum-Swatch-fill">
+        <div class="spectrum-Swatch-fill spectrum-OpacityCheckerboard">
           <div class="spectrum-Swatch-image" style="background: linear-gradient(to right, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, 0) 100%);"></div>
         </div>
       </div>

--- a/components/swatch/package.json
+++ b/components/swatch/package.json
@@ -18,10 +18,12 @@
     "build": "gulp"
   },
   "peerDependencies": {
+    "@spectrum-css/opacitycheckerboard": ">=1.0.0-alpha.0",
     "@spectrum-css/tokens": ">=10.0.0"
   },
   "devDependencies": {
     "@spectrum-css/component-builder-simple": "^2.0.15",
+    "@spectrum-css/opacitycheckerboard": ">=1.0.0-alpha.0",
     "@spectrum-css/tokens": "^11.0.1",
     "gulp": "^4.0.0"
   },

--- a/components/thumbnail/index.css
+++ b/components/thumbnail/index.css
@@ -17,11 +17,9 @@ governing permissions and limitations under the License.
 	--spectrum-thumbnail-border-width: var(--spectrum-border-width-100);
 	/* @todo Refactor with --spectrum-thumbnail-border-color once gray rgb token is no longer necessary to workaround nested rgb color token value using rgba(). */
 	--spectrum-thumbnail-border-color-rgba: rgba(
-		34,
-		34,
-		34,
-		0.1
-	); /* Why is this not working?? rgba(var(--spectrum-gray-800-rgb), var(--spectrum-thumbnail-border-color-opacity)); */
+		var(--spectrum-gray-800-rgb),
+		var(--spectrum-thumbnail-border-color-opacity)
+	);
 	--spectrum-thumbnail-layer-border-width-inner: var(
 		--spectrum-border-width-400
 	);
@@ -115,12 +113,15 @@ governing permissions and limitations under the License.
     box-shadow: inset 0 0 0 var(--mod-thumbnail-border-width, var(--spectrum-thumbnail-border-width)) var(--highcontrast-thumbnail-border-color, var(--mod-thumbnail-border-color, var(--spectrum-thumbnail-border-color-rgba)));
   }
 
-  &.is-disabled {
-    opacity: var(--mod-thumbnail-color-opacity-disabled, var(--spectrum-thumbnail-color-opacity-disabled));
-  }
-
+	&.is-disabled {
+		opacity: var(
+			--mod-thumbnail-color-opacity-disabled,
+			var(--spectrum-thumbnail-color-opacity-disabled)
+		);
+	}
+	/* stylelint-disable selector-pseudo-class-no-unknown */
 	&.is-focused,
-	&.focus-ring {
+	&:focus-ring {
 		overflow: visible;
 		&::after {
 			content: "";
@@ -198,6 +199,7 @@ governing permissions and limitations under the License.
 			);
 		}
 	}
+	/* stylelint-enable selector-pseudo-class-no-unknown */
 
   /* Friends should align to the top of the tabs */
   vertical-align: top;

--- a/components/thumbnail/index.css
+++ b/components/thumbnail/index.css
@@ -17,14 +17,19 @@ governing permissions and limitations under the License.
 	--spectrum-thumbnail-border-width: var(--spectrum-border-width-100);
 	/* @todo Refactor with --spectrum-thumbnail-border-color once gray rgb token is no longer necessary to workaround nested rgb color token value using rgba(). */
 	--spectrum-thumbnail-border-color-rgba: rgba(
-		var(--spectrum-gray-800-rgb),
-		var(--spectrum-thumbnail-border-opacity)
+		34,
+		34,
+		34,
+		0.1
+	); /* Why is this not working?? rgba(var(--spectrum-gray-800-rgb), var(--spectrum-thumbnail-border-color-opacity)); */
+	--spectrum-thumbnail-layer-border-width-inner: var(
+		--spectrum-border-width-400
 	);
-
-  --spectrum-thumbnail-layer-border-width-inner: var(--spectrum-border-width-400);
-  --spectrum-thumbnail-layer-border-color-inner: var(--spectrum-white);
-  --spectrum-thumbnail-layer-border-width-outer: var(--spectrum-border-width-100);
-  --spectrum-thumbnail-layer-border-color-outer: var(--spectrum-gray-500);
+	--spectrum-thumbnail-layer-border-color-inner: var(--spectrum-white);
+	--spectrum-thumbnail-layer-border-width-outer: var(
+		--spectrum-border-width-100
+	);
+	--spectrum-thumbnail-layer-border-color-outer: var(--spectrum-gray-500);
 
   --spectrum-thumbnail-border-width-selected: var(--spectrum-border-width-200);
   --spectrum-thumbnail-border-color-selected: var(--spectrum-accent-color-800);
@@ -33,11 +38,9 @@ governing permissions and limitations under the License.
   --spectrum-thumbnail-focus-indicator-gap: var(--spectrum-focus-indicator-gap);
   --spectrum-thumbnail-focus-indicator-color: var(--spectrum-focus-indicator-color);
 
-  --spectrum-thumbnail-color-opacity-disabled: var(--spectrum-thumbnail-opacity-disabled);
-
-  --spectrum-thumbnail-checkerboard-size: var(--spectrum-opacity-checkerboard-square-size);
-  --spectrum-thumbnail-checkerboard-dark-color: var(--spectrum-opacity-checkerboard-square-dark);
-  --spectrum-thumbnail-checkerboard-light-color: var(--spectrum-opacity-checkerboard-square-light);
+	--spectrum-thumbnail-color-opacity-disabled: var(
+		--spectrum-thumbnail-opacity-disabled
+	);
 }
 
 .spectrum-Thumbnail--size50 {
@@ -97,10 +100,10 @@ governing permissions and limitations under the License.
   inline-size: var(--mod-thumbnail-size, var(--spectrum-thumbnail-size));
   block-size: var(--mod-thumbnail-size, var(--spectrum-thumbnail-size));
 
-  border-radius: var(--mod-thumbnail-border-radius, var(--spectrum-thumbnail-border-radius));
-  background:
-    repeating-conic-gradient(var(--mod-thumbnail-checkerboard-light-color, var(--spectrum-thumbnail-checkerboard-light-color)) 0% 25%, var(--mod-thumbnail-checkerboard-dark-color, var(--spectrum-thumbnail-checkerboard-dark-color)) 0% 50%)
-    left top / calc(var(--mod-thumbnail-checkerboard-size, var(--spectrum-thumbnail-checkerboard-size)) * 2) calc(var(--mod-thumbnail-checkerboard-size, var(--spectrum-thumbnail-checkerboard-size)) * 2);
+	border-radius: var(
+		--mod-thumbnail-border-radius,
+		var(--spectrum-thumbnail-border-radius)
+	);
 
   &::before {
     content: '';
@@ -117,7 +120,7 @@ governing permissions and limitations under the License.
   }
 
 	&.is-focused,
-	&:focus-ring {
+	&.focus-ring {
 		overflow: visible;
 		&::after {
 			content: "";
@@ -214,6 +217,7 @@ governing permissions and limitations under the License.
     content: none;
   }
 
+	/* stylelint-disable declaration-block-no-redundant-longhand-properties */
 	&.is-selected {
 		outline-style: solid;
 		outline-color: var(
@@ -283,6 +287,7 @@ governing permissions and limitations under the License.
 			)
 	);
 }
+/* stylelint-enable declaration-block-no-redundant-longhand-properties */
 
 .spectrum-Thumbnail-image-wrapper {
   display: flex;
@@ -323,6 +328,7 @@ governing permissions and limitations under the License.
 }
 
 /* Windows High Contrast Mode */
+/* stylelint-disable declaration-property-value-no-unknown */
 @media (forced-colors: active) {
   .spectrum-Thumbnail {
     /* Allow checkerboard pattern to be visible. */
@@ -335,3 +341,4 @@ governing permissions and limitations under the License.
 		color: CanvasText;
 	}
 }
+/* stylelint-enable declaration-property-value-no-unknown */

--- a/components/thumbnail/metadata/mods.md
+++ b/components/thumbnail/metadata/mods.md
@@ -5,9 +5,6 @@
 | `--mod-thumbnail-border-radius`             |
 | `--mod-thumbnail-border-width`              |
 | `--mod-thumbnail-border-width-selected`     |
-| `--mod-thumbnail-checkerboard-dark-color`   |
-| `--mod-thumbnail-checkerboard-light-color`  |
-| `--mod-thumbnail-checkerboard-size`         |
 | `--mod-thumbnail-color-opacity-disabled`    |
 | `--mod-thumbnail-focus-indicator-color`     |
 | `--mod-thumbnail-focus-indicator-gap`       |

--- a/components/thumbnail/metadata/thumbnail.yml
+++ b/components/thumbnail/metadata/thumbnail.yml
@@ -15,7 +15,7 @@ examples:
   - id: thumbnail-image
     name: Thumbnail
     markup: |
-      <div class="spectrum-Thumbnail spectrum-Thumbnail--size700">
+      <div class="spectrum-Thumbnail spectrum-Thumbnail--size700 spectrum-OpacityCheckerboard">
         <div class="spectrum-Thumbnail-image-wrapper">
           <img class="spectrum-Thumbnail-image"src="img/example-ava.jpg" alt="women resting head in hands">
         </div>
@@ -23,7 +23,7 @@ examples:
   - id: thumbnail-focus
     name: Thumbnail (focused)
     markup: |
-      <div class="spectrum-Thumbnail spectrum-Thumbnail--size700 is-focused">
+      <div class="spectrum-Thumbnail spectrum-Thumbnail--size700 spectrum-OpacityCheckerboard is-focused">
         <div class="spectrum-Thumbnail-image-wrapper">
           <img class="spectrum-Thumbnail-image" src="img/example-ava.jpg" alt="Woman crouching">
         </div>
@@ -32,7 +32,7 @@ examples:
     name: Thumbnail (disabled)
     description: Thumbnail should only be displayed as disabled if the entire componet is also disabled.
     markup: |
-      <div class="spectrum-Thumbnail spectrum-Thumbnail--size700 is-disabled">
+      <div class="spectrum-Thumbnail spectrum-Thumbnail--size700 spectrum-OpacityCheckerboard is-disabled">
         <div class="spectrum-Thumbnail-image-wrapper">
           <img class="spectrum-Thumbnail-image" src="img/thumbnail.png" alt="Woman crouching">
         </div>
@@ -41,7 +41,7 @@ examples:
     name: Thumbnail (landscape image)
     description: Landscape images will fill horizontally and have space above and below.
     markup: |
-      <div class="spectrum-Thumbnail spectrum-Thumbnail--size700">
+      <div class="spectrum-Thumbnail spectrum-Thumbnail--size700 spectrum-OpacityCheckerboard">
         <div class="spectrum-Thumbnail-image-wrapper">
           <img class="spectrum-Thumbnail-image" src="img/example-card-landscape.jpeg" alt="Landscape with mountains and lake">
         </div>
@@ -50,7 +50,7 @@ examples:
     name: Thumbnail (portrait image)
     description: Portrait images will fill vertically and have space on either side.
     markup: |
-      <div class="spectrum-Thumbnail spectrum-Thumbnail--size700">
+      <div class="spectrum-Thumbnail spectrum-Thumbnail--size700 spectrum-OpacityCheckerboard">
         <div class="spectrum-Thumbnail-image-wrapper">
           <img class="spectrum-Thumbnail-image" src="img/example-card-portrait.jpg" alt="Eiffel Tower at night">
         </div>
@@ -59,7 +59,7 @@ examples:
     name: Thumbnail (layer)
     description: When used in layer management (such as the Compact or Detail Layers panels)
     markup: |
-      <div class="spectrum-Thumbnail spectrum-Thumbnail-layer spectrum-Thumbnail--size700">
+      <div class="spectrum-Thumbnail spectrum-Thumbnail-layer spectrum-Thumbnail--size700 spectrum-OpacityCheckerboard">
         <div class="spectrum-Thumbnail-layer-inner">
           <img class="spectrum-Thumbnail-image" src="img/example-ava.jpg" alt="women resting head in hands"></div>
       </div>
@@ -67,7 +67,7 @@ examples:
     name: Thumbnail (layer, selected)
     description: The thumbnail is given a thick blue border to indicate its selection when used in layer management.
     markup: |
-      <div class="spectrum-Thumbnail spectrum-Thumbnail-layer spectrum-Thumbnail--size700 is-selected">
+      <div class="spectrum-Thumbnail spectrum-Thumbnail-layer spectrum-Thumbnail--size700 spectrum-OpacityCheckerboard is-selected">
         <div class="spectrum-Thumbnail-layer-inner">
           <img class="spectrum-Thumbnail-image" src="img/thumbnail.png" alt="Woman crouching">
         </div>
@@ -76,7 +76,7 @@ examples:
     name: Thumbnail Cover (landscape image)
     description: Images will maintain their aspect ratio while filling the entire content box.
     markup: |
-      <div class="spectrum-Thumbnail spectrum-Thumbnail--cover spectrum-Thumbnail--size700">
+      <div class="spectrum-Thumbnail spectrum-Thumbnail--cover spectrum-Thumbnail--size700 spectrum-OpacityCheckerboard">
         <div class="spectrum-Thumbnail-image-wrapper">
           <img class="spectrum-Thumbnail-image" src="img/example-card-landscape.jpeg" alt="Landscape with mountains and lake">
         </div>
@@ -85,7 +85,7 @@ examples:
     name: Thumbnail (image against background)
     description: Thumbnail supports transparent images with a background (color or image) behind it.
     markup: |
-      <div class="spectrum-Thumbnail spectrum-Thumbnail--size700">
+      <div class="spectrum-Thumbnail spectrum-Thumbnail--size700 spectrum-OpacityCheckerboard">
         <div class="spectrum-Thumbnail-background" style="background-color: orange"></div>
         <div class="spectrum-Thumbnail-image-wrapper">
           <img class="spectrum-Thumbnail-image" src="img/thumbnail.png" alt="Woman crouching">
@@ -98,7 +98,7 @@ examples:
       <div class="spectrum-Examples spectrum-Examples--vertical">
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">50</h4>
-          <div class="spectrum-Thumbnail spectrum-Thumbnail--size50">
+          <div class="spectrum-Thumbnail spectrum-Thumbnail--size50 spectrum-OpacityCheckerboard">
             <div class="spectrum-Thumbnail-image-wrapper">
               <img class="spectrum-Thumbnail-image" src="img/thumbnail.png" alt="Woman crouching">
             </div>
@@ -107,7 +107,7 @@ examples:
 
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">75</h4>
-          <div class="spectrum-Thumbnail spectrum-Thumbnail--size75">
+          <div class="spectrum-Thumbnail spectrum-Thumbnail--size75 spectrum-OpacityCheckerboard">
             <div class="spectrum-Thumbnail-image-wrapper">
               <img class="spectrum-Thumbnail-image" src="img/thumbnail.png" alt="Woman crouching">
             </div>
@@ -116,7 +116,7 @@ examples:
 
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">100</h4>
-          <div class="spectrum-Thumbnail spectrum-Thumbnail--size100">
+          <div class="spectrum-Thumbnail spectrum-Thumbnail--size100 spectrum-OpacityCheckerboard">
             <div class="spectrum-Thumbnail-image-wrapper">
               <img class="spectrum-Thumbnail-image" src="img/thumbnail.png" alt="Woman crouching">
             </div>
@@ -125,7 +125,7 @@ examples:
 
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">200</h4>
-          <div class="spectrum-Thumbnail spectrum-Thumbnail--size200">
+          <div class="spectrum-Thumbnail spectrum-Thumbnail--size200 spectrum-OpacityCheckerboard">
             <div class="spectrum-Thumbnail-image-wrapper">
               <img class="spectrum-Thumbnail-image" src="img/thumbnail.png" alt="Woman crouching">
             </div>
@@ -134,7 +134,7 @@ examples:
 
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">300</h4>
-          <div class="spectrum-Thumbnail spectrum-Thumbnail--size300">
+          <div class="spectrum-Thumbnail spectrum-Thumbnail--size300 spectrum-OpacityCheckerboard">
             <div class="spectrum-Thumbnail-image-wrapper">
               <img class="spectrum-Thumbnail-image" src="img/thumbnail.png" alt="Woman crouching">
             </div>
@@ -143,7 +143,7 @@ examples:
 
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">400</h4>
-          <div class="spectrum-Thumbnail spectrum-Thumbnail--size400">
+          <div class="spectrum-Thumbnail spectrum-Thumbnail--size400 spectrum-OpacityCheckerboard">
             <div class="spectrum-Thumbnail-image-wrapper">
               <img class="spectrum-Thumbnail-image" src="img/thumbnail.png" alt="Woman crouching">
             </div>
@@ -152,7 +152,7 @@ examples:
 
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">500</h4>
-          <div class="spectrum-Thumbnail spectrum-Thumbnail--size500">
+          <div class="spectrum-Thumbnail spectrum-Thumbnail--size500 spectrum-OpacityCheckerboard">
             <div class="spectrum-Thumbnail-image-wrapper">
               <img class="spectrum-Thumbnail-image" src="img/thumbnail.png" alt="Woman crouching">
             </div>
@@ -161,7 +161,7 @@ examples:
 
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">600</h4>
-          <div class="spectrum-Thumbnail spectrum-Thumbnail--size600">
+          <div class="spectrum-Thumbnail spectrum-Thumbnail--size600 spectrum-OpacityCheckerboard">
             <div class="spectrum-Thumbnail-image-wrapper">
               <img class="spectrum-Thumbnail-image" src="img/thumbnail.png" alt="Woman crouching">
             </div>
@@ -170,7 +170,7 @@ examples:
 
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">700</h4>
-          <div class="spectrum-Thumbnail spectrum-Thumbnail--size700">
+          <div class="spectrum-Thumbnail spectrum-Thumbnail--size700 spectrum-OpacityCheckerboard">
             <div class="spectrum-Thumbnail-image-wrapper">
               <img class="spectrum-Thumbnail-image" src="img/thumbnail.png" alt="Woman crouching">
             </div>
@@ -179,7 +179,7 @@ examples:
 
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">800</h4>
-          <div class="spectrum-Thumbnail spectrum-Thumbnail--size800">
+          <div class="spectrum-Thumbnail spectrum-Thumbnail--size800 spectrum-OpacityCheckerboard">
             <div class="spectrum-Thumbnail-image-wrapper">
               <img class="spectrum-Thumbnail-image" src="img/thumbnail.png" alt="Woman crouching">
             </div>
@@ -188,7 +188,7 @@ examples:
 
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">900</h4>
-          <div class="spectrum-Thumbnail spectrum-Thumbnail--size900">
+          <div class="spectrum-Thumbnail spectrum-Thumbnail--size900 spectrum-OpacityCheckerboard">
             <div class="spectrum-Thumbnail-image-wrapper">
               <img class="spectrum-Thumbnail-image" src="img/thumbnail.png" alt="Woman crouching">
             </div>
@@ -197,7 +197,7 @@ examples:
 
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">1000</h4>
-          <div class="spectrum-Thumbnail spectrum-Thumbnail--size1000">
+          <div class="spectrum-Thumbnail spectrum-Thumbnail--size1000 spectrum-OpacityCheckerboard">
             <div class="spectrum-Thumbnail-image-wrapper">
               <img class="spectrum-Thumbnail-image" src="img/thumbnail.png" alt="Woman crouching">
             </div>

--- a/components/thumbnail/package.json
+++ b/components/thumbnail/package.json
@@ -18,10 +18,12 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/tokens": ">=10.0.0"
+    "@spectrum-css/opacitycheckerboard": ">=1.0.0-alpha.0",
+    "@spectrum-css/tokens": ">=11"
   },
   "devDependencies": {
     "@spectrum-css/component-builder-simple": "^2.0.15",
+    "@spectrum-css/opacitycheckerboard": ">=1.0.0-alpha.0",
     "@spectrum-css/tokens": "^11.0.1",
     "gulp": "^4.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2396,55 +2396,112 @@
   dependencies:
     nx "16.5.2"
 
+"@nrwl/tao@16.5.5":
+  version "16.5.5"
+  resolved "https://registry.yarnpkg.com/@nrwl/tao/-/tao-16.5.5.tgz#8279e0ebf1ccfb5bb615b9bb63000e36a7255725"
+  integrity sha512-6SYG3rlKkYvy/wauPwoUXQuN0PTJi95hCEC7lGfCEGye2Y/61UwJQf2xixMxafUM2X84WdEStEz3Jty85gVqkQ==
+  dependencies:
+    nx "16.5.5"
+
 "@nx/nx-darwin-arm64@16.5.2":
   version "16.5.2"
   resolved "https://registry.yarnpkg.com/@nx/nx-darwin-arm64/-/nx-darwin-arm64-16.5.2.tgz#0efcc62881eddd20e5bb8f881e6c8cc082c864f8"
   integrity sha512-myiNbDJLhhVHRLo6z3TeiaUeYTWdvBR3RdHQq4szTgb82Bnn8ruzteRGGJwKZd551YlttRcieBysxzUzHkmVBg==
+
+"@nx/nx-darwin-arm64@16.5.5":
+  version "16.5.5"
+  resolved "https://registry.yarnpkg.com/@nx/nx-darwin-arm64/-/nx-darwin-arm64-16.5.5.tgz#e8e9a0552954f8333912383da4dea99ba7fee8c3"
+  integrity sha512-Zzwy7pkSDFTiWcBk78qDe4VzygO9kemtz/kbbLvpisZkUlZX9nIQnLHT80Ms++iqA0enIQAwdTcJiaIHLVd5JQ==
 
 "@nx/nx-darwin-x64@16.5.2":
   version "16.5.2"
   resolved "https://registry.yarnpkg.com/@nx/nx-darwin-x64/-/nx-darwin-x64-16.5.2.tgz#6b03c1f4569411db7f8f90df90c820b083bde65f"
   integrity sha512-m354qmKrv7a5eD9Qv8bGEmrLCBEyCS6/y0PyOR32Dmi7qwlgHsQ4FfVkOnlWefC5ednhFLJQT6yxwhg8cFGDxw==
 
+"@nx/nx-darwin-x64@16.5.5":
+  version "16.5.5"
+  resolved "https://registry.yarnpkg.com/@nx/nx-darwin-x64/-/nx-darwin-x64-16.5.5.tgz#0c3c299228920f3f2dd6fd78d03cd301ba8401c5"
+  integrity sha512-d5O8BD5HFI2hJnMgVVV1pl2A+hlUmn4GxCZTmx2Tr329TYGdpvyXm8NnDFEAigZ77QVMHwFN6vqS07HARu+uVA==
+
 "@nx/nx-freebsd-x64@16.5.2":
   version "16.5.2"
   resolved "https://registry.yarnpkg.com/@nx/nx-freebsd-x64/-/nx-freebsd-x64-16.5.2.tgz#931e8be5c70d87b87f17d8faf0b9089383df0505"
   integrity sha512-qrR9yxcC2BLnw9JulecILmyp6Jco9unHHzQcfhLZTpw5c1PNHmZzHwJ3i3iNEf1o2kXEIa+SlOCis9ndvNQQVA==
+
+"@nx/nx-freebsd-x64@16.5.5":
+  version "16.5.5"
+  resolved "https://registry.yarnpkg.com/@nx/nx-freebsd-x64/-/nx-freebsd-x64-16.5.5.tgz#e30781a315ebea5b6aecb12f8c3c7685ddc55ab7"
+  integrity sha512-SqTvbz21iUc8DHKgisX9pPuXc7/DngbiZxInlEHPXi8zUtyUOqZI3yQk4NVj3dqLBMLwEOZDgvXs0XxzB5nn+g==
 
 "@nx/nx-linux-arm-gnueabihf@16.5.2":
   version "16.5.2"
   resolved "https://registry.yarnpkg.com/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-16.5.2.tgz#d9d865f99ba1128f6aa5b6bf0887bb743590eeb6"
   integrity sha512-+I1Oj54caDymMsQuRu/l4ULS4RVvwDUM1nXey5JhWulDOUF//09Ckz03Q9p0NCnvBvQd3SyE65++PMfZrrurbA==
 
+"@nx/nx-linux-arm-gnueabihf@16.5.5":
+  version "16.5.5"
+  resolved "https://registry.yarnpkg.com/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-16.5.5.tgz#9e10b77a9d91fa5b907186cd8881fc9f0fa2d81d"
+  integrity sha512-8C2KVFHqcyGViEgUicYo1frEgQARbD+CicIos6A5WRYLaxS+upb9FDblKU0eGYIwDp8oCagVjUjNX8d1WHLX7w==
+
 "@nx/nx-linux-arm64-gnu@16.5.2":
   version "16.5.2"
   resolved "https://registry.yarnpkg.com/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-16.5.2.tgz#c442df598108776cce297561555520ffbce251ea"
   integrity sha512-4Q4jpgtNBTb4lMegFKS9hkzS/WttH3MxkgM//8qs1zhgUz/AsuXTitBo71E3xCnQl/i38p0eIpiKXXwBJeHgDw==
+
+"@nx/nx-linux-arm64-gnu@16.5.5":
+  version "16.5.5"
+  resolved "https://registry.yarnpkg.com/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-16.5.5.tgz#867ca9057bfc5dabb1b684eceb62b1db318e8fcd"
+  integrity sha512-AGq4wp3Wn8bE0h2c7/bHj2wQWfp08DYJemwTNLkwLcoJWkUidLOBQePRvLxqPeo42Zmt3GYMi+fi5XtKCmvcjg==
 
 "@nx/nx-linux-arm64-musl@16.5.2":
   version "16.5.2"
   resolved "https://registry.yarnpkg.com/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-16.5.2.tgz#e07c0031f60372e726d2272fac5f3743c4d9591c"
   integrity sha512-VLukS/pfenr/Qw/EUn3GPAREDVXuSmfKeYBQKkALXEK6cRVQhXFXMLGHgMemCYbpoUJyFtFEO94PKV7VU7wZPg==
 
+"@nx/nx-linux-arm64-musl@16.5.5":
+  version "16.5.5"
+  resolved "https://registry.yarnpkg.com/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-16.5.5.tgz#d02403945cd9b21a11bf54671c42f68ca3feb51b"
+  integrity sha512-xPTYjDCPnXLPXZThAzugiithZaIHk42rTxussMZA00Cx0iEkh5zohqtC0vGBnaAPNcMv0uyCiWABhL4RRUVp2w==
+
 "@nx/nx-linux-x64-gnu@16.5.2":
   version "16.5.2"
   resolved "https://registry.yarnpkg.com/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-16.5.2.tgz#0748beae6944b42276f4705bc41b9e06cefb1d55"
   integrity sha512-TAGmY+MXbNl/aGg2KMvtg53rbmX0XHwnJRQtjhjqjAyvaOfFWI/WOqTU7xf/QCkXBUIK0D9xHWpALfA/fZFCBA==
+
+"@nx/nx-linux-x64-gnu@16.5.5":
+  version "16.5.5"
+  resolved "https://registry.yarnpkg.com/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-16.5.5.tgz#e54b44498212f363b8aeddd4313cb5d1fc840af2"
+  integrity sha512-Rq55OWD4SObfo4sWpjvaijWg33dm+cOf8e2cO06t2EmLMdOyyVnpNdtpjXh6A9tSi3EU5xPfYiy3I9O6gWOnuw==
 
 "@nx/nx-linux-x64-musl@16.5.2":
   version "16.5.2"
   resolved "https://registry.yarnpkg.com/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-16.5.2.tgz#7b150081e21ba7aa0da511f80aae1c5d230d1664"
   integrity sha512-YyWmqcNbZgU76+LThAt+0arx9C2ewfI5UUI6kooZRniAd408EA2xl5fx2AWLLrISGH4nTb5p20HGmeWfGqjHPA==
 
+"@nx/nx-linux-x64-musl@16.5.5":
+  version "16.5.5"
+  resolved "https://registry.yarnpkg.com/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-16.5.5.tgz#4f7d352e385ecd69f25d569547413f46408203a8"
+  integrity sha512-fnkSPv+VIKmQQOEQxFrGx5DlkHGxeH9Fzme6jwuDwmsvs+8Vv/uUnfcxkDZfJxKK+p27w37q3PQCfZGrFXE1cw==
+
 "@nx/nx-win32-arm64-msvc@16.5.2":
   version "16.5.2"
   resolved "https://registry.yarnpkg.com/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-16.5.2.tgz#f06f74b876c92d6b12cd351baff016b18bfd9a73"
   integrity sha512-pl7LluCc/57kl9VZ1ES27ym16ps4zgfCIeJiF8Ne8C6ALgt7C3PEG6417sFqbQw5J7NhsZ1aTb3eJ9fa9hurhA==
 
+"@nx/nx-win32-arm64-msvc@16.5.5":
+  version "16.5.5"
+  resolved "https://registry.yarnpkg.com/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-16.5.5.tgz#652da52a3eddb0c716ad0ccb1c288c7dca0ec425"
+  integrity sha512-9nWm+d+tlbxFMLvTLJqIfpTLDuSVDXfSBCSBampyeoI1mUALvq/6CVvWVBDlNqjmrZsYm0sudNqI4Ss7w3BUCQ==
+
 "@nx/nx-win32-x64-msvc@16.5.2":
   version "16.5.2"
   resolved "https://registry.yarnpkg.com/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-16.5.2.tgz#6ae96b6a90924daba81350863da4f9d12884fe8e"
   integrity sha512-bKSMElhzP37MkzWQ/Y12pQlesZ6TxwOOqwoaK/vHe6ZtxPxvG2+U8tQ21Nw5L3KyrDCnU5MJHGFtQVHHHt5MwA==
+
+"@nx/nx-win32-x64-msvc@16.5.5":
+  version "16.5.5"
+  resolved "https://registry.yarnpkg.com/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-16.5.5.tgz#86ef12c1180fb7a1c7fdc93f5de31c683818f31a"
+  integrity sha512-fB8miPr887GIGBDhyT6VX7MWX5aC40izEi+4GGSk38oh5dOUK9TLwjAEW/3vBE01fj5Hjcy0CPN7RA45fh/WUw==
 
 "@octokit/auth-token@^3.0.0":
   version "3.0.3"
@@ -2613,6 +2670,11 @@
   version "2.0.34"
   resolved "https://registry.yarnpkg.com/@spectrum-css/thumbnail/-/thumbnail-2.0.34.tgz#b10c6474490ca1ae88992cbecf752ae12b3e986f"
   integrity sha512-DjDpD+bbp8ef9LN1GvaS/88ajVoQ9CsvkiYh/tW9kCQhuGqMujRfg3HAbVBfZLrKHF/0+FspRB9U2xz6pBHCwA==
+
+"@spectrum-css/tokens@^10.1.2":
+  version "10.2.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/tokens/-/tokens-10.2.2.tgz#461697381575446542bbce8ae6d8ea948195ab3f"
+  integrity sha512-ljNXDPIJiS2q58dYn1EsXYF78gZaUCrLkOv8T8A5RBy/hM8fI85BghgiRkM0Dvsh87ej0juw3fO71Vkv3fuWlg==
 
 "@storybook/addon-a11y@^7.0.27":
   version "7.0.27"
@@ -12521,6 +12583,57 @@ nx@16.5.2, nx@^16.5.2:
     "@nx/nx-linux-x64-musl" "16.5.2"
     "@nx/nx-win32-arm64-msvc" "16.5.2"
     "@nx/nx-win32-x64-msvc" "16.5.2"
+
+nx@16.5.5, nx@^16.2.2:
+  version "16.5.5"
+  resolved "https://registry.yarnpkg.com/nx/-/nx-16.5.5.tgz#2b67150b72637647e10562b40a74d1ca62bd07a0"
+  integrity sha512-DHwoUtkirI52JIlCtRK78UI/Ik/VgCtM6FlkfPnFsy8PVyTYMQ40KoG6aZLHjqj5qxoGG2CUjcsbFjGXYrjDbw==
+  dependencies:
+    "@nrwl/tao" "16.5.5"
+    "@parcel/watcher" "2.0.4"
+    "@yarnpkg/lockfile" "^1.1.0"
+    "@yarnpkg/parsers" "3.0.0-rc.46"
+    "@zkochan/js-yaml" "0.0.6"
+    axios "^1.0.0"
+    chalk "^4.1.0"
+    cli-cursor "3.1.0"
+    cli-spinners "2.6.1"
+    cliui "^7.0.2"
+    dotenv "~10.0.0"
+    enquirer "~2.3.6"
+    fast-glob "3.2.7"
+    figures "3.2.0"
+    flat "^5.0.2"
+    fs-extra "^11.1.0"
+    glob "7.1.4"
+    ignore "^5.0.4"
+    js-yaml "4.1.0"
+    jsonc-parser "3.2.0"
+    lines-and-columns "~2.0.3"
+    minimatch "3.0.5"
+    npm-run-path "^4.0.1"
+    open "^8.4.0"
+    semver "7.5.3"
+    string-width "^4.2.3"
+    strong-log-transformer "^2.1.0"
+    tar-stream "~2.2.0"
+    tmp "~0.2.1"
+    tsconfig-paths "^4.1.2"
+    tslib "^2.3.0"
+    v8-compile-cache "2.3.0"
+    yargs "^17.6.2"
+    yargs-parser "21.1.1"
+  optionalDependencies:
+    "@nx/nx-darwin-arm64" "16.5.5"
+    "@nx/nx-darwin-x64" "16.5.5"
+    "@nx/nx-freebsd-x64" "16.5.5"
+    "@nx/nx-linux-arm-gnueabihf" "16.5.5"
+    "@nx/nx-linux-arm64-gnu" "16.5.5"
+    "@nx/nx-linux-arm64-musl" "16.5.5"
+    "@nx/nx-linux-x64-gnu" "16.5.5"
+    "@nx/nx-linux-x64-musl" "16.5.5"
+    "@nx/nx-win32-arm64-msvc" "16.5.5"
+    "@nx/nx-win32-x64-msvc" "16.5.5"
 
 object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
- Creates new component for Checkboard Opacity and refactors ColorSlider, Swatch, ColorHandle, and Thumbnail to use new component for their background checkerboards. 
- Address lint failures as needed 

[Jira Ticket](https://jira.corp.adobe.com/browse/CSS-482)

## How and where has this been tested?
Browser(s) and OS(s) this was tested with:
Chrome Version 113.0.5672.63 on macOS
Safari 16.4 on macOS
Firefox 112.0.2 on macOS

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following -->

- [x] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] I have tested these changes in Windows High Contrast mode.
- [x] I have updated any relevant storybook stories and templates.
- [x] If my change(s) include visual change(s), a designer has reviewed and approved those changes.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
