### PR TITLE
docs: additional args for checkbox and button

### DIFF
--- a/components/button/stories/template.js
+++ b/components/button/stories/template.js
@@ -22,6 +22,8 @@ export const Template = ({
   treatment,
   onclick,
   isDisabled = false,
+  ariaExpanded,
+  ariaControls,
   ...globals
 }) => {
 	const { express } = globals;
@@ -46,7 +48,10 @@ export const Template = ({
       id=${ifDefined(id)}
       ?disabled=${isDisabled}
       @click=${onclick}
-      aria-label=${hideLabel ? iconName : undefined}>
+      aria-label=${hideLabel ? iconName : undefined}
+      aria-expanded=${ifDefined(ariaExpanded?.toString())}
+      aria-controls=${ifDefined(ariaControls)}
+    >
       ${when(iconName, () => Icon({ ...globals, iconName, size }))}
       ${when(label && !hideLabel,
         () => html`<span class=${`${rootClass}-label`}>${label}</span>`

--- a/components/button/stories/template.js
+++ b/components/button/stories/template.js
@@ -48,7 +48,7 @@ export const Template = ({
       id=${ifDefined(id)}
       ?disabled=${isDisabled}
       @click=${onclick}
-      aria-label=${hideLabel ? iconName : undefined}
+      aria-label=${ifDefined(hideLabel ? iconName : undefined)}
       aria-expanded=${ifDefined(ariaExpanded?.toString())}
       aria-controls=${ifDefined(ariaControls)}
     >

--- a/components/checkbox/stories/checkbox.stories.js
+++ b/components/checkbox/stories/checkbox.stories.js
@@ -53,6 +53,15 @@ export default {
 			},
 			control: { type: "boolean" },
 		},
+		isIndeterminate: {
+			name: "Indeterminate",
+			type: { name: "boolean" },
+			table: {
+			type: { summary: "boolean" },
+			category: "Component",
+			},
+			control: "boolean",
+		},
 	},
 	args: {
 		rootClass: "spectrum-Checkbox",
@@ -61,6 +70,7 @@ export default {
 		isChecked: false,
 		isDisabled: false,
 		isEmphasized: false,
+		isIndeterminate: false,
 	},
 	parameters: {
 		actions: {

--- a/components/checkbox/stories/template.js
+++ b/components/checkbox/stories/template.js
@@ -15,6 +15,7 @@ export const Template = ({
 	label,
 	isChecked = false,
 	isEmphasized = false,
+	isIndeterminate = false,
 	isDisabled = false,
 	title,
 	value,
@@ -55,6 +56,7 @@ export const Template = ({
 				[`${rootClass}--size${size?.toUpperCase()}`]:
 					typeof size !== "undefined",
 				[`${rootClass}--emphasized`]: isEmphasized,
+				[`is-indeterminate`]: isIndeterminate,
 				[`is-disabled`]: isDisabled,
 				...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
 			})}


### PR DESCRIPTION
## Description

Cherry-pick of updates from the Table core tokens migration branch.

- Updated storybook for Checkbox to include the missing `is-indeterminate` option.
- Updated storybook for Button to include optional props for `aria-expanded` and `aria-controls`.

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [ ] Checkbox includes the isIndeterminate control, which changes display of checkbox when true
- [ ] Button stories still render normally

### Regression testing

Validate:

1. A legacy documentation page (such as [accordion](https://pr-###--spectrum-css.netlify.app/accordion.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

2. A migrated documentation page (such as [action group](https://pr-###--spectrum-css.netlify.app/actiongroup.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.

- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.

- [ ] ✨ This pull request is ready to merge. ✨
