### PR TITLE
feat(underlay)!: diy migration

### DIFF
--- a/components/dialog/stories/dialog.stories.js
+++ b/components/dialog/stories/dialog.stories.js
@@ -69,7 +69,6 @@ export const Default = Template.bind({});
 Default.args = {
 	heading: "Disclaimer",
 	showModal: true,
-	isOpen: true,
 	content: [
 		html`<p class="spectrum-Body spectrum-Body--sizeM">
 			Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod

--- a/components/dialog/stories/dialog.stories.js
+++ b/components/dialog/stories/dialog.stories.js
@@ -55,7 +55,7 @@ export default {
 	},
 	parameters: {
 		actions: {
-			handles: ["click .spectrum-Dialog button", "click .spectrum-CSSExample-overlayShowButton button"],
+			handles: ["click .spectrum-Dialog button"],
 		},
 		status: {
 			type: process.env.MIGRATED_PACKAGES.includes("dialog")

--- a/components/dialog/stories/dialog.stories.js
+++ b/components/dialog/stories/dialog.stories.js
@@ -55,7 +55,7 @@ export default {
 	},
 	parameters: {
 		actions: {
-			handles: [],
+			handles: ["click .spectrum-Dialog button", "click .spectrum-CSSExample-overlayShowButton button"],
 		},
 		status: {
 			type: process.env.MIGRATED_PACKAGES.includes("dialog")
@@ -69,6 +69,7 @@ export const Default = Template.bind({});
 Default.args = {
 	heading: "Disclaimer",
 	showModal: true,
+	isOpen: true,
 	content: [
 		html`<p class="spectrum-Body spectrum-Body--sizeM">
 			Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod

--- a/components/dialog/stories/template.js
+++ b/components/dialog/stories/template.js
@@ -16,7 +16,7 @@ import "../skin.css";
 export const Template = ({
 	rootClass = "spectrum-Dialog",
 	isDismissable = true,
-	isOpen,
+	isOpen = true,
 	showModal = false,
 	heading,
 	content = [],
@@ -66,27 +66,27 @@ export const Template = ({
 
 	if (showModal) {
 		return html`
-    ${Underlay({
-      ...globals,
-      isOpen,
-    })}
-    ${Button({
-      ...globals,
-      size: "m",
-      variant: "secondary",
-      label: "Click to open Dialog",
-      treatment: "outline",
-      customClasses: ['spectrum-CSSExample-overlayShowButton'],
-      onclick: () => {
-        updateArgs({ isOpen: !isOpen });
-      },
-    })}
-    ${Modal({
-      ...globals,
-      isOpen,
-      content: Dialog,
-    })}
-      `
+			${Underlay({
+				...globals,
+				isOpen,
+			})}
+			${Button({
+				...globals,
+				size: "m",
+				variant: "secondary",
+				label: "Click to open Dialog",
+				treatment: "outline",
+				customClasses: ['spectrum-CSSExample-overlayShowButton'],
+				onclick: () => {
+					updateArgs({ isOpen: !isOpen });
+				},
+			})}
+			${Modal({
+				...globals,
+				isOpen,
+				content: Dialog,
+			})}
+		`
 	} else {
 		return Dialog;
 	}

--- a/components/dialog/stories/template.js
+++ b/components/dialog/stories/template.js
@@ -2,10 +2,13 @@ import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { when } from "lit/directives/when.js";
+import { useArgs } from "@storybook/client-api";
 
+import { Template as Underlay } from '@spectrum-css/underlay/stories/template.js';
 import { Template as Modal } from "@spectrum-css/modal/stories/template.js";
 import { Template as Divider } from "@spectrum-css/divider/stories/template.js";
 import { Template as CloseButton } from "@spectrum-css/closebutton/stories/template.js";
+import { Template as Button } from '@spectrum-css/button/stories/template.js';
 
 import "../index.css";
 import "../skin.css";
@@ -13,15 +16,18 @@ import "../skin.css";
 export const Template = ({
 	rootClass = "spectrum-Dialog",
 	isDismissable = true,
-	isOpen = true,
+	isOpen,
 	showModal = false,
 	heading,
 	content = [],
 	customClasses = [],
+	onclick,
 	id,
 	...globals
 }) => {
 	const { scale } = globals;
+	const [_, updateArgs] = useArgs();
+
 	const Dialog = html`
 		<div
 			class=${classMap({
@@ -49,6 +55,9 @@ export const Template = ({
 					CloseButton({
 						customClasses: [`${rootClass}-closeButton`],
 						...globals,
+						onclick: () => {
+							updateArgs({ isOpen: !isOpen });
+						},
 					})
 				)}
 			</div>
@@ -56,11 +65,28 @@ export const Template = ({
 	`;
 
 	if (showModal) {
-		return Modal({
-			...globals,
-			isOpen,
-			content: Dialog,
-		});
+		return html`
+    ${Underlay({
+      ...globals,
+      isOpen,
+    })}
+    ${Button({
+      ...globals,
+      size: "m",
+      variant: "secondary",
+      label: "Click to open Dialog",
+      treatment: "outline",
+      customClasses: ['spectrum-CSSExample-overlayShowButton'],
+      onclick: () => {
+        updateArgs({ isOpen: !isOpen });
+      },
+    })}
+    ${Modal({
+      ...globals,
+      isOpen,
+      content: Dialog,
+    })}
+      `
 	} else {
 		return Dialog;
 	}

--- a/components/underlay/gulpfile.js
+++ b/components/underlay/gulpfile.js
@@ -1,1 +1,1 @@
-module.exports = require("@spectrum-css/component-builder");
+module.exports = require("@spectrum-css/component-builder-simple");

--- a/components/underlay/index.css
+++ b/components/underlay/index.css
@@ -13,12 +13,12 @@ governing permissions and limitations under the License.
 @import '../overlay/index.css';
 
 .spectrum-Underlay {
-  --spectrum-underlay-background-entry-animation-delay: var(--spectrum-animation-duration-0);   /* Bug: this must be 0ms, not 0 */
-  --spectrum-underlay-background-exit-animation-ease: cubic-bezier(0.5, 0, 1, 1); /* wrong in DNA */
-  --spectrum-underlay-background-entry-animation-ease: cubic-bezier(0, 0, 0.40, 1); /* wrong in DNA */
+  --spectrum-underlay-background-entry-animation-delay: var(--spectrum-animation-duration-0);
+  --spectrum-underlay-background-exit-animation-ease: var(--spectrum-animation-ease-in);
+  --spectrum-underlay-background-entry-animation-ease: var(--spectrum-animation-ease-out);
   --spectrum-underlay-background-exit-animation-duration: var(--spectrum-animation-duration-100);
   --spectrum-underlay-background-entry-animation-duration: var(--spectrum-animation-duration-600);
-  --spectrum-underlay-background-exit-animation-duration: var(----spectrum-animation-duration-300);
+  --spectrum-underlay-background-exit-animation-duration: var(--spectrum-animation-duration-300);
   --spectrum-underlay-background-exit-animation-delay: var(--spectrum-animation-duration-200);
 
   --spectrum-underlay-background-color-rgb: var(--spectrum-black-rgb);

--- a/components/underlay/index.css
+++ b/components/underlay/index.css
@@ -13,26 +13,35 @@ governing permissions and limitations under the License.
 @import '../overlay/index.css';
 
 .spectrum-Underlay {
-  /* Bug: this must be 0ms, not 0 */
-  --spectrum-dialog-confirm-background-entry-animation-delay: var(--spectrum-animation-duration-0);
-  --spectrum-dialog-confirm-background-exit-animation-ease: cubic-bezier(0.5, 0, 1, 1); /* wrong in DNA */
-  --spectrum-dialog-confirm-background-entry-animation-ease: cubic-bezier(0, 0, 0.40, 1); /* wrong in DNA */
-  --spectrum-dialog-background-exit-animation-duration: var(--spectrum-animation-duration-100);
-  --spectrum-dialog-confirm-background-entry-animation-duration: var(--spectrum-animation-duration-600);
-  --spectrum-dialog-confirm-background-exit-animation-duration: var(----spectrum-animation-duration-300);
-  --spectrum-dialog-confirm-background-exit-animation-delay: var(--spectrum-animation-duration-200);
+  --spectrum-underlay-background-entry-animation-delay: var(--spectrum-animation-duration-0);   /* Bug: this must be 0ms, not 0 */
+  --spectrum-underlay-background-exit-animation-ease: cubic-bezier(0.5, 0, 1, 1); /* wrong in DNA */
+  --spectrum-underlay-background-entry-animation-ease: cubic-bezier(0, 0, 0.40, 1); /* wrong in DNA */
+  --spectrum-underlay-background-exit-animation-duration: var(--spectrum-animation-duration-100);
+  --spectrum-underlay-background-entry-animation-duration: var(--spectrum-animation-duration-600);
+  --spectrum-underlay-background-exit-animation-duration: var(----spectrum-animation-duration-300);
+  --spectrum-underlay-background-exit-animation-delay: var(--spectrum-animation-duration-200);
+
+  --spectrum-underlay-background-color-rgb: var(--spectrum-black-rgb);
+  --spectrum-underlay-background-opacity-light: var(--spectrum-transparent-black-400-opacity);
+  --spectrum-underlay-background-opacity-dark: 0.5;
+  --spectrum-underlay-background-opacity-darkest: 0.6;
+
+
 
   .spectrum--light &,
 	.spectrum--lightest & {
-    --spectrum-dialog-background-color: rgba(var(--spectrum-black-rgb), var(--spectrum-transparent-black-400-opacity));
+    --spectrum-underlay-background-color: rgba(var(--mod-underlay-background-color-rgb, var(--spectrum-underlay-background-color-rgb)),
+                                              var(--mod-underlay-background-opacity-light, var(--spectrum-underlay-background-opacity-light)));
 	}
 
   .spectrum--dark & {
-    --spectrum-dialog-background-color: rgba(var(--spectrum-black-rgb), 0.5);
+    --spectrum-underlay-background-color: rgba(var(--mod-underlay-background-color-rgb, var(--spectrum-underlay-background-color-rgb)),
+                                              var(--mod-underlay-background-opacity-dark, var(--spectrum-underlay-background-opacity-dark)));
   }
 
   .spectrum--darkest & {
-    --spectrum-dialog-background-color: rgba(var(--spectrum-black-rgb), 0.6);
+    --spectrum-underlay-background-color: rgba(var(--mod-underlay-background-color-rgb, var(--spectrum-underlay-background-color-rgb)),
+                                              var(--mod-underlay-background-opacity-darkest, var(--spectrum-underlay-background-opacity-darkest)));
   }
 }
 
@@ -43,7 +52,7 @@ governing permissions and limitations under the License.
   inset-block: 0;
   inset-inline: 0;
 
-  background-color: var(--mod-dialog-background-color, var(--spectrum-dialog-background-color));
+  background-color: var(--mod-underlay-background-color, var(--spectrum-underlay-background-color));
 
   /* Float above things by default */
   z-index: 1;
@@ -51,20 +60,20 @@ governing permissions and limitations under the License.
   overflow: hidden;
 
   /* Exit animations */
-  transition: opacity var(--mod-dialog-confirm-background-exit-animation-duration, var(--spectrum-dialog-confirm-background-exit-animation-duration))
-                      var(--mod-dialog-confirm-background-exit-animation-ease, var(--spectrum-dialog-confirm-background-exit-animation-ease))
-                      var(--mod-dialog-confirm-background-exit-animation-delay, var(--spectrum-dialog-confirm-background-exit-animation-delay)),
+  transition: opacity var(--mod-underlay-background-exit-animation-duration, var(--spectrum-underlay-background-exit-animation-duration))
+                      var(--mod-underlay-background-exit-animation-ease, var(--spectrum-underlay-background-exit-animation-ease))
+                      var(--mod-underlay-background-exit-animation-delay, var(--spectrum-underlay-background-exit-animation-delay)),
               visibility 0ms
               linear calc(
-                      var(--mod-dialog-confirm-background-exit-animation-delay, var(--spectrum-dialog-confirm-background-exit-animation-delay)) +
-                      var(--mod-dialog-confirm-background-exit-animation-duration, var(--spectrum-dialog-confirm-background-exit-animation-duration)));
+                      var(--mod-underlay-background-exit-animation-delay, var(--spectrum-underlay-background-exit-animation-delay)) +
+                      var(--mod-underlay-background-exit-animation-duration, var(--spectrum-underlay-background-exit-animation-duration)));
 }
 
 .spectrum-Underlay.is-open {
   @inherit: %spectrum-overlay--open;
 
   /* Entry animations */
-  transition: opacity var(--mod-dialog-confirm-background-entry-animation-duration, var(--spectrum-dialog-confirm-background-entry-animation-duration))
-                      var(--mod-dialog-confirm-background-entry-animation-ease, var(--spectrum-dialog-confirm-background-entry-animation-ease))
-                      var(--mod-dialog-confirm-background-entry-animation-delay, var(--spectrum-dialog-confirm-background-entry-animation-delay));
+  transition: opacity var(--mod-underlay-background-entry-animation-duration, var(--spectrum-underlay-background-entry-animation-duration))
+                      var(--mod-underlay-background-entry-animation-ease, var(--spectrum-underlay-background-entry-animation-ease))
+                      var(--mod-underlay-background-entry-animation-delay, var(--spectrum-underlay-background-entry-animation-delay));
 }

--- a/components/underlay/index.css
+++ b/components/underlay/index.css
@@ -14,13 +14,13 @@ governing permissions and limitations under the License.
 
 .spectrum-Underlay {
   /* Bug: this must be 0ms, not 0 */
-  --spectrum-dialog-confirm-background-entry-animation-delay: 0ms;
+  --spectrum-dialog-confirm-background-entry-animation-delay: var(--spectrum-animation-duration-0);
   --spectrum-dialog-confirm-background-exit-animation-ease: cubic-bezier(0.5, 0, 1, 1); /* wrong in DNA */
   --spectrum-dialog-confirm-background-entry-animation-ease: cubic-bezier(0, 0, 0.40, 1); /* wrong in DNA */
-  --spectrum-dialog-background-exit-animation-duration: 130ms;
-  --spectrum-dialog-confirm-background-entry-animation-duration: 300ms;
-  --spectrum-dialog-confirm-background-exit-animation-duration: 190ms;
-  --spectrum-dialog-confirm-background-exit-animation-delay: 160ms;
+  --spectrum-dialog-background-exit-animation-duration: var(--spectrum-animation-duration-100);
+  --spectrum-dialog-confirm-background-entry-animation-duration: var(--spectrum-animation-duration-600);
+  --spectrum-dialog-confirm-background-exit-animation-duration: var(----spectrum-animation-duration-300);
+  --spectrum-dialog-confirm-background-exit-animation-delay: var(--spectrum-animation-duration-200);
 
   .spectrum--light &,
 	.spectrum--lightest & {

--- a/components/underlay/index.css
+++ b/components/underlay/index.css
@@ -17,16 +17,33 @@ governing permissions and limitations under the License.
   --spectrum-dialog-confirm-background-entry-animation-delay: 0ms;
   --spectrum-dialog-confirm-background-exit-animation-ease: cubic-bezier(0.5, 0, 1, 1); /* wrong in DNA */
   --spectrum-dialog-confirm-background-entry-animation-ease: cubic-bezier(0, 0, 0.40, 1); /* wrong in DNA */
+  --spectrum-dialog-background-exit-animation-duration: 130ms;
+  --spectrum-dialog-confirm-background-entry-animation-duration: 300ms;
+  --spectrum-dialog-confirm-background-exit-animation-duration: 190ms;
+  --spectrum-dialog-confirm-background-exit-animation-delay: 160ms;
+
+  .spectrum--light &,
+	.spectrum--lightest & {
+    --spectrum-dialog-background-color: rgba(var(--spectrum-black-rgb), var(--spectrum-transparent-black-400-opacity));
+	}
+
+  .spectrum--dark & {
+    --spectrum-dialog-background-color: rgba(var(--spectrum-black-rgb), 0.5);
+  }
+
+  .spectrum--darkest & {
+    --spectrum-dialog-background-color: rgba(var(--spectrum-black-rgb), 0.6);
+  }
 }
 
 .spectrum-Underlay {
   @inherit: %spectrum-overlay;
 
   position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
+  inset-block: 0;
+  inset-inline: 0;
+
+  background-color: var(--mod-dialog-background-color, var(--spectrum-dialog-background-color));
 
   /* Float above things by default */
   z-index: 1;
@@ -34,13 +51,20 @@ governing permissions and limitations under the License.
   overflow: hidden;
 
   /* Exit animations */
-  transition: opacity var(--spectrum-dialog-confirm-background-exit-animation-duration) var(--spectrum-dialog-confirm-background-exit-animation-ease) var(--spectrum-dialog-confirm-background-exit-animation-delay),
-              visibility 0ms linear calc(var(--spectrum-dialog-confirm-background-exit-animation-delay) + var(--spectrum-dialog-confirm-background-exit-animation-duration));
+  transition: opacity var(--mod-dialog-confirm-background-exit-animation-duration, var(--spectrum-dialog-confirm-background-exit-animation-duration))
+                      var(--mod-dialog-confirm-background-exit-animation-ease, var(--spectrum-dialog-confirm-background-exit-animation-ease))
+                      var(--mod-dialog-confirm-background-exit-animation-delay, var(--spectrum-dialog-confirm-background-exit-animation-delay)),
+              visibility 0ms
+              linear calc(
+                      var(--mod-dialog-confirm-background-exit-animation-delay, var(--spectrum-dialog-confirm-background-exit-animation-delay)) +
+                      var(--mod-dialog-confirm-background-exit-animation-duration, var(--spectrum-dialog-confirm-background-exit-animation-duration)));
 }
 
 .spectrum-Underlay.is-open {
   @inherit: %spectrum-overlay--open;
 
   /* Entry animations */
-  transition: opacity var(--spectrum-dialog-confirm-background-entry-animation-duration) var(--spectrum-dialog-confirm-background-entry-animation-ease) var(--spectrum-dialog-confirm-background-entry-animation-delay);
+  transition: opacity var(--mod-dialog-confirm-background-entry-animation-duration, var(--spectrum-dialog-confirm-background-entry-animation-duration))
+                      var(--mod-dialog-confirm-background-entry-animation-ease, var(--spectrum-dialog-confirm-background-entry-animation-ease))
+                      var(--mod-dialog-confirm-background-entry-animation-delay, var(--spectrum-dialog-confirm-background-entry-animation-delay));
 }

--- a/components/underlay/index.css
+++ b/components/underlay/index.css
@@ -21,28 +21,8 @@ governing permissions and limitations under the License.
   --spectrum-underlay-background-exit-animation-duration: var(--spectrum-animation-duration-300);
   --spectrum-underlay-background-exit-animation-delay: var(--spectrum-animation-duration-200);
 
-  --spectrum-underlay-background-color-rgb: var(--spectrum-black-rgb);
-  --spectrum-underlay-background-opacity-light: var(--spectrum-transparent-black-400-opacity);
-  --spectrum-underlay-background-opacity-dark: 0.5;
-  --spectrum-underlay-background-opacity-darkest: 0.6;
-
-
-
-  .spectrum--light &,
-	.spectrum--lightest & {
-    --spectrum-underlay-background-color: rgba(var(--mod-underlay-background-color-rgb, var(--spectrum-underlay-background-color-rgb)),
-                                              var(--mod-underlay-background-opacity-light, var(--spectrum-underlay-background-opacity-light)));
-	}
-
-  .spectrum--dark & {
-    --spectrum-underlay-background-color: rgba(var(--mod-underlay-background-color-rgb, var(--spectrum-underlay-background-color-rgb)),
-                                              var(--mod-underlay-background-opacity-dark, var(--spectrum-underlay-background-opacity-dark)));
-  }
-
-  .spectrum--darkest & {
-    --spectrum-underlay-background-color: rgba(var(--mod-underlay-background-color-rgb, var(--spectrum-underlay-background-color-rgb)),
-                                              var(--mod-underlay-background-opacity-darkest, var(--spectrum-underlay-background-opacity-darkest)));
-  }
+    /* TODO update to --spectrum-overlay-color token once an RGB stripped value is available */
+  --spectrum-underlay-background-color: rgba(var(--spectrum-black-rgb), var(--spectrum-overlay-opacity));;
 }
 
 .spectrum-Underlay {

--- a/components/underlay/metadata/mods.md
+++ b/components/underlay/metadata/mods.md
@@ -1,0 +1,9 @@
+| Modifiable Custom Properties                         |
+| ---------------------------------------------------- |
+| `--mod-underlay-background-color`                    |
+| `--mod-underlay-background-entry-animation-delay`    |
+| `--mod-underlay-background-entry-animation-duration` |
+| `--mod-underlay-background-entry-animation-ease`     |
+| `--mod-underlay-background-exit-animation-delay`     |
+| `--mod-underlay-background-exit-animation-duration`  |
+| `--mod-underlay-background-exit-animation-ease`      |

--- a/components/underlay/metadata/mods.md
+++ b/components/underlay/metadata/mods.md
@@ -1,13 +1,9 @@
 | Modifiable Custom Properties                         |
 | ---------------------------------------------------- |
 | `--mod-underlay-background-color`                    |
-| `--mod-underlay-background-color-rgb`                |
 | `--mod-underlay-background-entry-animation-delay`    |
 | `--mod-underlay-background-entry-animation-duration` |
 | `--mod-underlay-background-entry-animation-ease`     |
 | `--mod-underlay-background-exit-animation-delay`     |
 | `--mod-underlay-background-exit-animation-duration`  |
 | `--mod-underlay-background-exit-animation-ease`      |
-| `--mod-underlay-background-opacity-dark`             |
-| `--mod-underlay-background-opacity-darkest`          |
-| `--mod-underlay-background-opacity-light`            |

--- a/components/underlay/metadata/mods.md
+++ b/components/underlay/metadata/mods.md
@@ -1,9 +1,13 @@
 | Modifiable Custom Properties                         |
 | ---------------------------------------------------- |
+| `--mod-underlay-background-color`                    |
+| `--mod-underlay-background-color-rgb`                |
 | `--mod-underlay-background-entry-animation-delay`    |
 | `--mod-underlay-background-entry-animation-duration` |
 | `--mod-underlay-background-entry-animation-ease`     |
 | `--mod-underlay-background-exit-animation-delay`     |
 | `--mod-underlay-background-exit-animation-duration`  |
 | `--mod-underlay-background-exit-animation-ease`      |
-| `--mod-underlay-color`                               |
+| `--mod-underlay-background-opacity-dark`             |
+| `--mod-underlay-background-opacity-darkest`          |
+| `--mod-underlay-background-opacity-light`            |

--- a/components/underlay/metadata/mods.md
+++ b/components/underlay/metadata/mods.md
@@ -1,9 +1,9 @@
 | Modifiable Custom Properties                         |
 | ---------------------------------------------------- |
-| `--mod-underlay-background-color`                    |
 | `--mod-underlay-background-entry-animation-delay`    |
 | `--mod-underlay-background-entry-animation-duration` |
 | `--mod-underlay-background-entry-animation-ease`     |
 | `--mod-underlay-background-exit-animation-delay`     |
 | `--mod-underlay-background-exit-animation-duration`  |
 | `--mod-underlay-background-exit-animation-ease`      |
+| `--mod-underlay-color`                               |

--- a/components/underlay/package.json
+++ b/components/underlay/package.json
@@ -18,11 +18,11 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/vars": ">=9"
+    "@spectrum-css/tokens": ">=11"
   },
   "devDependencies": {
-    "@spectrum-css/component-builder": "^4.0.14",
-    "@spectrum-css/vars": "^9.0.8",
+    "@spectrum-css/component-builder-simple": "^2.0.16",
+    "@spectrum-css/tokens": "^11.2.0",
     "gulp": "^4.0.0"
   },
   "publishConfig": {

--- a/components/underlay/package.json
+++ b/components/underlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spectrum-css/underlay",
-  "version": "2.1.0",
+  "version": "3.0.0-beta.0",
   "description": "The Spectrum CSS underlay component",
   "license": "Apache-2.0",
   "author": "Adobe",

--- a/components/underlay/stories/template.js
+++ b/components/underlay/stories/template.js
@@ -3,7 +3,6 @@ import { classMap } from 'lit-html/directives/class-map.js';
 import { styleMap } from 'lit-html/directives/style-map.js';
 
 import "../index.css";
-import "../skin.css";
 
 export const Template = ({
   rootClass = "spectrum-Underlay",

--- a/components/underlay/stories/underlay.stories.js
+++ b/components/underlay/stories/underlay.stories.js
@@ -34,6 +34,7 @@ export default {
 
 export const Default = Template.bind({});
 Default.args = {
+	isOpen: true,
   content: [
     "This is a underlay. Don't use it like this. Use it with a Modal and a Dialog.",
   ],

--- a/components/underlay/themes/express.css
+++ b/components/underlay/themes/express.css
@@ -3,14 +3,10 @@ Copyright 2023 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software distributed under
 the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
 
-.spectrum-Underlay {
-  /* TODO update to --spectrum-overlay-color token once an RGB stripped value is available */
-  background: rgba(var(--spectrum-black-rgb), var(--spectrum-overlay-opacity));
-}
+@container (--system: express) {}

--- a/components/underlay/themes/spectrum.css
+++ b/components/underlay/themes/spectrum.css
@@ -1,0 +1,13 @@
+/*!
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+@container (--system: spectrum) {}
+


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->

## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

The DIY migration for Underlay 

- updates build system
- implements `--mods`
- uses custom tokens for animation values 
- adds `Underlay` to Storybook
- updates `Dialog` story to use the underlay component 

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

<!--
  Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

#### Test Outline 
1. Open the [docs site](https://pr-2096--spectrum-css.netlify.app/dialog) for the dialog component. Scroll to Dialog - Alert Confirmation, Click on the cancel button to close it, then use the `Open Alert Confirmation Dialog` button to reopen. Inspect underlay compared to the underlay on the [live docs site](https://opensource.adobe.com/spectrum-css/dialog.html) for any design regressions.
- [ ] Ensure underly color is correct in all 3 theme colors
- [ ] Animations on close and open should not of changed 

2. Open the [storybook site](http://localhost:63684/?path=/story/components-underlay--default) for the Underlay component
- [ ] controls should all function as expected
- [ ] styling should match docs site

3. Open the [storybook site](http://localhost:63684/?path=/story/components-dialog--default) for the Dialog component
- [ ] controls should all function as expected
- [ ] styling should match docs site

### Regression testing

Validate:

1. A legacy documentation page (such as [accordion](https://pr-###--spectrum-css.netlify.app/accordion.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

2. A migrated documentation page (such as [action group](https://pr-###--spectrum-css.netlify.app/actiongroup.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.

- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.

- [x] ✨ This pull request is ready to merge. ✨
