### PR TITLE
fix(actiongroup): focus indicator border radius

### DIFF
--- a/components/actiongroup/index.css
+++ b/components/actiongroup/index.css
@@ -21,16 +21,8 @@ governing permissions and limitations under the License.
   --spectrum-actiongroup-vertical-spacing-regular: var(--spectrum-spacing-75);
 }
 
-.spectrum-ActionGroup--sizeM {
-  --spectrum-actiongroup-horizontal-spacing-regular: var(--spectrum-spacing-100);
-  --spectrum-actiongroup-vertical-spacing-regular: var(--spectrum-spacing-100);
-}
-
-.spectrum-ActionGroup--sizeL {
-  --spectrum-actiongroup-horizontal-spacing-regular: var(--spectrum-spacing-100);
-  --spectrum-actiongroup-vertical-spacing-regular: var(--spectrum-spacing-100);
-}
-
+.spectrum-ActionGroup--sizeM,
+.spectrum-ActionGroup--sizeL,
 .spectrum-ActionGroup--sizeXL {
   --spectrum-actiongroup-horizontal-spacing-regular: var(--spectrum-spacing-100);
   --spectrum-actiongroup-vertical-spacing-regular: var(--spectrum-spacing-100);
@@ -71,7 +63,7 @@ governing permissions and limitations under the License.
 
       &:first-child {
         /* Action button passthrough styling */
-        --spectrum-actionbutton-focus-ring-border-radius: var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius)) 0px 0px var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius));
+        --mod-actionbutton-focus-indicator-border-radius: var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius)) 0px 0px var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius));
 
         border-start-start-radius: var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius));
         border-end-start-radius: var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius));
@@ -80,7 +72,7 @@ governing permissions and limitations under the License.
 
       & + .spectrum-ActionGroup-item {
         /* Action button passthrough styling */
-        --spectrum-actionbutton-focus-ring-border-radius: 0px;
+        --mod-actionbutton-focus-indicator-border-radius: 0px;
 
         margin-inline-start: var(--mod-actiongroup-horizontal-spacing-compact, var(--spectrum-actiongroup-horizontal-spacing-compact));
         margin-inline-end: var(--mod-actiongroup-horizontal-spacing-compact, var(--spectrum-actiongroup-horizontal-spacing-compact));
@@ -88,7 +80,7 @@ governing permissions and limitations under the License.
 
       &:last-child {
         /* Action button passthrough styling */
-        --spectrum-actionbutton-focus-ring-border-radius: 0px var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius)) var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius)) 0px;
+        --mod-actionbutton-focus-indicator-border-radius: 0px var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius)) var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius)) 0px;
 
         border-start-end-radius: var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius));
         border-end-end-radius: var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius));
@@ -123,7 +115,7 @@ governing permissions and limitations under the License.
 
         &:first-child {
           /* Action button passthrough styling */
-          --spectrum-actionbutton-focus-ring-border-radius: var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius)) var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius)) 0px 0px;
+          --mod-actionbutton-focus-indicator-border-radius: var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius)) var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius)) 0px 0px;
 
           border-start-start-radius: var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius));
           border-start-end-radius: var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius));
@@ -141,7 +133,7 @@ governing permissions and limitations under the License.
 
         &:last-child {
           /* Action button passthrough styling */
-          --spectrum-actionbutton-focus-ring-border-radius: 0px 0px var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius)) var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius));
+          --mod-actionbutton-focus-indicator-border-radius: 0px 0px var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius)) var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius));
 
           border-end-start-radius: var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius));
           border-end-end-radius: var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius));

