### PR TITLE
fix(switch): update selected background color tokens

### DIFF
--- a/components/switch/index.css
+++ b/components/switch/index.css
@@ -21,6 +21,11 @@ governing permissions and limitations under the License.
   --spectrum-switch-background-color-disabled: var(--spectrum-gray-300);
   --spectrum-switch-background-color-selected-disabled: var(--spectrum-disabled-content-color);
 
+  --spectrum-switch-background-color-selected-default: var(--spectrum-neutral-background-color-selected-default);
+  --spectrum-switch-background-color-selected-hover: var(--spectrum-neutral-background-color-selected-hover);
+  --spectrum-switch-background-color-selected-down: var(--spectrum-neutral-background-color-selected-down);
+  --spectrum-switch-background-color-selected-focus: var(--spectrum-neutral-background-color-selected-key-focus);
+
   --spectrum-switch-focus-indicator-thickness: var(--mod-focus-indicator-thickness, var(--spectrum-focus-indicator-thickness));
   --spectrum-switch-focus-indicator-color: var(--spectrum-focus-indicator-color);
 

--- a/components/switch/index.css
+++ b/components/switch/index.css
@@ -19,13 +19,13 @@ governing permissions and limitations under the License.
 
   --spectrum-switch-background-color: var(--spectrum-gray-300);
   --spectrum-switch-background-color-disabled: var(--spectrum-gray-300);
-  --spectrum-switch-background-color-selected-disabled: var(--spectrum-gray-400);
+  --spectrum-switch-background-color-selected-disabled: var(--spectrum-disabled-content-color);
 
   --spectrum-switch-focus-indicator-thickness: var(--mod-focus-indicator-thickness, var(--spectrum-focus-indicator-thickness));
   --spectrum-switch-focus-indicator-color: var(--spectrum-focus-indicator-color);
 
   --spectrum-switch-handle-background-color: var(--spectrum-gray-75);
