### PR TITLE
feat(page)!: migrate to spectrum-tokens

### DIFF
--- a/components/page/gulpfile.js
+++ b/components/page/gulpfile.js
@@ -1,1 +1,1 @@
-module.exports = require("@spectrum-css/component-builder");
+module.exports = require("@spectrum-css/component-builder-simple");

--- a/components/page/package.json
+++ b/components/page/package.json
@@ -18,11 +18,11 @@
     "build": "gulp"
   },
   "dependencies": {
-    "@spectrum-css/vars": "^9.0.8"
+    "@spectrum-css/tokens": "^11.3.3"
   },
   "devDependencies": {
-    "@spectrum-css/component-builder": "^4.0.14",
-    "@spectrum-css/vars": "*",
+    "@spectrum-css/component-builder-simple": "^2.0.17",
+    "@spectrum-css/tokens": "^11.3.3",
     "gulp": "^4.0.0"
   },
   "publishConfig": {

--- a/components/page/themes/express.css
+++ b/components/page/themes/express.css
@@ -10,9 +10,4 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-& {
-  background-color: var(--spectrum-alias-background-color-default);
-
-  /* Prevent tap highlights */
-  -webkit-tap-highlight-color: rgba(0,0,0,0);
-}
+@container (--system: express) {}

--- a/components/page/themes/spectrum.css
+++ b/components/page/themes/spectrum.css
@@ -10,9 +10,4 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-& {
-  background-color: var(--spectrum-gray-100);
-
-  /* Prevent tap highlights */
-  -webkit-tap-highlight-color: var(--spectrum-transparent-black-100);
-}
+@container (--system: spectrum) {}


### PR DESCRIPTION
BREAKING CHANGE: migrates the Page component to use `@adobe/spectrum-tokens`

<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->

## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

<!--
  Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

### Regression testing

Validate:

1. A legacy documentation page (such as [accordion](https://pr-###--spectrum-css.netlify.app/accordion.html)), including:

- [x] The page renders correctly
- [x] The page is accessible
- [x] The page is responsive

2. A migrated documentation page (such as [action group](https://pr-###--spectrum-css.netlify.app/actiongroup.html)), including:

- [x] The page renders correctly
- [x] The page is accessible
- [x] The page is responsive

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [ ] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.

- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.

- [ ] ✨ This pull request is ready to merge. ✨
