### PR TITLE
chore: Update dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,6 +35,12 @@ updates:
         patterns:
           - storybook
           - "@storybook/*"
+          - "@types/storybook*"
+          # manually added these because they weren't being included for some reason 🤷‍♀️
+          - "@storybook/core-events"
+          - "@storybook/components"
+          - "@storybook/blocks"
+          - "@storybook/preview-api"
       commitlint-ecosystem:
         patterns:
           - "@commitlint/*"


### PR DESCRIPTION
## Description

For some reason dependabot opened several storybook prefixed packages as separate PRs rather than as part of the grouping we defined. This attempts to manually call those to see if we can force dependabot to correctly group the packages.

## How and where has this been tested?

I expect (after this merges and if we close the current pull requests) dependabot to reopen a single storybook pull request for all the package updates.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] ✨ This pull request is ready to merge. ✨
