### PR TITLE
chore: unlock vrt runs to all PRs

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -11,7 +11,7 @@ jobs:
   vrt:
     name: Visual regression testing
     # Run VRT only if the PR is not a draft and has the label 'run_vrt' and does not have the label 'skip_vrt'
-    if: contains(github.event.pull_request.labels.*.name, 'run_vrt') && github.event.pull_request.draft == false
+    if: github.event.pull_request.draft != false || (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'run_vrt'))
 
     runs-on: ubuntu-latest
 
@@ -40,11 +40,6 @@ jobs:
           diagnostics: true
           # this lets the VRT pass without running it if the PR has the label 'skip_vrt'
           skip: ${{ contains(github.event.pull_request.labels.*.name, 'skip_vrt') }}
-      - name: Remove labels
-        uses: mondeja/remove-labels-gh-action@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          labels: "run_vrt"
       - name: Upload logs
         uses: actions/upload-artifact@v3
         if: always()

--- a/tools/preview/preview.js
+++ b/tools/preview/preview.js
@@ -1,3 +1,5 @@
+import isChromatic from "chromatic/isChromatic";
+
 import {
 	withContextWrapper,
 	withTextDirectionWrapper,
@@ -171,13 +173,23 @@ export const args = {
 	customClasses: [],
 };
 
+/** @type import('@storybook/types').StorybookParameters & import('@storybook/types').API_Layout */
 export const parameters = {
-	layout: "padded", // Valid: 'centered' | 'fullscreen' | 'padded' | 'none';
+	layout: "padded",
 	showNav: true,
+	showTabs: true,
 	showPanel: true,
 	panelPosition: "bottom",
-	showToolbar: false,
+	showToolbar: true,
 	isFullscreen: false,
+	//👇 Defines a list of viewport widths for a single story to be captured in Chromatic.
+	chromatic: isChromatic()
+		? {
+				// viewports: [320, 1200],
+				// forcedColors: 'active',
+				// prefersReducedMotion: 'reduce',
+		  }
+		: {},
 	controls: {
 		expanded: true,
 		hideNoControlsWarning: true,
@@ -223,6 +235,7 @@ export const decorators = [
 	withReducedMotionWrapper,
 	withContextWrapper,
 	withActions,
+	// ...[isChromatic() ? withSizingWrapper : false].filter(Boolean),
 ];
 
 export default {


### PR DESCRIPTION
RELEASE THE KRAKEN!!!

Unblock VRT runs for all active PRs.

Only run VRT for draft PRs if the run_vrt label is present.

## How and where has this been tested?

## To-do list

- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] This pull request is ready to merge.
