### PR TITLE
feat(tray): use token for top and bottom edge to content area

### DIFF
--- a/components/tooltip/metadata/mods.md
+++ b/components/tooltip/metadata/mods.md
@@ -26,4 +26,4 @@
 | `--mod-tooltip-tip-antialiasing-inset`       |
 | `--mod-tooltip-tip-block-size`               |
 | `--mod-tooltip-tip-height-percentage`        |
-| `--mod-tooltip-tip-inline-size`              |
+| `--mod-tooltip-tip-square-size`              |

--- a/components/tray/index.css
+++ b/components/tray/index.css
@@ -51,6 +51,9 @@ governing permissions and limitations under the License.
   inline-size: 100%;
   max-block-size: calc(100vh - var(--mod-tray-spacing-edge-to-tray-safe-zone, var(--spectrum-tray-spacing-edge-to-tray-safe-zone)));
   margin-block-start: var(--mod-tray-spacing-edge-to-tray-safe-zone, var(--spectrum-tray-spacing-edge-to-tray-safe-zone));
+  padding-block-start: var(--mod-tray-top-to-content-area, var(--spectrum-tray-top-to-content-area));
+  padding-block-end: var(--mod-tray-bottom-to-content-area, var(--spectrum-tray-top-to-content-area));
+  box-sizing: border-box;
   overflow: auto;
   outline: none;
 

--- a/components/tray/metadata/mods.md
+++ b/components/tray/metadata/mods.md
@@ -1,6 +1,7 @@
 | Modifiable Custom Properties                |
 | ------------------------------------------- |
 | `--mod-tray-background-color`               |
+| `--mod-tray-bottom-to-content-area`         |
 | `--mod-tray-corner-radius`                  |
 | `--mod-tray-entry-animation-delay`          |
 | `--mod-tray-entry-animation-duration`       |
@@ -8,3 +9,4 @@
 | `--mod-tray-exit-animation-duration`        |
 | `--mod-tray-max-inline-size`                |
 | `--mod-tray-spacing-edge-to-tray-safe-zone` |
+| `--mod-tray-top-to-content-area`            |


### PR DESCRIPTION
## Description

Update to **Tray** to use the new token `tray-top-to-content-area` that applies to both the top and the bottom (per design). This adds top and bottom padding to the tray. The tray is changed to `box-sizing: border-box` so that `max-block-size` and other size properties are not changed by the added padding.

CSS-469

## How and where has this been tested?

Reviewing the docs page and Storybook in Firefox and Chrome (Mac).

### Regression testing

Validate:

1. A legacy documentation page (such as [accordion](https://pr-###--spectrum-css.netlify.app/accordion.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

2. A migrated documentation page (such as [action group](https://pr-###--spectrum-css.netlify.app/actiongroup.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.

- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.

- [ ] ✨ This pull request is ready to merge. ✨
