### PR TITLE
refactor(textfield): invalid and valid padding inline end 

### DIFF
--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -72,6 +72,10 @@ governing permissions and limitations under the License.
 	--spectrum-textfield-icon-size-invalid: var(
 		--spectrum-workflow-icon-size-100
 	);
+	--spectrum-textfield-icon-size-valid: var(
+		--spectrum-checkmark-icon-size-100
+	);
+
 
 	/* default icon spacing */
 	--spectrum-textfield-icon-spacing-inline-start-invalid: var(
@@ -234,6 +238,9 @@ governing permissions and limitations under the License.
 		--spectrum-component-edge-to-text-75
 	);
 	--spectrum-textfield-icon-size-invalid: var(--spectrum-workflow-icon-size-75);
+	--spectrum-textfield-icon-size-valid: var(
+		--spectrum-checkmark-icon-size-75
+	);
 	--spectrum-textfield-icon-spacing-inline-end-invalid: var(
 		--spectrum-field-edge-to-alert-icon-small
 	);
@@ -283,6 +290,9 @@ governing permissions and limitations under the License.
 	);
 	--spectrum-textfield-icon-size-invalid: var(
 		--spectrum-workflow-icon-size-100
+	);
+	--spectrum-textfield-icon-size-valid: var(
+		--spectrum-checkmark-icon-size-100
 	);
 	--spectrum-textfield-icon-spacing-inline-end-invalid: var(
 		--spectrum-field-edge-to-alert-icon-medium
@@ -334,6 +344,9 @@ governing permissions and limitations under the License.
 	--spectrum-textfield-icon-size-invalid: var(
 		--spectrum-workflow-icon-size-200
 	);
+	--spectrum-textfield-icon-size-valid: var(
+		--spectrum-checkmark-icon-size-300
+	);
 	--spectrum-textfield-icon-spacing-inline-end-invalid: var(
 		--spectrum-field-edge-to-alert-icon-large
 	);
@@ -383,6 +396,9 @@ governing permissions and limitations under the License.
 	);
 	--spectrum-textfield-icon-size-invalid: var(
 		--spectrum-workflow-icon-size-300
+	);
+	--spectrum-textfield-icon-size-valid: var(
+		--spectrum-checkmark-icon-size-300
 	);
 	--spectrum-textfield-icon-spacing-inline-end-invalid: var(
 		--spectrum-field-edge-to-alert-icon-extra-large
@@ -496,8 +512,7 @@ governing permissions and limitations under the License.
 	}
 	&.is-valid{
 		.spectrum-Textfield-input{
-			--valid-icon-size: 10px;
-			padding-inline-end: calc(var(--spectrum-textfield-icon-spacing-inline-start-valid) + var(--valid-icon-size));
+			padding-inline-end: calc(var(--spectrum-textfield-icon-spacing-inline-start-valid) + var(-spectrum-textfield-icon-size-valid));
 		}
 	}
 }
