### PR TITLE
docs(picker): update markup for menu 

### DIFF
--- a/components/picker/metadata/picker.yml
+++ b/components/picker/metadata/picker.yml
@@ -76,7 +76,7 @@ examples:
             </svg>
           </button>
           <div class="spectrum-Popover spectrum-Popover--bottom spectrum-Picker-popover is-open" style="width: 240px;">
-            <ul class="spectrum-Menu" role="listbox">
+            <ul class="spectrum-Menu is-selectable" role="listbox">
               <li class="spectrum-Menu-item is-selected" role="option" aria-selected="true" tabindex="0">
                 <span class="spectrum-Menu-itemLabel">Donaudampfschifffahrtsgesellschaftskapitän</span>
                 <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Menu-checkmark spectrum-Menu-itemIcon" focusable="false" aria-hidden="true">
@@ -135,7 +135,7 @@ examples:
               </svg>
             </button>
             <div class="spectrum-Popover spectrum-Popover--bottom spectrum-Picker-popover is-open" style="width: 240px">
-              <ul class="spectrum-Menu" role="listbox">
+              <ul class="spectrum-Menu is-selectable" role="listbox">
                 <li class="spectrum-Menu-item is-selected" role="option" aria-selected="true" tabindex="0">
                   <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Menu-itemIcon spectrum-Menu-itemIcon--workflowIcon" focusable="false" aria-hidden="true" aria-label="Image">
                     <use xlink:href="#spectrum-icon-18-Image" />
@@ -268,7 +268,7 @@ examples:
             </svg>
           </button>
           <div class="spectrum-Popover spectrum-Popover--bottom spectrum-Picker-popover is-open" style="width: 240px">
-            <ul class="spectrum-Menu" role="listbox">
+            <ul class="spectrum-Menu is-selectable" role="listbox">
               <li class="spectrum-Menu-item is-selected" role="option" aria-selected="true" tabindex="0">
                 <span class="spectrum-Menu-itemLabel">Ballard</span>
                 <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Menu-checkmark spectrum-Menu-itemIcon" focusable="false" aria-hidden="true">
@@ -371,7 +371,7 @@ examples:
         </svg>
       </button>
       <div class="spectrum-Popover spectrum-Popover--bottom spectrum-Picker-popover is-open">
-        <ul class="spectrum-Menu" role="listbox">
+        <ul class="spectrum-Menu is-selectable" role="listbox">
           <li class="spectrum-Menu-item is-selected" role="option" aria-selected="true" tabindex="0">
             <span class="spectrum-Menu-itemLabel">Ballard</span>
             <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Menu-checkmark spectrum-Menu-itemIcon" focusable="false" aria-hidden="true">
@@ -413,9 +413,9 @@ examples:
         </svg>
       </button>
       <div class="spectrum-Popover spectrum-Popover--bottom spectrum-Picker-popover is-open">
-        <ul class="spectrum-Menu" role="listbox">
+        <ul class="spectrum-Menu is-selectable" role="listbox">
           <li class="spectrum-Menu-item is-selected" role="option" aria-selected="true" tabindex="0">
-            <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Menu-itemIcon" focusable="false" aria-hidden="true" aria-label="Image">
+            <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Menu-itemIcon spectrum-Menu-itemIcon--workflowIcon" focusable="false" aria-hidden="true" aria-label="Image">
               <use xlink:href="#spectrum-icon-18-Image" />
             </svg>
             <span class="spectrum-Menu-itemLabel">Ballard</span>
@@ -424,7 +424,7 @@ examples:
             </svg>
           </li>
           <li class="spectrum-Menu-item" role="option" tabindex="0">
-            <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Menu-itemIcon" focusable="false" aria-hidden="true" aria-label="Image">
+            <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Menu-itemIcon spectrum-Menu-itemIcon--workflowIcon"" focusable="false" aria-hidden="true" aria-label="Image">
               <use xlink:href="#spectrum-icon-18-Image" />
             </svg>
             <span class="spectrum-Menu-itemLabel">Fremont</span>
@@ -433,7 +433,7 @@ examples:
             </svg>
           </li>
           <li class="spectrum-Menu-item" role="option" tabindex="0">
-            <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Menu-itemIcon" focusable="false" aria-hidden="true" aria-label="Image">
+            <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Menu-itemIcon spectrum-Menu-itemIcon--workflowIcon"" focusable="false" aria-hidden="true" aria-label="Image">
               <use xlink:href="#spectrum-icon-18-Image" />
             </svg>
             <span class="spectrum-Menu-itemLabel">Greenwood</span>
@@ -443,7 +443,7 @@ examples:
           </li>
           <li class="spectrum-Menu-divider" role="separator"></li>
           <li class="spectrum-Menu-item is-disabled" role="option" aria-disabled="true">
-            <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Menu-itemIcon" focusable="false" aria-hidden="true" aria-label="Image">
+            <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Menu-itemIcon spectrum-Menu-itemIcon--workflowIcon"" focusable="false" aria-hidden="true" aria-label="Image">
               <use xlink:href="#spectrum-icon-18-Image" />
             </svg>
             <span class="spectrum-Menu-itemLabel">United States of America</span>
