### PR TITLE
fix(swatch): specify forced-color style for disabled swatch borders

### DIFF
--- a/components/swatch/index.css
+++ b/components/swatch/index.css
@@ -86,6 +86,10 @@ governing permissions and limitations under the License.
       forced-color-adjust: none;
     }
   }
+  .spectrum-Swatch[disabled],
+  .spectrum-Swatch.is-disabled {
+    --highcontrast-swatch-border-color: GrayText;
+  }
 }
 
 /* Swatch styles */


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description

* Adds a `forced-colors` style for the custom property that controls the border color in `disabled` Swatches

Refs: https://github.com/adobe/spectrum-web-components/issues/3295

## How and where has this been tested?

- **How this was tested:** <!-- Using steps in issue #000 -->
- **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following -->

- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] I have updated any relevant storybook stories and templates.
- [ ] If my change(s) include visual change(s), a designer has reviewed and approved those changes.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
