### PR TITLE
fix(thumbnail): border opacity typo

### DIFF
--- a/components/thumbnail/index.css
+++ b/components/thumbnail/index.css
@@ -13,10 +13,13 @@ governing permissions and limitations under the License.
 .spectrum-Thumbnail {
   --spectrum-thumbnail-size: var(--spectrum-thumbnail-size-500);
 
-  --spectrum-thumbnail-border-radius: var(--spectrum-corner-radius-75);
-  --spectrum-thumbnail-border-width: var(--spectrum-border-width-100);
-  /* @todo Refactor with --spectrum-thumbnail-border-color once gray rgb token is no longer necessary to workaround nested rgb color token value using rgba(). */
-  --spectrum-thumbnail-border-color-rgba: rgba(var(--spectrum-gray-800-rgb), var(--spectrum-thumbnail-border-color-opacity));
+	--spectrum-thumbnail-border-radius: var(--spectrum-corner-radius-75);
+	--spectrum-thumbnail-border-width: var(--spectrum-border-width-100);
+	/* @todo Refactor with --spectrum-thumbnail-border-color once gray rgb token is no longer necessary to workaround nested rgb color token value using rgba(). */
+	--spectrum-thumbnail-border-color-rgba: rgba(
+		var(--spectrum-gray-800-rgb),
+		var(--spectrum-thumbnail-border-opacity)
+	);
 
   --spectrum-thumbnail-layer-border-width-inner: var(--spectrum-border-width-400);
   --spectrum-thumbnail-layer-border-color-inner: var(--spectrum-white);
@@ -113,26 +116,87 @@ governing permissions and limitations under the License.
     opacity: var(--mod-thumbnail-color-opacity-disabled, var(--spectrum-thumbnail-color-opacity-disabled));
   }
 
-  &.is-focused,
-  &:focus-ring {
-    overflow: visible;
-    &::after {
-      content: "";
-      border-style: solid;
-      border-width: var(--mod-thumbnail-focus-indicator-thickness, var(--spectrum-thumbnail-focus-indicator-thickness));
-      border-color: var(--highcontrast-thumbnail-focus-indicator-color, var(--mod-thumbnail-focus-indicator-color, var(--spectrum-thumbnail-focus-indicator-color)));
-      border-radius: var(--mod-thumbnail-border-radius, var(--spectrum-thumbnail-border-radius));
-      position: absolute;
-      inset-inline-start: calc((var(--mod-thumbnail-focus-indicator-gap, var(--spectrum-thumbnail-focus-indicator-gap)) + var(--mod-thumbnail-focus-indicator-thickness, var(--spectrum-thumbnail-focus-indicator-thickness))) * -1);
-      inset-inline-end:  calc((var(--mod-thumbnail-focus-indicator-gap, var(--spectrum-thumbnail-focus-indicator-gap)) + var(--mod-thumbnail-focus-indicator-thickness, var(--spectrum-thumbnail-focus-indicator-thickness))) * -1);
-      inset-block-end:  calc((var(--mod-thumbnail-focus-indicator-gap, var(--spectrum-thumbnail-focus-indicator-gap)) + var(--mod-thumbnail-focus-indicator-thickness, var(--spectrum-thumbnail-focus-indicator-thickness))) * -1);
-      inset-block-start:  calc((var(--mod-thumbnail-focus-indicator-gap, var(--spectrum-thumbnail-focus-indicator-gap)) + var(--mod-thumbnail-focus-indicator-thickness, var(--spectrum-thumbnail-focus-indicator-thickness))) * -1);
-    }
-    .spectrum-Thumbnail-image-wrapper {
-      overflow: hidden;
-      border-radius: var(--mod-thumbnail-border-radius, var(--spectrum-thumbnail-border-radius));
-    }
-  }
+	/* stylelint-disable selector-pseudo-class-no-unknown */
+	&.is-focused,
+	&:focus-ring {
+		overflow: visible;
+		&::after {
+			content: "";
+			border-style: solid;
+			border-width: var(
+				--mod-thumbnail-focus-indicator-thickness,
+				var(--spectrum-thumbnail-focus-indicator-thickness)
+			);
+			border-color: var(
+				--highcontrast-thumbnail-focus-indicator-color,
+				var(
+					--mod-thumbnail-focus-indicator-color,
+					var(--spectrum-thumbnail-focus-indicator-color)
+				)
+			);
+			border-radius: var(
+				--mod-thumbnail-border-radius,
+				var(--spectrum-thumbnail-border-radius)
+			);
+			position: absolute;
+			inset-inline-start: calc(
+				(
+						var(
+								--mod-thumbnail-focus-indicator-gap,
+								var(--spectrum-thumbnail-focus-indicator-gap)
+							) +
+							var(
+								--mod-thumbnail-focus-indicator-thickness,
+								var(--spectrum-thumbnail-focus-indicator-thickness)
+							)
+					) * -1
+			);
+			inset-inline-end: calc(
+				(
+						var(
+								--mod-thumbnail-focus-indicator-gap,
+								var(--spectrum-thumbnail-focus-indicator-gap)
+							) +
+							var(
+								--mod-thumbnail-focus-indicator-thickness,
+								var(--spectrum-thumbnail-focus-indicator-thickness)
+							)
+					) * -1
+			);
+			inset-block-end: calc(
+				(
+						var(
+								--mod-thumbnail-focus-indicator-gap,
+								var(--spectrum-thumbnail-focus-indicator-gap)
+							) +
+							var(
+								--mod-thumbnail-focus-indicator-thickness,
+								var(--spectrum-thumbnail-focus-indicator-thickness)
+							)
+					) * -1
+			);
+			inset-block-start: calc(
+				(
+						var(
+								--mod-thumbnail-focus-indicator-gap,
+								var(--spectrum-thumbnail-focus-indicator-gap)
+							) +
+							var(
+								--mod-thumbnail-focus-indicator-thickness,
+								var(--spectrum-thumbnail-focus-indicator-thickness)
+							)
+					) * -1
+			);
+		}
+		.spectrum-Thumbnail-image-wrapper {
+			overflow: hidden;
+			border-radius: var(
+				--mod-thumbnail-border-radius,
+				var(--spectrum-thumbnail-border-radius)
+			);
+		}
+	}
+	/* stylelint-enable selector-pseudo-class-no-unknown */
 
   /* Friends should align to the top of the tabs */
   vertical-align: top;
