### PR TITLE
Swatch: disabled state is missing border & fill color in WHCM

### DIFF
--- a/components/swatch/index.css
+++ b/components/swatch/index.css
@@ -85,12 +85,6 @@ governing permissions and limitations under the License.
     .spectrum-Swatch-fill {
       forced-color-adjust: none;
     }
-
-    &.is-disabled {
-      .spectrum-Swatch-fill {
-        forced-color-adjust: auto;
-      }
-    }
   }
 }
 


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description

<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->

removed an override of forced colors in swatch HCM css in index.css

Related Issue:
https://github.com/adobe/spectrum-web-components/issues/3295
## How and where has this been tested?

- **How this was tested:** <!-- Using steps in issue #000 -->
- In HCM and Normal mode by switching proper
- **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->
Chrome

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->
Previously:
<img width="1059" alt="Screenshot 2023-06-21 at 6 53 31 PM" src="https://github.com/adobe/spectrum-css/assets/8790510/514c21b8-e642-48b2-87ea-df1baebe7f5f">

After fix:
<img width="1017" alt="Screenshot 2023-06-21 at 6 50 54 PM" src="https://github.com/adobe/spectrum-css/assets/8790510/05ae1ae3-cc73-4dcd-a664-2ad1a290ccc4">


## To-do list

<!-- Put an "x" to indicate you've done each of the following -->

- [x] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] I have tested these changes in Windows High Contrast mode.
- [ ] I have updated any relevant storybook stories and templates.
- [x] If my change(s) include visual change(s), a designer has reviewed and approved those changes.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
