### PR TITLE
chore(infieldbutton): adding back in example of small stacked variant

### DIFF
--- a/components/infieldbutton/metadata/infieldbutton.yml
+++ b/components/infieldbutton/metadata/infieldbutton.yml
@@ -124,6 +124,24 @@ examples:
     markup: |
       <div class="spectrum-Examples">
         <div class="spectrum-Examples-item">
+          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">S</h4>
+          <button class="spectrum-InfieldButton spectrum-InfieldButton--sizeS spectrum-InfieldButton--top" aria-haspopup="listbox" aria-label="Add">
+            <div class="spectrum-InfieldButton-fill">
+              <svg class="spectrum-Icon spectrum-UIIcon-ChevronUp50 spectrum-InfieldButton-icon" focusable="false" aria-hidden="true">
+                  <use xlink:href="#spectrum-css-icon-Chevron50" />
+                </svg>
+            </div>
+          </button>
+          <button class="spectrum-InfieldButton spectrum-InfieldButton--sizeS spectrum-InfieldButton--bottom" aria-haspopup="listbox" aria-label="Add">
+            <div class="spectrum-InfieldButton-fill">
+              <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown50 spectrum-InfieldButton-icon" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-Chevron50" />
+              </svg>
+            </div>
+          </button>
+        </div>
+
+        <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">M</h4>
           <button class="spectrum-InfieldButton spectrum-InfieldButton--sizeM spectrum-InfieldButton--top" aria-haspopup="listbox" aria-label="Add">
             <div class="spectrum-InfieldButton-fill">


### PR DESCRIPTION
## Description

Now that we have the Chevron50 icon, this just adds back in the example for the small stacked variant of In-Field button to the docs site.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

- [ ] Visit the docs site and verify that the small stacked variant displays and shows the correctly sized icons

### Regression testing

Validate:

1. A legacy documentation page (such as [accordion](https://pr-###--spectrum-css.netlify.app/accordion.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

2. A migrated documentation page (such as [action group](https://pr-###--spectrum-css.netlify.app/actiongroup.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.

- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.

- [ ] ✨ This pull request is ready to merge. ✨
