### PR TITLE
refactor(checkbox): remove .spectrum-Icon from Checkbox styles

### DIFF
--- a/components/checkbox/index.css
+++ b/components/checkbox/index.css
@@ -510,17 +510,20 @@ governing permissions and limitations under the License.
   }
 }
 
-.spectrum-Icon.spectrum-Checkbox-checkmark,
-.spectrum-Icon.spectrum-Checkbox-partialCheckmark {
-  color: var(--highcontrast-checkbox-background-color-default, var(--mode-checkbox-checkmark-color, var(--spectrum-checkbox-checkmark-color)));
-  opacity: 0;
-  transform: scale(0);
+.spectrum-Checkbox {
 
-  transition: opacity var(--mod-checkbox-animation-duration, var(--spectrum-checkbox-animation-duration)) ease-in-out, transform var(--mod-checkbox-animation-duration, var(--spectrum-checkbox-animation-duration)) ease-in-out;
-}
+  .spectrum-Checkbox-checkmark,
+  .spectrum-Checkbox-partialCheckmark {
+    color: var(--highcontrast-checkbox-background-color-default, var(--mode-checkbox-checkmark-color, var(--spectrum-checkbox-checkmark-color)));
+    opacity: 0;
+    transform: scale(0);
 
-.spectrum-Icon.spectrum-Checkbox-partialCheckmark {
-  display: none;
+    transition: opacity var(--mod-checkbox-animation-duration, var(--spectrum-checkbox-animation-duration)) ease-in-out, transform var(--mod-checkbox-animation-duration, var(--spectrum-checkbox-animation-duration)) ease-in-out;
+  }
+
+  .spectrum-Checkbox-partialCheckmark {
+    display: none;
+  }
 }
 
 /* Disabled */


### PR DESCRIPTION
## Description

Removes the need for the `.spectrum-Icon` class specifics in the Checkbox component by nesting to maintain specificity.

### Regression testing

Validate:

1. A legacy documentation page (such as [accordion](https://pr-###--spectrum-css.netlify.app/accordion.html)), including:

- [x] The page renders correctly
- [x] The page is accessible
- [x] The page is responsive

2. A migrated documentation page (such as [action group](https://pr-###--spectrum-css.netlify.app/actiongroup.html)), including:

- [x] The page renders correctly
- [x] The page is accessible
- [x] The page is responsive

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.

- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.

- [x] ✨ This pull request is ready to merge. ✨
