### PR TITLE
chore: remove duplicate dependency; lit-html - lit

### DIFF
--- a/components/accordion/stories/template.js
+++ b/components/accordion/stories/template.js
@@ -1,7 +1,7 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { repeat } from "lit-html/directives/repeat.js";
-import { ifDefined } from "lit-html/directives/if-defined.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { repeat } from "lit/directives/repeat.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 

--- a/components/actionbar/stories/template.js
+++ b/components/actionbar/stories/template.js
@@ -1,6 +1,6 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-// import { ifDefined } from 'lit-html/directives/if-defined.js';
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+// import { ifDefined } from 'lit/directives/if-defined.js';
 
 import { Template as Popover } from "@spectrum-css/popover/stories/template.js";
 import { Template as CloseButton } from "@spectrum-css/closebutton/stories/template.js";

--- a/components/actionbutton/stories/template.js
+++ b/components/actionbutton/stories/template.js
@@ -1,7 +1,7 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { ifDefined } from "lit-html/directives/if-defined.js";
-import { when } from "lit-html/directives/when.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { ifDefined } from "lit/directives/if-defined.js";
+import { when } from "lit/directives/when.js";
 
 import { lowerCase, capitalize } from "lodash-es";
 

--- a/components/actiongroup/stories/template.js
+++ b/components/actiongroup/stories/template.js
@@ -1,5 +1,5 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
 
 import { Template as ActionButton } from "@spectrum-css/actionbutton/stories/template.js";
 

--- a/components/actionmenu/stories/template.js
+++ b/components/actionmenu/stories/template.js
@@ -1,4 +1,4 @@
-import { html } from "lit-html";
+import { html } from "lit";
 
 import { Template as ActionButton } from "@spectrum-css/actionbutton/stories/template.js";
 import { Template as Popover } from "@spectrum-css/popover/stories/template.js";

--- a/components/alertbanner/stories/template.js
+++ b/components/alertbanner/stories/template.js
@@ -1,5 +1,5 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
 
 import { Template as Divider } from "@spectrum-css/divider/stories/template.js";
 import { Template as Button } from "@spectrum-css/button/stories/template.js";

--- a/components/asset/stories/template.js
+++ b/components/asset/stories/template.js
@@ -1,6 +1,6 @@
-import { html, svg } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { ifDefined } from "lit-html/directives/if-defined.js";
+import { html, svg } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import "../index.css";
 import "../skin.css";

--- a/components/assetcard/stories/template.js
+++ b/components/assetcard/stories/template.js
@@ -1,7 +1,7 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { ifDefined } from "lit-html/directives/if-defined.js";
-import { when } from "lit-html/directives/when.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { ifDefined } from "lit/directives/if-defined.js";
+import { when } from "lit/directives/when.js";
 
 import { useArgs } from "@storybook/client-api";
 

--- a/components/assetlist/stories/template.js
+++ b/components/assetlist/stories/template.js
@@ -1,7 +1,7 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { when } from "lit-html/directives/when.js";
-import { ifDefined } from "lit-html/directives/if-defined.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { when } from "lit/directives/when.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import { useArgs } from "@storybook/client-api";
 

--- a/components/avatar/stories/template.js
+++ b/components/avatar/stories/template.js
@@ -1,6 +1,6 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { ifDefined } from "lit-html/directives/if-defined.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import "../index.css";
 

--- a/components/badge/stories/template.js
+++ b/components/badge/stories/template.js
@@ -1,7 +1,7 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { ifDefined } from "lit-html/directives/if-defined.js";
-import { when } from "lit-html/directives/when.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { ifDefined } from "lit/directives/if-defined.js";
+import { when } from "lit/directives/when.js";
 
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 

--- a/components/breadcrumb/stories/template.js
+++ b/components/breadcrumb/stories/template.js
@@ -1,6 +1,6 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { when } from "lit-html/directives/when.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { when } from "lit/directives/when.js";
 
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 import { Template as ActionButton } from "@spectrum-css/actionbutton/stories/template.js";

--- a/components/button/stories/button.stories.js
+++ b/components/button/stories/button.stories.js
@@ -1,4 +1,4 @@
-import { html } from "lit-html";
+import { html } from "lit";
 
 // Import the component markup template
 import { Template } from "./template";

