### PR TITLE
fix(colorhandle): disabled class

### DIFF
--- a/components/colorhandle/metadata/colorhandle.yml
+++ b/components/colorhandle/metadata/colorhandle.yml
@@ -21,7 +21,7 @@ examples:
     name: Disabled
     demoClassName: spectrum-CSSExample-example--spacious
     markup: |
-      <div class="spectrum-ColorHandle spectrum-OpacityCheckerboard" is-disabled" style="--spectrum-picked-color: rgba(255, 0, 0, 0.5); position: absolute; inset-block: 50%; inset-inline: 50%">
+      <div class="spectrum-ColorHandle spectrum-OpacityCheckerboard is-disabled" style="--spectrum-picked-color: rgba(255, 0, 0, 0.5); position: absolute; inset-block: 50%; inset-inline: 50%">
         <div class="spectrum-ColorHandle-inner"></div>
       </div>
   - id: color-area


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->

## Description

In a [previous PR](https://github.com/adobe/spectrum-css/pull/1916/files#diff-cef567e64c5625ed55f2621dd2f740ccdbe66ecde7c18c440ef1fcf386e6f6e8R19) the `is-disabled` class was dropped from the disabled variant. This puts it back. 

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

<!--
  Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

1. Open the [docs site] () for the ColorHandle component. 
- [ ] The disabled variant should display as disabled (dark gray with light gray border) 

### Regression testing

Validate:

1. A legacy documentation page (such as [accordion](https://pr-###--spectrum-css.netlify.app/accordion.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

2. A migrated documentation page (such as [action group](https://pr-###--spectrum-css.netlify.app/actiongroup.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.

- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.

- [ ] ✨ This pull request is ready to merge. ✨
