### PR TITLE
feat: add Storybook Pseudo States addon

### DIFF
--- a/tools/preview/main.js
+++ b/tools/preview/main.js
@@ -33,6 +33,7 @@ module.exports = {
 		"@whitespace/storybook-addon-html",
 		// https://storybook.js.org/addons/@etchteam/storybook-addon-status
 		"@etchteam/storybook-addon-status",
+    "storybook-addon-pseudo-states",
 	],
 	core: {
 		disableTelemetry: true,

--- a/tools/preview/package.json
+++ b/tools/preview/package.json
@@ -61,6 +61,7 @@
     "rimraf": "^5.0.1",
     "source-map-loader": "^1.0.0",
     "storybook": "^7.0.26",
+    "storybook-addon-pseudo-states": "^2.1.0",
     "style-loader": "3.3.3",
     "webpack": "^5.83.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -15839,6 +15839,11 @@ store2@^2.14.2:
   resolved "https://registry.yarnpkg.com/store2/-/store2-2.14.2.tgz#56138d200f9fe5f582ad63bc2704dbc0e4a45068"
   integrity sha512-siT1RiqlfQnGqgT/YzXVUNsom9S0H1OX+dpdGN1xkyYATo4I6sep5NmsRD/40s3IIOvlCq6akxkqG82urIZW1w==
 
+storybook-addon-pseudo-states@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/storybook-addon-pseudo-states/-/storybook-addon-pseudo-states-2.1.0.tgz#05faffb7e0d19fc012035ecee2a02d432f312d2d"
+  integrity sha512-AwbCL1OiZ16aIeXSP/IOovkMwXy7NTZqmjkz+UM2guSGjvogHNA95NhuVyWoqieE+QWUpGO48+MrBGMeeJcHOQ==
+
 storybook@^7.0.26:
   version "7.0.26"
   resolved "https://registry.yarnpkg.com/storybook/-/storybook-7.0.26.tgz#70a55074644c265770cc015c576aa005dad3b2ef"


### PR DESCRIPTION
Adds the Storybook Pseudo States addon so that we can more easily test hover states in Chromatic.

- [Testing hover and focus states in Chromatic](https://www.chromatic.com/docs/hoverfocus)
- [Storybook addon](https://storybook.js.org/addons/storybook-addon-pseudo-states)

<!-- Summarize your changes in the Title field -->

## Description

<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/spectrum-css/issues
   - If there's no issue, file it: https://github.com/adobe/spectrum-css/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) (e.g., #000) -->

## How and where has this been tested?

- **How this was tested:** <!-- Using steps in issue #000 -->
- **Browser(s) and OS(s) this was tested with:** <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following -->

- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] I have updated any relevant storybook stories and templates.
- [ ] If my change(s) include visual change(s), a designer has reviewed and approved those changes.
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
