### PR TITLE
feat(badge): add non-semantic colors

### DIFF
--- a/components/badge/index.css
+++ b/components/badge/index.css
@@ -19,10 +19,20 @@ governing permissions and limitations under the License.
   --spectrum-badge-line-height-cjk: var(--spectrum-cjk-line-height-100);
 
   /* text and icon color default white for all t-shirt sizes and all themes */
-  --spectrum-badge-label-icon-color-white: var(--spectrum-white);
+  --spectrum-badge-label-icon-color: var(--spectrum-white);
 
   /* text and icon color black for all t-shirt sizes and all themes */
-  --spectrum-badge-label-icon-color-black: var(--spectrum-black);
+  &--black-text, &--orange, &--yellow, &--chartreuse, &--celery {
+    --spectrum-badge-label-icon-color: var(--spectrum-black);
+  }
+
+  /* dark theme all non-semantic colors are black */
+  .spectrum--dark &,
+  .spectrum--darkest & {
+    &--gray, &--red, &--green, &--seafoam, &--cyan, &--blue, &--indigo, &--purple, &--fuchsia, &--magenta {
+      --spectrum-badge-label-icon-color: var(--spectrum-black);
+    }
+  }
 
   /* background color default for all t-shirt sizes and all themes */
   --spectrum-badge-background-color-default: var(--spectrum-neutral-subdued-background-color-default);
@@ -34,6 +44,23 @@ governing permissions and limitations under the License.
   --spectrum-badge-background-color-negative: var(--spectrum-negative-background-color-default);
   --spectrum-badge-background-color-positive: var(--spectrum-positive-background-color-default);
   --spectrum-badge-background-color-notice: var(--spectrum-notice-background-color-default);
+
+  /* non-semantic background colors */
+  --spectrum-badge-background-color-gray: var(--spectrum-gray-background-color-default);
+  --spectrum-badge-background-color-red: var(--spectrum-red-background-color-default);
+  --spectrum-badge-background-color-orange: var(--spectrum-orange-background-color-default);
+  --spectrum-badge-background-color-yellow: var(--spectrum-yellow-background-color-default);
+  --spectrum-badge-background-color-chartreuse: var(--spectrum-chartreuse-background-color-default);
+  --spectrum-badge-background-color-celery: var(--spectrum-celery-background-color-default);
+  --spectrum-badge-background-color-green: var(--spectrum-green-background-color-default);
+  --spectrum-badge-background-color-seafoam: var(--spectrum-seafoam-background-color-default);
+  --spectrum-badge-background-color-cyan: var(--spectrum-cyan-background-color-default);
+  --spectrum-badge-background-color-blue: var(--spectrum-blue-background-color-default);
+  --spectrum-badge-background-color-indigo: var(--spectrum-indigo-background-color-default);
+  --spectrum-badge-background-color-purple: var(--spectrum-purple-background-color-default);
+  --spectrum-badge-background-color-fuchsia: var(--spectrum-fuchsia-background-color-default);
+  --spectrum-badge-background-color-magenta: var(--spectrum-magenta-background-color-default);
+
 
   /*** DEFAULT STYLE fallbacks if no t-shirt size - uses Medium t-shirt styles ***/
   /* badge height - fallback if no t-shirt size */
@@ -55,6 +82,8 @@ governing permissions and limitations under the License.
   --spectrum-badge-icon-spacing-horizontal: var(--spectrum-component-edge-to-visual-100);
   --spectrum-badge-icon-spacing-vertical-top: var(--spectrum-component-top-to-workflow-icon-100);
   --spectrum-badge-icon-only-spacing-horizontal: var(--spectrum-component-edge-to-visual-only-100);
+
+  
 }
 
 
@@ -154,14 +183,8 @@ governing permissions and limitations under the License.
 
   background: var(--mod-badge-background-color-default,
                   var(--spectrum-badge-background-color-default));
