### PR TITLE
docs(splitbutton): fix spectrum link

### DIFF
--- a/components/splitbutton/metadata/splitbutton.yml
+++ b/components/splitbutton/metadata/splitbutton.yml
@@ -1,5 +1,5 @@
 name: Split button
-description: Instead of a single split button (now a deprecated component), use a button group to show any additional actions related to the most critical action. Reference [Spectrum documentation](https://spectrum.corp.adobe.com/page/button-group/#Use-a-button-group-to-show-additional-actions) for more information.
+description: Instead of a single split button (now a deprecated component), use a button group to show any additional actions related to the most critical action. Reference [Spectrum documentation](https://spectrum.adobe.com/page/button-group/#Use-a-button-group-to-show-additional-actions) for more information.
 sections:
   - name: Migration Guide
     description: |


### PR DESCRIPTION
## Description

Update spectrum link because the one introduced in #2134 seems to be failing and it isn't the official public documentation anyway

<img width="1081" alt="image" src="https://github.com/adobe/spectrum-css/assets/9648559/22824900-d5f8-4a6f-8b6d-11b656b8e321">

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

Open the [Docs Site](https://pr-2178--spectrum-css.netlify.app/splitbutton) for the Split Button component:
- [ ] Ensure you can see updated Usage Notes

### Regression testing

Validate:

1. A legacy documentation page (such as [accordion](https://pr-###--spectrum-css.netlify.app/accordion.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

2. A migrated documentation page (such as [action group](https://pr-###--spectrum-css.netlify.app/actiongroup.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

- [ ] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
