### PR TITLE
fix(textfield): add line-height to prevent missing diacritics

### DIFF
--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -11,7 +11,11 @@ governing permissions and limitations under the License.
 */
 
 .spectrum-Textfield {
-	--spectrum-texfield-animation-duration: var(
+  /* set input line-height to the height of the textfield - prevents the cutting off of diacritics in some languages */
+  /* disallow mod for max compatibility */
+  --spectrum-textfield-input-line-height: var(--spectrum-textfield-height);
+	
+  --spectrum-texfield-animation-duration: var(
 		--spectrum-animation-duration-100
 	);
 
@@ -678,6 +682,8 @@ governing permissions and limitations under the License.
 
 /********* Child Element - Input *********/
 .spectrum-Textfield-input {
+  /* no mod defined to allow for maximum compatibility */
+  line-height: var(--spectrum-textfield-input-line-height);
 	box-sizing: border-box;
 	inline-size: 100%;
 	min-inline-size: var(
@@ -1251,7 +1257,8 @@ governing permissions and limitations under the License.
 
 /*** Text Area ***/
 .spectrum-Textfield--multiline {
-	.spectrum-Textfield-input {
+  --spectrum-textfield-input-line-height: normal;
+  .spectrum-Textfield-input {
 		min-inline-size: var(
 			--mod-text-area-min-inline-size,
 			var(--spectrum-text-area-min-inline-size)


### PR DESCRIPTION
This adds a line-height definition to the textfield's input and sets that value equal to the height of the input. This prevents diacritics from being cut off in certain languages. Only applies to non-multiline (textarea) inputs.

Similar to https://github.com/adobe/react-spectrum/pull/4579 in React Spectrum.

[Jira ticket](https://jira.corp.adobe.com/browse/CSS-532)

There's no visual difference for English.

Local with changes vs. production
<img width="1389" alt="Screenshot 2023-08-24 at 2 23 28 PM" src="https://github.com/adobe/spectrum-css/assets/360251/2d0b13d3-36cf-4529-8883-65da6353c4bd">

<img width="1368" alt="Screenshot 2023-08-24 at 2 23 58 PM" src="https://github.com/adobe/spectrum-css/assets/360251/67191a09-0246-41e6-8a18-51d3bb8e5e7d">


<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->

## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

<!--
  Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

### Regression testing

Validate:

1. A legacy documentation page (such as [accordion](https://pr-###--spectrum-css.netlify.app/accordion.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

2. A migrated documentation page (such as [action group](https://pr-###--spectrum-css.netlify.app/actiongroup.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [ ] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.

- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.

- [ ] ✨ This pull request is ready to merge. ✨