@@ -496,7 +496,7 @@ examples:
         </svg>
       </button>
       <div class="spectrum-Popover spectrum-Popover--bottom spectrum-Picker-popover is-open">
-        <ul class="spectrum-Menu" role="listbox">
+        <ul class="spectrum-Menu is-selectable" role="listbox">
           <li class="spectrum-Menu-item is-selected" role="option" aria-selected="true" tabindex="0">
             <span class="spectrum-Menu-itemLabel">Ballard</span>
             <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Menu-checkmark spectrum-Menu-itemIcon" focusable="false" aria-hidden="true">

--- a/components/picker/metadata/picker.yml
+++ b/components/picker/metadata/picker.yml
@@ -137,7 +137,7 @@ examples:
             <div class="spectrum-Popover spectrum-Popover--bottom spectrum-Picker-popover is-open" style="width: 240px">
               <ul class="spectrum-Menu" role="listbox">
                 <li class="spectrum-Menu-item is-selected" role="option" aria-selected="true" tabindex="0">
-                  <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Menu-itemIcon" focusable="false" aria-hidden="true" aria-label="Image">
+                  <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Menu-itemIcon spectrum-Menu-itemIcon--workflowIcon" focusable="false" aria-hidden="true" aria-label="Image">
                     <use xlink:href="#spectrum-icon-18-Image" />
                   </svg>
                   <span class="spectrum-Menu-itemLabel">Donaudampfschifffahrtsgesellschaftskapitän</span>
@@ -146,7 +146,7 @@ examples:
                   </svg>
                 </li>
                 <li class="spectrum-Menu-item" role="option" tabindex="0">
-                  <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Menu-itemIcon" focusable="false" aria-hidden="true" aria-label="Image">
+                  <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Menu-itemIcon spectrum-Menu-itemIcon--workflowIcon" focusable="false" aria-hidden="true" aria-label="Image">
                     <use xlink:href="#spectrum-icon-18-Image" />
                   </svg>
                   <span class="spectrum-Menu-itemLabel">Some long value that should be cut off</span>
@@ -155,7 +155,7 @@ examples:
                   </svg>
                 </li>
                 <li class="spectrum-Menu-item" role="option" tabindex="0">
-                  <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Menu-itemIcon" focusable="false" aria-hidden="true" aria-label="Image">
+                  <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Menu-itemIcon spectrum-Menu-itemIcon--workflowIcon" focusable="false" aria-hidden="true" aria-label="Image">
                     <use xlink:href="#spectrum-icon-18-Image" />
                   </svg>
                   <span class="spectrum-Menu-itemLabel">Very long text with hyphens-between-words</span>
@@ -165,7 +165,7 @@ examples:
                 </li>
                 <li class="spectrum-Menu-divider" role="separator"></li>
                 <li class="spectrum-Menu-item is-disabled" role="option" aria-disabled="true">
-                  <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Menu-itemIcon" focusable="false" aria-hidden="true" aria-label="Image">
+                  <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Menu-itemIcon spectrum-Menu-itemIcon--workflowIcon" focusable="false" aria-hidden="true" aria-label="Image">
                     <use xlink:href="#spectrum-icon-18-Image" />
                   </svg>
                   <span class="spectrum-Menu-itemLabel">United States of America</span>


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->

## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

Update picker docs site menu mark up to address #2180
- added class `spectrum-Menu-itemIcon--workflowIcon` to the menu item icons (thumbnails) to fix icon spacing
- added class  `is-selectable` to menu <ul> to fix check mark visibility

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

<!--
  Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->
### Testing Outline 
1. Open the [docs site](https://pr-2226--spectrum-css.netlify.app/picker) for the picker component and the [live docs site](https://opensource.adobe.com/spectrum-css/menu.html#standardwithsectionheadersanddividers) for the menu
- [ ] mark up for the menu with in picker (standard - open with thumbnails should match that of the Menu Variant [Standard with section headers and dividers](https://opensource.adobe.com/spectrum-css/menu.html#standardwithsectionheadersanddividers)
- [ ] there is margin-inline-end applied to the icon (thumbnail) 
- [ ] Only the menu items with `is-selected` display the checkmark icon



### Regression testing

Validate:

1. A legacy documentation page (such as [accordion](https://pr-###--spectrum-css.netlify.app/accordion.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

2. A migrated documentation page (such as [action group](https://pr-###--spectrum-css.netlify.app/actiongroup.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

### Before
![Screenshot 2023-10-26 at 8 07 01 AM](https://github.com/adobe/spectrum-css/assets/63808889/e24de965-3d6c-4433-b555-2197cbc2bb1f)


### After
![Screenshot 2023-10-26 at 8 07 19 AM](https://github.com/adobe/spectrum-css/assets/63808889/2bc3ac3f-2018-4bb4-aff4-5dd97a75c8c3)



## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.

- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.

- [ ] ✨ This pull request is ready to merge. ✨
