### PR TITLE
fix(expressvars): slider variable typo

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,8 +4,10 @@
 **/node_modules
 
 components/*/dist
+components/expressvars/custom.css
 components/expressvars/css/**/*.css
 components/vars/css/**/*.css
+components/vars/custom.css
 components/tokens/custom-*/*.css
 tools/preview/storybook-static/**
 tools/generator

--- a/components/expressvars/custom.css
+++ b/components/expressvars/custom.css
@@ -21,7 +21,7 @@
   --spectrum-colorcontrol-checkerboard-light-color: var(--spectrum-global-color-static-white);
   --spectrum-colorcontrol-checkerboard-dark-color: var(--spectrum-global-color-static-gray-200);
 
-  --spectrum-slide-label-text-size: var(--spectrum-global-dimension-font-size-100);
+  --spectrum-slider-label-text-size: var(--spectrum-global-dimension-font-size-100);
   --spectrum-slider-m-handle-gap: 0px;
   --spectrum-slider-m-handle-border-radius: 100%;
   --spectrum-slider-m-track-border-radius: var(--spectrum-alias-border-radius-xsmall);


### PR DESCRIPTION
## Description

https://github.com/adobe/spectrum-css/blob/73400d88b4aa7afd535a161eba81a644baf7235f/components/expressvars/custom.css#L24

Fixes typo in slider variable for custom express vars. I did a search and did not see this variable used in the slider component b/c it's already been migrated to the new token system.

That makes this a pretty low-priority PR but in case someone downstream wanted to use this I guess. 🤷 


## How and where has this been tested?

- **How this was tested:**
- [x] Validate slider express state for regressions


## To-do list

- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] I have tested these changes in Windows High Contrast mode.
- [x] I have updated any relevant storybook stories and templates.
- [x] If my change(s) include visual change(s), a designer has reviewed and approved those changes.
- [x] This pull request is ready to merge.