--- a/components/actiongroup/metadata/mods.md
+++ b/components/actiongroup/metadata/mods.md
@@ -1,10 +1,11 @@
-| Modifiable Custom Properties                   |
-| ---------------------------------------------- |
-| `--mod-actiongroup-border-radius`              |
-| `--mod-actiongroup-border-radius-reset`        |
-| `--mod-actiongroup-button-spacing-reset`       |
-| `--mod-actiongroup-gap-size-compact`           |
-| `--mod-actiongroup-horizontal-spacing-compact` |
-| `--mod-actiongroup-horizontal-spacing-regular` |
-| `--mod-actiongroup-vertical-spacing-compact`   |
-| `--mod-actiongroup-vertical-spacing-regular`   |
+| Modifiable Custom Properties                       |
+| -------------------------------------------------- |
+| `--mod-actionbutton-focus-indicator-border-radius` |
+| `--mod-actiongroup-border-radius`                  |
+| `--mod-actiongroup-border-radius-reset`            |
+| `--mod-actiongroup-button-spacing-reset`           |
+| `--mod-actiongroup-gap-size-compact`               |
+| `--mod-actiongroup-horizontal-spacing-compact`     |
+| `--mod-actiongroup-horizontal-spacing-regular`     |
+| `--mod-actiongroup-vertical-spacing-compact`       |
+| `--mod-actiongroup-vertical-spacing-regular`       |

--- a/components/actiongroup/stories/actiongroup.stories.js
+++ b/components/actiongroup/stories/actiongroup.stories.js
@@ -72,21 +72,55 @@ export default {
 	},
 };
 
+const items = [
+	{
+		iconName: "Edit",
+		label: "Edit",
+	},
+	{
+		iconName: "Copy",
+		label: "Copy",
+	},
+	{
+		iconName: "Delete",
+		label: "Delete",
+		isSelected: true,
+	},
+];
+
 export const Default = Template.bind({});
 Default.args = {
-	content: [
-		{
-			iconName: "Edit",
-			label: "Edit",
-		},
-		{
-			iconName: "Copy",
-			label: "Copy",
-		},
-		{
-			iconName: "Delete",
-			label: "Delete",
-			isSelected: true,
-		},
-	],
+	content: items
+};
+
+
+export const Compact = Template.bind({});
+Compact.args = {
+	compact: true,
+	content: items
+};
+
+export const Vertical = Template.bind({});
+Vertical.args = {
+	vertical: true,
+	content: items
+};
+
+export const VerticalCompact = Template.bind({});
+VerticalCompact.args = {
+	vertical: true,
+	compact: true,
+	content: items
+};
+
+export const Justified = Template.bind({});
+Justified.args = {
+	justified: true,
+	content: items
+};
+
+export const Quiet = Template.bind({});
+Quiet.args = {
+	areQuiet: true,
+	content: items
 };


### PR DESCRIPTION
## Description

This updates the pass-through variable names that were supposed to update the focus indicator border-radius when the `compact` variant was used. The variable names were incorrect so the value was not being updated and the focus indicator border radius was incorrect. 

This PR also adds a few more stories to Storybook to further flesh out or VRTs.

## Screenshots

### Current
![Screenshot 2023-06-28 at 9 29 43 AM](https://github.com/adobe/spectrum-css/assets/99203545/f32b673c-0f81-4b88-afa7-ab81e82bbf90)

![Screenshot 2023-06-28 at 9 30 23 AM](https://github.com/adobe/spectrum-css/assets/99203545/06e16822-edb5-4172-bf0f-06af3a7f117a)

### This PR
![Screenshot 2023-06-28 at 9 29 17 AM](https://github.com/adobe/spectrum-css/assets/99203545/b871805d-0b92-47df-adeb-41e6adc6dd60)

![Screenshot 2023-06-28 at 9 30 44 AM](https://github.com/adobe/spectrum-css/assets/99203545/30eec781-97ed-4251-ad8e-95d93e63baeb)

## To-do list

<!-- Put an "x" to indicate you've done each of the following -->

- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
- [x] I have updated any relevant storybook stories and templates.
- [ ] If my change(s) include visual change(s), a designer has reviewed and approved those changes.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
