### PR TITLE
refactor(fieldlabel): spectrum-Form cleanup and fixes

### DIFF
--- a/components/fieldlabel/index.css
+++ b/components/fieldlabel/index.css
@@ -14,7 +14,6 @@ governing permissions and limitations under the License.
   --spectrum-fieldlabel-min-height: var(--spectrum-component-height-75);
   --spectrum-fieldlabel-color: var(--spectrum-neutral-subdued-content-color-default);
 
-  --spectrum-field-label-top-to-asterisk: var(--spectrum-field-label-top-to-asterisk-medium);
   --spectrum-field-label-text-to-asterisk: var(--spectrum-field-label-text-to-asterisk-medium);
 
   --spectrum-fieldlabel-font-weight: var(--spectrum-regular-font-weight);
@@ -31,7 +30,6 @@ governing permissions and limitations under the License.
   --spectrum-fieldlabel-side-padding-top: var(--spectrum-component-top-to-text-75);
   --spectrum-fieldlabel-side-padding-right: var(--spectrum-spacing-100);
 
-  --spectrum-field-label-top-to-asterisk: var(--spectrum-field-label-top-to-asterisk-small);
   --spectrum-field-label-text-to-asterisk: var(--spectrum-field-label-text-to-asterisk-small);
 }
 
@@ -44,7 +42,6 @@ governing permissions and limitations under the License.
   --spectrum-fieldlabel-side-padding-top: var(--spectrum-component-top-to-text-75);
   --spectrum-fieldlabel-side-padding-right: var(--spectrum-spacing-200);
 
-  --spectrum-field-label-top-to-asterisk: var(--spectrum-field-label-top-to-asterisk-medium);
   --spectrum-field-label-text-to-asterisk: var(--spectrum-field-label-text-to-asterisk-medium);
 }
 
@@ -57,7 +54,6 @@ governing permissions and limitations under the License.
   --spectrum-fieldlabel-side-padding-top: var(--spectrum-component-top-to-text-100);
   --spectrum-fieldlabel-side-padding-right: var(--spectrum-spacing-200);
 
-  --spectrum-field-label-top-to-asterisk: var(--spectrum-field-label-top-to-asterisk-large);
   --spectrum-field-label-text-to-asterisk: var(--spectrum-field-label-text-to-asterisk-large);
 }
 
@@ -70,7 +66,6 @@ governing permissions and limitations under the License.
   --spectrum-fieldlabel-side-padding-top: var(--spectrum-component-top-to-text-200);
   --spectrum-fieldlabel-side-padding-right: var(--spectrum-spacing-200);
 
-  --spectrum-field-label-top-to-asterisk: var(--spectrum-field-label-top-to-asterisk-extra-large);
   --spectrum-field-label-text-to-asterisk: var(--spectrum-field-label-text-to-asterisk-extra-large);
 }
 
@@ -79,7 +74,7 @@ governing permissions and limitations under the License.
   box-sizing: border-box;
   min-block-size: var(--mod-fieldlabel-min-height, var(--spectrum-fieldlabel-min-height));
 
-  padding-block: var(--spectrum-fieldlabel-top-to-text) var(--spectrum-fieldlabel-bottom-to-text);
+  padding-block: var(--mod-field-label-top-to-text, var(--spectrum-fieldlabel-top-to-text)) var(--mod-field-label-bottom-to-text, var(--spectrum-fieldlabel-bottom-to-text));
   padding-inline: 0;
 
   font-size: var(--mod-fieldlabel-font-size, var(--spectrum-fieldlabel-font-size));
@@ -121,12 +116,11 @@ governing permissions and limitations under the License.
   text-align: end;
 }
 
+/* Form: two column alignment via display: table */
 .spectrum-Form {
-  /* for /docs/form.html to set field-label inside form */
-  --spectrum-tableform-border-spacing: 0 var(--mod-spacing-300, var(--spectrum-spacing-300));
-  /* matching 20px, missing global token for 20px */
-  --spectrum-tableform-margin-calc: calc(var(--spectrum-spacing-300) + var(--spectrum-spacing-200));
-  --spectrum-tableform-margin: calc(var(--spectrum-tableform-margin-calc) * -1) 0;
+  --spectrum-tableform-item-block-spacing: var(--spectrum-spacing-300);
+  --spectrum-tableform-border-spacing: 0 var(--mod-tableform-item-block-spacing, var(--spectrum-tableform-item-block-spacing));
+  --spectrum-tableform-margin: calc(var(--mod-tableform-item-block-spacing, var(--spectrum-tableform-item-block-spacing)) * -1) 0;
 
   display: table;
   border-collapse: separate;
@@ -138,11 +132,38 @@ governing permissions and limitations under the License.
   display: table-row;
 }
 
