### PR TITLE
feat(colorhandle): add --mod-colorhandle-hitarea-border-radius

### DIFF
--- a/components/colorhandle/index.css
+++ b/components/colorhandle/index.css
@@ -104,42 +104,18 @@ governing permissions and limitations under the License.
 				var(--spectrum-colorhandle-animation-easing)
 			);
 
-	&,
-	&::after {
-		border-radius: 100%;
-	}
+  border-radius: 100%;
 
-	&::after {
-		content: "";
-		inset-inline: calc(
-			50% -
-				calc(
-					var(
-							--mod-colorhandle-hitarea-size,
-							var(--spectrum-colorhandle-hitarea-size)
-						) / 2
-				)
-		);
-		inset-block: calc(
-			50% -
-				calc(
-					var(
-							--mod-colorhandle-hitarea-size,
-							var(--spectrum-colorhandle-hitarea-size)
-						) / 2
-				)
-		);
-		position: absolute;
-		display: block;
-		inline-size: var(
-			--mod-colorhandle-hitarea-size,
-			var(--spectrum-colorhandle-hitarea-size)
-		);
-		block-size: var(
-			--mod-colorhandle-hitarea-size,
-			var(--spectrum-colorhandle-hitarea-size)
-		);
-	}
+  &:after {
+    content: '';
+    inset-inline: calc(50% - calc(var(--mod-colorhandle-hitarea-size, var(--spectrum-colorhandle-hitarea-size)) / 2));
+    inset-block: calc(50% - calc(var(--mod-colorhandle-hitarea-size, var(--spectrum-colorhandle-hitarea-size)) / 2));
+    position: absolute;
+    display: block;
+    inline-size: var(--mod-colorhandle-hitarea-size, var(--spectrum-colorhandle-hitarea-size));
+    block-size: var(--mod-colorhandle-hitarea-size, var(--spectrum-colorhandle-hitarea-size));
+    border-radius: var(--mod-colorhandle-hitarea-border-radius, 100%);
+  }
 
   &.is-focused,
   &.focus-ring {

--- a/components/colorhandle/metadata/mods.md
+++ b/components/colorhandle/metadata/mods.md
@@ -7,6 +7,7 @@
 | `--mod-colorhandle-border-width`          |
 | `--mod-colorhandle-fill-color-disabled`   |
 | `--mod-colorhandle-focused-size`          |
+| `--mod-colorhandle-hitarea-border-radius` |
 | `--mod-colorhandle-hitarea-size`          |
 | `--mod-colorhandle-inner-border-color`    |
 | `--mod-colorhandle-inner-border-width`    |


### PR DESCRIPTION
## Description

Add the custom property `--mod-colorhandle-hitarea-border-radius` for the border radius of the hit area, so that other components that use colorhandle can easily customize it. Color slider sets it to square, not rounded in PR #1924 -- this update is cherry-picked from that PR so that it can merge in first.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

- [ ] Open Storybook for the component and confirm that nothing has changed
- [ ] Open the docs examples for the component and confirm that nothing has changed
- [ ] Run Chromatic VRT and confirm that nothing has changed

### Regression testing

Validate:

1. A legacy documentation page (such as [accordion](https://pr-###--spectrum-css.netlify.app/accordion.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

2. A migrated documentation page (such as [action group](https://pr-###--spectrum-css.netlify.app/actiongroup.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.

- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.

- [ ] ✨ This pull request is ready to merge. ✨
