### PR TITLE
feat: add `withThemesDisplayWrapper` decorator

### DIFF
--- a/components/actionbar/stories/actionbar.stories.js
+++ b/components/actionbar/stories/actionbar.stories.js
@@ -88,3 +88,9 @@ AllThemes.args = {...Default.args}
 AllThemes.parameters = {
   themesDisplay: 'side-by-side',
 }
+
+export const RTL = Template.bind({});
+RTL.args = {...Default.args};
+RTL.parameters = { 
+  textDirection: 'rtl'
+}

--- a/components/actionbar/stories/actionbar.stories.js
+++ b/components/actionbar/stories/actionbar.stories.js
@@ -86,10 +86,5 @@ Default.args = {};
 export const AllThemes = Template.bind({});
 AllThemes.args = {...Default.args}
 AllThemes.parameters = {
-  toolbar: {
-    themesDisplay: {
-      hidden: true,
-    }
-  }
-  // themesDisplay: 'stacked',
+  themesDisplay: 'side-by-side',
 }

--- a/components/actionbar/stories/actionbar.stories.js
+++ b/components/actionbar/stories/actionbar.stories.js
@@ -82,3 +82,14 @@ export default {
 
 export const Default = Template.bind({});
 Default.args = {};
+
+export const AllThemes = Template.bind({});
+AllThemes.args = {...Default.args}
+AllThemes.parameters = {
+  toolbar: {
+    themesDisplay: {
+      hidden: true,
+    }
+  }
+  // themesDisplay: 'stacked',
+}

--- a/components/badge/stories/badge.stories.js
+++ b/components/badge/stories/badge.stories.js
@@ -99,3 +99,15 @@ export default {
 
 export const Default = Template.bind({});
 Default.args = {};
+
+export const DarkDefault = Template.bind({});
+DarkDefault.args = {
+  ...Default.args,
+  color: 'dark'
+};
+
+export const DarkestDefault = Template.bind({});
+DarkestDefault.args = {
+  ...Default.args,
+  color: 'darkest'
+};

--- a/components/badge/stories/badge.stories.js
+++ b/components/badge/stories/badge.stories.js
@@ -99,15 +99,3 @@ export default {
 
 export const Default = Template.bind({});
 Default.args = {};
-
-export const DarkDefault = Template.bind({});
-DarkDefault.args = {
-  ...Default.args,
-  color: 'dark'
-};
-
-export const DarkestDefault = Template.bind({});
-DarkestDefault.args = {
-  ...Default.args,
-  color: 'darkest'
-};

--- a/tools/preview/decorators/index.js
+++ b/tools/preview/decorators/index.js
@@ -12,8 +12,9 @@ export const withTextDirectionWrapper = makeDecorator({
 	name: "withTextDirectionWrapper",
 	parameterName: "context",
 	wrapper: (StoryFn, context) => {
-		const { globals } = context;
-		const textDirection = globals.textDirection;
+		const { globals, parameters } = context;
+    const defaultDirection = 'ltr';
+		const textDirection =  parameters.textDirection || globals.textDirection || defaultDirection;
 
 		// Shortkeys for the global types
 		document.addEventListener("keydown", (e) => {

--- a/tools/preview/decorators/index.js
+++ b/tools/preview/decorators/index.js
@@ -39,8 +39,8 @@ export const withThemesDisplayWrapper = makeDecorator({
   name: "withThemesDisplayWrapper",
   parameterName: "context",
   wrapper: (StoryFn, context) => {
-    const { globals, args } = context;
-    const themesDisplay = globals.themesDisplay;
+    const { globals, args, parameters } = context;
+    const themesDisplay = parameters.themesDisplay || globals.themesDisplay;
     const isDefault = themesDisplay === 'default';
     const isStacked = themesDisplay === 'stacked';
     const bodyEl = document.body;

--- a/tools/preview/decorators/index.js
+++ b/tools/preview/decorators/index.js
@@ -1,5 +1,6 @@
 import { useEffect, makeDecorator } from "@storybook/preview-api";
 import { html } from "lit";
+import { styleMap } from "lit/directives/style-map.js";
 
 export { withContextWrapper } from "./contextsWrapper.js";
 
@@ -32,6 +33,41 @@ export const withTextDirectionWrapper = makeDecorator({
 
 		return StoryFn(context);
 	},
+});
+
+export const withThemesDisplayWrapper = makeDecorator({
+  name: "withThemesDisplayWrapper",
+  parameterName: "context",
+  wrapper: (StoryFn, context) => {
+    const { globals } = context;
+    const themesDisplay = globals.themesDisplay;
+    const isDefault = themesDisplay === 'default';
+    const isStacked = themesDisplay === 'stacked';
+    const isSideBySide = themesDisplay === 'side-by-side';
+    if (isDefault) return StoryFn(context);
+
+    const classes = ['spectrum--light', 'spectrum--dark', 'spectrum--darkest'];
+
+    const styles = {
+      grid: {
+        display: 'grid',
+        gridTemplateColumns: isStacked ? '1fr' : 'repeat(auto-fit, minmax(0px, 1fr))',
+        height: isStacked ? 'auto' : '100vh',
+      },
+      gridItem: {
+        outline: '1px solid #eee',
+      },
+    };
+
+    return html`
+      <div style=${styleMap(styles.grid)}>
+        ${classes.map((class) => {
+          const whatever = 'thing';
+          html``;
+        })}
+      </div>
+    `;
+  },
 });
 
 /**

--- a/tools/preview/decorators/index.js
+++ b/tools/preview/decorators/index.js
@@ -142,8 +142,9 @@ export const withLanguageWrapper = makeDecorator({
 	name: "withLanguageWrapper",
 	parameterName: "context",
 	wrapper: (StoryFn, context) => {
-		const { globals } = context;
-		const lang = globals.lang;
+		const { globals, parameters } = context;
+    const defaultLang = 'en-US';
+		const lang = parameters.lang || globals.lang || defaultLang;
 
 		useEffect(() => {
 			if (lang) document.documentElement.lang = lang;

--- a/tools/preview/decorators/index.js
+++ b/tools/preview/decorators/index.js
@@ -39,34 +39,57 @@ export const withThemesDisplayWrapper = makeDecorator({
   name: "withThemesDisplayWrapper",
   parameterName: "context",
   wrapper: (StoryFn, context) => {
-    const { globals } = context;
+    const { globals, args } = context;
     const themesDisplay = globals.themesDisplay;
     const isDefault = themesDisplay === 'default';
     const isStacked = themesDisplay === 'stacked';
-    const isSideBySide = themesDisplay === 'side-by-side';
-    if (isDefault) return StoryFn(context);
+    
+    // is it the "default" display option? Return early
 
-    const classes = ['spectrum--light', 'spectrum--dark', 'spectrum--darkest'];
+    if (!isDefault) {
+      // prep the display areas with the correct classes
+      const isExpress = args.express;
 
-    const styles = {
-      grid: {
-        display: 'grid',
-        gridTemplateColumns: isStacked ? '1fr' : 'repeat(auto-fit, minmax(0px, 1fr))',
-        height: isStacked ? 'auto' : '100vh',
-      },
-      gridItem: {
-        outline: '1px solid #eee',
-      },
-    };
+      const themeClassNames = ['spectrum--light', 'spectrum--dark', 'spectrum--darkest'];
+      const bodyEl = document.body;
 
-    return html`
-      <div style=${styleMap(styles.grid)}>
-        ${classes.map((class) => {
-          const whatever = 'thing';
-          html``;
-        })}
-      </div>
-    `;
+      // remove the classes from the Storybook body element
+      // use a timeout here to make it wait for other addons to modify classes first and then remove them after that
+      useEffect(() => {
+        setTimeout(() => {
+          bodyEl.classList.remove(...themeClassNames);
+        }, 1000);
+      }, [bodyEl]);
+
+      const styles = {
+        grid: {
+          display: 'grid',
+          gridTemplateColumns: isStacked ? '1fr' : 'repeat(auto-fit, minmax(0px, 1fr))',
+          height: isStacked ? 'auto' : '100vh',
+        },
+        gridItem: {
+          backgroundColor: 'var(--spectrum-alias-background-color-default)',
+          color: 'var(--spectrum-alias-text-color-default)',
+          outline: '2px solid var(--spectrum-blue-background-color-default)',
+          padding: '2rem',
+        },
+      };
+
+      return html`
+        <style>body { padding: 0 !important;}</style>
+        <div style=${styleMap(styles.grid)}>
+          ${themeClassNames.map((themeClassName) => {
+            return html`
+              <div class="spectrum spectrum--medium ${themeClassName} ${isExpress ? `spectrum--express` : null}" style=${styleMap(styles.gridItem)}>
+                ${StoryFn(context)}
+              </div>
+            `;
+          })}
+        </div>
+      `;
+    }
+
+    return StoryFn(context);
   },
 });
 

--- a/tools/preview/decorators/index.js
+++ b/tools/preview/decorators/index.js
@@ -40,8 +40,9 @@ export const withThemesDisplayWrapper = makeDecorator({
   parameterName: "context",
   wrapper: (StoryFn, context) => {
     const { globals, args, parameters } = context;
-    const themesDisplay = parameters.themesDisplay || globals.themesDisplay;
-    const isDefault = themesDisplay === 'default';
+    const defaultTheme = 'default';
+    const themesDisplay = parameters.themesDisplay || globals.themesDisplay || defaultTheme;
+    const isDefault = themesDisplay === defaultTheme;
     const isStacked = themesDisplay === 'stacked';
     const bodyEl = document.body;
     const bodyElClasses = bodyEl.classList;

--- a/tools/preview/decorators/index.js
+++ b/tools/preview/decorators/index.js
@@ -43,53 +43,56 @@ export const withThemesDisplayWrapper = makeDecorator({
     const themesDisplay = globals.themesDisplay;
     const isDefault = themesDisplay === 'default';
     const isStacked = themesDisplay === 'stacked';
-    
-    // is it the "default" display option? Return early
+    const bodyEl = document.body;
+    const bodyElClasses = bodyEl.classList;
 
-    if (!isDefault) {
-      // prep the display areas with the correct classes
-      const isExpress = args.express;
-
-      const themeClassNames = ['spectrum--light', 'spectrum--dark', 'spectrum--darkest'];
-      const bodyEl = document.body;
-
-      // remove the classes from the Storybook body element
-      // use a timeout here to make it wait for other addons to modify classes first and then remove them after that
-      useEffect(() => {
+    // remove the classes from the Storybook body element
+    // use a timeout here to make it wait for other addons to modify classes first and then remove them after that
+    useEffect(() => {
+      if (isDefault) {
+        setTimeout(() => {
+          bodyEl.className = bodyElClasses;
+        }, 1000);
+      } else {
         setTimeout(() => {
           bodyEl.classList.remove(...themeClassNames);
         }, 1000);
-      }, [bodyEl]);
+      }
+    }, [bodyEl]);
+    
+    // is it the "default" display option? Return early
+    if (isDefault) return StoryFn(context);
+    
+    // prep the display areas with the correct classes
+    const isExpress = args.express;
 
-      const styles = {
-        grid: {
-          display: 'grid',
-          gridTemplateColumns: isStacked ? '1fr' : 'repeat(auto-fit, minmax(0px, 1fr))',
-          height: isStacked ? 'auto' : '100vh',
-        },
-        gridItem: {
-          backgroundColor: 'var(--spectrum-alias-background-color-default)',
-          color: 'var(--spectrum-alias-text-color-default)',
-          outline: '2px solid var(--spectrum-blue-background-color-default)',
-          padding: '2rem',
-        },
-      };
+    const themeClassNames = ['spectrum--light', 'spectrum--dark', 'spectrum--darkest'];
+    const styles = {
+      grid: {
+        display: 'grid',
+        gridTemplateColumns: isStacked ? '1fr' : 'repeat(auto-fit, minmax(0px, 1fr))',
+        height: isStacked ? 'auto' : '100vh',
+      },
+      gridItem: {
+        backgroundColor: 'var(--spectrum-alias-background-color-default)',
+        color: 'var(--spectrum-alias-text-color-default)',
+        outline: '2px solid var(--spectrum-blue-background-color-default)',
+        padding: '2rem',
+      },
+    };
 
-      return html`
-        <style>body { padding: 0 !important;}</style>
-        <div style=${styleMap(styles.grid)}>
-          ${themeClassNames.map((themeClassName) => {
-            return html`
-              <div class="spectrum spectrum--medium ${themeClassName} ${isExpress ? `spectrum--express` : null}" style=${styleMap(styles.gridItem)}>
-                ${StoryFn(context)}
-              </div>
-            `;
-          })}
-        </div>
-      `;
-    }
-
-    return StoryFn(context);
+    return html`
+      <style>body { padding: 0 !important;}</style>
+      <div style=${styleMap(styles.grid)}>
+        ${themeClassNames.map((themeClassName) => {
+          return html`
+            <div class="spectrum spectrum--medium ${themeClassName} ${isExpress ? `spectrum--express` : null}" style=${styleMap(styles.gridItem)}>
+              ${StoryFn(context)}
+            </div>
+          `;
+        })}
+      </div>
+    `;
   },
 });
 

--- a/tools/preview/preview.js
+++ b/tools/preview/preview.js
@@ -3,6 +3,7 @@ import {
 	withTextDirectionWrapper,
 	withLanguageWrapper,
 	withReducedMotionWrapper,
+  withThemesDisplayWrapper
 	// withSizingWrapper,
 } from "./decorators/index.js";
 import { withActions } from "@storybook/addon-actions/decorator";
@@ -237,6 +238,7 @@ export const decorators = [
 	withReducedMotionWrapper,
 	withContextWrapper,
 	withActions,
+  withThemesDisplayWrapper
 ];
 
 export default {

--- a/tools/preview/preview.js
+++ b/tools/preview/preview.js
@@ -84,9 +84,9 @@ export const globalTypes = {
     defaultValue: 'default',
     toolbar: {
       items: [
-        {value: 'default', title: 'default', right: 'default'},
-        {value: 'stacked', title: 'stacked', right: 'stacked'},
-        {value: 'side-by-side', title: 'side-by-side', right: 'side-by-side'}
+        {value: 'default', icon: 'browser', title: 'default', right: 'default'},
+        {value: 'stacked', icon: 'bottombar', title: 'stacked', right: 'stacked'},
+        {value: 'side-by-side', icon: 'sidebaralt', title: 'side-by-side', right: 'side-by-side'}
       ],
       dynamicTitle: true,
     }

--- a/tools/preview/preview.js
+++ b/tools/preview/preview.js
@@ -76,6 +76,20 @@ export const globalTypes = {
 			dynamicTitle: true,
 		},
 	},
+  themesDisplay: {
+    title: "Themes Display",
+    description: "Show all themes at once",
+    showName: true,
+    defaultValue: 'default',
+    toolbar: {
+      items: [
+        {value: 'default', title: 'default', right: 'default'},
+        {value: 'stacked', title: 'stacked', right: 'stacked'},
+        {value: 'side-by-side', title: 'side-by-side', right: 'side-by-side'}
+      ],
+      dynamicTitle: true,
+    }
+  },
 };
 
 // Global properties added to each component;


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description

This adds the `withThemesDisplayWrapper` decorator to Storybook which will give us the ability to pass multiple theme variations to Chromatic via one story (and one snapshot).

The decorator adds a `themesDisplay` parameter to Storybook, which provides three options to the user: `default`, `stacked`, and `side-by-side`. These options give the user the ability to show a component in its "default" (single theme) state, in a "stacked" state where `light`, `dark`, and `darkest` are stacked atop one another, and in a "side-by-side" state where the component's themes are displayed next to one another.

Instead of us writing multiple, individual stories for these themes, we can now view them all at the same time, and also test them all at the same time!

### To-do:
* [x] configure a story (or all stories) to take advantage of this in Chromatic



## How and where has this been tested?

- **How this was tested:** <!-- Using steps in issue #000 -->
- **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots

<img width="1629" alt="Screenshot 2023-06-21 at 4 52 38 PM" src="https://github.com/adobe/spectrum-css/assets/360251/5fc536db-f9b9-4368-ad80-2c2a7d7d6aea">


## To-do list

<!-- Put an "x" to indicate you've done each of the following -->

- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] I have updated any relevant storybook stories and templates.
- [ ] If my change(s) include visual change(s), a designer has reviewed and approved those changes.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