-  color: var(--mod-badge-label-icon-color-white,
-            var(--spectrum-badge-label-icon-color-white));
-
-  /* text and icon black */
-  &--black-text {
-    color: var(--mod-badge-label-icon-color-black,
-              var(--spectrum-badge-label-icon-color-black));
-  }
+  color: var(--mod-badge-label-icon-color,
+            var(--spectrum-badge-label-icon-color));
 
   /* background color variants */
   &--neutral {
@@ -191,6 +214,69 @@ governing permissions and limitations under the License.
 
   &--notice {
     background: var(--mod-badge-background-color-notice, var(--spectrum-badge-background-color-notice));
+  }
+
+  /* non-semantic colors */
+  &--gray {
+    background: var(--mod-badge-background-color-gray, var(--spectrum-badge-background-color-gray));
+  }
+
+  &--red {
+    background: var(--mod-badge-background-color-red, var(--spectrum-badge-background-color-red));
+  }
+
+  &--orange {
+    background: var(--mod-badge-background-color-orange, var(--spectrum-badge-background-color-orange));
+  }
+
+  &--yellow {
+    background: var(--mod-badge-background-color-yellow, var(--spectrum-badge-background-color-yellow));
+  }
+
+  &--chartreuse {
+    background: var(--mod-badge-background-color-chartreuse, var(--spectrum-badge-background-color-chartreuse));
+    .spectrum-Badge-label, .spectrum-Badge-icon {
+      color: var(--mod-badge-label-icon-color-black, var(--spectrum-badge-label-icon-color-black));
+    }
+  }
+
+  &--celery {
+    background: var(--mod-badge-background-color-celery, var(--spectrum-badge-background-color-celery));
+    .spectrum-Badge-label, .spectrum-Badge-icon {
+      color: var(--mod-badge-label-icon-color-black, var(--spectrum-badge-label-icon-color-black));
+    }
+  }
+
+  &--green {
+    background: var(--mod-badge-background-color-green, var(--spectrum-badge-background-color-green));
+  }
+
+  &--seafoam {
+    background: var(--mod-badge-background-color-seafoam, var(--spectrum-badge-background-color-seafoam));
+  }
+
+  &--cyan {
+    background: var(--mod-badge-background-color-cyan, var(--spectrum-badge-background-color-cyan));
+  }
+
+  &--blue {
+    background: var(--mod-badge-background-color-blue, var(--spectrum-badge-background-color-blue));
+  }
+
+  &--indigo {
+    background: var(--mod-badge-background-color-indigo, var(--spectrum-badge-background-color-indigo));
+  }
+
+  &--purple {
+    background: var(--mod-badge-background-color-purple, var(--spectrum-badge-background-color-purple));
+  }
+
+  &--fuchsia {
+    background: var(--mod-badge-background-color-fuchsia, var(--spectrum-badge-background-color-fuchsia));
+  }
+
+  &--magenta {
+    background: var(--mod-badge-background-color-magenta, var(--spectrum-badge-background-color-magenta));
   }
 
   /* fixed position variants with border radius 0 on the fixed edge of the component */
@@ -231,14 +317,8 @@ governing permissions and limitations under the License.
   padding-block-end: var(--mod-badge-label-spacing-vertical-bottom,
                       var(--spectrum-badge-label-spacing-vertical-bottom));
 
-  color: var(--mod-badge-label-icon-color-white,
-                      var(--spectrum-badge-label-icon-color-white));
-
-  /* black text and icon variant */
-  .spectrum-Badge--black-text & {
-    color: var(--mod-badge-label-icon-color-black,
-                      var(--spectrum-badge-label-icon-color-black));
-  }
+  color: var(--mod-badge-label-icon-color,
+                      var(--spectrum-badge-label-icon-color));
 
   /* cjk language support */
   &:lang(ja),
@@ -275,8 +355,8 @@ governing permissions and limitations under the License.
   padding-block-end: var(--mod-badge-icon-spacing-vertical-top,
                       var(--spectrum-badge-icon-spacing-vertical-top));
 
-  color: var(--mod-badge-label-icon-color-white,
-                      var(--spectrum-badge-label-icon-color-white));
+  color: var(--mod-badge-label-icon-color,
+                      var(--spectrum-badge-label-icon-color));
 
   &--no-label {
     /* icon without label has identical padding left and right */
@@ -284,11 +364,5 @@ governing permissions and limitations under the License.
                       var(--spectrum-badge-icon-only-spacing-horizontal));
     padding-inline-end: var(--mod-badge-icon-only-spacing-horizontal,
                       var(--spectrum-badge-icon-only-spacing-horizontal));
-  }
-
-  /* black text and icon variant */
-  .spectrum-Badge--black-text & {
-    color: var(--mod-badge-label-icon-color-black,
-                      var(--spectrum-badge-label-icon-color-black));
   }
 }

