### PR TITLE
fix(menu): drill-in disabled menu item chevron

### DIFF
--- a/components/menu/index.css
+++ b/components/menu/index.css
@@ -512,34 +512,6 @@ governing permissions and limitations under the License.
   }
 }
 
-.spectrum-Menu-item.is-disabled,
-.spectrum-Menu-item[aria-disabled="true"] {
-  background-color: transparent;
-
-  .spectrum-Menu-itemLabel,
-  .spectrum-Menu-sectionHeading {
-    color: var(--highcontrast-menu-item-color-disabled, var(--mod-menu-item-label-content-color-disabled, var(--spectrum-menu-item-label-content-color-disabled)));
-  }
-  
-  .spectrum-Menu-itemDescription {
-    color: var(--highcontrast-menu-item-color-disabled, var(--mod-menu-item-description-color-disabled, var(--spectrum-menu-item-description-color-disabled)));
-  }
-  
-  .spectrum-Menu-itemIcon {
-    fill: var(--highcontrast-menu-item-color-disabled, var(--mod-menu-item-label-icon-color-disabled, var(--spectrum-menu-item-label-icon-color-disabled)));
-    color: var(--highcontrast-menu-item-color-disabled, var(--mod-menu-item-label-icon-color-disabled, var(--spectrum-menu-item-label-icon-color-disabled)));
-  }
-
-  &:hover {
-    cursor: default;
-
-    .spectrum-Menu-itemIcon {
-      fill: var(--highcontrast-menu-item-color-disabled, var(--mod-menu-item-label-icon-color-disabled, var(--spectrum-menu-item-label-icon-color-disabled)));
-      color: var(--highcontrast-menu-item-color-disabled, var(--mod-menu-item-label-icon-color-disabled, var(--spectrum-menu-item-label-icon-color-disabled)));
-    }
-  }
-}
-
 .spectrum-Menu-itemIcon {
   grid-area: iconArea;
   align-self: start;
@@ -780,5 +752,34 @@ governing permissions and limitations under the License.
       fill: var(--highcontrast-menu-item-color-focus, var(--mod-menu-drillin-icon-color-down, var(--spectrum-menu-drillin-icon-color-down)));
       color: var(--highcontrast-menu-item-color-focus, var(--mod-menu-drillin-icon-color-down, var(--spectrum-menu-drillin-icon-color-down)));
     }    
+  }
+}
+
+/* Disabled menu items */
+.spectrum-Menu-item.is-disabled,
+.spectrum-Menu-item[aria-disabled="true"] {
+  background-color: transparent;
+
+  .spectrum-Menu-itemLabel,
+  .spectrum-Menu-sectionHeading {
+    color: var(--highcontrast-menu-item-color-disabled, var(--mod-menu-item-label-content-color-disabled, var(--spectrum-menu-item-label-content-color-disabled)));
+  }
+  
+  .spectrum-Menu-itemDescription {
+    color: var(--highcontrast-menu-item-color-disabled, var(--mod-menu-item-description-color-disabled, var(--spectrum-menu-item-description-color-disabled)));
+  }
+  
+  .spectrum-Menu-itemIcon {
+    fill: var(--highcontrast-menu-item-color-disabled, var(--mod-menu-item-label-icon-color-disabled, var(--spectrum-menu-item-label-icon-color-disabled)));
+    color: var(--highcontrast-menu-item-color-disabled, var(--mod-menu-item-label-icon-color-disabled, var(--spectrum-menu-item-label-icon-color-disabled)));
+  }
+
+  &:hover {
+    cursor: default;
+
+    .spectrum-Menu-itemIcon {
+      fill: var(--highcontrast-menu-item-color-disabled, var(--mod-menu-item-label-icon-color-disabled, var(--spectrum-menu-item-label-icon-color-disabled)));
+      color: var(--highcontrast-menu-item-color-disabled, var(--mod-menu-item-label-icon-color-disabled, var(--spectrum-menu-item-label-icon-color-disabled)));
+    }
   }
 }

--- a/components/menu/stories/menu.stories.js
+++ b/components/menu/stories/menu.stories.js
@@ -342,7 +342,12 @@ DrillInSubmenu.args = {
       isDrillIn: true,
       isOpen: true,
     },
-    { label: "Select and Mask..." },
+    {
+      label: "Select and Mask...",
+      isDrillIn: true,
+      isDisabled: true,
+      isOpen: true,
+    },
     { label: "Save Selection" },
   ],
 };


### PR DESCRIPTION
## Description

A drill-in set to "open" was no longer showing the disabled color for the chevron icon. Moves disabled CSS after other CSS, which resolves this issue.

Also adds this case in the existing Storybook example for drill-in.

Fixes #2176

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation Steps

- [x] Open the drill-in example in Storybook and confirm that Issue #2176 is fixed. Including on hover. One of the menu items for this story is now set to open and disabled. - @mdt2 

### Regression testing

Validate:

1. A legacy documentation page (such as [accordion](https://pr-###--spectrum-css.netlify.app/accordion.html)), including:

- [x] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

2. A migrated documentation page (such as [action group](https://pr-###--spectrum-css.netlify.app/actiongroup.html)), including:

- [x] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.

- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.

- [ ] ✨ This pull request is ready to merge. ✨