@@ -1023,8 +1038,7 @@ governing permissions and limitations under the License.
 
 	/*** Input Valid ✅ ***/
 	.is-valid & {
-		--valid-icon-size: 10px;
-		padding-inline-end: calc(var(--spectrum-textfield-icon-spacing-inline-start-valid) + var(--valid-icon-size) + var(--spectrum-textfield-padding-inline-default));
+		padding-inline-end: calc(var(--spectrum-textfield-icon-spacing-inline-start-valid) + var(-spectrum-textfield-icon-size-valid) + var(--spectrum-textfield-padding-inline-default));
 		color: var(
 			--highcontrast-textfield-text-color-valid,
 			var(
@@ -1036,7 +1050,6 @@ governing permissions and limitations under the License.
 
 	/*** Input Invalid ⚠️ ***/
 	.is-invalid & {
-		--valid-icon-size: 10px;
 		padding-inline-end: calc(var(--spectrum-textfield-icon-spacing-inline-start-invalid) + var(--spectrum-textfield-icon-size-invalid) + var(--spectrum-textfield-padding-inline-default));
 		color: var(
 			--highcontrast-textfield-text-color-invalid,

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -92,6 +92,9 @@ governing permissions and limitations under the License.
 	--spectrum-textfield-icon-spacing-inline-start-valid: var(
 		--spectrum-field-text-to-validation-icon-medium
 	);
+	--spectrum-textfield-icon-spacing-inline-end-valid: var(
+		--spectrum-field-edge-to-validation-icon-medium
+	);
 	--spectrum-textfield-icon-spacing-inline-end-quiet-valid: var(
 		--spectrum-field-edge-to-validation-icon-quiet
 	);

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -512,7 +512,7 @@ governing permissions and limitations under the License.
 	}
 	&.is-valid{
 		.spectrum-Textfield-input{
-			padding-inline-end: calc(var(--spectrum-textfield-icon-spacing-inline-start-valid) + var(-spectrum-textfield-icon-size-valid));
+			padding-inline-end: calc(var(--spectrum-textfield-icon-spacing-inline-start-valid) + var(--spectrum-textfield-icon-size-valid));
 		}
 	}
 }

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -493,7 +493,7 @@ governing permissions and limitations under the License.
 	&.is-invalid{
 		.spectrum-Textfield-input{
 			padding-inline-end: calc(
-				var(--mod--textfield-icon-spacing-inline-start-invalid, var(--spectrum-textfield-icon-spacing-inline-start-invalid)) +
+				var(--mod-textfield-icon-spacing-inline-start-invalid, var(--spectrum-textfield-icon-spacing-inline-start-invalid)) +
 				var(--mod-textfield-icon-size-invalid, var(--spectrum-textfield-icon-size-invalid))
 			);
 		}

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -19,8 +19,6 @@ governing permissions and limitations under the License.
 		var(--spectrum-textfield-spacing-inline) -
 		var(--spectrum-textfield-border-width)
 		);
-	--spectrum-textfield-text-to-icon-valid: var(--spectrum-field-text-to-validation-icon-medium);
-
 
   --spectrum-texfield-animation-duration: var(
 		--spectrum-animation-duration-100
@@ -76,8 +74,7 @@ governing permissions and limitations under the License.
 		--spectrum-checkmark-icon-size-100
 	);
 
-
-	/* default icon spacing */
+	/* default icon spacing - invalid */
 	--spectrum-textfield-icon-spacing-inline-start-invalid: var(
 		--spectrum-field-text-to-alert-icon-medium
 	);
@@ -91,11 +88,9 @@ governing permissions and limitations under the License.
 		--spectrum-field-top-to-alert-icon-medium
 	);
 
+		/* default icon spacing - valid */
 	--spectrum-textfield-icon-spacing-inline-start-valid: var(
 		--spectrum-field-text-to-validation-icon-medium
-	);
-	--spectrum-textfield-icon-spacing-inline-end-valid: var(
-		--spectrum-field-edge-to-validation-icon-medium
 	);
 	--spectrum-textfield-icon-spacing-inline-end-quiet-valid: var(
 		--spectrum-field-edge-to-validation-icon-quiet
@@ -345,7 +340,7 @@ governing permissions and limitations under the License.
 		--spectrum-workflow-icon-size-200
 	);
 	--spectrum-textfield-icon-size-valid: var(
-		--spectrum-checkmark-icon-size-300
+		--spectrum-checkmark-icon-size-200
 	);
 	--spectrum-textfield-icon-spacing-inline-end-invalid: var(
 		--spectrum-field-edge-to-alert-icon-large
@@ -505,14 +500,24 @@ governing permissions and limitations under the License.
 			);
 		}
 	}
+
+	/*** Quiet Input Invalid ⚠️ ***/
 	&.is-invalid{
 		.spectrum-Textfield-input{
-			padding-inline-end: calc(var(--spectrum-textfield-icon-spacing-inline-start-invalid) + var(--spectrum-textfield-icon-size-invalid));
+			padding-inline-end: calc(
+				var(--mod--textfield-icon-spacing-inline-start-invalid, var(--spectrum-textfield-icon-spacing-inline-start-invalid)) +
+				var(--mod-textfield-icon-size-invalid, var(--spectrum-textfield-icon-size-invalid))
+			);
 		}
 	}
+
+	/*** Quiet Input Valid ✅ ***/
 	&.is-valid{
 		.spectrum-Textfield-input{
-			padding-inline-end: calc(var(--spectrum-textfield-icon-spacing-inline-start-valid) + var(--spectrum-textfield-icon-size-valid));
+			padding-inline-end: calc(
+				var(--mod-textfield-icon-spacing-inline-start-valid, var(--spectrum-textfield-icon-spacing-inline-start-valid)) +
+				var(--mod-textfield-icon-size-valid, var(--spectrum-textfield-icon-size-valid))
+			);
 		}
 	}
 }
