### PR TITLE
fix(popover): correct use of alert dialog with in popover

### DIFF
--- a/components/popover/metadata/popover.yml
+++ b/components/popover/metadata/popover.yml
@@ -154,7 +154,7 @@ examples:
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading" style="margin-bottom: 16px;">Alert Dialog - Error</h4>
             <div class="spectrum-Popover spectrum-Popover--top spectrum-Popover--withTip is-open" role="presentation">
-              <section class="spectrum-AlertDialog spectrum-AlertDialog--error"  role="dialog" tabindex="-1" aria-modal="true" aria-labelledby="dialog_label">
+              <section class="spectrum-AlertDialog spectrum-AlertDialog--error" role="dialog" tabindex="-1" aria-modal="true" aria-labelledby="dialog_label">
                 <div class="spectrum-AlertDialog-grid">
                   <div class="spectrum-AlertDialog-header">
                     <h1 class="spectrum-AlertDialog-heading">Unable to share</h1>

--- a/components/popover/metadata/popover.yml
+++ b/components/popover/metadata/popover.yml
@@ -131,7 +131,7 @@ examples:
 
   - id: popover-dialog
     name: Popover - Dialog style
-    description: Spectrum Popovers are implemented using the Dialog's inner elements.
+    description: Spectrum Popovers are implemented using the Dialog and Alert Dialog inner elements.
     markup: |
       <div class="spectrum-Examples">
         <div class="spectrum-Examples-item">
@@ -152,22 +152,21 @@ examples:
         </div>
 
         <div class="spectrum-Examples-item">
-          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading" style="margin-bottom: 16px;">Dialog with Error</h4>
+          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading" style="margin-bottom: 16px;">Alert Dialog - Error</h4>
             <div class="spectrum-Popover spectrum-Popover--top spectrum-Popover--withTip is-open" role="presentation">
-              <section class="spectrum-Dialog spectrum-Dialog--small spectrum-Dialog--error" role="dialog" tabindex="-1" aria-modal="true">
-                <div class="spectrum-Dialog-grid" style="display: grid;">
-                  <h1 class="spectrum-Dialog-heading spectrum-Dialog-heading--noHeader">Popover Title</h1>
-                  <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Dialog-typeIcon" focusable="false" aria-hidden="true">
-                    <use xlink:href="#spectrum-icon-18-Alert"></use>
-                  </svg>
-                  <hr class="spectrum-Divider spectrum-Divider--sizeM spectrum-Divider--horizontal spectrum-Dialog-divider">
-                  <section class="spectrum-Dialog-content">Cupcake ipsum dolor sit amet jelly beans. Chocolate jelly caramels. Icing soufflé chupa chups donut cheesecake. Jelly-o chocolate cake sweet roll cake danish candy biscuit halvah.</section>
-                  <div class="spectrum-ButtonGroup spectrum-Dialog-buttonGroup spectrum-Dialog-buttonGroup--noFooter">
-                    <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--outline spectrum-Button--secondary spectrum-ButtonGroup-item" type="button">
-                      <span class="spectrum-Button-label">Cancel</span>
-                    </button>
-                    <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--outline spectrum-Button--primary spectrum-ButtonGroup-item" type="button">
-                      <span class="spectrum-Button-label">Save</span>
+              <section class="spectrum-AlertDialog spectrum-AlertDialog--error"  role="dialog" tabindex="-1" aria-modal="true" aria-labelledby="dialog_label">
+                <div class="spectrum-AlertDialog-grid">
+                  <div class="spectrum-AlertDialog-header">
+                    <h1 class="spectrum-AlertDialog-heading">Unable to share</h1>
+                      <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true">
+                        <use xlink:href="#spectrum-icon-18-Alert" />
+                      </svg>
+                  </div>
+                  <div class="spectrum-Divider spectrum-Divider--sizeM spectrum-Divider--horizontal"></div>
+                  <section class="spectrum-AlertDialog-content">An error occured while sharing your project. Please verify the email address and try again.</section>
+                  <div class="spectrum-ButtonGroup">
+                    <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--outline spectrum-Button--primary spectrum-ButtonGroup-item" type="button" onclick="closeDialog(this.closest('.spectrum-Modal-wrapper'))">
+                      <span class="spectrum-Button-label">Continue</span>
                     </button>
                   </div>
                 </div>

--- a/components/popover/package.json
+++ b/components/popover/package.json
@@ -18,10 +18,12 @@
     "build": "gulp"
   },
   "peerDependencies": {
+    "@spectrum-css/alertdialog": ">=1",
     "@spectrum-css/dialog": ">=6",
     "@spectrum-css/tokens": ">=11"
   },
   "devDependencies": {
+    "@spectrum-css/alertdialog": "^1.0.9",
     "@spectrum-css/button": "^11.0.11",
     "@spectrum-css/component-builder-simple": "^2.0.17",
     "@spectrum-css/dialog": "^8.0.7",


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->

## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

Noticed an error introduced with recent alert dialog changes to an example on the popover component. 
Changes:
- Added new markup for the alert dialog
- Updated variant description to include alert dialog 
- Updated dependency to include alert dialog 

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Test Outline 
1. Open the Docs Page for the Popover component and scroll to Popover - Dialog Style
- [x] Styling for the Alert Dialog - error example should match [the alert dialog error] @jawinn (https://opensource.adobe.com/spectrum-css/alertdialog.html#error)  

### Regression testing

Validate: @jawinn

1. A legacy documentation page (such as [accordion](https://pr-###--spectrum-css.netlify.app/accordion.html)), including:

- [x] The page renders correctly
- [x] The page is accessible
- [x] The page is responsive

3. A migrated documentation page (such as [action group](https://pr-###--spectrum-css.netlify.app/actiongroup.html)), including:

- [x] The page renders correctly
- [x] The page is accessible
- [x] The page is responsive

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

#### Before

![Screenshot 2023-09-22 at 2 44 33 PM](https://github.com/adobe/spectrum-css/assets/63808889/4710987a-fef5-4a98-a4e6-783c3b4fa1fa)

#### After
 
![Screenshot 2023-09-22 at 2 45 17 PM](https://github.com/adobe/spectrum-css/assets/63808889/a6c1db75-e2f4-41e2-bc77-8ae901a8e759)

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.

- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.

- [ ] ✨ This pull request is ready to merge. ✨
