### PR TITLE
fix: missing semicolons in custom vars

### DIFF
--- a/components/tokens/custom-express/custom-dark-vars.css
+++ b/components/tokens/custom-express/custom-dark-vars.css
@@ -13,6 +13,6 @@ governing permissions and limitations under the License.
 
 .spectrum--express.spectrum--dark {
   /* Drop Zone background color rgb */
-  --spectrum-drop-zone-background-color-rgb: var( --spectrum-indigo-900-rgb); /* var(--spectrum-accent-color-900);*/
-  --spectrum-well-border-color:rgba(var(--spectrum-white-rgb), 0.05);
+  --spectrum-drop-zone-background-color-rgb: var(--spectrum-indigo-900-rgb); /* var(--spectrum-accent-color-900);*/
+  --spectrum-well-border-color: rgba(var(--spectrum-white-rgb), 0.05);
 }

--- a/components/tokens/custom-express/custom-darkest-vars.css
+++ b/components/tokens/custom-express/custom-darkest-vars.css
@@ -13,6 +13,6 @@ governing permissions and limitations under the License.
 
 .spectrum--express.spectrum--darkest {
   /* Drop Zone background color rgb */
-  --spectrum-drop-zone-background-color-rgb: var( --spectrum-indigo-900-rgb); /* var(--spectrum-accent-color-900);*/
-  --spectrum-well-border-color:rgba(var(--spectrum-white-rgb), 0.05);
+  --spectrum-drop-zone-background-color-rgb: var(--spectrum-indigo-900-rgb); /* var(--spectrum-accent-color-900);*/
+  --spectrum-well-border-color: rgba(var(--spectrum-white-rgb), 0.05);
 }

--- a/components/tokens/custom-express/custom-light-vars.css
+++ b/components/tokens/custom-express/custom-light-vars.css
@@ -14,6 +14,6 @@ governing permissions and limitations under the License.
 .spectrum--express.spectrum--light,
 .spectrum--express.spectrum--lightest {
   /* Drop Zone background color rgb */
-  --spectrum-drop-zone-background-color-rgb: var( --spectrum-indigo-800-rgb); /* var(--spectrum-accent-color-800);*/
-  --spectrum-well-border-color:rgba(var(--spectrum-black-rgb), 0.05);
+  --spectrum-drop-zone-background-color-rgb: var(--spectrum-indigo-800-rgb); /* var(--spectrum-accent-color-800);*/
+  --spectrum-well-border-color: rgba(var(--spectrum-black-rgb), 0.05);
 }

--- a/components/tokens/custom-spectrum/custom-dark-vars.css
+++ b/components/tokens/custom-spectrum/custom-dark-vars.css
@@ -34,6 +34,6 @@ governing permissions and limitations under the License.
   --spectrum-coach-indicator-ring-default-color: var(--spectrum-blue-700);
   --spectrum-coach-indicator-ring-dark-color: var(--spectrum-gray-900);
   --spectrum-coach-indicator-ring-light-color: var(--spectrum-gray-50);
-  --spectrum-well-border-color:rgba(var(--spectrum-white-rgb), 0.05);
+  --spectrum-well-border-color: rgba(var(--spectrum-white-rgb), 0.05);
   --spectrum-steplist-current-marker-color-key-focus: var(--spectrum-blue-700);
 }

--- a/components/tokens/custom-spectrum/custom-darkest-vars.css
+++ b/components/tokens/custom-spectrum/custom-darkest-vars.css
@@ -34,7 +34,7 @@ governing permissions and limitations under the License.
   --spectrum-coach-indicator-ring-default-color: var(--spectrum-blue-700);
   --spectrum-coach-indicator-ring-dark-color: var(--spectrum-gray-900);
   --spectrum-coach-indicator-ring-light-color: var(--spectrum-gray-50);
-  --spectrum-well-border-color:rgba(var(--spectrum-white-rgb), 0.05);
+  --spectrum-well-border-color: rgba(var(--spectrum-white-rgb), 0.05);
   --spectrum-steplist-current-marker-color-key-focus: var(--spectrum-blue-700);
 
   }

--- a/components/tokens/custom-spectrum/custom-large-vars.css
+++ b/components/tokens/custom-spectrum/custom-large-vars.css
@@ -74,8 +74,9 @@ governing permissions and limitations under the License.
   --spectrum-coachmark-buttongroup-mobile-display: flex;
   --spectrum-coachmark-menu-display: none;
   --spectrum-coachmark-menu-mobile-display: inline-flex;
+
   --spectrum-well-padding: 20px;
   --spectrum-well-margin-top: 5px;
   --spectrum-well-min-width: 300px;
-  --spectrum-well-border-radius: 5px
+  --spectrum-well-border-radius: 5px;
 }

--- a/components/tokens/custom-spectrum/custom-light-vars.css
+++ b/components/tokens/custom-spectrum/custom-light-vars.css
@@ -19,7 +19,7 @@ governing permissions and limitations under the License.
   --spectrum-menu-item-background-color-key-focus: var(--spectrum-transparent-black-200);
 
   /* Drop Zone background color rgb */
-  --spectrum-drop-zone-background-color-rgb: var( --spectrum-blue-800-rgb); /* var(--spectrum-accent-color-800);*/
+  --spectrum-drop-zone-background-color-rgb: var(--spectrum-blue-800-rgb); /* var(--spectrum-accent-color-800);*/
 
   --spectrum-calendar-day-background-color-selected: rgba(var(--spectrum-blue-900-rgb), 0.1);
   --spectrum-calendar-day-background-color-hover: rgba(var(--spectrum-black-rgb), 0.06);
@@ -35,7 +35,6 @@ governing permissions and limitations under the License.
   --spectrum-coach-indicator-ring-default-color: var(--spectrum-blue-800);
   --spectrum-coach-indicator-ring-dark-color: var(--spectrum-gray-900);
   --spectrum-coach-indicator-ring-light-color: var(--spectrum-gray-50);
-  --spectrum-well-border-color:var(--spectrum-black-rgb);
+  --spectrum-well-border-color: var(--spectrum-black-rgb);
   --spectrum-steplist-current-marker-color-key-focus: var(--spectrum-blue-800);
-
 }

--- a/components/tokens/custom-spectrum/custom-medium-vars.css
+++ b/components/tokens/custom-spectrum/custom-medium-vars.css
@@ -77,5 +77,5 @@ governing permissions and limitations under the License.
   --spectrum-well-padding: var(--spectrum-spacing-300);
   --spectrum-well-margin-top: var(--spectrum-spacing-75);
   --spectrum-well-min-width: 240px;
-  --spectrum-well-border-radius: var(--spectrum-spacing-75)
+  --spectrum-well-border-radius: var(--spectrum-spacing-75);
 }


### PR DESCRIPTION
## Description

- Add missing semicolons to two custom properties added to custom-large-vars and custom-medium-vars
- Cleans up formatting to remove/add some extra spaces on some other declarations with the custom CSS files.

<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

<!--
  Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

### Regression testing

Validate:

1. A legacy documentation page (such as [accordion](https://pr-###--spectrum-css.netlify.app/accordion.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

2. A migrated documentation page (such as [action group](https://pr-###--spectrum-css.netlify.app/actiongroup.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.

- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.

- [ ] ✨ This pull request is ready to merge. ✨
