### PR TITLE
fix: update opacitycheckerboard peer deps

### DIFF
--- a/components/colorhandle/package.json
+++ b/components/colorhandle/package.json
@@ -19,7 +19,7 @@
   },
   "peerDependencies": {
     "@spectrum-css/colorloupe": ">=3",
-    "@spectrum-css/opacitycheckerboard": ">=1.0.0-alpha.0",
+    "@spectrum-css/opacitycheckerboard": ">=1",
     "@spectrum-css/tokens": ">=11"
   },
   "devDependencies": {

--- a/components/colorslider/package.json
+++ b/components/colorslider/package.json
@@ -19,7 +19,7 @@
   },
   "peerDependencies": {
     "@spectrum-css/colorhandle": ">=5.0.0",
-    "@spectrum-css/opacitycheckerboard": ">=1.0.0-alpha.0",
+    "@spectrum-css/opacitycheckerboard": ">=1",
     "@spectrum-css/vars": ">=9"
   },
   "devDependencies": {

--- a/components/swatch/package.json
+++ b/components/swatch/package.json
@@ -18,8 +18,8 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/opacitycheckerboard": ">=1.0.0-alpha.0",
-    "@spectrum-css/tokens": ">=10.0.0"
+    "@spectrum-css/opacitycheckerboard": ">=1",
+    "@spectrum-css/tokens": ">=11"
   },
   "devDependencies": {
     "@spectrum-css/component-builder-simple": "^2.0.15",

--- a/components/thumbnail/package.json
+++ b/components/thumbnail/package.json
@@ -18,7 +18,7 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/opacitycheckerboard": ">=1.0.0-alpha.0",
+    "@spectrum-css/opacitycheckerboard": ">=1",
     "@spectrum-css/tokens": ">=11"
   },
   "devDependencies": {


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->

## Description

Clarifies that consuming Opacity Checkerboard packages use the full release.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

<!--
  Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

### Regression testing

Validate:

1. A legacy documentation page (such as [accordion](https://pr-###--spectrum-css.netlify.app/accordion.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

2. A migrated documentation page (such as [action group](https://pr-###--spectrum-css.netlify.app/actiongroup.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [ ] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.

- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.

- [ ] ✨ This pull request is ready to merge. ✨
