### PR TITLE
refactor(radio, checkbox): use new disabled content color token

### DIFF
--- a/components/checkbox/index.css
+++ b/components/checkbox/index.css
@@ -27,7 +27,7 @@ governing permissions and limitations under the License.
   --spectrum-checkbox-focus-indicator-color: var(--spectrum-focus-indicator-color);
 
   --spectrum-checkbox-content-color-disabled: var(--spectrum-disabled-content-color);
-  --spectrum-checkbox-control-color-disabled: var(--spectrum-gray-400);
+  --spectrum-checkbox-control-color-disabled: var(--spectrum-disabled-content-color);
   --spectrum-checkbox-checkmark-color: var(--spectrum-gray-75);
 
   --spectrum-checkbox-invalid-color-default: var(--spectrum-negative-color-900);
@@ -454,7 +454,7 @@ governing permissions and limitations under the License.
     &:before {
       border-color: var(--highcontrast-checkbox-color-focus, var(--mod-checkbox-control-color-focus, var(--spectrum-checkbox-control-color-focus)));
     }
-    
+
     &:after {
       forced-color-adjust: none;
       box-shadow:

--- a/components/radio/index.css
+++ b/components/radio/index.css
@@ -31,7 +31,7 @@ governing permissions and limitations under the License.
 
   /* disabled all themes */
   --spectrum-radio-disabled-content-color: var(--spectrum-disabled-content-color);
-  --spectrum-radio-disabled-border-color: var(--spectrum-gray-400);
+  --spectrum-radio-disabled-border-color: var(--spectrum-disabled-content-color);
 
   /* emphasized state colors selection indicator all themes */
   --spectrum-radio-emphasized-accent-color: var(--spectrum-accent-color-900);


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->

## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

Updates the Radio and Checkbox components to use new token for disabled content 
- replaces `--spectrum-gray-400` with `--spectrum-disabled-content-color` 

Note that the [Jira ticket ](https://jira.corp.adobe.com/browse/CSS-390) calls for the Switch component to also be updated, however this was already done in [this previously merged PR](https://github.com/adobe/spectrum-css/pull/2057/files#diff-ea9307b0b8fe931f6510d7704e8c86a215ec97918c5e306eaf8aa2074ba718a2R22). 

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

1. Open the [docs site](https://pr-2097--spectrum-css.netlify.app/checkbox) for the Checkbox component, find a disabled variant 
- [x] `--spectrum-disabled-content-color` is used for the color of the label text [@castastrophe]
- [x] `--spectrum-disabled-content-color` is used for the color of the box border [@castastrophe]
- [x] `--spectrum-disabled-content-color` is used for the color of the box border when selected [@castastrophe]
- [x] there are no visible design changes when compared to live docs site [@castastrophe]

2. Open the [docs site](https://pr-2097--spectrum-css.netlify.app/radio) for the Radio component, find a disabled variant
- [x] `--spectrum-disabled-content-color` is used for the color of the label text [@castastrophe]
- [x] `--spectrum-disabled-content-color` is used for the color of the radio border [@castastrophe]
- [x] `--spectrum-disabled-content-color` is used for the color of the radio border when selected [@castastrophe]
- [x] there are no visible design changes when compared to live docs site [@castastrophe]

### Regression testing

Validate: [@castastrophe]

1. A legacy documentation page (such as [accordion](https://pr-###--spectrum-css.netlify.app/accordion.html)), including:

- [x] The page renders correctly
- [x] The page is accessible
- [x] The page is responsive

2. A migrated documentation page (such as [action group](https://pr-###--spectrum-css.netlify.app/actiongroup.html)), including:

- [x] The page renders correctly
- [x] The page is accessible
- [x] The page is responsive

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.

- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.

- [x] ✨ This pull request is ready to merge. ✨
