### PR TITLE
feat(menu): tray submenus

### DIFF
--- a/components/checkbox/stories/template.js
+++ b/components/checkbox/stories/template.js
@@ -66,10 +66,10 @@ export const Template = ({
 			<input
 				type="checkbox"
 				class="${rootClass}-input"
-				aria-labelledby=${ariaLabelledby}
+				aria-labelledby=${ifDefined(ariaLabelledby)}
 				?checked=${isChecked}
 				?disabled=${isDisabled}
-				title=${ifDefined(label || title)}
+				title=${ifDefined(title)}
 				value=${ifDefined(value)}
 				@change=${() => {
 					if (isDisabled) return;

--- a/components/menu/index.css
+++ b/components/menu/index.css
@@ -794,15 +794,43 @@ governing permissions and limitations under the License.
 }
 
 /* Tray submenu */
-.spectrum-Menu-item--back {
+.spectrum-Menu-back {
   display: flex;
   flex-flow: row wrap;
   align-items: center;
   padding-inline-start: var(--mod-menu-back-padding-inline-start, 0);
   padding-block: var(--mod-menu-back-padding-block, 0);
+
+  .spectrum-Menu-sectionHeading {
+    padding: 0;
+  }
+}
+
+.spectrum-Menu-backButton {
+  padding: 0;
+  margin: 0;
+  background: transparent;
+  border: 0;
+  display: inline-flex;
+  cursor: pointer;
+
+  &:focus-visible {
+    outline: var(--spectrum-focus-indicator-thickness) solid var(--spectrum-focus-indicator-color);
+    outline-offset: calc(-1 * (var(--spectrum-focus-indicator-thickness) + 1px));
+  }
+}
+
+.spectrum-Menu-backHeading {
+  display: block;
+  color: var(--highcontrast-menu-item-color-default, var(--mod-menu-back-heading-color, var(--spectrum-menu-section-header-color)));
+  font-size: var(--mod-menu-section-header-font-size, var(--spectrum-menu-section-header-font-size));
+  font-weight: var(--mod-menu-section-header-font-weight, var(--spectrum-menu-section-header-font-weight));
+  line-height: var(--mod-menu-section-header-line-height, var(--spectrum-menu-section-header-line-height));
 }
 
 .spectrum-Menu-backIcon {
   margin-block: var(--mod-menu-back-icon-margin-block, var(--spectrum-menu-back-icon-margin));
   margin-inline: var(--mod-menu-back-icon-margin-inline, var(--spectrum-menu-back-icon-margin));
+  fill: var(--highcontrast-menu-item-color-default, var(--mod-menu-back-icon-color-default));
+  color: var(--highcontrast-menu-item-color-default, var(--mod-menu-back-icon-color-default));
 }

--- a/components/menu/index.css
+++ b/components/menu/index.css
@@ -91,6 +91,8 @@ governing permissions and limitations under the License.
   --spectrum-menu-checkmark-display-shown: block;
   --spectrum-menu-checkmark-display: var(--spectrum-menu-checkmark-display-shown);
 
+  --spectrum-menu-back-icon-margin: var(--spectrum-navigational-indicator-top-to-back-icon-medium);
+
   /* "one" icon: chevron + additional icon (we don't count the chevron as an icon because it HAS to be there for a collapsible) */
   --spectrum-menu-item-collapsible-has-icon-submenu-item-padding-x-start:
     calc((
@@ -135,6 +137,8 @@ governing permissions and limitations under the License.
   --spectrum-menu-item-checkmark-height: var(--spectrum-menu-item-checkmark-height-small);
   --spectrum-menu-item-checkmark-width: var(--spectrum-menu-item-checkmark-width-small);
   --spectrum-menu-item-top-to-checkmark: var(--spectrum-menu-item-top-to-selected-icon-small);
+
+  --spectrum-menu-back-icon-margin: var(--spectrum-navigational-indicator-top-to-back-icon-small);
 }
 
 .spectrum-Menu--sizeL {
@@ -160,6 +164,8 @@ governing permissions and limitations under the License.
   --spectrum-menu-item-checkmark-height: var(--spectrum-menu-item-checkmark-height-large);
   --spectrum-menu-item-checkmark-width: var(--spectrum-menu-item-checkmark-width-large);
   --spectrum-menu-item-top-to-checkmark: var(--spectrum-menu-item-top-to-selected-icon-large);
+
+  --spectrum-menu-back-icon-margin: var(--spectrum-navigational-indicator-top-to-back-icon-large);
 }
 
 .spectrum-Menu--sizeXL {
@@ -185,6 +191,8 @@ governing permissions and limitations under the License.
   --spectrum-menu-item-checkmark-height: var(--spectrum-menu-item-checkmark-height-extra-large);
   --spectrum-menu-item-checkmark-width: var(--spectrum-menu-item-checkmark-width-extra-large);
   --spectrum-menu-item-top-to-checkmark: var(--spectrum-menu-item-top-to-selected-icon-extra-large);
+
+  --spectrum-menu-back-icon-margin: var(--spectrum-navigational-indicator-top-to-back-icon-extra-large);
 }
 
 @media (forced-colors: active) {
@@ -202,7 +210,6 @@ governing permissions and limitations under the License.
 
     --highcontrast-menu-item-selected-background-color: Highlight;
     --highcontrast-menu-item-selected-color: HighlightText;
-
 
     @supports (color: SelectedItem) {
       --highcontrast-menu-item-selected-background-color: SelectedItem;
@@ -256,6 +263,7 @@ governing permissions and limitations under the License.
 
 .spectrum-Menu {
   display: inline-block;
+  inline-size: var(--mod-menu-inline-size, auto);
   box-sizing: border-box;
   margin: 0;
   padding: 0;
@@ -431,7 +439,8 @@ governing permissions and limitations under the License.
   }
 }
 
-.spectrum-Menu-item:focus-visible {
+.spectrum-Menu-item:focus-visible,
+.spectrum-Menu-back:focus-visible {
   box-shadow: inset
     calc(var(--mod-menu-item-focus-indicator-width, var(--spectrum-menu-item-focus-indicator-width)) * var(--spectrum-menu-item-focus-indicator-direction-scalar, 1))
     0 0 0
@@ -782,4 +791,18 @@ governing permissions and limitations under the License.
       color: var(--highcontrast-menu-item-color-disabled, var(--mod-menu-item-label-icon-color-disabled, var(--spectrum-menu-item-label-icon-color-disabled)));
     }
   }
+}
+
+/* Tray submenu */
+.spectrum-Menu-item--back {
+  display: flex;
+  flex-flow: row wrap;
+  align-items: center;
+  padding-inline-start: var(--mod-menu-back-padding-inline-start, 0);
+  padding-block: var(--mod-menu-back-padding-block, 0);
+}
+
+.spectrum-Menu-backIcon {
+  margin-block: var(--mod-menu-back-icon-margin-block, var(--spectrum-menu-back-icon-margin));
+  margin-inline: var(--mod-menu-back-icon-margin-inline, var(--spectrum-menu-back-icon-margin));
 }

--- a/components/menu/index.css
+++ b/components/menu/index.css
@@ -798,8 +798,8 @@ governing permissions and limitations under the License.
   display: flex;
   flex-flow: row wrap;
   align-items: center;
-  padding-inline-start: var(--mod-menu-back-padding-inline-start, 0);
-  padding-block: var(--mod-menu-back-padding-block, 0);
+  padding-inline: var(--mod-menu-back-padding-inline-start, 0) var(--mod-menu-back-padding-inline-end, var(--spectrum-menu-item-label-inline-edge-to-content));
+  padding-block: var(--mod-menu-back-padding-block-start, 0) var(--mod-menu-back-padding-block-end, 0);
 
   .spectrum-Menu-sectionHeading {
     padding: 0;

--- a/components/menu/metadata/menu.yml
+++ b/components/menu/metadata/menu.yml
@@ -1340,7 +1340,8 @@ examples:
       </div>
   - id: tray-submenus
     name: Tray submenus
-    description: When a menu is displayed within a tray, a submenu will replace the tray content when the parent menu item is selected. A submenu displays a back button (labeled by the title of the parent item) at the top of the tray to return the user to the previous level of the menu.
+    description: "When a menu is displayed within a tray, a submenu will replace the tray content when the parent menu item is selected. A submenu displays a back button (labeled by the title of the parent item) at the top of the tray to return the user to the previous level of the menu.
+      The back arrow size scale used with the various menu sizes are small: `200`, medium: `300`, large: `400`, and extra large: `500`."
     markup: |
       <div class="spectrum-Tray-wrapper spectrum-CSSExample-dialog" style="background: rgba(0,0,0,0.4);">
         <div class="spectrum-Modal spectrum-Tray is-open spectrum-Tray">
@@ -1349,9 +1350,9 @@ examples:
               <div class="spectrum-Menu-back">
                 <button aria-label="Back to previous menu" class="spectrum-Menu-backButton" type="button" role="menuitem">
                   <svg
-                    class="spectrum-Icon spectrum-Icon--sizeM spectrum-UIIcon-ArrowLeft100 spectrum-Menu-backIcon"
+                    class="spectrum-Icon spectrum-Icon--sizeM spectrum-UIIcon-ArrowLeft200 spectrum-Menu-backIcon"
                     aria-hidden="true"
-                  ><use xlink:href="#spectrum-css-icon-Arrow100" /></svg>
+                  ><use xlink:href="#spectrum-css-icon-Arrow200" /></svg>
                 </button>
                 <span class="spectrum-Menu-backHeading" id="back-menu-heading" aria-hidden="true">Snap to</span>
               </div>

--- a/components/menu/metadata/menu.yml
+++ b/components/menu/metadata/menu.yml
@@ -1344,7 +1344,7 @@ examples:
       The back arrow size scale used with the various menu sizes are small: `200`, medium: `300`, large: `400`, and extra large: `500`."
     markup: |
       <div class="spectrum-Tray-wrapper spectrum-CSSExample-dialog" style="background: rgba(0,0,0,0.4);">
-        <div class="spectrum-Modal spectrum-Tray is-open spectrum-Tray">
+        <div class="spectrum-Modal spectrum-Tray is-open">
           <ul class="spectrum-Menu is-selectableMultiple" role="menu" style="--mod-menu-inline-size: 100%;">
             <li role="presentation">
               <div class="spectrum-Menu-back">

--- a/components/menu/metadata/menu.yml
+++ b/components/menu/metadata/menu.yml
@@ -41,7 +41,7 @@ examples:
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">M</h4>
           <div class="spectrum-Examples-itemGroup">
-            <ul class="spectrum-Menu spectrum-Menu--sizeM" role="menu">
+            <ul class="spectrum-Menu" role="menu">
               <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
                 <span class="spectrum-Menu-itemLabel">Medium Menu</span>
               </li>
@@ -128,7 +128,7 @@ examples:
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">M</h4>
           <div class="spectrum-Examples-itemGroup">
-            <ul class="spectrum-Menu spectrum-Menu--sizeM" role="menu">
+            <ul class="spectrum-Menu" role="menu">
               <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
                 <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Menu-itemIcon spectrum-Menu-itemIcon--workflowIcon" focusable="false" aria-hidden="true" aria-label="Cut Icon">
                   <use xlink:href="#spectrum-icon-18-Cut"></use>
@@ -208,7 +208,7 @@ examples:
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Menu with icons</h4>
           <div class="spectrum-Examples-itemGroup">
-            <ul class="spectrum-Menu spectrum-Menu--sizeM" role="menu">
+            <ul class="spectrum-Menu" role="menu">
               <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
                 <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Menu-itemIcon spectrum-Menu-itemIcon--workflowIcon" focusable="false" aria-hidden="true" aria-label="Cut Icon">
                   <use xlink:href="#spectrum-icon-18-Cut"></use>
@@ -233,7 +233,7 @@ examples:
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Menu with descriptions</h4>
           <div class="spectrum-Examples-itemGroup">
-            <ul class="spectrum-Menu spectrum-Menu--sizeM" role="menu">
+            <ul class="spectrum-Menu" role="menu">
               <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
                 <span class="spectrum-Menu-itemLabel">Quick export</span>
                 <span class="spectrum-Menu-itemDescription">Share a snapshot</span>
@@ -252,7 +252,7 @@ examples:
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Menu with icons & descriptions</h4>
           <div class="spectrum-Examples-itemGroup">
-            <ul class="spectrum-Menu spectrum-Menu--sizeM" role="menu">
+            <ul class="spectrum-Menu" role="menu">
               <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
                 <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Menu-itemIcon spectrum-Menu-itemIcon--workflowIcon" focusable="false" aria-hidden="true" aria-label="Export Icon">
                   <use xlink:href="#spectrum-icon-18-Export"></use>
@@ -285,7 +285,7 @@ examples:
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Menu without descriptions</h4>
           <div class="spectrum-Examples-itemGroup" style="max-width: 150px;">
-            <ul class="spectrum-Menu spectrum-Menu--sizeM" role="menu">
+            <ul class="spectrum-Menu" role="menu">
               <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
                 <span class="spectrum-Menu-itemLabel">Small (works best for mobile phones)</span>
               </li>
@@ -301,7 +301,7 @@ examples:
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Menu with descriptions</h4>
           <div class="spectrum-Examples-itemGroup" style="max-width: 150px;">
-            <ul class="spectrum-Menu spectrum-Menu--sizeM" role="menu">
+            <ul class="spectrum-Menu" role="menu">
               <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
                 <span class="spectrum-Menu-itemLabel">Small (works best for mobile phones)</span>
                 <span class="spectrum-Menu-itemDescription">A lengthy description about small is here</span>
@@ -344,7 +344,7 @@ examples:
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">M</h4>
           <div class="spectrum-Examples-itemGroup">
-            <ul class="spectrum-Menu spectrum-Menu--sizeM" role="menu">
+            <ul class="spectrum-Menu" role="menu">
               <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
                 <span class="spectrum-Menu-itemLabel">Quick export</span>
                 <span class="spectrum-Menu-itemDescription">Share a snapshot</span>
@@ -434,7 +434,7 @@ examples:
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">M</h4>
           <div class="spectrum-Examples-itemGroup">
-            <ul class="spectrum-Menu spectrum-Menu--sizeM" role="menu">
+            <ul class="spectrum-Menu" role="menu">
               <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
                 <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Menu-itemIcon spectrum-Menu-itemIcon--workflowIcon" focusable="false" aria-hidden="true" aria-label="Export Icon">
                   <use xlink:href="#spectrum-icon-18-Export"></use>
@@ -531,8 +531,8 @@ examples:
                 <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-Menu-itemIcon spectrum-Menu-itemIcon--workflowIcon" focusable="false" aria-hidden="true" aria-label="Desktop & Mobile Icon">
                   <use xlink:href="#spectrum-icon-18-DesktopAndMobile"></use>
                 </svg>
-                <span class="spectrum-Menu-sectionHeading" id="menu-heading-category-1" aria-hidden="true">Web Design</span>
-                <ul id="spectrum-menu-item-0-submenu" class="spectrum-Menu spectrum-Menu--sizeS is-open" aria-labelledby="menu-heading-category-1" role="menu">
+                <span class="spectrum-Menu-sectionHeading" id="ex1-menu-heading-1" aria-hidden="true">Web Design</span>
+                <ul id="spectrum-menu-item-0-submenu" class="spectrum-Menu spectrum-Menu--sizeS is-open" aria-labelledby="ex1-menu-heading-2" role="menu">
                   <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
                     <span class="spectrum-Menu-itemLabel">Web Large</span>
                     <span class="spectrum-Menu-itemValue">1920 x 1080</span>
@@ -552,8 +552,8 @@ examples:
                   <use xlink:href="#spectrum-css-icon-Chevron75" />
                 </svg>
                 
-                <span class="spectrum-Menu-sectionHeading" id="menu-heading-category-1" aria-hidden="true">Mobile</span>
-                <ul id="spectrum-menu-item-1-submenu" class="spectrum-Menu spectrum-Menu--sizeS is-open" aria-labelledby="spectrum-menu-item-1-label" role="menu">
+                <span class="spectrum-Menu-sectionHeading" id="ex1-menu-heading-2" aria-hidden="true">Mobile</span>
+                <ul id="spectrum-menu-item-1-submenu" class="spectrum-Menu spectrum-Menu--sizeS is-open" aria-labelledby="ex1-menu-heading-2" role="menu">
                   <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
                     <span class="spectrum-Menu-itemLabel">Mobile Large</span>
                     <span class="spectrum-Menu-itemValue">1920 x 1080</span>
@@ -575,8 +575,8 @@ examples:
                 <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-Menu-itemIcon spectrum-Menu-itemIcon--workflowIcon" focusable="false" aria-hidden="true" aria-label="Tablet Icon" style="transform: rotate(90deg);">
                   <use xlink:href="#spectrum-icon-18-DeviceTablet"></use>
                 </svg>
-                <span class="spectrum-Menu-sectionHeading" id="menu-heading-category-1" aria-hidden="true">Tablet</span>
-                <ul id="spectrum-menu-item-1-submenu" class="spectrum-Menu spectrum-Menu--sizeS" aria-labelledby="spectrum-menu-item-1-label" role="menu">
+                <span class="spectrum-Menu-sectionHeading" id="ex1-menu-heading-3" aria-hidden="true">Tablet</span>
+                <ul id="spectrum-menu-item-1-submenu" class="spectrum-Menu spectrum-Menu--sizeS" aria-labelledby="ex1-menu-heading-3" role="menu">
                   <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
                     <span class="spectrum-Menu-itemLabel">Tablet Large</span>
                     <span class="spectrum-Menu-itemValue">1920 x 1080</span>
@@ -598,8 +598,8 @@ examples:
                 <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-Menu-itemIcon spectrum-Menu-itemIcon--workflowIcon" focusable="false" aria-hidden="true" aria-label="Share Icon">
                   <use xlink:href="#spectrum-icon-18-ShareAndroid"></use>
                 </svg>
-                <span class="spectrum-Menu-sectionHeading" id="menu-heading-category-1" aria-hidden="true">Social Media</span>
-                <ul id="spectrum-menu-item-1-submenu" class="spectrum-Menu spectrum-Menu--sizeS" aria-labelledby="spectrum-menu-item-1-label" role="menu">
+                <span class="spectrum-Menu-sectionHeading" id="ex1-menu-heading-4" aria-hidden="true">Social Media</span>
+                <ul id="spectrum-menu-item-1-submenu" class="spectrum-Menu spectrum-Menu--sizeS" aria-labelledby="ex1-menu-heading-4" role="menu">
                   <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
                     <span class="spectrum-Menu-itemLabel">Social Media Large</span>
                     <span class="spectrum-Menu-itemValue">1920 x 1080</span>
@@ -621,8 +621,8 @@ examples:
                 <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-Menu-itemIcon spectrum-Menu-itemIcon--workflowIcon" focusable="false" aria-hidden="true" aria-label="Watch Icon">
                   <use xlink:href="#spectrum-icon-18-Watch"></use>
                 </svg>
-                <span class="spectrum-Menu-sectionHeading" id="menu-heading-category-1" aria-hidden="true">Watches</span>
-                <ul id="spectrum-menu-item-1-submenu" class="spectrum-Menu spectrum-Menu--sizeS" aria-labelledby="spectrum-menu-item-1-label" role="menu">
+                <span class="spectrum-Menu-sectionHeading" id="ex1-menu-heading-5" aria-hidden="true">Watches</span>
+                <ul id="spectrum-menu-item-1-submenu" class="spectrum-Menu spectrum-Menu--sizeS" aria-labelledby="ex1-menu-heading-5" role="menu">
                   <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
                     <span class="spectrum-Menu-itemLabel">Watch Large</span>
                     <span class="spectrum-Menu-itemValue">1920 x 1080</span>
@@ -643,7 +643,7 @@ examples:
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">M</h4>
           <div class="spectrum-Examples-itemGroup">
-            <ul class="spectrum-Menu spectrum-Menu--sizeM" role="menu">
+            <ul class="spectrum-Menu" role="menu">
               <li class="spectrum-Menu-item spectrum-Menu-item--collapsible spectrum-Menu-item--collapsible-withWorkflowIcon is-open" role="menuitem" tabindex="0">
                 <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-UIIcon-ChevronRight100 spectrum-Menu-chevron spectrum-Menu-itemIcon" focusable="false" aria-hidden="true" aria-label="Next">
                   <use xlink:href="#spectrum-css-icon-Chevron100" />
@@ -651,8 +651,8 @@ examples:
                 <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Menu-itemIcon spectrum-Menu-itemIcon--workflowIcon" focusable="false" aria-hidden="true" aria-label="Desktop & Mobile Icon">
                   <use xlink:href="#spectrum-icon-18-DesktopAndMobile"></use>
                 </svg>
-                <span class="spectrum-Menu-sectionHeading" id="menu-heading-category-1" aria-hidden="true">Web Design</span>
-                <ul id="spectrum-menu-item-0-submenu" class="spectrum-Menu spectrum-Menu--sizeM is-open" aria-labelledby="menu-heading-category-1" role="menu">
+                <span class="spectrum-Menu-sectionHeading" id="ex2-menu-heading-1" aria-hidden="true">Web Design</span>
+                <ul id="spectrum-menu-item-0-submenu" class="spectrum-Menu is-open" aria-labelledby="ex2-menu-heading-1" role="menu">
                   <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
                     <span class="spectrum-Menu-itemLabel">Web Large</span>
                     <span class="spectrum-Menu-itemValue">1920 x 1080</span>
@@ -672,8 +672,8 @@ examples:
                   <use xlink:href="#spectrum-css-icon-Chevron100" />
                 </svg>
                 
-                <span class="spectrum-Menu-sectionHeading" id="menu-heading-category-1" aria-hidden="true">Mobile</span>
-                <ul id="spectrum-menu-item-1-submenu" class="spectrum-Menu spectrum-Menu--sizeM is-open" aria-labelledby="spectrum-menu-item-1-label" role="menu">
+                <span class="spectrum-Menu-sectionHeading" id="ex2-menu-heading-2" aria-hidden="true">Mobile</span>
+                <ul id="spectrum-menu-item-1-submenu" class="spectrum-Menu is-open" aria-labelledby="ex2-menu-heading-2" role="menu">
                   <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
                     <span class="spectrum-Menu-itemLabel">Mobile Large</span>
                     <span class="spectrum-Menu-itemValue">1920 x 1080</span>
@@ -695,8 +695,8 @@ examples:
                 <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Menu-itemIcon spectrum-Menu-itemIcon--workflowIcon" focusable="false" aria-hidden="true" aria-label="Tablet Icon" style="transform: rotate(90deg);">
                   <use xlink:href="#spectrum-icon-18-DeviceTablet"></use>
                 </svg>
-                <span class="spectrum-Menu-sectionHeading" id="menu-heading-category-1" aria-hidden="true">Tablet</span>
-                <ul id="spectrum-menu-item-1-submenu" class="spectrum-Menu spectrum-Menu--sizeM" aria-labelledby="spectrum-menu-item-1-label" role="menu">
+                <span class="spectrum-Menu-sectionHeading" id="ex2-menu-heading-3" aria-hidden="true">Tablet</span>
+                <ul id="spectrum-menu-item-1-submenu" class="spectrum-Menu" aria-labelledby="ex2-menu-heading-3" role="menu">
                   <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
                     <span class="spectrum-Menu-itemLabel">Tablet Large</span>
                     <span class="spectrum-Menu-itemValue">1920 x 1080</span>
@@ -718,8 +718,8 @@ examples:
                 <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Menu-itemIcon spectrum-Menu-itemIcon--workflowIcon" focusable="false" aria-hidden="true" aria-label="Share Icon">
                   <use xlink:href="#spectrum-icon-18-ShareAndroid"></use>
                 </svg>
-                <span class="spectrum-Menu-sectionHeading" id="menu-heading-category-1" aria-hidden="true">Social Media</span>
-                <ul id="spectrum-menu-item-1-submenu" class="spectrum-Menu spectrum-Menu--sizeM" aria-labelledby="spectrum-menu-item-1-label" role="menu">
+                <span class="spectrum-Menu-sectionHeading" id="ex2-menu-heading-4" aria-hidden="true">Social Media</span>
+                <ul id="spectrum-menu-item-1-submenu" class="spectrum-Menu" aria-labelledby="ex2-menu-heading-4" role="menu">
                   <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
                     <span class="spectrum-Menu-itemLabel">Social Media Large</span>
                     <span class="spectrum-Menu-itemValue">1920 x 1080</span>
@@ -741,8 +741,8 @@ examples:
                 <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Menu-itemIcon spectrum-Menu-itemIcon--workflowIcon" focusable="false" aria-hidden="true" aria-label="Watch Icon">
                   <use xlink:href="#spectrum-icon-18-Watch"></use>
                 </svg>
-                <span class="spectrum-Menu-sectionHeading" id="menu-heading-category-1" aria-hidden="true">Watches</span>
-                <ul id="spectrum-menu-item-1-submenu" class="spectrum-Menu spectrum-Menu--sizeM" aria-labelledby="spectrum-menu-item-1-label" role="menu">
+                <span class="spectrum-Menu-sectionHeading" id="ex2-menu-heading-5" aria-hidden="true">Watches</span>
+                <ul id="spectrum-menu-item-1-submenu" class="spectrum-Menu" aria-labelledby="ex2-menu-heading-5" role="menu">
                   <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
                     <span class="spectrum-Menu-itemLabel">Watch Large</span>
                     <span class="spectrum-Menu-itemValue">1920 x 1080</span>
@@ -771,8 +771,8 @@ examples:
                 <svg class="spectrum-Icon spectrum-Icon--sizeL spectrum-Menu-itemIcon spectrum-Menu-itemIcon--workflowIcon" focusable="false" aria-hidden="true" aria-label="Desktop & Mobile Icon">
                   <use xlink:href="#spectrum-icon-18-DesktopAndMobile"></use>
                 </svg>
-                <span class="spectrum-Menu-sectionHeading" id="menu-heading-category-1" aria-hidden="true">Web Design</span>
-                <ul id="spectrum-menu-item-0-submenu" class="spectrum-Menu spectrum-Menu--sizeL is-open" aria-labelledby="menu-heading-category-1" role="menu">
+                <span class="spectrum-Menu-sectionHeading" id="ex3-menu-heading-1" aria-hidden="true">Web Design</span>
+                <ul id="spectrum-menu-item-0-submenu" class="spectrum-Menu spectrum-Menu--sizeL is-open" aria-labelledby="ex3-menu-heading-1" role="menu">
                   <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
                     <span class="spectrum-Menu-itemLabel">Web Large</span>
                     <span class="spectrum-Menu-itemValue">1920 x 1080</span>
@@ -792,8 +792,8 @@ examples:
                   <use xlink:href="#spectrum-css-icon-Chevron200" />
                 </svg>
                 
-                <span class="spectrum-Menu-sectionHeading" id="menu-heading-category-1" aria-hidden="true">Mobile</span>
-                <ul id="spectrum-menu-item-1-submenu" class="spectrum-Menu spectrum-Menu--sizeL is-open" aria-labelledby="spectrum-menu-item-1-label" role="menu">
+                <span class="spectrum-Menu-sectionHeading" id="ex3-menu-heading-2" aria-hidden="true">Mobile</span>
+                <ul id="spectrum-menu-item-1-submenu" class="spectrum-Menu spectrum-Menu--sizeL is-open" aria-labelledby="ex3-menu-heading-2" role="menu">
                   <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
                     <span class="spectrum-Menu-itemLabel">Mobile Large</span>
                     <span class="spectrum-Menu-itemValue">1920 x 1080</span>
@@ -815,8 +815,8 @@ examples:
                 <svg class="spectrum-Icon spectrum-Icon--sizeL spectrum-Menu-itemIcon spectrum-Menu-itemIcon--workflowIcon" focusable="false" aria-hidden="true" aria-label="Tablet Icon" style="transform: rotate(90deg);">
                   <use xlink:href="#spectrum-icon-18-DeviceTablet"></use>
                 </svg>
-                <span class="spectrum-Menu-sectionHeading" id="menu-heading-category-1" aria-hidden="true">Tablet</span>
-                <ul id="spectrum-menu-item-1-submenu" class="spectrum-Menu spectrum-Menu--sizeL" aria-labelledby="spectrum-menu-item-1-label" role="menu">
+                <span class="spectrum-Menu-sectionHeading" id="ex3-menu-heading-3" aria-hidden="true">Tablet</span>
+                <ul id="spectrum-menu-item-1-submenu" class="spectrum-Menu spectrum-Menu--sizeL" aria-labelledby="ex3-menu-heading-3" role="menu">
                   <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
                     <span class="spectrum-Menu-itemLabel">Tablet Large</span>
                     <span class="spectrum-Menu-itemValue">1920 x 1080</span>
@@ -838,8 +838,8 @@ examples:
                 <svg class="spectrum-Icon spectrum-Icon--sizeL spectrum-Menu-itemIcon spectrum-Menu-itemIcon--workflowIcon" focusable="false" aria-hidden="true" aria-label="Share Icon">
                   <use xlink:href="#spectrum-icon-18-ShareAndroid"></use>
                 </svg>
-                <span class="spectrum-Menu-sectionHeading" id="menu-heading-category-1" aria-hidden="true">Social Media</span>
-                <ul id="spectrum-menu-item-1-submenu" class="spectrum-Menu spectrum-Menu--sizeL" aria-labelledby="spectrum-menu-item-1-label" role="menu">
+                <span class="spectrum-Menu-sectionHeading" id="ex3-menu-heading-4" aria-hidden="true">Social Media</span>
+                <ul id="spectrum-menu-item-1-submenu" class="spectrum-Menu spectrum-Menu--sizeL" aria-labelledby="ex3-menu-heading-4" role="menu">
                   <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
                     <span class="spectrum-Menu-itemLabel">Social Media Large</span>
                     <span class="spectrum-Menu-itemValue">1920 x 1080</span>
@@ -861,8 +861,8 @@ examples:
                 <svg class="spectrum-Icon spectrum-Icon--sizeL spectrum-Menu-itemIcon spectrum-Menu-itemIcon--workflowIcon" focusable="false" aria-hidden="true" aria-label="Watch Icon">
                   <use xlink:href="#spectrum-icon-18-Watch"></use>
                 </svg>
-                <span class="spectrum-Menu-sectionHeading" id="menu-heading-category-1" aria-hidden="true">Watches</span>
-                <ul id="spectrum-menu-item-1-submenu" class="spectrum-Menu spectrum-Menu--sizeL" aria-labelledby="spectrum-menu-item-1-label" role="menu">
+                <span class="spectrum-Menu-sectionHeading" id="ex3-menu-heading-5" aria-hidden="true">Watches</span>
+                <ul id="spectrum-menu-item-1-submenu" class="spectrum-Menu spectrum-Menu--sizeL" aria-labelledby="ex3-menu-heading-5" role="menu">
                   <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
                     <span class="spectrum-Menu-itemLabel">Watch Large</span>
                     <span class="spectrum-Menu-itemValue">1920 x 1080</span>
@@ -891,8 +891,8 @@ examples:
                 <svg class="spectrum-Icon spectrum-Icon--sizeXL spectrum-Menu-itemIcon spectrum-Menu-itemIcon--workflowIcon" focusable="false" aria-hidden="true" aria-label="Desktop & Mobile Icon">
                   <use xlink:href="#spectrum-icon-18-DesktopAndMobile"></use>
                 </svg>
-                <span class="spectrum-Menu-sectionHeading" id="menu-heading-category-1" aria-hidden="true">Web Design</span>
-                <ul id="spectrum-menu-item-0-submenu" class="spectrum-Menu spectrum-Menu--sizeXL is-open" aria-labelledby="menu-heading-category-1" role="menu">
+                <span class="spectrum-Menu-sectionHeading" id="ex4-menu-heading-1" aria-hidden="true">Web Design</span>
+                <ul id="spectrum-menu-item-0-submenu" class="spectrum-Menu spectrum-Menu--sizeXL is-open" aria-labelledby="ex4-menu-heading-1" role="menu">
                   <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
                     <span class="spectrum-Menu-itemLabel">Web Large</span>
                     <span class="spectrum-Menu-itemValue">1920 x 1080</span>
@@ -912,8 +912,8 @@ examples:
                   <use xlink:href="#spectrum-css-icon-Chevron300" />
                 </svg>
                 
-                <span class="spectrum-Menu-sectionHeading" id="menu-heading-category-1" aria-hidden="true">Mobile</span>
-                <ul id="spectrum-menu-item-1-submenu" class="spectrum-Menu spectrum-Menu--sizeXL is-open" aria-labelledby="spectrum-menu-item-1-label" role="menu">
+                <span class="spectrum-Menu-sectionHeading" id="ex4-menu-heading-2" aria-hidden="true">Mobile</span>
+                <ul id="spectrum-menu-item-1-submenu" class="spectrum-Menu spectrum-Menu--sizeXL is-open" aria-labelledby="ex4-menu-heading-2" role="menu">
                   <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
                     <span class="spectrum-Menu-itemLabel">Mobile Large</span>
                     <span class="spectrum-Menu-itemValue">1920 x 1080</span>
@@ -935,8 +935,8 @@ examples:
                 <svg class="spectrum-Icon spectrum-Icon--sizeXL spectrum-Menu-itemIcon spectrum-Menu-itemIcon--workflowIcon" focusable="false" aria-hidden="true" aria-label="Tablet Icon" style="transform: rotate(90deg);">
                   <use xlink:href="#spectrum-icon-18-DeviceTablet"></use>
                 </svg>
-                <span class="spectrum-Menu-sectionHeading" id="menu-heading-category-1" aria-hidden="true">Tablet</span>
-                <ul id="spectrum-menu-item-1-submenu" class="spectrum-Menu spectrum-Menu--sizeXL" aria-labelledby="spectrum-menu-item-1-label" role="menu">
+                <span class="spectrum-Menu-sectionHeading" id="ex4-menu-heading-3" aria-hidden="true">Tablet</span>
+                <ul id="spectrum-menu-item-1-submenu" class="spectrum-Menu spectrum-Menu--sizeXL" aria-labelledby="ex4-menu-heading-3" role="menu">
                   <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
                     <span class="spectrum-Menu-itemLabel">Tablet Large</span>
                     <span class="spectrum-Menu-itemValue">1920 x 1080</span>
@@ -958,8 +958,8 @@ examples:
                 <svg class="spectrum-Icon spectrum-Icon--sizeXL spectrum-Menu-itemIcon spectrum-Menu-itemIcon--workflowIcon" focusable="false" aria-hidden="true" aria-label="Share Icon">
                   <use xlink:href="#spectrum-icon-18-ShareAndroid"></use>
                 </svg>
-                <span class="spectrum-Menu-sectionHeading" id="menu-heading-category-1" aria-hidden="true">Social Media</span>
-                <ul id="spectrum-menu-item-1-submenu" class="spectrum-Menu spectrum-Menu--sizeXL" aria-labelledby="spectrum-menu-item-1-label" role="menu">
+                <span class="spectrum-Menu-sectionHeading" id="ex4-menu-heading-4" aria-hidden="true">Social Media</span>
+                <ul id="spectrum-menu-item-1-submenu" class="spectrum-Menu spectrum-Menu--sizeXL" aria-labelledby="ex4-menu-heading-4" role="menu">
                   <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
                     <span class="spectrum-Menu-itemLabel">Social Media Large</span>
                     <span class="spectrum-Menu-itemValue">1920 x 1080</span>
@@ -981,8 +981,8 @@ examples:
                 <svg class="spectrum-Icon spectrum-Icon--sizeXL spectrum-Menu-itemIcon spectrum-Menu-itemIcon--workflowIcon" focusable="false" aria-hidden="true" aria-label="Watch Icon">
                   <use xlink:href="#spectrum-icon-18-Watch"></use>
                 </svg>
-                <span class="spectrum-Menu-sectionHeading" id="menu-heading-category-1" aria-hidden="true">Watches</span>
-                <ul id="spectrum-menu-item-1-submenu" class="spectrum-Menu spectrum-Menu--sizeM" aria-labelledby="spectrum-menu-item-1-label" role="menu">
+                <span class="spectrum-Menu-sectionHeading" id="ex4-menu-heading-5" aria-hidden="true">Watches</span>
+                <ul id="spectrum-menu-item-1-submenu" class="spectrum-Menu" aria-labelledby="ex4-menu-heading-5" role="menu">
                   <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
                     <span class="spectrum-Menu-itemLabel">Watch Large</span>
                     <span class="spectrum-Menu-itemValue">1920 x 1080</span>
@@ -1006,7 +1006,7 @@ examples:
     markup: |
       <div class="spectrum-Examples">
         <div class="spectrum-Examples-item">
-          <ul class="spectrum-Menu spectrum-Menu--sizeM" role="menu">
+          <ul class="spectrum-Menu" role="menu">
             <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
               <span class="spectrum-Menu-itemLabel">Deselect</span>
             </li>
@@ -1034,10 +1034,10 @@ examples:
     markup: |
       <div class="spectrum-Examples">
         <div class="spectrum-Examples-item">
-          <ul class="spectrum-Menu spectrum-Menu--sizeM" role="menu">
+          <ul class="spectrum-Menu" role="menu">
             <li role="presentation">
-              <span class="spectrum-Menu-sectionHeading" id="menu-heading-category-1"  aria-hidden="true">Tools</span>
-              <ul class="spectrum-Menu spectrum-Menu--sizeM is-selectable" role="group" aria-labelledby="menu-heading-category-1">
+              <span class="spectrum-Menu-sectionHeading" id="menu-sections-heading-1" aria-hidden="true">Tools</span>
+              <ul class="spectrum-Menu is-selectable" role="group" aria-labelledby="menu-sections-heading-1">
                 <li class="spectrum-Menu-item is-selected" role="menuitem" tabindex="0">
                   <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-UIIcon-Checkmark100 spectrum-Menu-itemIcon spectrum-Menu-checkmark" focusable="false" aria-hidden="true">
                     <use xlink:href="#spectrum-css-icon-Checkmark100" />
@@ -1063,8 +1063,8 @@ examples:
             </li>
             <li class="spectrum-Divider spectrum-Divider--sizeS spectrum-Menu-divider" role="separator"></li>
             <li role="presentation">
-              <span class="spectrum-Menu-sectionHeading" id="menu-heading-category-2"  aria-hidden="true">Actions</span>
-              <ul class="spectrum-Menu spectrum-Menu--sizeM is-selectable" role="group" aria-labelledby="menu-heading-category-2" aria-disabled="true">
+              <span class="spectrum-Menu-sectionHeading" id="menu-sections-heading-2"  aria-hidden="true">Actions</span>
+              <ul class="spectrum-Menu is-selectable" role="group" aria-labelledby="menu-sections-heading-2" aria-disabled="true">
                 <li class="spectrum-Menu-item spectrum-Menu-item--is-selectable is-disabled" role="menuitem" aria-disabled="true">
                   <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Menu-itemIcon spectrum-Menu-itemIcon--workflowIcon" focusable="false" aria-hidden="true" aria-label="Deselect Icon">
                     <use xlink:href="#spectrum-icon-18-Deselect"></use>
@@ -1083,7 +1083,7 @@ examples:
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Without icons</h4>
           <div class="spectrum-Examples-itemGroup">
-            <ul class="spectrum-Menu spectrum-Menu--sizeM is-selectable" role="menu">
+            <ul class="spectrum-Menu is-selectable" role="menu">
               <li class="spectrum-Menu-item is-selected" role="menuitem" tabindex="0">
                 <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-UIIcon-Checkmark100 spectrum-Menu-itemIcon spectrum-Menu-checkmark" focusable="false" aria-hidden="true">
                   <use xlink:href="#spectrum-css-icon-Checkmark100" />
@@ -1102,7 +1102,7 @@ examples:
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">With icons</h4>
           <div class="spectrum-Examples-itemGroup">
-            <ul class="spectrum-Menu spectrum-Menu--sizeM is-selectable" role="menu">
+            <ul class="spectrum-Menu is-selectable" role="menu">
               <li class="spectrum-Menu-item is-selected" role="menuitem" tabindex="0">
                 <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-UIIcon-Checkmark100 spectrum-Menu-itemIcon spectrum-Menu-checkmark" focusable="false" aria-hidden="true">
                   <use xlink:href="#spectrum-css-icon-Checkmark100" />
@@ -1135,38 +1135,38 @@ examples:
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Without icons</h4>
           <div class="spectrum-Examples-itemGroup">
-            <ul class="spectrum-Menu spectrum-Menu--sizeM is-selectableMultiple" role="menu">
+            <ul class="spectrum-Menu is-selectableMultiple" role="menu">
               <li class="spectrum-Menu-item is-selected" role="menuitem" tabindex="0">
                 <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-Checkbox--emphasized spectrum-Menu-itemCheckbox">
-                  <input type="checkbox" class="spectrum-Checkbox-input" aria-labelledby="ms-label1" checked>
+                  <input type="checkbox" class="spectrum-Checkbox-input" checked>
                   <span class="spectrum-Checkbox-box">
                     <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
                       <use xlink:href="#spectrum-css-icon-Checkmark100" />
                     </svg>
                   </span>
-                  <span class="spectrum-Checkbox-label spectrum-Menu-itemLabel" id="ms-label1">Marquee</span>
+                  <span class="spectrum-Checkbox-label spectrum-Menu-itemLabel">Marquee</span>
                 </label>
               </li>
               <li class="spectrum-Menu-item is-selectable" role="menuitem" tabindex="0">
                 <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-Checkbox--emphasized spectrum-Menu-itemCheckbox">
-                  <input type="checkbox" class="spectrum-Checkbox-input" aria-labelledby="ms-label2">
+                  <input type="checkbox" class="spectrum-Checkbox-input">
                   <span class="spectrum-Checkbox-box">
                     <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
                       <use xlink:href="#spectrum-css-icon-Checkmark100" />
                     </svg>
                   </span>
-                  <span class="spectrum-Checkbox-label spectrum-Menu-itemLabel" id="ms-label2">Add</span>
+                  <span class="spectrum-Checkbox-label spectrum-Menu-itemLabel">Add</span>
                 </label>
               </li>
               <li class="spectrum-Menu-item is-selectable" role="menuitem" tabindex="0">
                 <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-Checkbox--emphasized spectrum-Menu-itemCheckbox">
-                  <input type="checkbox" class="spectrum-Checkbox-input" aria-labelledby="ms-label3">
+                  <input type="checkbox" class="spectrum-Checkbox-input">
                   <span class="spectrum-Checkbox-box">
                     <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
                       <use xlink:href="#spectrum-css-icon-Checkmark100" />
                     </svg>
                   </span>
-                  <span class="spectrum-Checkbox-label spectrum-Menu-itemLabel" id="ms-label3">Subtract</span>
+                  <span class="spectrum-Checkbox-label spectrum-Menu-itemLabel">Subtract</span>
                 </label>
               </li>
             </ul>
@@ -1175,10 +1175,10 @@ examples:
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">With icons</h4>
           <div class="spectrum-Examples-itemGroup">
-            <ul class="spectrum-Menu spectrum-Menu--sizeM is-selectableMultiple" role="menu">
+            <ul class="spectrum-Menu is-selectableMultiple" role="menu">
               <li class="spectrum-Menu-item is-selected" role="menuitem" tabindex="0">
                 <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-Checkbox--emphasized spectrum-Menu-itemCheckbox">
-                  <input type="checkbox" class="spectrum-Checkbox-input" aria-labelledby="ms-label4" checked>
+                  <input type="checkbox" class="spectrum-Checkbox-input" checked>
                   <span class="spectrum-Checkbox-box">
                     <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
                       <use xlink:href="#spectrum-css-icon-Checkmark100" />
@@ -1187,12 +1187,12 @@ examples:
                   <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Menu-itemIcon spectrum-Menu-itemIcon--workflowIcon" focusable="false" aria-hidden="true" aria-label="Selection Icon">
                     <use xlink:href="#spectrum-icon-18-Selection"></use>
                   </svg>
-                  <span class="spectrum-Checkbox-label spectrum-Menu-itemLabel" id="ms-label4">Marquee</span>
+                  <span class="spectrum-Checkbox-label spectrum-Menu-itemLabel">Marquee</span>
                 </label>
               </li>
               <li class="spectrum-Menu-item is-selectable" role="menuitem" tabindex="0">
                 <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-Checkbox--emphasized spectrum-Menu-itemCheckbox">
-                  <input type="checkbox" class="spectrum-Checkbox-input" aria-labelledby="ms-label5">
+                  <input type="checkbox" class="spectrum-Checkbox-input">
                   <span class="spectrum-Checkbox-box">
                     <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
                       <use xlink:href="#spectrum-css-icon-Checkmark100" />
@@ -1201,12 +1201,12 @@ examples:
                   <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Menu-itemIcon spectrum-Menu-itemIcon--workflowIcon" focusable="false" aria-hidden="true" aria-label="Select Add Icon">
                     <use xlink:href="#spectrum-icon-18-SelectAdd"></use>
                   </svg>
-                  <span class="spectrum-Checkbox-label spectrum-Menu-itemLabel" id="ms-label5">Add</span>
+                  <span class="spectrum-Checkbox-label spectrum-Menu-itemLabel">Add</span>
                 </label>
               </li>
               <li class="spectrum-Menu-item is-selectable" role="menuitem" tabindex="0">
                 <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-Checkbox--emphasized spectrum-Menu-itemCheckbox">
-                  <input type="checkbox" class="spectrum-Checkbox-input" aria-labelledby="ms-label6">
+                  <input type="checkbox" class="spectrum-Checkbox-input">
                   <span class="spectrum-Checkbox-box">
                     <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
                       <use xlink:href="#spectrum-css-icon-Checkmark100" />
@@ -1215,7 +1215,7 @@ examples:
                   <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Menu-itemIcon spectrum-Menu-itemIcon--workflowIcon" focusable="false" aria-hidden="true" aria-label="Select Subtract Icon">
                     <use xlink:href="#spectrum-icon-18-SelectSubtract"></use>
                   </svg>
-                  <span class="spectrum-Checkbox-label spectrum-Menu-itemLabel" id="ms-label6">Subtract</span>
+                  <span class="spectrum-Checkbox-label spectrum-Menu-itemLabel">Subtract</span>
                 </label>
               </li>
             </ul>
@@ -1229,7 +1229,7 @@ examples:
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Without icons</h4>
           <div class="spectrum-Examples-itemGroup">
-            <ul class="spectrum-Menu spectrum-Menu--sizeM" role="menu">
+            <ul class="spectrum-Menu" role="menu">
               <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
                 <label class="spectrum-Switch-label spectrum-Menu-itemLabel" for="switch-onoff-0">Marquee</label>
                 <div class="spectrum-Menu-itemActions">
@@ -1263,7 +1263,7 @@ examples:
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">With icons</h4>
           <div class="spectrum-Examples-itemGroup">
-            <ul class="spectrum-Menu spectrum-Menu--sizeM" role="menu">
+            <ul class="spectrum-Menu" role="menu">
               <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
                 <label class="spectrum-Switch-label spectrum-Menu-itemLabel" for="switch-onoff-3">
                   <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Menu-itemIcon spectrum-Menu-itemIcon--workflowIcon" focusable="false" aria-hidden="true" aria-label="Selection Icon">
@@ -1316,7 +1316,7 @@ examples:
     markup: |
       <div class="spectrum-Examples">
         <div class="spectrum-Examples-item">
-          <ul class="spectrum-Menu spectrum-Menu--sizeM" role="menu">
+          <ul class="spectrum-Menu" role="menu">
             <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
               <span class="spectrum-Menu-itemLabel">Deselect</span>
             </li>
@@ -1335,6 +1335,60 @@ examples:
             <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
               <span class="spectrum-Menu-itemLabel">Save Selection</span>
             </li>
+          </ul>
+        </div>
+      </div>
+  - id: tray-submenus
+    name: Tray submenus
+    description: When a menu is displayed within a tray, a submenu will replace the tray content when the parent menu item is selected. A submenu displays a back button (labeled by the title of the parent item) at the top of the tray to return the user to the previous level of the menu.
+    markup: |
+      <div class="spectrum-Tray-wrapper spectrum-CSSExample-dialog" style="background: rgba(0,0,0,0.4);">
+        <div class="spectrum-Modal spectrum-Tray is-open spectrum-Tray">
+          <ul class="spectrum-Menu is-selectableMultiple" role="menu" style="--mod-menu-inline-size: 100%;">
+            <li role="presentation">
+              <li class="spectrum-Menu-item spectrum-Menu-item--back" role="menuitem" tabindex="0">
+                <svg 
+                  class="spectrum-Icon spectrum-Icon--sizeM spectrum-UIIcon-ArrowLeft100 spectrum-Menu-backIcon"
+                  focusable="false" 
+                  aria-label="View previous menu"
+                >
+                  <use xlink:href="#spectrum-css-icon-Arrow100" />
+                </svg>
+                <span class="spectrum-Menu-itemLabel">Snap to</span>
+              </li>
+              <li class="spectrum-Menu-item is-selected" role="menuitem" tabindex="0">
+                <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-Checkbox--emphasized spectrum-Menu-itemCheckbox">
+                  <input type="checkbox" class="spectrum-Checkbox-input" checked>
+                  <span class="spectrum-Checkbox-box">
+                    <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                      <use xlink:href="#spectrum-css-icon-Checkmark100" />
+                    </svg>
+                  </span>
+                  <span class="spectrum-Checkbox-label spectrum-Menu-itemLabel">Guides</span>
+                </label>
+              </li>
+              <li class="spectrum-Menu-item is-selectable" role="menuitem" tabindex="0">
+                <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-Checkbox--emphasized spectrum-Menu-itemCheckbox">
+                  <input type="checkbox" class="spectrum-Checkbox-input">
+                  <span class="spectrum-Checkbox-box">
+                    <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                      <use xlink:href="#spectrum-css-icon-Checkmark100" />
+                    </svg>
+                  </span>
+                  <span class="spectrum-Checkbox-label spectrum-Menu-itemLabel"">Grid</span>
+                </label>
+              </li>
+              <li class="spectrum-Menu-item is-selected" role="menuitem" tabindex="0">
+                <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-Checkbox--emphasized spectrum-Menu-itemCheckbox">
+                  <input type="checkbox" class="spectrum-Checkbox-input" checked>
+                  <span class="spectrum-Checkbox-box">
+                    <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                      <use xlink:href="#spectrum-css-icon-Checkmark100" />
+                    </svg>
+                  </span>
+                  <span class="spectrum-Checkbox-label spectrum-Menu-itemLabel">Rulers</span>
+                </label>
+              </li>
           </ul>
         </div>
       </div>

--- a/components/menu/metadata/menu.yml
+++ b/components/menu/metadata/menu.yml
@@ -1346,49 +1346,39 @@ examples:
         <div class="spectrum-Modal spectrum-Tray is-open spectrum-Tray">
           <ul class="spectrum-Menu is-selectableMultiple" role="menu" style="--mod-menu-inline-size: 100%;">
             <li role="presentation">
-              <li class="spectrum-Menu-item spectrum-Menu-item--back" role="menuitem" tabindex="0">
-                <svg 
-                  class="spectrum-Icon spectrum-Icon--sizeM spectrum-UIIcon-ArrowLeft100 spectrum-Menu-backIcon"
-                  focusable="false" 
-                  aria-label="View previous menu"
-                >
-                  <use xlink:href="#spectrum-css-icon-Arrow100" />
-                </svg>
-                <span class="spectrum-Menu-itemLabel">Snap to</span>
-              </li>
-              <li class="spectrum-Menu-item is-selected" role="menuitem" tabindex="0">
-                <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-Checkbox--emphasized spectrum-Menu-itemCheckbox">
-                  <input type="checkbox" class="spectrum-Checkbox-input" checked>
-                  <span class="spectrum-Checkbox-box">
-                    <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-                      <use xlink:href="#spectrum-css-icon-Checkmark100" />
-                    </svg>
-                  </span>
-                  <span class="spectrum-Checkbox-label spectrum-Menu-itemLabel">Guides</span>
-                </label>
-              </li>
-              <li class="spectrum-Menu-item is-selectable" role="menuitem" tabindex="0">
-                <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-Checkbox--emphasized spectrum-Menu-itemCheckbox">
-                  <input type="checkbox" class="spectrum-Checkbox-input">
-                  <span class="spectrum-Checkbox-box">
-                    <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-                      <use xlink:href="#spectrum-css-icon-Checkmark100" />
-                    </svg>
-                  </span>
-                  <span class="spectrum-Checkbox-label spectrum-Menu-itemLabel"">Grid</span>
-                </label>
-              </li>
-              <li class="spectrum-Menu-item is-selected" role="menuitem" tabindex="0">
-                <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-Checkbox--emphasized spectrum-Menu-itemCheckbox">
-                  <input type="checkbox" class="spectrum-Checkbox-input" checked>
-                  <span class="spectrum-Checkbox-box">
-                    <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-                      <use xlink:href="#spectrum-css-icon-Checkmark100" />
-                    </svg>
-                  </span>
-                  <span class="spectrum-Checkbox-label spectrum-Menu-itemLabel">Rulers</span>
-                </label>
-              </li>
+              <div class="spectrum-Menu-back">
+                <button aria-label="Back to previous menu" class="spectrum-Menu-backButton" type="button" role="menuitem">
+                  <svg
+                    class="spectrum-Icon spectrum-Icon--sizeM spectrum-UIIcon-ArrowLeft100 spectrum-Menu-backIcon"
+                    aria-hidden="true"
+                  ><use xlink:href="#spectrum-css-icon-Arrow100" /></svg>
+                </button>
+                <span class="spectrum-Menu-backHeading" id="back-menu-heading" aria-hidden="true">Snap to</span>
+              </div>
+              <ul class="spectrum-Menu is-selectable" role="group" aria-labelledby="back-menu-heading">
+                <li class="spectrum-Menu-item is-selected" role="menuitem" tabindex="0">
+                  <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-UIIcon-Checkmark100 spectrum-Menu-itemIcon spectrum-Menu-checkmark" focusable="false" aria-hidden="true">
+                    <use xlink:href="#spectrum-css-icon-Checkmark100" />
+                  </svg>
+                  <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Menu-itemIcon spectrum-Menu-itemIcon--workflowIcon" focusable="false" aria-hidden="true" aria-label="Selection Icon">
+                    <use xlink:href="#spectrum-icon-18-Selection"></use>
+                  </svg>
+                  <span class="spectrum-Menu-itemLabel">Marquee</span>
+                </li>
+                <li class="spectrum-Menu-item is-selectable" role="menuitem" tabindex="0">
+                  <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Menu-itemIcon spectrum-Menu-itemIcon--workflowIcon" focusable="false" aria-hidden="true" aria-label="Select Add Icon">
+                    <use xlink:href="#spectrum-icon-18-SelectAdd"></use>
+                  </svg>
+                  <span class="spectrum-Menu-itemLabel">Add</span>
+                </li>
+                <li class="spectrum-Menu-item is-selectable" role="menuitem" tabindex="0">
+                  <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Menu-itemIcon spectrum-Menu-itemIcon--workflowIcon" focusable="false" aria-hidden="true" aria-label="Select Subtract Icon">
+                    <use xlink:href="#spectrum-icon-18-SelectSubtract"></use>
+                  </svg>
+                  <span class="spectrum-Menu-itemLabel">Subtract</span>
+                </li>
+              </ul>
+            </li>
           </ul>
         </div>
       </div>

--- a/components/menu/metadata/mods.md
+++ b/components/menu/metadata/mods.md
@@ -1,5 +1,7 @@
 | Modifiable Custom Properties                                       |
 | ------------------------------------------------------------------ |
+| `--mod-menu-back-heading-color`                                    |
+| `--mod-menu-back-icon-color-default`                               |
 | `--mod-menu-back-icon-margin-block`                                |
 | `--mod-menu-back-icon-margin-inline`                               |
 | `--mod-menu-back-padding-block`                                    |

--- a/components/menu/metadata/mods.md
+++ b/components/menu/metadata/mods.md
@@ -4,7 +4,9 @@
 | `--mod-menu-back-icon-color-default`                               |
 | `--mod-menu-back-icon-margin-block`                                |
 | `--mod-menu-back-icon-margin-inline`                               |
-| `--mod-menu-back-padding-block`                                    |
+| `--mod-menu-back-padding-block-end`                                |
+| `--mod-menu-back-padding-block-start`                              |
+| `--mod-menu-back-padding-inline-end`                               |
 | `--mod-menu-back-padding-inline-start`                             |
 | `--mod-menu-checkmark-display`                                     |
 | `--mod-menu-checkmark-icon-color-default`                          |

--- a/components/menu/metadata/mods.md
+++ b/components/menu/metadata/mods.md
@@ -1,5 +1,9 @@
 | Modifiable Custom Properties                                       |
 | ------------------------------------------------------------------ |
+| `--mod-menu-back-icon-margin-block`                                |
+| `--mod-menu-back-icon-margin-inline`                               |
+| `--mod-menu-back-padding-block`                                    |
+| `--mod-menu-back-padding-inline-start`                             |
 | `--mod-menu-checkmark-display`                                     |
 | `--mod-menu-checkmark-icon-color-default`                          |
 | `--mod-menu-checkmark-icon-color-down`                             |
@@ -10,6 +14,7 @@
 | `--mod-menu-drillin-icon-color-down`                               |
 | `--mod-menu-drillin-icon-color-focus`                              |
 | `--mod-menu-drillin-icon-color-hover`                              |
+| `--mod-menu-inline-size`                                           |
 | `--mod-menu-item-background-color-default`                         |
 | `--mod-menu-item-background-color-down`                            |
 | `--mod-menu-item-background-color-hover`                           |

--- a/components/menu/package.json
+++ b/components/menu/package.json
@@ -22,7 +22,7 @@
     "@spectrum-css/divider": ">=2",
     "@spectrum-css/icon": ">=4",
     "@spectrum-css/switch": ">=4",
-    "@spectrum-css/tokens": ">=11.1.0",
+    "@spectrum-css/tokens": ">=13",
     "@spectrum-css/tray": ">=2.1"
   },
   "devDependencies": {

--- a/components/menu/package.json
+++ b/components/menu/package.json
@@ -22,7 +22,8 @@
     "@spectrum-css/divider": ">=2",
     "@spectrum-css/icon": ">=4",
     "@spectrum-css/switch": ">=4",
-    "@spectrum-css/tokens": ">=11.1.0"
+    "@spectrum-css/tokens": ">=11.1.0",
+    "@spectrum-css/tray": ">=2.1"
   },
   "devDependencies": {
     "@spectrum-css/checkbox": "^8.0.2",
@@ -31,6 +32,7 @@
     "@spectrum-css/icon": "^4.0.5",
     "@spectrum-css/switch": "^4.0.15",
     "@spectrum-css/tokens": "^13.0.4",
+    "@spectrum-css/tray": "^2.1.17",
     "gulp": "^4.0.0"
   },
   "publishConfig": {

--- a/components/menu/stories/menu.stories.js
+++ b/components/menu/stories/menu.stories.js
@@ -412,3 +412,29 @@ Collapsible.args = {
     },
   ],
 };
+
+export const TraySubmenu = Template.bind({});
+TraySubmenu.args = {
+  selectionMode: "multiple",
+  customStyles: {
+    '--mod-menu-inline-size': '100%',
+  },
+  isTraySubmenu: true,
+  items: [
+    {
+      label: "Snap to",
+      isTraySubmenuBack: true,
+    },
+    {
+      label: "Guides",
+      isSelected: true,
+      isChecked: true,
+    },
+    {
+      label: "Grid",
+    },
+    {
+      label: "Rulers",
+    },
+  ],
+};

--- a/components/menu/stories/menu.stories.js
+++ b/components/menu/stories/menu.stories.js
@@ -422,19 +422,21 @@ TraySubmenu.args = {
   isTraySubmenu: true,
   items: [
     {
-      label: "Snap to",
-      isTraySubmenuBack: true,
-    },
-    {
-      label: "Guides",
-      isSelected: true,
-      isChecked: true,
-    },
-    {
-      label: "Grid",
-    },
-    {
-      label: "Rulers",
-    },
+      heading: "Snap to",
+      idx: 1,
+      items: [
+        {
+          label: "Guides",
+          isSelected: true,
+          isChecked: true,
+        },
+        {
+          label: "Grid",
+        },
+        {
+          label: "Rulers",
+        },
+      ]
+    }
   ],
 };

--- a/components/menu/stories/template.js
+++ b/components/menu/stories/template.js
@@ -24,7 +24,6 @@ export const MenuItem = ({
   isFocused = false,
   isDrillIn = false,
   isCollapsible = false,
-  isTraySubmenuBack = false,
   isOpen = false,
   role = "menuitem",
   items = [],
@@ -47,7 +46,6 @@ export const MenuItem = ({
         "is-disabled": isDisabled,
         [`${rootClass}--drillIn`]: isDrillIn,
         [`${rootClass}--collapsible`]: isCollapsible,
-        [`${rootClass}--back`]: isTraySubmenuBack,
         "is-open": isOpen,
       })}
       id=${ifDefined(id)}
@@ -74,13 +72,6 @@ export const MenuItem = ({
               `${rootClass}Icon`,
               `${rootClass}Icon--workflowIcon`
             ]
-          }) : ''}
-      ${isTraySubmenuBack
-        ? Icon({
-            ...globals,
-            iconName: "ArrowLeft",
-            size,
-            customClasses: [`spectrum-Menu-backIcon`] 
           }) : ''}
       ${isCollapsible
         ? html`<span class="spectrum-Menu-sectionHeading">${label}</span>`
@@ -113,8 +104,9 @@ export const MenuItem = ({
           ...globals,
           size,
           isEmphasized: true,
+          isChecked: isSelected,
           label: label,
-          id: `checkbox-${idx}`,
+          id: `menu-checkbox-${idx}`,
           customClasses: [
             `${rootClass}Checkbox`,
           ],
@@ -139,8 +131,9 @@ export const MenuItem = ({
           ${Switch({
               ...globals,
               size,
+              isChecked: isSelected,
               label: null,
-              id: `switch-${idx}`,
+              id: `menu-switch-${idx}`,
               customClasses: [
                 `${rootClass}Switch`,
               ],
@@ -159,33 +152,49 @@ export const MenuGroup = ({
   items = [],
   isDisabled = false,
   isSelectable = false,
+  isTraySubmenu = false,
   subrole,
   size,
   ...globals
 }) => html`
-    <li
-      id=${ifDefined(id)}
-      role="presentation">
-      ${heading
-        ? html`<span
-            class="spectrum-Menu-sectionHeading"
+  <li
+    id=${ifDefined(id)}
+    role="presentation"
+  >
+    ${!isTraySubmenu 
+      ? html`<span
+          class="spectrum-Menu-sectionHeading"
+          id=${id ?? `menu-heading-category-${idx}`}
+          aria-hidden="true"
+        >${heading}</span>`
+      : html`<div class="spectrum-Menu-back">
+          <button aria-label="Back to previous menu" class="spectrum-Menu-backButton" type="button" role="menuitem">
+            ${Icon({
+              ...globals,
+              iconName: "ArrowLeft",
+              size,
+              customClasses: [`spectrum-Menu-backIcon`] 
+            })}
+          </button>
+          <span
+            class="spectrum-Menu-backHeading"
             id=${id ?? `menu-heading-category-${idx}`}
             aria-hidden="true"
-            >${heading}</span
-          >`
-        : ""}
-      ${Template({
-        ...globals,
-        role: "group",
-        subrole,
-        labelledby: id,
-        items,
-        isDisabled,
-        isSelectable,
-        size,
-      })}
-    </li>
-  `;
+          >${heading}</span>
+        </div>`
+    }
+    ${Template({
+      ...globals,
+      role: "group",
+      subrole,
+      labelledby: id ?? `menu-heading-category-${idx}`,
+      items,
+      isDisabled,
+      isSelectable,
+      size,
+    })}
+  </li>
+`;
 
 export const Template = ({
   rootClass = "spectrum-Menu",
@@ -228,7 +237,15 @@ export const Template = ({
             size: "s",
             customClasses: [`${rootClass}-divider`],
           });
-        else if (i.heading) return MenuGroup({ ...i, ...globals, subrole, size, selectionMode });
+        else if (i.heading || i.isTraySubmenu)
+          return MenuGroup({ 
+            ...i,
+            ...globals,
+            subrole,
+            size,
+            selectionMode,
+            isTraySubmenu,
+          });
         else
           return MenuItem({
             ...globals,
@@ -237,7 +254,7 @@ export const Template = ({
             rootClass: `${rootClass}-item`,
             role: subrole,
             size,
-            selectionMode: idx == 0 && isTraySubmenu ? "none" : selectionMode,
+            selectionMode,
             hasActions,
           });
       })}

--- a/components/menu/stories/template.js
+++ b/components/menu/stories/template.js
@@ -7,6 +7,7 @@ import { Template as Checkbox } from "@spectrum-css/checkbox/stories/template.js
 import { Template as Divider } from "@spectrum-css/divider/stories/template.js";
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 import { Template as Switch } from "@spectrum-css/switch/stories/template.js";
+import { Template as Tray } from "@spectrum-css/tray/stories/template.js";
 
 import "../index.css";
 
@@ -23,6 +24,7 @@ export const MenuItem = ({
   isFocused = false,
   isDrillIn = false,
   isCollapsible = false,
+  isTraySubmenuBack = false,
   isOpen = false,
   role = "menuitem",
   items = [],
@@ -45,6 +47,7 @@ export const MenuItem = ({
         "is-disabled": isDisabled,
         [`${rootClass}--drillIn`]: isDrillIn,
         [`${rootClass}--collapsible`]: isCollapsible,
+        [`${rootClass}--back`]: isTraySubmenuBack,
         "is-open": isOpen,
       })}
       id=${ifDefined(id)}
@@ -72,14 +75,21 @@ export const MenuItem = ({
               `${rootClass}Icon--workflowIcon`
             ]
           }) : ''}
+      ${isTraySubmenuBack
+        ? Icon({
+            ...globals,
+            iconName: "ArrowLeft",
+            size,
+            customClasses: [`spectrum-Menu-backIcon`] 
+          }) : ''}
       ${isCollapsible
         ? html`<span class="spectrum-Menu-sectionHeading">${label}</span>`
         : ''
       }
       ${selectionMode != "multiple" && !isCollapsible
         ? html`<span class=${classMap({
-          [`${rootClass}Label`]: true,
-          ['spectrum-Switch-label']: hasActions,
+            [`${rootClass}Label`]: true,
+            ['spectrum-Switch-label']: hasActions,
           })}>
           ${label}
         </span>`
@@ -110,7 +120,7 @@ export const MenuItem = ({
           ],
         })
       : ''}
-      ${isChecked && selectionMode != "multiple"
+      ${isChecked && selectionMode == "single"
         ? Icon({
             ...globals,
             iconName: "Checkmark100",
@@ -187,14 +197,14 @@ export const Template = ({
   selectionMode = "none",
   isOpen = false,
   hasActions = false,
+  isTraySubmenu = false,
   items = [],
   role = "menu",
   subrole = "menuitem",
   id,
   ...globals
 }) => {
-
-  return html`
+  const menuMarkup = html`
     <ul
       class=${classMap({
         [rootClass]: true,
@@ -227,10 +237,15 @@ export const Template = ({
             rootClass: `${rootClass}-item`,
             role: subrole,
             size,
-            selectionMode,
+            selectionMode: idx == 0 && isTraySubmenu ? "none" : selectionMode,
             hasActions,
           });
       })}
     </ul>
   `;
+
+  if (isTraySubmenu){
+    return Tray({ content: [menuMarkup] });
+  }
+  return menuMarkup;
 };

--- a/components/menu/stories/template.js
+++ b/components/menu/stories/template.js
@@ -145,6 +145,22 @@ export const MenuItem = ({
   `
 };
 
+/**
+ * Get the tray submenu back arrow name with scale number (defined in design spec).
+ */
+const backArrowWithScale = (size = "m", iconName = "ArrowLeft") => {
+  switch (size) {
+    case "s":
+      return `${iconName}200`;
+    case "l":
+      return `${iconName}400`;
+    case "xl":
+      return `${iconName}500`;
+    default:
+      return `${iconName}300`;
+  }
+}
+
 export const MenuGroup = ({
   heading,
   id,
@@ -171,7 +187,7 @@ export const MenuGroup = ({
           <button aria-label="Back to previous menu" class="spectrum-Menu-backButton" type="button" role="menuitem">
             ${Icon({
               ...globals,
-              iconName: "ArrowLeft",
+              iconName: backArrowWithScale(size),
               size,
               customClasses: [`spectrum-Menu-backIcon`] 
             })}

--- a/components/tray/metadata/tray.yml
+++ b/components/tray/metadata/tray.yml
@@ -12,7 +12,7 @@ examples:
     name: Tray
     markup: |
       <div class="spectrum-Tray-wrapper spectrum-CSSExample-dialog" style="background: rgba(0,0,0,0.4);">
-        <div class="spectrum-Modal spectrum-Tray is-open spectrum-Tray">
+        <div class="spectrum-Modal spectrum-Tray is-open">
           <section class="spectrum-Dialog spectrum-Dialog--large" role="dialog" tabindex="-1" aria-modal="true">
             <div class="spectrum-Dialog-grid">
               <h1 class="spectrum-Dialog-heading spectrum-Dialog-heading--noHeader">New Messages</h1>


### PR DESCRIPTION
## Description

**Menu - Tray Submenus**
Adds the "Tray submenus" feature to the **Menu** component. [Guidelines](https://spectrum.adobe.com/page/menu/#Tray-submenus):
> When a menu is displayed within a tray, a submenu will replace the tray content when the parent menu item is selected. A submenu displays a back button (labeled by the title of the parent item) at the top of the tray to return the user to the previous level of the menu.

This adds some additional CSS, a new example on the docs, and a new story in Storybook.
Some additional markup was adjusted in the docs to rename some duplicate IDs.

The markup for this is based on the existing "Standard with section headers and dividers" example. As the back item functions like a "section header", but with an additional button for navigating back. I've included the button as an additional `role="menuitem"`, along with ARIA label text describing the function of the icon ("Back to previous menu").

CSS-303

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [x] Validated by design [to be confirmed by @jawinn]
- [x] Menu tray submenu examples appear on docs and Storybook
- [x] Menu tray submenu looks correct, including at different t-shirt sizes. Note: the icon is now larger than appears on the Guidelines. The latest Xd design shows the updated larger arrow icon scale and usage of `navigational-indicator-top-to-back-icon-*` tokens. The icon and header text not lining up with the items below is also expected, per Slack discussion in the verification channel on Oct 9th.
- [x] Back button shows focus indicator on tab focus but not on click

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

![Screenshot 2023-11-15 at 12 55 35 PM](https://github.com/adobe/spectrum-css/assets/965114/a2a03d0b-1d00-4d53-9e55-acb07c344e50)

Updated design reference:
![Screenshot 2023-11-15 at 1 00 57 PM](https://github.com/adobe/spectrum-css/assets/965114/6d2af856-69ad-4754-91cb-aed131cffa21)

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