@@ -1038,7 +1043,12 @@ governing permissions and limitations under the License.
 
 	/*** Input Valid ✅ ***/
 	.is-valid & {
-		padding-inline-end: calc(var(--spectrum-textfield-icon-spacing-inline-start-valid) + var(-spectrum-textfield-icon-size-valid) + var(--spectrum-textfield-padding-inline-default));
+		padding-inline-end: calc(
+			var(--mod-textfield-icon-spacing-inline-start-valid, var(--spectrum-textfield-icon-spacing-inline-start-valid)) +
+			var(--mod-textfield-icon-size-valid, var(--spectrum-textfield-icon-size-valid)) +
+			var(--mod-textfield-icon-spacing-inline-end-valid, var(--spectrum-textfield-icon-spacing-inline-end-valid)) -
+			var(--mod-textfield-border-width, var(--spectrum-textfield-border-width))
+		);
 		color: var(
 			--highcontrast-textfield-text-color-valid,
 			var(
@@ -1050,7 +1060,12 @@ governing permissions and limitations under the License.
 
 	/*** Input Invalid ⚠️ ***/
 	.is-invalid & {
-		padding-inline-end: calc(var(--spectrum-textfield-icon-spacing-inline-start-invalid) + var(--spectrum-textfield-icon-size-invalid) + var(--spectrum-textfield-padding-inline-default));
+		padding-inline-end: calc(
+			var(--mod-textfield-icon-spacing-inline-start-invalid, var(--spectrum-textfield-icon-spacing-inline-start-invalid)) +
+			var(--mod-textfield-icon-size-invalid, var(--spectrum-textfield-icon-size-invalid)) +
+			var(--mod-textfield-icon-spacing-inline-end-invalid, var(--spectrum-textfield-icon-spacing-inline-end-invalid)) -
+			var(--mod-textfield-border-width, var(--spectrum-textfield-border-width))
+		);
 		color: var(
 			--highcontrast-textfield-text-color-invalid,
 			var(

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -14,12 +14,6 @@ governing permissions and limitations under the License.
   /* set input line-height to the height of the textfield - prevents the cutting off of diacritics in some languages */
   /* disallow mod for max compatibility */
   --spectrum-textfield-input-line-height: var(--spectrum-textfield-height);
-
-	--spectrum-textfield-padding-inline-default: calc(
-		var(--spectrum-textfield-spacing-inline) -
-		var(--spectrum-textfield-border-width)
-		);
-
   --spectrum-texfield-animation-duration: var(
 		--spectrum-animation-duration-100
 	);
@@ -101,15 +95,6 @@ governing permissions and limitations under the License.
 	--spectrum-textfield-icon-spacing-block-valid: var(
 		--spectrum-field-top-to-validation-icon-medium
 	);
-
-	/* icon end spacing override for combobox */
-	--spectrum-textfield-icon-spacing-inline-end-override: 32px; /* TODO - placeholder - reevaluate after combobox migration */
-
-	/* TODO - icon spacing override for search - reevaluate after search is migrated */
-	/* @deprecation --spectrum-Textfield-workflow-icon-width and --spectrum-Textfield-workflow-icon-gap will be removed during the S2 migration;
-	please update your code to --spectrum-textfield-workflow-icon-width and --spectrum-textfield-workflow-icon-gap */
-	--spectrum-textfield-workflow-icon-width: var(--spectrum-Textfield-workflow-icon-width, 18px);
-	--spectrum-textfield-workflow-icon-gap: var(--spectrum-Textfield-workflow-icon-gap, 6px);
 
 	/* font styles */
 	--spectrum-textfield-font-family: var(--spectrum-sans-font-family-stack);
@@ -624,13 +609,6 @@ governing permissions and limitations under the License.
 		);
 	}
 
-	/* TODO - reevaluate InputGroup override after combobox is migrated - this ensures icon is not hidden under picker button */
-	.spectrum-InputGroup & {
-		margin-inline-end: var(
-			--spectrum-textfield-icon-spacing-inline-end-override
-		);
-	}
-}
 
 /********* Child Component - Label *********/
 .spectrum-FieldLabel {
@@ -746,9 +724,12 @@ governing permissions and limitations under the License.
 			) -
 			var(--mod-textfield-border-width, var(--spectrum-textfield-border-width))
 	);
-	/* can I use just the one or do I need both here */
-	padding-inline-start: var(--mod-textfield-padding-inline-default, var(--spectrum-textfield-padding-inline-default));
-	padding-inline-end: var(--mod-textfield-padding-inline-default, var(--spectrum-textfield-padding-inline-default));
+
+	padding-inline: calc(
+		var(--mod-textfield-spacing-inline, var(--spectrum-textfield-spacing-inline)) -
+		var(--mod-textfield-border-width, var(--spectrum-textfield-border-width))
+	);
+
 	/* Use padding instead of text-indent because text-indent does not left align the text in Edge browser  */
 	text-indent: 0;
 	vertical-align: top; /* used to align them correctly in forms. */
@@ -820,20 +801,6 @@ governing permissions and limitations under the License.
 	/* place in same cell: input, focus indicator, and grows sizer */
 	grid-row: 2;
 	grid-column: 1 / span 2;
-
-	/* TODO - quiet search field left padding - reevaluate when search is migrated */
-	.spectrum-Textfield--quiet .spectrum-Textfield-icon ~ & {
-		padding-inline-start: calc(
-			var(
-					--mod-textfield-workflow-icon-gap,
-					var(--spectrum-textfield-workflow-icon-gap)
-				) +
-				var(
-					--mod-textfield-workflow-icon-width,
-					var(--spectrum-textfield-workflow-icon-width)
-				)
-		);
-	}
 
 	/* Remove the native clear button in IE */
 	/* http://stackoverflow.com/questions/14007655/remove-ie10s-clear-field-x-button-on-certain-inputs */
@@ -1190,15 +1157,10 @@ governing permissions and limitations under the License.
 			--mod-textfield-spacing-block-start,
 			var(--spectrum-textfield-spacing-block-start)
 		);
-		padding-inline-start: var(
+		padding-inline: var(
 			--mod-textfield-spacing-inline-quiet,
 			var(--spectrum-textfield-spacing-inline-quiet)
 		);
-		padding-inline-end: var(
-			--mod-textfield-spacing-inline-quiet,
-			var(--spectrum-textfield-spacing-inline-quiet)
-		);
-
 		background-color: transparent;
 		border-radius: 0;
 

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -14,7 +14,14 @@ governing permissions and limitations under the License.
   /* set input line-height to the height of the textfield - prevents the cutting off of diacritics in some languages */
   /* disallow mod for max compatibility */
   --spectrum-textfield-input-line-height: var(--spectrum-textfield-height);
-	
+
+	--spectrum-textfield-padding-inline-default: calc(
+		var(--spectrum-textfield-spacing-inline) -
+		var(--spectrum-textfield-border-width)
+		);
+	--spectrum-textfield-text-to-icon-valid: var(--spectrum-field-text-to-validation-icon-medium);
+
+
   --spectrum-texfield-animation-duration: var(
 		--spectrum-animation-duration-100
 	);
@@ -97,7 +104,7 @@ governing permissions and limitations under the License.
 	--spectrum-textfield-icon-spacing-inline-end-override: 32px; /* TODO - placeholder - reevaluate after combobox migration */
 
 	/* TODO - icon spacing override for search - reevaluate after search is migrated */
-	/* @deprecation --spectrum-Textfield-workflow-icon-width and --spectrum-Textfield-workflow-icon-gap will be removed during the S2 migration; 
+	/* @deprecation --spectrum-Textfield-workflow-icon-width and --spectrum-Textfield-workflow-icon-gap will be removed during the S2 migration;
 	please update your code to --spectrum-textfield-workflow-icon-width and --spectrum-textfield-workflow-icon-gap */
 	--spectrum-textfield-workflow-icon-width: var(--spectrum-Textfield-workflow-icon-width, 18px);
 	--spectrum-textfield-workflow-icon-gap: var(--spectrum-Textfield-workflow-icon-gap, 6px);
@@ -705,13 +712,9 @@ governing permissions and limitations under the License.
 			) -
 			var(--mod-textfield-border-width, var(--spectrum-textfield-border-width))
 	);
