### PR TITLE
chore(calendar): storybook fix for today highlighter

### DIFF
--- a/components/calendar/stories/calendar.stories.js
+++ b/components/calendar/stories/calendar.stories.js
@@ -1,7 +1,8 @@
 // Import the component markup template
 import { Template } from "./template";
 
-import { default as ActionButtonStories } from "@spectrum-css/actionbutton/stories/actionbutton.stories.js";
+import isChromatic from "chromatic/isChromatic";
+import ActionButtonStories from "@spectrum-css/actionbutton/stories/actionbutton.stories.js";
 
 const months = [...Array(12).keys()].map((key) =>
 	new Date(0, key).toLocaleString("en", { month: "long" })
@@ -120,4 +121,10 @@ RangeSelection.args = {
 	year: 2023,
 	useDOWAbbrev: true,
 	padded: true,
+};
+
+export const TodayHighlighted = Template.bind({});
+TodayHighlighted.args = {
+	month: isChromatic() ? months[0] : months[new Date().getMonth()],
+	year: isChromatic() ? 2021 : new Date().getFullYear(),
 };

--- a/components/calendar/stories/template.js
+++ b/components/calendar/stories/template.js
@@ -3,6 +3,7 @@ import { classMap } from "lit/directives/class-map.js";
 import { repeat } from "lit/directives/repeat.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
+import isChromatic from "chromatic/isChromatic";
 import { useArgs, useGlobals } from "@storybook/client-api";
 import { action } from "@storybook/addon-actions";
 
@@ -71,7 +72,7 @@ export const Template = ({
 	 */
 	const generateMonthArray = ({ selectedDate, lastSelectedDate }) => {
 		/* Fetch a clean (time-free) version of today's date */
-		const today = new Date();
+		const today = !isChromatic() ? new Date() : displayedDate;
 		today.setHours(0, 0, 0, 0);
 		const todayDatetime = today.getTime();
 


### PR DESCRIPTION
## Description

VRT throwing errors on the today highlighter as it updates every day the tests are run.

This leverages the isChromatic() flag to hardcode the "today" value for VRT but leaves it variable in development mode.

## How and where has this been tested?

- **How this was tested:**
- [x] Local calendar today story shows the current month and year with the correct date highlighted
- [ ] VRT shows the today highlighter for January 1st, 2021

## To-do list

- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] I have updated any relevant storybook stories and templates.
- [x] This pull request is ready to merge.
