### PR TITLE
docs: update story titles to reflect components categorization

### DIFF
--- a/components/accordion/stories/accordion.stories.js
+++ b/components/accordion/stories/accordion.stories.js
@@ -2,7 +2,7 @@
 import { Template } from "./template";
 
 export default {
-	title: "Accordion",
+	title: "Components/Accordion",
 	description:
 		"The accordion element contains a list of items that can be expanded or collapsed to reveal additional content or information associated with each item. There can be zero expanded items, exactly one expanded item, or more than one item expanded at a time, depending on the configuration. This list of items is defined by child accordion item elements.",
 	component: "Accordion",

--- a/components/colorhandle/stories/colorhandle.stories.js
+++ b/components/colorhandle/stories/colorhandle.stories.js
@@ -2,7 +2,7 @@
 import { Template } from "./template";
 
 export default {
-	title: "Color handle",
+	title: "Components/Color handle",
 	description:
 		"The Color Handle component is used with ColorArea, ColorSlider and ColorWheel as the color selector",
 	component: "Colorhandle",


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description

Updates a few stories to reflect our new "Components" organization in Storybook.

## How and where has this been tested?

- **How this was tested:** <!-- Using steps in issue #000 -->
- **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following -->

- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] I have updated any relevant storybook stories and templates.
- [ ] If my change(s) include visual change(s), a designer has reviewed and approved those changes.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
