### PR TITLE
fix(popover): add highcontrast variables and additional height in docs

### DIFF
--- a/components/popover/index.css
+++ b/components/popover/index.css
@@ -82,8 +82,8 @@ governing permissions and limitations under the License.
       .spectrum-Popover-tip-triangle {
         stroke-linecap: square;
         stroke-linejoin: miter;
-        fill: var(--mod-popover-background-color, var(--spectrum-popover-background-color));
-        stroke: var(--mod-popover-border-color, var(--spectrum-popover-border-color));
+        fill: var(--highcontrast-popover-background-color, var(--mod-popover-background-color, var(--spectrum-popover-background-color)));
+        stroke: var(--highcontrast-popover-border-color, var(--mod-popover-border-color, var(--spectrum-popover-border-color)));
         stroke-width: var(--mod-popover-border-width, var(--spectrum-popover-border-width));
       }
     }

--- a/components/popover/metadata/popover.yml
+++ b/components/popover/metadata/popover.yml
@@ -98,7 +98,7 @@ examples:
               <path class="spectrum-Popover-tip-triangle" d="M-1,-1 8,8 17,-1">
             </svg>
           </div>
-          <div class="dummy-spacing" style="position: relative; box-sizing: border-box; height: 224px; min-width: 400px; max-width: 50%;"></div>
+          <div class="dummy-spacing" style="position: relative; box-sizing: border-box; height: 235px; min-width: 400px; max-width: 50%;"></div>
 
           <div class="dummy-source" style="position: relative; display: flex; align-items: center; justify-content: center; width: 100px; height: 50px; background: #E6E6E6; border-radius: 8px; box-sizing: border-box;">
             <span><em>Source 50x100</em></span>


### PR DESCRIPTION
## Description

Add highcontrast variables for Popover tip fill and stroke
Make dummy spacing a bit larger to keep from hiding the Popover tip on our docs site

Fixes Issue #1885 

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

  1. Open the [docs site](https://pr-###--spectrum-css.netlify.app/popover.html) for the Popover component:
    - [ ] View the site in WHCM using Assistiv Labs
    - [ ] Observe that all Popover examples (minus the Standard - Default) have a visible tip with a white border

### Regression testing

Validate:

1. A legacy documentation page (such as [accordion](https://pr-###--spectrum-css.netlify.app/accordion.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

2. A migrated documentation page (such as [action group](https://pr-###--spectrum-css.netlify.app/actiongroup.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

## Screenshots

### Before
![image](https://github.com/adobe/spectrum-css/assets/99203545/ffe3356d-340d-4020-977e-b86fff7a2332)

### After
![Screenshot 2023-07-27 at 11 26 54 AM](https://github.com/adobe/spectrum-css/assets/99203545/3ca3aa76-cc11-4459-8d6a-5515e0818774)

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.

- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.

- [ ] ✨ This pull request is ready to merge. ✨