--- a/components/button/stories/template.js
+++ b/components/button/stories/template.js
@@ -1,7 +1,7 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { ifDefined } from "lit-html/directives/if-defined.js";
-import { when } from "lit-html/directives/when.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { ifDefined } from "lit/directives/if-defined.js";
+import { when } from "lit/directives/when.js";
 
 import { lowerCase, capitalize } from "lodash-es";
 

--- a/components/buttongroup/stories/template.js
+++ b/components/buttongroup/stories/template.js
@@ -1,6 +1,6 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-// import { ifDefined } from 'lit-html/directives/if-defined.js';
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+// import { ifDefined } from 'lit/directives/if-defined.js';
 
 import { Template as Button } from "@spectrum-css/button/stories/template.js";
 

--- a/components/calendar/stories/template.js
+++ b/components/calendar/stories/template.js
@@ -1,7 +1,7 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { repeat } from "lit-html/directives/repeat.js";
-import { ifDefined } from "lit-html/directives/if-defined.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { repeat } from "lit/directives/repeat.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import { useArgs, useGlobals } from "@storybook/client-api";
 import { action } from "@storybook/addon-actions";
@@ -59,7 +59,7 @@ export const Template = ({
 	};
 
 	/**
-	 * @typedef {{ date: Date, dateClassList: import('lit-html').ClassInfo, isSelected: boolean, isToday: boolean, isOutsideMonth: boolean }} DateMetadata
+	 * @typedef {{ date: Date, dateClassList: import('lit').ClassInfo, isSelected: boolean, isToday: boolean, isOutsideMonth: boolean }} DateMetadata
 	 **/
 
 	/**

--- a/components/card/stories/card.stories.js
+++ b/components/card/stories/card.stories.js
@@ -1,4 +1,4 @@
-import { html } from "lit-html";
+import { html } from "lit";
 
 // Import the component markup template
 import { Template } from "./template";

--- a/components/card/stories/template.js
+++ b/components/card/stories/template.js
@@ -1,7 +1,7 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { ifDefined } from "lit-html/directives/if-defined.js";
-import { when } from "lit-html/directives/when.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { ifDefined } from "lit/directives/if-defined.js";
+import { when } from "lit/directives/when.js";
 
 import { useArgs } from "@storybook/client-api";
 

--- a/components/checkbox/stories/template.js
+++ b/components/checkbox/stories/template.js
@@ -1,7 +1,7 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { ifDefined } from "lit-html/directives/if-defined.js";
-import { when } from "lit-html/directives/when.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { ifDefined } from "lit/directives/if-defined.js";
+import { when } from "lit/directives/when.js";
 
 import { useArgs } from "@storybook/client-api";
 

--- a/components/clearbutton/stories/template.js
+++ b/components/clearbutton/stories/template.js
@@ -1,6 +1,6 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-// import { ifDefined } from 'lit-html/directives/if-defined.js';
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+// import { ifDefined } from 'lit/directives/if-defined.js';
 
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 

--- a/components/closebutton/stories/template.js
+++ b/components/closebutton/stories/template.js
@@ -1,6 +1,6 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { ifDefined } from "lit-html/directives/if-defined.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import { upperCase, lowerCase, capitalize } from "lodash-es";
 

--- a/components/coachmark/stories/template.js
+++ b/components/coachmark/stories/template.js
@@ -1,6 +1,6 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-// import { ifDefined } from 'lit-html/directives/if-defined.js';
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+// import { ifDefined } from 'lit/directives/if-defined.js';
 
 import { Template as Button } from "@spectrum-css/button/stories/template.js";
 

--- a/components/colorarea/stories/template.js
+++ b/components/colorarea/stories/template.js
@@ -1,6 +1,6 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { styleMap } from "lit-html/directives/style-map.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { styleMap } from "lit/directives/style-map.js";
 import { Template as ColorHandle } from "@spectrum-css/colorhandle/stories/template.js";
 
 import "../index.css";

--- a/components/colorhandle/stories/template.js
+++ b/components/colorhandle/stories/template.js
@@ -1,6 +1,6 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { styleMap } from "lit-html/directives/style-map.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { styleMap } from "lit/directives/style-map.js";
 
 import "../index.css";
 

--- a/components/colorloupe/stories/template.js
+++ b/components/colorloupe/stories/template.js
@@ -1,6 +1,6 @@
-import { svg } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { styleMap } from "lit-html/directives/style-map.js";
+import { svg } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { styleMap } from "lit/directives/style-map.js";
 
 import "../index.css";
 

--- a/components/colorslider/stories/template.js
+++ b/components/colorslider/stories/template.js
@@ -1,5 +1,5 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
 
 import { Template as ColorHandle } from "@spectrum-css/colorhandle/stories/template.js";
 

--- a/components/colorwheel/stories/template.js
+++ b/components/colorwheel/stories/template.js
@@ -1,5 +1,5 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
 import { Template as ColorHandle } from "@spectrum-css/colorhandle/stories/template.js";
 
 import "../index.css";

--- a/components/combobox/stories/template.js
+++ b/components/combobox/stories/template.js
@@ -1,6 +1,6 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { ifDefined } from "lit-html/directives/if-defined.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import { Template as Menu } from "@spectrum-css/menu/stories/template.js";
 import { Template as TextField } from "@spectrum-css/textfield/stories/template.js";

--- a/components/contextualhelp/stories/template.js
+++ b/components/contextualhelp/stories/template.js
@@ -1,6 +1,6 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { ifDefined } from "lit-html/directives/if-defined.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import { Template as ActionButton } from "@spectrum-css/actionbutton/stories/template.js";
 import { Template as Popover } from "@spectrum-css/popover/stories/template.js";

--- a/components/cyclebutton/stories/template.js
+++ b/components/cyclebutton/stories/template.js
@@ -1,4 +1,4 @@
-import { html } from "lit-html";
+import { html } from "lit";
 import { useArgs } from "@storybook/client-api";
 
 import { Template as ActionButton } from "@spectrum-css/actionbutton/stories/template.js";

--- a/components/datepicker/stories/template.js
+++ b/components/datepicker/stories/template.js
@@ -1,6 +1,6 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { ifDefined } from "lit-html/directives/if-defined.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import { Template as Calendar } from "@spectrum-css/calendar/stories/template.js";
 import { Template as TextField } from "@spectrum-css/textfield/stories/template.js";

--- a/components/dial/stories/template.js
+++ b/components/dial/stories/template.js
@@ -1,7 +1,7 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { ifDefined } from "lit-html/directives/if-defined.js";
-import { when } from "lit-html/directives/when.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { ifDefined } from "lit/directives/if-defined.js";
+import { when } from "lit/directives/when.js";
 
 import "../index.css";
 import "../skin.css";

--- a/components/dialog/stories/dialog.stories.js
+++ b/components/dialog/stories/dialog.stories.js
@@ -1,4 +1,4 @@
-import { html } from "lit-html";
+import { html } from "lit";
 
 // Import the component markup template
 import { Template } from "./template";

--- a/components/dialog/stories/template.js
+++ b/components/dialog/stories/template.js
@@ -1,7 +1,7 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { ifDefined } from "lit-html/directives/if-defined.js";
-import { when } from "lit-html/directives/when.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { ifDefined } from "lit/directives/if-defined.js";
+import { when } from "lit/directives/when.js";
 
 import { Template as Modal } from "@spectrum-css/modal/stories/template.js";
 import { Template as Divider } from "@spectrum-css/divider/stories/template.js";

--- a/components/divider/stories/template.js
+++ b/components/divider/stories/template.js
@@ -1,5 +1,5 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
 
 import { upperCase, lowerCase, capitalize } from "lodash-es";
 

--- a/components/dropindicator/stories/template.js
+++ b/components/dropindicator/stories/template.js
@@ -1,6 +1,6 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { styleMap } from "lit-html/directives/style-map.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { styleMap } from "lit/directives/style-map.js";
 
 import "../index.css";
 import "../skin.css";

--- a/components/dropzone/stories/template.js
+++ b/components/dropzone/stories/template.js
@@ -1,6 +1,6 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { ifDefined } from "lit-html/directives/if-defined.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import { AccentColor as IllustratedMessageStory } from "@spectrum-css/illustratedmessage/stories/illustratedmessage.stories.js";
 import { Template as IllustratedMessage } from "@spectrum-css/illustratedmessage/stories/template.js";

--- a/components/fieldgroup/stories/template.js
+++ b/components/fieldgroup/stories/template.js
@@ -1,6 +1,6 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { repeat } from "lit-html/directives/repeat.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { repeat } from "lit/directives/repeat.js";
 
 import { Template as FieldLabel } from "@spectrum-css/fieldlabel/stories/template.js";
 import { Template as Radio } from "@spectrum-css/radio/stories/template.js";

--- a/components/fieldlabel/stories/template.js
+++ b/components/fieldlabel/stories/template.js
@@ -1,7 +1,7 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { styleMap } from "lit-html/directives/style-map.js";
-import { ifDefined } from "lit-html/directives/if-defined.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { styleMap } from "lit/directives/style-map.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 

--- a/components/floatingactionbutton/stories/template.js
+++ b/components/floatingactionbutton/stories/template.js
@@ -1,6 +1,6 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { ifDefined } from "lit-html/directives/if-defined.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import "../index.css";
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";

--- a/components/helptext/stories/template.js
+++ b/components/helptext/stories/template.js
@@ -1,6 +1,6 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { ifDefined } from "lit-html/directives/if-defined.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 

--- a/components/icon/stories/template.js
+++ b/components/icon/stories/template.js
@@ -1,7 +1,7 @@
-import { html } from "lit-html";
-import { ifDefined } from "lit-html/directives/if-defined.js";
-import { unsafeHTML } from "lit-html/directives/unsafe-html.js";
-import { classMap } from "lit-html/directives/class-map.js";
+import { html } from "lit";
+import { ifDefined } from "lit/directives/if-defined.js";
+import { unsafeHTML } from "lit/directives/unsafe-html.js";
+import { classMap } from "lit/directives/class-map.js";
 
 import { fetchIconSVG, workflowIcons, uiIcons } from "./utilities.js";
 
@@ -24,7 +24,7 @@ import "../index.css";
  * @param {string} props.id
  * @param {string[]} props.customClasses
  * @param {boolean} props.useRef
- * @returns {import('lit-html').TemplateResult<1>}
+ * @returns {import('lit').TemplateResult<1>}
  */
 export const Template = ({
 	rootClass = "spectrum-Icon",

--- a/components/illustratedmessage/stories/illustratedmessage.stories.js
+++ b/components/illustratedmessage/stories/illustratedmessage.stories.js
@@ -1,4 +1,4 @@
-import { html } from "lit-html";
+import { html } from "lit";
 
 // Import the component markup template
 import { Template } from "./template";

--- a/components/illustratedmessage/stories/template.js
+++ b/components/illustratedmessage/stories/template.js
@@ -1,6 +1,6 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { when } from "lit-html/directives/when.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { when } from "lit/directives/when.js";
 
 import "../index.css";
 

--- a/components/infieldbutton/stories/template.js
+++ b/components/infieldbutton/stories/template.js
@@ -1,6 +1,6 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { when } from "lit-html/directives/when.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { when } from "lit/directives/when.js";
 
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 

--- a/components/inlinealert/stories/template.js
+++ b/components/inlinealert/stories/template.js
@@ -1,6 +1,6 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-// import { ifDefined } from 'lit-html/directives/if-definedjs';
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+// import { ifDefined } from 'lit/directives/if-definedjs';
 
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 import { Template as Button } from "@spectrum-css/button/stories/template.js";

--- a/components/link/stories/template.js
+++ b/components/link/stories/template.js
@@ -1,6 +1,6 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { ifDefined } from "lit-html/directives/if-defined.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import { lowerCase, capitalize } from "lodash-es";
 

--- a/components/logicbutton/stories/template.js
+++ b/components/logicbutton/stories/template.js
@@ -1,5 +1,5 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
 
 import "../index.css";
 

--- a/components/menu/stories/template.js
+++ b/components/menu/stories/template.js
@@ -1,7 +1,7 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { ifDefined } from "lit-html/directives/if-defined.js";
-import { repeat } from "lit-html/directives/repeat.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { ifDefined } from "lit/directives/if-defined.js";
+import { repeat } from "lit/directives/repeat.js";
 
 import { Template as Divider } from "@spectrum-css/divider/stories/template.js";
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";

--- a/components/miller/stories/template.js
+++ b/components/miller/stories/template.js
@@ -1,6 +1,6 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-// import { ifDefined } from 'lit-html/directives/if-defined.js';
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+// import { ifDefined } from 'lit/directives/if-defined.js';
 
 import { Template as AssetList } from "@spectrum-css/assetlist/stories/template.js";
 

--- a/components/modal/stories/template.js
+++ b/components/modal/stories/template.js
@@ -1,5 +1,5 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
 
 import "../index.css";
 import "../skin.css";

--- a/components/pagination/stories/template.js
+++ b/components/pagination/stories/template.js
@@ -1,6 +1,6 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { repeat } from "lit-html/directives/repeat.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { repeat } from "lit/directives/repeat.js";
 
 import { Template as Button } from "@spectrum-css/button/stories/template.js";
 import { Template as ActionButton } from "@spectrum-css/actionbutton/stories/template.js";

--- a/components/picker/stories/template.js
+++ b/components/picker/stories/template.js
@@ -1,6 +1,6 @@
-import { html } from "lit-html";
+import { html } from "lit";
 import { useArgs } from "@storybook/client-api";
-import { classMap } from "lit-html/directives/class-map.js";
+import { classMap } from "lit/directives/class-map.js";
 
 import { Template as FieldLabel } from "@spectrum-css/fieldlabel/stories/template.js";
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";

--- a/components/pickerbutton/stories/template.js
+++ b/components/pickerbutton/stories/template.js
@@ -1,7 +1,7 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { styleMap } from "lit-html/directives/style-map.js";
-import { ifDefined } from "lit-html/directives/if-defined.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { styleMap } from "lit/directives/style-map.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import { useArgs } from "@storybook/client-api";
 

--- a/components/popover/stories/template.js
+++ b/components/popover/stories/template.js
@@ -1,7 +1,7 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { styleMap } from "lit-html/directives/style-map.js";
-import { ifDefined } from "lit-html/directives/if-defined.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { styleMap } from "lit/directives/style-map.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import "../index.css";
 

--- a/components/progressbar/stories/template.js
+++ b/components/progressbar/stories/template.js
@@ -1,8 +1,8 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
 import { Template as FieldLabel } from "@spectrum-css/fieldlabel/stories/template.js";
-import { ifDefined } from "lit-html/directives/if-defined.js";
-import { styleMap } from "lit-html/directives/style-map.js";
+import { ifDefined } from "lit/directives/if-defined.js";
+import { styleMap } from "lit/directives/style-map.js";
 
 import "../index.css";
 

--- a/components/progresscircle/stories/template.js
+++ b/components/progresscircle/stories/template.js
@@ -1,6 +1,6 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-// import { ifDefined } from 'lit-html/directives/if-definedjs';
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+// import { ifDefined } from 'lit/directives/if-definedjs';
 
 import "../index.css";
 

--- a/components/quickaction/stories/template.js
+++ b/components/quickaction/stories/template.js
@@ -1,6 +1,6 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { ifDefined } from "lit-html/directives/if-defined.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import { Template as ActionButton } from "@spectrum-css/actionbutton/stories/template.js";
 

--- a/components/radio/stories/template.js
+++ b/components/radio/stories/template.js
@@ -1,6 +1,6 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { ifDefined } from "lit-html/directives/if-defined.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import "../index.css";
 

--- a/components/rating/stories/template.js
+++ b/components/rating/stories/template.js
@@ -1,7 +1,7 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { repeat } from "lit-html/directives/repeat.js";
-import { ifDefined } from "lit-html/directives/if-defined.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { repeat } from "lit/directives/repeat.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import { useArgs } from "@storybook/client-api";
 

--- a/components/search/stories/template.js
+++ b/components/search/stories/template.js
@@ -1,5 +1,5 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
 
 import { Template as ClearButton } from "@spectrum-css/clearbutton/stories/template.js";
 import { Template as TextField } from "@spectrum-css/textfield/stories/template.js";

--- a/components/searchwithin/stories/template.js
+++ b/components/searchwithin/stories/template.js
@@ -1,7 +1,7 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { styleMap } from "lit-html/directives/style-map.js";
-import { ifDefined } from "lit-html/directives/if-defined.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { styleMap } from "lit/directives/style-map.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import { Template as PickerButton } from "@spectrum-css/pickerbutton/stories/template.js";
 import { Template as Popover } from "@spectrum-css/popover/stories/template.js";

--- a/components/sidenav/stories/template.js
+++ b/components/sidenav/stories/template.js
@@ -1,7 +1,7 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { repeat } from "lit-html/directives/repeat.js";
-import { ifDefined } from "lit-html/directives/if-defined.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { repeat } from "lit/directives/repeat.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 

--- a/components/slider/stories/template.js
+++ b/components/slider/stories/template.js
@@ -1,7 +1,7 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { styleMap } from "lit-html/directives/style-map.js";
-import { ifDefined } from "lit-html/directives/if-defined.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { styleMap } from "lit/directives/style-map.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import { useArgs, useGlobals } from "@storybook/client-api";
 

--- a/components/splitbutton/stories/template.js
+++ b/components/splitbutton/stories/template.js
@@ -1,5 +1,5 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
 
 import { Template as Button } from "@spectrum-css/button/stories/template.js";
 

--- a/components/splitview/stories/template.js
+++ b/components/splitview/stories/template.js
@@ -1,7 +1,7 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { when } from "lit-html/directives/when.js";
-// import { ifDefined } from 'lit-html/directives/if-defined.js';
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { when } from "lit/directives/when.js";
+// import { ifDefined } from 'lit/directives/if-defined.js';
 
 import "../index.css";
 import "../skin.css";

--- a/components/statuslight/stories/template.js
+++ b/components/statuslight/stories/template.js
@@ -1,6 +1,6 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-// import { ifDefined } from 'lit-html/directives/if-defined.js';
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+// import { ifDefined } from 'lit/directives/if-defined.js';
 
 import "../index.css";
 

--- a/components/steplist/stories/template.js
+++ b/components/steplist/stories/template.js
@@ -1,7 +1,7 @@
-import { html, nothing } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { repeat } from "lit-html/directives/repeat.js";
-import { ifDefined } from "lit-html/directives/if-defined.js";
+import { html, nothing } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { repeat } from "lit/directives/repeat.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import { Template as Tooltip } from "@spectrum-css/tooltip/stories/template.js";
 

--- a/components/stepper/stories/template.js
+++ b/components/stepper/stories/template.js
@@ -1,7 +1,7 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { styleMap } from "lit-html/directives/style-map.js";
-import { ifDefined } from "lit-html/directives/if-defined.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { styleMap } from "lit/directives/style-map.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import { Template as Textfield } from "@spectrum-css/textfield/stories/template.js";
 import { Template as ActionButton } from "@spectrum-css/actionbutton/stories/template.js";

--- a/components/swatch/stories/template.js
+++ b/components/swatch/stories/template.js
@@ -1,6 +1,6 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { ifDefined } from "lit-html/directives/if-defined.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import "../index.css";
 

--- a/components/swatchgroup/stories/template.js
+++ b/components/swatchgroup/stories/template.js
@@ -1,6 +1,6 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-// import { ifDefined } from 'lit-html/directives/if-defined.js';
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+// import { ifDefined } from 'lit/directives/if-defined.js';
 
 import { lowerCase, capitalize } from "lodash-es";
 

--- a/components/switch/stories/template.js
+++ b/components/switch/stories/template.js
@@ -1,6 +1,6 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { ifDefined } from "lit-html/directives/if-defined.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import "../index.css";
 

--- a/components/table/stories/template.js
+++ b/components/table/stories/template.js
@@ -1,6 +1,6 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { ifDefined } from "lit-html/directives/if-defined.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 

--- a/components/tabs/stories/template.js
+++ b/components/tabs/stories/template.js
@@ -1,8 +1,8 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { styleMap } from "lit-html/directives/style-map.js";
-import { repeat } from "lit-html/directives/repeat.js";
-import { ifDefined } from "lit-html/directives/if-defined.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { styleMap } from "lit/directives/style-map.js";
+import { repeat } from "lit/directives/repeat.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 

--- a/components/tag/stories/template.js
+++ b/components/tag/stories/template.js
@@ -1,6 +1,6 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { ifDefined } from "lit-html/directives/if-defined.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 import { Template as Avatar } from "@spectrum-css/avatar/stories/template.js";

--- a/components/taggroup/stories/template.js
+++ b/components/taggroup/stories/template.js
@@ -1,6 +1,6 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { ifDefined } from "lit-html/directives/if-defined.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import { Template as Tag } from "@spectrum-css/tag/stories/template.js";
 

--- a/components/textfield/stories/template.js
+++ b/components/textfield/stories/template.js
@@ -1,7 +1,7 @@
-import { html } from "lit-html";
-import { ifDefined } from "lit-html/directives/if-defined.js";
-import { classMap } from "lit-html/directives/class-map.js";
-import { styleMap } from "lit-html/directives/style-map.js";
+import { html } from "lit";
+import { ifDefined } from "lit/directives/if-defined.js";
+import { classMap } from "lit/directives/class-map.js";
+import { styleMap } from "lit/directives/style-map.js";
 import { useArgs } from "@storybook/client-api";
 
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";

--- a/components/thumbnail/stories/template.js
+++ b/components/thumbnail/stories/template.js
@@ -1,7 +1,7 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { styleMap } from "lit-html/directives/style-map.js";
-import { ifDefined } from "lit-html/directives/if-defined.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { styleMap } from "lit/directives/style-map.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import "../index.css";
 

--- a/components/toast/stories/template.js
+++ b/components/toast/stories/template.js
@@ -1,6 +1,6 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { ifDefined } from "lit-html/directives/if-defined.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 import { Template as CloseButton } from "@spectrum-css/closebutton/stories/template.js";

--- a/components/tooltip/stories/template.js
+++ b/components/tooltip/stories/template.js
@@ -1,6 +1,6 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { when } from "lit-html/directives/when.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { when } from "lit/directives/when.js";
 
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 

--- a/components/tray/stories/template.js
+++ b/components/tray/stories/template.js
@@ -1,6 +1,6 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { ifDefined } from "lit-html/directives/if-defined.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import { Template as Modal } from "@spectrum-css/modal/stories/template.js";
 

--- a/components/treeview/stories/template.js
+++ b/components/treeview/stories/template.js
@@ -1,6 +1,6 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { repeat } from "lit-html/directives/repeat.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { repeat } from "lit/directives/repeat.js";
 
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 import { Template as Thumbnail } from "@spectrum-css/thumbnail/stories/template.js";

--- a/components/typography/stories/template.js
+++ b/components/typography/stories/template.js
@@ -1,6 +1,6 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { ifDefined } from "lit-html/directives/if-defined.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import { capitalize } from "lodash-es";
 

--- a/components/typography/stories/typography.stories.js
+++ b/components/typography/stories/typography.stories.js
@@ -1,6 +1,6 @@
 import { Template } from "./template";
 
-import { html } from "lit-html";
+import { html } from "lit";
 
 export default {
 	title: "Components/Typography",

--- a/components/well/stories/template.js
+++ b/components/well/stories/template.js
@@ -1,5 +1,5 @@
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
 
 import "../index.css";
 import "../skin.css";

--- a/components/well/stories/well.stories.js
+++ b/components/well/stories/well.stories.js
@@ -1,5 +1,5 @@
 // Import the component markup template
-import { html } from "lit-html";
+import { html } from "lit";
 import { Template } from "./template";
 
 export default {

--- a/tools/generator/templates/stories/template.js.hbs
+++ b/tools/generator/templates/stories/template.js.hbs
@@ -1,6 +1,6 @@
-import { html } from 'lit-html';
-import { classMap } from 'lit-html/directives/class-map.js';
-import { ifDefined } from 'lit-html/directives/if-defined.js';
+import { html } from 'lit';
+import { classMap } from 'lit/directives/class-map.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 
 import "../index.css";
 

--- a/tools/preview/README.md
+++ b/tools/preview/README.md
@@ -29,9 +29,9 @@ Storybook leverages webpack for bundling and we have updated it with the followi
 - CSS for other components can be loaded in a story using the package name (rather than the directory path), i.e. `@spectrum-css/toast` vs. `../toast/index.css`. The local version of the package is used regardless but the webpack settings will resolve the pathing for you.
 
   ```js
-  import { html } from "lit-html";
-  import { classMap } from "lit-html/directives/class-map.js";
-  import { ifDefined } from "lit-html/directives/if-defined.js";
+  import { html } from "lit";
+  import { classMap } from "lit/directives/class-map.js";
+  import { ifDefined } from "lit/directives/if-defined.js";
   ```
 
 - Images can be loaded automatically from the `assets/images` directory at the root of the project.
@@ -57,7 +57,7 @@ Storybook leverages webpack for bundling and we have updated it with the followi
   }
   ```
 
-We are leaning on Storybook's `@storybook/web-components-webpack5` framework configuration as our stories rely on lit-html for dynamic attribute assignment.
+We are leaning on Storybook's `@storybook/web-components-webpack5` framework configuration as our stories rely on lit for dynamic attribute assignment.
 
 ## Add-ons
 
@@ -230,16 +230,16 @@ The rest of the variables provided in the Template function's input object will 
 
 - [More on component templates](https://storybook.js.org/docs/web-components/writing-stories/introduction#using-args)
 
-To help in making a dynamic mark-up template, you can leverage any of the [directives](https://lit.dev/docs/templates/directives/) available in the `lit-html` package. Our most commonly used ones are: `html`, `classMap`, `ifDefined`.
+To help in making a dynamic mark-up template, you can leverage any of the [directives](https://lit.dev/docs/templates/directives/) available in the `lit` package. Our most commonly used ones are: `html`, `classMap`, `ifDefined`.
 
 All return values for Template functions should be outputting TemplateResults. Said another way, all mark-up needs to be wrapped in the html template literal.
 
 ### Full example
 
 ```js
-import { html } from "lit-html";
-import { classMap } from "lit-html/directives/class-map.js";
-import { ifDefined } from "lit-html/directives/if-defined.js";
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 import { Template as Avatar } from "@spectrum-css/avatar/stories/template.js";
@@ -428,7 +428,7 @@ export const Basic = {
 `*` Docs is now added to every component on the sidebar with the below code in Storybook 7
 ```js
   docs: {
-    autodocs: true, 
+    autodocs: true,
     defaultName: 'Docs',
   },
 ```

--- a/tools/preview/decorators/index.js
+++ b/tools/preview/decorators/index.js
@@ -1,5 +1,5 @@
 import { useEffect, makeDecorator } from "@storybook/preview-api";
-import { html } from "lit-html";
+import { html } from "lit";
 
 export { withContextWrapper } from "./contextsWrapper.js";
 

--- a/tools/preview/package.json
+++ b/tools/preview/package.json
@@ -44,7 +44,6 @@
     "chromatic": "^6.19.8",
     "file-loader": "6.2.0",
     "lit": "^2.7.4",
-    "lit-html": "^2.7.4",
     "lodash-es": "^4.17.21",
     "npm-run-all": "^4.1.5",
     "postcss": "^7.0.36",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10933,7 +10933,7 @@ lit-element@^3.3.0:
     "@lit/reactive-element" "^1.3.0"
     lit-html "^2.7.0"
 
-lit-html@^2.7.0, lit-html@^2.7.4:
+lit-html@^2.7.0:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-2.7.4.tgz#6d75001977c206683685b9d76594a516afda2954"
   integrity sha512-/Jw+FBpeEN+z8X6PJva5n7+0MzCVAH2yypN99qHYYkq8bI+j7I39GH+68Z/MZD6rGKDK9RpzBw7CocfmHfq6+g==


### PR DESCRIPTION
## Description

The storybook upgrade (https://github.com/adobe/spectrum-css/commit/6dcf09b60207142d82e3ca1de632a813491f8f75) added the `lit` dependency which comes with `lit-html` bundled. This PR removes the lit-html dependency and pulls the storybook assets directly from lit.

## How and where has this been tested?

**How this was tested:**

- [x] Storybook shows no regressions in rendering

## To-do list

- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] I have updated any relevant storybook stories and templates.
- [x] This pull request is ready to merge.
