### PR TITLE
fix(button): add explicit highcontrast variables for disabled color

### DIFF
--- a/components/button/index.css
+++ b/components/button/index.css
@@ -261,6 +261,10 @@ a.spectrum-Button {
         --highcontrast-button-content-color-hover: ButtonFace;
         --highcontrast-button-content-color-down: ButtonFace;
         --highcontrast-button-content-color-focus: ButtonFace;
+
+        .spectrum-Button-label {
+          forced-color-adjust: none;
+        }
         
       }
     }

--- a/components/button/index.css
+++ b/components/button/index.css
@@ -239,6 +239,9 @@ a.spectrum-Button {
 /* windows high contrast mode over-writes for accent variant */
 @media (forced-colors: active) {
   .spectrum-Button {
+    --highcontrast-button-content-color-disabled: GrayText;
+    --highcontrast-button-border-color-disabled: GrayText;
+
     &:focus-ring {
       &:after {
         forced-color-adjust: none;
@@ -248,14 +251,11 @@ a.spectrum-Button {
 
     &.spectrum-Button--accent {
       &.spectrum-Button--fill {
-        background-color: ButtonText;
-        color: ButtonFace;
+        --highcontrast-button-background-color-default: ButtonText;
+        --highcontrast-button-content-color-default: ButtonFace;
+        --highcontrast-button-background-color-disabled: ButtonFace;
 
-        &:disabled,
-        &.is-disabled {
-          background-color: ButtonFace;
-          color: GrayText;
-        }
+
 
         /* simplified for a lot of state for high contrast mode */
         &:active,
@@ -266,6 +266,10 @@ a.spectrum-Button {
         }
         .spectrum-Button-label {
           forced-color-adjust: none;
+        }
+
+        &:disabled {
+          background-color: ButtonFace;
         }
       }
     }

--- a/components/button/index.css
+++ b/components/button/index.css
@@ -255,22 +255,13 @@ a.spectrum-Button {
         --highcontrast-button-content-color-default: ButtonFace;
         --highcontrast-button-background-color-disabled: ButtonFace;
 
-
-
-        /* simplified for a lot of state for high contrast mode */
-        &:active,
-        &:hover,
-        &:focus-ring,
-        &.is-focused {
-          background-color: Highlight;
-        }
-        .spectrum-Button-label {
-          forced-color-adjust: none;
-        }
-
-        &:disabled {
-          background-color: ButtonFace;
-        }
+        --highcontrast-button-background-color-hover: Highlight;
+        --highcontrast-button-background-color-down: Highlight;
+        --highcontrast-button-background-color-focus: Highlight;
+        --highcontrast-button-content-color-hover: ButtonFace;
+        --highcontrast-button-content-color-down: ButtonFace;
+        --highcontrast-button-content-color-focus: ButtonFace;
+        
       }
     }
   }

--- a/components/button/stories/button.stories.js
+++ b/components/button/stories/button.stories.js
@@ -167,12 +167,10 @@ Disabled.args = {
 	iconName: "Actions",
 };
 
-export const WithForcedColors = CustomButton.bind({
-	parameters: {
-    // Sets the forced-colors media feature for a specific story.
-    chromatic: { forcedColors: 'active' },
-  },
-});
+export const WithForcedColors = CustomButton.bind({});
+WithForcedColors.parameters = {
+  chromatic: { forcedColors: "active" },
+};
 WithForcedColors.args = {
 	iconName: "Actions",
 };

--- a/components/button/stories/button.stories.js
+++ b/components/button/stories/button.stories.js
@@ -166,3 +166,13 @@ Disabled.args = {
 	isDisabled: true,
 	iconName: "Actions",
 };
+
+export const WithForcedColors = CustomButton.bind({
+	parameters: {
+    // Sets the forced-colors media feature for a specific story.
+    chromatic: { forcedColors: 'active' },
+  },
+});
+WithForcedColors.args = {
+	iconName: "Actions",
+};


### PR DESCRIPTION
## Description

In SWC, the highcontrast text color for disabled buttons was incorrect. We were not explicitly assigning that color variable, so this PR adds `--highcontrast` variables for disabled color and border color.

[SWC Github Issue](https://github.com/adobe/spectrum-web-components/issues/3244)

## How and where has this been tested?

- **How this was tested:** Tested using `yarn link` to verify that the change does indeed make the desired update in SWC

## Screenshots

### Current
![Screenshot 2023-06-30 at 10 36 56 AM](https://github.com/adobe/spectrum-css/assets/99203545/063b15aa-cef9-46a2-8a29-f04652208bcb)

### This PR
![Screenshot 2023-06-30 at 10 32 26 AM](https://github.com/adobe/spectrum-css/assets/99203545/e1a3e6f5-2d8e-40b1-b2b8-aa68b1aa6f28)

## To-do list

<!-- Put an "x" to indicate you've done each of the following -->

- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] I have tested these changes in Windows High Contrast mode.
- [x] I have updated any relevant storybook stories and templates.
- [ ] If my change(s) include visual change(s), a designer has reviewed and approved those changes.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
