### PR TITLE
feat(slider): add side label variant

### DIFF
--- a/components/slider/index.css
+++ b/components/slider/index.css
@@ -20,9 +20,6 @@ governing permissions and limitations under the License.
   --spectrum-slider-handle-border-width-down: var(--spectrum-slider-handle-border-width-down-medium);
   --spectrum-slider-label-top-to-text: var(--spectrum-component-top-to-text-75);
   --spectrum-slider-control-to-field-label: var(--spectrum-slider-control-to-field-label-medium);
-  --spectrum-slider-control-to-stepper: var(--spectrum-spacing-200);
-
-  --spectrum-slider-value-side-padding-block: var(--spectrum-field-label-top-margin-medium);
   --spectrum-slider-value-side-padding-inline: var(--spectrum-spacing-200);
 }
 
@@ -35,8 +32,6 @@ governing permissions and limitations under the License.
   --spectrum-slider-handle-border-width-down: var(--spectrum-slider-handle-border-width-down-small);
   --spectrum-slider-label-top-to-text: var(--spectrum-component-top-to-text-75);
   --spectrum-slider-control-to-field-label: var(--spectrum-slider-control-to-field-label-small);
-
-  --spectrum-slider-value-side-padding-block: var(--spectrum-field-label-top-margin-small);
   --spectrum-slider-value-side-padding-inline: var(--spectrum-spacing-100);
 }
 
@@ -48,8 +43,6 @@ governing permissions and limitations under the License.
   --spectrum-slider-handle-border-width-down: var(--spectrum-slider-handle-border-width-down-large);
   --spectrum-slider-label-top-to-text: var(--spectrum-component-top-to-text-100);
   --spectrum-slider-control-to-field-label: var(--spectrum-slider-control-to-field-label-large);
-
-  --spectrum-slider-value-side-padding-block: var(--spectrum-field-label-top-margin-large);
   --spectrum-slider-value-side-padding-inline: var(--spectrum-spacing-200);
 }
 
@@ -61,8 +54,6 @@ governing permissions and limitations under the License.
   --spectrum-slider-handle-border-width-down: var(--spectrum-slider-handle-border-width-down-extra-large);
   --spectrum-slider-label-top-to-text: var(--spectrum-component-top-to-text-200);
   --spectrum-slider-control-to-field-label: var(--spectrum-slider-control-to-field-label-extra-large);
-
-  --spectrum-slider-value-side-padding-block: var(--spectrum-field-label-top-margin-extra-large);
   --spectrum-slider-value-side-padding-inline: var(--spectrum-spacing-200);
 }
 

--- a/components/slider/index.css
+++ b/components/slider/index.css
@@ -20,6 +20,7 @@ governing permissions and limitations under the License.
   --spectrum-slider-handle-border-width-down: var(--spectrum-slider-handle-border-width-down-medium);
   --spectrum-slider-label-top-to-text: var(--spectrum-component-top-to-text-75);
   --spectrum-slider-control-to-field-label: var(--spectrum-slider-control-to-field-label-medium);
+  --spectrum-slider-control-to-stepper: var(--spectrum-spacing-200);
 }
 
 
@@ -96,6 +97,19 @@ governing permissions and limitations under the License.
   min-inline-size: var(--mod-slider-min-size, var(--spectrum-slider-min-size));
 
   user-select: none;
+}
+
+.spectrum-Slider--sideLabel {
+  display: flex;
+  align-items: center;
+
+  .spectrum-Slider-labelContainer {
+    margin-block-start: 0;
+  }
+}
+
+.spectrum-Slider .spectrum-Stepper {
+  margin-inline-start: var(--mod-slider-control-to-stepper, var(--spectrum-slider-control-to-stepper));
 }
 
 .spectrum-Slider-controls {

--- a/components/slider/index.css
+++ b/components/slider/index.css
@@ -21,6 +21,9 @@ governing permissions and limitations under the License.
   --spectrum-slider-label-top-to-text: var(--spectrum-component-top-to-text-75);
   --spectrum-slider-control-to-field-label: var(--spectrum-slider-control-to-field-label-medium);
   --spectrum-slider-value-side-padding-inline: var(--spectrum-spacing-200);
+
+  /* TODO: placeholder value for sideLabel variant value width */
+  --spectrum-slider-value-inline-size: 18px;
 }
 
 
