### PR TITLE
fix(picker): add separate mod for label font-weight 

### DIFF
--- a/components/picker/index.css
+++ b/components/picker/index.css
@@ -406,7 +406,7 @@ governing permissions and limitations under the License.
 
   font-size: var(--mod-picker-font-size, var(--spectrum-picker-font-size));
   line-height: var(--mod-picker-line-height, var(--spectrum-picker-line-height));
-  
+  font-weight: var(--mod-picker-font-weight, var(--spectrum-picker-font-weight));
 
   text-overflow: ellipsis;
   text-align: start;
@@ -415,7 +415,7 @@ governing permissions and limitations under the License.
   margin-block-end: calc(var(--mod-picker-spacing-bottom-to-text, var(--spectrum-picker-spacing-bottom-to-text)) - var(--mod-picker-border-width, var(--spectrum-picker-border-width)));
 
   &.is-placeholder {
-    font-weight: var(--mod-picker-font-weight, var(--spectrum-picker-font-weight));
+    font-weight: var(--mod-picker-placeholder-font-weight, var(--spectrum-picker-font-weight));
     font-style: var(--mod-picker-placeholder-font-style, var(--spectrum-picker-placeholder-font-style));
     transition: color var(--mod-picker-animation-duration, var(--spectrum-picker-animation-duration)) ease-in-out;
 

--- a/components/picker/metadata/mods.md
+++ b/components/picker/metadata/mods.md
@@ -46,6 +46,7 @@
 | `--mod-picker-inline-size`                             |
 | `--mod-picker-line-height`                             |
 | `--mod-picker-placeholder-font-style`                  |
+| `--mod-picker-placeholder-font-weight`                 |
 | `--mod-picker-spacing-bottom-to-text`                  |
 | `--mod-picker-spacing-edge-to-disclosure-icon`         |
 | `--mod-picker-spacing-edge-to-disclosure-icon-quiet`   |

--- a/components/picker/stories/template.js
+++ b/components/picker/stories/template.js
@@ -1,6 +1,8 @@
 import { html } from "lit";
 import { useArgs } from "@storybook/client-api";
 import { classMap } from "lit/directives/class-map.js";
+import { styleMap } from "lit/directives/style-map.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import { Template as FieldLabel } from "@spectrum-css/fieldlabel/stories/template.js";
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
@@ -10,7 +12,7 @@ import { Template as HelpText } from "@spectrum-css/helptext/stories/template.js
 
 import "../index.css";
 
-export const PickerButton = ({
+export const Picker = ({
 	rootClass = "spectrum-Picker",
 	size = "m",
 	labelPosition,
@@ -55,6 +57,7 @@ export const PickerButton = ({
 			})}
 			?disabled=${isDisabled}
 			aria-haspopup="listbox"
+			style=${ifDefined(styleMap(customStyles))}
 			@click=${(e) => {
 				updateArgs({ isOpen: !isOpen });
 			}}
@@ -141,7 +144,7 @@ export const Template = ({
 			: ""}
 		${labelPosition == "left" ?
 			html`<div style="display: inline-block">
-				${PickerButton({
+				${Picker({
 					...globals,
 					rootClass,
 					size,
@@ -163,7 +166,7 @@ export const Template = ({
 			</div>
 			`
 		: 
-			PickerButton({
+			Picker({
 				...globals,
 				rootClass,
 				size,
@@ -176,7 +179,7 @@ export const Template = ({
 				isDisabled,
 				isReadOnly,
 				customClasses,
-				customStyles,
+				customStyles: customStyles,
 				content,
 				iconName,
 				labelPosition,


### PR DESCRIPTION
## Description

[CSS-573](https://jira.corp.adobe.com/browse/CSS-573)

This adds a `font-weight` property with a mod to the `.spectrum-Picker-label` class. There is a font-weight mod that already existed for the placeholder (if the label also had the `.is-placeholder` class) so I also updated that mod to be `--mod-picker-placeholder-font-weight` so that they stayed separate.

In testing this I also realized that the Picker storybook did not implement customStyles so I added that ability too. I also renamed the internal component of PickerButton to Picker to avoid confusion with the actual Picker Button component. 

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

  1. Open the [docs](url) for the Picker component:
    - [ ] Inspect the page and add a `--mod-picker-font-weight: 800` to the first example.
    - [ ] Verify that the placeholder font-weight does not change
    - [ ] Add the same mod `--mod-picker-font-weight: 800` to the Open example
    - [ ] Verify that the font weight for the selected value inside the Picker changes  

![Screenshot 2023-08-09 at 3 26 14 PM](https://github.com/adobe/spectrum-css/assets/99203545/3f13ddeb-a73a-4f88-92dc-3fbf6b8cd5a6)

### Regression testing

Validate:

1. A legacy documentation page (such as [accordion](https://pr-###--spectrum-css.netlify.app/accordion.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

2. A migrated documentation page (such as [action group](https://pr-###--spectrum-css.netlify.app/actiongroup.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.

- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.

- [x] ✨ This pull request is ready to merge. ✨
