### PR TITLE
refactor(checkbox): remove spectrum-Icon class from checkbox css

### DIFF
--- a/components/checkbox/index.css
+++ b/components/checkbox/index.css
@@ -240,7 +240,7 @@ governing permissions and limitations under the License.
         display: none;
       }
 
-      .spectrum-Icon.spectrum-Checkbox-partialCheckmark {
+      .spectrum-Checkbox-partialCheckmark {
         display: block;
 
         transform: scale(1);


### PR DESCRIPTION
## Description

Fixes Issue #2054 

Removes `.spectrum-Icon` class name from the Checkbox CSS to prevent the components from bleeding into each other. The CSS should be specific enough already to not need that additional selector.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

  1. Open the [docs](url) for the checkbox component:
 - [ ] Verify that the partial checkbox still displays as it should

### Regression testing

Validate:

1. A legacy documentation page (such as [accordion](https://pr-###--spectrum-css.netlify.app/accordion.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

3. A migrated documentation page (such as [action group](https://pr-###--spectrum-css.netlify.app/actiongroup.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.

- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.

- [x] ✨ This pull request is ready to merge. ✨
