### PR TITLE
fix(picker): add side label variant

### DIFF
--- a/components/picker/index.css
+++ b/components/picker/index.css
@@ -37,6 +37,7 @@ governing permissions and limitations under the License.
   /* spacing */
   --spectrum-picker-spacing-edge-to-text: var(--spectrum-component-edge-to-text-100);
   --spectrum-picker-spacing-edge-to-text-quiet: var(--spectrum-field-edge-to-text-quiet);
+  --spectrum-picker-spacing-top-to-text-side-label-quiet: var(--spectrum-field-label-top-margin-medium);
 
   --spectrum-picker-spacing-text-to-icon: var(--spectrum-text-to-visual-100);
   --spectrum-picker-spacing-text-to-alert-icon-inline-start: var(--spectrum-field-text-to-alert-icon-medium);
@@ -90,6 +91,7 @@ governing permissions and limitations under the License.
 .spectrum-Picker--sizeS {
   --spectrum-picker-font-size: var(--spectrum-font-size-75);
   --spectrum-picker-block-size: var(--spectrum-component-height-75);
+  --spectrum-picker-spacing-top-to-text-side-label-quiet: var(--spectrum-field-label-top-margin-small);
   --spectrum-picker-spacing-text-to-icon: var(--spectrum-text-to-visual-75);
   --spectrum-picker-spacing-text-to-alert-icon-inline-start: var(--spectrum-field-text-to-alert-icon-small);
   --spectrum-picker-spacing-icon-to-disclosure-icon: var(--spectrum-picker-visual-to-disclosure-icon-small);
@@ -105,6 +107,7 @@ governing permissions and limitations under the License.
 .spectrum-Picker--sizeM {
   --spectrum-picker-font-size: var(--spectrum-font-size-100);
   --spectrum-picker-block-size: var(--spectrum-component-height-100);
+  --spectrum-picker-spacing-top-to-text-side-label-quiet: var(--spectrum-field-label-top-margin-medium);
   --spectrum-picker-spacing-text-to-icon: var(--spectrum-text-to-visual-100);
   --spectrum-picker-spacing-text-to-alert-icon-inline-start: var(--spectrum-field-text-to-alert-icon-medium);
   --spectrum-picker-spacing-icon-to-disclosure-icon: var(--spectrum-picker-visual-to-disclosure-icon-medium);
@@ -120,6 +123,7 @@ governing permissions and limitations under the License.
 .spectrum-Picker--sizeL {
   --spectrum-picker-font-size: var(--spectrum-font-size-200);
   --spectrum-picker-block-size: var(--spectrum-component-height-200);
+  --spectrum-picker-spacing-top-to-text-side-label-quiet: var(--spectrum-field-label-top-margin-large);
   --spectrum-picker-spacing-text-to-icon: var(--spectrum-text-to-visual-200);
   --spectrum-picker-spacing-text-to-alert-icon-inline-start: var(--spectrum-field-text-to-alert-icon-large);
   --spectrum-picker-spacing-icon-to-disclosure-icon: var(--spectrum-picker-visual-to-disclosure-icon-large);
@@ -135,6 +139,7 @@ governing permissions and limitations under the License.
 .spectrum-Picker--sizeXL {
   --spectrum-picker-font-size: var(--spectrum-font-size-300);
   --spectrum-picker-block-size: var(--spectrum-component-height-300);
+  --spectrum-picker-spacing-top-to-text-side-label-quiet: var(--spectrum-field-label-top-margin-extra-large);
   --spectrum-picker-spacing-text-to-icon: var(--spectrum-text-to-visual-300);
   --spectrum-picker-spacing-text-to-alert-icon-inline-start: var(--spectrum-field-text-to-alert-icon-extra-large);
   --spectrum-picker-spacing-icon-to-disclosure-icon: var(--spectrum-picker-visual-to-disclosure-icon-extra-large);
@@ -400,12 +405,9 @@ governing permissions and limitations under the License.
   white-space: nowrap;
   overflow: hidden;
 
-  line-height: calc(
-    var(--mod-picker-block-size, var(--spectrum-picker-block-size)) - calc(var(--mod-picker-border-width, var(--spectrum-picker-border-width)) * 2)
-  );
-
   font-size: var(--mod-picker-font-size, var(--spectrum-picker-font-size));
   line-height: var(--mod-picker-line-height, var(--spectrum-picker-line-height));
+  
 
   text-overflow: ellipsis;
   text-align: start;
@@ -468,6 +470,10 @@ governing permissions and limitations under the License.
   margin-block-start: calc( var(--mod-picker-spacing-label-to-picker-quiet, var(--spectrum-picker-spacing-label-to-picker-quiet)) + (1px));
   color: var(--highcontrast-picker-font-color-default, var(--mod-picker-font-color-default, var(--spectrum-picker-font-color-default)));
   background-color: transparent;
+
+  &.spectrum-Picker--sideLabel {
+    margin-block-start: calc(-1 * var(--spectrum-picker-spacing-top-to-text-side-label-quiet)); 
+  }
 
   .spectrum-Picker-menuIcon {
     margin-inline-end: var(--mod-picker-spacing-edge-to-disclosure-icon-quiet, var(--spectrum-picker-spacing-edge-to-disclosure-icon-quiet));

--- a/components/picker/index.css
+++ b/components/picker/index.css
@@ -202,6 +202,7 @@ governing permissions and limitations under the License.
 
   /* Layout */
   display: flex;
+  box-sizing: border-box;
 
   /* Minimum width is 2 times the height */
   max-inline-size: 100%;
@@ -459,10 +460,6 @@ governing permissions and limitations under the License.
   transform: translateY(var(--mod-picker-spacing-picker-to-popover, var(--spectrum-picker-spacing-picker-to-popover)));
 }
 
-.spectrum-Picker--quiet + .spectrum-Popover--bottom.is-open {
-  margin-inline-start: calc(-1 * var(--mod-picker-popover-quiet-offset-x, var(--spectrum-picker-popover-quiet-offset-x)));
-}
-
 .spectrum-Picker--quiet {
   border: none;
   border-radius: 0;
@@ -511,4 +508,9 @@ governing permissions and limitations under the License.
   &.is-disabled {
     background-color: transparent;
   }
+}
+
+.spectrum-Picker--sideLabel {
+  display: inline-flex;
+  vertical-align: top;
 }

--- a/components/picker/metadata/picker.yml
+++ b/components/picker/metadata/picker.yml
@@ -73,7 +73,7 @@ examples:
               <use xlink:href="#spectrum-css-icon-Chevron100" />
             </svg>
           </button>
-          <div class="spectrum-Popover spectrum-Popover--bottom spectrum-Picker-popover is-open" style="width: 240px">
+          <div class="spectrum-Popover spectrum-Popover--bottom spectrum-Picker-popover is-open" style="width: 240px;">
             <ul class="spectrum-Menu" role="listbox">
               <li class="spectrum-Menu-item is-selected" role="option" aria-selected="true" tabindex="0">
                 <span class="spectrum-Menu-itemLabel">Donaudampfschifffahrtsgesellschaftskapitän</span>
@@ -110,22 +110,20 @@ examples:
         <div class="spectrum-Examples-item">
           <h4>Side Label</h4>
           <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left">Country</div>
-          <div style="display: inline-block">
-            <button class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--sideLabel" aria-haspopup="listbox" style="width: 240px">
-              <span class="spectrum-Picker-label is-placeholder">Select a Country with a very long label, too long in fact</span>
-              <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
-                <use xlink:href="#spectrum-css-icon-Chevron100" />
-              </svg>
-            </button>
-          </div>
+          <button class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--sideLabel" aria-haspopup="listbox" style="width: 240px">
+            <span class="spectrum-Picker-label is-placeholder">Select a Country with a very long label, too long in fact</span>
+            <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Chevron100" />
+            </svg>
+          </button>
         </div>
 
         <!-- Open with Thumbnails -->
         <div class="spectrum-Examples-item">
 
           <h4>Open with Thumbnails</h4>
-          <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left">Country</div>
-            <button class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--sideLabel is-open" aria-haspopup="listbox" style="width: 240px">
+          <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Country</div>
+            <button class="spectrum-Picker spectrum-Picker--sizeM is-open" aria-haspopup="listbox" style="width: 240px">
               <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Picker-icon" focusable="false" aria-hidden="true" aria-label="Image">
                 <use xlink:href="#spectrum-icon-18-Image" />
               </svg>
@@ -458,45 +456,12 @@ examples:
 
       <h4>Side Label</h4>
       <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left">Country</div>
-      <div style="display: inline-block">
-        <button class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet spectrum-Picker--sideLabel is-open" aria-haspopup="listbox">
-          <span class="spectrum-Picker-label">Ballard</span>
-          <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Chevron100" />
-          </svg>
-        </button>
-        <div class="spectrum-Popover spectrum-Popover--bottom spectrum-Picker-popover is-open">
-          <ul class="spectrum-Menu" role="listbox">
-            <li class="spectrum-Menu-item is-selected" role="option" aria-selected="true" tabindex="0">
-              <span class="spectrum-Menu-itemLabel">Ballard</span>
-              <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Menu-checkmark spectrum-Menu-itemIcon" focusable="false" aria-hidden="true">
-                <use xlink:href="#spectrum-css-icon-Checkmark100" />
-              </svg>
-            </li>
-            <li class="spectrum-Menu-item" role="option" tabindex="0">
-              <span class="spectrum-Menu-itemLabel">Fremont</span>
-              <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Menu-checkmark spectrum-Menu-itemIcon" focusable="false" aria-hidden="true">
-                <use xlink:href="#spectrum-css-icon-Checkmark100" />
-              </svg>
-            </li>
-            <li class="spectrum-Menu-item" role="option" tabindex="0">
-              <span class="spectrum-Menu-itemLabel">Greenwood</span>
-              <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Menu-checkmark spectrum-Menu-itemIcon" focusable="false" aria-hidden="true">
-                <use xlink:href="#spectrum-css-icon-Checkmark100" />
-              </svg>
-            </li>
-            <li class="spectrum-Menu-divider" role="separator"></li>
-            <li class="spectrum-Menu-item is-disabled" role="option" aria-disabled="true">
-              <span class="spectrum-Menu-itemLabel">United States of America</span>
-              <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Menu-checkmark spectrum-Menu-itemIcon" focusable="false" aria-hidden="true">
-                <use xlink:href="#spectrum-css-icon-Checkmark100" />
-              </svg>
-            </li>
-          </ul>
-        </div>
-      </div>
-
-      <div class="dummy-spacing"></div>
+      <button class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet spectrum-Picker--sideLabel is-open" aria-haspopup="listbox">
+        <span class="spectrum-Picker-label">Ballard</span>
+        <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
+          <use xlink:href="#spectrum-css-icon-Chevron100" />
+        </svg>
+      </button>
 
       <h4>Disabled</h4>
       <button class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet" disabled aria-haspopup="listbox">

--- a/components/picker/metadata/picker.yml
+++ b/components/picker/metadata/picker.yml
@@ -109,9 +109,9 @@ examples:
         <!-- Side Label -->
         <div class="spectrum-Examples-item">
           <h4>Side Label</h4>
-          <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Picker--sideLabel spectrum-FieldLabel--left">Country</div>
+          <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left">Country</div>
           <div style="display: inline-block">
-            <button class="spectrum-Picker spectrum-Picker--sizeM" aria-haspopup="listbox" style="width: 240px">
+            <button class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--sideLabel" aria-haspopup="listbox" style="width: 240px">
               <span class="spectrum-Picker-label is-placeholder">Select a Country with a very long label, too long in fact</span>
               <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
                 <use xlink:href="#spectrum-css-icon-Chevron100" />
@@ -457,7 +457,7 @@ examples:
       <div class="dummy-spacing"></div>
 
       <h4>Side Label</h4>
-      <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Picker--sideLabel spectrum-FieldLabel--left">Country</div>
+      <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left">Country</div>
       <div style="display: inline-block">
         <button class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet spectrum-Picker--sideLabel is-open" aria-haspopup="listbox">
           <span class="spectrum-Picker-label">Ballard</span>

--- a/components/picker/metadata/picker.yml
+++ b/components/picker/metadata/picker.yml
@@ -103,59 +103,76 @@ examples:
 
         <div class="dummy-spacing" style="block-size: 15rem;"></div>
 
+        <!-- Side Label -->
+        <div class="spectrum-Examples-item">
+          <h4>Side Label</h4>
+          <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left">Country</div>
+          <div style="display: inline-block">
+            <button class="spectrum-Picker spectrum-Picker--sizeM" aria-haspopup="listbox" style="width: 240px">
+              <span class="spectrum-Picker-label is-placeholder">Select a Country with a very long label, too long in fact</span>
+              <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-Chevron100" />
+              </svg>
+            </button>
+          </div>
+        </div>
+
         <!-- Open with Thumbnails -->
         <div class="spectrum-Examples-item">
 
           <h4>Open with Thumbnails</h4>
-          <button class="spectrum-Picker spectrum-Picker--sizeM is-open" aria-haspopup="listbox" style="width: 240px">
-            <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Picker-icon" focusable="false" aria-hidden="true" aria-label="Image">
-              <use xlink:href="#spectrum-icon-18-Image" />
-            </svg>
-            <span class="spectrum-Picker-label">Donaudampfschifffahrtsgesellschaftskapitän</span>
-            <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
-              <use xlink:href="#spectrum-css-icon-Chevron100" />
-            </svg>
-          </button>
-          <div class="spectrum-Popover spectrum-Popover--bottom spectrum-Picker-popover is-open" style="width: 240px">
-            <ul class="spectrum-Menu" role="listbox">
-              <li class="spectrum-Menu-item is-selected" role="option" aria-selected="true" tabindex="0">
-                <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Menu-itemIcon" focusable="false" aria-hidden="true" aria-label="Image">
-                  <use xlink:href="#spectrum-icon-18-Image" />
-                </svg>
-                <span class="spectrum-Menu-itemLabel">Donaudampfschifffahrtsgesellschaftskapitän</span>
-                <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Menu-checkmark spectrum-Menu-itemIcon" focusable="false" aria-hidden="true">
-                  <use xlink:href="#spectrum-css-icon-Checkmark100" />
-                </svg>
-              </li>
-              <li class="spectrum-Menu-item" role="option" tabindex="0">
-                <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Menu-itemIcon" focusable="false" aria-hidden="true" aria-label="Image">
-                  <use xlink:href="#spectrum-icon-18-Image" />
-                </svg>
-                <span class="spectrum-Menu-itemLabel">Some long value that should be cut off</span>
-                <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Menu-checkmark spectrum-Menu-itemIcon" focusable="false" aria-hidden="true">
-                  <use xlink:href="#spectrum-css-icon-Checkmark100" />
-                </svg>
-              </li>
-              <li class="spectrum-Menu-item" role="option" tabindex="0">
-                <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Menu-itemIcon" focusable="false" aria-hidden="true" aria-label="Image">
-                  <use xlink:href="#spectrum-icon-18-Image" />
-                </svg>
-                <span class="spectrum-Menu-itemLabel">Very long text with hyphens-between-words</span>
-                <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Menu-checkmark spectrum-Menu-itemIcon" focusable="false" aria-hidden="true">
-                  <use xlink:href="#spectrum-css-icon-Checkmark100" />
-                </svg>
-              </li>
-              <li class="spectrum-Menu-divider" role="separator"></li>
-              <li class="spectrum-Menu-item is-disabled" role="option" aria-disabled="true">
-                <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Menu-itemIcon" focusable="false" aria-hidden="true" aria-label="Image">
-                  <use xlink:href="#spectrum-icon-18-Image" />
-                </svg>
-                <span class="spectrum-Menu-itemLabel">United States of America</span>
-                <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Menu-checkmark spectrum-Menu-itemIcon" focusable="false" aria-hidden="true">
-                  <use xlink:href="#spectrum-css-icon-Checkmark100" />
-                </svg>
-              </li>
-            </ul>
+          <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left">Country</div>
+          <div style="display: inline-block">
+            <button class="spectrum-Picker spectrum-Picker--sizeM is-open" aria-haspopup="listbox" style="width: 240px">
+              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Picker-icon" focusable="false" aria-hidden="true" aria-label="Image">
+                <use xlink:href="#spectrum-icon-18-Image" />
+              </svg>
+              <span class="spectrum-Picker-label">Donaudampfschifffahrtsgesellschaftskapitän</span>
+              <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-Chevron100" />
+              </svg>
+            </button>
+            <div class="spectrum-Popover spectrum-Popover--bottom spectrum-Picker-popover is-open" style="width: 240px">
+              <ul class="spectrum-Menu" role="listbox">
+                <li class="spectrum-Menu-item is-selected" role="option" aria-selected="true" tabindex="0">
+                  <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Menu-itemIcon" focusable="false" aria-hidden="true" aria-label="Image">
+                    <use xlink:href="#spectrum-icon-18-Image" />
+                  </svg>
+                  <span class="spectrum-Menu-itemLabel">Donaudampfschifffahrtsgesellschaftskapitän</span>
+                  <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Menu-checkmark spectrum-Menu-itemIcon" focusable="false" aria-hidden="true">
+                    <use xlink:href="#spectrum-css-icon-Checkmark100" />
+                  </svg>
+                </li>
+                <li class="spectrum-Menu-item" role="option" tabindex="0">
+                  <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Menu-itemIcon" focusable="false" aria-hidden="true" aria-label="Image">
+                    <use xlink:href="#spectrum-icon-18-Image" />
+                  </svg>
+                  <span class="spectrum-Menu-itemLabel">Some long value that should be cut off</span>
+                  <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Menu-checkmark spectrum-Menu-itemIcon" focusable="false" aria-hidden="true">
+                    <use xlink:href="#spectrum-css-icon-Checkmark100" />
+                  </svg>
+                </li>
+                <li class="spectrum-Menu-item" role="option" tabindex="0">
+                  <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Menu-itemIcon" focusable="false" aria-hidden="true" aria-label="Image">
+                    <use xlink:href="#spectrum-icon-18-Image" />
+                  </svg>
+                  <span class="spectrum-Menu-itemLabel">Very long text with hyphens-between-words</span>
+                  <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Menu-checkmark spectrum-Menu-itemIcon" focusable="false" aria-hidden="true">
+                    <use xlink:href="#spectrum-css-icon-Checkmark100" />
+                  </svg>
+                </li>
+                <li class="spectrum-Menu-divider" role="separator"></li>
+                <li class="spectrum-Menu-item is-disabled" role="option" aria-disabled="true">
+                  <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Menu-itemIcon" focusable="false" aria-hidden="true" aria-label="Image">
+                    <use xlink:href="#spectrum-icon-18-Image" />
+                  </svg>
+                  <span class="spectrum-Menu-itemLabel">United States of America</span>
+                  <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Menu-checkmark spectrum-Menu-itemIcon" focusable="false" aria-hidden="true">
+                    <use xlink:href="#spectrum-css-icon-Checkmark100" />
+                  </svg>
+                </li>
+              </ul>
+            </div>
           </div>
         </div>
 

--- a/components/picker/metadata/picker.yml
+++ b/components/picker/metadata/picker.yml
@@ -106,7 +106,7 @@ examples:
         <!-- Side Label -->
         <div class="spectrum-Examples-item">
           <h4>Side Label</h4>
-          <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left">Country</div>
+          <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Picker--sideLabel spectrum-FieldLabel--left">Country</div>
           <div style="display: inline-block">
             <button class="spectrum-Picker spectrum-Picker--sizeM" aria-haspopup="listbox" style="width: 240px">
               <span class="spectrum-Picker-label is-placeholder">Select a Country with a very long label, too long in fact</span>
@@ -123,7 +123,7 @@ examples:
           <h4>Open with Thumbnails</h4>
           <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left">Country</div>
           <div style="display: inline-block">
-            <button class="spectrum-Picker spectrum-Picker--sizeM is-open" aria-haspopup="listbox" style="width: 240px">
+            <button class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--sideLabel is-open" aria-haspopup="listbox" style="width: 240px">
               <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Picker-icon" focusable="false" aria-hidden="true" aria-label="Image">
                 <use xlink:href="#spectrum-icon-18-Image" />
               </svg>

--- a/components/picker/metadata/picker.yml
+++ b/components/picker/metadata/picker.yml
@@ -15,6 +15,9 @@ sections:
 
       Additionally, `.spectrum-Picker` should not contain the `.spectrum-Popover` that it opens.
 
+      In order to use a side label with a Picker, wrap the Picker in a `<div style="display: inline-flex">` to allow for the correct spacing.
+      Additionally, add the `spectrum-Picker--sideLabel` class to the Picker.
+
       ### Icon classname changes
 
       Each of the 3 possible icons now has its own specific classname:

--- a/components/picker/metadata/picker.yml
+++ b/components/picker/metadata/picker.yml
@@ -125,7 +125,6 @@ examples:
 
           <h4>Open with Thumbnails</h4>
           <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left">Country</div>
-          <div style="display: inline-block">
             <button class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--sideLabel is-open" aria-haspopup="listbox" style="width: 240px">
               <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Picker-icon" focusable="false" aria-hidden="true" aria-label="Image">
                 <use xlink:href="#spectrum-icon-18-Image" />
@@ -176,7 +175,6 @@ examples:
                 </li>
               </ul>
             </div>
-          </div>
         </div>
 
         <div class="dummy-spacing" style="block-size: 15rem;"></div>
@@ -458,6 +456,48 @@ examples:
 
       <div class="dummy-spacing"></div>
 
+      <h4>Side Label</h4>
+      <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Picker--sideLabel spectrum-FieldLabel--left">Country</div>
+      <div style="display: inline-block">
+        <button class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet spectrum-Picker--sideLabel is-open" aria-haspopup="listbox">
+          <span class="spectrum-Picker-label">Ballard</span>
+          <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
+            <use xlink:href="#spectrum-css-icon-Chevron100" />
+          </svg>
+        </button>
+        <div class="spectrum-Popover spectrum-Popover--bottom spectrum-Picker-popover is-open">
+          <ul class="spectrum-Menu" role="listbox">
+            <li class="spectrum-Menu-item is-selected" role="option" aria-selected="true" tabindex="0">
+              <span class="spectrum-Menu-itemLabel">Ballard</span>
+              <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Menu-checkmark spectrum-Menu-itemIcon" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-Checkmark100" />
+              </svg>
+            </li>
+            <li class="spectrum-Menu-item" role="option" tabindex="0">
+              <span class="spectrum-Menu-itemLabel">Fremont</span>
+              <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Menu-checkmark spectrum-Menu-itemIcon" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-Checkmark100" />
+              </svg>
+            </li>
+            <li class="spectrum-Menu-item" role="option" tabindex="0">
+              <span class="spectrum-Menu-itemLabel">Greenwood</span>
+              <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Menu-checkmark spectrum-Menu-itemIcon" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-Checkmark100" />
+              </svg>
+            </li>
+            <li class="spectrum-Menu-divider" role="separator"></li>
+            <li class="spectrum-Menu-item is-disabled" role="option" aria-disabled="true">
+              <span class="spectrum-Menu-itemLabel">United States of America</span>
+              <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Menu-checkmark spectrum-Menu-itemIcon" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-Checkmark100" />
+              </svg>
+            </li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="dummy-spacing"></div>
+
       <h4>Disabled</h4>
       <button class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet" disabled aria-haspopup="listbox">
         <span class="spectrum-Picker-label is-placeholder">Select a Country</span>
@@ -466,7 +506,7 @@ examples:
         </svg>
       </button>
 
-      <h4>Closed</h4>
+      <h4>Closed and Invalid</h4>
       <button class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet is-invalid" aria-haspopup="listbox">
         <span class="spectrum-Picker-label is-placeholder">Select a Country</span>
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Picker-validationIcon" focusable="false" aria-hidden="true" aria-label="Folder">
@@ -477,7 +517,7 @@ examples:
         </svg>
       </button>
 
-      <h4>Open</h4>
+      <h4>Open and Invalid</h4>
       <button class="spectrum-Picker spectrum-Picker--sizeM
       spectrum-Picker--quiet is-invalid is-open" aria-haspopup="listbox">
         <span class="spectrum-Picker-label">Ballard</span>
@@ -520,7 +560,7 @@ examples:
 
       <div class="dummy-spacing"></div>
 
-      <h4>Disabled</h4>
+      <h4>Disabled and Invalid</h4>
       <button class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet is-invalid" disabled aria-haspopup="listbox">
         <span class="spectrum-Picker-label is-placeholder">Select a Country</span>
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Picker-validationIcon" focusable="false" aria-hidden="true" aria-label="Alert">

--- a/components/picker/metadata/picker.yml
+++ b/components/picker/metadata/picker.yml
@@ -15,8 +15,7 @@ sections:
 
       Additionally, `.spectrum-Picker` should not contain the `.spectrum-Popover` that it opens.
 
-      In order to use a side label with a Picker, wrap the Picker in a `<div style="display: inline-flex">` to allow for the correct spacing.
-      Additionally, add the `spectrum-Picker--sideLabel` class to the Picker.
+      In order to use a side label with a Picker, add the `spectrum-Picker--sideLabel` class to the Picker.
 
       ### Icon classname changes
 

--- a/components/picker/stories/picker.stories.js
+++ b/components/picker/stories/picker.stories.js
@@ -28,6 +28,16 @@ export default {
 			},
 			control: { type: "text" },
 		},
+		labelPosition: {
+			name: "Label position",
+			type: { name: "string" },
+			table: {
+				type: { summary: "string" },
+				category: "Content",
+			},
+			options: ["top", "left"],
+			control: { type: "select" },
+		},
 		placeholder: {
 			name: "Placeholder",
 			type: { name: "string" },
@@ -126,6 +136,12 @@ export const Open = Template.bind({});
 Open.args = {
 	isOpen: true,
 	content: [MenuStories(MenuStories.args)],
+};
+
+export const SideLabel = Template.bind({});
+SideLabel.args = {
+	content: [MenuStories(MenuStories.args)],
+	labelPosition: "left"
 };
 
 export const Quiet = Template.bind({});

--- a/components/picker/stories/picker.stories.js
+++ b/components/picker/stories/picker.stories.js
@@ -169,3 +169,13 @@ Focused.args = {
 	isFocused: true,
 	content: [MenuStories(MenuStories.args)],
 };
+
+export const WithForcedColors = Template.bind({
+  parameters: {
+    // Sets the forced-colors media feature for a specific story.
+    chromatic: { forcedColors: 'active' },
+  },
+});
+WithForcedColors.args = {
+	content: [MenuStories(MenuStories.args)],
+}

--- a/components/picker/stories/template.js
+++ b/components/picker/stories/template.js
@@ -10,13 +10,10 @@ import { Template as HelpText } from "@spectrum-css/helptext/stories/template.js
 
 import "../index.css";
 
-export const Template = ({
+export const PickerButton = ({
 	rootClass = "spectrum-Picker",
 	size = "m",
-	label,
-	labelPosition = "top",
 	placeholder,
-	helpText,
 	isQuiet = false,
 	isFocused = false,
 	isOpen = false,
@@ -26,8 +23,8 @@ export const Template = ({
 	isReadOnly = false,
 	customClasses = [],
 	customStyles = {},
-	customPopoverStyles = {},
 	content = [],
+	iconName,
 	id,
 	...globals
 }) => {
@@ -42,16 +39,7 @@ export const Template = ({
 	}
 
 	return html`
-		${label
-			? FieldLabel({
-					...globals,
-					size,
-					label,
-					isDisabled,
-					alignment: labelPosition,
-			  })
-			: ""}
-		<button
+	<button
 			class=${classMap({
 				[rootClass]: true,
 				[`${rootClass}--size${size?.toUpperCase()}`]:
@@ -91,6 +79,107 @@ export const Template = ({
 				customClasses: [`${rootClass}-menuIcon`],
 			})}
 		</button>
+	`;
+}
+
+export const Template = ({
+	rootClass = "spectrum-Picker",
+	size = "m",
+	label,
+	labelPosition = "top",
+	placeholder,
+	helpText,
+	isQuiet = false,
+	isFocused = false,
+	isOpen = false,
+	isInvalid = false,
+	isLoading = false,
+	isDisabled = false,
+	isReadOnly = false,
+	customClasses = [],
+	customStyles = {},
+	customPopoverStyles = {},
+	content = [],
+	id,
+	...globals
+}) => {
+
+	const { express } = globals;
+	try {
+		if (!express) import(/* webpackPrefetch: true */ "../themes/spectrum.css");
+		else import(/* webpackPrefetch: true */ "../themes/express.css");
+	} catch (e) {
+		console.warn(e);
+	}
+
+	let iconName = "ChevronDown200";
+	switch (size) {
+		case "s":
+			iconName = "ChevronDown75";
+			break;
+		case "m":
+			iconName = "ChevronDown100";
+			break;
+		case "xl":
+			iconName = "ChevronDown300";
+			break;
+		default:
+			iconName = "ChevronDown200";
+	}
+
+	return html`
+		${label
+			? FieldLabel({
+					...globals,
+					size,
+					label,
+					isDisabled,
+					alignment: labelPosition,
+			  })
+			: ""}
+		${labelPosition == "left" ?
+			html`<div style="display: inline-block">
+				${PickerButton({
+					...globals,
+					rootClass,
+					size,
+					placeholder,
+					isQuiet,
+					isFocused,
+					isOpen,
+					isInvalid,
+					isLoading,
+					isDisabled,
+					isReadOnly,
+					customClasses,
+					customStyles,
+					content,
+					iconName,
+					id,
+				})}
+			</div>
+			`
+		: 
+			PickerButton({
+				...globals,
+				rootClass,
+				size,
+				placeholder,
+				isQuiet,
+				isFocused,
+				isOpen,
+				isInvalid,
+				isLoading,
+				isDisabled,
+				isReadOnly,
+				customClasses,
+				customStyles,
+				content,
+				iconName,
+				id,
+			})
+		}
+		
 		${helpText
 			? HelpText({
 					text: helpText,

--- a/components/picker/stories/template.js
+++ b/components/picker/stories/template.js
@@ -13,6 +13,7 @@ import "../index.css";
 export const PickerButton = ({
 	rootClass = "spectrum-Picker",
 	size = "m",
+	labelPosition,
 	placeholder,
 	isQuiet = false,
 	isFocused = false,
@@ -45,6 +46,7 @@ export const PickerButton = ({
 				[`${rootClass}--size${size?.toUpperCase()}`]:
 					typeof size !== "undefined",
 				[`${rootClass}--quiet`]: isQuiet,
+				[`${rootClass}--sideLabel`]: labelPosition != "top",
 				[`is-invalid`]: isInvalid,
 				[`is-open`]: isOpen,
 				[`is-loading`]: isLoading,
@@ -155,6 +157,7 @@ export const Template = ({
 					customStyles,
 					content,
 					iconName,
+					labelPosition,
 					id,
 				})}
 			</div>
@@ -176,6 +179,7 @@ export const Template = ({
 				customStyles,
 				content,
 				iconName,
+				labelPosition,
 				id,
 			})
 		}

--- a/site/resources/js/enhancement.js
+++ b/site/resources/js/enhancement.js
@@ -282,6 +282,7 @@ governing permissions and limitations under the License.
 		var isOpen =
 			force !== undefined ? force : !picker.classList.contains("is-open");
 		var popover = getPopoverForPicker(picker);
+		console.log(popover);
 
 		picker[isOpen ? "setAttribute" : "removeAttribute"](
 			"aria-expanded",
@@ -290,19 +291,21 @@ governing permissions and limitations under the License.
 		picker.classList[isOpen ? "add" : "remove"]("is-open");
 		picker.classList[isOpen ? "add" : "remove"]("is-selected");
 
+		// We have to get the coordinates relative to the parent
+		const parent = popover.closest('.spectrum-CSSExample-container');
+		const parentRect = parent.getBoundingClientRect();
+
 		if (popover) {
+			const transforms = [];
 			popover.style.zIndex = 1;
-			var rect = picker.getBoundingClientRect();
-			popover.style.top = rect.bottom + "px";
+			const rect = picker.getBoundingClientRect();
+			const triggerBottom = rect.bottom - parentRect.top;
+			popover.style.left = rect.left - parentRect.left + "px";
+			popover.style.top = triggerBottom + "px";
+			popover.style.transform = transforms.join(" ");
+
 			popover.classList[isOpen ? "add" : "remove"]("is-open");
 			popover.querySelector(".spectrum-Menu-item").focus();
-		}
-
-		if (isOpen) {
-			if (openPicker && openPicker !== picker) {
-				toggleOpen(openPicker, false);
-			}
-			openPicker = picker;
 		}
 	}
 


### PR DESCRIPTION
## Description

This adds a side label variant and styling to Picker. 

- In order for this to work correctly, the Picker component must be wrapped in a `div` with `display: inline-block`. This allows for the picker to be placed next to the inline label. The styling cannot be added to the Picker itself as it throws off the positioning of the Menu. This is already being implemented in SWC. 
- Added a `spectrum-Picker--sideLabel` class to allow for easier targeting (and translating in SWC) for when additional styling needs to be applied, specifically when used with the quiet variant.
- `margin-block-start` is changed to match the label when side label is used with the Quiet variant 

## Screenshots

### Before
![Screenshot 2023-07-05 at 11 14 49 AM](https://github.com/adobe/spectrum-css/assets/99203545/dce4ce77-362b-48e3-8cb3-b49e475fa00c)

### After
![Screenshot 2023-07-05 at 11 16 47 AM](https://github.com/adobe/spectrum-css/assets/99203545/5b68d275-610b-45d6-bb94-e72cb6fe56dc)


## To-do list

<!-- Put an "x" to indicate you've done each of the following -->

- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] I have tested these changes in Windows High Contrast mode.
- [x] I have updated any relevant storybook stories and templates.
- [x] If my change(s) include visual change(s), a designer has reviewed and approved those changes.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
