### PR TITLE
chore: add main pushes to vrt

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,7 +14,7 @@ jobs:
   vrt:
     name: Visual regression testing
     # Run VRT only if the PR is not a draft and has the label 'run_vrt' and does not have the label 'skip_vrt'
-    if: github.event.pull_request.draft != false || (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'run_vrt'))
+    if: github.event.pull_request.draft != true || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run_vrt'))
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,6 +1,9 @@
 name: Testing
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     paths:


### PR DESCRIPTION
To ensure up-to-date ancestors for Chromatic, we'll need to ensure we rerun VRT on every push to main.

## To-do list

- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] This pull request is ready to merge.
