### PR TITLE
feat(overlay): diy migration

### DIFF
--- a/components/commons/metadata/mods.md
+++ b/components/commons/metadata/mods.md
@@ -1,8 +1,4 @@
-| Modifiable Custom Properties   |
-| ------------------------------ |
-| `--mod-animation-duration-100` |
-| `--mod-focus-indicator-gap`    |
-| `--mod-line-height-100`        |
-| `--mod-sans-font-family-stack` |
+| Modifiable Custom Properties              |
+| ----------------------------------------- |
+| `--mod-overlay-animation-distance`        |
 | `--mod-overlay-animation-duration-opened` |
-| `--mod-overlay-animation-distance` |

--- a/components/commons/metadata/mods.md
+++ b/components/commons/metadata/mods.md
@@ -4,3 +4,5 @@
 | `--mod-focus-indicator-gap`    |
 | `--mod-line-height-100`        |
 | `--mod-sans-font-family-stack` |
+| `--mod-overlay-animation-duration-opened` |
+| `--mod-overlay-animation-distance` |

--- a/components/commons/overlay-coretokens.css
+++ b/components/commons/overlay-coretokens.css
@@ -14,6 +14,7 @@ governing permissions and limitations under the License.
   /* TODO: replace with core tokens */
   --spectrum-overlay-animation-distance: 6px;
   --spectrum-overlay-animation-duration: var(--spectrum-animation-duration-100);
+  --spectrum-overlay-animation-duration-opened: var(--spectrum-animation-duration-0);
 
   visibility: hidden;
 
@@ -29,26 +30,26 @@ governing permissions and limitations under the License.
 %spectrum-overlay--open {
   visibility: visible;
   opacity: 1;
-  transition-delay: 0ms;
+  transition-delay: var(--mod-overlay-animation-duration-opened, var(--spectrum-overlay-animation-duration-opened));
   pointer-events: auto;
 }
 
 %spectrum-overlay--bottom--open {
   --spectrum-overlay-animation-distance: 6px;
-  transform: translateY(var(--spectrum-overlay-animation-distance));
+  transform: translateY(var(--mod-overlay-animation-distance, var(--spectrum-overlay-animation-distance)));
 }
 
 %spectrum-overlay--top--open {
   --spectrum-overlay-animation-distance: 6px;
-  transform: translateY(calc(-1 * var(--spectrum-overlay-animation-distance)));
+  transform: translateY(calc(-1 * var(--mod-overlay-animation-distance, var(--spectrum-overlay-animation-distance))));
 }
 
 %spectrum-overlay--right--open {
   --spectrum-overlay-animation-distance: 6px;
-  transform: translateX(var(--spectrum-overlay-animation-distance));
+  transform: translateX(var(--mod-overlay-animation-distance, var(--spectrum-overlay-animation-distance)));
 }
 
 %spectrum-overlay--left--open {
   --spectrum-overlay-animation-distance: 6px;
-  transform: translateX(calc(-1 * var(--spectrum-overlay-animation-distance)));
+  transform: translateX(calc(-1 * var(--mod-overlay-animation-distance, var(--spectrum-overlay-animation-distance))));
 }

--- a/components/overlay/index.css
+++ b/components/overlay/index.css
@@ -10,15 +10,17 @@ governing permissions and limitations under the License.
 */
 
 %spectrum-overlay {
-  --spectrum-overlay-animation-distance: var(--spectrum-picker-m-texticon-popover-offset-y);
+  --spectrum-overlay-animation-distance: 6px;
+  --spectrum-overlay-animation-duration: var(--spectrum-animation-duration-100);
+  --spectrum-overlay-animation-duration-opened: var(--spectrum-animation-duration-0);
 
   visibility: hidden;
 
   opacity: 0;
 
-  transition: transform var(--spectrum-global-animation-duration-100) ease-in-out,
-              opacity var(--spectrum-global-animation-duration-100) ease-in-out,
-              visibility 0ms linear var(--spectrum-global-animation-duration-100);
+  transition: transform var(--spectrum-overlay-animation-duration) ease-in-out,
+              opacity var(--spectrum-overlay-animation-duration) ease-in-out,
+              visibility 0ms linear var(--spectrum-overlay-animation-duration);
 
   pointer-events: none;
 }
@@ -28,23 +30,23 @@ governing permissions and limitations under the License.
 
   opacity: 1;
 
-  transition-delay: 0ms;
+  transition-delay: var(--mod-overlay-animation-duration-opened, var(--spectrum-overlay-animation-duration-opened));
 
   pointer-events: auto;
 }
 
 %spectrum-overlay--bottom--open {
-  transform: translateY(var(--spectrum-overlay-animation-distance));
+  transform: translateY(var(--mod-overlay-animation-distance, var(--spectrum-overlay-animation-distance)));
 }
 
 %spectrum-overlay--top--open {
-  transform: translateY(calc(-1 * var(--spectrum-overlay-animation-distance)));
+  transform: translateY(calc(-1 * var(--mod-overlay-animation-distance, var(--spectrum-overlay-animation-distance))));
 }
 
 %spectrum-overlay--right--open {
-  transform: translateX(var(--spectrum-overlay-animation-distance));
+  transform: translateX(var(--mod-overlay-animation-distance, var(--spectrum-overlay-animation-distance)));
 }
 
 %spectrum-overlay--left--open {
-  transform: translateX(calc(-1 * var(--spectrum-overlay-animation-distance)));
+  transform: translateX(calc(-1 * var(--mod-overlay-animation-distance, var(--spectrum-overlay-animation-distance))));
 }

--- a/components/overlay/metadata/mods.md
+++ b/components/overlay/metadata/mods.md
@@ -1,0 +1,4 @@
+| Modifiable Custom Properties   |
+| ------------------------------ |
+| `--mod-overlay-animation-duration-opened` |
+| `--mod-overlay-animation-distance` |

--- a/components/overlay/metadata/mods.md
+++ b/components/overlay/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties   |
-| ------------------------------ |
+| Modifiable Custom Properties              |
+| ----------------------------------------- |
+| `--mod-overlay-animation-distance`        |
 | `--mod-overlay-animation-duration-opened` |
-| `--mod-overlay-animation-distance` |


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->

## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->
Migrating overlay component to diy core tokens.
Adding --mod values to `commons/overlay-coretokens.css`

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

<!--
  Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

### Regression testing

Validate:

1. A legacy documentation page (such as [accordion](https://pr-###--spectrum-css.netlify.app/accordion.html)), including:

- [x] The page renders correctly
- [x] The page is accessible
- [x] The page is responsive

2. A migrated documentation page (such as [action group](https://pr-###--spectrum-css.netlify.app/actiongroup.html)), including:

- [x] The page renders correctly
- [x] The page is accessible
- [x] The page is responsive

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.

- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.

- [x] ✨ This pull request is ready to merge. ✨
