### PR TITLE
feat(cyclebutton)!: migrate to spectrum tokens

### DIFF
--- a/components/cyclebutton/gulpfile.js
+++ b/components/cyclebutton/gulpfile.js
@@ -1,1 +1,1 @@
-module.exports = require("@spectrum-css/component-builder");
+module.exports = require("@spectrum-css/component-builder-simple");

--- a/components/cyclebutton/index.css
+++ b/components/cyclebutton/index.css
@@ -11,6 +11,14 @@ governing permissions and limitations under the License.
 */
 
 .spectrum-CycleButton {
+  /* 
+    force button to be square by negating
+    the :only-child selector from ActionButton-icon
+  */
+  &.spectrum-ActionButton-icon:not(:only-child) {
+    margin-inline-start: calc(var(--mod-actionbutton-edge-to-visual-only, var(--spectrum-actionbutton-edge-to-visual-only)) - var(--mod-actionbutton-edge-to-text, var(--spectrum-actionbutton-edge-to-text)));
+  }
+  
   .spectrum-CycleButton-item:not(.is-selected) {
     display: none
   }

--- a/components/cyclebutton/metadata/mods.md
+++ b/components/cyclebutton/metadata/mods.md
@@ -1,0 +1,3 @@
+| Modifiable Custom Properties      |
+| --------------------------------- |
+| `--mod-actionbutton-edge-to-text` |

--- a/components/cyclebutton/package.json
+++ b/components/cyclebutton/package.json
@@ -18,15 +18,15 @@
     "build": "gulp"
   },
   "peerDependencies": {
-    "@spectrum-css/actionbutton": ">=4",
-    "@spectrum-css/icon": ">=3",
-    "@spectrum-css/vars": ">=9"
+    "@spectrum-css/actionbutton": ">=5",
+    "@spectrum-css/icon": ">=4",
+    "@spectrum-css/tokens": ">=11"
   },
   "devDependencies": {
     "@spectrum-css/actionbutton": "^5.0.7",
-    "@spectrum-css/component-builder": "^4.0.14",
+    "@spectrum-css/component-builder-simple": "^2.0.17",
     "@spectrum-css/icon": "^4.0.1",
-    "@spectrum-css/vars": "^9.0.8",
+    "@spectrum-css/tokens": "^11.3.4",
     "gulp": "^4.0.0"
   },
   "publishConfig": {

--- a/components/cyclebutton/stories/cyclebutton.stories.js
+++ b/components/cyclebutton/stories/cyclebutton.stories.js
@@ -1,3 +1,4 @@
+import { userEvent, within } from '@storybook/testing-library';
 // Import the component markup template
 import { Template } from "./template";
 
@@ -45,3 +46,17 @@ export default {
 
 export const Default = Template.bind({});
 Default.args = {};
+
+export const Hovered = Template.bind({})
+Hovered.args = Default.args;
+Hovered.parameters = {
+  pseudo: { hover: true },
+}
+
+export const Focused = Template.bind({});
+Focused.args = Default.args;
+Focused.play = async ({ canvasElement }) => {
+	const canvas = within(canvasElement);
+	await new Promise((resolve) => setTimeout(resolve, 100));
+	await userEvent.click(canvas.getByRole('button'));
+};

--- a/components/cyclebutton/themes/express.css
+++ b/components/cyclebutton/themes/express.css
@@ -9,3 +9,5 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
+
+@container (--system: express) {}

--- a/components/cyclebutton/themes/spectrum.css
+++ b/components/cyclebutton/themes/spectrum.css
@@ -10,8 +10,4 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-.spectrum-CycleButton {
-  .spectrum-CycleButton-item:not(.is-selected) {
-    display: none
-  }
-}
+@container (--system: spectrum) {}


### PR DESCRIPTION
BREAKING CHANGE: Migrates to use `@adobe/spectrum-tokens`

Additionally:
* Removes now unnecessary padding overrides—these are provided by ActionButton definitions

<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->

## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

<!--
  Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

### Regression testing

Validate:

1. A legacy documentation page (such as [accordion](https://pr-###--spectrum-css.netlify.app/accordion.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

2. A migrated documentation page (such as [action group](https://pr-###--spectrum-css.netlify.app/actiongroup.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [ ] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.

- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.

- [ ] ✨ This pull request is ready to merge. ✨
