### PR TITLE
chore: add groups to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,9 +17,23 @@ updates:
     rebase-strategy: "auto"
     versioning-strategy: "increase"
     ignore:
+      # Always ignore our internal dependencies
       - dependency-name: "@spectrum-css/*"
       # Ignore gulp versions until build migration complete
       - dependency-name: "gulp*"
+      # Ignore postcss versions until build migration complete
+      - dependency-name: "postcss*"
+    groups:
+      # Specify a name for the group, which will be used in pull request titles
+      # and branch names
+      storybook-ecosystem:
+        # Define patterns to include dependencies in the group (based on
+        # dependency name)
+        patterns:
+          - "@storybook/*"
+      commitlint-ecosystem:
+        patterns:
+          - "@commitlint/*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Description

A grouping setting is in public beta now for dependabot which would combine dependency updates for packages that exist within the same monorepo ecosystem. I have set up groups for storybook and commitlint. Hopefully this reduces the amount of dependabot PRs we get; especially ones that are redundant.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] ✨ This pull request is ready to merge. ✨