-	padding-inline: calc(
-		var(
-				--mod-textfield-spacing-inline,
-				var(--spectrum-textfield-spacing-inline)
-			) -
-			var(--mod-textfield-border-width, var(--spectrum-textfield-border-width))
-	);
+	/* can I use just the one or do I need both here */
+	padding-inline-start: var(--mod-textfield-padding-inline-default, var(--spectrum-textfield-padding-inline-default));
+	padding-inline-end: var(--mod-textfield-padding-inline-default, var(--spectrum-textfield-padding-inline-default));
 	/* Use padding instead of text-indent because text-indent does not left align the text in Edge browser  */
 	text-indent: 0;
 	vertical-align: top; /* used to align them correctly in forms. */
@@ -1009,6 +1012,9 @@ governing permissions and limitations under the License.
 
 	/*** Input Valid ✅ ***/
 	.is-valid & {
+		/* left padding + icon size + right padding */
+		--valid-icon-size: 10px;
+		padding-inline-end: calc(var(--spectrum-textfield-icon-spacing-inline-start-valid) + var(--valid-icon-size) + var(--spectrum-textfield-padding-inline-default));
 		color: var(
 			--highcontrast-textfield-text-color-valid,
 			var(
@@ -1020,6 +1026,10 @@ governing permissions and limitations under the License.
 
 	/*** Input Invalid ⚠️ ***/
 	.is-invalid & {
+		/* left padding + icon size + right padding */
+
+		--valid-icon-size: 10px;
+		padding-inline-end: calc(var(--spectrum-textfield-icon-spacing-inline-start-invalid) + var(--spectrum-textfield-icon-size-invalid) + var(--spectrum-textfield-padding-inline-default));
 		color: var(
 			--highcontrast-textfield-text-color-invalid,
 			var(

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -489,6 +489,17 @@ governing permissions and limitations under the License.
 			);
 		}
 	}
+	&.is-invalid{
+		.spectrum-Textfield-input{
+			padding-inline-end: calc(var(--spectrum-textfield-icon-spacing-inline-start-invalid) + var(--spectrum-textfield-icon-size-invalid));
+		}
+	}
+	&.is-valid{
+		.spectrum-Textfield-input{
+			--valid-icon-size: 10px;
+			padding-inline-end: calc(var(--spectrum-textfield-icon-spacing-inline-start-valid) + var(--valid-icon-size));
+		}
+	}
 }
 
 /********* Child Element - Validation Icons - ⚠️ ✅ *********/
@@ -1012,7 +1023,6 @@ governing permissions and limitations under the License.
 
 	/*** Input Valid ✅ ***/
 	.is-valid & {
-		/* left padding + icon size + right padding */
 		--valid-icon-size: 10px;
 		padding-inline-end: calc(var(--spectrum-textfield-icon-spacing-inline-start-valid) + var(--valid-icon-size) + var(--spectrum-textfield-padding-inline-default));
 		color: var(
@@ -1026,8 +1036,6 @@ governing permissions and limitations under the License.
 
 	/*** Input Invalid ⚠️ ***/
 	.is-invalid & {
-		/* left padding + icon size + right padding */
-
 		--valid-icon-size: 10px;
 		padding-inline-end: calc(var(--spectrum-textfield-icon-spacing-inline-start-invalid) + var(--spectrum-textfield-icon-size-invalid) + var(--spectrum-textfield-padding-inline-default));
 		color: var(
@@ -1151,7 +1159,11 @@ governing permissions and limitations under the License.
 			--mod-textfield-spacing-block-start,
 			var(--spectrum-textfield-spacing-block-start)
 		);
-		padding-inline: var(
+		padding-inline-start: var(
+			--mod-textfield-spacing-inline-quiet,
+			var(--spectrum-textfield-spacing-inline-quiet)
+		);
+		padding-inline-end: var(
 			--mod-textfield-spacing-inline-quiet,
 			var(--spectrum-textfield-spacing-inline-quiet)
 		);
@@ -1293,6 +1305,7 @@ governing permissions and limitations under the License.
 
 	&.spectrum-Textfield--quiet {
 		.spectrum-Textfield-input {
+
 			min-block-size: var(
 				--mod-text-area-min-block-size-quiet,
 				var(--spectrum-text-area-min-block-size-quiet)

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -608,7 +608,7 @@ governing permissions and limitations under the License.
 			var(--spectrum-textfield-icon-spacing-inline-end-quiet-invalid)
 		);
 	}
-
+}
 
 /********* Child Component - Label *********/
 .spectrum-FieldLabel {

--- a/components/textfield/metadata/mods.md
+++ b/components/textfield/metadata/mods.md
@@ -1,6 +1,5 @@
 | Modifiable Custom Properties                            |
 | ------------------------------------------------------- |
-| `--mod--textfield-icon-spacing-inline-start-invalid`    |
 | `--mod-texfield-animation-duration`                     |
 | `--mod-text-area-min-block-size`                        |
 | `--mod-text-area-min-block-size-quiet`                  |
@@ -67,5 +66,3 @@
 | `--mod-textfield-text-color-readonly`                   |
 | `--mod-textfield-text-color-valid`                      |
 | `--mod-textfield-width`                                 |
-| `--mod-textfield-workflow-icon-gap`                     |
-| `--mod-textfield-workflow-icon-width`                   |

--- a/components/textfield/metadata/mods.md
+++ b/components/textfield/metadata/mods.md
@@ -51,11 +51,11 @@
 | `--mod-textfield-label-spacing-block-quiet`             |
 | `--mod-textfield-label-spacing-inline-side-label`       |
 | `--mod-textfield-min-width`                             |
-| `--mod-textfield-padding-inline-default`                |
 | `--mod-textfield-placeholder-font-size`                 |
 | `--mod-textfield-spacing-block-end`                     |
 | `--mod-textfield-spacing-block-quiet`                   |
 | `--mod-textfield-spacing-block-start`                   |
+| `--mod-textfield-spacing-inline`                        |
 | `--mod-textfield-spacing-inline-quiet`                  |
 | `--mod-textfield-text-color-default`                    |
 | `--mod-textfield-text-color-disabled`                   |

--- a/components/textfield/metadata/mods.md
+++ b/components/textfield/metadata/mods.md
@@ -1,5 +1,6 @@
 | Modifiable Custom Properties                            |
 | ------------------------------------------------------- |
+| `--mod--textfield-icon-spacing-inline-start-invalid`    |
 | `--mod-texfield-animation-duration`                     |
 | `--mod-text-area-min-block-size`                        |
 | `--mod-text-area-min-block-size-quiet`                  |
@@ -37,6 +38,7 @@
 | `--mod-textfield-icon-color-invalid`                    |
 | `--mod-textfield-icon-color-valid`                      |
 | `--mod-textfield-icon-size-invalid`                     |
+| `--mod-textfield-icon-size-valid`                       |
 | `--mod-textfield-icon-spacing-block-invalid`            |
 | `--mod-textfield-icon-spacing-block-valid`              |
 | `--mod-textfield-icon-spacing-inline-end-invalid`       |

--- a/components/textfield/metadata/mods.md
+++ b/components/textfield/metadata/mods.md
@@ -49,11 +49,11 @@
 | `--mod-textfield-label-spacing-block-quiet`             |
 | `--mod-textfield-label-spacing-inline-side-label`       |
 | `--mod-textfield-min-width`                             |
+| `--mod-textfield-padding-inline-default`                |
 | `--mod-textfield-placeholder-font-size`                 |
 | `--mod-textfield-spacing-block-end`                     |
 | `--mod-textfield-spacing-block-quiet`                   |
 | `--mod-textfield-spacing-block-start`                   |
-| `--mod-textfield-spacing-inline`                        |
 | `--mod-textfield-spacing-inline-quiet`                  |
 | `--mod-textfield-text-color-default`                    |
 | `--mod-textfield-text-color-disabled`                   |


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->

## Description

Address issue with Text field and Text area where input text was appearing behind the icon when the user entered text (see screenshots). 
- added padding inline end to inputs of valid and invalid variants to match designs and address reported issue
- looked into and removed old code as indicated with TODO comments 




<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

<!--
  Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

### Testing Outline 
1. Open the [docs site](https://pr-2220--spectrum-css.netlify.app/textfield#valid) for text-field. 
- [x] Enter text into alert and valid text fields until input is full, padding should prevent text from going behind the valid/invalid icons 
2. Open the [docs site](https://pr-2220--spectrum-css.netlify.app/textarea#valid) for text-area. 
- [x] Enter text into alert and valid text fields until input is full, padding should prevent text from going behind the valid/invalid icons 

### Regression testing

Validate:

1. A legacy documentation page (such as [accordion](https://pr-###--spectrum-css.netlify.app/accordion.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

3. A migrated documentation page (such as [action group](https://pr-###--spectrum-css.netlify.app/actiongroup.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

### Before
![Screenshot 2023-10-19 at 4 49 58 PM](https://github.com/adobe/spectrum-css/assets/63808889/d8cab26c-5caa-4692-8281-2d5b9d83eba9)
![Screenshot 2023-10-19 at 4 50 18 PM](https://github.com/adobe/spectrum-css/assets/63808889/095214ec-f112-4bb2-b2e6-05f071d3f849)

### After
![Screenshot 2023-10-19 at 4 51 15 PM](https://github.com/adobe/spectrum-css/assets/63808889/3b2c8834-d679-4356-a72d-d6aecc6e8f81)
![Screenshot 2023-10-19 at 4 51 46 PM](https://github.com/adobe/spectrum-css/assets/63808889/0f7cf497-c5f8-4580-babe-cc3b38ccb711)

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.

- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.

- [ ] ✨ This pull request is ready to merge. ✨