@@ -152,12 +216,32 @@ governing permissions and limitations under the License.
     content: none;
   }
 
-  &.is-selected {
-    outline-style: solid;
-    outline-color: var(--highcontrast-thumbnail-border-color-selected, var(--mod-thumbnail-border-color-selected, var(--spectrum-thumbnail-border-color-selected)));
-    outline-width: var(--mod-thumbnail-border-width-selected, var(--spectrum-thumbnail-border-width-selected));
-    outline-offset: calc(var(--mod-thumbnail-border-width-selected, var(--spectrum-thumbnail-border-width-selected)) - var(--mod-thumbnail-layer-border-width-inner, var(--spectrum-thumbnail-layer-border-width-inner)))
-  }
+	/* stylelint-disable declaration-block-no-redundant-longhand-properties */
+	&.is-selected {
+		outline-style: solid;
+		outline-color: var(
+			--highcontrast-thumbnail-border-color-selected,
+			var(
+				--mod-thumbnail-border-color-selected,
+				var(--spectrum-thumbnail-border-color-selected)
+			)
+		);
+		outline-width: var(
+			--mod-thumbnail-border-width-selected,
+			var(--spectrum-thumbnail-border-width-selected)
+		);
+		outline-offset: calc(
+			var(
+					--mod-thumbnail-border-width-selected,
+					var(--spectrum-thumbnail-border-width-selected)
+				) -
+				var(
+					--mod-thumbnail-layer-border-width-inner,
+					var(--spectrum-thumbnail-layer-border-width-inner)
+				)
+		);
+	}
+	/* stylelint-enable declaration-block-no-redundant-longhand-properties */
 }
 
 .spectrum-Thumbnail-layer-inner {
@@ -165,12 +249,45 @@ governing permissions and limitations under the License.
   align-items: center;
   justify-content: center;
 
-  inline-size: calc(var(--spectrum-thumbnail-size) - ((var(--mod-thumbnail-layer-border-width-inner, var(--spectrum-thumbnail-layer-border-width-inner)))) * 2);
-  block-size: calc(var(--spectrum-thumbnail-size) - ((var(--mod-thumbnail-layer-border-width-inner, var(--spectrum-thumbnail-layer-border-width-inner)))) * 2);
-
-  outline-style: solid;
-  outline-color: var(--mod-thumbnail-layer-border-color-inner, var(--spectrum-thumbnail-layer-border-color-inner));
-  outline-width: calc(var(--mod-thumbnail-layer-border-width-inner, var(--spectrum-thumbnail-layer-border-width-inner)) - var(--mod-thumbnail-layer-border-width-outer, var(--spectrum-thumbnail-layer-border-width-outer)));
+	inline-size: calc(
+		var(--spectrum-thumbnail-size) -
+			(
+				(
+					var(
+						--mod-thumbnail-layer-border-width-inner,
+						var(--spectrum-thumbnail-layer-border-width-inner)
+					)
+				)
+			) * 2
+	);
+	block-size: calc(
+		var(--spectrum-thumbnail-size) -
+			(
+				(
+					var(
+						--mod-thumbnail-layer-border-width-inner,
+						var(--spectrum-thumbnail-layer-border-width-inner)
+					)
+				)
+			) * 2
+	);
+	/* stylelint-disable declaration-block-no-redundant-longhand-properties */
+	outline-style: solid;
+	outline-color: var(
+		--mod-thumbnail-layer-border-color-inner,
+		var(--spectrum-thumbnail-layer-border-color-inner)
+	);
+	outline-width: calc(
+		var(
+				--mod-thumbnail-layer-border-width-inner,
+				var(--spectrum-thumbnail-layer-border-width-inner)
+			) -
+			var(
+				--mod-thumbnail-layer-border-width-outer,
+				var(--spectrum-thumbnail-layer-border-width-outer)
+			)
+	);
+	/* stylelint-enable declaration-block-no-redundant-longhand-properties */
 }
 
 .spectrum-Thumbnail-image-wrapper {
@@ -212,15 +329,17 @@ governing permissions and limitations under the License.
 }
 
 /* Windows High Contrast Mode */
