### PR TITLE
docs: minor docs cleanup for table and accordion

### DIFF
--- a/components/accordion/index.css
+++ b/components/accordion/index.css
@@ -10,8 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-/* https://git.corp.adobe.com/Spectrum/spectrum-origins/pull/60 */
-
 .spectrum-Accordion {
 	--spectrum-accordion-item-height: var(--spectrum-component-height-200);
 	--spectrum-accordion-item-width: var(--spectrum-accordion-minimum-width);

--- a/components/table/metadata/table.yml
+++ b/components/table/metadata/table.yml
@@ -910,8 +910,8 @@ examples:
 
       To make sure that reverse keyboard link navigation (shift-tab) keeps the whole cell in focus, `--mod-table-current-header-height` should be dynamically updated with JS to match the height of `.spectrum-Table-head`.
     markup: |
-      <div class="spectrum-Table-scroller spectrum-Table spectrum-Table--sizeM" style="height: 200px">
-        <table class="spectrum-Table-main spectrum-Table--emphasized">
+      <div class="spectrum-Table-scroller spectrum-Table spectrum-Table--emphasized spectrum-Table--sizeM" style="height: 200px">
+        <table class="spectrum-Table-main">
           <thead class="spectrum-Table-head">
             <tr>
               <th class="spectrum-Table-headCell is-sortable is-sorted-desc" aria-sort="descending" tabindex="0">
@@ -967,7 +967,7 @@ examples:
     markup: |
       <div class="spectrum-Table-scroller spectrum-Table spectrum-Table--sizeM spectrum-Table--emphasized" style="height: 200px">
         <div class="spectrum-Table-main" role="table">
-          <div class="spectrum-Table-head role="rowgroup">
+          <div class="spectrum-Table-head" role="rowgroup">
             <div role="row">
               <div class="spectrum-Table-headCell is-sortable is-sorted-desc" role="columnheader" aria-sort="descending" tabindex="0">
                 <svg class="spectrum-Icon spectrum-UIIcon-ArrowDown100 spectrum-Table-sortedIcon" focusable="false" aria-hidden="true">


### PR DESCRIPTION
## Description

A small update to the docs
- Remove old link at top of Accordion CSS that shouldn't be there
- Move emphasized class to parent in Table scroller example markup

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.

- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.

- [ ] ✨ This pull request is ready to merge. ✨
