### PR TITLE
fix(tag)!: update tag color tokens

### DIFF
--- a/components/tag/index.css
+++ b/components/tag/index.css
@@ -26,8 +26,8 @@ governing permissions and limitations under the License.
   --spectrum-tag-label-line-height: var(--spectrum-line-height-100);
   --spectrum-tag-label-font-weight: var(--spectrum-regular-font-weight);
 
-  /* selected content */
-  --spectrum-tag-content-color-selected: var(--spectrum-white);
+  /* selected */
+  --spectrum-tag-content-color-selected: var(--spectrum-gray-50);
 
   /* invalid variant */
   --spectrum-tag-border-color-invalid: var(--spectrum-negative-color-900);
@@ -204,7 +204,7 @@ governing permissions and limitations under the License.
               background-color var(--mod-tag-animation-duration, var(--spectrum-tag-animation-duration)) ease-in-out;
 
 
-  .spectrum-Tags-itemIcon {
+  .spectrum-Tag-itemIcon {
     block-size: var(--mod-tag-icon-size, var(--spectrum-tag-icon-size));
     inline-size: var(--mod-tag-icon-size, var(--spectrum-tag-icon-size));
 
@@ -255,7 +255,7 @@ governing permissions and limitations under the License.
     }
   }
 
-  .spectrum-Tags-itemLabel {
+  .spectrum-Tag-itemLabel {
     block-size: 100%;
     box-sizing: border-box;
     line-height: var(--mod-tag-label-line-height, var(--spectrum-tag-label-line-height));

--- a/components/tag/index.css
+++ b/components/tag/index.css
@@ -28,6 +28,10 @@ governing permissions and limitations under the License.
 
   /* selected */
   --spectrum-tag-content-color-selected: var(--spectrum-gray-50);
+  --spectrum-tag-background-color-selected: var(--spectrum-neutral-background-color-selected-default);
+  --spectrum-tag-background-color-selected-hover: var(--spectrum-neutral-background-color-selected-hover);
+  --spectrum-tag-background-color-selected-active: var(--spectrum-neutral-background-color-selected-down);
+  --spectrum-tag-background-color-selected-focus: var(--spectrum-neutral-background-color-selected-key-focus);
 
   /* invalid variant */
   --spectrum-tag-border-color-invalid: var(--spectrum-negative-color-900);

--- a/components/tag/metadata/tag.yml
+++ b/components/tag/metadata/tag.yml
@@ -26,21 +26,21 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Default</h4>
 
           <div class="spectrum-Tag spectrum-Tag--sizeS" tabindex="0">
-            <span class="spectrum-Tags-itemLabel">Tag label</span>
+            <span class="spectrum-Tag-itemLabel">Tag label</span>
           </div>
 
           <div class="spectrum-Tag spectrum-Tag--sizeS" tabindex="0">
-            <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-Tags-itemIcon" focusable="false" aria-hidden="true" aria-label="Tag">
+            <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-Tag-itemIcon" focusable="false" aria-hidden="true" aria-label="Tag">
               <use xlink:href="#spectrum-icon-18-CheckmarkCircle" />
             </svg>
-            <span class="spectrum-Tags-itemLabel">Tag label</span>
+            <span class="spectrum-Tag-itemLabel">Tag label</span>
           </div>
 
           <div class="spectrum-Tag spectrum-Tag--sizeS" tabindex="0">
             <div class="spectrum-Avatar spectrum-Avatar--size50">
               <img class="spectrum-Avatar-image" src="img/example-ava.jpg" alt="Avatar">
             </div>
-            <span class="spectrum-Tags-itemLabel">Tag label</span>
+            <span class="spectrum-Tag-itemLabel">Tag label</span>
             <button type="reset" class="spectrum-ClearButton spectrum-ClearButton--sizeM spectrum-Tag-clearButton" tabindex="-1">
               <div class="spectrum-ClearButton-fill">
                 <svg class="spectrum-Icon spectrum-ClearButton-icon spectrum-UIIcon-Cross75" focusable="false" aria-hidden="true">
@@ -55,20 +55,20 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Selected</h4>
 
           <div class="spectrum-Tag spectrum-Tag--sizeS is-selected" tabindex="0">
-            <span class="spectrum-Tags-itemLabel">Tag label</span>
+            <span class="spectrum-Tag-itemLabel">Tag label</span>
           </div>
 
           <div class="spectrum-Tag spectrum-Tag--sizeS is-selected" tabindex="0">
-            <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-Tags-itemIcon" focusable="false" aria-hidden="true" aria-label="Tag">
+            <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-Tag-itemIcon" focusable="false" aria-hidden="true" aria-label="Tag">
               <use xlink:href="#spectrum-icon-18-CheckmarkCircle" />
             </svg>
-            <span class="spectrum-Tags-itemLabel">Tag label</span>
+            <span class="spectrum-Tag-itemLabel">Tag label</span>
           </div>
           <div class="spectrum-Tag spectrum-Tag--sizeS is-selected" tabindex="0">
             <div class="spectrum-Avatar spectrum-Avatar--size50">
               <img class="spectrum-Avatar-image" src="img/example-ava.jpg" alt="Avatar">
             </div>
-            <span class="spectrum-Tags-itemLabel">Tag label</span>
+            <span class="spectrum-Tag-itemLabel">Tag label</span>
             <button type="reset" class="spectrum-ClearButton spectrum-ClearButton--sizeM spectrum-Tag-clearButton" tabindex="-1">
               <div class="spectrum-ClearButton-fill">
                 <svg class="spectrum-Icon spectrum-ClearButton-icon spectrum-UIIcon-Cross75" focusable="false" aria-hidden="true">
@@ -84,21 +84,21 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Invalid</h4>
 
           <div class="spectrum-Tag spectrum-Tag--sizeS is-invalid" tabindex="0">
-            <span class="spectrum-Tags-itemLabel">Tag label</span>
+            <span class="spectrum-Tag-itemLabel">Tag label</span>
           </div>
 
           <div class="spectrum-Tag spectrum-Tag--sizeS is-invalid" tabindex="0">
-            <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-Tags-itemIcon" focusable="false" aria-hidden="true" aria-label="Tag">
+            <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-Tag-itemIcon" focusable="false" aria-hidden="true" aria-label="Tag">
               <use xlink:href="#spectrum-icon-24-Alert" />
             </svg>
-            <span class="spectrum-Tags-itemLabel">Tag label</span>
+            <span class="spectrum-Tag-itemLabel">Tag label</span>
           </div>
 
           <div class="spectrum-Tag spectrum-Tag--sizeS is-invalid" tabindex="0">
             <div class="spectrum-Avatar spectrum-Avatar--size50">
               <img class="spectrum-Avatar-image" src="img/example-ava.jpg" alt="Avatar">
             </div>
-            <span class="spectrum-Tags-itemLabel">Tag label</span>
+            <span class="spectrum-Tag-itemLabel">Tag label</span>
             <button type="reset" class="spectrum-ClearButton spectrum-ClearButton--sizeM spectrum-Tag-clearButton" tabindex="-1">
               <div class="spectrum-ClearButton-fill">
                 <svg class="spectrum-Icon spectrum-ClearButton-icon spectrum-UIIcon-Cross75" focusable="false" aria-hidden="true">
@@ -114,21 +114,21 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Disabled</h4>
 
           <div class="spectrum-Tag spectrum-Tag--sizeS is-disabled" tabindex="-1">
-            <span class="spectrum-Tags-itemLabel">Tag label</span>
+            <span class="spectrum-Tag-itemLabel">Tag label</span>
           </div>
 
           <div class="spectrum-Tag spectrum-Tag--sizeS is-disabled" tabindex="-1">
-            <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-Tags-itemIcon" focusable="false" aria-hidden="true" aria-label="Tag">
+            <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-Tag-itemIcon" focusable="false" aria-hidden="true" aria-label="Tag">
               <use xlink:href="#spectrum-icon-18-CheckmarkCircle" />
             </svg>
-            <span class="spectrum-Tags-itemLabel">Tag label</span>
+            <span class="spectrum-Tag-itemLabel">Tag label</span>
           </div>
 
           <div class="spectrum-Tag spectrum-Tag--sizeS is-disabled" tabindex="-1">
             <div class="spectrum-Avatar spectrum-Avatar--size50">
               <img class="spectrum-Avatar-image" src="img/example-ava.jpg" alt="Avatar">
             </div>
-            <span class="spectrum-Tags-itemLabel">Tag label</span>
+            <span class="spectrum-Tag-itemLabel">Tag label</span>
             <button type="reset" class="spectrum-ClearButton spectrum-ClearButton--sizeM spectrum-Tag-clearButton" tabindex="-1">
               <div class="spectrum-ClearButton-fill">
                 <svg class="spectrum-Icon spectrum-ClearButton-icon spectrum-UIIcon-Cross75" focusable="false" aria-hidden="true">
@@ -144,21 +144,21 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Selected + Invalid</h4>
 
           <div class="spectrum-Tag spectrum-Tag--sizeS is-selected is-invalid" tabindex="0">
-            <span class="spectrum-Tags-itemLabel">Tag label</span>
+            <span class="spectrum-Tag-itemLabel">Tag label</span>
           </div>
 
           <div class="spectrum-Tag spectrum-Tag--sizeS is-selected is-invalid" tabindex="0">
-            <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-Tags-itemIcon" focusable="false" aria-hidden="true" aria-label="Tag">
+            <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-Tag-itemIcon" focusable="false" aria-hidden="true" aria-label="Tag">
               <use xlink:href="#spectrum-icon-24-Alert" />
             </svg>
-            <span class="spectrum-Tags-itemLabel">Tag label</span>
+            <span class="spectrum-Tag-itemLabel">Tag label</span>
           </div>
 
           <div class="spectrum-Tag spectrum-Tag--sizeS is-selected is-invalid" tabindex="0">
             <div class="spectrum-Avatar spectrum-Avatar--size50">
               <img class="spectrum-Avatar-image" src="img/example-ava.jpg" alt="Avatar">
             </div>
-            <span class="spectrum-Tags-itemLabel">Tag label</span>
+            <span class="spectrum-Tag-itemLabel">Tag label</span>
             <button type="reset" class="spectrum-ClearButton spectrum-ClearButton--sizeM spectrum-Tag-clearButton" tabindex="-1">
               <div class="spectrum-ClearButton-fill">
                 <svg class="spectrum-Icon spectrum-ClearButton-icon spectrum-UIIcon-Cross75" focusable="false" aria-hidden="true">
@@ -174,21 +174,21 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Emphasized</h4>
 
           <div class="spectrum-Tag spectrum-Tag--sizeS is-emphasized" tabindex="0">
-            <span class="spectrum-Tags-itemLabel">Tag label</span>
+            <span class="spectrum-Tag-itemLabel">Tag label</span>
           </div>
 
           <div class="spectrum-Tag spectrum-Tag--sizeS is-emphasized" tabindex="0">
-            <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-Tags-itemIcon" focusable="false" aria-hidden="true" aria-label="Tag">
+            <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-Tag-itemIcon" focusable="false" aria-hidden="true" aria-label="Tag">
               <use xlink:href="#spectrum-icon-18-CheckmarkCircle" />
             </svg>
-            <span class="spectrum-Tags-itemLabel">Tag label</span>
+            <span class="spectrum-Tag-itemLabel">Tag label</span>
           </div>
 
           <div class="spectrum-Tag spectrum-Tag--sizeS is-emphasized" tabindex="0">
             <div class="spectrum-Avatar spectrum-Avatar--size50">
               <img class="spectrum-Avatar-image" src="img/example-ava.jpg" alt="Avatar">
             </div>
-            <span class="spectrum-Tags-itemLabel">Tag label</span>
+            <span class="spectrum-Tag-itemLabel">Tag label</span>
             <button type="reset" class="spectrum-ClearButton spectrum-ClearButton--sizeM spectrum-Tag-clearButton" tabindex="-1">
               <div class="spectrum-ClearButton-fill">
                 <svg class="spectrum-Icon spectrum-ClearButton-icon spectrum-UIIcon-Cross75" focusable="false" aria-hidden="true">
@@ -209,18 +209,18 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">S (default)</h4>
 
           <div class="spectrum-Tag spectrum-Tag--sizeS" tabindex="0">
-            <span class="spectrum-Tags-itemLabel">Tag label</span>
+            <span class="spectrum-Tag-itemLabel">Tag label</span>
           </div>
 
           <div class="spectrum-Tag spectrum-Tag--sizeS" tabindex="0">
-            <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-Tags-itemIcon" focusable="false" aria-hidden="true" aria-label="Tag">
+            <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-Tag-itemIcon" focusable="false" aria-hidden="true" aria-label="Tag">
               <use xlink:href="#spectrum-icon-18-CheckmarkCircle" />
             </svg>
-            <span class="spectrum-Tags-itemLabel">Tag label</span>
+            <span class="spectrum-Tag-itemLabel">Tag label</span>
           </div>
 
           <div class="spectrum-Tag spectrum-Tag--sizeS" tabindex="0">
-            <span class="spectrum-Tags-itemLabel">Tag label</span>
+            <span class="spectrum-Tag-itemLabel">Tag label</span>
             <button type="reset" class="spectrum-ClearButton spectrum-ClearButton--sizeS spectrum-Tag-clearButton" tabindex="-1">
               <div class="spectrum-ClearButton-fill">
                 <svg class="spectrum-Icon spectrum-ClearButton-icon spectrum-UIIcon-Cross75" focusable="false" aria-hidden="true">
@@ -234,7 +234,7 @@ examples:
             <div class="spectrum-Avatar spectrum-Avatar--size50">
               <img class="spectrum-Avatar-image" src="img/example-ava.jpg" alt="Avatar">
             </div>
-            <span class="spectrum-Tags-itemLabel">Tag label</span>
+            <span class="spectrum-Tag-itemLabel">Tag label</span>
             <button type="reset" class="spectrum-ClearButton spectrum-ClearButton--sizeS spectrum-Tag-clearButton" tabindex="-1">
               <div class="spectrum-ClearButton-fill">
                 <svg class="spectrum-Icon spectrum-ClearButton-icon spectrum-UIIcon-Cross75" focusable="false" aria-hidden="true">
@@ -249,18 +249,18 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">M</h4>
 
           <div class="spectrum-Tag spectrum-Tag--sizeM" tabindex="0">
-            <span class="spectrum-Tags-itemLabel">Tag label</span>
+            <span class="spectrum-Tag-itemLabel">Tag label</span>
           </div>
 
           <div class="spectrum-Tag spectrum-Tag--sizeM" tabindex="0">
-            <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Tags-itemIcon" focusable="false" aria-hidden="true" aria-label="Tag">
+            <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Tag-itemIcon" focusable="false" aria-hidden="true" aria-label="Tag">
               <use xlink:href="#spectrum-icon-18-CheckmarkCircle" />
             </svg>
-            <span class="spectrum-Tags-itemLabel">Tag label</span>
+            <span class="spectrum-Tag-itemLabel">Tag label</span>
           </div>
 
           <div class="spectrum-Tag spectrum-Tag--sizeM" tabindex="0">
-            <span class="spectrum-Tags-itemLabel">Tag label</span>
+            <span class="spectrum-Tag-itemLabel">Tag label</span>
             <button type="reset" class="spectrum-ClearButton spectrum-ClearButton--sizeM spectrum-Tag-clearButton" tabindex="-1">
               <div class="spectrum-ClearButton-fill">
                 <svg class="spectrum-Icon spectrum-ClearButton-icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
@@ -274,7 +274,7 @@ examples:
             <div class="spectrum-Avatar spectrum-Avatar--size100">
               <img class="spectrum-Avatar-image" src="img/example-ava.jpg" alt="Avatar">
             </div>
-            <span class="spectrum-Tags-itemLabel">Tag label</span>
+            <span class="spectrum-Tag-itemLabel">Tag label</span>
             <button type="reset" class="spectrum-ClearButton spectrum-ClearButton--sizeM spectrum-Tag-clearButton" tabindex="-1">
               <div class="spectrum-ClearButton-fill">
                 <svg class="spectrum-Icon spectrum-ClearButton-icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
@@ -289,18 +289,18 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">L</h4>
 
           <div class="spectrum-Tag spectrum-Tag--sizeL" tabindex="0">
-            <span class="spectrum-Tags-itemLabel">Tag label</span>
+            <span class="spectrum-Tag-itemLabel">Tag label</span>
           </div>
 
           <div class="spectrum-Tag spectrum-Tag--sizeL" tabindex="0">
-            <svg class="spectrum-Icon spectrum-Icon--sizeL spectrum-Tags-itemIcon" focusable="false" aria-hidden="true" aria-label="Tag">
+            <svg class="spectrum-Icon spectrum-Icon--sizeL spectrum-Tag-itemIcon" focusable="false" aria-hidden="true" aria-label="Tag">
               <use xlink:href="#spectrum-icon-18-CheckmarkCircle" />
             </svg>
-            <span class="spectrum-Tags-itemLabel">Tag label</span>
+            <span class="spectrum-Tag-itemLabel">Tag label</span>
           </div>
 
           <div class="spectrum-Tag spectrum-Tag--sizeL" tabindex="0">
-            <span class="spectrum-Tags-itemLabel">Tag label</span>
+            <span class="spectrum-Tag-itemLabel">Tag label</span>
             <button type="reset" class="spectrum-ClearButton spectrum-ClearButton--sizeL spectrum-Tag-clearButton" tabindex="-1">
               <div class="spectrum-ClearButton-fill">
                 <svg class="spectrum-Icon spectrum-ClearButton-icon spectrum-UIIcon-Cross200" focusable="false" aria-hidden="true">
@@ -314,7 +314,7 @@ examples:
             <div class="spectrum-Avatar spectrum-Avatar--size200">
               <img class="spectrum-Avatar-image" src="img/example-ava.jpg" alt="Avatar">
             </div>
-            <span class="spectrum-Tags-itemLabel">Tag label</span>
+            <span class="spectrum-Tag-itemLabel">Tag label</span>
             <button type="reset" class="spectrum-ClearButton spectrum-ClearButton--sizeL spectrum-Tag-clearButton" tabindex="-1">
               <div class="spectrum-ClearButton-fill">
                 <svg class="spectrum-Icon spectrum-ClearButton-icon spectrum-UIIcon-Cross200" focusable="false" aria-hidden="true">
@@ -334,7 +334,7 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Default</h4>
 
           <div class="spectrum-Tag spectrum-Tag--sizeS spectrum-Tag--removable" tabindex="0">
-            <span class="spectrum-Tags-itemLabel">Tag label</span>
+            <span class="spectrum-Tag-itemLabel">Tag label</span>
             <button type="reset" class="spectrum-ClearButton spectrum-ClearButton--sizeS spectrum-Tag-clearButton" tabindex="-1">
               <div class="spectrum-ClearButton-fill">
                 <svg class="spectrum-Icon spectrum-ClearButton-icon spectrum-UIIcon-Cross75" focusable="false" aria-hidden="true">
@@ -345,10 +345,10 @@ examples:
           </div>
 
           <div class="spectrum-Tag spectrum-Tag--sizeS spectrum-Tag--removable" tabindex="0">
-            <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-Tags-itemIcon" focusable="false" aria-hidden="true" aria-label="Tag">
+            <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-Tag-itemIcon" focusable="false" aria-hidden="true" aria-label="Tag">
               <use xlink:href="#spectrum-icon-18-CheckmarkCircle" />
             </svg>
-            <span class="spectrum-Tags-itemLabel">Tag label</span>
+            <span class="spectrum-Tag-itemLabel">Tag label</span>
             <button type="reset" class="spectrum-ClearButton spectrum-ClearButton--sizeS spectrum-Tag-clearButton" tabindex="-1">
               <div class="spectrum-ClearButton-fill">
                 <svg class="spectrum-Icon spectrum-ClearButton-icon spectrum-UIIcon-Cross75" focusable="false" aria-hidden="true">
@@ -363,7 +363,7 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Selected</h4>
 
           <div class="spectrum-Tag spectrum-Tag--sizeS is-selected spectrum-Tag--removable" tabindex="0">
-            <span class="spectrum-Tags-itemLabel">Tag label</span>
+            <span class="spectrum-Tag-itemLabel">Tag label</span>
             <button type="reset" class="spectrum-ClearButton spectrum-ClearButton--sizeS spectrum-Tag-clearButton" tabindex="-1">
               <div class="spectrum-ClearButton-fill">
                 <svg class="spectrum-Icon spectrum-ClearButton-icon spectrum-UIIcon-Cross75" focusable="false" aria-hidden="true">
@@ -374,10 +374,10 @@ examples:
           </div>
 
           <div class="spectrum-Tag spectrum-Tag--sizeS is-selected spectrum-Tag--removable" tabindex="0">
-            <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-Tags-itemIcon" focusable="false" aria-hidden="true" aria-label="Tag">
+            <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-Tag-itemIcon" focusable="false" aria-hidden="true" aria-label="Tag">
               <use xlink:href="#spectrum-icon-18-CheckmarkCircle" />
             </svg>
-            <span class="spectrum-Tags-itemLabel">Tag label</span>
+            <span class="spectrum-Tag-itemLabel">Tag label</span>
             <button type="reset" class="spectrum-ClearButton spectrum-ClearButton--sizeS spectrum-Tag-clearButton" tabindex="-1">
               <div class="spectrum-ClearButton-fill">
                 <svg class="spectrum-Icon spectrum-ClearButton-icon spectrum-UIIcon-Cross75" focusable="false" aria-hidden="true">
@@ -392,7 +392,7 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Invalid</h4>
 
           <div class="spectrum-Tag spectrum-Tag--sizeS is-invalid spectrum-Tag--removable" tabindex="0">
-            <span class="spectrum-Tags-itemLabel">Tag label</span>
+            <span class="spectrum-Tag-itemLabel">Tag label</span>
             <button type="reset" class="spectrum-ClearButton spectrum-ClearButton--sizeS spectrum-Tag-clearButton" tabindex="-1">
               <div class="spectrum-ClearButton-fill">
                 <svg class="spectrum-Icon spectrum-ClearButton-icon spectrum-UIIcon-Cross75" focusable="false" aria-hidden="true">
@@ -403,10 +403,10 @@ examples:
           </div>
 
           <div class="spectrum-Tag spectrum-Tag--sizeS is-invalid spectrum-Tag--removable" tabindex="0">
-            <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-Tags-itemIcon" focusable="false" aria-hidden="true" aria-label="Tag">
+            <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-Tag-itemIcon" focusable="false" aria-hidden="true" aria-label="Tag">
               <use xlink:href="#spectrum-icon-24-Alert" />
             </svg>
-            <span class="spectrum-Tags-itemLabel">Tag label</span>
+            <span class="spectrum-Tag-itemLabel">Tag label</span>
             <button type="reset" class="spectrum-ClearButton spectrum-ClearButton--sizeS spectrum-Tag-clearButton" tabindex="-1">
               <div class="spectrum-ClearButton-fill">
                 <svg class="spectrum-Icon spectrum-ClearButton-icon spectrum-UIIcon-Cross75" focusable="false" aria-hidden="true">
@@ -421,7 +421,7 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Disabled</h4>
 
           <div class="spectrum-Tag spectrum-Tag--sizeS is-disabled spectrum-Tag--removable" tabindex="-1">
-            <span class="spectrum-Tags-itemLabel">Tag label</span>
+            <span class="spectrum-Tag-itemLabel">Tag label</span>
             <button type="reset" class="spectrum-ClearButton spectrum-ClearButton--sizeS spectrum-Tag-clearButton" tabindex="-1">
               <div class="spectrum-ClearButton-fill">
                 <svg class="spectrum-Icon spectrum-ClearButton-icon spectrum-UIIcon-Cross75" focusable="false" aria-hidden="true">
@@ -432,10 +432,10 @@ examples:
           </div>
 
           <div class="spectrum-Tag spectrum-Tag--sizeS is-disabled spectrum-Tag--removable" tabindex="-1">
-            <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-Tags-itemIcon" focusable="false" aria-hidden="true" aria-label="Tag">
+            <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-Tag-itemIcon" focusable="false" aria-hidden="true" aria-label="Tag">
               <use xlink:href="#spectrum-icon-18-CheckmarkCircle" />
             </svg>
-            <span class="spectrum-Tags-itemLabel">Tag label</span>
+            <span class="spectrum-Tag-itemLabel">Tag label</span>
             <button type="reset" class="spectrum-ClearButton spectrum-ClearButton--sizeS spectrum-Tag-clearButton" tabindex="-1">
               <div class="spectrum-ClearButton-fill">
                 <svg class="spectrum-Icon spectrum-ClearButton-icon spectrum-UIIcon-Cross75" focusable="false" aria-hidden="true">
@@ -449,7 +449,7 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Selected + Invalid</h4>
 
           <div class="spectrum-Tag spectrum-Tag--sizeS is-selected is-invalid spectrum-Tag--removable" tabindex="0">
-            <span class="spectrum-Tags-itemLabel">Tag label</span>
+            <span class="spectrum-Tag-itemLabel">Tag label</span>
             <button type="reset" class="spectrum-ClearButton spectrum-ClearButton--sizeS spectrum-Tag-clearButton" tabindex="-1">
               <div class="spectrum-ClearButton-fill">
                 <svg class="spectrum-Icon spectrum-ClearButton-icon spectrum-UIIcon-Cross75" focusable="false" aria-hidden="true">
@@ -460,10 +460,10 @@ examples:
           </div>
 
           <div class="spectrum-Tag spectrum-Tag--sizeS is-selected is-invalid spectrum-Tag--removable" tabindex="0">
-            <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-Tags-itemIcon" focusable="false" aria-hidden="true" aria-label="Tag">
+            <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-Tag-itemIcon" focusable="false" aria-hidden="true" aria-label="Tag">
               <use xlink:href="#spectrum-icon-24-Alert" />
             </svg>
-            <span class="spectrum-Tags-itemLabel">Tag label</span>
+            <span class="spectrum-Tag-itemLabel">Tag label</span>
             <button type="reset" class="spectrum-ClearButton spectrum-ClearButton--sizeS spectrum-Tag-clearButton" tabindex="-1">
               <div class="spectrum-ClearButton-fill">
                 <svg class="spectrum-Icon spectrum-ClearButton-icon spectrum-UIIcon-Cross75" focusable="false" aria-hidden="true">

--- a/components/tag/stories/tag.stories.js
+++ b/components/tag/stories/tag.stories.js
@@ -18,18 +18,40 @@ export default {
 			options: ["s", "m", "l"],
 			control: "select",
 		},
+		hasIcon: {
+			name: "Has icon",
+			type: { name: "boolean" },
+			table: {
+				type: { summary: "boolean" },
+				category: "Component",
+			},
+			control: "boolean",
+			if: { arg: "hasAvatar", truthy: false },
+		},
 		iconName: {
 			...(IconStories?.argTypes?.iconName ?? {}),
 			if: false,
+			if: { arg: "hasIcon", truthy: true },
+		},
+		hasAvatar: {
+			name: "Has avatar",
+			type: { name: "boolean" },
+			table: {
+				type: { summary: "boolean" },
+				category: "Component",
+			},
+			control: "boolean",
+			if: { arg: "hasIcon", truthy: false },
 		},
 		avatarUrl: {
 			name: "Avatar image",
 			type: { name: "string" },
 			table: {
 				type: { summary: "string" },
-				category: "Component",
+				category: "Content",
 			},
 			control: { type: "file", accept: ".svg,.png,.jpg,.jpeg,.webc" },
+			if: { arg: "hasAvatar", truthy: true },
 		},
 		label: {
 			name: "Label",
@@ -91,7 +113,10 @@ export default {
 		rootClass: "spectrum-Tag",
 		size: "m",
 		label: "Tag label",
-		avatarUrl: undefined,
+		hasIcon: false,
+		iconName: 'Info',
+		avatarUrl: "example-ava.png",
+		hasAvatar: false,
 		isSelected: false,
 		isDisabled: false,
 		isInvalid: false,
@@ -115,11 +140,13 @@ Default.args = {};
 
 export const Icon = Template.bind({});
 Icon.args = {
+	hasIcon: true,
 	iconName: 'Info'
 };
 
 export const Avatar = Template.bind({});
 Avatar.args = {
+	hasAvatar: true,
 	avatarUrl: "example-ava.png"
 };
 

--- a/components/tag/stories/tag.stories.js
+++ b/components/tag/stories/tag.stories.js
@@ -91,12 +91,12 @@ export default {
 		rootClass: "spectrum-Tag",
 		size: "m",
 		label: "Tag label",
-		avatarUrl: "example-ava.png",
+		avatarUrl: undefined,
 		isSelected: false,
 		isDisabled: false,
 		isInvalid: false,
 		isEmphasized: false,
-		hasClearButton: true,
+		hasClearButton: false,
 	},
 	parameters: {
 		actions: {
@@ -112,3 +112,18 @@ export default {
 
 export const Default = Template.bind({});
 Default.args = {};
+
+export const Icon = Template.bind({});
+Icon.args = {
+	iconName: 'Info'
+};
+
+export const Avatar = Template.bind({});
+Avatar.args = {
+	avatarUrl: "example-ava.png"
+};
+
+export const Removeable = Template.bind({});
+Removeable.args = {
+	hasClearButton: true,
+};

--- a/components/tag/stories/template.js
+++ b/components/tag/stories/template.js
@@ -48,14 +48,14 @@ export const Template = ({
 			id=${ifDefined(id)}
 			tabindex="0"
 		>
-			${avatarUrl && !iconName
+			${avatarUrl
 				? Avatar({
 						...globals,
 						image: avatarUrl,
 						size: "50",
 				  })
 				: ""}
-			${iconName && !avatarUrl
+			${iconName
 				? Icon({
 						...globals,
 						size,

--- a/components/tag/stories/template.js
+++ b/components/tag/stories/template.js
@@ -55,15 +55,15 @@ export const Template = ({
 						size: "50",
 				  })
 				: ""}
-			${iconName
+			${iconName && !avatarUrl
 				? Icon({
 						...globals,
 						size,
 						iconName,
-						customClasses: [`${rootClass}s-itemIcon`],
+						customClasses: [`${rootClass}-itemIcon`],
 				  })
 				: ""}
-			<span class="${rootClass}s-itemLabel">${label}</span>
+			<span class="${rootClass}-itemLabel">${label}</span>
 			${hasClearButton
 				? ClearButton({
 						...globals,

--- a/components/tag/themes/express.css
+++ b/components/tag/themes/express.css
@@ -41,11 +41,6 @@ governing permissions and limitations under the License.
     --spectrum-tag-border-color-selected-active: var(--spectrum-neutral-background-color-down);
     --spectrum-tag-border-color-selected-focus: var(--spectrum-neutral-background-color-key-focus);
 
-    --spectrum-tag-background-color-selected: var(--spectrum-neutral-background-color-default);
-    --spectrum-tag-background-color-selected-hover: var(--spectrum-neutral-background-color-hover);
-    --spectrum-tag-background-color-selected-active: var(--spectrum-neutral-background-color-down);
-    --spectrum-tag-background-color-selected-focus: var(--spectrum-neutral-background-color-key-focus);
-
     /* disabled */
     --spectrum-tag-border-color-disabled: var(--spectrum-disabled-border-color);
     --spectrum-tag-background-color-disabled: transparent;

--- a/components/tag/themes/spectrum.css
+++ b/components/tag/themes/spectrum.css
@@ -41,11 +41,6 @@ governing permissions and limitations under the License.
     --spectrum-tag-border-color-selected-active: var(--spectrum-neutral-subdued-background-color-down);
     --spectrum-tag-border-color-selected-focus: var(--spectrum-neutral-subdued-background-color-key-focus);
 
-    --spectrum-tag-background-color-selected: var(--spectrum-neutral-subdued-background-color-default);
-    --spectrum-tag-background-color-selected-hover: var(--spectrum-neutral-subdued-background-color-hover);
-    --spectrum-tag-background-color-selected-active: var(--spectrum-neutral-subdued-background-color-down);
-    --spectrum-tag-background-color-selected-focus: var(--spectrum-neutral-subdued-background-color-key-focus);
-
     /* disabled variant */
     --spectrum-tag-border-color-disabled: transparent;
     --spectrum-tag-background-color-disabled: var(--spectrum-disabled-background-color);


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->

## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

This PR updated the Tag component to use new color tokens. 
- use new tokens for selected, not emphasized background colors 
- Updated content color for selected not emphasized to be `gray-50` in order to match XD file 
- Change instances of `--spectrum-Tags` to be `--spectrum-Tag` 
- Updated storybook to include variants: with Avatar, with Icon, and Removable 

Breaking Change:
- updated two class names from `--spectrum-Tags-*` to `--spectrum-Tag` 

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

Test outline:
  1. Open the [deploy url](https://pr-2039--spectrum-css.netlify.app/tag.html) or storybook for the tag component:
- [x] Inspect the selected variant (not emphasized) 
- [x] Check selected, not emphasized background colors are using:

  - neutral-background-color-selected-default
  - neutral-background-color-selected-hover
  - neutral-background-color-selected-down
  - neutral-background-color-selected-key-focus


- [x] check label, icon, and cross icon color (selected not emphasized), should be using `--spectrum-gray-50` 

 2. Open the [storybook](https://pr-2039--spectrum-css.netlify.app/preview/?path=/docs/components-tag--docs) for the tag component. Check that each variant is displayed properly and controls work as expected: 

- [x] Default
- [x] Removable  
- [x] Icon 
- [x] Avatar 




### Regression testing

Validate:

1. A legacy documentation page (such as [accordion](https://pr-###--spectrum-css.netlify.app/accordion.html)), including:

- [x] The page renders correctly
- [x] The page is accessible
- [x] The page is responsive

2. A migrated documentation page (such as [action group](https://pr-###--spectrum-css.netlify.app/actiongroup.html)), including:

- [x] The page renders correctly
- [x] The page is accessible
- [x] The page is responsive

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.

- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.

- [ ] ✨ This pull request is ready to merge. ✨
