### PR TITLE
chore(tokens): add custom animation token

### DIFF
--- a/components/tokens/custom-spectrum/custom-vars.css
+++ b/components/tokens/custom-spectrum/custom-vars.css
@@ -30,12 +30,13 @@ governing permissions and limitations under the License.
   --spectrum-animation-duration-1000: 500ms;
   --spectrum-animation-duration-2000: 1000ms;
   --spectrum-animation-duration-4000: 2000ms;
+  --spectrum-animation-duration-6000: 3000ms;
   --spectrum-animation-ease-in-out: cubic-bezier(.45, 0, .40, 1);
   --spectrum-animation-ease-in: cubic-bezier(.50, 0, 1, 1);
   --spectrum-animation-ease-out: cubic-bezier(0, 0, 0.40, 1);
   --spectrum-animation-ease-linear: cubic-bezier(0, 0, 1, 1);
 
-  
+
   --spectrum-sans-font-family-stack: adobe-clean, var(--spectrum-sans-serif-font-family), 'Source Sans Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Ubuntu, 'Trebuchet MS', 'Lucida Grande', sans-serif;
   --spectrum-sans-serif-font: var(--spectrum-sans-font-family-stack);
 
@@ -43,7 +44,7 @@ governing permissions and limitations under the License.
   --spectrum-serif-font: var(--spectrum-serif-font-family-stack);
 
   --spectrum-code-font-family-stack: 'Source Code Pro', Monaco, monospace;
-  
+
   --spectrum-cjk-font-family-stack: adobe-clean-han-japanese, var(--spectrum-cjk-font-family), sans-serif;
   --spectrum-cjk-font: var(--spectrum-code-font-family-stack);
 


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->

## Description

Adds additional animation duration token, 3000ms, to be used in coach indicator for `--spectrum-coach-animation-indicator-ring-duration` 

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

<!--
  Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

### Regression testing

Validate:

1. A legacy documentation page (such as [accordion](https://pr-###--spectrum-css.netlify.app/accordion.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

2. A migrated documentation page (such as [action group](https://pr-###--spectrum-css.netlify.app/actiongroup.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.

- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.

- [ ] ✨ This pull request is ready to merge. ✨
