### PR TITLE
fix: tag focus issue solved

### DIFF
--- a/components/tag/index.css
+++ b/components/tag/index.css
@@ -299,32 +299,17 @@ governing permissions and limitations under the License.
       content: "";
       display: inline-block;
       position: absolute;
-      margin: auto;
-      top: 0;
-      bottom: 0;
-      left: 0;
-      right: 0;
-      /* ensures focus indicator centers if borders or gap change */
-      margin-inline-start: calc((var(--mod-tag-focus-ring-gap, var(--spectrum-tag-focus-ring-gap))
-                                + var(--mod-tag-border-width, var(--spectrum-tag-border-width))
-                                + var(--mod-tag-focus-ring-thickness, var(--spectrum-tag-focus-ring-thickness)))
-                                * -1);
-      margin-block-start: calc((var(--mod-tag-focus-ring-gap, var(--spectrum-tag-focus-ring-gap))
-                                + var(--mod-tag-border-width, var(--spectrum-tag-border-width))
-                                + var(--mod-tag-focus-ring-thickness, var(--spectrum-tag-focus-ring-thickness)))
-                                * -1);
-
-      inline-size: calc(100% + (var(--mod-tag-focus-ring-gap, var(--spectrum-tag-focus-ring-gap)) * 2)
-                  + (var(--mod-tag-border-width, var(--spectrum-tag-border-width)) * 2));
-      block-size: calc(100% + (var(--mod-tag-focus-ring-gap, var(--spectrum-tag-focus-ring-gap)) * 2)
-                  + (var(--mod-tag-border-width, var(--spectrum-tag-border-width)) * 2));
-
+      top: calc(-1 * var(--mod-tag-focus-ring-gap, var(--spectrum-tag-focus-ring-gap)) - var(--mod-tag-border-width, var(--spectrum-tag-border-width)) - var(--mod-tag-focus-ring-thickness, var(--spectrum-tag-focus-ring-thickness)));
+      bottom: calc(-1 * var(--mod-tag-focus-ring-gap, var(--spectrum-tag-focus-ring-gap)) - var(--mod-tag-border-width, var(--spectrum-tag-border-width)) - var(--mod-tag-focus-ring-thickness, var(--spectrum-tag-focus-ring-thickness)));
+      left: calc(-1 * var(--mod-tag-focus-ring-gap, var(--spectrum-tag-focus-ring-gap)) - var(--mod-tag-border-width, var(--spectrum-tag-border-width)) - var(--mod-tag-focus-ring-thickness, var(--spectrum-tag-focus-ring-thickness)));
+      right: calc(-1 * var(--mod-tag-focus-ring-gap, var(--spectrum-tag-focus-ring-gap)) - var(--mod-tag-border-width, var(--spectrum-tag-border-width)) - var(--mod-tag-focus-ring-thickness, var(--spectrum-tag-focus-ring-thickness)));
       border-color: var(--highcontrast-tag-focus-ring-color, var(--mod-tag-focus-ring-color, var(--spectrum-tag-focus-ring-color)));
       border-radius: calc(var(--mod-tag-corner-radius, var(--spectrum-tag-corner-radius))
                            + var(--mod-tag-focus-ring-gap, var(--spectrum-tag-focus-ring-gap))
                            + var(--mod-tag-border-width, var(--spectrum-tag-border-width)));
       border-width: var(--mod-tag-focus-ring-thickness, var(--spectrum-tag-focus-ring-thickness));
       border-style: solid;
+      pointer-events:none;
     }
   }
 }


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
The issue was related to the ::after pseudo-element being positioned absolutely with a top, bottom, left, and right value of 0, and having negative margin values for margin-inline-start and margin-block-start and the pseudo-element was covering the entire element, including the interactive parts.


<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->

## How and where has this been tested?

- **How this was tested:** <!-- Using steps in issue #000 -->
- **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->
Chrome, Storybook
## Screenshots

https://github.com/adobe/spectrum-css/assets/8790510/d2701e92-9ae1-4194-b9aa-adb8ec490580



<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following -->

- [x] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [] I have tested these changes in Windows High Contrast mode.
- [x] I have updated any relevant storybook stories and templates.
- [ ] If my change(s) include visual change(s), a designer has reviewed and approved those changes.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
