### PR TITLE
refactor(radio): remove deprecated use of invalid

### DIFF
--- a/components/fieldgroup/metadata/fieldgroup.yml
+++ b/components/fieldgroup/metadata/fieldgroup.yml
@@ -1,20 +1,20 @@
 name: Field group
 description: |
   - A group of fields, usually Radios or Checkboxes.
-  - Fieldgroup incorporates the help text component which may appear below a fieldgroup.
+  - Field group incorporates the Help text component which may appear below a Field group.
   - Help text is necessary to denote invalid checkbox fields, invalid radio button fields, and required fields.
-  - Invalid radio buttons are signified only by alert help text.
-  - Invalid checkboxes are signified by alert help text and alert input box color.
+  - Invalid radio buttons are signified only by negative Help text.
+  - Invalid checkboxes are signified by negative Help text and the negative/invalid color on the input box.
 sections:
   - name: Migration Guide
     description: |
-      ### Field Group Now Includes Label and Helptext
+      ### Field group now includes Field label and Help text
       - Include Field Label as size medium, `spectrum-FieldLabel spectrum-FieldLabel--sizeM`.
-      - Include Helptext as `spectrum-HelpText-text`.
-      ### Field Group Label has two layout options
+      - Include Help text as `spectrum-HelpText-text`.
+      ### Field group label has two layout options
       - Label can be top aligned with `spectrum-FieldGroup spectrum-FieldGroup--toplabel`.
       - Label can be side aligned with `spectrum-FieldGroup spectrum-FieldGroup--sidelabel`.
-      ### Field Group must now include `spectrum-FieldGroupInputLayout` as the immediate parent of the FieldGroup items
+      ### Field group must now include `spectrum-FieldGroupInputLayout` as the immediate parent of the Field group items
       - Due to the addition of label, a new nested div must wrap the fieldgroup items to control their layout separately from the label
 
 examples:
@@ -198,17 +198,22 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Radio</h4>
 
           <form class="spectrum-Form">
-            <div class="spectrum-FieldGroup spectrum-FieldGroup--toplabel spectrum-FieldGroup--horizontal" role="radiogroup" aria-labelledby="radiogroup-label-3">
+            <div
+              class="spectrum-FieldGroup spectrum-FieldGroup--toplabel spectrum-FieldGroup--horizontal"
+              role="radiogroup"
+              aria-invalid="true"
+              aria-labelledby="radiogroup-label-3"
+            >
               <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="radiogroup-label-3">Radio Group Label</div>
 
               <div class="spectrum-FieldGroupInputLayout" aria-describedby="helptext-radio-3">
-                <div class="spectrum-Radio spectrum-FieldGroup-item is-invalid">
+                <div class="spectrum-Radio spectrum-FieldGroup-item">
                   <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-4">
                   <span class="spectrum-Radio-button"></span>
                   <label class="spectrum-Radio-label" for="radio-0">Kittens</label>
                 </div>
 
-                <div class="spectrum-Radio spectrum-FieldGroup-item is-invalid">
+                <div class="spectrum-Radio spectrum-FieldGroup-item">
                   <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-5" checked>
                   <span class="spectrum-Radio-button"></span>
                   <label class="spectrum-Radio-label" for="radio-1">Puppies</label>

--- a/components/fieldgroup/stories/fieldgroup.stories.js
+++ b/components/fieldgroup/stories/fieldgroup.stories.js
@@ -1,6 +1,6 @@
 // Import the component markup template
-import { Template } from "./template";
 import { default as Radio } from "@spectrum-css/radio/stories/radio.stories.js";
