### PR TITLE
refactor(pagination)!: migrate to spectrum tokens

### DIFF
--- a/components/button/stories/template.js
+++ b/components/button/stories/template.js
@@ -3,7 +3,7 @@ import { classMap } from "lit/directives/class-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { when } from "lit/directives/when.js";
 
-import { lowerCase, capitalize } from "lodash-es";
+import { capitalize, lowerCase } from "lodash-es";
 
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 
@@ -17,6 +17,7 @@ export const Template = ({
   label,
   hideLabel = false,
   iconName,
+  iconAfterLabel = false,
   variant,
   staticColor,
   treatment,
@@ -52,10 +53,11 @@ export const Template = ({
       aria-expanded=${ifDefined(ariaExpanded?.toString())}
       aria-controls=${ifDefined(ariaControls)}
     >
-      ${when(iconName, () => Icon({ ...globals, iconName, size }))}
+      ${when(iconName && !iconAfterLabel, () => Icon({ ...globals, iconName, size }))}
       ${when(label && !hideLabel,
         () => html`<span class=${`${rootClass}-label`}>${label}</span>`
       )}
+      ${when(iconName && iconAfterLabel, () => Icon({ ...globals, iconName, size }))}
     </button>
   `;
 };

--- a/components/pagination/gulpfile.js
+++ b/components/pagination/gulpfile.js
@@ -1,1 +1,1 @@
-module.exports = require("@spectrum-css/component-builder");
+module.exports = require('@spectrum-css/component-builder-simple');

--- a/components/pagination/index.css
+++ b/components/pagination/index.css
@@ -10,6 +10,14 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+.spectrum-Pagination {
+  --spectrum-pagination-counter-margin-inline-start: var(--spectrum-pagination-item-inline-spacing);
+  --spectrum-pagination-page-button-inline-spacing: var(--spectrum-pagination-item-inline-spacing);
+  --spectrum-pagination-counter-color: var(--spectrum-neutral-subdued-content-color-default);
+  --spectrum-pagination-counter-font-size: var(--spectrum-font-size-100);
+  --spectrum-pagination-counter-line-height: var(-spectrum-line-height-100);
+}
+
 .spectrum-Pagination--explicit,
 .spectrum-Pagination--listing {
   display: flex;
@@ -17,26 +25,33 @@ governing permissions and limitations under the License.
   align-items: center;
 }
 
+/* Explicit variant elements */
 .spectrum-Pagination-textfield {
-  inline-size: var(--spectrum-pagination-textfield-width);
-  min-inline-size: var(--spectrum-pagination-textfield-width);
+  --mod-textfield-width: var(--mod-pagination-textfield-width, var(--spectrum-pagination-textfield-width));
+  --mod-textfield-min-width: var(--mod-pagination-textfield-width, var(--spectrum-pagination-textfield-width));
 }
 
 .spectrum-Pagination-counter {
-  margin-inline-start: var(--spectrum-pagination-counter-margin-left);
+  font-size: var(--mod-pagination-counter-font-size, var(--spectrum-pagination-counter-font-size));
+  line-height: var(--mod-pagination-counter-line-height, var(--spectrum-pagination-counter-line-height));
+  margin-inline-start: var(--mod-pagination-counter-margin-inline-start, var(--spectrum-pagination-counter-margin-inline-start));
+  color: var(--mod-pagination-counter-color, var(--spectrum-pagination-counter-color));
 }
 
+/* Previous and next buttons */
 .spectrum-Pagination-prevButton {
-  margin-inline-end: var(--spectrum-pagination-page-button-margin-horizontal);
+  margin-inline-end: var(--mod-pagination-page-button-inline-spacing, var(--spectrum-pagination-page-button-inline-spacing));
 }
 
 .spectrum-Pagination-nextButton {
-  margin-inline-start: var(--spectrum-pagination-page-button-margin-horizontal);
+  margin-inline-start: var(--mod-pagination-page-button-inline-spacing, var(--spectrum-pagination-page-button-inline-spacing));
 }
 
-.spectrum-Pagination-prevButton,
-.spectrum-Pagination-nextButton {
-  .spectrum-Icon {
-    transform: logical rotate(0deg);
-  }
+/* Correct the direction of the arrows when viewing right-to-left */
+.spectrum-Pagination-prevButton .spectrum-Icon {
+  transform: logical rotate(180deg);
+}
+
+.spectrum-Pagination-nextButton .spectrum-Icon {
+  transform: logical rotate(0deg);
 }

--- a/components/pagination/metadata/mods.md
+++ b/components/pagination/metadata/mods.md
@@ -1,0 +1,10 @@
+| Modifiable Custom Properties                   |
+| ---------------------------------------------- |
+| `--mod-pagination-counter-color`               |
+| `--mod-pagination-counter-font-size`           |
+| `--mod-pagination-counter-line-height`         |
+| `--mod-pagination-counter-margin-inline-start` |
+| `--mod-pagination-page-button-inline-spacing`  |
+| `--mod-pagination-textfield-width`             |
+| `--mod-textfield-min-width`                    |
+| `--mod-textfield-width`                        |

--- a/components/pagination/metadata/pagination-explicit.yml
+++ b/components/pagination/metadata/pagination-explicit.yml
@@ -18,7 +18,7 @@ examples:
         <div class="spectrum-Textfield spectrum-Pagination-textfield">
           <input type="text" name="field" value="2" class="spectrum-Textfield-input">
         </div>
-        <span class="spectrum-Body--secondary spectrum-Pagination-counter">of 89 pages</span>
+        <span class="spectrum-Pagination-counter">of 89 pages</span>
         <a href="#" class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-Pagination-nextButton">
           <svg class="spectrum-Icon spectrum-UIIcon-ChevronRight100" focusable="false" aria-hidden="true" aria-label="ChevronLeft">
             <use xlink:href="#spectrum-css-icon-Chevron100"></use>

--- a/components/pagination/package.json
+++ b/components/pagination/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spectrum-css/pagination",
   "version": "6.0.50",
-  "description": "The Spectrum CSS pagination component",
+  "description": "The Spectrum CSS Pagination component",
   "license": "Apache-2.0",
   "author": "Adobe",
   "homepage": "https://opensource.adobe.com/spectrum-css/pagination",
@@ -23,16 +23,16 @@
     "@spectrum-css/icon": ">=3",
     "@spectrum-css/splitbutton": ">=5",
     "@spectrum-css/textfield": ">=5",
-    "@spectrum-css/vars": ">=9"
+    "@spectrum-css/tokens": ">=11"
   },
   "devDependencies": {
     "@spectrum-css/actionbutton": "^5.0.11",
     "@spectrum-css/button": "^11.0.12",
-    "@spectrum-css/component-builder": "^4.0.14",
+    "@spectrum-css/component-builder-simple": "^2.0.17",
     "@spectrum-css/icon": "^4.0.3",
     "@spectrum-css/splitbutton": "^6.0.12",
     "@spectrum-css/textfield": "^6.0.24",
-    "@spectrum-css/vars": "^9.0.8",
+    "@spectrum-css/tokens": "^11.3.7",
     "gulp": "^4.0.0"
   },
   "publishConfig": {

--- a/components/pagination/stories/pagination.stories.js
+++ b/components/pagination/stories/pagination.stories.js
@@ -13,6 +13,7 @@ export default {
 			name: "Size",
 			type: { name: "string", required: true },
 			table: {
+				disable: true,
 				type: { summary: "string" },
 				category: "Component",
 			},
@@ -66,4 +67,10 @@ Default.args = {
 export const Explicit = Template.bind({});
 Explicit.args = {
 	variant: "explicit",
+};
+
+export const Button = Template.bind({});
+Button.storyName = "Button style";
+Button.args = {
+	variant: "button",
 };

--- a/components/pagination/stories/template.js
+++ b/components/pagination/stories/template.js
@@ -2,12 +2,12 @@ import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { repeat } from "lit/directives/repeat.js";
 
-import { Template as Button } from "@spectrum-css/button/stories/template.js";
 import { Template as ActionButton } from "@spectrum-css/actionbutton/stories/template.js";
+import { Template as Button } from "@spectrum-css/button/stories/template.js";
+import { Template as SplitButton } from "@spectrum-css/splitbutton/stories/template.js";
 import { Template as Textfield } from "@spectrum-css/textfield/stories/template.js";
 
 import "../index.css";
-import "../skin.css";
 
 // More on component templates: https://storybook.js.org/docs/web-components/writing-stories/introduction#using-args
 export const Template = ({
@@ -34,12 +34,11 @@ export const Template = ({
 					customClasses: [`${rootClass}-prevButton`],
 				})}
 				${Textfield({
+					size,
 					value: "1",
 					customClasses: [`${rootClass}-textfield`],
 				})}
-				<span class="spectrum-Body--secondary ${rootClass}-counter"
-					>of 89 pages</span
-				>
+				<span class="${rootClass}-counter">of 89 pages</span>
 				${ActionButton({
 					size,
 					isQuiet: true,
@@ -48,6 +47,16 @@ export const Template = ({
 				})}
 			</nav>
 		`;
+	} else if (variant == "button") {
+		return SplitButton({
+			position: "left",
+			variant: "accent",
+			label: "Next",
+			iconName: "ChevronLeft100",
+			labelIconName: "ChevronRight100",
+			customFirstButtonClasses: ["spectrum-Pagination-prevButton"],
+			customLastButtonClasses: ["spectrum-Pagination-nextButton"]
+		});
 	}
 	return html`
 		<nav
@@ -73,6 +82,7 @@ export const Template = ({
 						return ActionButton({
 							...globals,
 							...item,
+							size,
 							isQuiet: true,
 						});
 					} else return item;

--- a/components/pagination/themes/express.css
+++ b/components/pagination/themes/express.css
@@ -1,0 +1,13 @@
+/*!
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+@container (--system: express) {}

--- a/components/pagination/themes/spectrum.css
+++ b/components/pagination/themes/spectrum.css
@@ -10,21 +10,4 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-.spectrum-Pagination-pageButton {
-  &:hover {
-    background-color: var(--spectrum-pagination-page-button-background-color-hover);
-  }
-
-  &:focus {
-    border-color: var(--spectrum-pagination-page-button-border-color-key-focus);
-  }
-
-  &.is-selected {
-    background-color: var(--spectrum-pagination-page-button-background-color-down);
-    color: var(--spectrum-pagination-page-button-text-color-down);
-  }
-}
-
-.spectrum-Pagination-counter {
-  color: var(--spectrum-alias-label-text-color);
-}
+@container (--system: spectrum) {}

--- a/components/splitbutton/stories/splitbutton.stories.js
+++ b/components/splitbutton/stories/splitbutton.stories.js
@@ -18,7 +18,7 @@ export default {
 			name: "Variant",
 			type: { name: "string" },
 			table: { disable: true },
-			options: ["cta", "primary", "secondary"],
+			options: ["accent", "primary", "secondary"],
 			control: "select",
 		},
 		position: {

--- a/components/splitbutton/stories/template.js
+++ b/components/splitbutton/stories/template.js
@@ -8,9 +8,12 @@ import "../index.css";
 export const Template = ({
 	rootClass = "spectrum-SplitButton",
 	customClasses = [],
+	customFirstButtonClasses = [],
+	customLastButtonClasses = [],
 	size = "m",
 	variant = "cta",
 	iconName = "ChevronDown100",
+	labelIconName = undefined,
 	position = "right",
 	label = "Split Button",
 	...globals
@@ -28,25 +31,34 @@ export const Template = ({
 				...globals,
 				variant,
 				size,
-				iconName: position === "right" ? undefined : iconName,
+				iconName: position === "right"
+					? typeof labelIconName != "undefined" ? labelIconName : undefined
+					: iconName,
 				label: position === "right" ? label : undefined,
 				hideLabel: position === "right" ? false : true,
-				customClasses:
+				customClasses: [
 					position === "right"
-						? ["spectrum-SplitButton-action"]
-						: ["spectrum-SplitButton-trigger"],
+						? "spectrum-SplitButton-action"
+						: "spectrum-SplitButton-trigger",
+					...customFirstButtonClasses
+				]
 			})}
 			${Button({
 				...globals,
 				variant,
 				size,
-				iconName: position === "right" ? iconName : undefined,
+				iconName: position === "right"
+					? iconName 
+					: typeof labelIconName != "undefined" ? labelIconName : undefined,
+				iconAfterLabel: true,
 				label: position === "right" ? undefined : label,
 				hideLabel: position === "right" ? true : false,
-				customClasses:
+				customClasses: [
 					position === "right"
-						? ["spectrum-SplitButton-trigger"]
-						: ["spectrum-SplitButton-action"],
+						? "spectrum-SplitButton-trigger"
+						: "spectrum-SplitButton-action",
+					...customLastButtonClasses
+				]
 			})}
 		</div>
 	`;


### PR DESCRIPTION
## Description

Migrates the **Pagination** component to use Spectrum tokens.
This also:
- Removes the `.spectrum-Pagination-pageButton` class styles, as this is no longer used anywhere in the repository
- Fixes the following bug with RTL arrows, as seen in prod:
  ![Screenshot 2023-09-27 at 4 48 53 PM](https://github.com/adobe/spectrum-css/assets/965114/d1de5929-e599-4d57-bf4f-4afeb6c1264e)

CSS-505

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation Steps

<!--
  Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

### Regression testing

Validate:

1. A legacy documentation page (such as [accordion](https://pr-###--spectrum-css.netlify.app/accordion.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

2. A migrated documentation page (such as [action group](https://pr-###--spectrum-css.netlify.app/actiongroup.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.

- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.

- [ ] ✨ This pull request is ready to merge. ✨
