### PR TITLE
feat(well)!: diy migration 

### DIFF
--- a/components/tokens/custom-express/custom-dark-vars.css
+++ b/components/tokens/custom-express/custom-dark-vars.css
@@ -14,4 +14,5 @@ governing permissions and limitations under the License.
 .spectrum--express.spectrum--dark {
   /* Drop Zone background color rgb */
   --spectrum-drop-zone-background-color-rgb: var( --spectrum-indigo-900-rgb); /* var(--spectrum-accent-color-900);*/
+  --spectrum-well-border-color:rgba(var(--spectrum-white-rgb), 0.05);
 }

--- a/components/tokens/custom-express/custom-darkest-vars.css
+++ b/components/tokens/custom-express/custom-darkest-vars.css
@@ -14,4 +14,5 @@ governing permissions and limitations under the License.
 .spectrum--express.spectrum--darkest {
   /* Drop Zone background color rgb */
   --spectrum-drop-zone-background-color-rgb: var( --spectrum-indigo-900-rgb); /* var(--spectrum-accent-color-900);*/
+  --spectrum-well-border-color:rgba(var(--spectrum-white-rgb), 0.05);
 }

--- a/components/tokens/custom-express/custom-light-vars.css
+++ b/components/tokens/custom-express/custom-light-vars.css
@@ -15,4 +15,5 @@ governing permissions and limitations under the License.
 .spectrum--express.spectrum--lightest {
   /* Drop Zone background color rgb */
   --spectrum-drop-zone-background-color-rgb: var( --spectrum-indigo-800-rgb); /* var(--spectrum-accent-color-800);*/
+  --spectrum-well-border-color:rgba(var(--spectrum-black-rgb), 0.05);
 }

--- a/components/tokens/custom-spectrum/custom-dark-vars.css
+++ b/components/tokens/custom-spectrum/custom-dark-vars.css
@@ -34,4 +34,5 @@ governing permissions and limitations under the License.
   --spectrum-coach-indicator-ring-default-color: var(--spectrum-blue-700);
   --spectrum-coach-indicator-ring-dark-color: var(--spectrum-gray-900);
   --spectrum-coach-indicator-ring-light-color: var(--spectrum-gray-50);
+  --spectrum-well-border-color:rgba(var(--spectrum-white-rgb), 0.05);
 }

--- a/components/tokens/custom-spectrum/custom-darkest-vars.css
+++ b/components/tokens/custom-spectrum/custom-darkest-vars.css
@@ -34,4 +34,5 @@ governing permissions and limitations under the License.
   --spectrum-coach-indicator-ring-default-color: var(--spectrum-blue-700);
   --spectrum-coach-indicator-ring-dark-color: var(--spectrum-gray-900);
   --spectrum-coach-indicator-ring-light-color: var(--spectrum-gray-50);
+  --spectrum-well-border-color:rgba(var(--spectrum-white-rgb), 0.05);
   }

--- a/components/tokens/custom-spectrum/custom-large-vars.css
+++ b/components/tokens/custom-spectrum/custom-large-vars.css
@@ -74,4 +74,8 @@ governing permissions and limitations under the License.
   --spectrum-coachmark-buttongroup-mobile-display: flex;
   --spectrum-coachmark-menu-display: none;
   --spectrum-coachmark-menu-mobile-display: inline-flex;
+  --spectrum-well-padding: 20px;
+  --spectrum-well-margin-top: 5px;
+  --spectrum-well-min-width: 300px;
+  --spectrum-well-border-radius: 5px
 }

--- a/components/tokens/custom-spectrum/custom-light-vars.css
+++ b/components/tokens/custom-spectrum/custom-light-vars.css
@@ -35,4 +35,5 @@ governing permissions and limitations under the License.
   --spectrum-coach-indicator-ring-default-color: var(--spectrum-blue-800);
   --spectrum-coach-indicator-ring-dark-color: var(--spectrum-gray-900);
   --spectrum-coach-indicator-ring-light-color: var(--spectrum-gray-50);
+  --spectrum-well-border-color:var(--spectrum-black-rgb);
 }

--- a/components/tokens/custom-spectrum/custom-medium-vars.css
+++ b/components/tokens/custom-spectrum/custom-medium-vars.css
@@ -74,4 +74,8 @@ governing permissions and limitations under the License.
   --spectrum-coachmark-buttongroup-mobile-display: none;
   --spectrum-coachmark-menu-display: inline-flex;
   --spectrum-coachmark-menu-mobile-display: none;
+  --spectrum-well-padding: var(--spectrum-spacing-300);
+  --spectrum-well-margin-top: var(--spectrum-spacing-75);
+  --spectrum-well-min-width: 240px;
+  --spectrum-well-border-radius: var(--spectrum-spacing-75)
 }

