### PR TITLE
fix: reorder build:all script

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "build": "yarn build:components",
-    "build:all": "run-s build:components build:site build:preview",
+    "build:all": "run-s build:preview build:site",
     "postbuild:all": "yarn mv:preview",
     "build:clean": "run-s clean build",
     "build:components": "lerna run --scope \"${SCOPE:-@spectrum-css/*}\" --ignore \"@spectrum-css/{*-builder*,preview,generator}\" build",


### PR DESCRIPTION
## Description

The `build:all` command was throwing errors due to the order of tasks conflicting with the caching technique. Removed the `build:components` task as this is being performed during the `build:preview` command; components are dependencies of the storybook build and so are always built before storybook starts. The `build:site` task is still managed by gulp but this will also be optimized when it migrates to being fired & cached by nx.

## How and where has this been tested?

- **How this was tested:**
- [x] `git clean -dfX && yarn install && yarn build:all`

## To-do list

- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] I have updated any relevant storybook stories and templates.
- [x] This pull request is ready to merge.
