### PR TITLE
feat(fieldlabel): required asterisk vertical alignment

### DIFF
--- a/components/fieldlabel/index.css
+++ b/components/fieldlabel/index.css
@@ -91,14 +91,12 @@ governing permissions and limitations under the License.
 
   -webkit-font-smoothing: subpixel-antialiased;
   -moz-osx-font-smoothing: auto;
-  font-smoothing: subpixel-antialiased;
 
   color: var(--spectrum-fieldlabel-color);
 }
 
 /* international lang support */
 .spectrum-FieldLabel {
-
   &:lang(ja),
   &:lang(zh),
   &:lang(ko) {
@@ -109,24 +107,18 @@ governing permissions and limitations under the License.
 .spectrum-FieldLabel-requiredIcon {
   margin-block: 0;
   margin-inline: var(--mod-field-label-text-to-asterisk, var(--spectrum-field-label-text-to-asterisk)) 0;
+  vertical-align: var(--mod-field-label-asterisk-vertical-align, baseline);
 }
 
-.spectrum-FieldLabel--left {
+.spectrum-FieldLabel--left,
+.spectrum-FieldLabel--right {
   display: inline-block;
   padding-block: var(--mod-fieldlabel-side-padding-top, var(--spectrum-fieldlabel-side-padding-top)) 0;
   padding-inline: 0 var(--mod-fieldlabel-side-padding-right, var(--spectrum-fieldlabel-side-padding-right));
-
-  & .spectrum-FieldLabel-requiredIcon {
-    margin-block: var(--mod-field-label-text-to-asterisk, var(--spectrum-field-label-text-to-asterisk)) 0;
-    margin-inline: var(--mod-field-label-text-to-asterisk, var(--spectrum-field-label-text-to-asterisk)) 0;
-  }
 }
 
 .spectrum-FieldLabel--right {
-  display: inline-block;
   text-align: end;
-  padding-block: var(--mod-fieldlabel-side-padding-top, var(--spectrum-fieldlabel-side-padding-top)) 0;
-  padding-inline: 0 var(--mod-fieldlabel-side-padding-right, var(--spectrum-fieldlabel-side-padding-right));
 }
 
 .spectrum-Form {
@@ -151,7 +143,6 @@ governing permissions and limitations under the License.
 }
 
 /* disabled state */
-
 .spectrum-FieldLabel,
 .spectrum-Form-itemLabel {
   &.is-disabled {
@@ -176,7 +167,7 @@ governing permissions and limitations under the License.
     display: flex;
     flex-direction: column;
 
-    &+.spectrum-Form-item {
+    & + .spectrum-Form-item {
       margin-block-start: var(--mod-field-label-top-to-asterisk, var(--spectrum-field-label-top-to-asterisk));
     }
   }

--- a/components/fieldlabel/metadata/fieldlabel.yml
+++ b/components/fieldlabel/metadata/fieldlabel.yml
@@ -7,7 +7,7 @@ sections:
   - name: Migration Guide
     description: |
       ### T-shirt sizing
-      Field Label now supports t-shirt sizing and requires that you specify the size by adding a `.spectrum-FieldLabel--size*` class.
+      Field label now supports t-shirt sizing and requires that you specify the size by adding a `.spectrum-FieldLabel--size*` class.
 examples:
   - id: fieldlabel-sizing
     name: Sizing
@@ -16,7 +16,7 @@ examples:
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">S</h4>
 
-          <label for="lifestory" class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">Life Story</label>
+          <label for="lifestory" class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">Life story</label>
           <div class="spectrum-Textfield">
             <input id="lifestory" name="field" value="" class="spectrum-Textfield-input">
           </div>
@@ -24,7 +24,7 @@ examples:
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">M (default)</h4>
 
-          <label for="lifestory" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Life Story</label>
+          <label for="lifestory" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Life story</label>
           <div class="spectrum-Textfield">
             <input id="lifestory" name="field" value="" class="spectrum-Textfield-input">
           </div>
@@ -33,7 +33,7 @@ examples:
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">L</h4>
 
-          <label for="lifestory" class="spectrum-FieldLabel spectrum-FieldLabel--sizeL">Life Story</label>
+          <label for="lifestory" class="spectrum-FieldLabel spectrum-FieldLabel--sizeL">Life story</label>
           <div class="spectrum-Textfield">
             <input id="lifestory" name="field" value="" class="spectrum-Textfield-input">
           </div>
@@ -42,7 +42,7 @@ examples:
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">XL</h4>
 
-          <label for="lifestory" class="spectrum-FieldLabel spectrum-FieldLabel--sizeXL">Life Story</label>
+          <label for="lifestory" class="spectrum-FieldLabel spectrum-FieldLabel--sizeXL">Life story</label>
           <div class="spectrum-Textfield">
             <input id="lifestory" name="field" value="" class="spectrum-Textfield-input">
           </div>
@@ -51,39 +51,40 @@ examples:
   - id: fieldlabel-standard
     name: Standard
     markup: |
-      <label for="lifestory" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Life Story</label>
+      <label for="lifestory" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Life story</label>
       <div class="spectrum-Textfield">
         <input id="lifestory" name="field" value="" class="spectrum-Textfield-input">
       </div>
 
-      <label for="lifestory2" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM is-disabled">Life Story</label>
+      <label for="lifestory2" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM is-disabled">Life story</label>
       <div class="spectrum-Textfield is-disabled">
         <input id="lifestory2" name="field" value="" class="spectrum-Textfield-input" disabled>
       </div>
   - id: fieldlabel-side-left
     name: Left
-    description: A left aligned field label.
+    description: A left aligned Field label.
     markup: |
-      <label for="lifestory3" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left" style="width: 72px">Life Story</label>
+      <label for="lifestory3" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left" style="width: 72px">Life story</label>
 
       <div class="spectrum-Textfield spectrum-Textfield--multiline">
         <textarea id="lifestory3" name="field" value="" class="spectrum-Textfield-input"></textarea>
       </div>
   - id: fieldlabel-side-right
     name: Right
-    description: A right aligned field label.
+    description: A right aligned Field label.
     markup: |
-      <label for="lifestory4" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--right" style="width: 72px">Life Story</label>
+      <label for="lifestory4" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--right" style="width: 72px">Life story</label>
 
       <div class="spectrum-Textfield spectrum-Textfield--multiline">
         <textarea id="lifestory4" name="field" value="" class="spectrum-Textfield-input"></textarea>
       </div>
   - id: fieldlabel-required
     name: Required
-    description: Field label for a required field.
+    description: A Field label for a required field can display either the text "(required)", or an asterisk. If using the asterisk icon, do not leave any space between the label text and the start of the `<svg>` element in the markup, so extra space is not added in addition to the inline margin.
     markup: |
-      <label for="lifestory5" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Life Story
-        <svg class="spectrum-Icon spectrum-UIIcon-Asterisk100 spectrum-FieldLabel-requiredIcon" focusable="false" aria-hidden="true">
+      <label for="lifestory5" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">
+        Life story<svg 
+          class="spectrum-Icon spectrum-UIIcon-Asterisk100 spectrum-FieldLabel-requiredIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-css-icon-Asterisk100" />
         </svg>
       </label>
@@ -91,7 +92,7 @@ examples:
         <input id="lifestory5" name="field" value="" class="spectrum-Textfield-input">
       </div>
 
-      <label for="lifestory6" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Life Story (Required)</label>
+      <label for="lifestory6" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Life story (required)</label>
       <div class="spectrum-Textfield">
         <input id="lifestory6" name="field" value="" class="spectrum-Textfield-input">
       </div>
@@ -99,8 +100,9 @@ examples:
       <br/>
       <br/>
 
-      <label for="lifestory7" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left">Life Story
-        <svg class="spectrum-Icon spectrum-UIIcon-Asterisk100 spectrum-FieldLabel-requiredIcon" focusable="false" aria-hidden="true">
+      <label for="lifestory7" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left">
+        Life story<svg
+          class="spectrum-Icon spectrum-UIIcon-Asterisk100 spectrum-FieldLabel-requiredIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-css-icon-Asterisk100" />
         </svg>
       </label>
@@ -108,9 +110,9 @@ examples:
         <textarea id="lifestory7" name="field" value="" class="spectrum-Textfield-input"></textarea>
       </div>
 
-
-      <label for="lifestory8" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM is-disabled">Life Story
-        <svg class="spectrum-Icon spectrum-UIIcon-Asterisk100 spectrum-FieldLabel-requiredIcon" focusable="false" aria-hidden="true">
+      <label for="lifestory8" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM is-disabled">
+        Life story<svg 
+          class="spectrum-Icon spectrum-UIIcon-Asterisk100 spectrum-FieldLabel-requiredIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-css-icon-Asterisk100" />
         </svg>
       </label>

--- a/components/fieldlabel/metadata/mods.md
+++ b/components/fieldlabel/metadata/mods.md
@@ -1,15 +1,16 @@
-| Modifiable Custom Properties          |
-| ------------------------------------- |
-| `--mod-disabled-content-color`        |
-| `--mod-field-label-text-to-asterisk`  |
-| `--mod-field-label-top-to-asterisk`   |
-| `--mod-fieldlabel-font-size`          |
-| `--mod-fieldlabel-font-weight`        |
-| `--mod-fieldlabel-line-height`        |
-| `--mod-fieldlabel-line-height-cjk`    |
-| `--mod-fieldlabel-min-height`         |
-| `--mod-fieldlabel-side-padding-right` |
-| `--mod-fieldlabel-side-padding-top`   |
-| `--mod-spacing-300`                   |
-| `--mod-tableform-border-spacing`      |
-| `--mod-tableform-margin`              |
+| Modifiable Custom Properties                |
+| ------------------------------------------- |
+| `--mod-disabled-content-color`              |
+| `--mod-field-label-asterisk-vertical-align` |
+| `--mod-field-label-text-to-asterisk`        |
+| `--mod-field-label-top-to-asterisk`         |
+| `--mod-fieldlabel-font-size`                |
+| `--mod-fieldlabel-font-weight`              |
+| `--mod-fieldlabel-line-height`              |
+| `--mod-fieldlabel-line-height-cjk`          |
+| `--mod-fieldlabel-min-height`               |
+| `--mod-fieldlabel-side-padding-right`       |
+| `--mod-fieldlabel-side-padding-top`         |
+| `--mod-spacing-300`                         |
+| `--mod-tableform-border-spacing`            |
+| `--mod-tableform-margin`                    |

--- a/components/fieldlabel/stories/fieldlabel.stories.js
+++ b/components/fieldlabel/stories/fieldlabel.stories.js
@@ -85,3 +85,19 @@ RightAligned.args = {
 	alignment: "right",
 	style: { width: "72px" },
 };
+
+export const Required = Template.bind({});
+Required.args = {
+	label: "Label example",
+	alignment: "left",
+	isRequired: true,
+	style: { width: "200px" },
+};
+
+export const WrappingAndRequired = Template.bind({});
+WrappingAndRequired.args = {
+	label: "Label example with longer text that will wrap to the next line. And with an asterisk that marks it as required.",
+	alignment: "left",
+	isRequired: true,
+	style: { width: "200px" },
+};

--- a/components/fieldlabel/stories/template.js
+++ b/components/fieldlabel/stories/template.js
@@ -63,13 +63,12 @@ export const Template = ({
 			id=${ifDefined(id)}
 			for=${ifDefined(forInput)}
 		>
-			${label}
-			${isRequired
+			${label}${isRequired
 				? Icon({
 						...globals,
 						size,
 						iconName,
-						customClasses: [`${rootClass}-UIIcon`],
+						customClasses: [`${rootClass}-UIIcon`, `${rootClass}-requiredIcon`],
 				  })
 				: ""}
 		</label>


### PR DESCRIPTION
## Description

Update the required asterisk icon (which is set to `display: inline-block`) to be vertically aligned with the baseline of the text using the `vertical-align` property, instead of using new snapshot tokens. Removes some margin-block from the asterisk that was not needed.

Also adds stories for required and wrapping + required, and updates the docs.

Note: Per confirmation with design about the original Slack discussion, the asterisk should stay inline at the end of the text. It's not currently achievable in Figma due to container/frame layouts in the tool. Because of that, the asterisk placement in Figma will not match the asterisk placement in code.

CSS-582

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation Steps

1. Design validation:
  - [x] Designer has confirmed that this alignment method looks good @jawinn 
2. Testing site validation:
  - [ ] Asterisk is aligned middle in example docs and 2 Storybook stories
  - [ ] Spacing between text and asterisk is no longer larger than it should be in examples and Storybook (markup space removed, token value should be only inline margin)
  - [ ] No other changes noticed, other than the required asterisk
3. VRT
  - [ ] VRT results are as expected and any changes accepted. There will be two new stories.

### Regression testing

Validate:

1. A legacy documentation page (such as [accordion](https://pr-###--spectrum-css.netlify.app/accordion.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

2. A migrated documentation page (such as [action group](https://pr-###--spectrum-css.netlify.app/actiongroup.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.

- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.

- [ ] ✨ This pull request is ready to merge. ✨
