### PR TITLE
fix: revert prettier

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,9 @@ updates:
       - dependency-name: "gulp*"
       # Ignore postcss versions until build migration complete
       - dependency-name: "postcss*"
+      # Ignore prettier 3.x until we resolve the lerna publishing error
+      - dependency-name: "prettier"
+        versions: ["3.x"]
     groups:
       # Specify a name for the group, which will be used in pull request titles
       # and branch names

--- a/components/tokens/package.json
+++ b/components/tokens/package.json
@@ -39,7 +39,7 @@
     "postcss-merge-rules": "^6.0.0",
     "postcss-rgb-mapping": "^1.0.1",
     "postcss-sorting": "^8.0.2",
-    "prettier": "^3.0.1",
+    "prettier": "^2.8.8",
     "rimraf": "^5.0.1",
     "style-dictionary": "^3.8.0",
     "style-dictionary-sets": "^2.3.0"

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "markdown-it": "^12.3.2",
     "npm-run-all": "^4.1.5",
     "nx": "^16.6.0",
-    "prettier": "^3.0.1",
+    "prettier": "^2.8.8",
     "prettier-package-json": "^2.8.0",
     "prismjs": "^1.23.0",
     "rimraf": "^5.0.1",

--- a/tools/preview/package.json
+++ b/tools/preview/package.json
@@ -53,7 +53,7 @@
     "postcss-prefix-selector": "^1.16.0",
     "postcss-selector-replace": "^1.0.2",
     "postcss-warn-cleaner": "^0.1.9",
-    "prettier": "^3.0.1",
+    "prettier": "^2.8.8",
     "raw-loader": "^4.0.2",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",


### PR DESCRIPTION
There's some kind of incompatibility with the `3.x` releases of Prettier and our project. When we accept the Dependabot PRs that bump it to the latest version, we encounter errors during the Lerna-driven release process.

<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->

## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

<!--
  Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

### Regression testing

Validate:

1. A legacy documentation page (such as [accordion](https://pr-###--spectrum-css.netlify.app/accordion.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

2. A migrated documentation page (such as [action group](https://pr-###--spectrum-css.netlify.app/actiongroup.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [ ] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.

- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.

- [ ] ✨ This pull request is ready to merge. ✨