-.spectrum-Form-itemLabel {
+.spectrum-Form-itemLabel,
+.spectrum-Form-itemField {
   display: table-cell;
 }
 
-/* disabled state */
+/* Fix extra space after inline-flex elements such as stepper. */
+.spectrum-Form-itemField > * {
+  vertical-align: top;
+}
+
+/* Form: stacked alignment via display: flex */
+.spectrum-Form--labelsAbove {
+  --mod-tableform-margin: var(--mod-tableform-margin-labels-above, 0);
+  display: flex;
+  flex-direction: column;
+
+  .spectrum-Form-item {
+    display: flex;
+    flex-direction: column;
+
+    .spectrum-Form-itemLabel,
+    .spectrum-Form-itemField {
+      display: block;
+    }
+
+    & + .spectrum-Form-item {
+      margin-block-start: var(--mod-tableform-item-block-spacing-labels-above, var(--spectrum-spacing-200));
+    }
+  }
+}
+
+/* Disabled state */
 .spectrum-FieldLabel,
 .spectrum-Form-itemLabel {
   &.is-disabled {
@@ -150,25 +171,6 @@ governing permissions and limitations under the License.
 
     .spectrum-FieldLabel-requiredIcon {
       color: var(--highcontrast-disabled-content-color, var(--mod-disabled-content-color, var(--spectrum-disabled-content-color)));
-    }
-  }
-}
-
-.spectrum-Form-itemField {
-  display: table-cell;
-}
-
-.spectrum-Form--labelsAbove {
-  display: flex;
-  flex-direction: column;
-  margin: 0;
-
-  .spectrum-Form-item {
-    display: flex;
-    flex-direction: column;
-
-    & + .spectrum-Form-item {
-      margin-block-start: var(--mod-field-label-top-to-asterisk, var(--spectrum-field-label-top-to-asterisk));
     }
   }
 }

--- a/components/fieldlabel/metadata/form.yml
+++ b/components/fieldlabel/metadata/form.yml
@@ -2,8 +2,8 @@ name: Form
 description: Form provides structure and spacing for your form fields.
 examples:
   - id: form-labels-left
-    name: Form (labels left)
-    description: Apply `.spectrum-FieldLabel--left` to each FieldLabel to get left labels.
+    name: Standard - left-aligned text
+    description: A two column layout with left-aligned label text. Apply `.spectrum-FieldLabel--left` to each Field label.
     markup: |
       <form class="spectrum-Form">
         <div class="spectrum-Form-item">
@@ -34,8 +34,8 @@ examples:
           </div>
         </div>
 
-        <div class="spectrum-Form-item">
-          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Form-itemLabel spectrum-FieldLabel--left" for="spectrum-textinput-instance">Interests</label>
+        <div class="spectrum-Form-item" role="group" aria-labelledby="checkboxgroup-label-1">
+          <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Form-itemLabel spectrum-FieldLabel--left" id="checkboxgroup-label-1">Interests</div>
           <div class="spectrum-Form-itemField">
             <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical">
               <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
@@ -84,8 +84,8 @@ examples:
         </div>
       </form>
   - id: form-labels-right
-    name: Form (labels right)
-    description: Apply `.spectrum-FieldLabel--right` to each FieldLabel to get right labels.
+    name: Right-aligned text
+    description: A two column layout with right-aligned label text. Apply `.spectrum-FieldLabel--right` to each Field label.
     markup: |
       <form class="spectrum-Form">
         <div class="spectrum-Form-item">
@@ -116,8 +116,8 @@ examples:
           </div>
         </div>
 
-        <div class="spectrum-Form-item">
-          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Form-itemLabel spectrum-FieldLabel--right" for="spectrum-textinput-instance">Interests</label>
+        <div class="spectrum-Form-item" role="group" aria-labelledby="checkboxgroup-label-2">
+          <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Form-itemLabel spectrum-FieldLabel--right" id="checkboxgroup-label-2">Interests</div>
           <div class="spectrum-Form-itemField">
             <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical">
               <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
@@ -166,8 +166,8 @@ examples:
         </div>
       </form>
   - id: form-labels-above
-    name: Form (labels above)
-    description: "For labels above, the layout changes completely, so you must apply `.spectrum-Form--labelsAbove` to the Form itself. You do not need to apply a specific class to the FieldLabel."
+    name: Labels above
+    description: "A stacked layout with the labels above the form fields. Apply the variant class `.spectrum-Form--labelsAbove` to the Form itself. You do not need to apply a specific class to the Field label."
     markup: |
       <form class="spectrum-Form spectrum-Form--labelsAbove">
         <div class="spectrum-Form-item">
@@ -199,9 +199,9 @@ examples:
         </div>
 
         <div class="spectrum-Form-item">
-          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Form-itemLabel" for="spectrum-textinput-instance">Interests</label>
+          <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Form-itemLabel" role="group" aria-labelledby="checkboxgroup-label-3">Interests</div>
           <div class="spectrum-Form-itemField">
-            <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical">
+            <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical" id="checkboxgroup-label-3">
               <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
                 <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-0">
                 <span class="spectrum-Checkbox-box">

--- a/components/fieldlabel/metadata/mods.md
+++ b/components/fieldlabel/metadata/mods.md
@@ -1,16 +1,19 @@
-| Modifiable Custom Properties                |
-| ------------------------------------------- |
-| `--mod-disabled-content-color`              |
-| `--mod-field-label-asterisk-vertical-align` |
-| `--mod-field-label-text-to-asterisk`        |
-| `--mod-field-label-top-to-asterisk`         |
-| `--mod-fieldlabel-font-size`                |
-| `--mod-fieldlabel-font-weight`              |
-| `--mod-fieldlabel-line-height`              |
-| `--mod-fieldlabel-line-height-cjk`          |
-| `--mod-fieldlabel-min-height`               |
-| `--mod-fieldlabel-side-padding-right`       |
-| `--mod-fieldlabel-side-padding-top`         |
-| `--mod-spacing-300`                         |
-| `--mod-tableform-border-spacing`            |
-| `--mod-tableform-margin`                    |
+| Modifiable Custom Properties                      |
+| ------------------------------------------------- |
+| `--mod-disabled-content-color`                    |
+| `--mod-field-label-asterisk-vertical-align`       |
+| `--mod-field-label-bottom-to-text`                |
+| `--mod-field-label-text-to-asterisk`              |
+| `--mod-field-label-top-to-text`                   |
+| `--mod-fieldlabel-font-size`                      |
+| `--mod-fieldlabel-font-weight`                    |
+| `--mod-fieldlabel-line-height`                    |
+| `--mod-fieldlabel-line-height-cjk`                |
+| `--mod-fieldlabel-min-height`                     |
+| `--mod-fieldlabel-side-padding-right`             |
+| `--mod-fieldlabel-side-padding-top`               |
+| `--mod-tableform-border-spacing`                  |
+| `--mod-tableform-item-block-spacing`              |
+| `--mod-tableform-item-block-spacing-labels-above` |
+| `--mod-tableform-margin`                          |
+| `--mod-tableform-margin-labels-above`             |

--- a/components/fieldlabel/stories/form-template.js
+++ b/components/fieldlabel/stories/form-template.js
@@ -1,0 +1,96 @@
+import { html } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+import { styleMap } from "lit/directives/style-map.js";
+import { ifDefined } from "lit/directives/if-defined.js";
+
+import { Template as FieldLabel } from "@spectrum-css/fieldlabel/stories/template.js";
+import { Template as TextField } from "@spectrum-css/textfield/stories/template.js";
+import { Template as Picker } from "@spectrum-css/picker/stories/template.js";
+import { Template as Stepper } from "@spectrum-css/stepper/stories/template.js";
+
+import "../index.css";
+
+export const Template = ({
+	rootClass = "spectrum-Form",
+    labelsAbove,
+	customClasses = [],
+	id,
+	...globals
+}) => {
+	const { express } = globals;
+
+	try {
+		if (!express) import(/* webpackPrefetch: true */ "../themes/spectrum.css");
+		else import(/* webpackPrefetch: true */ "../themes/express.css");
+	} catch (e) {
+		console.warn(e);
+	}
+
+	return html`
+		<form
+			class=${classMap({
+				[rootClass]: true,
+                [`${rootClass}--labelsAbove`]: labelsAbove,
+				...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
+			})}
+			id=${ifDefined(id)}
+		>
+            <div class="spectrum-Form-item">
+                ${FieldLabel({
+                    label: 'Company Title',
+                    forInput: 'form-example-company',
+                    alignment: 'left',
+                })}
+                <div class="spectrum-Form-itemField">
+                    ${TextField({  
+                        multiline: true,
+                        placeholder: 'Enter your company name',
+                        name: 'field',
+                        id: 'form-example-company',
+                    })}
+                </div>
+            </div>
+            <div class="spectrum-Form-item">
+                ${FieldLabel({
+                    label: 'Email Address',
+                    forInput: 'form-example-email',
+                    alignment: labelsAbove ? undefined : 'left',
+                })}
+                <div class="spectrum-Form-itemField">
+                    ${TextField({  
+                        placeholder: 'Enter your email address',
+                        name: 'email',
+                        type: 'email',
+                        id: 'form-example-email',
+                    })}
+                </div>
+            </div>
+            <div class="spectrum-Form-item">
+                ${FieldLabel({
+                    label: 'Country',
+                    forInput: 'form-example-country',
+                    alignment: labelsAbove ? undefined : 'left',
+                })}
+                <div class="spectrum-Form-itemField">
+                    ${Picker({
+                        placeholder: 'Select a Country',
+                        name: 'country',
+                        id: 'form-example-country',
+                    })}
+                </div>
+            </div>
+            <div class="spectrum-Form-item">
+                ${FieldLabel({
+                    label: 'Amount',
+                    forInput: 'form-example-amount',
+                    alignment: labelsAbove ? undefined : 'left',
+                })}
+                <div class="spectrum-Form-itemField">
+                    ${Stepper({
+                        id: 'form-example-amount'
+                    })}
+                </div>
+            </div>
+		</form>
+	`;
+};

--- a/components/fieldlabel/stories/form.stories.js
+++ b/components/fieldlabel/stories/form.stories.js
@@ -1,0 +1,42 @@
+import { Template } from "./form-template";
+
+export default {
+	title: "Components/Form",
+	description: "The Form component is used for aligning multiple inputs and field groups within a form.",
+	component: "Form",
+	argTypes: {
+		labelsAbove: {
+			name: "Labels Above",
+			type: { name: "boolean" },
+			table: {
+				type: { summary: "boolean" },
+				category: "State",
+			},
+			control: "boolean",
+		},
+	},
+	args: {
+		rootClass: "spectrum-Form",
+		labelsAbove: false,
+	},
+	parameters: {
+		actions: {
+			handles: [],
+		},
+		status: {
+			type: process.env.MIGRATED_PACKAGES.includes("fieldlabel")
+				? "migrated"
+				: undefined,
+		},
+	},
+};
+
+export const Standard = Template.bind({});
+Standard.args = {
+	labelsAbove: false,
+};
+
+export const LabelsAbove = Template.bind({});
+LabelsAbove.args = {
+	labelsAbove: true,
+};

--- a/components/picker/metadata/picker.yml
+++ b/components/picker/metadata/picker.yml
@@ -58,7 +58,7 @@ examples:
         <div class="spectrum-Examples-item">
           <h4>Closed</h4>
           <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Country</div>
-          <button class="spectrum-Picker spectrum-Picker--sizeM" aria-haspopup="listbox" style="width: 240px">
+          <button type="button" class="spectrum-Picker spectrum-Picker--sizeM" aria-haspopup="listbox" style="width: 240px">
             <span class="spectrum-Picker-label is-placeholder">Select a Country with a very long label, too long in fact</span>
             <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
               <use xlink:href="#spectrum-css-icon-Chevron100" />
@@ -69,7 +69,7 @@ examples:
         <!-- Open -->
         <div class="spectrum-Examples-item">
           <h4>Open</h4>
-          <button class="spectrum-Picker spectrum-Picker--sizeM is-open" aria-haspopup="listbox" style="width: 240px">
+          <button type="button" class="spectrum-Picker spectrum-Picker--sizeM is-open" aria-haspopup="listbox" style="width: 240px">
             <span class="spectrum-Picker-label">Donaudampfschifffahrtsgesellschaftskapitän</span>
             <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
               <use xlink:href="#spectrum-css-icon-Chevron100" />
@@ -112,7 +112,7 @@ examples:
         <div class="spectrum-Examples-item">
           <h4>Side Label</h4>
           <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left">Country</div>
-          <button class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--sideLabel" aria-haspopup="listbox" style="width: 240px">
+          <button type="button" class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--sideLabel" aria-haspopup="listbox" style="width: 240px">
             <span class="spectrum-Picker-label is-placeholder">Select a Country with a very long label, too long in fact</span>
             <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
               <use xlink:href="#spectrum-css-icon-Chevron100" />
@@ -125,7 +125,7 @@ examples:
 
           <h4>Open with Thumbnails</h4>
           <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Country</div>
-            <button class="spectrum-Picker spectrum-Picker--sizeM is-open" aria-haspopup="listbox" style="width: 240px">
+            <button type="button" class="spectrum-Picker spectrum-Picker--sizeM is-open" aria-haspopup="listbox" style="width: 240px">
               <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Picker-icon" focusable="false" aria-hidden="true" aria-label="Image">
                 <use xlink:href="#spectrum-icon-18-Image" />
               </svg>
@@ -182,7 +182,7 @@ examples:
         <!-- Disabled -->
         <div class="spectrum-Examples-item">
           <h4>Disabled</h4>
-          <button class="spectrum-Picker spectrum-Picker--sizeM" disabled aria-haspopup="listbox" style="width: 240px">
+          <button type="button" class="spectrum-Picker spectrum-Picker--sizeM" disabled aria-haspopup="listbox" style="width: 240px">
             <span class="spectrum-Picker-label is-placeholder">Select a Country</span>
             <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
               <use xlink:href="#spectrum-css-icon-Chevron100" />
@@ -193,7 +193,7 @@ examples:
         <!-- Closed and Loading -->
         <div class="spectrum-Examples-item">
           <h4>Closed and Loading</h4>
-          <button class="spectrum-Picker spectrum-Picker--sizeM is-loading" aria-haspopup="listbox" style="width: 240px">
+          <button type="button" class="spectrum-Picker spectrum-Picker--sizeM is-loading" aria-haspopup="listbox" style="width: 240px">
             <span class="spectrum-Picker-label is-placeholder">Loading...</span>
             <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small">
                 <div class="spectrum-ProgressCircle-track"></div>
@@ -220,7 +220,7 @@ examples:
         <!-- Close and Invalid -->
         <div class="spectrum-Examples-item">
           <h4>Closed and Invalid</h4>
-          <button class="spectrum-Picker spectrum-Picker--sizeM is-invalid" aria-haspopup="listbox" style="width: 240px">
+          <button type="button" class="spectrum-Picker spectrum-Picker--sizeM is-invalid" aria-haspopup="listbox" style="width: 240px">
             <span class="spectrum-Picker-label is-placeholder">Select a Country</span>
             <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Picker-validationIcon" focusable="false" aria-hidden="true" aria-label="Folder">
               <use xlink:href="#spectrum-icon-18-Alert" />
@@ -240,7 +240,7 @@ examples:
               <use xlink:href="#spectrum-css-icon-Asterisk100" />
             </svg>
           </div>
-          <button class="spectrum-Picker spectrum-Picker--sizeM is-invalid" aria-haspopup="listbox" style="width: 240px">
+          <button type="button" class="spectrum-Picker spectrum-Picker--sizeM is-invalid" aria-haspopup="listbox" style="width: 240px">
             <span class="spectrum-Picker-label is-placeholder">Select a contact method</span>
             <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Picker-validationIcon" focusable="false" aria-hidden="true" aria-label="Folder">
               <use xlink:href="#spectrum-icon-18-Alert" />
@@ -258,7 +258,7 @@ examples:
         <!-- Open and Invalid -->
         <div class="spectrum-Examples-item">
           <h4>Open and Invalid </h4>
-          <button class="spectrum-Picker spectrum-Picker--sizeM is-invalid is-open" aria-haspopup="listbox" style="width: 240px">
+          <button type="button" class="spectrum-Picker spectrum-Picker--sizeM is-invalid is-open" aria-haspopup="listbox" style="width: 240px">
             <span class="spectrum-Picker-label">Ballard</span>
             <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Picker-validationIcon" focusable="false" aria-hidden="true" aria-label="Alert">
               <use xlink:href="#spectrum-icon-18-Alert" />
@@ -303,7 +303,7 @@ examples:
         <div class="spectrum-Examples-item">
           <h4>Closed and Disabled with Thumbnails</h4>
           <div style="position: relative; width: 240px;">
-            <button class="spectrum-Picker spectrum-Picker--sizeM is-invalid" disabled aria-haspopup="listbox" style="width: 240px">
+            <button type="button" class="spectrum-Picker spectrum-Picker--sizeM is-invalid" disabled aria-haspopup="listbox" style="width: 240px">
               <span class="spectrum-Picker-label is-placeholder">Select a Country</span>
               <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Picker-validationIcon" focusable="false" aria-hidden="true" aria-label="Alert">
                 <use xlink:href="#spectrum-icon-18-Alert" />
@@ -320,7 +320,7 @@ examples:
     name: Sizing
     markup: |
       <h4>S</h4>
-      <button class="spectrum-Picker spectrum-Picker--sizeS" aria-haspopup="listbox" style="width: 240px">
+      <button type="button" class="spectrum-Picker spectrum-Picker--sizeS" aria-haspopup="listbox" style="width: 240px">
         <span class="spectrum-Picker-label is-placeholder">Select a Country</span>
         <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown75 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-css-icon-Chevron75" />
@@ -328,7 +328,7 @@ examples:
       </button>
 
       <h4>M</h4>
-      <button class="spectrum-Picker spectrum-Picker--sizeM" aria-haspopup="listbox" style="width: 240px">
+      <button type="button" class="spectrum-Picker spectrum-Picker--sizeM" aria-haspopup="listbox" style="width: 240px">
         <span class="spectrum-Picker-label is-placeholder">Select a Country</span>
         <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-css-icon-Chevron100" />
@@ -336,7 +336,7 @@ examples:
       </button>
 
       <h4>L</h4>
-      <button class="spectrum-Picker spectrum-Picker--sizeL" aria-haspopup="listbox" style="width: 240px">
+      <button type="button" class="spectrum-Picker spectrum-Picker--sizeL" aria-haspopup="listbox" style="width: 240px">
         <span class="spectrum-Picker-label is-placeholder">Select a Country</span>
         <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown200 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-css-icon-Chevron200" />
@@ -344,7 +344,7 @@ examples:
       </button>
 
       <h4>XL</h4>
-      <button class="spectrum-Picker spectrum-Picker--sizeXL" aria-haspopup="listbox" style="width: 240px">
+      <button type="button" class="spectrum-Picker spectrum-Picker--sizeXL" aria-haspopup="listbox" style="width: 240px">
         <span class="spectrum-Picker-label is-placeholder">Select a Country</span>
         <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown300 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-css-icon-Chevron300" />
@@ -356,7 +356,7 @@ examples:
     markup: |
       <h4>Closed</h4>
       <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Country</div>
-      <button class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet" aria-haspopup="listbox">
+      <button type="button" class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet" aria-haspopup="listbox">
         <span class="spectrum-Picker-label is-placeholder">Select a Country</span>
         <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-css-icon-Chevron100" />
@@ -364,7 +364,7 @@ examples:
       </button>
 
       <h4>Open</h4>
-      <button class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet is-open" aria-haspopup="listbox">
+      <button type="button" class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet is-open" aria-haspopup="listbox">
         <span class="spectrum-Picker-label">Ballard</span>
         <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-css-icon-Chevron100" />
@@ -403,7 +403,7 @@ examples:
       <div class="dummy-spacing"></div>
 
       <h4>Open - With Thumbnails</h4>
-      <button class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet is-open" aria-haspopup="listbox">
+      <button type="button" class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet is-open" aria-haspopup="listbox">
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Picker-icon" focusable="false" aria-hidden="true" aria-label="Image">
           <use xlink:href="#spectrum-icon-18-Image" />
         </svg>
@@ -458,7 +458,7 @@ examples:
 
       <h4>Side Label</h4>
       <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left">Country</div>
-      <button class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet spectrum-Picker--sideLabel is-open" aria-haspopup="listbox">
+      <button type="button" class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet spectrum-Picker--sideLabel is-open" aria-haspopup="listbox">
         <span class="spectrum-Picker-label">Ballard</span>
         <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-css-icon-Chevron100" />
@@ -466,7 +466,7 @@ examples:
       </button>
 
       <h4>Disabled</h4>
-      <button class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet" disabled aria-haspopup="listbox">
+      <button type="button" class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet" disabled aria-haspopup="listbox">
         <span class="spectrum-Picker-label is-placeholder">Select a Country</span>
         <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-css-icon-Chevron100" />
@@ -474,7 +474,7 @@ examples:
       </button>
 
       <h4>Closed and Invalid</h4>
-      <button class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet is-invalid" aria-haspopup="listbox">
+      <button type="button" class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet is-invalid" aria-haspopup="listbox">
         <span class="spectrum-Picker-label is-placeholder">Select a Country</span>
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Picker-validationIcon" focusable="false" aria-hidden="true" aria-label="Folder">
           <use xlink:href="#spectrum-icon-18-Alert" />
@@ -485,7 +485,7 @@ examples:
       </button>
 
       <h4>Open and Invalid</h4>
-      <button class="spectrum-Picker spectrum-Picker--sizeM
+      <button type="button" class="spectrum-Picker spectrum-Picker--sizeM
       spectrum-Picker--quiet is-invalid is-open" aria-haspopup="listbox">
         <span class="spectrum-Picker-label">Ballard</span>
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Picker-validationIcon" focusable="false" aria-hidden="true" aria-label="Alert">
@@ -528,7 +528,7 @@ examples:
       <div class="dummy-spacing"></div>
 
       <h4>Disabled and Invalid</h4>
-      <button class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet is-invalid" disabled aria-haspopup="listbox">
+      <button type="button" class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet is-invalid" disabled aria-haspopup="listbox">
         <span class="spectrum-Picker-label is-placeholder">Select a Country</span>
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Picker-validationIcon" focusable="false" aria-hidden="true" aria-label="Alert">
           <use xlink:href="#spectrum-icon-18-Alert" />

--- a/components/picker/stories/template.js
+++ b/components/picker/stories/template.js
@@ -58,6 +58,7 @@ export const Picker = ({
 			?disabled=${isDisabled}
 			aria-haspopup="listbox"
 			style=${ifDefined(styleMap(customStyles))}
+			type="button"
 			@click=${(e) => {
 				updateArgs({ isOpen: !isOpen });
 			}}


### PR DESCRIPTION
## Description

### `.spectrum-Form` cleanup and fixes (this CSS exists within the fieldlabel component)

- Fixes missing spacing between form items in Labels Above variant. This was using the wrong token (top-to-asterisk)
- Removes --spectrum-field-label-top-to-asterisk as it is no longer used
- Cleans up the CSS and its custom properties a bit. Adds some additional -mod properties.
- Removed two comments that were no longer applicable. One mentioned a docs file that does not seem to exist anymore, and the other mentioned a token value of 20px but it didn't equal 20px.
- Fixes form negative margin being too large and it moving outside its container. Instead use same value as border-spacing to remove the extra space, to make this like a margin top and bottom of zero which seems like the intention.
- Adds Form stories to Storybook (previously did not exist within Storybook)
- Fixes some incorrect markup around field group in the examples

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [x] Standard variant looks the same in example docs
- [x] Margins between items in _Labels above_ variant looks correct (no longer smushed) _@jawinn I confirmed this one with the design team_
- [x] Negative margin on Standard form equals the border spacing; content no longer overflows its container (screenshot below shows previous behavior)
- [x] Two new stories appear for "Form" and look okay
- [ ] Adjusted example markup around field group looks correct

### Regression testing

Validate:

1. A legacy documentation page (such as [accordion](https://pr-###--spectrum-css.netlify.app/accordion.html)), including:

- [x] The page renders correctly
- [x] The page is accessible
- [x] The page is responsive

2. A migrated documentation page (such as [action group](https://pr-###--spectrum-css.netlify.app/actiongroup.html)), including:

- [x] The page renders correctly
- [x] The page is accessible
- [x] The page is responsive

## Screenshots

Negative margin bug in prod (negative margin too large):
<img width="486" alt="Screenshot 2023-09-15 at 7 23 28 PM" src="https://github.com/adobe/spectrum-css/assets/965114/73e78903-5488-493e-9555-efc735c6bb9b">

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.

- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.

- [ ] ✨ This pull request is ready to merge. ✨