+import { Template } from "./template";
 
 export default {
 	title: "Components/Field group",
@@ -58,6 +58,7 @@ export default {
 export const Vertical = Template.bind({});
 Vertical.args = {
 	layout: "vertical",
+	isInvalid: true,
 	items: [
 		{
 			id: "1",
@@ -73,6 +74,7 @@ Vertical.args = {
 export const Horizontal = Template.bind({});
 Horizontal.args = {
 	layout: "horizontal",
+	isInvalid: true,
 	items: [
 		{
 			id: "1",

--- a/components/fieldgroup/stories/template.js
+++ b/components/fieldgroup/stories/template.js
@@ -1,10 +1,11 @@
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 import { repeat } from "lit/directives/repeat.js";
 
 import { Template as FieldLabel } from "@spectrum-css/fieldlabel/stories/template.js";
-import { Template as Radio } from "@spectrum-css/radio/stories/template.js";
 import { Template as HelpText } from "@spectrum-css/helptext/stories/template.js";
+import { Template as Radio } from "@spectrum-css/radio/stories/template.js";
 
 import "../index.css";
 
@@ -35,6 +36,7 @@ export const Template = ({
 				[`${rootClass}--${layout}`]: typeof layout !== "undefined",
 				...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
 			})}
+			aria-invalid=${ifDefined(isInvalid ? "true" : undefined)}
 		>
 			${FieldLabel({
 				...globals,

--- a/components/helptext/stories/helptext.stories.js
+++ b/components/helptext/stories/helptext.stories.js
@@ -18,8 +18,8 @@ export default {
 			},
 			control: { type: "text" },
 		},
-		treatment: {
-			name: "Treatment",
+		variant: {
+			name: "Variant",
 			type: { name: "string" },
 			table: {
 				type: { summary: "string" },
@@ -28,17 +28,27 @@ export default {
 			options: ["neutral", "negative"],
 			control: "inline-radio",
 		},
+		size: {
+			name: "Size",
+			type: { name: "string", required: true },
+			table: {
+				type: { summary: "string" },
+				category: "Component",
+			},
+			options: ["s", "m", "l", "xl"],
+			control: "select",
+		},
 		hideIcon: {
 			name: "Hide icon",
 			type: { name: "boolean" },
-			description: "Only applicable if treatment is negative.",
+			description: "Help text using the negative variant can have an optional icon.",
 			table: {
 				type: { summary: "boolean" },
 				disable: false,
-				category: "Advanced",
+				category: "Component",
 			},
 			control: "boolean",
-			if: { arg: "treatment", eq: "negative" },
+			if: { arg: "variant", eq: "negative" },
 		},
 		isDisabled: {
 			name: "Disabled",
@@ -49,13 +59,23 @@ export default {
 			},
 			control: "boolean",
 		},
+		customStyles: {
+			name: "Custom styles",
+			description: "Storybook only styles for testing the story, applied to the parent element.",
+			table: {
+				type: { summary: "object" },
+				category: "Advanced",
+			},
+			if: { arg: 'customStyles' }
+		}
 	},
 	args: {
 		rootClass: "spectrum-HelpText",
 		text: "Create a password with at least 8 characters.",
-		treatment: "neutral",
+		variant: "neutral",
 		hideIcon: false,
 		isDisabled: false,
+		size: "m",
 	},
 	parameters: {
 		actions: {
@@ -70,4 +90,13 @@ export default {
 };
 
 export const Default = Template.bind({});
+Default.storyName = "Neutral";
 Default.args = {};
+
+export const Negative = Template.bind({});
+Negative.storyName = "Negative";
+Negative.args = {
+	variant: "negative",
+	text: "This is an example with wrapping text. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+	customStyles: {'max-width': '350px'},
+};

--- a/components/helptext/stories/template.js
+++ b/components/helptext/stories/template.js
@@ -1,6 +1,7 @@
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
+import { styleMap } from "lit/directives/style-map.js";
 
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 
@@ -16,6 +17,7 @@ export const Template = ({
 	variant,
 	id,
 	customClasses = [],
+	customStyles = {},
 	...globals
 }) => {
 	const { express } = globals;
@@ -37,13 +39,14 @@ export const Template = ({
 				[`${rootClass}--${variant}`]: typeof variant !== "undefined",
 				...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
 			})}
+			style=${styleMap(customStyles)}
 			id=${ifDefined(id)}
 		>
-			${!hideIcon
+			${!hideIcon && variant == "negative"
 				? Icon({
-						iconName: "Alert",
-						size,
-						customClasses: [`${rootClass}-validationIcon`],
+					iconName: "Alert",
+					size,
+					customClasses: [`${rootClass}-validationIcon`],
 				  })
 				: ""}
 			<div class=${`${rootClass}-text`}>${text}</div>

--- a/components/radio/index.css
+++ b/components/radio/index.css
@@ -177,8 +177,7 @@ governing permissions and limitations under the License.
   position: relative;
   vertical-align: top;
 
-  min-block-size: var(--mod-radio-height,
-                      var(--spectrum-radio-height));
+  min-block-size: var(--mod-radio-height, var(--spectrum-radio-height));
   max-inline-size: 100%;
 
   &:hover {
@@ -256,14 +255,7 @@ governing permissions and limitations under the License.
     .spectrum-Radio-label {
       color: var(--highcontrast-radio-neutral-content-color-focus,
                 var(--mod-radio-neutral-content-color-focus,
-                    var(--spectrum-radio-neutral-content-color-focus)));    }
-  }
-
-  &.is-invalid {
-    .spectrum-Radio-label {
-      color: var(--highcontrast-radio-neutral-content-color,
-                var(--mod-radio-neutral-content-color,
-                    var(--spectrum-radio-neutral-content-color)));
+                    var(--spectrum-radio-neutral-content-color-focus)));
     }
   }
 
@@ -284,7 +276,7 @@ governing permissions and limitations under the License.
     .spectrum-Radio-label,
     /* ensure disabled readonly has normal text color */
     & .spectrum-Radio-input:disabled ~ .spectrum-Radio-label,
-    & .spectrum-Radio-input:checked:disabled ~ .spectrum-Radio-label, {
+    & .spectrum-Radio-input:checked:disabled ~ .spectrum-Radio-label {
       margin-inline-start: auto;
       color: inherit;
     }
@@ -383,7 +375,7 @@ governing permissions and limitations under the License.
     }
   }
 
- /* focused state */
+  /* focused state */
   &:focus-visible {
     + .spectrum-Radio-button::after {
       border-width: var(--mod-radio-focus-indicator-thickness,

--- a/components/radio/metadata/radio.yml
+++ b/components/radio/metadata/radio.yml
@@ -21,7 +21,7 @@ sections:
       - Read-only radio buttons do not have a focus ring, but the button should be focusable.]
 
       ### Invalid/Error State
-      - Invalid radio buttons are signified by including [HelpText](helptext.html) in a [FieldGroup](fieldgroup.html).
+      - Invalid radio buttons are signified by including [Help text](helptext.html) in a [Field group](fieldgroup.html). The `.is-invalid` class has been removed. See Field group for an example with an invalid radio group. 
 
       ### Remove focus-ring class
       We've migrated away from the focus-ring class in favor of the native `:focus-visible` pseudo-class due to changes in browser support.


### PR DESCRIPTION
## Description

The invalid state of radios is now defined on the Field group (with `role="radiogroup"`):
> In updating documentation on properly showing invalid state in radio groups in SWC. We discussed removing the invalid attribute from the Radio component—favoring the Radio Group instead. In WAI-ARIA 1.2, the aria-invalid state is deprecated on role="radio"...

Some of the Spectrum CSS documentation was updated previously, but there were specific styles covering the invalid state in the Radio component's CSS. This `is-invalid` class has been removed in this PR. This does not to appear to have any visual effect, as the color was already a default. Per the guidelines and existing Field group example, "the error is indicated with negative Help text, along with an Icon."

The `aria-invalid` attribute mentioned in the writeup for this issue has also been added to the example markup for FieldGroup.

This PR also includes some docs and Storybook updates noticed while making updates:
- **FieldGroup**: existing stories now set `isInvalid` to true, as they were previously showing the neutral colors with the invalid icon, which didn't match with the guidelines.  
:framed_picture: _Expected VRT Change:_ Both stories will now show negative (red) text color

- **HelpText**: storybook templates had a mismatched arg name between the stories file and template file ("treatment" vs "variant"), and the "treatment" control did not work. This is now "variant" for both, and the control works . The template will also no longer show the invalid icon for the "neutral" variant, to conform with the guidelines. There was previously only one story in Storybook. I've added another story so both the "neutral" and "negative" (+ wrapping text) variants are represented in VRTs. The missing "size" control has also been added.
:framed_picture: _Expected VRT Change:_ Default story will now show neutral text color and no icon. New story is added that shows negative text color and invalid icon.

CSS-583

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation Steps

- [ ] Invalid radio examples still display the same (default, emphasized, focus, etc)
- [ ] Field group invalid radios example has `aria-invalid="true"` in docs and Storybook
- [ ] Confirm and test the Storybook changes for Field group and Help text as described in the PR description

### Regression testing

Validate:

1. A legacy documentation page (such as [accordion](https://pr-###--spectrum-css.netlify.app/accordion.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

2. A migrated documentation page (such as [action group](https://pr-###--spectrum-css.netlify.app/actiongroup.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.

- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.

- [ ] ✨ This pull request is ready to merge. ✨
