### PR TITLE
refactor!: replace focus-ring with focus-visible

### DIFF
--- a/components/actionbutton/index.css
+++ b/components/actionbutton/index.css
@@ -120,11 +120,11 @@ governing permissions and limitations under the License.
 @media (forced-colors: active) {
   .spectrum-ActionButton {
     &:after {
-      /* make sure focus-ring renders */
+      /* make sure focus indicator renders */
       forced-color-adjust: none;
     }
 
-    /* force a more visible focus-ring color */
+    /* force a more visible focus indicator color */
     --highcontrast-actionbutton-focus-indicator-color: ButtonText;
 
     &.is-selected {
@@ -182,7 +182,7 @@ governing permissions and limitations under the License.
     color: var(--highcontrast-actionbutton-content-color-hover, var(--mod-actionbutton-content-color-hover, var(--spectrum-actionbutton-content-color-hover)));
   }
 
-  &:focus-ring {
+  &:focus-visible {
     background-color: var(--highcontrast-actionbutton-background-color-focus, var(--mod-actionbutton-background-color-focus, var(--spectrum-actionbutton-background-color-focus)));
     border-color: var(--highcontrast-actionbutton-border-color-focus, var(--mod-actionbutton-border-color-focus, var(--spectrum-actionbutton-border-color-focus)));
     color: var(--highcontrast-actionbutton-content-color-focus, var(--mod-actionbutton-content-color-focus, var(--spectrum-actionbutton-content-color-focus)));
@@ -273,9 +273,10 @@ a.spectrum-ActionButton {
     content: '';
   }
 
-  &:focus-ring {
+  &:focus-visible {
     /* kill the default ring */
     box-shadow: none;
+    outline: none;
 
     &:after {
       box-shadow: 0 0 0 var(--mod-actionbutton-focus-indicator-thickness, var(--spectrum-actionbutton-focus-indicator-thickness)) var(--highcontrast-actionbutton-focus-indicator-color, var(--mod-actionbutton-focus-indicator-color, var(--spectrum-actionbutton-focus-indicator-color)));

--- a/components/actiongroup/index.css
+++ b/components/actiongroup/index.css
@@ -53,6 +53,13 @@ governing permissions and limitations under the License.
 .spectrum-ActionGroup--compact {
   gap: var(--mod-actiongroup-gap-size-compact, var(--spectrum-actiongroup-gap-size-compact));
 
+  .spectrum-ActionGroup-item {
+    /* Focus indicator should appear above hovered and selected borders */
+    &:focus-visible {
+      z-index: 3;
+    }
+  }
+
   &:not(.spectrum-ActionGroup--quiet) {
     flex-wrap: nowrap;
 
@@ -96,11 +103,10 @@ governing permissions and limitations under the License.
         z-index: 2;
       }
 
-      /* Appear above hovered and selected borders */
-      &:focus-ring {
+      /* Focus indicator should appear above hovered and selected borders */
+      &:focus-visible {
         z-index: 3;
       }
-
 
       .spectrum-ActionButton-label {
         inline-size: auto;

--- a/components/actiongroup/index.css
+++ b/components/actiongroup/index.css
@@ -35,6 +35,11 @@ governing permissions and limitations under the License.
 
   .spectrum-ActionGroup-item {
     flex-shrink: 0;
+    
+    /* Focus indicator should appear above hovered and selected borders */
+    &:focus-visible {
+      z-index: 3;
+    }
   }
 
   &:not(.spectrum-ActionGroup--vertical)&:not(.spectrum-ActionGroup--compact) {
@@ -52,13 +57,6 @@ governing permissions and limitations under the License.
 
 .spectrum-ActionGroup--compact {
   gap: var(--mod-actiongroup-gap-size-compact, var(--spectrum-actiongroup-gap-size-compact));
-
-  .spectrum-ActionGroup-item {
-    /* Focus indicator should appear above hovered and selected borders */
-    &:focus-visible {
-      z-index: 3;
-    }
-  }
 
   &:not(.spectrum-ActionGroup--quiet) {
     flex-wrap: nowrap;

--- a/components/assetcard/index.css
+++ b/components/assetcard/index.css
@@ -69,7 +69,7 @@ governing permissions and limitations under the License.
   outline: none;
 
   &.is-focused,
-  &:focus-ring {
+  &:focus-visible {
     .spectrum-AssetCard-assetContainer {
       &:before {
         opacity: 1;
@@ -96,7 +96,7 @@ governing permissions and limitations under the License.
 
   transition: border var(--spectrum-global-animation-duration-100) ease-in-out;
 
-  /* focus-ring */
+  /* focus indicator */
   &:before {
     content: '';
 

--- a/components/breadcrumb/index.css
+++ b/components/breadcrumb/index.css
@@ -300,7 +300,7 @@ governing permissions and limitations under the License.
     cursor: pointer;
 
     &:hover,
-    &:focus-ring {
+    &:focus-visible {
       text-decoration: underline;
       text-decoration-thickness: var(--mod-breadcrumbs-text-decoration-thickness, var(--spectrum-breadcrumbs-text-decoration-thickness));
       text-underline-offset: var(--mod-breadcrumbs-text-decoration-gap, var(--spectrum-breadcrumbs-text-decoration-gap));
@@ -310,7 +310,7 @@ governing permissions and limitations under the License.
 
 /* focus indicator */
 .spectrum-Breadcrumbs-item.is-dragged .spectrum-Breadcrumbs-itemLink:before,
-.spectrum-Breadcrumbs-itemLink:focus-ring:before {
+.spectrum-Breadcrumbs-itemLink:focus-visible:before {
   position: absolute;
 
   margin-inline-start: calc((var(--mod-breadcrumbs-focus-indicator-gap, var(--spectrum-breadcrumbs-focus-indicator-gap))

--- a/components/button/index.css
+++ b/components/button/index.css
@@ -129,7 +129,7 @@ governing permissions and limitations under the License.
     color: inherit;
   }
 
-  /* correct focus-ring radius for t-shirt sizing */
+  /* correct focus indicator radius for t-shirt sizing */
   &:after {
     border-radius: calc(var(--mod-button-border-radius, var(--spectrum-button-border-radius)) + var(--mod-focus-indicator-gap, var(--spectrum-focus-indicator-gap)));
   }
@@ -163,7 +163,7 @@ a.spectrum-Button {
 }
 
 .spectrum-Button {
-  &:focus-ring,
+  &:focus-visible,
   &.is-focused {
     &:after {
       box-shadow: 0 0 0 var(--mod-button-focus-ring-thickness, var(--spectrum-button-focus-ring-thickness)) var(--mod-button-focus-ring-color, var(--spectrum-button-focus-indicator-color));
@@ -189,9 +189,10 @@ a.spectrum-Button {
     content: '';
   }
 
-  &:focus-ring {
+  &:focus-visible {
     /* kill the default ring */
     box-shadow: none;
+    outline: none;
 
     &:after {
       box-shadow: 0 0 0 var(--mod-button-focus-ring-thickness, var(--spectrum-button-focus-ring-thickness)) var(--highcontrast-button-focus-ring-color, var(--mod-button-focus-ring-color,
@@ -216,7 +217,7 @@ a.spectrum-Button {
     color: var(--highcontrast-button-content-color-hover, var(--mod-button-content-color-hover, var(--spectrum-button-content-color-hover)));
   }
 
-  &:focus-ring {
+  &:focus-visible {
     background-color: var(--highcontrast-button-background-color-focus, var(--mod-button-background-color-focus, var(--spectrum-button-background-color-focus)));
     border-color: var(--highcontrast-button-border-color-focus, var(--mod-button-border-color-focus, var(--spectrum-button-border-color-focus)));
     color: var(--highcontrast-button-content-color-focus, var(--mod-button-content-color-focus, var(--spectrum-button-content-color-focus)));
@@ -242,7 +243,7 @@ a.spectrum-Button {
     --highcontrast-button-content-color-disabled: GrayText;
     --highcontrast-button-border-color-disabled: GrayText;
 
-    &:focus-ring {
+    &:focus-visible {
       &:after {
         forced-color-adjust: none;
         box-shadow: 0 0 0 var(--mod-button-focus-ring-thickness, var(--spectrum-button-focus-ring-thickness)) ButtonText;

--- a/components/clearbutton/index.css
+++ b/components/clearbutton/index.css
@@ -84,7 +84,7 @@ governing permissions and limitations under the License.
     color: var(--spectrum-clearbutton-fill-uiicon-color-down);
   }
 
-  &:focus-ring {
+  &:focus-visible {
     color: var(--spectrum-clearbutton-fill-uiicon-color-key-focus);
   }
 
@@ -101,7 +101,7 @@ governing permissions and limitations under the License.
     background-color: var(--spectrum-clearbutton-fill-background-color-down);
   }
 
-  &:focus-ring .spectrum-ClearButton-fill {
+  &:focus-visible .spectrum-ClearButton-fill {
     background-color: var(--spectrum-clearbutton-fill-background-color-key-focus);
   }
 
@@ -124,7 +124,7 @@ governing permissions and limitations under the License.
     color: var(--spectrum-alias-icon-color-overbackground);
   }
 
-  &:focus-ring {
+  &:focus-visible {
     color: var(--spectrum-alias-icon-color-overbackground);
   }
 
@@ -145,11 +145,12 @@ governing permissions and limitations under the License.
     color: var(--spectrum-button-m-primary-outline-white-texticon-text-color-hover);
   }
 
-  &:focus-ring {
+  &:focus-visible {
     background-color: var(--spectrum-button-m-primary-outline-white-texticon-background-color-hover);
     border-color: var(--spectrum-button-m-primary-outline-white-texticon-border-color-hover);
     color: var(--spectrum-button-m-primary-outline-white-texticon-text-color-hover);
     box-shadow: none;
+    outline: none;
 
     &:after {
       box-shadow: 0 0 0 var(--spectrum-alias-focus-ring-size) var(--spectrum-button-m-primary-outline-white-texticon-border-color-key-focus);

--- a/components/closebutton/index.css
+++ b/components/closebutton/index.css
@@ -103,20 +103,9 @@ governing permissions and limitations under the License.
     --highcontrast-closebutton-background-color-default: ButtonFace;
     --highcontrast-closebutton-focus-indicator-color: ButtonText;
 
-    &:focus-ring {
+    &:focus-visible {
       &:after {
         forced-color-adjust: none;
-        box-shadow:
-        0 0 0 var(--mod-closebutton-focus-indicator-thickness, var(--spectrum-closebutton-focus-indicator-thickness))
-        var(--highcontrast-closebutton-focus-indicator-color, var(--mod-closebutton-focus-indicator-color, var(--spectrum-closebutton-focus-indicator-color)));
-        border-radius: 100%;
-        content: "";
-        display: block;
-        position: absolute;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        top: 0;
         margin: var(--mod-closebutton-focus-indicator-gap, var(--spectrum-closebutton-focus-indicator-gap));
         transition:
         opacity var(--mod-closebutton-animation-duration, var(--spectrum-closebutton-animation-duration)) ease-out,margin var(--mod-closebutton-animation-duraction, var(--spectrum-closebutton-animation-duration)) ease-out;
@@ -180,8 +169,9 @@ a.spectrum-CloseButton {
     transition: box-shadow var(--mod-closebutton-animation-duration, var(--spectrum-closebutton-animation-duration)) ease-in-out;
   }
 
-  &:focus-ring {
+  &:focus-visible {
     box-shadow: none;
+    outline: none;
 
     &:after {
       box-shadow:

--- a/components/colorhandle/index.css
+++ b/components/colorhandle/index.css
@@ -120,7 +120,7 @@ governing permissions and limitations under the License.
   transition: all var(--mod-colorhandle-animation-duration, var(--spectrum-colorhandle-animation-duration)) var(--mod-colorhandle-animation-easing, var(--spectrum-colorhandle-animation-easing));
 
   &.is-focused,
-  &.focus-ring {
+  &:focus-visible {
       /* Bigger handle when focused */
       inline-size: var(--mod-colorhandle-focused-size, var(--spectrum-colorhandle-focused-size));
       block-size: var(--mod-colorhandle-focused-size, var(--spectrum-colorhandle-focused-size));

--- a/components/commons/basebutton-coretokens.css
+++ b/components/commons/basebutton-coretokens.css
@@ -97,7 +97,7 @@ governing permissions and limitations under the License.
                 margin var(--mod-animation-duration-100, var(--spectrum-animation-duration-100)) ease-out;
   }
 
-  &:focus-ring {
+  &:focus-visible {
     &:after {
       margin: calc(var(--mod-focus-indicator-gap, var(--spectrum-focus-indicator-gap)) * -2);
     }

--- a/components/commons/basebutton.css
+++ b/components/commons/basebutton.css
@@ -102,7 +102,7 @@ governing permissions and limitations under the License.
                 margin var(--spectrum-global-animation-duration-100) ease-out;
   }
 
-  &:focus-ring {
+  &:focus-visible {
     &:after {
       margin: calc(var(--spectrum-alias-focus-ring-gap) * -2);
     }


### PR DESCRIPTION
## Description

This PR replaces `:focus-ring` with `:focus-visible` for the following components:
- Action Button
- Action Group
- Asset Card
- Breadcrumbs
- Button
- Clear Button
- Close Button
    - Removes some duplicated styles that are already applied to the `:after` element on lines 159-170. 
- Color Handle

No visible styling changes should be present in this PR. 

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

  1. Open the [docs](https://pr-2082--spectrum-css.netlify.app/) for this PR and compare to the [live docs site](https://opensource.adobe.com/spectrum-css/index.html):

- [x] Action button focus styles are the same
- [x] Action group focus styles are the same
- [x] Asset card focus styles are the same
- [x] Breadcrumbs focus styles are the same
- [x] Button focus styles are the same
- [x] Clear button focus styles are the same
- [x] Close button focus styles are the same
- [x] Color handle focus styles are the same

Tested by @jawinn 

### Regression testing

Validate:

1. A legacy documentation page (such as [accordion](https://pr-2082--spectrum-css.netlify.app/accordion.html)), including:

- [x] The page renders correctly
- [x] The page is accessible
- [x] The page is responsive

4. A migrated documentation page (such as [action group](https://pr-2082--spectrum-css.netlify.app/actiongroup.html)), including:

- [x] The page renders correctly
- [x] The page is accessible
- [x] The page is responsive

Tested by @jawinn 

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.

- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.

- [ ] ✨ This pull request is ready to merge. ✨
