### PR TITLE
refactor(dialog): remove unused custom properties

### DIFF
--- a/components/dialog/index.css
+++ b/components/dialog/index.css
@@ -21,8 +21,6 @@ governing permissions and limitations under the License.
   --spectrum-dialog-confirm-small-width: 400px;
   --spectrum-dialog-confirm-medium-width: 480px;
   --spectrum-dialog-confirm-large-width: 640px;
-  --spectrum-dialog-confirm-max-inline-size: 90vw;
-  --spectrum-dialog-confirm-max-height: 90vh;
   --spectrum-dialog-confirm-divider-block-spacing-start: var(--spectrum-spacing-300);
   --spectrum-dialog-confirm-divider-block-spacing-end: var(--spectrum-spacing-200);
   --spectrum-dialog-confirm-description-text-color: var(--spectrum-gray-800);


### PR DESCRIPTION
* removes two unused custom properties: `--spectrum-dialog-confirm-max-inline-size` `--spectrum-dialog-confirm-max-height`

Those have been in the repo for quite some time, but have never been used in Spectrum CSS itself.

<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->

## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

<!--
  Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

### Regression testing

Validate:

1. A legacy documentation page (such as [accordion](https://pr-###--spectrum-css.netlify.app/accordion.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

2. A migrated documentation page (such as [action group](https://pr-###--spectrum-css.netlify.app/actiongroup.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [ ] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.

- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.

- [ ] ✨ This pull request is ready to merge. ✨
