### PR TITLE
fix(slider): focus state matches spec, supports forced-colors

### DIFF
--- a/components/slider/index.css
+++ b/components/slider/index.css
@@ -613,15 +613,9 @@ governing permissions and limitations under the License.
 .spectrum-Slider--ramp {
   .spectrum-Slider-handle {
     box-shadow: 0 0 0 var(--spectrum-slider-handle-gap) var(--highcontrast-slider-ramp-handle-border-color-active, var(--mod-sectrum-slider-ramp-handle-border-color-active, var(--spectrum-slider-ramp-handle-border-color-active)));
-    background: var(--mod-slider-ramp-handle-background-color, var(--spectrum-slider-ramp-handle-background-color));
-
-    @media (forced-colors: active) {
-      /* forced-color-adjust required to ensure the "circle" around the handle is transparent */
-      forced-color-adjust: none;
-      box-shadow: 0 0 0 var(--spectrum-slider-handle-gap) ButtonFace;
-      border-color: ButtonText;
-      background-color: ButtonFace;
-    }
+    background: var(--mod-slider-ramp-handle-background-color, var(--highcontrast-slider-ramp-handle-background-color, var(--spectrum-slider-ramp-handle-background-color)));
+    /* forced-color-adjust required to ensure the "circle" around the handle is transparent */
+    forced-color-adjust: none;
   }
 }
 