--- a/components/badge/index.css
+++ b/components/badge/index.css
@@ -27,12 +27,13 @@ governing permissions and limitations under the License.
   /* background color default for all t-shirt sizes and all themes */
   --spectrum-badge-background-color-default: var(--spectrum-neutral-subdued-background-color-default);
 
-  /* background colors for all t-shirt sizes and all themes */
+  /* semantic background colors for all t-shirt sizes and all themes */
   --spectrum-badge-background-color-default: var(--spectrum-neutral-subdued-background-color-default);
   --spectrum-badge-background-color-accent: var(--spectrum-accent-background-color-default);
   --spectrum-badge-background-color-informative: var(--spectrum-informative-background-color-default);
   --spectrum-badge-background-color-negative: var(--spectrum-negative-background-color-default);
   --spectrum-badge-background-color-positive: var(--spectrum-positive-background-color-default);
+  --spectrum-badge-background-color-notice: var(--spectrum-notice-background-color-default);
 
   /*** DEFAULT STYLE fallbacks if no t-shirt size - uses Medium t-shirt styles ***/
   /* badge height - fallback if no t-shirt size */
@@ -186,6 +187,10 @@ governing permissions and limitations under the License.
   &--positive {
     background: var(--mod-badge-background-color-positive,
                     var(--spectrum-badge-background-color-positive));
+  }
+
+  &--notice {
+    background: var(--mod-badge-background-color-notice, var(--spectrum-badge-background-color-notice));
   }
 
   /* fixed position variants with border radius 0 on the fixed edge of the component */

--- a/components/badge/index.css
+++ b/components/badge/index.css
@@ -18,6 +18,7 @@ governing permissions and limitations under the License.
   --spectrum-badge-line-height: var(--spectrum-line-height-100);
   --spectrum-badge-line-height-cjk: var(--spectrum-cjk-line-height-100);
 
+
   /* text and icon color default white for all t-shirt sizes and all themes */
   --spectrum-badge-label-icon-color: var(--spectrum-white);
 
@@ -27,11 +28,8 @@ governing permissions and limitations under the License.
   }
 
   /* dark theme all non-semantic colors are black */
-  .spectrum--dark &,
-  .spectrum--darkest & {
-    &--gray, &--red, &--green, &--seafoam, &--cyan, &--blue, &--indigo, &--purple, &--fuchsia, &--magenta {
-      --spectrum-badge-label-icon-color: var(--spectrum-black);
-    }
+  &--gray, &--red, &--green, &--seafoam, &--cyan, &--blue, &--indigo, &--purple, &--fuchsia, &--magenta {
+    --spectrum-badge-label-icon-color: var(--spectrum-badge-label-icon-color-primary);
   }
 
   /* background color default for all t-shirt sizes and all themes */

--- a/components/badge/index.css
+++ b/components/badge/index.css
@@ -82,8 +82,6 @@ governing permissions and limitations under the License.
   --spectrum-badge-icon-spacing-horizontal: var(--spectrum-component-edge-to-visual-100);
   --spectrum-badge-icon-spacing-vertical-top: var(--spectrum-component-top-to-workflow-icon-100);
   --spectrum-badge-icon-only-spacing-horizontal: var(--spectrum-component-edge-to-visual-only-100);
-
-  
 }
 
 
@@ -102,23 +100,6 @@ governing permissions and limitations under the License.
   --spectrum-badge-icon-spacing-horizontal: var(--spectrum-component-edge-to-visual-75);
   --spectrum-badge-icon-spacing-vertical-top: var(--spectrum-component-top-to-workflow-icon-75);
   --spectrum-badge-icon-only-spacing-horizontal: var(--spectrum-component-edge-to-visual-only-75);
