### PR TITLE
fix(button): button text centering on firefox

### DIFF
--- a/components/button/index.css
+++ b/components/button/index.css
@@ -155,7 +155,6 @@ a.spectrum-Button {
   @inherit: %spectrum-ButtonLabel;
   padding-block-start: calc(var(--mod-button-top-to-text, var(--spectrum-button-top-to-text)) - var(--mod-button-border-width, var(--spectrum-button-border-width)));
   padding-block-end: calc(var(--mod-button-bottom-to-text, var(--spectrum-button-bottom-to-text)) - var(--mod-button-border-width, var(--spectrum-button-border-width)));
-  white-space: nowrap;
   line-height: var(--mod-button-line-height, var(--spectrum-button-line-height));
   align-self: start;
 }

--- a/components/button/index.css
+++ b/components/button/index.css
@@ -88,7 +88,22 @@ governing permissions and limitations under the License.
   --spectrum-button-padding-label-to-icon: var(--spectrum-text-to-visual-300);
   --spectrum-button-top-to-text: var(--spectrum-button-top-to-text-extra-large);
   --spectrum-button-bottom-to-text: var(--spectrum-button-bottom-to-text-extra-large);
+}
 
+/* addresses differences in lineheight in firefox */
+@supports (-moz-appearance:none){
+  .spectrum-Button--sizeS {
+    --mod-button-top-to-text: 4px;
+  }
+  .spectrum-Button--sizeM {
+    --mod-button-top-to-text: 6px;
+  }
+  .spectrum-Button--sizeL {
+    --mod-button-top-to-text: 9px;
+  }
+  .spectrum-Button--sizeXL {
+    --mod-button-top-to-text: 13px;
+  }
 }
 
 .spectrum-Button {
@@ -261,12 +276,14 @@ a.spectrum-Button {
       --highcontrast-button-content-color-down: ButtonFace;
       --highcontrast-button-content-color-focus: ButtonFace;
 
-      .spectrum-Button-label {
-        forced-color-adjust: none;
+        .spectrum-Button-label {
+          forced-color-adjust: none;
+        }
+
       }
     }
   }
-}
+
 
 /* static variants */
 .spectrum-Button--staticWhite {

--- a/components/button/index.css
+++ b/components/button/index.css
@@ -90,22 +90,6 @@ governing permissions and limitations under the License.
   --spectrum-button-bottom-to-text: var(--spectrum-button-bottom-to-text-extra-large);
 }
 
-/* addresses differences in lineheight in firefox */
-@supports (-moz-appearance:none){
-  .spectrum-Button--sizeS {
-    --mod-button-top-to-text: 4px;
-  }
-  .spectrum-Button--sizeM {
-    --mod-button-top-to-text: 6px;
-  }
-  .spectrum-Button--sizeL {
-    --mod-button-top-to-text: 9px;
-  }
-  .spectrum-Button--sizeXL {
-    --mod-button-top-to-text: 13px;
-  }
-}
-
 .spectrum-Button {
   @inherit: %spectrum-BaseButton;
   @inherit: %spectrum-ButtonWithFocusRing;

--- a/components/button/index.css
+++ b/components/button/index.css
@@ -258,11 +258,9 @@ a.spectrum-Button {
       --highcontrast-button-content-color-hover: ButtonFace;
       --highcontrast-button-content-color-down: ButtonFace;
       --highcontrast-button-content-color-focus: ButtonFace;
-
         .spectrum-Button-label {
           forced-color-adjust: none;
         }
-
       }
     }
   }

--- a/components/tokens/custom-spectrum/custom-large-vars.css
+++ b/components/tokens/custom-spectrum/custom-large-vars.css
@@ -47,12 +47,18 @@ governing permissions and limitations under the License.
 
   --spectrum-button-top-to-text-small: 6px;
   --spectrum-button-bottom-to-text-small: 5px;
-  --spectrum-button-top-to-text-medium: 9px;
-  --spectrum-button-bottom-to-text-medium: 10px;
-  --spectrum-button-top-to-text-large: 12px;
+  --spectrum-button-top-to-text-medium: 10px;
+  --spectrum-button-bottom-to-text-medium: 9px;
+  --spectrum-button-top-to-text-large: 13px;
   --spectrum-button-bottom-to-text-large: 13px;
   --spectrum-button-top-to-text-extra-large: 16px;
   --spectrum-button-bottom-to-text-extra-large: 17px;