-  --spectrum-switch-handle-border-color-disabled: var(--spectrum-gray-400);
+  --spectrum-switch-handle-border-color-disabled: var(--spectrum-disabled-content-color);
 }
 
 .spectrum-Switch--disabled {

--- a/components/switch/stories/switch.stories.js
+++ b/components/switch/stories/switch.stories.js
@@ -6,9 +6,57 @@ export default {
 	description:
 		"A switch is used to turn an option on or off. Switches allow users to select the state of a single option at a time.",
 	component: "Switch",
-	argTypes: {},
+	argTypes: {
+		size: {
+			name: "Size",
+			type: { name: "string", required: true },
+			table: {
+				type: { summary: "string" },
+				category: "Component",
+			},
+			options: ["s", "m", "l", "xl"],
+			control: "select",
+		},
+		isEmphasized: {
+			name: "Emphasized",
+			type: { name: "boolean" },
+			table: {
+				type: { summary: "boolean" },
+				category: "State",
+			},
+			control: "boolean",
+		},
+		isDisabled: {
+			name: "Disabled",
+			type: { name: "boolean" },
+			table: {
+				type: { summary: "boolean" },
+				category: "State",
+			},
+			control: "boolean",
+		},
+		isChecked: {
+			name: "Disabled",
+			type: { name: "boolean" },
+			table: {
+				type: { summary: "boolean" },
+				category: "State",
+			},
+			control: "boolean",
+		},
+		label: {
+			name: "Label",
+			type: { name: "string" },
+			table: {
+				type: { summary: "string" },
+				category: "Content",
+			},
+			control: { type: "text" },
+		},
+	},
 	args: {
 		rootClass: "spectrum-Switch",
+		isDisabled: false,
 	},
 	parameters: {
 		actions: {
@@ -24,3 +72,13 @@ export default {
 
 export const Default = Template.bind({});
 Default.args = {};
+
+export const Emphasized = Template.bind({});
+Emphasized.args = {
+	isEmphasized: true
+};
+
+export const Disabled = Template.bind({});
+Disabled.args = {
+	isDisabled: true
+};

--- a/components/switch/stories/switch.stories.js
+++ b/components/switch/stories/switch.stories.js
@@ -36,7 +36,7 @@ export default {
 			control: "boolean",
 		},
 		isChecked: {
-			name: "Disabled",
+			name: "Checked",
 			type: { name: "boolean" },
 			table: {
 				type: { summary: "boolean" },
@@ -57,6 +57,10 @@ export default {
 	args: {
 		rootClass: "spectrum-Switch",
 		isDisabled: false,
+		isChecked: false,
+		isEmphasized: false,
+		label: "Switch label",
+		size: "m",
 	},
 	parameters: {
 		actions: {
@@ -76,6 +80,11 @@ Default.args = {};
 export const Emphasized = Template.bind({});
 Emphasized.args = {
 	isEmphasized: true
+};
+
+export const Checked = Template.bind({});
+Checked.args = {
+	isChecked: true
 };
 
 export const Disabled = Template.bind({});

--- a/components/switch/stories/template.js
+++ b/components/switch/stories/template.js
@@ -7,9 +7,11 @@ import "../index.css";
 export const Template = ({
 	rootClass = "spectrum-Switch",
 	size = "m",
+	label = "Switch label",
+	isDisabled,
+	isEmphasized,
 	customClasses = [],
 	id,
-	label,
 	...globals
 }) => {
 	const { express } = globals;
@@ -25,13 +27,15 @@ export const Template = ({
 		<div
 			class=${classMap({
 				[rootClass]: true,
+				[`${rootClass}--disabled`] : isDisabled,
+				[`${rootClass}--emphasized`] : isEmphasized,
 				[`${rootClass}--size${size?.toUpperCase()}`]:
 					typeof size !== "undefined",
 				...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
 			})}
 			id=${ifDefined(id)}
 		>
-			<input type="checkbox" class="${rootClass}-input" id="switch-onoff-0" />
+			<input type="checkbox" class="${rootClass}-input" id="switch-onoff-0" ?disabled=${isDisabled} />
 			<span class="${rootClass}-switch"></span>
 			${label
 				? html`<label class="${rootClass}-label" for="switch-onoff-0"

--- a/components/switch/stories/template.js
+++ b/components/switch/stories/template.js
@@ -9,6 +9,7 @@ export const Template = ({
 	size = "m",
 	label = "Switch label",
 	isDisabled,
+	isChecked,
 	isEmphasized,
 	customClasses = [],
 	id,
@@ -35,7 +36,7 @@ export const Template = ({
 			})}
 			id=${ifDefined(id)}
 		>
-			<input type="checkbox" class="${rootClass}-input" id="switch-onoff-0" ?disabled=${isDisabled} />
+			<input type="checkbox" class="${rootClass}-input" id="switch-onoff-0" ?disabled=${isDisabled} ?checked=${isChecked}/>
 			<span class="${rootClass}-switch"></span>
 			${label
 				? html`<label class="${rootClass}-label" for="switch-onoff-0"

--- a/components/switch/themes/express.css
+++ b/components/switch/themes/express.css
@@ -12,11 +12,6 @@ governing permissions and limitations under the License.
 
 @container (--system: express) {
   .spectrum-Switch {
-    --spectrum-switch-background-color-selected-default: var(--spectrum-gray-800);
-    --spectrum-switch-background-color-selected-hover: var(--spectrum-gray-900);
-    --spectrum-switch-background-color-selected-down: var(--spectrum-gray-900);
-    --spectrum-switch-background-color-selected-focus: var(--spectrum-gray-900);
-
     --spectrum-switch-handle-border-color-default: var(--spectrum-gray-800);
     --spectrum-switch-handle-border-color-hover: var(--spectrum-gray-900);
     --spectrum-switch-handle-border-color-down: var(--spectrum-gray-900);

--- a/components/switch/themes/spectrum.css
+++ b/components/switch/themes/spectrum.css
@@ -13,11 +13,6 @@ governing permissions and limitations under the License.
 
 @container (--system: spectrum) {
   .spectrum-Switch {
-    --spectrum-switch-background-color-selected-default: var(--spectrum-gray-700);
-    --spectrum-switch-background-color-selected-hover: var(--spectrum-gray-800);
-    --spectrum-switch-background-color-selected-down: var(--spectrum-gray-900);
-    --spectrum-switch-background-color-selected-focus: var(--spectrum-gray-800);
-
     --spectrum-switch-handle-border-color-default: var(--spectrum-gray-600);
     --spectrum-switch-handle-border-color-hover: var(--spectrum-gray-700);
     --spectrum-switch-handle-border-color-down: var(--spectrum-gray-800);


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->

## Description
Updated selected (not emphasized) background color tokens to use: 
- neutral-background-color-selected-default
- neutral-background-color-selected-hover
- neutral-background-color-selected-down
- neutral-background-color-selected-key-focus

Updated storybook to include disabled and emphasized variants and controls for sizing and label

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.


#### Test outline:
  1. Open the [storybook](https://pr-2057--spectrum-css.netlify.app/preview/?path=/docs/components-switch--docs) for the Switch component:
- [x] All variants load without error and displayed appropriately @mlogsdon18 
  
2. Open the [Docs Site](https://pr-2057--spectrum-css.netlify.app/switch.html) for the Switch component:
- [x] Inspect and confirm new tokens are being used for the selected not emphasized variants @mlogsdon18 

### Regression testing

Validate:

1. A legacy documentation page (such as [accordion](https://pr-2057--spectrum-css.netlify.app/accordion.html)), including:

- [x] The page renders correctly
- [x] The page is accessible
- [x] The page is responsive
@mlogsdon18 
2. A migrated documentation page (such as [action group](https://pr-2057--spectrum-css.netlify.app/actiongroup.html)), including:

- [x] The page renders correctly
- [x] The page is accessible
- [x] The page is responsive
@mlogsdon18 

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.

- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.

- [ ] ✨ This pull request is ready to merge. ✨
