### PR TITLE
fix(tag): update whcm focus ring color

### DIFF
--- a/components/tag/index.css
+++ b/components/tag/index.css
@@ -428,7 +428,7 @@ governing permissions and limitations under the License.
     --highcontrast-tag-border-color: ButtonText;
     --highcontrast-tag-border-color-hover: ButtonText;
     --highcontrast-tag-border-color-active: ButtonText;
-    --highcontrast-tag-border-color-focus: ButtonText;
+    --highcontrast-tag-border-color-focus: Highlight;
 
     --highcontrast-tag-background-color: ButtonFace;
     --highcontrast-tag-background-color-hover: ButtonFace;

--- a/components/tag/index.css
+++ b/components/tag/index.css
@@ -440,6 +440,8 @@ governing permissions and limitations under the License.
     --highcontrast-tag-content-color-active: ButtonText;
     --highcontrast-tag-content-color-focus: ButtonText;
 
+    --highcontrast-tag-focus-ring-color: Highlight;
+
     &.is-selected {
       --highcontrast-tag-border-color-selected: Highlight;
       --highcontrast-tag-border-color-selected-hover: Highlight;

--- a/components/tag/metadata/tag.yml
+++ b/components/tag/metadata/tag.yml
@@ -124,7 +124,7 @@ examples:
             <span class="spectrum-Tags-itemLabel">Tag label</span>
           </div>
 
-          <div class="spectrum-Tag spectrum-Tag--sizeS is-disabled" tabindex="0">
+          <div class="spectrum-Tag spectrum-Tag--sizeS is-disabled" tabindex="-1">
             <div class="spectrum-Avatar spectrum-Avatar--size50">
               <img class="spectrum-Avatar-image" src="img/example-ava.jpg" alt="Avatar">
             </div>


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->

## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

Addresses [CSS-551](https://jira.corp.adobe.com/browse/CSS-551) and [SWC issue 3365](https://github.com/adobe/spectrum-web-components/issues/3365) by adding WHCM system color for focus ring abd border. 

Also addressed an issue where one of the disabled variants was receiving keyboard focus. 


## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

<!--
  Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

  Test outline:
  1. Open the [deployed URL](https://pr-2043--spectrum-css.netlify.app/tag.html) for the tag component:
    - [ ] Emulate WHCM, either in browser or assistive lags
    - [ ] Tab through the tags to see that the focus ring and border changed to the highlight color on keyboard focus


### Regression testing

Validate:
1. A legacy documentation page (such as [accordion](https://pr-2043--spectrum-css.netlify.app/accordion.html)), including:

- [x] The page renders correctly (@castastrophe)
- [x] The page is accessible (@castastrophe)
- [x] The page is responsive (@castastrophe)

2. A migrated documentation page (such as [action group](https://pr-2043--spectrum-css.netlify.app/actiongroup.html)), including:

- [x] The page renders correctly (@castastrophe)
- [x] The page is accessible (@castastrophe)
- [x] The page is responsive (@castastrophe)

## Screenshots

### Before
![Screenshot 2023-07-25 at 12 05 05 PM](https://github.com/adobe/spectrum-css/assets/63808889/ee28039e-da6e-4929-afeb-a7a14db07b92)


### After
![Screenshot 2023-07-25 at 12 03 23 PM](https://github.com/adobe/spectrum-css/assets/63808889/80f7d7f5-3630-439d-8b48-3dd6aea6d85a)


## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