+/* stylelint-disable declaration-property-value-no-unknown */
 @media (forced-colors: active) {
   .spectrum-Thumbnail {
     /* Allow checkerboard pattern to be visible. */
     forced-color-adjust: none;
 
-    --highcontrast-thumbnail-border-color-selected: SelectedItem;
-    --highcontrast-thumbnail-focus-indicator-color: Highlight;
-    --highcontrast-thumbnail-border-color: CanvasText;
-    background-color: Canvas;
-    color: CanvasText;
-  }
+		--highcontrast-thumbnail-border-color-selected: SelectedItem;
+		--highcontrast-thumbnail-focus-indicator-color: Highlight;
+		--highcontrast-thumbnail-border-color: CanvasText;
+		background-color: Canvas;
+		color: CanvasText;
+	}
 }
+/* stylelint-enable declaration-property-value-no-unknown */

--- a/components/thumbnail/index.css
+++ b/components/thumbnail/index.css
@@ -116,7 +116,6 @@ governing permissions and limitations under the License.
     opacity: var(--mod-thumbnail-color-opacity-disabled, var(--spectrum-thumbnail-color-opacity-disabled));
   }
 
-	/* stylelint-disable selector-pseudo-class-no-unknown */
 	&.is-focused,
 	&:focus-ring {
 		overflow: visible;
@@ -196,7 +195,6 @@ governing permissions and limitations under the License.
 			);
 		}
 	}
-	/* stylelint-enable selector-pseudo-class-no-unknown */
 
   /* Friends should align to the top of the tabs */
   vertical-align: top;
@@ -216,7 +214,6 @@ governing permissions and limitations under the License.
     content: none;
   }
 
-	/* stylelint-disable declaration-block-no-redundant-longhand-properties */
 	&.is-selected {
 		outline-style: solid;
 		outline-color: var(
@@ -241,7 +238,6 @@ governing permissions and limitations under the License.
 				)
 		);
 	}
-	/* stylelint-enable declaration-block-no-redundant-longhand-properties */
 }
 
 .spectrum-Thumbnail-layer-inner {
@@ -271,7 +267,6 @@ governing permissions and limitations under the License.
 				)
 			) * 2
 	);
-	/* stylelint-disable declaration-block-no-redundant-longhand-properties */
 	outline-style: solid;
 	outline-color: var(
 		--mod-thumbnail-layer-border-color-inner,
@@ -287,7 +282,6 @@ governing permissions and limitations under the License.
 				var(--spectrum-thumbnail-layer-border-width-outer)
 			)
 	);
-	/* stylelint-enable declaration-block-no-redundant-longhand-properties */
 }
 
 .spectrum-Thumbnail-image-wrapper {
@@ -329,7 +323,6 @@ governing permissions and limitations under the License.
 }
 
 /* Windows High Contrast Mode */
-/* stylelint-disable declaration-property-value-no-unknown */
 @media (forced-colors: active) {
   .spectrum-Thumbnail {
     /* Allow checkerboard pattern to be visible. */
@@ -342,4 +335,3 @@ governing permissions and limitations under the License.
 		color: CanvasText;
 	}
 }
-/* stylelint-enable declaration-property-value-no-unknown */


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description

I noticed that border on thumbnail was missing and found a small typo.
Changes `var(--spectrum-thumbnail-border-color-opacity)` to `var(--spectrum-thumbnail-border-opacity)`

## How and where has this been tested?
Browser(s) and OS(s) this was tested with:
Chrome Version 113.0.5672.63 on macOS
Safari 16.4 on macOS
Firefox 112.0.2 on macOS

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following -->

- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] I have tested these changes in Windows High Contrast mode.
- [x] I have updated any relevant storybook stories and templates.
- [x] If my change(s) include visual change(s), a designer has reviewed and approved those changes.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