+
+  /* addresses differences in button text positioning in firefox */
+  @supports (-moz-appearance:none){
+    --spectrum-button-top-to-text-small: 5px;
+    --spectrum-button-top-to-text-extra-large: 15px;
+  }
 
   --spectrum-alert-banner-close-button-spacing: var(--spectrum-spacing-200);
   --spectrum-alert-banner-edge-to-divider: var(--spectrum-spacing-200);

--- a/components/tokens/custom-spectrum/custom-large-vars.css
+++ b/components/tokens/custom-spectrum/custom-large-vars.css
@@ -55,11 +55,11 @@ governing permissions and limitations under the License.
   --spectrum-button-bottom-to-text-extra-large: 17px;
 
   /* addresses differences in button text positioning in firefox */
-  @-mox-document url-prefix() {
-    @supports (-moz-apperence:none){
+  @-moz-document url-prefix() {
+
     --spectrum-button-top-to-text-small: 5px;
     --spectrum-button-top-to-text-extra-large: 15px;
-    }
+
   }
 
   --spectrum-alert-banner-close-button-spacing: var(--spectrum-spacing-200);

--- a/components/tokens/custom-spectrum/custom-large-vars.css
+++ b/components/tokens/custom-spectrum/custom-large-vars.css
@@ -55,9 +55,11 @@ governing permissions and limitations under the License.
   --spectrum-button-bottom-to-text-extra-large: 17px;
 
   /* addresses differences in button text positioning in firefox */
-  @supports (-moz-appearance:none){
+  @-mox-document url-prefix() {
+    @supports (-moz-apperence:none){
     --spectrum-button-top-to-text-small: 5px;
     --spectrum-button-top-to-text-extra-large: 15px;
+    }
   }
 
   --spectrum-alert-banner-close-button-spacing: var(--spectrum-spacing-200);

--- a/components/tokens/custom-spectrum/custom-large-vars.css
+++ b/components/tokens/custom-spectrum/custom-large-vars.css
@@ -56,10 +56,8 @@ governing permissions and limitations under the License.
 
   /* addresses differences in button text positioning in firefox */
   @-moz-document url-prefix() {
-
     --spectrum-button-top-to-text-small: 5px;
     --spectrum-button-top-to-text-extra-large: 15px;
-
   }
 
   --spectrum-alert-banner-close-button-spacing: var(--spectrum-spacing-200);

--- a/components/tokens/custom-spectrum/custom-medium-vars.css
+++ b/components/tokens/custom-spectrum/custom-medium-vars.css
@@ -54,6 +54,14 @@ governing permissions and limitations under the License.
   --spectrum-button-top-to-text-extra-large: 13px;
   --spectrum-button-bottom-to-text-extra-large: 13px;
 
+  /* addresses differences in button text positioning in firefox */
+  @supports (-moz-appearance:none){
+    --spectrum-button-top-to-text-small: 4px;
+    --spectrum-button-top-to-text-medium: 6px;
+    --spectrum-button-top-to-text-large: 9px;
+    --spectrum-button-top-to-text-extra-large: 12px;
+  }
+
   --spectrum-alert-banner-close-button-spacing: var(--spectrum-spacing-100);
   --spectrum-alert-banner-edge-to-divider: var(--spectrum-spacing-100);
   --spectrum-alert-banner-edge-to-button: var(--spectrum-spacing-100);

--- a/components/tokens/custom-spectrum/custom-medium-vars.css
+++ b/components/tokens/custom-spectrum/custom-medium-vars.css
@@ -45,21 +45,26 @@ governing permissions and limitations under the License.
 
   --spectrum-rating-icon-spacing: var(--spectrum-spacing-75);
 
-  --spectrum-button-top-to-text-small: 5px;
-  --spectrum-button-bottom-to-text-small: 4px;
-  --spectrum-button-top-to-text-medium: 7px;
-  --spectrum-button-bottom-to-text-medium: 8px;
-  --spectrum-button-top-to-text-large: 10px;
-  --spectrum-button-bottom-to-text-large: 10px;
-  --spectrum-button-top-to-text-extra-large: 13px;
-  --spectrum-button-bottom-to-text-extra-large: 13px;
+
+    --spectrum-button-top-to-text-small: 5px;
+    --spectrum-button-bottom-to-text-small: 4px;
+    --spectrum-button-top-to-text-medium: 7px;
+    --spectrum-button-bottom-to-text-medium: 8px;
+    --spectrum-button-top-to-text-large: 10px;
+    --spectrum-button-bottom-to-text-large: 10px;
+    --spectrum-button-top-to-text-extra-large: 13px;
+    --spectrum-button-bottom-to-text-extra-large: 13px;
+
+
 
   /* addresses differences in button text positioning in firefox */
-  @supports (-moz-appearance:none){
-    --spectrum-button-top-to-text-small: 4px;
-    --spectrum-button-top-to-text-medium: 6px;
-    --spectrum-button-top-to-text-large: 9px;
-    --spectrum-button-top-to-text-extra-large: 12px;
+  @-mox-document url-prefix() {
+    @supports (-moz-apperence:none){
+      --spectrum-button-top-to-text-small: 4px;
+      --spectrum-button-top-to-text-medium: 6px;
+      --spectrum-button-top-to-text-large: 9px;
+      --spectrum-button-top-to-text-extra-large: 12px;
+    }
   }
 
   --spectrum-alert-banner-close-button-spacing: var(--spectrum-spacing-100);

--- a/components/tokens/custom-spectrum/custom-medium-vars.css
+++ b/components/tokens/custom-spectrum/custom-medium-vars.css
@@ -57,12 +57,10 @@ governing permissions and limitations under the License.
 
   /* addresses differences in button text positioning in firefox */
   @-moz-document url-prefix() {
-
       --spectrum-button-top-to-text-small: 4px;
       --spectrum-button-top-to-text-medium: 6px;
       --spectrum-button-top-to-text-large: 9px;
       --spectrum-button-top-to-text-extra-large: 12px;
-
   }
 
   --spectrum-alert-banner-close-button-spacing: var(--spectrum-spacing-100);

--- a/components/tokens/custom-spectrum/custom-medium-vars.css
+++ b/components/tokens/custom-spectrum/custom-medium-vars.css
@@ -55,8 +55,6 @@ governing permissions and limitations under the License.
     --spectrum-button-top-to-text-extra-large: 13px;
     --spectrum-button-bottom-to-text-extra-large: 13px;
 
-
-
   /* addresses differences in button text positioning in firefox */
   @-mox-document url-prefix() {
     @supports (-moz-apperence:none){

--- a/components/tokens/custom-spectrum/custom-medium-vars.css
+++ b/components/tokens/custom-spectrum/custom-medium-vars.css
@@ -56,13 +56,13 @@ governing permissions and limitations under the License.
     --spectrum-button-bottom-to-text-extra-large: 13px;
 
   /* addresses differences in button text positioning in firefox */
-  @-mox-document url-prefix() {
-    @supports (-moz-apperence:none){
+  @-moz-document url-prefix() {
+
       --spectrum-button-top-to-text-small: 4px;
       --spectrum-button-top-to-text-medium: 6px;
       --spectrum-button-top-to-text-large: 9px;
       --spectrum-button-top-to-text-extra-large: 12px;
-    }
+
   }
 
   --spectrum-alert-banner-close-button-spacing: var(--spectrum-spacing-100);


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->

## Description

Addresses reported inconsistencies with text positioning with in the button component. 
Looking closer at it, this was observed only on Firefox. 

![image](https://github.com/adobe/spectrum-css/assets/63808889/841318ca-1e5f-48c9-8f81-1e52e4a35720)
In the screenshot Firefox is on the left and you can see how it is not positioned with in the line height the same as it is in chrome on the right despite having the same padding. 


Fix: 
- Use separate values for button top padding (top-to-text) for Firefox to account for the different positioning. 

[Jira CSS-576](https://jira.corp.adobe.com/browse/CSS-576)


<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

<!--
  Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->
1. Open the [Docs site](https://pr-2145--spectrum-css.netlify.app/button-primary#outline) for one of the button components on Firefox 
- [x] Text should be centered with in the button component 
- [x] Text positioning with in the button component should match that of chrome and safari [@mlogsdon18 ]

2. Open the [Docs site](https://pr-2145--spectrum-css.netlify.app/button-primary#outline) for one of the button components on Chrome or Safari  
- [ ] Text should be centered with in the button component 

### Regression testing

Validate: @jawinn 

1. A legacy documentation page (such as [accordion](https://pr-###--spectrum-css.netlify.app/accordion.html)), including:

- [x] The page renders correctly
- [x] The page is accessible
- [x] The page is responsive

5. A migrated documentation page (such as [action group](https://pr-###--spectrum-css.netlify.app/actiongroup.html)), including:

- [x] The page renders correctly
- [x] The page is accessible
- [x] The page is responsive

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.

- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.

- [ ] ✨ This pull request is ready to merge. ✨