-}
-
-.spectrum-Badge--sizeM {
-  --spectrum-badge-height: var(--spectrum-component-height-100);
-
-  /* label */
-  --spectrum-badge-font-size: var(--spectrum-font-size-100);
-  --spectrum-badge-label-spacing-vertical-top: var(--spectrum-component-top-to-text-100);
-  --spectrum-badge-label-spacing-vertical-bottom: var(--spectrum-component-bottom-to-text-100);
-  --spectrum-badge-label-spacing-horizontal: var(--spectrum-component-edge-to-text-100);
-
-  /* icon */
-  --spectrum-badge-workflow-icon-size: var(--spectrum-workflow-icon-size-100);
-  --spectrum-badge-icon-text-spacing: var(--spectrum-text-to-visual-100);
-  --spectrum-badge-icon-spacing-horizontal: var(--spectrum-component-edge-to-visual-100);
-  --spectrum-badge-icon-spacing-vertical-top: var(--spectrum-component-top-to-workflow-icon-100);
-  --spectrum-badge-icon-only-spacing-horizontal: var(--spectrum-component-edge-to-visual-only-100);
 }
 
 .spectrum-Badge--sizeL {

--- a/components/badge/index.css
+++ b/components/badge/index.css
@@ -21,8 +21,8 @@ governing permissions and limitations under the License.
   /* text and icon color default white for all t-shirt sizes and all themes */
   --spectrum-badge-label-icon-color: var(--spectrum-white);
 
-  /* text and icon color black for all t-shirt sizes and all themes */
-  &--black-text, &--orange, &--yellow, &--chartreuse, &--celery {
+  /* text and icon color is black for these background colors */
+  &--orange, &--yellow, &--chartreuse, &--celery {
     --spectrum-badge-label-icon-color: var(--spectrum-black);
   }
 
@@ -235,16 +235,10 @@ governing permissions and limitations under the License.
 
   &--chartreuse {
     background: var(--mod-badge-background-color-chartreuse, var(--spectrum-badge-background-color-chartreuse));
-    .spectrum-Badge-label, .spectrum-Badge-icon {
-      color: var(--mod-badge-label-icon-color-black, var(--spectrum-badge-label-icon-color-black));
-    }
   }
 
   &--celery {
     background: var(--mod-badge-background-color-celery, var(--spectrum-badge-background-color-celery));
-    .spectrum-Badge-label, .spectrum-Badge-icon {
-      color: var(--mod-badge-label-icon-color-black, var(--spectrum-badge-label-icon-color-black));
-    }
   }
 
   &--green {

--- a/components/badge/metadata/badge.yml
+++ b/components/badge/metadata/badge.yml
@@ -15,18 +15,10 @@ sections:
       - Label and icon elements must be nested inside a parent container of class `.spectrum-Badge` in order to achieve the correct layout and wrapping behavior.
       - Layout of Badge is applied with a display of inline-flex, allowing badge to display as inline while the child elements for the label and icon utilize flexbox for layout.
 
-      ### Badge now includes white text/icon color and black text/icon color
-      - The color is applied to the parent container so that the icon and text child elements will inherit a unified color.
-      - White text/icon color is the default and requires no additional class.
-      - Black text/icon color is applied to the parent container with modifier class `.spectrum-Badge--black-text`
-
       ### Badge now includes fixed positioning
       - This document represents the border radius style which applies to each position.
       - border radius is 0 along the fixed edge of the component.
       - The actual component position is not represented in this document.
-
-      ### Notice Variant
-      - The notice variant can be used by adding the `spectrum-Badge--notice` class.
 
 examples:
   - id: badge
@@ -261,33 +253,4 @@ examples:
           </div>
         </div>
 
-      </div>
-
-  - id: badge
-    name: Text and Icon Color
-    markup: |
-      <div class="spectrum-Examples">
-        <div class="spectrum-Examples-item">
-          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">White (default)</h4>
-
-          <div class="spectrum-Badge spectrum-Badge--sizeM spectrum-Badge--neutral">
-            <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Badge-icon spectrum-Badge-icon" focusable="false" aria-hidden="true">
-              <use xlink:href="#spectrum-icon-18-Info" />
-            </svg>
-            <div class="spectrum-Badge-label">Label Text</div>
-          </div>
-
-        </div>
-
-        <div class="spectrum-Examples-item">
-          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Black</h4>
-
-          <div class="spectrum-Badge spectrum-Badge--sizeM spectrum-Badge--neutral spectrum-Badge--black-text">
-            <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Badge-icon spectrum-Badge-icon" focusable="false" aria-hidden="true">
-              <use xlink:href="#spectrum-icon-18-Info" />
-            </svg>
-            <div class="spectrum-Badge-label">Label Text</div>
-          </div>
-
-        </div>
       </div>

--- a/components/badge/metadata/badge.yml
+++ b/components/badge/metadata/badge.yml
@@ -56,7 +56,66 @@ examples:
         <div class="spectrum-Badge-label">Notice</div>
       </div>
 
-  - id: badge
+  - id: badge-non-semantic
+    name: Non-Semantic
+    markup: |
+      <div class="spectrum-Badge spectrum-Badge--sizeM spectrum-Badge--gray">
+        <div class="spectrum-Badge-label">Gray</div>
+      </div>
+
+      <div class="spectrum-Badge spectrum-Badge--sizeM spectrum-Badge--red">
+        <div class="spectrum-Badge-label">Red</div>
+      </div>
+
+      <div class="spectrum-Badge spectrum-Badge--sizeM spectrum-Badge--orange">
+        <div class="spectrum-Badge-label">Orange</div>
+      </div>
+
+      <div class="spectrum-Badge spectrum-Badge--sizeM spectrum-Badge--yellow">
+        <div class="spectrum-Badge-label">Yellow</div>
+      </div>
+
+      <div class="spectrum-Badge spectrum-Badge--sizeM spectrum-Badge--chartreuse">
+        <div class="spectrum-Badge-label">Chartreuse</div>
+      </div>
+
+      <div class="spectrum-Badge spectrum-Badge--sizeM spectrum-Badge--celery">
+        <div class="spectrum-Badge-label">Celery</div>
+      </div>
+
+      <div class="spectrum-Badge spectrum-Badge--sizeM spectrum-Badge--green">
+        <div class="spectrum-Badge-label">Green</div>
+      </div>
+
+      <div class="spectrum-Badge spectrum-Badge--sizeM spectrum-Badge--seafoam">
+        <div class="spectrum-Badge-label">Seafoam</div>
+      </div>
+
+      <div class="spectrum-Badge spectrum-Badge--sizeM spectrum-Badge--cyan">
+        <div class="spectrum-Badge-label">Cyan</div>
+      </div>
+
+      <div class="spectrum-Badge spectrum-Badge--sizeM spectrum-Badge--blue">
+        <div class="spectrum-Badge-label">Blue</div>
+      </div>
+
+      <div class="spectrum-Badge spectrum-Badge--sizeM spectrum-Badge--indigo">
+        <div class="spectrum-Badge-label">Indigo</div>
+      </div>
+
+      <div class="spectrum-Badge spectrum-Badge--sizeM spectrum-Badge--purple">
+        <div class="spectrum-Badge-label">Purple</div>
+      </div>
+
+      <div class="spectrum-Badge spectrum-Badge--sizeM spectrum-Badge--fuchsia">
+        <div class="spectrum-Badge-label">Fuchsia</div>
+      </div>
+
+      <div class="spectrum-Badge spectrum-Badge--sizeM spectrum-Badge--magenta">
+        <div class="spectrum-Badge-label">Magenta</div>
+      </div>
+
+  - id: badge-sizing
     name: Sizing
     markup: |
       <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Label Only</h4>

--- a/components/badge/metadata/badge.yml
+++ b/components/badge/metadata/badge.yml
@@ -25,6 +25,9 @@ sections:
       - border radius is 0 along the fixed edge of the component.
       - The actual component position is not represented in this document.
 
+      ### Notice Variant
+      - The notice variant can be used by adding the `spectrum-Badge--notice` class.
+
 examples:
   - id: badge
     name: Standard
@@ -47,6 +50,10 @@ examples:
 
       <div class="spectrum-Badge spectrum-Badge--sizeM spectrum-Badge--negative">
         <div class="spectrum-Badge-label">Negative</div>
+      </div>
+
+      <div class="spectrum-Badge spectrum-Badge--sizeM spectrum-Badge--notice">
+        <div class="spectrum-Badge-label">Notice</div>
       </div>
 
   - id: badge

--- a/components/badge/metadata/mods.md
+++ b/components/badge/metadata/mods.md
@@ -28,7 +28,6 @@
 | `--mod-badge-icon-spacing-vertical-top`     |
 | `--mod-badge-icon-text-spacing`             |
 | `--mod-badge-label-icon-color`              |
-| `--mod-badge-label-icon-color-black`        |
 | `--mod-badge-label-spacing-horizontal`      |
 | `--mod-badge-label-spacing-vertical-bottom` |
 | `--mod-badge-label-spacing-vertical-top`    |

--- a/components/badge/metadata/mods.md
+++ b/components/badge/metadata/mods.md
@@ -1,11 +1,25 @@
 | Modifiable Custom Properties                |
 | ------------------------------------------- |
 | `--mod-badge-background-color-accent`       |
+| `--mod-badge-background-color-blue`         |
+| `--mod-badge-background-color-celery`       |
+| `--mod-badge-background-color-chartreuse`   |
+| `--mod-badge-background-color-cyan`         |
 | `--mod-badge-background-color-default`      |
+| `--mod-badge-background-color-fuchsia`      |
+| `--mod-badge-background-color-gray`         |
+| `--mod-badge-background-color-green`        |
+| `--mod-badge-background-color-indigo`       |
 | `--mod-badge-background-color-informative`  |
+| `--mod-badge-background-color-magenta`      |
 | `--mod-badge-background-color-negative`     |
 | `--mod-badge-background-color-notice`       |
+| `--mod-badge-background-color-orange`       |
 | `--mod-badge-background-color-positive`     |
+| `--mod-badge-background-color-purple`       |
+| `--mod-badge-background-color-red`          |
+| `--mod-badge-background-color-seafoam`      |
+| `--mod-badge-background-color-yellow`       |
 | `--mod-badge-corner-radius`                 |
 | `--mod-badge-font-size`                     |
 | `--mod-badge-height`                        |
@@ -13,8 +27,8 @@
 | `--mod-badge-icon-spacing-horizontal`       |
 | `--mod-badge-icon-spacing-vertical-top`     |
 | `--mod-badge-icon-text-spacing`             |
+| `--mod-badge-label-icon-color`              |
 | `--mod-badge-label-icon-color-black`        |
-| `--mod-badge-label-icon-color-white`        |
 | `--mod-badge-label-spacing-horizontal`      |
 | `--mod-badge-label-spacing-vertical-bottom` |
 | `--mod-badge-label-spacing-vertical-top`    |

--- a/components/badge/metadata/mods.md
+++ b/components/badge/metadata/mods.md
@@ -4,6 +4,7 @@
 | `--mod-badge-background-color-default`      |
 | `--mod-badge-background-color-informative`  |
 | `--mod-badge-background-color-negative`     |
+| `--mod-badge-background-color-notice`       |
 | `--mod-badge-background-color-positive`     |
 | `--mod-badge-corner-radius`                 |
 | `--mod-badge-font-size`                     |

--- a/components/badge/stories/badge.stories.js
+++ b/components/badge/stories/badge.stories.js
@@ -50,7 +50,6 @@ export default {
 				category: "Advanced",
 			},
 			options: [
-				"none",
 				"fixed-inline-start",
 				"fixed-inline-end",
 				"fixed-block-start",

--- a/components/badge/stories/badge.stories.js
+++ b/components/badge/stories/badge.stories.js
@@ -39,7 +39,7 @@ export default {
 				type: { summary: "string" },
 				category: "Component",
 			},
-			options: ["neutral", "accent", "informative", "positive", "negative"],
+			options: ["neutral", "accent", "informative", "positive", "negative", "gray", "red", "orange", "yellow", "chartreuse", "celery", "green", "seafoam", "cyan", "blue", "indigo", "purple", "fuchsia", "magenta"],
 			control: "select",
 		},
 		hideLabel: {

--- a/components/badge/stories/badge.stories.js
+++ b/components/badge/stories/badge.stories.js
@@ -80,7 +80,6 @@ export default {
 	args: {
 		rootClass: "spectrum-Badge",
 		size: "m",
-		iconName: "Info",
 		label: "Badge",
 		variant: "neutral",
 		hideLabel: false,
@@ -99,3 +98,14 @@ export default {
 
 export const Default = Template.bind({});
 Default.args = {};
+
+export const WithIcon = Template.bind({});
+WithIcon.args = {
+	iconName: "Info"
+};
+
+export const IconOnly = Template.bind({});
+IconOnly.args = {
+	iconName: "Info",
+	hideLabel: true
+};

--- a/components/badge/stories/badge.stories.js
+++ b/components/badge/stories/badge.stories.js
@@ -61,7 +61,6 @@ export default {
 	args: {
 		rootClass: "spectrum-Badge",
 		size: "m",
-		label: "Badge",
 		variant: "neutral",
 	},
 	parameters: {
@@ -77,15 +76,17 @@ export default {
 };
 
 export const Default = Template.bind({});
-Default.args = {};
+Default.args = {
+	label: "Badge",
+};
 
 export const WithIcon = Template.bind({});
 WithIcon.args = {
-	iconName: "Info"
+	iconName: "Info",
+	label: "Badge",
 };
 
 export const IconOnly = Template.bind({});
 IconOnly.args = {
 	iconName: "Info",
-	label: undefined
 };

--- a/components/badge/stories/badge.stories.js
+++ b/components/badge/stories/badge.stories.js
@@ -42,33 +42,15 @@ export default {
 			options: ["neutral", "accent", "informative", "positive", "negative", "gray", "red", "orange", "yellow", "chartreuse", "celery", "green", "seafoam", "cyan", "blue", "indigo", "purple", "fuchsia", "magenta"],
 			control: "select",
 		},
-		hideLabel: {
-			name: "Hide label",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "Component",
-			},
-			control: "boolean",
-		},
-		customColor: {
-			name: "Custom color",
-			type: { name: "string" },
-			table: {
-				type: { summary: "string" },
-				category: "Advanced",
-			},
-			options: ["black-text"],
-			control: "select",
-		},
-		customLayout: {
-			name: "Custom layout",
+		fixed: {
+			name: "Fixed layout",
 			type: { name: "string" },
 			table: {
 				type: { summary: "string" },
 				category: "Advanced",
 			},
 			options: [
+				"none",
 				"fixed-inline-start",
 				"fixed-inline-end",
 				"fixed-block-start",
@@ -82,7 +64,6 @@ export default {
 		size: "m",
 		label: "Badge",
 		variant: "neutral",
-		hideLabel: false,
 	},
 	parameters: {
 		actions: {
@@ -107,5 +88,5 @@ WithIcon.args = {
 export const IconOnly = Template.bind({});
 IconOnly.args = {
 	iconName: "Info",
-	hideLabel: true
+	label: undefined
 };

--- a/components/badge/stories/template.js
+++ b/components/badge/stories/template.js
@@ -12,9 +12,7 @@ export const Template = ({
 	size = "m",
 	label,
 	iconName,
-	hideLabel = false,
 	variant = "neutral",
-	customColor,
 	customLayout,
 	customClasses = [],
 	id,
@@ -53,8 +51,8 @@ export const Template = ({
 				})
 			)}
 			${when(
-				!hideLabel || (!label && !variant),
-				() => html`<div class="${rootClass}-label">${label ?? variant}</div>`
+				label,
+				() => html`<div class="${rootClass}-label">${label}</div>`
 			)}
 		</div>
 	`;

--- a/components/badge/stories/template.js
+++ b/components/badge/stories/template.js
@@ -13,7 +13,7 @@ export const Template = ({
 	label,
 	iconName,
 	variant = "neutral",
-	customLayout,
+	fixed,
 	customClasses = [],
 	id,
 	...globals
@@ -34,8 +34,7 @@ export const Template = ({
 				[`${rootClass}--size${size?.toUpperCase()}`]:
 					typeof size !== "undefined",
 				[`${rootClass}--${variant}`]: typeof variant !== "undefined",
-				[`${rootClass}--${customColor}`]: typeof customColor !== "undefined",
-				[`${rootClass}--${customLayout}`]: typeof customLayout !== "undefined",
+				[`${rootClass}--${fixed}`]: typeof fixed !== "undefined",
 				...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
 			})}
 			id=${ifDefined(id)}

--- a/components/badge/stories/template.js
+++ b/components/badge/stories/template.js
@@ -44,7 +44,7 @@ export const Template = ({
 					...globals,
 					iconName,
 					customClasses: [
-						...(hideLabel ? [`${rootClass}-icon--no-label`] : []),
+						...(typeof label === "undefined" ? [`${rootClass}-icon--no-label`] : []),
 						`${rootClass}-icon`,
 					],
 				})

--- a/components/tokens/custom-spectrum/custom-dark-vars.css
+++ b/components/tokens/custom-spectrum/custom-dark-vars.css
@@ -28,4 +28,6 @@ governing permissions and limitations under the License.
   --spectrum-calendar-day-background-color-cap-selected: rgba(var(--spectrum-blue-800-rgb), 0.25);
   --spectrum-calendar-day-background-color-key-focus: rgba(var(--spectrum-white-rgb), 0.07);
   --spectrum-calendar-day-border-color-key-focus: var(--spectrum-blue-700);
+
+  --spectrum-badge-label-icon-color-primary: var(--spectrum-black);
 }

--- a/components/tokens/custom-spectrum/custom-darkest-vars.css
+++ b/components/tokens/custom-spectrum/custom-darkest-vars.css
@@ -28,4 +28,6 @@ governing permissions and limitations under the License.
   --spectrum-calendar-day-background-color-cap-selected: rgba(var(--spectrum-blue-800-rgb), 0.3);
   --spectrum-calendar-day-background-color-key-focus: rgba(var(--spectrum-white-rgb), 0.08);
   --spectrum-calendar-day-border-color-key-focus: var(--spectrum-blue-700);
+
+  --spectrum-badge-label-icon-color-primary: var(--spectrum-black);
   }

--- a/components/tokens/custom-spectrum/custom-light-vars.css
+++ b/components/tokens/custom-spectrum/custom-light-vars.css
@@ -29,4 +29,6 @@ governing permissions and limitations under the License.
   --spectrum-calendar-day-background-color-cap-selected: rgba(var(--spectrum-blue-900-rgb), 0.2);
   --spectrum-calendar-day-background-color-key-focus: rgba(var(--spectrum-black-rgb), 0.06);
   --spectrum-calendar-day-border-color-key-focus: var(--spectrum-blue-800);
+
+  --spectrum-badge-label-icon-color-primary: var(--spectrum-white);
 }


### PR DESCRIPTION
## Description

[CSS-478](https://jira.corp.adobe.com/browse/CSS-478)
- Adds non-semantic color variants to the Badge component
- Adds the `notice` variant to the Badge component
- Removes the `black-text` custom text color options
- Updates `customLayout` to `fixed` to match design spec
- Docs and Storybook updated accordingly

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

  1. Open the [docs](url) for the Badge component:
    - [ ] Validate that the `notice` variant appears with the semantic examples
    - [ ] Validate that all of the non-semantic color options are shown as examples and match the XD file in background color and text color(gray, red, orange, yellow, chartreuse, celery, green, seafoam, cyan, blue, indigo, purple, fuchsia, magenta)

### Regression testing

Validate:

1. A legacy documentation page (such as [accordion](https://pr-###--spectrum-css.netlify.app/accordion.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

2. A migrated documentation page (such as [action group](https://pr-###--spectrum-css.netlify.app/actiongroup.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.

- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.

- [ ] ✨ This pull request is ready to merge. ✨
