### PR TITLE
chore(coachindicator): adds custom tokens

### DIFF
--- a/components/tokens/custom-spectrum/custom-dark-vars.css
+++ b/components/tokens/custom-spectrum/custom-dark-vars.css
@@ -30,4 +30,8 @@ governing permissions and limitations under the License.
   --spectrum-calendar-day-border-color-key-focus: var(--spectrum-blue-700);
 
   --spectrum-badge-label-icon-color-primary: var(--spectrum-black);
+
+  --spectrum-coach-indicator-ring-default-color: var(--spectrum-blue-700);
+  --spectrum-coach-indicator-ring-dark-color: var(--spectrum-gray-900);
+  --spectrum-coach-indicator-ring-light-color: var(--spectrum-gray-50);
 }

--- a/components/tokens/custom-spectrum/custom-darkest-vars.css
+++ b/components/tokens/custom-spectrum/custom-darkest-vars.css
@@ -30,4 +30,8 @@ governing permissions and limitations under the License.
   --spectrum-calendar-day-border-color-key-focus: var(--spectrum-blue-700);
 
   --spectrum-badge-label-icon-color-primary: var(--spectrum-black);
+
+  --spectrum-coach-indicator-ring-default-color: var(--spectrum-blue-700);
+  --spectrum-coach-indicator-ring-dark-color: var(--spectrum-gray-900);
+  --spectrum-coach-indicator-ring-light-color: var(--spectrum-gray-50);
   }

--- a/components/tokens/custom-spectrum/custom-large-vars.css
+++ b/components/tokens/custom-spectrum/custom-large-vars.css
@@ -65,4 +65,8 @@ governing permissions and limitations under the License.
 
   --spectrum-alert-dialog-padding: var(--spectrum-spacing-400);
   --spectrum-alert-dialog-description-to-buttons: var(--spectrum-spacing-600);
+
+  --spectrum-coach-indicator-gap: 8px;
+  --spectrum-coach-indicator-ring-diameter: 20px;
+  --spectrum-coach-indicator-quiet-ring-diameter: 10px;
 }

--- a/components/tokens/custom-spectrum/custom-light-vars.css
+++ b/components/tokens/custom-spectrum/custom-light-vars.css
@@ -31,4 +31,8 @@ governing permissions and limitations under the License.
   --spectrum-calendar-day-border-color-key-focus: var(--spectrum-blue-800);
 
   --spectrum-badge-label-icon-color-primary: var(--spectrum-white);
+
+  --spectrum-coach-indicator-ring-default-color: var(--spectrum-blue-800);
+  --spectrum-coach-indicator-ring-dark-color: var(--spectrum-gray-900);
+  --spectrum-coach-indicator-ring-light-color: var(--spectrum-gray-50);
 }

--- a/components/tokens/custom-spectrum/custom-medium-vars.css
+++ b/components/tokens/custom-spectrum/custom-medium-vars.css
@@ -65,4 +65,8 @@ governing permissions and limitations under the License.
 
   --spectrum-alert-dialog-padding: var(--spectrum-spacing-500);
   --spectrum-alert-dialog-description-to-buttons: var(--spectrum-spacing-700);
+
+  --spectrum-coach-indicator-gap: 6px;
+  --spectrum-coach-indicator-ring-diameter: var(--spectrum-spacing-300);
+  --spectrum-coach-indicator-quiet-ring-diameter: var(--spectrum-spacing-100);
 }


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->

## Description

Add custom tokens for Coach Indicator, DIY migration with in #1992 

Should be no visible changes. 

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

<!--
  Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

### Regression testing

Validate:

1. A legacy documentation page (such as [accordion](https://pr-###--spectrum-css.netlify.app/accordion.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

2. A migrated documentation page (such as [action group](https://pr-###--spectrum-css.netlify.app/actiongroup.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.

- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.

- [ ] ✨ This pull request is ready to merge. ✨