@@ -707,17 +701,20 @@ governing permissions and limitations under the License.
 @media (forced-colors: active) {
 
   .spectrum-Slider {
-
     /*  over-writes */
     --highcontrast-slider-track-color: ButtonText;
     --highcontrast-slider-track-fill-color: ButtonText;
     --highcontrast-slider-ramp-track-color: ButtonText;
     --highcontrast-slider-ramp-track-color-disabled: GrayText;
     --highcontrast-slider-tick-mark-color: ButtonText;
+    --highcontrast-slider-handle-border-color: ButtonText;
     --highcontrast-slider-handle-border-color-hover: Highlight;
     --highcontrast-slider-handle-border-color-down: Highlight;
     --highcontrast-slider-handle-border-color-key-focus: Highlight;
     --highcontrast-slider-handle-focus-ring-color-key-focus: CanvasText;
+    --highcontrast-slider-handle-background-color: ButtonFace;
+    --highcontrast-slider-ramp-handle-border-color-active: ButtonFace;
+    --highcontrast-slider-ramp-handle-background-color: ButtonFace;
 
     --spectrum-slider-track-color: ButtonText;
     --spectrum-slider-track-fill-color: ButtonText;
@@ -746,21 +743,17 @@ governing permissions and limitations under the License.
     --spectrum-slider-label-text-color-disabled: GrayText;
 
     --spectrum-slider-ramp-handle-border-color-active: ButtonText;
-
   }
 
-  .spectrum-Slider:not(.is-disabled) {
-    /* We only need these states in high contrast mode */
-    .spectrum-Slider-controls:hover,
-    .spectrum-Slider-controls:active,
-    .spectrum-Slider-controls:focus-within {
-      --highcontrast-slider-track-fill-color: Highlight;
-      --highcontrast-slider-track-color: Highlight;
-      --highcontrast-slider-handle-border-color: Highlight;
-      --highcontrast-slider-ramp-track-color: Highlight;
-    }
+  .spectrum-Slider:not(.is-disabled):hover,
+  .spectrum-Slider:not(.is-disabled):active,
+  .spectrum-Slider:not(.is-disabled):focus-within {
+    --highcontrast-slider-track-fill-color: Highlight;
+    --highcontrast-slider-track-color: Highlight;
+    --highcontrast-slider-handle-border-color: Highlight;
+    --highcontrast-slider-ramp-track-color: Highlight;
+    --highcontrast-slider-tick-mark-color: Highlight;
   }
-
 
   /* Slider handle turns transparent in high contrast mode for ramp */
   .spectrum-Slider.is-disabled {

--- a/components/slider/index.css
+++ b/components/slider/index.css
@@ -599,6 +599,7 @@ governing permissions and limitations under the License.
 
     &::before {
       box-shadow: 0 0 0 var(--spectrum-focus-indicator-thickness) var(--highcontrast-slider-handle-focus-ring-color-key-focus, var(--mod-slider-handle-focus-ring-color-key-focus, var(--spectrum-slider-handle-focus-ring-color-key-focus)));
+      forced-color-adjust: none;
     }
   }
 
@@ -714,7 +715,9 @@ governing permissions and limitations under the License.
     --highcontrast-slider-ramp-track-color-disabled: GrayText;
     --highcontrast-slider-tick-mark-color: ButtonText;
     --highcontrast-slider-handle-border-color-hover: Highlight;
-    --highcontrast-slider-track-color-hover: Highlight;
+    --highcontrast-slider-handle-border-color-down: Highlight;
+    --highcontrast-slider-handle-border-color-key-focus: Highlight;
+    --highcontrast-slider-handle-focus-ring-color-key-focus: CanvasText;
 
     --spectrum-slider-track-color: ButtonText;
     --spectrum-slider-track-fill-color: ButtonText;
@@ -746,32 +749,15 @@ governing permissions and limitations under the License.
 
   }
 
-  /* Slider track background color doesn't show in high contrast mode, but border does */
   .spectrum-Slider:not(.is-disabled) {
-    .spectrum-Slider-track {
-      &::before {
-        border-block-start: 2px solid transparent;
-      }
-    }
-
     /* We only need these states in high contrast mode */
     .spectrum-Slider-controls:hover,
     .spectrum-Slider-controls:active,
     .spectrum-Slider-controls:focus-within {
-      .spectrum-Slider-track::before {
-        background: var(--highcontrast-slider-track-color-hover, var(--mod-slider-track-color, var(--spectrum-slider-track-color)));
-        border-block-start: none;
-      }
-
-      .spectrum-Slider-handle {
-        border-color: var(--highcontrast-slider-handle-border-color-hover, var(--mod-slider-handle-border-color-hover, var(--spectrum-slider-handle-border-color-hover)));
-
-        &.is-focused {
-          &::before {
-            border: 2px solid transparent;
-          }
-        }
-      }
+      --highcontrast-slider-track-fill-color: Highlight;
+      --highcontrast-slider-track-color: Highlight;
+      --highcontrast-slider-handle-border-color: Highlight;
+      --highcontrast-slider-ramp-track-color: Highlight;
     }
   }
 

--- a/components/slider/index.css
+++ b/components/slider/index.css
@@ -520,6 +520,10 @@ governing permissions and limitations under the License.
   &.is-disabled {
     cursor: default;
 
+    .spectrum-Slider-controls {
+      cursor: default;
+    }
+
     .spectrum-Slider-handle {
       cursor: default;
       pointer-events: none;

--- a/components/slider/index.css
+++ b/components/slider/index.css
@@ -47,7 +47,7 @@ governing permissions and limitations under the License.
   --spectrum-slider-label-top-to-text: var(--spectrum-component-top-to-text-100);
   --spectrum-slider-control-to-field-label: var(--spectrum-slider-control-to-field-label-large);
   --spectrum-slider-value-side-padding-inline: var(--spectrum-spacing-200);
-  
+
   /* TODO: placeholder value for sideLabel variant value width */
   --spectrum-slider-value-inline-size: 18px;
 }
@@ -316,7 +316,6 @@ governing permissions and limitations under the License.
   outline: none;
 
   &:active,
-  &.is-focused,
   &.is-dragged {
     border-width: var(--mod-slider-handle-border-width-down, var(--spectrum-slider-handle-border-width-down));
   }
@@ -732,7 +731,7 @@ governing permissions and limitations under the License.
 
     --spectrum-slider-track-color-disabled: GrayText;
     --spectrum-slider-track-fill-color-disabled: GrayText;
-    
+
     --spectrum-slider-handle-border-color-disabled: GrayText;
 
     --spectrum-slider-label-text-color: CanvasText;

--- a/components/slider/index.css
+++ b/components/slider/index.css
@@ -745,14 +745,16 @@ governing permissions and limitations under the License.
     --spectrum-slider-ramp-handle-border-color-active: ButtonText;
   }
 
-  .spectrum-Slider:not(.is-disabled):hover,
-  .spectrum-Slider:not(.is-disabled):active,
-  .spectrum-Slider:not(.is-disabled):focus-within {
-    --highcontrast-slider-track-fill-color: Highlight;
-    --highcontrast-slider-track-color: Highlight;
-    --highcontrast-slider-handle-border-color: Highlight;
-    --highcontrast-slider-ramp-track-color: Highlight;
-    --highcontrast-slider-tick-mark-color: Highlight;
+  .spectrum-Slider:not(.is-disabled) {
+    .spectrum-Slider-controls:hover,
+    .spectrum-Slider-controls:active,
+    .spectrum-Slider-controls:focus-within {
+      --highcontrast-slider-track-fill-color: Highlight;
+      --highcontrast-slider-track-color: Highlight;
+      --highcontrast-slider-handle-border-color: Highlight;
+      --highcontrast-slider-ramp-track-color: Highlight;
+      --highcontrast-slider-tick-mark-color: Highlight;
+    }
   }
 
   /* Slider handle turns transparent in high contrast mode for ramp */

--- a/components/slider/index.css
+++ b/components/slider/index.css
@@ -743,25 +743,26 @@ governing permissions and limitations under the License.
     --spectrum-slider-label-text-color-disabled: GrayText;
 
     --spectrum-slider-ramp-handle-border-color-active: ButtonText;
-  }
 
-  .spectrum-Slider:not(.is-disabled) {
-    .spectrum-Slider-controls:hover,
-    .spectrum-Slider-controls:active,
-    .spectrum-Slider-controls:focus-within {
-      --highcontrast-slider-track-fill-color: Highlight;
-      --highcontrast-slider-track-color: Highlight;
-      --highcontrast-slider-handle-border-color: Highlight;
-      --highcontrast-slider-ramp-track-color: Highlight;
-      --highcontrast-slider-tick-mark-color: Highlight;
+    /* Slider control hover and focus colors for high contrast mode */
+    &:not(.is-disabled) {
+      .spectrum-Slider-controls:hover,
+      .spectrum-Slider-controls:active,
+      .spectrum-Slider-controls:focus-within {
+        --highcontrast-slider-track-fill-color: Highlight;
+        --highcontrast-slider-track-color: Highlight;
+        --highcontrast-slider-handle-border-color: Highlight;
+        --highcontrast-slider-ramp-track-color: Highlight;
+        --highcontrast-slider-tick-mark-color: Highlight;
+      }
     }
-  }
 
-  /* Slider handle turns transparent in high contrast mode for ramp */
-  .spectrum-Slider.is-disabled {
-    .spectrum-Slider-ramp + .spectrum-Slider-handle {
-      fill: ButtonFace;
-      background-color: ButtonFace;
+    /* Slider handle turns transparent in high contrast mode for ramp */
+    &.is-disabled {
+      .spectrum-Slider-ramp + .spectrum-Slider-handle {
+        fill: ButtonFace;
+        background-color: ButtonFace;
+      }
     }
   }
 }

--- a/components/slider/index.css
+++ b/components/slider/index.css
@@ -709,7 +709,8 @@ governing permissions and limitations under the License.
     --highcontrast-slider-ramp-track-color: ButtonText;
     --highcontrast-slider-ramp-track-color-disabled: GrayText;
     --highcontrast-slider-tick-mark-color: ButtonText;
-
+    --highcontrast-slider-handle-border-color-hover: Highlight;
+    --highcontrast-slider-track-color-hover: Highlight;
 
     --spectrum-slider-track-color: ButtonText;
     --spectrum-slider-track-fill-color: ButtonText;
@@ -740,6 +741,36 @@ governing permissions and limitations under the License.
     --spectrum-slider-ramp-handle-border-color-active: ButtonText;
 
   }
+
+  /* Slider track background color doesn't show in high contrast mode, but border does */
+  .spectrum-Slider:not(.is-disabled) {
+    .spectrum-Slider-track {
+      &::before {
+        border-block-start: 2px solid transparent;
+      }
+    }
+
+    /* We only need these states in high contrast mode */
+    .spectrum-Slider-controls:hover,
+    .spectrum-Slider-controls:active,
+    .spectrum-Slider-controls:focus-within {
+      .spectrum-Slider-track::before {
+        background: var(--highcontrast-slider-track-color-hover, var(--mod-slider-track-color, var(--spectrum-slider-track-color)));
+        border-block-start: none;
+      }
+
+      .spectrum-Slider-handle {
+        border-color: var(--highcontrast-slider-handle-border-color-hover, var(--mod-slider-handle-border-color-hover, var(--spectrum-slider-handle-border-color-hover)));
+
+        &.is-focused {
+          &::before {
+            border: 2px solid transparent;
+          }
+        }
+      }
+    }
+  }
+
 
   /* Slider handle turns transparent in high contrast mode for ramp */
   .spectrum-Slider.is-disabled {

--- a/components/slider/index.css
+++ b/components/slider/index.css
@@ -740,7 +740,8 @@ governing permissions and limitations under the License.
     &:not(.is-disabled) {
       .spectrum-Slider-controls:hover,
       .spectrum-Slider-controls:active,
-      .spectrum-Slider-controls:focus-within {
+      .spectrum-Slider-controls:focus-within,
+      .spectrum-Slider-controls.is-focused {
         --highcontrast-slider-track-fill-color: Highlight;
         --highcontrast-slider-track-color: Highlight;
         --highcontrast-slider-handle-border-color: Highlight;

--- a/components/slider/index.css
+++ b/components/slider/index.css
@@ -579,7 +579,6 @@ governing permissions and limitations under the License.
 
     &::before {
       box-shadow: 0 0 0 var(--spectrum-focus-indicator-thickness) var(--highcontrast-slider-handle-focus-ring-color-key-focus, var(--mod-slider-handle-focus-ring-color-key-focus, var(--spectrum-slider-handle-focus-ring-color-key-focus)));
-      forced-color-adjust: none;
     }
   }
 
@@ -594,8 +593,6 @@ governing permissions and limitations under the License.
   .spectrum-Slider-handle {
     box-shadow: 0 0 0 var(--spectrum-slider-handle-gap) var(--highcontrast-slider-ramp-handle-border-color-active, var(--mod-sectrum-slider-ramp-handle-border-color-active, var(--spectrum-slider-ramp-handle-border-color-active)));
     background: var(--mod-slider-ramp-handle-background-color, var(--highcontrast-slider-ramp-handle-background-color, var(--spectrum-slider-ramp-handle-background-color)));
-    /* forced-color-adjust required to ensure the "circle" around the handle is transparent */
-    forced-color-adjust: none;
   }
 }
 
@@ -735,6 +732,15 @@ governing permissions and limitations under the License.
     --spectrum-slider-label-text-color-disabled: GrayText;
 
     --spectrum-slider-ramp-handle-border-color-active: ButtonText;
+
+    .spectrum-Slider-handle.is-focused::before {
+      forced-color-adjust: none;
+    }
+
+    .spectrum-Slider--ramp .spectrum-Slider-handle {
+      /* forced-color-adjust required to ensure the "circle" around the handle is transparent */
+      forced-color-adjust: none;
+    }
 
     /* Slider control hover and focus colors for high contrast mode */
     &:not(.is-disabled) {

--- a/components/slider/index.css
+++ b/components/slider/index.css
@@ -515,26 +515,6 @@ governing permissions and limitations under the License.
   }
 }
 
-
-.spectrum-Slider {
-  &.is-disabled {
-    cursor: default;
-
-    .spectrum-Slider-controls {
-      cursor: default;
-    }
-
-    .spectrum-Slider-handle {
-      cursor: default;
-      pointer-events: none;
-    }
-
-    .spectrum-Slider-tickLabel {
-      color: var(--highcontrast-slider-label-text-color-disabled, var(--mod-slider-label-text-color-disabled, var(--spectrum-slider-label-text-color-disabled)));
-    }
-  }
-}
-
 /* backwards compatibility: these are not required, but they make the handle go to the edegs and align right */
 .spectrum-Slider-handleContainer,
 .spectrum-Slider-trackContainer {
@@ -646,6 +626,16 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Slider.is-disabled {
+  cursor: default;
+
+  .spectrum-Slider-controls {
+    cursor: default;
+  }
+
+  .spectrum-Slider-tickLabel {
+    color: var(--highcontrast-slider-label-text-color-disabled, var(--mod-slider-label-text-color-disabled, var(--spectrum-slider-label-text-color-disabled)));
+  }
+
   .spectrum-Slider-labelContainer {
     color: var(--highcontrast-slider-label-text-color-disabled, var(--mod-slider-label-text-color-disabled, var(--spectrum-slider-label-text-color-disabled)));
   }
@@ -653,6 +643,8 @@ governing permissions and limitations under the License.
   .spectrum-Slider-handle {
     border-color: var(--highcontrast-slider-handle-border-color-disabled, var(--mod-slider-handle-border-color-disabled, var(--spectrum-slider-handle-border-color-disabled)));
     background: var(--highcontrast-slider-handle-disabled-background-color, var(--mod-slider-handle-disabled-background-color, var(--spectrum-slider-handle-disabled-background-color)));
+    cursor: default;
+    pointer-events: none;
 
     &:hover,
     &:active {

--- a/components/slider/metadata/slider.yml
+++ b/components/slider/metadata/slider.yml
@@ -180,7 +180,7 @@ examples:
         <div class="spectrum-Slider-controls">
           <div class="spectrum-Slider-track"></div>
           <div class="spectrum-Slider-handle" style="left: 40%;">
-            <input type="range" class="spectrum-Slider-input" value="14" step="2" min="10" max="20" disabled id="spectrum-Slider-input-6">
+            <input type="range" class="spectrum-Slider-input" value="14" step="2" min="10" max="20" disabled id="spectrum-Slider-input-6" disabled>
           </div>
           <div class="spectrum-Slider-track"></div>
         </div>
@@ -229,7 +229,7 @@ examples:
         <div class="spectrum-Slider-controls">
           <div class="spectrum-Slider-track"></div>
           <div class="spectrum-Slider-handle" style="left: 40%;">
-            <input type="range" class="spectrum-Slider-input" value="14" step="2" min="10" max="20" disabled id="spectrum-Slider-input-8">
+            <input type="range" class="spectrum-Slider-input" value="14" step="2" min="10" max="20" disabled id="spectrum-Slider-input-8" disabled>
           </div>
           <div class="spectrum-Slider-track"></div>
         </div>
@@ -274,7 +274,7 @@ examples:
         <div class="spectrum-Slider-controls">
           <div class="spectrum-Slider-track" style="width: 25%;"></div>
           <div class="spectrum-Slider-handle" style="left: 70%;">
-            <input type="range" class="spectrum-Slider-input" value="14" min="10" max="20" id="spectrum-Slider-input-11">
+            <input type="range" class="spectrum-Slider-input" value="14" min="10" max="20" id="spectrum-Slider-input-11" disabled>
           </div>
           <div class="spectrum-Slider-track" style="width: 50%;"></div>
           <div class="spectrum-Slider-fill spectrum-Slider-fill--right" style="left: 50%; width: 20%"></div>
@@ -310,11 +310,11 @@ examples:
         <div class="spectrum-Slider-controls" role="presentation">
           <div class="spectrum-Slider-track" style="width: 20%;"></div>
           <div class="spectrum-Slider-handle" style="left: 20%;" role="presentation">
-            <input type="range" class="spectrum-Slider-input" value="14" step="2" min="10" max="20" aria-label="min" disabled id="spectrum-Slider-input-13-0" aria-labelledby="spectrum-Slider-label-5 spectrum-Slider-input-5-0">
+            <input type="range" class="spectrum-Slider-input" value="14" step="2" min="10" max="20" aria-label="min" disabled id="spectrum-Slider-input-13-0" aria-labelledby="spectrum-Slider-label-5 spectrum-Slider-input-5-0" disabled>
           </div>
           <div class="spectrum-Slider-track" style="left: 20%; right: 40%;"></div>
           <div class="spectrum-Slider-handle" style="left: 60%;" role="presentation">
-            <input type="range" class="spectrum-Slider-input" value="14" step="2" min="10" max="20" aria-label="max" disabled id="spectrum-Slider-input-13-1" aria-labelledby="spectrum-Slider-label-5 spectrum-Slider-input-5-1">
+            <input type="range" class="spectrum-Slider-input" value="14" step="2" min="10" max="20" aria-label="max" disabled id="spectrum-Slider-input-13-1" aria-labelledby="spectrum-Slider-label-5 spectrum-Slider-input-5-1" disabled>
           </div>
           <div class="spectrum-Slider-track" style="width: 40%;"></div>
         </div>
@@ -366,7 +366,7 @@ examples:
           </div>
           <div class="spectrum-Slider-handleContainer">
             <div class="spectrum-Slider-handle" style="left: 75%;">
-              <input type="range" class="spectrum-Slider-input" value="14" step="2" min="10" max="20" id="spectrum-Slider-input-15">
+              <input type="range" class="spectrum-Slider-input" value="14" step="2" min="10" max="20" id="spectrum-Slider-input-15" disabled>
             </div>
           </div>
         </div>
@@ -445,7 +445,7 @@ examples:
           </div>
           <div class="spectrum-Slider-handleContainer">
             <div class="spectrum-Slider-handle" style="left: 40%;">
-              <input type="range" class="spectrum-Slider-input" value="14" step="2" min="10" max="20" id="spectrum-Slider-input-17">
+              <input type="range" class="spectrum-Slider-input" value="14" step="2" min="10" max="20" id="spectrum-Slider-input-17" disabled>
             </div>
           </div>
         </div>

--- a/components/slider/metadata/slider.yml
+++ b/components/slider/metadata/slider.yml
@@ -23,7 +23,7 @@ sections:
 
       * `.is-disabled` - when the slider is disabled
 
-      Implementations should also add the following class to the `.spectrum-Slider-handle` parent class in the following situations:
+      Implementations should also bubble the following class to the `.spectrum-Slider-controls` parent class in the following situations:
 
       * `.is-focused` - when the handle input is focused with the mouse or keyboard
 examples:

--- a/components/slider/metadata/slider.yml
+++ b/components/slider/metadata/slider.yml
@@ -15,6 +15,17 @@ sections:
 
       ### Three Handles is included in the `range` variant
       When using a slider with three handles, classify it as a `range` variant to apply correct styling
+
+      ### Indicating focus
+      Focus must be bubbled up to the parent so descendants siblings can be styled.
+
+      Thus, implementations should add the following class to the `.spectrum-Slider` parent class in the following situations:
+
+      * `.is-disabled` - when the slider is disabled
+
+      Implementations should also add the following class to the `.spectrum-Slider-handle` parent class in the following situations:
+
+      * `.is-focused` - when the handle input is focused with the mouse or keyboard
 examples:
   - id: slider
     name: Standard
@@ -118,7 +129,7 @@ examples:
             </div>
           </div>
         </div>
-        
+
         <div class="spectrum-Examples-item" style="width: 200px">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">XL</h4>
           <div class="spectrum-Slider spectrum-Slider--sizeXL">

--- a/components/slider/stories/slider.stories.js
+++ b/components/slider/stories/slider.stories.js
@@ -186,6 +186,13 @@ Disabled.args = {
 	isDisabled: true,
 };
 
+export const WithFocus = Template.bind({});
+WithFocus.args = {
+	...Default.args,
+	variant: "with focus",
+	isFocused: true,
+};
+
 export const Gradient = Template.bind({});
 Gradient.args = {
 	...Default.args,

--- a/components/slider/stories/template.js
+++ b/components/slider/stories/template.js
@@ -175,7 +175,11 @@ export const Template = ({
 
 			<!-- Slider controls -->
 			<div
-				class="${rootClass}-controls"
+				class=${classMap({
+					[`${rootClass}-controls`]: true,
+					"is-focused": isFocused,
+					...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
+				})}
 				role=${ifDefined(isRamp ? "presentation" : undefined)}
 			>
 				${values.map((value, idx) => {

--- a/components/slider/stories/template.js
+++ b/components/slider/stories/template.js
@@ -1,7 +1,7 @@
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
-import { styleMap } from "lit/directives/style-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
+import { styleMap } from "lit/directives/style-map.js";
 
 import { useArgs, useGlobals } from "@storybook/client-api";
 
@@ -142,6 +142,14 @@ export const Template = ({
 			})}
 			role=${ifDefined(values.length > 1 ? "group" : undefined)}
 			aria-labelledby=${ifDefined(label && id ? `${id}-label` : undefined)}
+			@focusin=${() => {
+				const focusClass = { isFocused: true };
+				updateArgs(focusClass);
+			}}
+			@focusout=${() => {
+				const focusClass = { isFocused: false };
+				updateArgs(focusClass);
+			}}
 		>
 			<!-- Label region -->
 			${label


### PR DESCRIPTION
## Description

This PR addresses issue #2200.

- Adjust focus state to match [the spec](https://spectrum.corp.adobe.com/page/slider/#Keyboard-focus) (previously it looked like the active state which was incorrect)
- Standard variant works in high contrast mode. See Xd file in spec for reference.
- Disabled slider has the default cursor on hover. This was already set in a couple places (`.spectrum-Slider` and `.spectrum-Slider-handle`) but needed to be explicitly set on `.spectrum-Slider-controls` to take effect since this class has a specified `cursor: pointer` when the slider isn't disabled.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation

- [x] On focus, the slider handle should match the spec (it shouldn't be filled in and should have a focus ring). Confirm this for high contrast mode as well
- [x] On hover in high contrast mode, the slider track and handle are the `Highlight` color
- [x] On active/dragged in high contrast mode, the handle fills in with `Highlight` to match the spec
- [x] Disabled sliders should get the default cursor on hover
- [x] Focus and disabled states are documented on the docs site

### Regression testing

Validate:

1. A legacy documentation page (such as [accordion](https://pr-###--spectrum-css.netlify.app/accordion.html)), including:

- [x] The page renders correctly
- [x] The page is accessible
- [x] The page is responsive

2. A migrated documentation page (such as [action group](https://pr-###--spectrum-css.netlify.app/actiongroup.html)), including:

- [x] The page renders correctly
- [x] The page is accessible
- [x] The page is responsive


## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.

- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.

- [ ] ✨ This pull request is ready to merge. ✨