@@ -44,6 +47,9 @@ governing permissions and limitations under the License.
   --spectrum-slider-label-top-to-text: var(--spectrum-component-top-to-text-100);
   --spectrum-slider-control-to-field-label: var(--spectrum-slider-control-to-field-label-large);
   --spectrum-slider-value-side-padding-inline: var(--spectrum-spacing-200);
+  
+  /* TODO: placeholder value for sideLabel variant value width */
+  --spectrum-slider-value-inline-size: 18px;
 }
 
 .spectrum-Slider--sizeXL {
@@ -55,6 +61,9 @@ governing permissions and limitations under the License.
   --spectrum-slider-label-top-to-text: var(--spectrum-component-top-to-text-200);
   --spectrum-slider-control-to-field-label: var(--spectrum-slider-control-to-field-label-extra-large);
   --spectrum-slider-value-side-padding-inline: var(--spectrum-spacing-200);
+
+  /* TODO: placeholder value for sideLabel variant value width */
+  --spectrum-slider-value-inline-size: 22px;
 }
 
 .spectrum-Slider {
@@ -120,6 +129,8 @@ governing permissions and limitations under the License.
 
   .spectrum-Slider-value {
     margin-inline-start: var(--mod-slider-value-side-padding-inline, var(--spectrum-slider-value-side-padding-inline));
+    inline-size: var(--mod-slider-value-inline-size, var(--spectrum-slider-value-inline-size));
+    text-align: start;
   }
 }
 

--- a/components/slider/index.css
+++ b/components/slider/index.css
@@ -106,6 +106,10 @@ governing permissions and limitations under the License.
   .spectrum-Slider-labelContainer {
     margin-block-start: 0;
   }
+
+  .spectrum-Slider-labelContainer + .spectrum-Slider-controls {
+    margin-block-start: 0;
+  }
 }
 
 .spectrum-Slider .spectrum-Stepper {

--- a/components/slider/index.css
+++ b/components/slider/index.css
@@ -21,6 +21,9 @@ governing permissions and limitations under the License.
   --spectrum-slider-label-top-to-text: var(--spectrum-component-top-to-text-75);
   --spectrum-slider-control-to-field-label: var(--spectrum-slider-control-to-field-label-medium);
   --spectrum-slider-control-to-stepper: var(--spectrum-spacing-200);
+
+  --spectrum-slider-value-side-padding-block: var(--spectrum-field-label-top-margin-medium);
+  --spectrum-slider-value-side-padding-inline: var(--spectrum-spacing-200);
 }
 
 
@@ -32,6 +35,9 @@ governing permissions and limitations under the License.
   --spectrum-slider-handle-border-width-down: var(--spectrum-slider-handle-border-width-down-small);
   --spectrum-slider-label-top-to-text: var(--spectrum-component-top-to-text-75);
   --spectrum-slider-control-to-field-label: var(--spectrum-slider-control-to-field-label-small);
+
+  --spectrum-slider-value-side-padding-block: var(--spectrum-field-label-top-margin-small);
+  --spectrum-slider-value-side-padding-inline: var(--spectrum-spacing-100);
 }
 
 .spectrum-Slider--sizeL {
@@ -42,6 +48,9 @@ governing permissions and limitations under the License.
   --spectrum-slider-handle-border-width-down: var(--spectrum-slider-handle-border-width-down-large);
   --spectrum-slider-label-top-to-text: var(--spectrum-component-top-to-text-100);
   --spectrum-slider-control-to-field-label: var(--spectrum-slider-control-to-field-label-large);
+
+  --spectrum-slider-value-side-padding-block: var(--spectrum-field-label-top-margin-large);
+  --spectrum-slider-value-side-padding-inline: var(--spectrum-spacing-200);
 }
 
 .spectrum-Slider--sizeXL {
@@ -52,6 +61,9 @@ governing permissions and limitations under the License.
   --spectrum-slider-handle-border-width-down: var(--spectrum-slider-handle-border-width-down-extra-large);
   --spectrum-slider-label-top-to-text: var(--spectrum-component-top-to-text-200);
   --spectrum-slider-control-to-field-label: var(--spectrum-slider-control-to-field-label-extra-large);
+
+  --spectrum-slider-value-side-padding-block: var(--spectrum-field-label-top-margin-extra-large);
+  --spectrum-slider-value-side-padding-inline: var(--spectrum-spacing-200);
 }
 
 .spectrum-Slider {
@@ -110,10 +122,14 @@ governing permissions and limitations under the License.
   .spectrum-Slider-labelContainer + .spectrum-Slider-controls {
     margin-block-start: 0;
   }
-}
 