--- a/components/well/gulpfile.js
+++ b/components/well/gulpfile.js
@@ -1,1 +1,1 @@
-module.exports = require("@spectrum-css/component-builder");
+module.exports = require("@spectrum-css/component-builder-simple");

--- a/components/well/index.css
+++ b/components/well/index.css
@@ -11,19 +11,18 @@ governing permissions and limitations under the License.
 */
 
 .spectrum-Well {
-  --spectrum-well-padding: var(--spectrum-global-dimension-size-200);
-  --spectrum-well-border-width: var(--spectrum-alias-border-size-thin);
-  --spectrum-well-margin-top: var(--spectrum-global-dimension-size-50);
-  --spectrum-well-min-width: var(--spectrum-global-dimension-size-3000);
+  --spectrum-well-border-width: var(--spectrum-border-width-100);
 }
 
 .spectrum-Well {
   text-align: start;
   display: block;
-  min-inline-size: var(--spectrum-well-min-width);
-  padding: var(--spectrum-well-padding);
-  margin-block-start: var(--spectrum-well-margin-top);
-  border-width: var(--spectrum-well-border-width);
+  min-inline-size: var(--mod-well-min-width, var(--spectrum-well-min-width));
+  padding: var(--mod-well-padding, var(--spectrum-well-padding));
+  margin-block-start: var(--mod-well-margin-top, var(--spectrum-well-margin-top));
+  border-width: var(--mod-well-border-width, var(--spectrum-well-border-width));
   border-style: solid;
-  border-radius: var(--spectrum-alias-border-radius-regular);
+  border-radius: var(--mod-well-border-radius, var(--spectrum-well-border-radius));
+  background-color: var(--mod-well-background-color, rgba(var(--spectrum-gray-800-rgb), 0.02));
+  border-color: var(--mod-well-border-color, var(--spectrum-well-border-color));
 }

--- a/components/well/metadata/mods.md
+++ b/components/well/metadata/mods.md
@@ -1,0 +1,9 @@
+| Modifiable Custom Properties  |
+| ----------------------------- |
+| `--mod-well-background-color` |
+| `--mod-well-border-color`     |
+| `--mod-well-border-radius`    |
+| `--mod-well-border-width`     |
+| `--mod-well-margin-top`       |
+| `--mod-well-min-width`        |
+| `--mod-well-padding`          |

--- a/components/well/metadata/well.yml
+++ b/components/well/metadata/well.yml
@@ -5,9 +5,11 @@ examples:
     markup: |
       <h3 class="spectrum-Heading spectrum-Heading--sizeXXS">Well Label (Optional)</h3>
       <span class="spectrum-Well">
+       <p class="spectrum-Body">
         <em>Well done is better than well said.</em>
         <br>
         <strong>Benjamin Franklin</strong>
         <br><br>
         Well said Ben!
+        </p>
       </span>

--- a/components/well/package.json
+++ b/components/well/package.json
@@ -18,11 +18,11 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/vars": ">=9"
+    "@spectrum-css/tokens": ">=11"
   },
   "devDependencies": {
-    "@spectrum-css/component-builder": "^4.0.14",
-    "@spectrum-css/vars": "^9.0.8",
+    "@spectrum-css/component-builder-simple": "^2.0.17",
+    "@spectrum-css/tokens": "^11.2.1",
     "gulp": "^4.0.0"
   },
   "publishConfig": {

--- a/components/well/stories/template.js
+++ b/components/well/stories/template.js
@@ -2,7 +2,6 @@ import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 
 import "../index.css";
-import "../skin.css";
 
 export const Template = ({
 	rootClass = "spectrum-Well",

--- a/components/well/themes/express.css
+++ b/components/well/themes/express.css
@@ -3,14 +3,10 @@ Copyright 2023 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software distributed under
 the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
 
-.spectrum-Well {
-  background-color: var(--spectrum-well-background-color);
-  border-color: var(--spectrum-well-border-color);
-}
+@container (--system: express) {}

--- a/components/well/themes/spectrum.css
+++ b/components/well/themes/spectrum.css
@@ -1,0 +1,12 @@
+/*!
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+@container (--system: spectrum) {}


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->

## Description
The DIY migration for Well

Build system updated
implemented --mods
used custom tokens for padding, background color values

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

<!--
  Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

### Regression testing

Validate:

1. A legacy documentation page (such as [accordion](https://pr-###--spectrum-css.netlify.app/accordion.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

2. A migrated documentation page (such as [action group](https://pr-###--spectrum-css.netlify.app/actiongroup.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.

- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.

- [ ] ✨ This pull request is ready to merge. ✨
