### PR TITLE
fix: revert prettier version bump

### DIFF
--- a/components/tokens/package.json
+++ b/components/tokens/package.json
@@ -39,7 +39,7 @@
     "postcss-merge-rules": "^6.0.0",
     "postcss-rgb-mapping": "^1.0.1",
     "postcss-sorting": "^8.0.2",
-    "prettier": "^3.0.0",
+    "prettier": "^2.8.8",
     "rimraf": "^5.0.1",
     "style-dictionary": "^3.8.0",
     "style-dictionary-sets": "^2.3.0"

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "markdown-it": "^12.3.2",
     "npm-run-all": "^4.1.5",
     "nx": "^16.5.1",
-    "prettier": "^3.0.0",
+    "prettier": "^2.8.8",
     "prettier-package-json": "^2.8.0",
     "prismjs": "^1.23.0",
     "rimraf": "^5.0.1",

--- a/tools/preview/package.json
+++ b/tools/preview/package.json
@@ -53,7 +53,7 @@
     "postcss-prefix-selector": "^1.16.0",
     "postcss-selector-replace": "^1.0.2",
     "postcss-warn-cleaner": "^0.1.9",
-    "prettier": "^3.0.0",
+    "prettier": "^2.8.8",
     "raw-loader": "^4.0.2",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13930,15 +13930,10 @@ prettier-package-json@^2.8.0:
     sort-object-keys "^1.1.3"
     sort-order "^1.0.1"
 
-prettier@^2.8.0:
+prettier@^2.8.0, prettier@^2.8.8:
   version "2.8.8"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
   integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
-
-prettier@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.0.tgz#e7b19f691245a21d618c68bc54dc06122f6105ae"
-  integrity sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==
 
 pretty-error@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
We're encountering an error with our release process that appears to be due to an incompatibility in the latest release of Prettier, which we recently moved to as per Dependabot. This reverts that change to the version we had been using.

<!-- Summarize your changes in the Title field -->

## Description

<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->

## How and where has this been tested?

- **How this was tested:** <!-- Using steps in issue #000 -->
- **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following -->

- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] I have updated any relevant storybook stories and templates.
- [ ] If my change(s) include visual change(s), a designer has reviewed and approved those changes.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
