### PR TITLE
fix(popover): docs site popover bug fix

### DIFF
--- a/site/resources/js/enhancement.js
+++ b/site/resources/js/enhancement.js
@@ -307,6 +307,13 @@ governing permissions and limitations under the License.
 			popover.classList[isOpen ? "add" : "remove"]("is-open");
 			popover.querySelector(".spectrum-Menu-item").focus();
 		}
+
+		if (isOpen) {
+			if (openPicker && openPicker !== picker) {
+					toggleOpen(openPicker, false);
+				}
+				openPicker = picker;
+			}
 	}
 
 	function closeAndFocusPicker(picker) {

--- a/site/resources/js/enhancement.js
+++ b/site/resources/js/enhancement.js
@@ -291,7 +291,7 @@ governing permissions and limitations under the License.
 		picker.classList[isOpen ? "add" : "remove"]("is-selected");
 
 		// We have to get the coordinates relative to the parent
-		const parent = popover.closest('.spectrum-CSSExample-container') || popover.closest("body")
+		const parent = popover.closest('.spectrum-CSSExample-container') || document.querySelector("body");
 
 		const parentRect = parent.getBoundingClientRect();
 

--- a/site/resources/js/enhancement.js
+++ b/site/resources/js/enhancement.js
@@ -282,7 +282,6 @@ governing permissions and limitations under the License.
 		var isOpen =
 			force !== undefined ? force : !picker.classList.contains("is-open");
 		var popover = getPopoverForPicker(picker);
-		console.log(popover);
 
 		picker[isOpen ? "setAttribute" : "removeAttribute"](
 			"aria-expanded",
@@ -292,7 +291,8 @@ governing permissions and limitations under the License.
 		picker.classList[isOpen ? "add" : "remove"]("is-selected");
 
 		// We have to get the coordinates relative to the parent
-		const parent = popover.closest('.spectrum-CSSExample-container');
+		const parent = popover.closest('.spectrum-CSSExample-container') || popover.closest("body")
+
 		const parentRect = parent.getBoundingClientRect();
 
 		if (popover) {


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->

## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

Noticed an issue on main with the docs site scale, theme, directions, and vars popovers not appearing and I was seeing an error in console. 

![Screenshot 2023-08-04 at 2 18 28 PM](https://github.com/adobe/spectrum-css/assets/63808889/87ab7b13-dac7-43c1-bab7-88ef3c71a7e4)

Determined that `parent` [enhancement.js: 295](https://github.com/adobe/spectrum-css/pull/1991/files#diff-0ca3b69929af0604381cde30c53cb81b0e8be463dbbcfe37852529e8b15e6690R295) was returning `null` for these popovers. 

Fixes:
- Added fallback to body for when `popover.closest('.spectrum-CSSExample-container')` is null 
- removed console.log 
- addressed issue existing after fix with popover not closing when another was opened 



## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

#### Test outline:
  1. Open the [Docs Site](https://pr-2068--spectrum-css.netlify.app/calendar) for the any component:
- [x] Click on any of the top right toggles
- [x]  Popover should appear and be functional 
- [x] If you have one popover open and open another the first one should close @mlogsdon18 
2. Open the [Docs Site](https://pr-2068--spectrum-css.netlify.app/picker) for the the picker component:
- [ ] Any of the pickers with popovers present (i.e. Standard variant, open example) should open and close as expected



### Regression testing

Validate:

1. A legacy documentation page (such as [accordion](https://pr-###--spectrum-css.netlify.app/accordion.html)), including:

- [x] The page renders correctly
- [x] The page is accessible
- [x] The page is responsive @mlogsdon18 

2. A migrated documentation page (such as [action group](https://pr-###--spectrum-css.netlify.app/actiongroup.html)), including:

- [x] The page renders correctly
- [x] The page is accessible
- [x] The page is responsive @mlogsdon18 

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.

- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.

- [ ] ✨ This pull request is ready to merge. ✨
