### PR TITLE
refactor: prefer GH Action for Stylelint

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "docs:mod": "node tasks/mod-extractor.js",
     "postdocs:mod": "prettier --cache --write components/*/metadata/*.md > /dev/null",
     "lint:components": "node ./tasks/packageLint.js",
-    "lint:styles": "stylelint",
     "mv:preview": "rimraf dist/preview && mv tools/preview/storybook-static dist/preview",
     "new": "nx run @spectrum-css/generator:new",
     "precommit": "lint-staged",
@@ -103,9 +102,6 @@
   "lint-staged": {
     "*.{md,js,css,yml,hbs}": [
       "prettier --write --cache"
-    ],
-    "components/*/*.css": [
-      "stylelint --write"
     ],
     "components/*/package.json": [
       "yarn lint:components",


### PR DESCRIPTION
* Removes the `lint-staged` step for Stylelint, and instead relies on the GH Action in `.github/workflows/linting.yml` for CSS linting

<!-- Summarize your changes in the Title field -->

## Description

<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->

## How and where has this been tested?

- **How this was tested:** <!-- Using steps in issue #000 -->
- **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following -->

- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] I have updated any relevant storybook stories and templates.
- [ ] If my change(s) include visual change(s), a designer has reviewed and approved those changes.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
