### PR TITLE
refactor(treeview): fixes for sizes, height, and indicator alignment

### DIFF
--- a/components/treeview/index.css
+++ b/components/treeview/index.css
@@ -343,17 +343,24 @@ governing permissions and limitations under the License.
   pointer-events: all;
 }
 
+/* Section headings */
+.spectrum-TreeView-section > .spectrum-TreeView {
+  display: block;
+  block-size: auto;
+  padding-inline-start: 0;
+}
+
+.spectrum-TreeView-section:not(:first-child) {
+  margin-block-start: var(--mod-treeview-section-spacing, var(--spectrum-treeview-section-spacing));
+}
+
 .spectrum-TreeView-heading {
   padding-block-end: var(--mod-treeview-heading-bottom-to-text, var(--spectrum-treeview-heading-bottom-to-text));
   font-weight: var(--mod-treeview-heading-font-weight, var(--spectrum-treeview-heading-font-weight));
   color: var(--highcontrast-treeview-heading-color, var(--mod-treeview-heading-color, inherit));
-
-  &:not(:first-child) {
-    margin-block-start: var(--mod-treeview-section-spacing, var(--spectrum-treeview-section-spacing));
-  }
 }
 
-/* ***** INDENTATION LEVELS ***** */
+/* Indentation levels used with Flat structure variant. */
 .spectrum-TreeView-item {
   &--indent1 {
     padding-inline-start: var(--mod-treeview-item-indentation, var(--spectrum-treeview-item-indentation));

--- a/components/treeview/index.css
+++ b/components/treeview/index.css
@@ -11,22 +11,20 @@ governing permissions and limitations under the License.
 */
 
 .spectrum-TreeView {
+  /* A line-height of 17px at --spectrum-font-size-100 (14px). */
   --spectrum-treeview-line-height: 1.214285;
   --spectrum-treeview-margin-block: 1.0em;
   --spectrum-treeview-font-size: var(--spectrum-font-size-100);
 
   --spectrum-treeview-item-min-block-size: var(--spectrum-component-height-100);
   --spectrum-treeview-item-indentation: var(--spectrum-treeview-item-indentation-medium);
-  --spectrum-treeview-item-padding-default: 0px;
-  --spectrum-treeview-item-padding-block-end: var(--spectrum-component-edge-to-text-100);
-  --spectrum-treeview-item-text-padding-block-start: var(--spectrum-component-top-to-text-100);
-  --spectrum-treeview-item-text-padding-block-end: var(--spectrum-component-bottom-to-text-100);
 
   --spectrum-treeview-item-padding-inline-start: var(--spectrum-component-height-100);
   --spectrum-treeview-item-padding-inline-end: var(--spectrum-component-edge-to-text-100);
 
   --spectrum-treeview-section-spacing: var(--spectrum-treeview-item-indentation-medium);
   --spectrum-treeview-heading-font-weight: var(--spectrum-bold-font-weight);
+  --spectrum-treeview-heading-bottom-to-text: var(--spectrum-component-edge-to-text-100);
 
   --spectrum-treeview-item-border-size: var(--spectrum-border-width-200);
   --spectrum-treeview-item-border-size-selected: 1px;
@@ -41,7 +39,6 @@ governing permissions and limitations under the License.
   --spectrum-treeview-item-border-color-quiet-selected: transparent;
 
   --spectrum-treeview-item-icon-gap: var(--spectrum-text-to-visual-75);
-  --spectrum-treeview-item-icon-offset-block: -1px;
   --spectrum-treeview-item-icon-color: var(--spectrum-gray-700);
   --spectrum-treeview-item-icon-color-hover: var(--spectrum-gray-900);
   --spectrum-treeview-item-icon-color-focus: var(--spectrum-gray-900);
@@ -55,21 +52,19 @@ governing permissions and limitations under the License.
   --spectrum-treeview-item-text-color-hover: var(--spectrum-gray-900);
 
   --spectrum-treeview-indicator-margin-inline-start: calc(-1 * var(--spectrum-component-height-100));
-  --spectrum-treeview-indicator-margin-block-end: calc(-1 * var(--spectrum-component-edge-to-visual-only-200));
   --spectrum-treeview-indicator-padding: var(--spectrum-disclosure-indicator-top-to-disclosure-icon-medium);
+
+  --spectrum-treeview-thumbnail-margin-block: 5px;
 
   --spectrum-treeview-indicator-animation-duration: var(--spectrum-animation-duration-100);
 }
 
 .spectrum-TreeView--sizeS {
   --spectrum-treeview-font-size: var(--spectrum-font-size-75);
-  --spectrum-treeview-item-icon-offset-block: 0;
 
   --spectrum-treeview-item-min-block-size: var(--spectrum-component-height-75);
-  --spectrum-treeview-item-text-padding-block-start: var(--spectrum-spacing-75);
-  --spectrum-treeview-item-text-padding-block-end: var(--spectrum-component-bottom-to-text-75);
   --spectrum-treeview-item-indentation: var(--spectrum-treeview-item-indentation-small);
-  --spectrum-treeview-item-padding-block-end: var(--spectrum-component-edge-to-text-75);
+  --spectrum-treeview-heading-bottom-to-text: var(--spectrum-component-edge-to-text-75);
 
   --spectrum-treeview-item-padding-inline-start: var(--spectrum-component-height-75);
   --spectrum-treeview-indicator-margin-inline-start: calc(-1 * var(--spectrum-component-height-75));
@@ -80,41 +75,48 @@ governing permissions and limitations under the License.
 
 .spectrum-TreeView--sizeL {
   --spectrum-treeview-font-size: var(--spectrum-font-size-200);
-  --spectrum-treeview-item-icon-offset-block: 0;
 
-  --spectrum-treeview-item-text-padding-block-start: var(--spectrum-component-top-to-text-200);
-  --spectrum-treeview-item-text-padding-block-end: var(--spectrum-component-bottom-to-text-200);
   --spectrum-treeview-item-indentation: var(--spectrum-treeview-item-indentation-large);
   --spectrum-treeview-item-min-block-size: var(--spectrum-component-height-200);
-  --spectrum-treeview-item-padding-block-end: var(--spectrum-component-edge-to-text-200);
+  --spectrum-treeview-heading-bottom-to-text: var(--spectrum-component-edge-to-text-200);
 
   --spectrum-treeview-item-padding-inline-start: var(--spectrum-component-height-200);
   --spectrum-treeview-indicator-margin-inline-start: calc(-1 * var(--spectrum-component-height-200));
   --spectrum-treeview-item-padding-inline-end: var(--spectrum-component-edge-to-text-200);
 
   --spectrum-treeview-indicator-padding: var(--spectrum-disclosure-indicator-top-to-disclosure-icon-large);
+  --spectrum-treeview-thumbnail-margin-block: 7px;
 }
 
 .spectrum-TreeView--sizeXL {
   --spectrum-treeview-font-size: var(--spectrum-font-size-300);
-  --spectrum-treeview-item-icon-offset-block: 0;
 
-  --spectrum-treeview-item-text-padding-block-start: var(--spectrum-component-top-to-text-300);
-  --spectrum-treeview-item-text-padding-block-end: var(--spectrum-component-bottom-to-text-300);
   --spectrum-treeview-item-indentation: var(--spectrum-treeview-item-indentation-extra-large);
   --spectrum-treeview-item-min-block-size: var(--spectrum-component-height-300);
-  --spectrum-treeview-item-padding-block-end: var(--spectrum-component-edge-to-text-300);
+  --spectrum-treeview-heading-bottom-to-text: var(--spectrum-component-edge-to-text-300);
 
   --spectrum-treeview-item-padding-inline-start: var(--spectrum-component-height-300);
   --spectrum-treeview-indicator-margin-inline-start: calc(-1 * var(--spectrum-component-height-300));
   --spectrum-treeview-item-padding-inline-end: var(--spectrum-component-edge-to-text-300);
 
   --spectrum-treeview-indicator-padding: var(--spectrum-disclosure-indicator-top-to-disclosure-icon-extra-large);
+  --spectrum-treeview-thumbnail-margin-block: 7px;
 }
 
 .spectrum-TreeView--quiet {
   --mod-treeview-item-background-color-selected: var(--highcontrast-treeview-item-background-color-selected, var(--mod-treeview-item-background-color-quiet-selected, var(--spectrum-treeview-item-background-color-quiet-selected)));
   --mod-treeview-item-border-color-selected: var(--highcontrast-treeview-item-border-color-selected, var(--mod-treeview-item-border-color-selected-quiet, transparent));
+}
+
+.spectrum-TreeView--thumbnail {
+  --mod-treeview-item-min-block-size: var(--mod-treeview-item-min-block-size-thumbnail, calc(
+    var(--spectrum-treeview-item-min-block-size) +
+    (2 * var(--mod-treeview-thumbnail-margin-block, var(--spectrum-treeview-thumbnail-margin-block)))
+  ));
+}
+
+.spectrum-TreeView--detached {
+  --mod-treeview-item-border-radius: var(--mod-treeview-item-border-radius-detached, var(--spectrum-corner-radius-100));
 }
 
 @media (forced-colors: active){
@@ -153,7 +155,7 @@ governing permissions and limitations under the License.
     background: transparent;
   }
 
-  .spectrum-TreeView-itemLink:before {
+  .spectrum-TreeView-itemLink::before {
     forced-color-adjust: none;
   }
 }
@@ -201,7 +203,7 @@ governing permissions and limitations under the License.
     > .spectrum-TreeView-itemLink {
       color: var(--highcontrast-treeview-item-text-color-selected, var(--mod-treeview-item-text-color-selected, var(--spectrum-treeview-item-text-color-selected)));
 
-      &:before {
+      &::before {
         background-color: var(--highcontrast-treeview-item-background-color-selected, var(--mod-treeview-item-background-color-selected, var(--spectrum-treeview-item-background-color-selected)));
       }
 
@@ -211,7 +213,7 @@ governing permissions and limitations under the License.
     }
 
     > .spectrum-TreeView-itemLink:not(:focus-visible) {
-      &:before {
+      &::before {
         border-color: var(--highcontrast-treeview-item-border-color-selected, var(--mod-treeview-item-border-color-selected, var(--spectrum-treeview-item-border-color-selected)));
       }
     }
@@ -219,7 +221,7 @@ governing permissions and limitations under the License.
 
   &.is-selected {
     > .spectrum-TreeView-itemLink:not(:focus-visible) {
-      &:before {
+      &::before {
         border-width: var(--mod-treeview-item-border-size-selected, var(--spectrum-treeview-item-border-size-selected));
       }
     }
@@ -227,7 +229,7 @@ governing permissions and limitations under the License.
 
   &.is-drop-target {
     > .spectrum-TreeView-itemLink {
-      &:before {
+      &::before {
         border-width: var(--mod-treeview-item-border-size, var(--spectrum-treeview-item-border-size));
       }
     }
@@ -237,7 +239,7 @@ governing permissions and limitations under the License.
     > .spectrum-TreeView-itemLink {
       color: var(--highcontrast-treeview-item-text-color-disabled, var(--mod-treeview-item-text-color-disabled, var(--spectrum-treeview-item-text-color-disabled)));
 
-      &:before {
+      &::before {
         background-color: var(--highcontrast-treeview-item-background-color-disabled, transparent);
       }
 
@@ -257,12 +259,10 @@ governing permissions and limitations under the License.
 .spectrum-TreeView-itemLink {
   box-sizing: border-box;
   display: flex;
-  flex-direction: row;
-  flex-wrap: nowrap;
+  flex-flow: row nowrap;
   align-items: center;
 
   min-block-size: var(--mod-treeview-item-min-block-size, var(--spectrum-treeview-item-min-block-size));
-  padding-block: var(--mod-treeview-item-text-padding-block-start, var(--spectrum-treeview-item-text-padding-block-start)) var(--mod-treeview-item-text-padding-block-end, var(--spectrum-treeview-item-text-padding-block-end));
   padding-inline: var(--mod-treeview-item-padding-inline-start, var(--spectrum-treeview-item-padding-inline-start)) var(--mod-treeview-item-padding-inline-end, var(--spectrum-treeview-item-padding-inline-end));
 
   color: var(--highcontrast-treeview-item-text-color, var(--mod-treeview-item-text-color, var(--spectrum-treeview-item-text-color)));
@@ -276,22 +276,12 @@ governing permissions and limitations under the License.
   overflow: hidden;
 
   /* Background for hover, focus, and selection, that extends the full width of the list. */
-  &:before {
+  &::before {
     content: '\00a0';
-
     box-sizing: border-box;
     position: absolute;
     inset-inline: 0;
-
     min-block-size: var(--mod-treeview-item-min-block-size, var(--spectrum-treeview-item-min-block-size));
-    padding-block-start: calc(
-      var(--mod-treeview-item-text-padding-block-start, var(--spectrum-treeview-item-text-padding-block-start)) -
-      var(--mod-treeview-item-border-size, var(--spectrum-treeview-item-border-size))
-    );
-    padding-block-end: calc(
-      var(--mod-treeview-item-text-padding-block-end, var(--spectrum-treeview-item-text-padding-block-end)) -
-      var(--mod-treeview-item-border-size, var(--spectrum-treeview-item-border-size))
-    );
 
     border-style: solid;
     border-color: transparent;
@@ -303,7 +293,7 @@ governing permissions and limitations under the License.
   &:focus-visible {
     color: var(--highcontrast-treeview-item-text-color-focus, var(--mod-treeview-item-text-color-focus, var(--spectrum-treeview-item-text-color-focus)));
 
-    &:before {
+    &::before {
       background-color: var(--highcontrast-treeview-item-background-color-focus, var(--mod-treeview-item-background-color-focus, var(--spectrum-treeview-item-background-color-focus)));
       border-width: var(--mod-treeview-item-border-size, var(--spectrum-treeview-item-border-size));
       border-color: var(--highcontrast-treeview-item-border-color-focus, var(--mod-treeview-item-border-color-focus, var(--spectrum-treeview-item-border-color-focus)));
@@ -317,7 +307,7 @@ governing permissions and limitations under the License.
   &:hover {
     color: var(--highcontrast-treeview-item-text-color-focus, var(--mod-treeview-item-text-color-hover, var(--spectrum-treeview-item-text-color-hover)));
 
-    &:before {
+    &::before {
       background-color: var(--highcontrast-treeview-item-background-color-focus, var(--mod-treeview-item-background-color-hover, var(--spectrum-treeview-item-background-color-hover)));
     }
 
@@ -332,48 +322,29 @@ governing permissions and limitations under the License.
   vertical-align: top;
   flex-shrink: 0;
   margin-inline-end: var(--mod-treeview-item-icon-gap, var(--spectrum-treeview-item-icon-gap));
-  /* Margin-block is to ensure proper overall item height because at medium, the line-height is 17px but the icon is 18px. */
-  margin-block-end: var(--mod-treeview-item-icon-offset-block, var(--spectrum-treeview-item-icon-offset-block));
   color: var(--highcontrast-treeview-item-icon-color, var(--mod-treeview-item-icon-color, var(--spectrum-treeview-item-icon-color)));
 }
 
 .spectrum-TreeView-itemIndicator {
-  /* How much taller the indicator is than the line-height. */
-  --spectrum-treeview-indicator-offset: calc((
-      var(--mod-treeview-item-text-padding-block-end, var(--spectrum-treeview-item-text-padding-block-end)) +
-      var(--mod-treeview-item-text-padding-block-start, var(--spectrum-treeview-item-text-padding-block-start))
-    ) / 2
-  );
-
   display: block;
   box-sizing: content-box;
   position: relative;
   flex-shrink: 0;
 
-  /* Make sure hover doesn't block clicks on the chevron. */
+  /* Make sure the hover background pseudo element doesn't block clicks on the chevron. */
   z-index: 1;
 
   padding-inline: var(--mod-treeview-indicator-padding-inline, var(--spectrum-treeview-indicator-padding));
   padding-block: var(--mod-treeview-indicator-padding-block, var(--spectrum-treeview-indicator-padding));
   margin-inline-start: var(--mod-treeview-indicator-margin-inline-start, var(--spectrum-treeview-indicator-margin-inline-start));
 
-  /* Block spacing adjustments prevent treeview item height increase due to indicator being larger than line-height. */
-  margin-block-end: var(--mod-treeview-indicator-margin-block-end, calc(-2 * var(--spectrum-treeview-indicator-offset)));
-  inset-block-start: var(--mod-treeview-indicator-inset-block-start, calc(-1 * var(--spectrum-treeview-indicator-offset)));
-
   transform: logical rotate(0deg);
   transition: transform ease var(--mod-treeview-indicator-animation-duration, var(--spectrum-treeview-indicator-animation-duration));
-
   pointer-events: all;
 }
 
 .spectrum-TreeView-heading {
-  padding-block:
-    var(--mod-treeview-item-padding-block-start, var(--mod-treeview-item-padding-default, var(--spectrum-treeview-item-padding-default)))
-    var(--mod-treeview-item-padding-block-end, var(--spectrum-treeview-item-padding-block-end));
-  padding-inline:
-    var(--mod-treeview-item-padding-inline-start, var(--mod-treeview-item-padding-default, var(--spectrum-treeview-item-padding-default)))
-    var(--mod-treeview-item-padding-inline-end, var(--mod-treeview-item-padding-default, var(--spectrum-treeview-item-padding-default)));
+  padding-block-end: var(--mod-treeview-heading-bottom-to-text, var(--spectrum-treeview-heading-bottom-to-text));
   font-weight: var(--mod-treeview-heading-font-weight, var(--spectrum-treeview-heading-font-weight));
   color: var(--highcontrast-treeview-heading-color, var(--mod-treeview-heading-color, inherit));
 
@@ -426,37 +397,9 @@ governing permissions and limitations under the License.
 }
 
 /* ***** VARIANTS ***** */
-.spectrum-TreeView--standalone {
-  .spectrum-TreeView-itemLink {
-    &:before {
-      border-radius: var(--mod-treeview-item-border-radius, var(--spectrum-treeview-item-border-radius));
-      border-width: var(--mod-treeview-item-border-size, var(--spectrum-treeview-item-border-size));
-    }
-  }
-}
-
 .spectrum-TreeView--thumbnail {
   .spectrum-TreeView-itemThumbnail {
     flex-shrink: 0;
     margin-inline-end: var(--mod-treeview-item-icon-gap, var(--spectrum-treeview-item-icon-gap));
-  }
-
-  .spectrum-TreeView-itemLink {
-    --spectrum-treeview-link-min-block-size: calc(
-      var(--mod-treeview-item-padding-inline-start, var(--spectrum-treeview-item-padding-inline-start)) +
-      var(--mod-treeview-item-text-padding-block-start, var(--spectrum-treeview-item-text-padding-block-start)) +
-      (var(--mod-treeview-item-text-padding-block-end, var(--spectrum-treeview-item-text-padding-block-end)) - var(--mod-treeview-item-border-size, var(--spectrum-treeview-item-border-size)))
-    );
-
-    min-block-size: var(--mod-treeview-link-min-block-size-thumbnail, var(--spectrum-treeview-link-min-block-size));
-    padding-block-start: var(--mod-treeview-item-text-padding-block-start, var(--spectrum-treeview-item-text-padding-block-start));
-    padding-block-end: calc(
-      var(--mod-treeview-item-text-padding-block-end, var(--spectrum-treeview-item-text-padding-block-end)) -
-      var(--mod-treeview-item-border-size, var(--spectrum-treeview-item-border-size))
-    );
-
-    &:before {
-      min-block-size: var(--mod-treeview-link-min-block-size-thumbnail, var(--spectrum-treeview-link-min-block-size));
-    }
   }
 }

--- a/components/treeview/index.css
+++ b/components/treeview/index.css
@@ -54,8 +54,8 @@ governing permissions and limitations under the License.
   --spectrum-treeview-indicator-margin-inline-start: calc(-1 * var(--spectrum-component-height-200));
   --spectrum-treeview-indicator-margin-block-end: calc(-1 * var(--spectrum-component-edge-to-visual-only-200));
   --spectrum-treeview-indicator-margin-inline-end: var(--spectrum-text-to-visual-75);
-  --spectrum-treeview-indicator-padding-inline: var(--spectrum-component-edge-to-text-100);
-  --spectrum-treeview-indicator-padding-block: var(--spectrum-component-edge-to-visual-only-200);
+  --spectrum-treeview-indicator-padding: var(--spectrum-disclosure-indicator-top-to-disclosure-icon-medium);
+
   --spectrum-treeview-indicator-animation-duration: var(--spectrum-animation-duration-100);
 }
 
@@ -65,6 +65,7 @@ governing permissions and limitations under the License.
   --spectrum-treeview-item-indentation: var(--spectrum-treeview-item-indentation-small);
   --spectrum-treeview-item-padding-block-end: var(--spectrum-component-edge-to-text-75);
   --spectrum-treeview-item-affordance-size: var(--spectrum-component-height-75);
+  --spectrum-treeview-indicator-padding: var(--spectrum-disclosure-indicator-top-to-disclosure-icon-small);
 }
 
 .spectrum-TreeView--sizeL {
@@ -73,6 +74,7 @@ governing permissions and limitations under the License.
   --spectrum-treeview-item-min-block-size: var(--spectrum-component-height-100);
   --spectrum-treeview-item-padding-block-end: var(--spectrum-component-edge-to-text-200);
   --spectrum-treeview-item-affordance-size: var(--spectrum-component-height-200);
+  --spectrum-treeview-indicator-padding: var(--spectrum-disclosure-indicator-top-to-disclosure-icon-medium);
 }
 
 .spectrum-TreeView--sizeXL {
@@ -82,6 +84,7 @@ governing permissions and limitations under the License.
   --spectrum-treeview-item-min-block-size: var(--spectrum-component-height-200);
   --spectrum-treeview-item-padding-block-end: var(--spectrum-component-edge-to-text-300);
   --spectrum-treeview-item-affordance-size: var(--spectrum-component-height-300);
+  --spectrum-treeview-indicator-padding: var(--spectrum-disclosure-indicator-top-to-disclosure-icon-large);
 }
 
 .spectrum-TreeView--quiet {
@@ -96,13 +99,6 @@ governing permissions and limitations under the License.
     --highcontrast-treeview-item-text-color-selected: HighlightText;
     --highcontrast-treeview-item-icon-color-selected: HighlightText;
 
-    @supports (color: SelectedItem) {
-      --highcontrast-treeview-item-background-color-selected: SelectedItem;
-      --highcontrast-treeview-item-border-color-selected: SelectedItem;
-      --highcontrast-treeview-item-text-color-selected: SelectedItemText;
-      --highcontrast-treeview-item-icon-color-selected: SelectedItemText;
-    }
-
     --highcontrast-treeview-item-icon-color: LinkText;
     --highcontrast-treeview-item-text-color: LinkText;
 
@@ -116,6 +112,15 @@ governing permissions and limitations under the License.
     --highcontrast-treeview-item-icon-color-disabled: GrayText;
 
     --highcontrast-treeview-heading-color: CanvasText;
+  }
+
+  @supports (color: SelectedItem) {
+    .spectrum-TreeView {
+      --highcontrast-treeview-item-background-color-selected: SelectedItem;
+      --highcontrast-treeview-item-border-color-selected: SelectedItem;
+      --highcontrast-treeview-item-text-color-selected: SelectedItemText;
+      --highcontrast-treeview-item-icon-color-selected: SelectedItemText;
+    }
   }
 
   .spectrum-TreeView-itemLabel {
@@ -185,7 +190,6 @@ governing permissions and limitations under the License.
       }
     }
   }
-
 
   &.is-selected {
     > .spectrum-TreeView-itemLink:not(:focus-visible) {
@@ -321,8 +325,8 @@ governing permissions and limitations under the License.
   margin-block-end: var(--mod-treeview-indicator-margin-block-end, var(--spectrum-treeview-indicator-margin-block-end));
   margin-inline-end: var(--mod-treeview-indicator-margin-inline-end, var(--spectrum-treeview-indicator-margin-inline-end));
 
-  padding-inline: var(--mod-treeview-indicator-padding-inline, var(--spectrum-treeview-indicator-padding-inline));
-  padding-block: var(--mod-treeview-indicator-padding-block, var(--spectrum-treeview-indicator-padding-block));
+  padding-inline: var(--mod-treeview-indicator-padding-inline, var(--spectrum-treeview-indicator-padding));
+  padding-block: var(--mod-treeview-indicator-padding-block, var(--spectrum-treeview-indicator-padding));
 
   transform: logical rotate(0deg);
   transition: transform ease var(--mod-treeview-indicator-animation-duration, var(--spectrum-treeview-indicator-animation-duration));

--- a/components/treeview/index.css
+++ b/components/treeview/index.css
@@ -11,8 +11,7 @@ governing permissions and limitations under the License.
 */
 
 .spectrum-TreeView {
-  /* A line-height of 17px at --spectrum-font-size-100 (14px). */
-  --spectrum-treeview-line-height: 1.214285;
+  --spectrum-treeview-line-height: var(--spectrum-line-height-200);
   --spectrum-treeview-margin-block: 1.0em;
   --spectrum-treeview-font-size: var(--spectrum-font-size-100);
 

--- a/components/treeview/index.css
+++ b/components/treeview/index.css
@@ -54,7 +54,7 @@ governing permissions and limitations under the License.
   --spectrum-treeview-indicator-margin-inline-start: calc(-1 * var(--spectrum-component-height-100));
   --spectrum-treeview-indicator-padding: var(--spectrum-disclosure-indicator-top-to-disclosure-icon-medium);
 
-  --spectrum-treeview-thumbnail-margin-block: 5px;
+  --spectrum-treeview-item-min-block-size-thumbnail-offset: var(--spectrum-treeview-item-min-block-size-thumbnail-offset-medium, 0px);
 
   --spectrum-treeview-indicator-animation-duration: var(--spectrum-animation-duration-100);
 }
@@ -71,7 +71,7 @@ governing permissions and limitations under the License.
   --spectrum-treeview-item-padding-inline-end: var(--spectrum-component-edge-to-text-75);
   --spectrum-treeview-indicator-padding: var(--spectrum-disclosure-indicator-top-to-disclosure-icon-small);
 
-  --spectrum-treeview-thumbnail-margin-block: 6px;
+  --spectrum-treeview-item-min-block-size-thumbnail-offset: 6px;
 }
 
 .spectrum-TreeView--sizeL {
@@ -86,7 +86,7 @@ governing permissions and limitations under the License.
   --spectrum-treeview-item-padding-inline-end: var(--spectrum-component-edge-to-text-200);
   --spectrum-treeview-indicator-padding: var(--spectrum-disclosure-indicator-top-to-disclosure-icon-large);
 
-  --spectrum-treeview-thumbnail-margin-block: 5px;
+  --spectrum-treeview-item-min-block-size-thumbnail-offset: 0px;
 }
 
 .spectrum-TreeView--sizeXL {
@@ -101,7 +101,7 @@ governing permissions and limitations under the License.
   --spectrum-treeview-item-padding-inline-end: var(--spectrum-component-edge-to-text-300);
   --spectrum-treeview-indicator-padding: var(--spectrum-disclosure-indicator-top-to-disclosure-icon-extra-large);
 
-  --spectrum-treeview-thumbnail-margin-block: 6px;
+  --spectrum-treeview-item-min-block-size-thumbnail-offset: 0px;
 }
 
 .spectrum-TreeView--quiet {
@@ -111,8 +111,7 @@ governing permissions and limitations under the License.
 
 .spectrum-TreeView--thumbnail {
   --mod-treeview-item-min-block-size: var(--mod-treeview-item-min-block-size-thumbnail, calc(
-    var(--spectrum-treeview-item-min-block-size) +
-    (2 * var(--mod-treeview-thumbnail-margin-block, var(--spectrum-treeview-thumbnail-margin-block)))
+    var(--spectrum-treeview-item-min-block-size) + var(--spectrum-treeview-item-min-block-size-thumbnail-offset)
   ));
 }
 

--- a/components/treeview/index.css
+++ b/components/treeview/index.css
@@ -69,8 +69,9 @@ governing permissions and limitations under the License.
   --spectrum-treeview-item-padding-inline-start: var(--spectrum-component-height-75);
   --spectrum-treeview-indicator-margin-inline-start: calc(-1 * var(--spectrum-component-height-75));
   --spectrum-treeview-item-padding-inline-end: var(--spectrum-component-edge-to-text-75);
-
   --spectrum-treeview-indicator-padding: var(--spectrum-disclosure-indicator-top-to-disclosure-icon-small);
+
+  --spectrum-treeview-thumbnail-margin-block: 6px;
 }
 
 .spectrum-TreeView--sizeL {
@@ -83,9 +84,9 @@ governing permissions and limitations under the License.
   --spectrum-treeview-item-padding-inline-start: var(--spectrum-component-height-200);
   --spectrum-treeview-indicator-margin-inline-start: calc(-1 * var(--spectrum-component-height-200));
   --spectrum-treeview-item-padding-inline-end: var(--spectrum-component-edge-to-text-200);
-
   --spectrum-treeview-indicator-padding: var(--spectrum-disclosure-indicator-top-to-disclosure-icon-large);
-  --spectrum-treeview-thumbnail-margin-block: 7px;
+
+  --spectrum-treeview-thumbnail-margin-block: 5px;
 }
 
 .spectrum-TreeView--sizeXL {
@@ -98,9 +99,9 @@ governing permissions and limitations under the License.
   --spectrum-treeview-item-padding-inline-start: var(--spectrum-component-height-300);
   --spectrum-treeview-indicator-margin-inline-start: calc(-1 * var(--spectrum-component-height-300));
   --spectrum-treeview-item-padding-inline-end: var(--spectrum-component-edge-to-text-300);
-
   --spectrum-treeview-indicator-padding: var(--spectrum-disclosure-indicator-top-to-disclosure-icon-extra-large);
-  --spectrum-treeview-thumbnail-margin-block: 7px;
+
+  --spectrum-treeview-thumbnail-margin-block: 6px;
 }
 
 .spectrum-TreeView--quiet {

--- a/components/treeview/index.css
+++ b/components/treeview/index.css
@@ -39,7 +39,7 @@ governing permissions and limitations under the License.
   --spectrum-treeview-item-background-color-focus: var(--spectrum-gray-200);
 
   --spectrum-treeview-item-border-color-quiet-selected: transparent;
-  
+
   --spectrum-treeview-item-icon-gap: var(--spectrum-text-to-visual-75);
   --spectrum-treeview-item-icon-offset-block: -1px;
   --spectrum-treeview-item-icon-color: var(--spectrum-gray-700);
@@ -70,11 +70,11 @@ governing permissions and limitations under the License.
   --spectrum-treeview-item-text-padding-block-end: var(--spectrum-component-bottom-to-text-75);
   --spectrum-treeview-item-indentation: var(--spectrum-treeview-item-indentation-small);
   --spectrum-treeview-item-padding-block-end: var(--spectrum-component-edge-to-text-75);
-  
+
   --spectrum-treeview-item-padding-inline-start: var(--spectrum-component-height-75);
   --spectrum-treeview-indicator-margin-inline-start: calc(-1 * var(--spectrum-component-height-75));
   --spectrum-treeview-item-padding-inline-end: var(--spectrum-component-edge-to-text-75);
-  
+
   --spectrum-treeview-indicator-padding: var(--spectrum-disclosure-indicator-top-to-disclosure-icon-small);
 }
 
@@ -173,7 +173,7 @@ governing permissions and limitations under the License.
   .spectrum-TreeView {
     position: static;
     block-size: 0;
-    visibility: hidden;
+    display: none;
     padding-inline-start: var(--mod-treeview-item-indentation, var(--spectrum-treeview-item-indentation));
     margin-block: 0;
   }
@@ -192,7 +192,7 @@ governing permissions and limitations under the License.
     > .spectrum-TreeView {
       /* Open the treeview */
       block-size: auto;
-      visibility: visible;
+      display: block;
     }
   }
 
@@ -224,7 +224,7 @@ governing permissions and limitations under the License.
       }
     }
   }
-  
+
   &.is-drop-target {
     > .spectrum-TreeView-itemLink {
       &:before {
@@ -352,7 +352,7 @@ governing permissions and limitations under the License.
 
   /* Make sure hover doesn't block clicks on the chevron. */
   z-index: 1;
-  
+
   padding-inline: var(--mod-treeview-indicator-padding-inline, var(--spectrum-treeview-indicator-padding));
   padding-block: var(--mod-treeview-indicator-padding-block, var(--spectrum-treeview-indicator-padding));
   margin-inline-start: var(--mod-treeview-indicator-margin-inline-start, var(--spectrum-treeview-indicator-margin-inline-start));
@@ -391,15 +391,15 @@ governing permissions and limitations under the License.
   &--indent2 {
     padding-inline-start: calc(2 * var(--mod-treeview-item-indentation, var(--spectrum-treeview-item-indentation)));
   }
-  
+
   &--indent3 {
     padding-inline-start: calc(3 * var(--mod-treeview-item-indentation, var(--spectrum-treeview-item-indentation)));
   }
-  
+
   &--indent4 {
     padding-inline-start: calc(4 * var(--mod-treeview-item-indentation, var(--spectrum-treeview-item-indentation)));
   }
-  
+
   &--indent5 {
     padding-inline-start: calc(5 * var(--mod-treeview-item-indentation, var(--spectrum-treeview-item-indentation)));
   }
@@ -407,19 +407,19 @@ governing permissions and limitations under the License.
   &--indent6 {
     padding-inline-start: calc(6 * var(--mod-treeview-item-indentation, var(--spectrum-treeview-item-indentation)));
   }
-  
+
   &--indent7 {
     padding-inline-start: calc(7 * var(--mod-treeview-item-indentation, var(--spectrum-treeview-item-indentation)));
   }
-  
+
   &-indent8 {
     padding-inline-start: calc(8 * var(--mod-treeview-item-indentation, var(--spectrum-treeview-item-indentation)));
   }
-  
+
   &--indent9 {
     padding-inline-start: calc(9 * var(--mod-treeview-item-indentation, var(--spectrum-treeview-item-indentation)));
   }
-  
+
   &--indent10 {
     padding-inline-start: calc(10 * var(--mod-treeview-item-indentation, var(--spectrum-treeview-item-indentation)));
   }
@@ -451,7 +451,7 @@ governing permissions and limitations under the License.
     min-block-size: var(--mod-treeview-link-min-block-size-thumbnail, var(--spectrum-treeview-link-min-block-size));
     padding-block-start: var(--mod-treeview-item-text-padding-block-start, var(--spectrum-treeview-item-text-padding-block-start));
     padding-block-end: calc(
-      var(--mod-treeview-item-text-padding-block-end, var(--spectrum-treeview-item-text-padding-block-end)) - 
+      var(--mod-treeview-item-text-padding-block-end, var(--spectrum-treeview-item-text-padding-block-end)) -
       var(--mod-treeview-item-border-size, var(--spectrum-treeview-item-border-size))
     );
 

--- a/components/treeview/index.css
+++ b/components/treeview/index.css
@@ -11,8 +11,9 @@ governing permissions and limitations under the License.
 */
 
 .spectrum-TreeView {
-  --spectrum-treeview-line-height: 1.2;
+  --spectrum-treeview-line-height: 1.214285;
   --spectrum-treeview-margin-block: 1.0em;
+  --spectrum-treeview-font-size: var(--spectrum-font-size-100);
 
   --spectrum-treeview-item-min-block-size: var(--spectrum-component-height-100);
   --spectrum-treeview-item-indentation: var(--spectrum-treeview-item-indentation-medium);
@@ -20,7 +21,9 @@ governing permissions and limitations under the License.
   --spectrum-treeview-item-padding-block-end: var(--spectrum-component-edge-to-text-100);
   --spectrum-treeview-item-text-padding-block-start: var(--spectrum-component-top-to-text-100);
   --spectrum-treeview-item-text-padding-block-end: var(--spectrum-component-bottom-to-text-100);
-  --spectrum-treeview-item-affordance-size: var(--spectrum-component-height-100);
+
+  --spectrum-treeview-item-padding-inline-start: var(--spectrum-component-height-100);
+  --spectrum-treeview-item-padding-inline-end: var(--spectrum-component-edge-to-text-100);
 
   --spectrum-treeview-section-spacing: var(--spectrum-treeview-item-indentation-medium);
   --spectrum-treeview-heading-font-weight: var(--spectrum-bold-font-weight);
@@ -38,6 +41,7 @@ governing permissions and limitations under the License.
   --spectrum-treeview-item-border-color-quiet-selected: transparent;
   
   --spectrum-treeview-item-icon-gap: var(--spectrum-text-to-visual-75);
+  --spectrum-treeview-item-icon-offset-block: -1px;
   --spectrum-treeview-item-icon-color: var(--spectrum-gray-700);
   --spectrum-treeview-item-icon-color-hover: var(--spectrum-gray-900);
   --spectrum-treeview-item-icon-color-focus: var(--spectrum-gray-900);
@@ -50,41 +54,62 @@ governing permissions and limitations under the License.
   --spectrum-treeview-item-text-color-focus: var(--spectrum-gray-900);
   --spectrum-treeview-item-text-color-hover: var(--spectrum-gray-900);
 
-  --spectrum-treeview-indicator-inset-inline-start: var(--spectrum-component-edge-to-visual-only-200);
-  --spectrum-treeview-indicator-margin-inline-start: calc(-1 * var(--spectrum-component-height-200));
+  --spectrum-treeview-indicator-margin-inline-start: calc(-1 * var(--spectrum-component-height-100));
   --spectrum-treeview-indicator-margin-block-end: calc(-1 * var(--spectrum-component-edge-to-visual-only-200));
-  --spectrum-treeview-indicator-margin-inline-end: var(--spectrum-text-to-visual-75);
   --spectrum-treeview-indicator-padding: var(--spectrum-disclosure-indicator-top-to-disclosure-icon-medium);
 
   --spectrum-treeview-indicator-animation-duration: var(--spectrum-animation-duration-100);
 }
 
 .spectrum-TreeView--sizeS {
+  --spectrum-treeview-font-size: var(--spectrum-font-size-75);
+  --spectrum-treeview-item-icon-offset-block: 0;
+
   --spectrum-treeview-item-min-block-size: var(--spectrum-component-height-75);
   --spectrum-treeview-item-text-padding-block-start: var(--spectrum-spacing-75);
+  --spectrum-treeview-item-text-padding-block-end: var(--spectrum-component-bottom-to-text-75);
   --spectrum-treeview-item-indentation: var(--spectrum-treeview-item-indentation-small);
   --spectrum-treeview-item-padding-block-end: var(--spectrum-component-edge-to-text-75);
-  --spectrum-treeview-item-affordance-size: var(--spectrum-component-height-75);
+  
+  --spectrum-treeview-item-padding-inline-start: var(--spectrum-component-height-75);
+  --spectrum-treeview-indicator-margin-inline-start: calc(-1 * var(--spectrum-component-height-75));
+  --spectrum-treeview-item-padding-inline-end: var(--spectrum-component-edge-to-text-75);
+  
   --spectrum-treeview-indicator-padding: var(--spectrum-disclosure-indicator-top-to-disclosure-icon-small);
 }
 
 .spectrum-TreeView--sizeL {
+  --spectrum-treeview-font-size: var(--spectrum-font-size-200);
+  --spectrum-treeview-item-icon-offset-block: 0;
+
+  --spectrum-treeview-item-text-padding-block-start: var(--spectrum-component-top-to-text-200);
   --spectrum-treeview-item-text-padding-block-end: var(--spectrum-component-bottom-to-text-200);
   --spectrum-treeview-item-indentation: var(--spectrum-treeview-item-indentation-large);
-  --spectrum-treeview-item-min-block-size: var(--spectrum-component-height-100);
+  --spectrum-treeview-item-min-block-size: var(--spectrum-component-height-200);
   --spectrum-treeview-item-padding-block-end: var(--spectrum-component-edge-to-text-200);
-  --spectrum-treeview-item-affordance-size: var(--spectrum-component-height-200);
-  --spectrum-treeview-indicator-padding: var(--spectrum-disclosure-indicator-top-to-disclosure-icon-medium);
+
+  --spectrum-treeview-item-padding-inline-start: var(--spectrum-component-height-200);
+  --spectrum-treeview-indicator-margin-inline-start: calc(-1 * var(--spectrum-component-height-200));
+  --spectrum-treeview-item-padding-inline-end: var(--spectrum-component-edge-to-text-200);
+
+  --spectrum-treeview-indicator-padding: var(--spectrum-disclosure-indicator-top-to-disclosure-icon-large);
 }
 
 .spectrum-TreeView--sizeXL {
+  --spectrum-treeview-font-size: var(--spectrum-font-size-300);
+  --spectrum-treeview-item-icon-offset-block: 0;
+
   --spectrum-treeview-item-text-padding-block-start: var(--spectrum-component-top-to-text-300);
   --spectrum-treeview-item-text-padding-block-end: var(--spectrum-component-bottom-to-text-300);
   --spectrum-treeview-item-indentation: var(--spectrum-treeview-item-indentation-extra-large);
-  --spectrum-treeview-item-min-block-size: var(--spectrum-component-height-200);
+  --spectrum-treeview-item-min-block-size: var(--spectrum-component-height-300);
   --spectrum-treeview-item-padding-block-end: var(--spectrum-component-edge-to-text-300);
-  --spectrum-treeview-item-affordance-size: var(--spectrum-component-height-300);
-  --spectrum-treeview-indicator-padding: var(--spectrum-disclosure-indicator-top-to-disclosure-icon-large);
+
+  --spectrum-treeview-item-padding-inline-start: var(--spectrum-component-height-300);
+  --spectrum-treeview-indicator-margin-inline-start: calc(-1 * var(--spectrum-component-height-300));
+  --spectrum-treeview-item-padding-inline-end: var(--spectrum-component-edge-to-text-300);
+
+  --spectrum-treeview-indicator-padding: var(--spectrum-disclosure-indicator-top-to-disclosure-icon-extra-large);
 }
 
 .spectrum-TreeView--quiet {
@@ -142,6 +167,7 @@ governing permissions and limitations under the License.
   user-select: none;
   line-height: var(--mod-treeview-line-height, var(--spectrum-treeview-line-height));
   margin-block: var(--mod-treeview-margin-block, var(--spectrum-treeview-margin-block));
+  font-size: var(--mod-treeview-font-size, var(--spectrum-treeview-font-size));
 
   /* Close (hide) nested treeviews by default. */
   .spectrum-TreeView {
@@ -232,11 +258,12 @@ governing permissions and limitations under the License.
   box-sizing: border-box;
   display: flex;
   flex-direction: row;
+  flex-wrap: nowrap;
   align-items: center;
 
   min-block-size: var(--mod-treeview-item-min-block-size, var(--spectrum-treeview-item-min-block-size));
   padding-block: var(--mod-treeview-item-text-padding-block-start, var(--spectrum-treeview-item-text-padding-block-start)) var(--mod-treeview-item-text-padding-block-end, var(--spectrum-treeview-item-text-padding-block-end));
-  padding-inline: var(--mod-treeview-item-affordance-size, var(--spectrum-treeview-item-affordance-size));
+  padding-inline: var(--mod-treeview-item-padding-inline-start, var(--spectrum-treeview-item-padding-inline-start)) var(--mod-treeview-item-padding-inline-end, var(--spectrum-treeview-item-padding-inline-end));
 
   color: var(--highcontrast-treeview-item-text-color, var(--mod-treeview-item-text-color, var(--spectrum-treeview-item-text-color)));
 
@@ -254,8 +281,7 @@ governing permissions and limitations under the License.
 
     box-sizing: border-box;
     position: absolute;
-    inset-inline-start: var(--mod-treeview-item-border-size, var(--spectrum-treeview-item-border-size));
-    inset-inline-end: 0;
+    inset-inline: 0;
 
     min-block-size: var(--mod-treeview-item-min-block-size, var(--spectrum-treeview-item-min-block-size));
     padding-block-start: calc(
@@ -304,29 +330,36 @@ governing permissions and limitations under the License.
 .spectrum-TreeView-itemIcon {
   position: relative;
   vertical-align: top;
+  flex-shrink: 0;
   margin-inline-end: var(--mod-treeview-item-icon-gap, var(--spectrum-treeview-item-icon-gap));
+  /* Margin-block is to ensure proper overall item height because at medium, the line-height is 17px but the icon is 18px. */
+  margin-block-end: var(--mod-treeview-item-icon-offset-block, var(--spectrum-treeview-item-icon-offset-block));
   color: var(--highcontrast-treeview-item-icon-color, var(--mod-treeview-item-icon-color, var(--spectrum-treeview-item-icon-color)));
 }
 
 .spectrum-TreeView-itemIndicator {
+  /* How much taller the indicator is than the line-height. */
+  --spectrum-treeview-indicator-offset: calc((
+      var(--mod-treeview-item-text-padding-block-end, var(--spectrum-treeview-item-text-padding-block-end)) +
+      var(--mod-treeview-item-text-padding-block-start, var(--spectrum-treeview-item-text-padding-block-start))
+    ) / 2
+  );
+
   display: block;
   box-sizing: content-box;
-
-  float: inline-start;
   position: relative;
+  flex-shrink: 0;
 
   /* Make sure hover doesn't block clicks on the chevron. */
   z-index: 1;
-
-  inset-inline-start: var(--mod-treeview-indicator-inset-inline-start, var(--spectrum-treeview-indicator-inset-inline-start));
-  inset-block-start: var(--mod-treeview-indicator-inset-block-start, calc(-1 * var(--spectrum-treeview-indicator-inset-block-start)));
-
-  margin-inline-start: var(--mod-treeview-indicator-margin-inline-start, var(--spectrum-treeview-indicator-margin-inline-start));
-  margin-block-end: var(--mod-treeview-indicator-margin-block-end, var(--spectrum-treeview-indicator-margin-block-end));
-  margin-inline-end: var(--mod-treeview-indicator-margin-inline-end, var(--spectrum-treeview-indicator-margin-inline-end));
-
+  
   padding-inline: var(--mod-treeview-indicator-padding-inline, var(--spectrum-treeview-indicator-padding));
   padding-block: var(--mod-treeview-indicator-padding-block, var(--spectrum-treeview-indicator-padding));
+  margin-inline-start: var(--mod-treeview-indicator-margin-inline-start, var(--spectrum-treeview-indicator-margin-inline-start));
+
+  /* Block spacing adjustments prevent treeview item height increase due to indicator being larger than line-height. */
+  margin-block-end: var(--mod-treeview-indicator-margin-block-end, calc(-2 * var(--spectrum-treeview-indicator-offset)));
+  inset-block-start: var(--mod-treeview-indicator-inset-block-start, calc(-1 * var(--spectrum-treeview-indicator-offset)));
 
   transform: logical rotate(0deg);
   transition: transform ease var(--mod-treeview-indicator-animation-duration, var(--spectrum-treeview-indicator-animation-duration));
@@ -404,12 +437,13 @@ governing permissions and limitations under the License.
 
 .spectrum-TreeView--thumbnail {
   .spectrum-TreeView-itemThumbnail {
+    flex-shrink: 0;
     margin-inline-end: var(--mod-treeview-item-icon-gap, var(--spectrum-treeview-item-icon-gap));
   }
 
   .spectrum-TreeView-itemLink {
     --spectrum-treeview-link-min-block-size: calc(
-      var(--mod-treeview-item-affordance-size, var(--spectrum-treeview-item-affordance-size)) +
+      var(--mod-treeview-item-padding-inline-start, var(--spectrum-treeview-item-padding-inline-start)) +
       var(--mod-treeview-item-text-padding-block-start, var(--spectrum-treeview-item-text-padding-block-start)) +
       (var(--mod-treeview-item-text-padding-block-end, var(--spectrum-treeview-item-text-padding-block-end)) - var(--mod-treeview-item-border-size, var(--spectrum-treeview-item-border-size)))
     );

--- a/components/treeview/metadata/mods.md
+++ b/components/treeview/metadata/mods.md
@@ -15,7 +15,6 @@
 | `--mod-treeview-item-border-color-focus`              |
 | `--mod-treeview-item-border-color-selected`           |
 | `--mod-treeview-item-border-color-selected-quiet`     |
-| `--mod-treeview-item-border-radius`                   |
 | `--mod-treeview-item-border-radius-detached`          |
 | `--mod-treeview-item-border-size`                     |
 | `--mod-treeview-item-border-size-selected`            |
@@ -38,4 +37,3 @@
 | `--mod-treeview-line-height`                          |
 | `--mod-treeview-margin-block`                         |
 | `--mod-treeview-section-spacing`                      |
-| `--mod-treeview-thumbnail-margin-block`               |

--- a/components/treeview/metadata/mods.md
+++ b/components/treeview/metadata/mods.md
@@ -1,16 +1,14 @@
 | Modifiable Custom Properties                          |
 | ----------------------------------------------------- |
+| `--mod-treeview-font-size`                            |
 | `--mod-treeview-heading-color`                        |
 | `--mod-treeview-heading-font-weight`                  |
 | `--mod-treeview-indicator-animation-duration`         |
 | `--mod-treeview-indicator-inset-block-start`          |
-| `--mod-treeview-indicator-inset-inline-start`         |
 | `--mod-treeview-indicator-margin-block-end`           |
-| `--mod-treeview-indicator-margin-inline-end`          |
 | `--mod-treeview-indicator-margin-inline-start`        |
 | `--mod-treeview-indicator-padding-block`              |
 | `--mod-treeview-indicator-padding-inline`             |
-| `--mod-treeview-item-affordance-size`                 |
 | `--mod-treeview-item-background-color-focus`          |
 | `--mod-treeview-item-background-color-hover`          |
 | `--mod-treeview-item-background-color-quiet-selected` |
@@ -27,6 +25,7 @@
 | `--mod-treeview-item-icon-color-hover`                |
 | `--mod-treeview-item-icon-color-selected`             |
 | `--mod-treeview-item-icon-gap`                        |
+| `--mod-treeview-item-icon-offset-block`               |
 | `--mod-treeview-item-indentation`                     |
 | `--mod-treeview-item-min-block-size`                  |
 | `--mod-treeview-item-padding-block-end`               |

--- a/components/treeview/metadata/mods.md
+++ b/components/treeview/metadata/mods.md
@@ -1,11 +1,10 @@
 | Modifiable Custom Properties                          |
 | ----------------------------------------------------- |
 | `--mod-treeview-font-size`                            |
+| `--mod-treeview-heading-bottom-to-text`               |
 | `--mod-treeview-heading-color`                        |
 | `--mod-treeview-heading-font-weight`                  |
 | `--mod-treeview-indicator-animation-duration`         |
-| `--mod-treeview-indicator-inset-block-start`          |
-| `--mod-treeview-indicator-margin-block-end`           |
 | `--mod-treeview-indicator-margin-inline-start`        |
 | `--mod-treeview-indicator-padding-block`              |
 | `--mod-treeview-indicator-padding-inline`             |
@@ -17,6 +16,7 @@
 | `--mod-treeview-item-border-color-selected`           |
 | `--mod-treeview-item-border-color-selected-quiet`     |
 | `--mod-treeview-item-border-radius`                   |
+| `--mod-treeview-item-border-radius-detached`          |
 | `--mod-treeview-item-border-size`                     |
 | `--mod-treeview-item-border-size-selected`            |
 | `--mod-treeview-item-icon-color`                      |
@@ -25,12 +25,9 @@
 | `--mod-treeview-item-icon-color-hover`                |
 | `--mod-treeview-item-icon-color-selected`             |
 | `--mod-treeview-item-icon-gap`                        |
-| `--mod-treeview-item-icon-offset-block`               |
 | `--mod-treeview-item-indentation`                     |
 | `--mod-treeview-item-min-block-size`                  |
-| `--mod-treeview-item-padding-block-end`               |
-| `--mod-treeview-item-padding-block-start`             |
-| `--mod-treeview-item-padding-default`                 |
+| `--mod-treeview-item-min-block-size-thumbnail`        |
 | `--mod-treeview-item-padding-inline-end`              |
 | `--mod-treeview-item-padding-inline-start`            |
 | `--mod-treeview-item-text-color`                      |
@@ -38,9 +35,7 @@
 | `--mod-treeview-item-text-color-focus`                |
 | `--mod-treeview-item-text-color-hover`                |
 | `--mod-treeview-item-text-color-selected`             |
-| `--mod-treeview-item-text-padding-block-end`          |
-| `--mod-treeview-item-text-padding-block-start`        |
 | `--mod-treeview-line-height`                          |
-| `--mod-treeview-link-min-block-size-thumbnail`        |
 | `--mod-treeview-margin-block`                         |
 | `--mod-treeview-section-spacing`                      |
+| `--mod-treeview-thumbnail-margin-block`               |

--- a/components/treeview/metadata/treeview.yml
+++ b/components/treeview/metadata/treeview.yml
@@ -19,7 +19,6 @@ sections:
       * `.spectrum-TreeView-label` is now required to wrap labels to enable truncation behavior
       * `.spectrum-Treeview-icon` is now required on all non-indicator icons
 
-
       ### Renamed classes
 
       * `.spectrum-TreeView-standalone` renamed to `.spectrum-TreeView-detached`
@@ -34,8 +33,12 @@ sections:
 
       * Please replace `.spectrum-Icon--sizeS` with `.spectrum-Icon--sizeM`.
 
-      ### Remove `focus-ring` class
+      ### Removed `focus-ring` class
       We've migrated away from the focus-ring class in favor of the native `:focus-visible` pseudo-class due to changes in browser support.
+
+      ### Revised sections markup
+      The markup for sections has changed so that the heading is now a child of an `li` instead of the `ul`, to ensure valid markup. An additional
+      class `spectrum-TreeView-section` has been added for the first level `li` elements that contain the section heading and its child Tree view. 
 
 examples:
   - id: treeview-standard
@@ -43,7 +46,7 @@ examples:
     description: |
       Standard treeviews span the entire width of their parent container and are used within panels.
     markup: |
-      <ul class="spectrum-TreeView spectrum-TreeView--sizeM" style="width: 250px">
+      <ul class="spectrum-TreeView" style="width: 250px">
         <li class="spectrum-TreeView-item">
           <a class="spectrum-TreeView-itemLink" href="#"><span class="spectrum-TreeView-itemLabel">Layer 1</span></a>
         </li>
@@ -55,7 +58,7 @@ examples:
             </svg>
             <span class="spectrum-TreeView-itemLabel">Design Files</span>
           </a>
-          <ul class="spectrum-TreeView spectrum-TreeView--sizeM">
+          <ul class="spectrum-TreeView">
             <li class="spectrum-TreeView-item">
               <a class="spectrum-TreeView-itemLink" href="#"><span class="spectrum-TreeView-itemLabel">Layer 2</span></a>
             </li>
@@ -79,7 +82,7 @@ examples:
             </svg>
             <span class="spectrum-TreeView-itemLabel">Group 2</span>
           </a>
-          <ul class="spectrum-TreeView spectrum-TreeView--sizeM">
+          <ul class="spectrum-TreeView">
             <li class="spectrum-TreeView-item is-open">
               <a class="spectrum-TreeView-itemLink" href="#">
                 <svg class="spectrum-Icon spectrum-UIIcon-ChevronRight100 spectrum-TreeView-itemIndicator" focusable="false" aria-hidden="true">
@@ -87,7 +90,7 @@ examples:
                 </svg>
                 <span class="spectrum-TreeView-itemLabel">Group 3</span>
               </a>
-              <ul class="spectrum-TreeView spectrum-TreeView--sizeM">
+              <ul class="spectrum-TreeView">
                 <li class="spectrum-TreeView-item">
                   <a class="spectrum-TreeView-itemLink" href="#">
                     <svg class="spectrum-Icon spectrum-UIIcon-ChevronRight100 spectrum-TreeView-itemIndicator" focusable="false" aria-hidden="true">
@@ -95,7 +98,7 @@ examples:
                     </svg>
                     <span class="spectrum-TreeView-itemLabel">Group 4</span>
                   </a>
-                  <ul class="spectrum-TreeView spectrum-TreeView--sizeM">
+                  <ul class="spectrum-TreeView">
                     <li class="spectrum-TreeView-item">
                       <a class="spectrum-TreeView-itemLink" href="#"><span class="spectrum-TreeView-itemLabel">Layer 6</span></a>
                     </li>
@@ -111,7 +114,7 @@ examples:
                 </li>
               </ul>
             </li>
-          </ui>
+          </ul>
         </li>
       </ul>
 
@@ -120,7 +123,7 @@ examples:
     description: |
       A Tree view with a selected item.
     markup: |
-      <ul class="spectrum-TreeView spectrum-TreeView--sizeM" style="width: 250px">
+      <ul class="spectrum-TreeView" style="width: 250px">
         <li class="spectrum-TreeView-item">
           <a class="spectrum-TreeView-itemLink" href="#"><span class="spectrum-TreeView-itemLabel">Layer 1</span></a>
         </li>
@@ -135,7 +138,7 @@ examples:
     description: |
       A Tree view with quiet selection.
     markup: |
-      <ul class="spectrum-TreeView spectrum-TreeView--sizeM spectrum-TreeView--quiet" style="width: 250px">
+      <ul class="spectrum-TreeView spectrum-TreeView--quiet" style="width: 250px">
         <li class="spectrum-TreeView-item">
           <a class="spectrum-TreeView-itemLink" href="#"><span class="spectrum-TreeView-itemLabel">Layer 1</span></a>
         </li>
@@ -150,7 +153,7 @@ examples:
     description: |
       Detached Tree views are meant to be used outside of a panel. Items in detached Tree views have rounded corners.
     markup: |
-      <ul class="spectrum-TreeView spectrum-TreeView--sizeM spectrum-TreeView--detached" style="width: 250px">
+      <ul class="spectrum-TreeView spectrum-TreeView--detached" style="width: 250px">
         <li class="spectrum-TreeView-item">
           <a class="spectrum-TreeView-itemLink" href="#"><span class="spectrum-TreeView-itemLabel">Layer 1</span></a>
         </li>
@@ -165,7 +168,7 @@ examples:
     description: |
       A detached, quiet Tree view.
     markup: |
-      <ul class="spectrum-TreeView spectrum-TreeView--sizeM spectrum-TreeView--quiet spectrum-TreeView--detached" style="width: 250px">
+      <ul class="spectrum-TreeView spectrum-TreeView--quiet spectrum-TreeView--detached" style="width: 250px">
         <li class="spectrum-TreeView-item">
           <a class="spectrum-TreeView-itemLink" href="#"><span class="spectrum-TreeView-itemLabel">Layer 1</span></a>
         </li>
@@ -179,7 +182,7 @@ examples:
     name: Folders & Files
     description: A nested Tree view with folders and files.
     markup: |
-      <ul class="spectrum-TreeView spectrum-TreeView--sizeM" style="width: 250px">
+      <ul class="spectrum-TreeView" style="width: 250px">
         <li class="spectrum-TreeView-item is-open">
           <a class="spectrum-TreeView-itemLink" href="#">
             <svg class="spectrum-Icon spectrum-UIIcon-ChevronRight100 spectrum-TreeView-itemIndicator" focusable="false" aria-hidden="true">
@@ -190,7 +193,7 @@ examples:
             </svg>
             <span class="spectrum-TreeView-itemLabel">Design Files</span>
           </a>
-          <ul class="spectrum-TreeView spectrum-TreeView--sizeM">
+          <ul class="spectrum-TreeView">
             <li class="spectrum-TreeView-item">
               <a class="spectrum-TreeView-itemLink" href="#">
                 <svg class="spectrum-Icon spectrum-UIIcon-ChevronRight100 spectrum-TreeView-itemIndicator" focusable="false" aria-hidden="true">
@@ -212,7 +215,7 @@ examples:
                 </svg>
                 <span class="spectrum-TreeView-itemLabel">Work in Progress</span>
               </a>
-              <ul class="spectrum-TreeView spectrum-TreeView--sizeM">
+              <ul class="spectrum-TreeView">
                 <li class="spectrum-TreeView-item is-open">
                   <a class="spectrum-TreeView-itemLink" href="#">
                     <svg class="spectrum-Icon spectrum-UIIcon-ChevronRight100 spectrum-TreeView-itemIndicator" focusable="false" aria-hidden="true">
@@ -223,7 +226,7 @@ examples:
                     </svg>
                     <span class="spectrum-TreeView-itemLabel">Branding</span>
                   </a>
-                  <ul class="spectrum-TreeView spectrum-TreeView--sizeM">
+                  <ul class="spectrum-TreeView">
                     <li class="spectrum-TreeView-item">
                       <a class="spectrum-TreeView-itemLink" href="#">
                         <svg class="spectrum-Icon spectrum-UIIcon-ChevronRight100 spectrum-TreeView-itemIndicator" focusable="false" aria-hidden="true">
@@ -245,7 +248,7 @@ examples:
                         </svg>
                         <span class="spectrum-TreeView-itemLabel">Explorations</span>
                       </a>
-                      <ul class="spectrum-TreeView spectrum-TreeView--sizeM">
+                      <ul class="spectrum-TreeView">
                         <li class="spectrum-TreeView-item">
                           <a class="spectrum-TreeView-itemLink" href="#">
                             <svg class="spectrum-TreeView-itemIcon spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Document">
@@ -298,7 +301,7 @@ examples:
     name: Thumbnail
     description: Use Thumbnails when a user needs to have a preview of the content contained in a Tree view item. For its primary use within layer panels, the first example uses the layer variant of Thumbnail. The second example uses the default Thumbnail.
     markup: |
-      <ul class="spectrum-TreeView spectrum-TreeView--sizeM spectrum-TreeView--thumbnail" style="width: 250px">
+      <ul class="spectrum-TreeView spectrum-TreeView--thumbnail" style="width: 250px">
         <li class="spectrum-TreeView-item is-open">
           <a class="spectrum-TreeView-itemLink" href="#">
             <svg class="spectrum-Icon spectrum-UIIcon-ChevronRight100 spectrum-TreeView-itemIndicator" focusable="false" aria-hidden="true">
@@ -311,7 +314,7 @@ examples:
             </div>
             <span class="spectrum-TreeView-itemLabel">Composition</span>
           </a>
-          <ul class="spectrum-TreeView spectrum-TreeView--sizeM">
+          <ul class="spectrum-TreeView">
             <li class="spectrum-TreeView-item is-selected">
               <a class="spectrum-TreeView-itemLink" href="#">
                 <div class="spectrum-Thumbnail spectrum-Thumbnail--size500 spectrum-TreeView-itemThumbnail spectrum-Thumbnail-layer is-selected">
@@ -336,7 +339,7 @@ examples:
         </li>
       </ul>
 
-      <ul class="spectrum-TreeView spectrum-TreeView--sizeM spectrum-TreeView--thumbnail" style="width: 250px">
+      <ul class="spectrum-TreeView spectrum-TreeView--thumbnail" style="width: 250px">
         <li class="spectrum-TreeView-item is-open">
           <a class="spectrum-TreeView-itemLink" href="#">
             <svg class="spectrum-Icon spectrum-UIIcon-ChevronRight100 spectrum-TreeView-itemIndicator" focusable="false" aria-hidden="true">
@@ -349,7 +352,7 @@ examples:
             </div>
             <span class="spectrum-TreeView-itemLabel">Composition</span>
           </a>
-          <ul class="spectrum-TreeView spectrum-TreeView--sizeM">
+          <ul class="spectrum-TreeView">
             <li class="spectrum-TreeView-item is-selected">
               <a class="spectrum-TreeView-itemLink" href="#">
                 <div class="spectrum-Thumbnail spectrum-Thumbnail--size500 spectrum-TreeView-itemThumbnail is-selected">
@@ -379,7 +382,7 @@ examples:
     description: A quiet Tree view with Thumbnails using the layer variant.
       When using the quiet variant, less visual emphasis is given to the selected Tree view item.
     markup: |
-      <ul class="spectrum-TreeView spectrum-TreeView--sizeM spectrum-TreeView--thumbnail spectrum-TreeView--quiet" style="width: 250px">
+      <ul class="spectrum-TreeView spectrum-TreeView--thumbnail spectrum-TreeView--quiet" style="width: 250px">
         <li class="spectrum-TreeView-item is-open">
           <a class="spectrum-TreeView-itemLink" href="#" style="width: 250px">
             <svg class="spectrum-Icon spectrum-UIIcon-ChevronRight100 spectrum-TreeView-itemIndicator" focusable="false" aria-hidden="true">
@@ -392,7 +395,7 @@ examples:
             </div>
             <span class="spectrum-TreeView-itemLabel">Composition</span>
           </a>
-          <ul class="spectrum-TreeView spectrum-TreeView--sizeM">
+          <ul class="spectrum-TreeView">
             <li class="spectrum-TreeView-item is-selected">
               <a class="spectrum-TreeView-itemLink" href="#">
                 <div class="spectrum-Thumbnail spectrum-Thumbnail--size500 spectrum-TreeView-itemThumbnail spectrum-Thumbnail-layer is-selected">
@@ -420,7 +423,7 @@ examples:
   - id: treeview-disabled
     name: Disabled
     markup: |
-      <ul class="spectrum-TreeView spectrum-TreeView--sizeM" style="width: 250px">
+      <ul class="spectrum-TreeView" style="width: 250px">
         <li class="spectrum-TreeView-item">
           <a class="spectrum-TreeView-itemLink" href="#"><span class="spectrum-TreeView-itemLabel">Layer 1</span></a>
         </li>
@@ -432,7 +435,7 @@ examples:
             </svg>
             <span class="spectrum-TreeView-itemLabel">Group 1</span>
           </a>
-          <ul class="spectrum-TreeView spectrum-TreeView--sizeM">
+          <ul class="spectrum-TreeView">
             <li class="spectrum-TreeView-item">
               <a class="spectrum-TreeView-itemLink" href="#"><span class="spectrum-TreeView-itemLabel">Layer 2</span></a>
             </li>
@@ -456,7 +459,7 @@ examples:
             </svg>
             <span class="spectrum-TreeView-itemLabel">Group 2</span>
           </a>
-          <ul class="spectrum-TreeView spectrum-TreeView--sizeM">
+          <ul class="spectrum-TreeView">
             <li class="spectrum-TreeView-item is-open">
               <a class="spectrum-TreeView-itemLink" href="#">
                 <svg class="spectrum-Icon spectrum-UIIcon-ChevronRight100 spectrum-TreeView-itemIndicator" focusable="false" aria-hidden="true">
@@ -464,7 +467,7 @@ examples:
                 </svg>
                 <span class="spectrum-TreeView-itemLabel">Group 3</span>
               </a>
-              <ul class="spectrum-TreeView spectrum-TreeView--sizeM">
+              <ul class="spectrum-TreeView">
                 <li class="spectrum-TreeView-item">
                   <a class="spectrum-TreeView-itemLink" href="#">
                     <svg class="spectrum-Icon spectrum-UIIcon-ChevronRight100 spectrum-TreeView-itemIndicator" focusable="false" aria-hidden="true">
@@ -472,7 +475,7 @@ examples:
                     </svg>
                     <span class="spectrum-TreeView-itemLabel">Group 4</span>
                   </a>
-                  <ul class="spectrum-TreeView spectrum-TreeView--sizeM">
+                  <ul class="spectrum-TreeView">
                     <li class="spectrum-TreeView-item">
                       <a class="spectrum-TreeView-itemLink" href="#"><span class="spectrum-TreeView-itemLabel">Layer 6</span></a>
                     </li>
@@ -495,72 +498,84 @@ examples:
   - id: treeview-sections
     name: Sections
     markup: |
-      <ul class="spectrum-TreeView spectrum-TreeView--sizeM" style="width: 250px">
-        <div class="spectrum-TreeView-heading"><span class="spectrum-TreeView-itemLabel">Section 1</span></div>
-        <li class="spectrum-TreeView-item">
-          <a class="spectrum-TreeView-itemLink" href="#">
-            <svg class="spectrum-Icon spectrum-UIIcon-ChevronRight100 spectrum-TreeView-itemIndicator" focusable="false" aria-hidden="true">
-              <use xlink:href="#spectrum-css-icon-Chevron100" />
-            </svg>
-            <span class="spectrum-TreeView-itemLabel">Group 1</span>
-          </a>
-          <ul class="spectrum-TreeView spectrum-TreeView--sizeM">
+      <ul class="spectrum-TreeView" style="width: 250px">
+        <li class="spectrum-TreeView-section">
+          <div class="spectrum-TreeView-heading">
+            <span class="spectrum-TreeView-itemLabel">Section 1</span>
+          </div>
+          <ul class="spectrum-TreeView">
             <li class="spectrum-TreeView-item">
-              <a class="spectrum-TreeView-itemLink" href="#"><span class="spectrum-TreeView-itemLabel">Layer 2</span></a>
+              <a class="spectrum-TreeView-itemLink" href="#">
+                <svg class="spectrum-Icon spectrum-UIIcon-ChevronRight100 spectrum-TreeView-itemIndicator" focusable="false" aria-hidden="true">
+                  <use xlink:href="#spectrum-css-icon-Chevron100" />
+                </svg>
+                <span class="spectrum-TreeView-itemLabel">Group 1</span>
+              </a>
+              <ul class="spectrum-TreeView">
+                <li class="spectrum-TreeView-item">
+                  <a class="spectrum-TreeView-itemLink" href="#"><span class="spectrum-TreeView-itemLabel">Layer 2</span></a>
+                </li>
+                <li class="spectrum-TreeView-item">
+                  <a class="spectrum-TreeView-itemLink" href="#"><span class="spectrum-TreeView-itemLabel">Layer 3</span></a>
+                </li>
+              </ul>
+            </li>
+
+            <li class="spectrum-TreeView-item">
+              <a class="spectrum-TreeView-itemLink" href="#"><span class="spectrum-TreeView-itemLabel">Layer 4</span></a>
             </li>
             <li class="spectrum-TreeView-item">
-              <a class="spectrum-TreeView-itemLink" href="#"><span class="spectrum-TreeView-itemLabel">Layer 3</span></a>
+              <a class="spectrum-TreeView-itemLink" href="#"><span class="spectrum-TreeView-itemLabel">Layer 5</span></a>
             </li>
           </ul>
         </li>
-
-        <li class="spectrum-TreeView-item">
-          <a class="spectrum-TreeView-itemLink" href="#"><span class="spectrum-TreeView-itemLabel">Layer 4</span></a>
-        </li>
-        <li class="spectrum-TreeView-item">
-          <a class="spectrum-TreeView-itemLink" href="#"><span class="spectrum-TreeView-itemLabel">Layer 5</span></a>
-        </li>
-        <div class="spectrum-TreeView-heading"><span class="spectrum-TreeView-itemLabel">Section 2</span></div>
-        <li class="spectrum-TreeView-item is-open">
-          <a class="spectrum-TreeView-itemLink" href="#">
-            <svg class="spectrum-Icon spectrum-UIIcon-ChevronRight100 spectrum-TreeView-itemIndicator" focusable="false" aria-hidden="true">
-              <use xlink:href="#spectrum-css-icon-Chevron100" />
-            </svg>
-            <span class="spectrum-TreeView-itemLabel">Group 2</span>
-          </a>
-          <ul class="spectrum-TreeView spectrum-TreeView--sizeM">
+        <li class="spectrum-TreeView-section">
+          <div class="spectrum-TreeView-heading">
+            <span class="spectrum-TreeView-itemLabel">Section 2</span>
+          </div>
+          <ul class="spectrum-TreeView">
             <li class="spectrum-TreeView-item is-open">
               <a class="spectrum-TreeView-itemLink" href="#">
                 <svg class="spectrum-Icon spectrum-UIIcon-ChevronRight100 spectrum-TreeView-itemIndicator" focusable="false" aria-hidden="true">
                   <use xlink:href="#spectrum-css-icon-Chevron100" />
                 </svg>
-                <span class="spectrum-TreeView-itemLabel">Group 3</span>
+                <span class="spectrum-TreeView-itemLabel">Group 2</span>
               </a>
-              <ul class="spectrum-TreeView spectrum-TreeView--sizeM">
-                <li class="spectrum-TreeView-item">
+              <ul class="spectrum-TreeView">
+                <li class="spectrum-TreeView-item is-open">
                   <a class="spectrum-TreeView-itemLink" href="#">
                     <svg class="spectrum-Icon spectrum-UIIcon-ChevronRight100 spectrum-TreeView-itemIndicator" focusable="false" aria-hidden="true">
                       <use xlink:href="#spectrum-css-icon-Chevron100" />
                     </svg>
-                    <span class="spectrum-TreeView-itemLabel">Group 4</span>
+                    <span class="spectrum-TreeView-itemLabel">Group 3</span>
                   </a>
-                  <ul class="spectrum-TreeView spectrum-TreeView--sizeM">
-                    <li class="spectrum-TreeView-item">
-                      <a class="spectrum-TreeView-itemLink" href="#"><span class="spectrum-TreeView-itemLabel">Layer 6</span></a>
-                    </li>
+                  <ul class="spectrum-TreeView">
                     <li class="spectrum-TreeView-item">
                       <a class="spectrum-TreeView-itemLink" href="#">
                         <svg class="spectrum-Icon spectrum-UIIcon-ChevronRight100 spectrum-TreeView-itemIndicator" focusable="false" aria-hidden="true">
                           <use xlink:href="#spectrum-css-icon-Chevron100" />
                         </svg>
-                        <span class="spectrum-TreeView-itemLabel">Group 5</span>
+                        <span class="spectrum-TreeView-itemLabel">Group 4</span>
                       </a>
+                      <ul class="spectrum-TreeView">
+                        <li class="spectrum-TreeView-item">
+                          <a class="spectrum-TreeView-itemLink" href="#"><span class="spectrum-TreeView-itemLabel">Layer 6</span></a>
+                        </li>
+                        <li class="spectrum-TreeView-item">
+                          <a class="spectrum-TreeView-itemLink" href="#">
+                            <svg class="spectrum-Icon spectrum-UIIcon-ChevronRight100 spectrum-TreeView-itemIndicator" focusable="false" aria-hidden="true">
+                              <use xlink:href="#spectrum-css-icon-Chevron100" />
+                            </svg>
+                            <span class="spectrum-TreeView-itemLabel">Group 5</span>
+                          </a>
+                        </li>
+                      </ul>
                     </li>
                   </ul>
                 </li>
               </ul>
             </li>
-          </ui>
+          </ul>
         </li>
       </ul>
 
@@ -569,7 +584,7 @@ examples:
     description: |
       A Tree view with an item that's a drop target.
     markup: |
-      <ul class="spectrum-TreeView spectrum-TreeView--sizeM" style="width: 250px">
+      <ul class="spectrum-TreeView" style="width: 250px">
         <li class="spectrum-TreeView-item">
           <a class="spectrum-TreeView-itemLink" href="#"><span class="spectrum-TreeView-itemLabel">Layer 1</span></a>
         </li>
@@ -598,7 +613,7 @@ examples:
       </div>
       <div>
         <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">M</h4>
-        <ul class="spectrum-TreeView spectrum-TreeView--sizeM" style="width: 250px">
+        <ul class="spectrum-TreeView" style="width: 250px">
           <li class="spectrum-TreeView-item">
             <a class="spectrum-TreeView-itemLink" href="#"><span class="spectrum-TreeView-itemLabel">Layer 1</span></a>
           </li>
@@ -637,7 +652,7 @@ examples:
     name: Icons
     description: A Tree view with icons.
     markup: |
-      <ul class="spectrum-TreeView spectrum-TreeView--sizeM" style="width: 250px">
+      <ul class="spectrum-TreeView" style="width: 250px">
         <li class="spectrum-TreeView-item">
           <a class="spectrum-TreeView-itemLink" href="#">
             <svg class="spectrum-TreeView-itemIcon spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Layers">
@@ -657,7 +672,7 @@ examples:
             </svg>
             <span class="spectrum-TreeView-itemLabel">Group 1</span>
           </a>
-          <ul class="spectrum-TreeView spectrum-TreeView--sizeM">
+          <ul class="spectrum-TreeView">
             <li class="spectrum-TreeView-item">
               <a class="spectrum-TreeView-itemLink" href="#">
                 <svg class="spectrum-TreeView-itemIcon spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Layers">
@@ -704,7 +719,7 @@ examples:
             </svg>
             <span class="spectrum-TreeView-itemLabel">Group 2</span>
           </a>
-          <ul class="spectrum-TreeView spectrum-TreeView--sizeM">
+          <ul class="spectrum-TreeView">
             <li class="spectrum-TreeView-item is-open">
               <a class="spectrum-TreeView-itemLink" href="#">
                 <svg class="spectrum-Icon spectrum-UIIcon-ChevronRight100 spectrum-TreeView-itemIndicator" focusable="false" aria-hidden="true">
@@ -715,7 +730,7 @@ examples:
                 </svg>
                 <span class="spectrum-TreeView-itemLabel">Group 3</span>
               </a>
-              <ul class="spectrum-TreeView spectrum-TreeView--sizeM">
+              <ul class="spectrum-TreeView">
                 <li class="spectrum-TreeView-item">
                   <a class="spectrum-TreeView-itemLink" href="#">
                     <svg class="spectrum-Icon spectrum-UIIcon-ChevronRight100 spectrum-TreeView-itemIndicator" focusable="false" aria-hidden="true">
@@ -726,7 +741,7 @@ examples:
                     </svg>
                     <span class="spectrum-TreeView-itemLabel">Group 4</span>
                   </a>
-                  <ul class="spectrum-TreeView spectrum-TreeView--sizeM">
+                  <ul class="spectrum-TreeView">
                     <li class="spectrum-TreeView-item">
                       <a class="spectrum-TreeView-itemLink" href="#">
                         <svg class="spectrum-TreeView-itemIcon spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="Layers">
@@ -750,7 +765,7 @@ examples:
                 </li>
               </ul>
             </li>
-          </ui>
+          </ul>
         </li>
       </ul>
 
@@ -759,7 +774,7 @@ examples:
     description: |
       A Tree view drawn without nesting, suitable for infinite scrolling. With this version of the treeview, you must manage the visibility of "child items" manually based on the open state of the "parent item." The level of visual indentation is handled by a numbered `indent` variant class.
     markup: |
-      <ul class="spectrum-TreeView spectrum-TreeView--sizeM" style="width: 250px">
+      <ul class="spectrum-TreeView" style="width: 250px">
         <li class="spectrum-TreeView-item">
           <a class="spectrum-TreeView-itemLink" href="#"><span class="spectrum-TreeView-itemLabel">Layer 1 with a long name that doesn't fit at all</span></a>
         </li>

--- a/components/treeview/metadata/treeview.yml
+++ b/components/treeview/metadata/treeview.yml
@@ -22,6 +22,7 @@ sections:
 
       ### Renamed classes
 
+      * `.spectrum-TreeView-standalone` renamed to `.spectrum-TreeView-detached`
       * `.spectrum-TreeView-indicator` renamed to `.spectrum-TreeView-itemIndicator`
       * `.spectrum-TreeView-icon` renamed to `.spectrum-TreeView-itemIcon`
 
@@ -65,7 +66,7 @@ examples:
         </li>
 
         <li class="spectrum-TreeView-item">
-          <a class="spectrum-TreeView-itemLink" href="#"><span class="spectrum-TreeView-itemLabel">Layer 4</span></a>
+          <a class="spectrum-TreeView-itemLink" href="#"><span class="spectrum-TreeView-itemLabel">Layer 4 - Per the guidelines, long text will truncate with an ellipsis, and the full text should be available in a tooltip.</span></a>
         </li>
         <li class="spectrum-TreeView-item">
           <a class="spectrum-TreeView-itemLink" href="#"><span class="spectrum-TreeView-itemLabel">Layer 5</span></a>
@@ -144,13 +145,12 @@ examples:
         </li>
       </ul>
 
-  - id: treeview-standalone
-    name: Standalone
+  - id: treeview-detached
+    name: Detached
     description: |
-      Standalone treeviews are meant to be used outside of a panel.
-      Items in standalone treeviews have rounded corners.
+      Detached Tree views are meant to be used outside of a panel. Items in detached Tree views have rounded corners.
     markup: |
-      <ul class="spectrum-TreeView spectrum-TreeView--sizeM spectrum-TreeView--standalone" style="width: 250px">
+      <ul class="spectrum-TreeView spectrum-TreeView--sizeM spectrum-TreeView--detached" style="width: 250px">
         <li class="spectrum-TreeView-item">
           <a class="spectrum-TreeView-itemLink" href="#"><span class="spectrum-TreeView-itemLabel">Layer 1</span></a>
         </li>
@@ -160,12 +160,12 @@ examples:
         </li>
       </ul>
 
-  - id: treeview-standalone-quiet
-    name: Standalone (quiet)
+  - id: treeview-detached-quiet
+    name: Detached (quiet)
     description: |
-      A standalone, quiet treeview.
+      A detached, quiet Tree view.
     markup: |
-      <ul class="spectrum-TreeView spectrum-TreeView--sizeM spectrum-TreeView--quiet spectrum-TreeView--standalone" style="width: 250px">
+      <ul class="spectrum-TreeView spectrum-TreeView--sizeM spectrum-TreeView--quiet spectrum-TreeView--detached" style="width: 250px">
         <li class="spectrum-TreeView-item">
           <a class="spectrum-TreeView-itemLink" href="#"><span class="spectrum-TreeView-itemLabel">Layer 1</span></a>
         </li>
@@ -296,8 +296,46 @@ examples:
 
   - id: treeview-thumbnail
     name: Thumbnail
-    description: A Tree view with Thumbnails.
+    description: Use Thumbnails when a user needs to have a preview of the content contained in a Tree view item. For its primary use within layer panels, the first example uses the layer variant of Thumbnail. The second example uses the default Thumbnail.
     markup: |
+      <ul class="spectrum-TreeView spectrum-TreeView--sizeM spectrum-TreeView--thumbnail" style="width: 250px">
+        <li class="spectrum-TreeView-item is-open">
+          <a class="spectrum-TreeView-itemLink" href="#">
+            <svg class="spectrum-Icon spectrum-UIIcon-ChevronRight100 spectrum-TreeView-itemIndicator" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Chevron100" />
+            </svg>
+            <div class="spectrum-Thumbnail spectrum-Thumbnail--size500 spectrum-TreeView-itemThumbnail spectrum-Thumbnail-layer">
+              <div class="spectrum-Thumbnail-layer-inner spectrum-OpacityCheckerboard">
+                <img class="spectrum-Thumbnail-image" src="img/thumbnail.png" alt="Woman crouching">
+              </div>
+            </div>
+            <span class="spectrum-TreeView-itemLabel">Composition</span>
+          </a>
+          <ul class="spectrum-TreeView spectrum-TreeView--sizeM">
+            <li class="spectrum-TreeView-item is-selected">
+              <a class="spectrum-TreeView-itemLink" href="#">
+                <div class="spectrum-Thumbnail spectrum-Thumbnail--size500 spectrum-TreeView-itemThumbnail spectrum-Thumbnail-layer is-selected">
+                  <div class="spectrum-Thumbnail-layer-inner spectrum-OpacityCheckerboard">
+                    <img class="spectrum-Thumbnail-image" src="img/flowers.png" alt="Flowers">
+                  </div>
+                </div>
+                <span class="spectrum-TreeView-itemLabel">Flowers</span>
+              </a>
+            </li>
+            <li class="spectrum-TreeView-item">
+              <a class="spectrum-TreeView-itemLink" href="#">
+                <div class="spectrum-Thumbnail spectrum-Thumbnail--size500 spectrum-TreeView-itemThumbnail spectrum-Thumbnail-layer">
+                  <div class="spectrum-Thumbnail-layer-inner spectrum-OpacityCheckerboard">
+                    <img class="spectrum-Thumbnail-image" src="img/thumbnail.png" alt="Woman crouching">
+                  </div>
+                </div>
+                <span class="spectrum-TreeView-itemLabel">Figure</span>
+              </a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+
       <ul class="spectrum-TreeView spectrum-TreeView--sizeM spectrum-TreeView--thumbnail" style="width: 250px">
         <li class="spectrum-TreeView-item is-open">
           <a class="spectrum-TreeView-itemLink" href="#">
@@ -307,15 +345,14 @@ examples:
             <div class="spectrum-Thumbnail spectrum-Thumbnail--size500 spectrum-TreeView-itemThumbnail">
               <div class="spectrum-Thumbnail-image-wrapper spectrum-OpacityCheckerboard">
                 <img class="spectrum-Thumbnail-image" src="img/thumbnail.png" alt="Woman crouching">
-                <img class="spectrum-Thumbnail-image" src="img/flowers.png" alt="Flowers">
               </div>
             </div>
             <span class="spectrum-TreeView-itemLabel">Composition</span>
           </a>
           <ul class="spectrum-TreeView spectrum-TreeView--sizeM">
-            <li class="spectrum-TreeView-item">
+            <li class="spectrum-TreeView-item is-selected">
               <a class="spectrum-TreeView-itemLink" href="#">
-                <div class="spectrum-Thumbnail spectrum-Thumbnail--size500 spectrum-TreeView-itemThumbnail">
+                <div class="spectrum-Thumbnail spectrum-Thumbnail--size500 spectrum-TreeView-itemThumbnail is-selected">
                   <div class="spectrum-Thumbnail-image-wrapper spectrum-OpacityCheckerboard">
                     <img class="spectrum-Thumbnail-image" src="img/flowers.png" alt="Flowers">
                   </div>
@@ -339,7 +376,8 @@ examples:
 
   - id: treeview-thumbnail-quiet
     name: Thumbnail (quiet)
-    description: A quiet Tree view with Thumbnails.
+    description: A quiet Tree view with Thumbnails using the layer variant.
+      When using the quiet variant, less visual emphasis is given to the selected Tree view item.
     markup: |
       <ul class="spectrum-TreeView spectrum-TreeView--sizeM spectrum-TreeView--thumbnail spectrum-TreeView--quiet" style="width: 250px">
         <li class="spectrum-TreeView-item is-open">
@@ -347,19 +385,18 @@ examples:
             <svg class="spectrum-Icon spectrum-UIIcon-ChevronRight100 spectrum-TreeView-itemIndicator" focusable="false" aria-hidden="true">
               <use xlink:href="#spectrum-css-icon-Chevron100" />
             </svg>
-            <div class="spectrum-Thumbnail spectrum-Thumbnail--size500 spectrum-TreeView-itemThumbnail">
-              <div class="spectrum-Thumbnail-image-wrapper spectrum-OpacityCheckerboard">
+            <div class="spectrum-Thumbnail spectrum-Thumbnail--size500 spectrum-TreeView-itemThumbnail spectrum-Thumbnail-layer">
+              <div class="spectrum-Thumbnail-layer-inner spectrum-OpacityCheckerboard">
                 <img class="spectrum-Thumbnail-image" src="img/thumbnail.png" alt="Woman crouching">
-                <img class="spectrum-Thumbnail-image" src="img/flowers.png" alt="Flowers">
               </div>
             </div>
             <span class="spectrum-TreeView-itemLabel">Composition</span>
           </a>
           <ul class="spectrum-TreeView spectrum-TreeView--sizeM">
-            <li class="spectrum-TreeView-item">
+            <li class="spectrum-TreeView-item is-selected">
               <a class="spectrum-TreeView-itemLink" href="#">
-                <div class="spectrum-Thumbnail spectrum-Thumbnail--size500 spectrum-TreeView-itemThumbnail">
-                  <div class="spectrum-Thumbnail-image-wrapper spectrum-OpacityCheckerboard">
+                <div class="spectrum-Thumbnail spectrum-Thumbnail--size500 spectrum-TreeView-itemThumbnail spectrum-Thumbnail-layer is-selected">
+                  <div class="spectrum-Thumbnail-layer-inner spectrum-OpacityCheckerboard">
                     <img class="spectrum-Thumbnail-image" src="img/flowers.png" alt="Flowers">
                   </div>
                 </div>
@@ -368,8 +405,8 @@ examples:
             </li>
             <li class="spectrum-TreeView-item">
               <a class="spectrum-TreeView-itemLink" href="#">
-                <div class="spectrum-Thumbnail spectrum-Thumbnail--size500 spectrum-TreeView-itemThumbnail">
-                  <div class="spectrum-Thumbnail-image-wrapper spectrum-OpacityCheckerboard">
+                <div class="spectrum-Thumbnail spectrum-Thumbnail--size500 spectrum-TreeView-itemThumbnail spectrum-Thumbnail-layer">
+                  <div class="spectrum-Thumbnail-layer-inner spectrum-OpacityCheckerboard">
                     <img class="spectrum-Thumbnail-image" src="img/thumbnail.png" alt="Woman crouching">
                   </div>
                 </div>

--- a/components/treeview/metadata/treeview.yml
+++ b/components/treeview/metadata/treeview.yml
@@ -307,7 +307,7 @@ examples:
             <svg class="spectrum-Icon spectrum-UIIcon-ChevronRight100 spectrum-TreeView-itemIndicator" focusable="false" aria-hidden="true">
               <use xlink:href="#spectrum-css-icon-Chevron100" />
             </svg>
-            <div class="spectrum-Thumbnail spectrum-Thumbnail--size500 spectrum-TreeView-itemThumbnail spectrum-Thumbnail-layer">
+            <div class="spectrum-Thumbnail spectrum-Thumbnail--size200 spectrum-TreeView-itemThumbnail spectrum-Thumbnail-layer">
               <div class="spectrum-Thumbnail-layer-inner spectrum-OpacityCheckerboard">
                 <img class="spectrum-Thumbnail-image" src="img/thumbnail.png" alt="Woman crouching">
               </div>
@@ -317,7 +317,7 @@ examples:
           <ul class="spectrum-TreeView">
             <li class="spectrum-TreeView-item is-selected">
               <a class="spectrum-TreeView-itemLink" href="#">
-                <div class="spectrum-Thumbnail spectrum-Thumbnail--size500 spectrum-TreeView-itemThumbnail spectrum-Thumbnail-layer is-selected">
+                <div class="spectrum-Thumbnail spectrum-Thumbnail--size200 spectrum-TreeView-itemThumbnail spectrum-Thumbnail-layer is-selected">
                   <div class="spectrum-Thumbnail-layer-inner spectrum-OpacityCheckerboard">
                     <img class="spectrum-Thumbnail-image" src="img/flowers.png" alt="Flowers">
                   </div>
@@ -327,7 +327,7 @@ examples:
             </li>
             <li class="spectrum-TreeView-item">
               <a class="spectrum-TreeView-itemLink" href="#">
-                <div class="spectrum-Thumbnail spectrum-Thumbnail--size500 spectrum-TreeView-itemThumbnail spectrum-Thumbnail-layer">
+                <div class="spectrum-Thumbnail spectrum-Thumbnail--size200 spectrum-TreeView-itemThumbnail spectrum-Thumbnail-layer">
                   <div class="spectrum-Thumbnail-layer-inner spectrum-OpacityCheckerboard">
                     <img class="spectrum-Thumbnail-image" src="img/thumbnail.png" alt="Woman crouching">
                   </div>
@@ -345,7 +345,7 @@ examples:
             <svg class="spectrum-Icon spectrum-UIIcon-ChevronRight100 spectrum-TreeView-itemIndicator" focusable="false" aria-hidden="true">
               <use xlink:href="#spectrum-css-icon-Chevron100" />
             </svg>
-            <div class="spectrum-Thumbnail spectrum-Thumbnail--size500 spectrum-TreeView-itemThumbnail">
+            <div class="spectrum-Thumbnail spectrum-Thumbnail--size200 spectrum-TreeView-itemThumbnail">
               <div class="spectrum-Thumbnail-image-wrapper spectrum-OpacityCheckerboard">
                 <img class="spectrum-Thumbnail-image" src="img/thumbnail.png" alt="Woman crouching">
               </div>
@@ -355,7 +355,7 @@ examples:
           <ul class="spectrum-TreeView">
             <li class="spectrum-TreeView-item is-selected">
               <a class="spectrum-TreeView-itemLink" href="#">
-                <div class="spectrum-Thumbnail spectrum-Thumbnail--size500 spectrum-TreeView-itemThumbnail is-selected">
+                <div class="spectrum-Thumbnail spectrum-Thumbnail--size200 spectrum-TreeView-itemThumbnail is-selected">
                   <div class="spectrum-Thumbnail-image-wrapper spectrum-OpacityCheckerboard">
                     <img class="spectrum-Thumbnail-image" src="img/flowers.png" alt="Flowers">
                   </div>
@@ -365,7 +365,7 @@ examples:
             </li>
             <li class="spectrum-TreeView-item">
               <a class="spectrum-TreeView-itemLink" href="#">
-                <div class="spectrum-Thumbnail spectrum-Thumbnail--size500 spectrum-TreeView-itemThumbnail">
+                <div class="spectrum-Thumbnail spectrum-Thumbnail--size200 spectrum-TreeView-itemThumbnail">
                   <div class="spectrum-Thumbnail-image-wrapper spectrum-OpacityCheckerboard">
                     <img class="spectrum-Thumbnail-image" src="img/thumbnail.png" alt="Woman crouching">
                   </div>
@@ -388,7 +388,7 @@ examples:
             <svg class="spectrum-Icon spectrum-UIIcon-ChevronRight100 spectrum-TreeView-itemIndicator" focusable="false" aria-hidden="true">
               <use xlink:href="#spectrum-css-icon-Chevron100" />
             </svg>
-            <div class="spectrum-Thumbnail spectrum-Thumbnail--size500 spectrum-TreeView-itemThumbnail spectrum-Thumbnail-layer">
+            <div class="spectrum-Thumbnail spectrum-Thumbnail--size200 spectrum-TreeView-itemThumbnail spectrum-Thumbnail-layer">
               <div class="spectrum-Thumbnail-layer-inner spectrum-OpacityCheckerboard">
                 <img class="spectrum-Thumbnail-image" src="img/thumbnail.png" alt="Woman crouching">
               </div>
@@ -398,7 +398,7 @@ examples:
           <ul class="spectrum-TreeView">
             <li class="spectrum-TreeView-item is-selected">
               <a class="spectrum-TreeView-itemLink" href="#">
-                <div class="spectrum-Thumbnail spectrum-Thumbnail--size500 spectrum-TreeView-itemThumbnail spectrum-Thumbnail-layer is-selected">
+                <div class="spectrum-Thumbnail spectrum-Thumbnail--size200 spectrum-TreeView-itemThumbnail spectrum-Thumbnail-layer is-selected">
                   <div class="spectrum-Thumbnail-layer-inner spectrum-OpacityCheckerboard">
                     <img class="spectrum-Thumbnail-image" src="img/flowers.png" alt="Flowers">
                   </div>
@@ -408,7 +408,7 @@ examples:
             </li>
             <li class="spectrum-TreeView-item">
               <a class="spectrum-TreeView-itemLink" href="#">
-                <div class="spectrum-Thumbnail spectrum-Thumbnail--size500 spectrum-TreeView-itemThumbnail spectrum-Thumbnail-layer">
+                <div class="spectrum-Thumbnail spectrum-Thumbnail--size200 spectrum-TreeView-itemThumbnail spectrum-Thumbnail-layer">
                   <div class="spectrum-Thumbnail-layer-inner spectrum-OpacityCheckerboard">
                     <img class="spectrum-Thumbnail-image" src="img/thumbnail.png" alt="Woman crouching">
                   </div>

--- a/components/treeview/metadata/treeview.yml
+++ b/components/treeview/metadata/treeview.yml
@@ -720,8 +720,7 @@ examples:
   - id: treeview-flat
     name: Flat
     description: |
-      A Tree view drawn without nesting, suitable for infinite scrolling.
-      With this version of the treeview, you must manage the visibility of "child items" manually based on the open state of the "parent item."
+      A Tree view drawn without nesting, suitable for infinite scrolling. With this version of the treeview, you must manage the visibility of "child items" manually based on the open state of the "parent item." The level of visual indentation is handled by a numbered `indent` variant class.
     markup: |
       <ul class="spectrum-TreeView spectrum-TreeView--sizeM" style="width: 250px">
         <li class="spectrum-TreeView-item">

--- a/components/treeview/stories/template.js
+++ b/components/treeview/stories/template.js
@@ -96,11 +96,11 @@ export const TreeViewItem = ({
 					? Thumbnail({
 							...globals,
 							...thumbnail,
-							size: size == "s"  ? "400"
-								: size == "m"  ? "500"
-								: size == "l"  ? "700"
-								: size == "xl" ? "800"
-								: "500",
+							size: size == "s"  ? "200"
+								: size == "m"  ? "200"
+								: size == "l"  ? "400"
+								: size == "xl" ? "600"
+								: "300",
 							isLayer: true,
 							isSelected,
 							customClasses: [`${rootClass}-itemThumbnail`],

--- a/components/treeview/stories/template.js
+++ b/components/treeview/stories/template.js
@@ -62,7 +62,7 @@ export const TreeViewItem = ({
 					? Icon({
 							...globals,
 							size,
-							iconName: "Chevron",
+							iconName: "ChevronRight",
 							customClasses: [`${rootClass}-itemIndicator`],
 					  })
 					: ""}
@@ -124,6 +124,7 @@ export const Template = ({
 					return TreeViewItem({
 						...globals,
 						...item,
+						size,
 					});
 				}
 			)}

--- a/components/treeview/stories/template.js
+++ b/components/treeview/stories/template.js
@@ -1,6 +1,7 @@
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { repeat } from "lit/directives/repeat.js";
+import { styleMap } from "lit/directives/style-map.js";
 
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 import { Template as Thumbnail } from "@spectrum-css/thumbnail/stories/template.js";
@@ -100,6 +101,7 @@ export const TreeViewItem = ({
 export const Template = ({
 	rootClass = "spectrum-TreeView",
 	customClasses = [],
+	customStyles = {},
 	size = "m",
 	variant,
 	isQuiet,
@@ -116,6 +118,7 @@ export const Template = ({
 				[`${rootClass}--quiet`]: isQuiet,
 				...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
 			})}
+			style=${styleMap(customStyles)}
 		>
 			${repeat(
 				items,

--- a/components/treeview/stories/template.js
+++ b/components/treeview/stories/template.js
@@ -96,7 +96,11 @@ export const TreeViewItem = ({
 					? Thumbnail({
 							...globals,
 							...thumbnail,
-							size: "300",
+							size: size == "s"  ? "400"
+								: size == "m"  ? "500"
+								: size == "l"  ? "700"
+								: size == "xl" ? "800"
+								: "500",
 							isLayer: true,
 							isSelected,
 							customClasses: [`${rootClass}-itemThumbnail`],

--- a/components/treeview/stories/template.js
+++ b/components/treeview/stories/template.js
@@ -85,7 +85,7 @@ export const TreeViewItem = ({
 					: ""}
 				<span class="${rootClass}-itemLabel">${label}</span>
 			</a>
-			${typeof items !== "undefined"
+			${typeof items !== "undefined" && items.length > 0
 				? Template({
 						...globals,
 						items: items,

--- a/components/treeview/stories/template.js
+++ b/components/treeview/stories/template.js
@@ -80,6 +80,8 @@ export const TreeViewItem = ({
 							...globals,
 							...thumbnail,
 							size: "300",
+							isLayer: true,
+							isSelected,
 							customClasses: [`${rootClass}-itemThumbnail`],
 					  })
 					: ""}

--- a/components/treeview/stories/template.js
+++ b/components/treeview/stories/template.js
@@ -27,9 +27,26 @@ export const TreeViewItem = ({
 }) => {
 	if (type === "heading") {
 		return html`
-			<div class="${rootClass}-heading">
-				<span class="${rootClass}-itemLabel">${label}</span>
-			</div>
+			<li
+				id=${id}
+				class=${classMap({
+					[`${rootClass}-section`]: true,
+					...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
+				})}
+			>
+				<div class="${rootClass}-heading">
+					<span class="${rootClass}-itemLabel">${label}</span>
+				</div>
+				${typeof items !== "undefined" && items.length > 0
+					? Template({
+							...globals,
+							items: items,
+							size,
+							rootClass: "spectrum-TreeView",
+							customClasses: ["is-opened"],
+					})
+					: ""}
+			</li>
 		`;
 	}
 

--- a/components/treeview/stories/treeview.stories.js
+++ b/components/treeview/stories/treeview.stories.js
@@ -205,6 +205,7 @@ Thumbnails.args = {
 					id: "label2",
 					label: "Label 2",
 					link: "#",
+					isSelected: true,
 					thumbnail: {
 						imageURL: "thumbnail.png",
 						altText: "Woman crouching",

--- a/components/treeview/stories/treeview.stories.js
+++ b/components/treeview/stories/treeview.stories.js
@@ -28,11 +28,23 @@ export default {
 			},
 			control: "boolean",
 		},
+		customStyles: {
+			name: "Custom styles",
+			description: "Storybook only styles for testing the story, applied to the parent element.",
+			table: {
+				type: { summary: "object" },
+				category: "Advanced",
+			},
+			if: { arg: 'customStyles' }
+		}
 	},
 	args: {
 		rootClass: "spectrum-TreeView",
 		size: "m",
 		isQuiet: false,
+		customStyles: {
+			'max-inline-size': '600px',
+		},
 	},
 	parameters: {
 		actions: {
@@ -133,6 +145,12 @@ FoldersAndFiles.args = {
 				{
 					id: "label3",
 					label: "Label 3",
+					link: "#",
+					icon: "Document",
+				},
+				{
+					id: "label4",
+					label: "This example has longer text. Per the guidelines, long text will truncate with an ellipsis, and the full text should be available in a tooltip.",
 					link: "#",
 					icon: "Document",
 				},

--- a/components/treeview/stories/treeview.stories.js
+++ b/components/treeview/stories/treeview.stories.js
@@ -231,33 +231,37 @@ WithSections.args = {
 		{
 			type: "heading",
 			label: "Section 1",
-		},
-		{
-			id: "group1",
-			label: "Group 1",
-			link: "#",
-			isOpen: true,
 			items: [
 				{
-					id: "label2",
-					label: "Label 2",
+					id: "group1",
+					label: "Group 1",
 					link: "#",
-				},
-				{
-					id: "label3",
-					label: "Label 3",
-					link: "#",
+					isOpen: true,
+					items: [
+						{
+							id: "label2",
+							label: "Label 2",
+							link: "#",
+						},
+						{
+							id: "label3",
+							label: "Label 3",
+							link: "#",
+						},
+					],
 				},
 			],
 		},
 		{
 			type: "heading",
 			label: "Section 2",
-		},
-		{
-			id: "label4",
-			label: "Label 4",
-			link: "#",
+			items: [
+				{
+					id: "label4",
+					label: "Label 4",
+					link: "#",
+				},
+			]
 		},
 	],
 };

--- a/components/treeview/stories/treeview.stories.js
+++ b/components/treeview/stories/treeview.stories.js
@@ -277,3 +277,68 @@ WithDropTarget.args = {
 		},
 	],
 };
+
+export const Flat = Template.bind({});
+Flat.storyName = 'Flat Markup';
+Flat.args = {
+	items: [
+		{
+			id: "label1",
+			label: "Label 1. This example has longer text. Per the guidelines, long text will truncate with an ellipsis, and the full text should be available in a tooltip.",
+			link: "#",
+			isSelected: true,
+		},
+		{
+			id: "group1",
+			label: "Group 1",
+			link: "#",
+			isOpen: true,
+			items: [],
+		},
+		{
+			id: "label2",
+			label: "Label 2",
+			link: "#",
+			isDisabled: true,
+			customClasses: ['spectrum-TreeView-item--indent1'],
+		},
+		{
+			id: "label3",
+			label: "Label 3",
+			link: "#",
+			customClasses: ['spectrum-TreeView-item--indent1'],
+		},
+		{
+			id: "label4",
+			label: "Label 4",
+			link: "#",
+		},
+		{
+			id: "group2",
+			label: "Group 2",
+			link: "#",
+			isOpen: true,
+			items: [],
+		},
+		{
+			id: "label5",
+			label: "Label 5",
+			link: "#",
+			customClasses: ['spectrum-TreeView-item--indent1'],
+		},
+		{
+			id: "group3",
+			label: "Group 3",
+			link: "#",
+			isOpen: true,
+			items: [],
+			customClasses: ['spectrum-TreeView-item--indent1'],
+		},
+		{
+			id: "label6",
+			label: "Label 6",
+			link: "#",
+			customClasses: ['spectrum-TreeView-item--indent2'],
+		},
+	],
+};

--- a/site/resources/js/enhancement.js
+++ b/site/resources/js/enhancement.js
@@ -473,7 +473,7 @@ window.addEventListener("click", function (event) {
 								".spectrum-TreeView-itemThumbnail"
 							);
 							if (thumbnail) {
-								thumbnail.classList.remove("is-focused");
+								thumbnail.classList.remove("is-selected");
 							}
 						}
 					}
@@ -486,7 +486,7 @@ window.addEventListener("click", function (event) {
 			".spectrum-TreeView-itemThumbnail"
 		);
 		if (thumbnail) {
-			thumbnail.classList[selected ? "add" : "remove"]("is-focused");
+			thumbnail.classList[selected ? "add" : "remove"]("is-selected");
 		}
 		event.preventDefault();
 	}


### PR DESCRIPTION
## Description

**Tree view fixes**
A refactor to fix these various issues discovered with Tree view:
- Incorrect indentation at various t-shirt sizes.
- Tree view items and their link element had irregular heights depending on whether they had a chevron or not. 
- Tree view items were not the correct component heights at various t-shirt sizes.
- Tree view item indicator (chevron) was not square and not the right size at various t-shirt sizes.
- Font-size was not changing. Now uses font-size tokens, confirmed with design.
- Standalone was not showing rounded corners (now renamed to "detached" per guidelines).
- Selected Thumbnail items were showing focus styles instead of selected styles; examples now include the "layer" variant of Thumbnail.
- "Section" had heading divs that were a child of `ul`, which was not valid markup. This markup has been adjusted and an additional class added to help display this properly within an `li`.

CSS-592

**Storybook additions** 
Also adds a long text truncation example to a story, and an additional story for the missing "Flat" markup example from the docs page. The selected state for the thumbnail variant has also been added to the examples.

**Display property change** 
For hidden items, `display: none` is now used instead of `visibility: hidden`, to improve performance. Addresses #2201 

CSS-603

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation instructions

- [x] The treeview item _and_ treeview itemLink (`<a>` tag) are 32px height at medium, 24px at small, 40px at large, and 48px at extra large
- [x] "Folders and Files" Story: Nested items maintain indentation at large and extra large sizing (in previous behavior, indentation kept decreasing as t-shirt size increased, till there was none left)
- [x] The Treeview indicator (chevron) element is now square, aligned properly to the left of the item without escaping it, and is the width and height of the treeview item (same heights mentioned in first validation item)
- [x] All stories look to render correctly at all t-shirt sizes, including selected item, hover, and tab focus (note, Storybook psuedo addon may cause an issue with focus on selected item; refreshing the page usually fixes)
- [x] New Storybook "Flat markup" story appears and indentation looks correct (+ at different sizes)
- [x] The Thumbnail variant looks correct, and like the design on the Xd file from the guidelines: the height of the tree view items with the thumbnail, per that file, should be 6px taller than default for small (both medium and large scale), and 2px taller at medium when at large scale (test in Storybook).
- [x] "Sections" now has valid HTML markup; a div is no longer a child of a `ul`, and the styling looks the same

### Regression testing

Validate:

1. A legacy documentation page (such as [accordion](https://pr-###--spectrum-css.netlify.app/accordion.html)), including:

- [x] The page renders correctly
- [x] The page is accessible
- [x] The page is responsive

2. A migrated documentation page (such as [action group](https://pr-###--spectrum-css.netlify.app/actiongroup.html)), including:

- [x] The page renders correctly
- [x] The page is accessible
- [x] The page is responsive

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.

- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.

- [ ] ✨ This pull request is ready to merge. ✨
