### PR TITLE
feat(actiongroup): add support for extra small

### DIFF
--- a/components/actiongroup/index.css
+++ b/components/actiongroup/index.css
@@ -16,6 +16,7 @@ governing permissions and limitations under the License.
   --spectrum-actiongroup-border-radius: var(--spectrum-corner-radius-100);
 }
 
+.spectrum-ActionGroup--sizeXS,
 .spectrum-ActionGroup--sizeS {
   --spectrum-actiongroup-horizontal-spacing-regular: var(--spectrum-spacing-75);
   --spectrum-actiongroup-vertical-spacing-regular: var(--spectrum-spacing-75);

--- a/components/actiongroup/metadata/actiongroup.yml
+++ b/components/actiongroup/metadata/actiongroup.yml
@@ -308,6 +308,20 @@ examples:
     markup: |
       <div class="spectrum-Examples">
         <div class="spectrum-Examples-item">
+          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">XS</h4>
+          <div class="spectrum-ActionGroup spectrum-ActionGroup--sizeXS">
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeXS spectrum-ActionGroup-item">
+              <span class="spectrum-ActionButton-label">Edit</span>
+            </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeXS spectrum-ActionGroup-item">
+              <span class="spectrum-ActionButton-label">Copy</span>
+            </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeXS spectrum-ActionGroup-item is-selected">
+              <span class="spectrum-ActionButton-label">Delete</span>
+            </button>
+          </div>
+        </div>
+        <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">S</h4>
           <div class="spectrum-ActionGroup spectrum-ActionGroup--sizeS">
             <button class="spectrum-ActionButton spectrum-ActionButton--sizeS spectrum-ActionGroup-item">
@@ -369,6 +383,20 @@ examples:
     name: Vertical Sizing
     markup: |
       <div class="spectrum-Examples">
+        <div class="spectrum-Examples-item">
+          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">XS</h4>
+          <div class="spectrum-ActionGroup spectrum-ActionGroup--vertical spectrum-ActionGroup--sizeXS">
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeXS spectrum-ActionGroup-item">
+              <span class="spectrum-ActionButton-label">Edit</span>
+            </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeXS spectrum-ActionGroup-item">
+              <span class="spectrum-ActionButton-label">Copy</span>
+            </button>
+            <button class="spectrum-ActionButton spectrum-ActionButton--sizeXS spectrum-ActionGroup-item is-selected">
+              <span class="spectrum-ActionButton-label">Delete</span>
+            </button>
+          </div>
+        </div>
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">S</h4>
           <div class="spectrum-ActionGroup spectrum-ActionGroup--vertical spectrum-ActionGroup--sizeS">

--- a/components/actiongroup/stories/actiongroup.stories.js
+++ b/components/actiongroup/stories/actiongroup.stories.js
@@ -19,7 +19,7 @@ export default {
 				type: { summary: "string" },
 				category: "Component",
 			},
-			options: ["s", "m", "l", "xl"],
+			options: ["xs", "s", "m", "l", "xl"],
 			control: "select",
 		},
 		vertical: {


### PR DESCRIPTION
## Description

Add extra small spacing support to Action group
Extra small was recently added to Action button, but support for it had not yet been added to Action group.
Includes same spacing token as small, as defined in token specs design. Adds XS to examples and storybook.

CSS-273

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation Instructions

  1. Open the [storybook](https://pr-2154--spectrum-css.netlify.app/preview/?path=/story/components-action-group--default&args=size:xs) for the Action group component:
     - [ ] Confirm that extra small is a size option and that there is spacing between the buttons that matches the small spacing (for both horizontal and vertical).
  2. Open the [docs](https://pr-2154--spectrum-css.netlify.app/actiongroup) for the Action group component:
     - [ ] Confirm that extra small appears in both "Horizontal Sizing" and "Vertical Sizing".
     - [ ] Confirm that there is spacing between the buttons that matches the small spacing.

### Regression testing

Validate:

1. A legacy documentation page (such as [accordion](https://pr-###--spectrum-css.netlify.app/accordion.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

2. A migrated documentation page (such as [action group](https://pr-###--spectrum-css.netlify.app/actiongroup.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

- [ ] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.

- [ ] ✨ This pull request is ready to merge. ✨