-.spectrum-Slider .spectrum-Stepper {
-  margin-inline-start: var(--mod-slider-control-to-stepper, var(--spectrum-slider-control-to-stepper));
+  .spectrum-Slider-controls {
+    margin-inline-end: var(--mod-slider-controls-margin, var(--spectrum-slider-controls-margin));
+  }
+
+  .spectrum-Slider-value {
+    margin-inline-start: var(--mod-slider-value-side-padding-inline, var(--spectrum-slider-value-side-padding-inline));
+  }
 }
 
 .spectrum-Slider-controls {

--- a/components/slider/metadata/mods.md
+++ b/components/slider/metadata/mods.md
@@ -53,3 +53,4 @@
 | `--mod-slider-track-margin-offset`                     |
 | `--mod-slider-track-middle-handleoffset`               |
 | `--mod-slider-track-thickness`                         |
+| `--mod-slider-value-side-padding-inline`               |

--- a/components/slider/metadata/mods.md
+++ b/components/slider/metadata/mods.md
@@ -53,4 +53,5 @@
 | `--mod-slider-track-margin-offset`                     |
 | `--mod-slider-track-middle-handleoffset`               |
 | `--mod-slider-track-thickness`                         |
+| `--mod-slider-value-inline-size`                       |
 | `--mod-slider-value-side-padding-inline`               |

--- a/components/slider/metadata/slider.yml
+++ b/components/slider/metadata/slider.yml
@@ -145,7 +145,7 @@ examples:
           </div>
         </div>
       </div>
-  - id: slider
+  - id: slider-label
     name: With Label
     markup: |
       <div class="spectrum-Slider spectrum-Slider--sizeM">
@@ -174,6 +174,23 @@ examples:
           <div class="spectrum-Slider-track"></div>
         </div>
       </div>
+  - id: slider-side-label
+    name: With Side Label
+    markup: |
+      <div class="spectrum-Slider spectrum-Slider--sizeM spectrum-Slider--sideLabel">
+        <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left spectrum-Slider-label" id="spectrum-Slider-label-6" for="spectrum-Slider-input-6">Label</label>
+        <div class="spectrum-Slider-controls">
+          <div class="spectrum-Slider-track"></div>
+          <div class="spectrum-Slider-handle" style="left: 40%;">
+            <input type="range" class="spectrum-Slider-input" value="14" step="2" min="10" max="20" id="spectrum-Slider-input-5">
+          </div>
+          <div class="spectrum-Slider-track"></div>
+        </div>
+        <div class="spectrum-Slider-labelContainer">
+          <div class="spectrum-Slider-value" role="textbox" aria-readonly="true" aria-labelledby="spectrum-Slider-label-6">14</div>
+        </div>
+      </div>
+
   - id: slider-fill
     name: Filled
     description: With fill.

--- a/components/slider/metadata/slider.yml
+++ b/components/slider/metadata/slider.yml
@@ -178,7 +178,9 @@ examples:
     name: With Side Label
     markup: |
       <div class="spectrum-Slider spectrum-Slider--sizeM spectrum-Slider--sideLabel">
-        <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left spectrum-Slider-label" id="spectrum-Slider-label-6" for="spectrum-Slider-input-6">Label</label>
+        <div class="spectrum-Slider-labelContainer">
+          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left spectrum-Slider-label" id="spectrum-Slider-label-6" for="spectrum-Slider-input-6">Label</label>
+        </div>
         <div class="spectrum-Slider-controls">
           <div class="spectrum-Slider-track"></div>
           <div class="spectrum-Slider-handle" style="left: 40%;">

--- a/components/slider/stories/slider.stories.js
+++ b/components/slider/stories/slider.stories.js
@@ -64,6 +64,16 @@ export default {
 			control: "select",
 			options: ["ramp", "offset", "filled"],
 		},
+		labelPosition: {
+			name: "Label Position",
+			type: { name: "string" },
+			table: {
+				type: { summary: "string" },
+				category: "Component",
+			},
+			control: "select",
+			options: ["top", "side"],
+		},
 		fillColor: {
 			name: "Fill color",
 			type: { name: "string" },
@@ -110,6 +120,7 @@ export default {
 		isDisabled: false,
 		isFocused: false,
 		showTicks: false,
+		labelPosition: "top"
 	},
 	parameters: {
 		actions: {
@@ -184,4 +195,10 @@ Gradient.args = {
 		"--spectrum-slider-track-color-rtl":
 			"linear-gradient(to left, red, green 100%)",
 	},
+};
+
+export const SideLabel = Template.bind({});
+SideLabel.args = {
+	...Default.args,
+	labelPosition: "side",
 };

--- a/components/slider/stories/template.js
+++ b/components/slider/stories/template.js
@@ -18,6 +18,7 @@ export const Template = ({
 	step = 2,
 	values = [],
 	variant,
+	labelPosition,
 	fillColor = "rgb(213, 213, 213)",
 	showTicks = false,
 	isDisabled = false,
@@ -130,6 +131,7 @@ export const Template = ({
 				[`${rootClass}--filled`]: variant === "filled",
 				[`${rootClass}--tick`]: showTicks,
 				"is-disabled": isDisabled,
+				[`${rootClass}--sideLabel`]: labelPosition === "side",
 				...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
 			})}
 			id=${ifDefined(id)}
@@ -156,7 +158,7 @@ export const Template = ({
 							forInput: id ? `${id}-1` : undefined,
 							customClasses: [`${rootClass}-label`],
 						})}
-						${values.length
+						${values.length && labelPosition != "side"
 							? html`<div
 									class="${rootClass}-value"
 									role="textbox"
@@ -222,6 +224,23 @@ export const Template = ({
 					];
 				})}
 			</div>
+			${values.length && labelPosition === "side"
+				? html`<div
+						class="${rootClass}-labelContainer"
+						role=${ifDefined(values.length > 1 ? "presentation" : undefined)}
+					>
+						<div
+							class="${rootClass}-value"
+							role="textbox"
+							aria-readonly="true"
+							aria-labelledby=${ifDefined(
+								id && label ? `${id}-label` : undefined
+							)}
+						>
+							${values[0]}${values.length > 1 ? ` - ${values[1]}` : ""}
+						</div>
+					</div>`
+				: ""}
 		</div>
 	`;
 };


### PR DESCRIPTION
## Description

This adds a side label variant to the Slider component and adds CSS to support it.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

  1. Open the [docs site](https://pr-2067--spectrum-css.netlify.app/slider) for the Slider component:
  - [ ] Validate that there is a new Side Label example that looks like the screenshot below
![Screenshot 2023-08-04 at 3 00 00 PM](https://github.com/adobe/spectrum-css/assets/99203545/603a3fc9-3251-4dda-b76b-d665bdb57a61)

  2. Open the [storybook](https://pr-2067--spectrum-css.netlify.app/preview/?path=/docs/components-slider--docs) for the Slider component
  - [ ] View each of the stories (including the new Side Label story) and make sure that they display properly 

### Regression testing

Validate:

1. A legacy documentation page (such as [accordion](https://pr-2067--spectrum-css.netlify.app/accordion.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

2. A migrated documentation page (such as [action group](https://pr-2067--spectrum-css.netlify.app/actiongroup.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.

- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.

- [ ] ✨ This pull request is ready to merge. ✨
