### PR TITLE
chore(tokens): add custom tokens for dropindicator, assetlist, treeview

### DIFF
--- a/components/tokens/custom-spectrum/custom-dark-vars.css
+++ b/components/tokens/custom-spectrum/custom-dark-vars.css
@@ -37,7 +37,9 @@ governing permissions and limitations under the License.
   --spectrum-coach-indicator-ring-default-color: var(--spectrum-blue-700);
   --spectrum-coach-indicator-ring-dark-color: var(--spectrum-gray-900);
   --spectrum-coach-indicator-ring-light-color: var(--spectrum-gray-50);
+
   --spectrum-well-border-color: rgba(var(--spectrum-white-rgb), 0.05);
+
   --spectrum-steplist-current-marker-color-key-focus: var(--spectrum-blue-700);
 
   --spectrum-treeview-item-background-color-quiet-selected: rgba(var(--spectrum-gray-900-rgb), 0.07);

--- a/components/tokens/custom-spectrum/custom-dark-vars.css
+++ b/components/tokens/custom-spectrum/custom-dark-vars.css
@@ -20,7 +20,7 @@ governing permissions and limitations under the License.
   /* Drop Zone background color rgb */
   --spectrum-drop-zone-background-color-rgb: var( --spectrum-blue-900-rgb); /* var(--spectrum-accent-color-900);*/
 
-  /* Drop Indicator color rgb */  
+  /* Drop Indicator color rgb */
   --spectrum-dropindicator-color: var(--spectrum-blue-700);
 
   --spectrum-calendar-day-background-color-selected: rgba(var(--spectrum-blue-800-rgb), 0.15);

--- a/components/tokens/custom-spectrum/custom-dark-vars.css
+++ b/components/tokens/custom-spectrum/custom-dark-vars.css
@@ -58,4 +58,8 @@ governing permissions and limitations under the License.
   --spectrum-assetcard-border-color-selected-down: var(--spectrum-blue-900);
   --spectrum-assetcard-selectionindicator-background-color-ordered: var(--spectrum-blue-800);
   --spectrum-assestcard-focus-indicator-color: var(--spectrum-blue-700);
+
+  --spectrum-assetlist-item-background-color-selected-hover: rgba(var(--spectrum-blue-800-rgb), 0.25);
+  --spectrum-assetlist-item-background-color-selected: rgba(var(--spectrum-blue-800-rgb), 0.15);
+  --spectrum-assetlist-border-color-key-focus: var(--spectrum-blue-700);
 }

--- a/components/tokens/custom-spectrum/custom-darkest-vars.css
+++ b/components/tokens/custom-spectrum/custom-darkest-vars.css
@@ -58,4 +58,8 @@ governing permissions and limitations under the License.
   --spectrum-assetcard-border-color-selected-down: var(--spectrum-blue-900);
   --spectrum-assetcard-selectionindicator-background-color-ordered: var(--spectrum-blue-800);
   --spectrum-assestcard-focus-indicator-color: var(--spectrum-blue-700);
+
+  --spectrum-assetlist-item-background-color-selected-hover: rgba(var(--spectrum-blue-800-rgb), 0.3);
+  --spectrum-assetlist-item-background-color-selected: rgba(var(--spectrum-blue-800-rgb), 0.2);
+  --spectrum-assetlist-border-color-key-focus: var(--spectrum-blue-700);
 }

--- a/components/tokens/custom-spectrum/custom-darkest-vars.css
+++ b/components/tokens/custom-spectrum/custom-darkest-vars.css
@@ -20,7 +20,7 @@ governing permissions and limitations under the License.
   /* Drop Zone background color rgb */
   --spectrum-drop-zone-background-color-rgb: var( --spectrum-blue-900-rgb); /* var(--spectrum-accent-color-900);*/
 
-  /* Drop Indicator color rgb */  
+  /* Drop Indicator color rgb */
   --spectrum-dropindicator-color: var(--spectrum-blue-700);
 
   --spectrum-calendar-day-background-color-selected: rgba(var(--spectrum-blue-800-rgb), 0.2);

--- a/components/tokens/custom-spectrum/custom-darkest-vars.css
+++ b/components/tokens/custom-spectrum/custom-darkest-vars.css
@@ -37,7 +37,9 @@ governing permissions and limitations under the License.
   --spectrum-coach-indicator-ring-default-color: var(--spectrum-blue-700);
   --spectrum-coach-indicator-ring-dark-color: var(--spectrum-gray-900);
   --spectrum-coach-indicator-ring-light-color: var(--spectrum-gray-50);
+
   --spectrum-well-border-color: rgba(var(--spectrum-white-rgb), 0.05);
+
   --spectrum-steplist-current-marker-color-key-focus: var(--spectrum-blue-700);
 
   --spectrum-treeview-item-background-color-quiet-selected: rgba(var(--spectrum-gray-900-rgb), 0.08);

--- a/components/tokens/custom-spectrum/custom-large-vars.css
+++ b/components/tokens/custom-spectrum/custom-large-vars.css
@@ -92,7 +92,6 @@ governing permissions and limitations under the License.
   --spectrum-dialog-confirm-padding-grid: 24px;
 
   --spectrum-datepicker-initial-width: 160px;
-  --spectrum-datepicker-initial-height: var(--spectrum-component-height-100);
   --spectrum-datepicker-generic-padding: 15px;
   --spectrum-datepicker-dash-line-height: 30px;
   --spectrum-datepicker-width-quiet-first: 90px;

--- a/components/tokens/custom-spectrum/custom-large-vars.css
+++ b/components/tokens/custom-spectrum/custom-large-vars.css
@@ -92,6 +92,7 @@ governing permissions and limitations under the License.
   --spectrum-dialog-confirm-padding-grid: 24px;
 
   --spectrum-datepicker-initial-width: 160px;
+  --spectrum-datepicker-initial-height: var(--spectrum-component-height-100);
   --spectrum-datepicker-generic-padding: 15px;
   --spectrum-datepicker-dash-line-height: 30px;
   --spectrum-datepicker-width-quiet-first: 90px;

--- a/components/tokens/custom-spectrum/custom-large-vars.css
+++ b/components/tokens/custom-spectrum/custom-large-vars.css
@@ -83,8 +83,9 @@ governing permissions and limitations under the License.
   --spectrum-treeview-item-indentation-large: 25px;
   --spectrum-treeview-item-indentation-extra-large: 30px;
   --spectrum-treeview-indicator-inset-block-start: 6px;
-  --spectrum-dialog-confirm-entry-animation-distance: 25px;
+  --spectrum-treeview-item-min-block-size-thumbnail-offset-medium: 2px;
 
+  --spectrum-dialog-confirm-entry-animation-distance: 25px;
   --spectrum-dialog-confirm-hero-height: 160px;
   --spectrum-dialog-confirm-border-radius: 5px;
   --spectrum-dialog-confirm-title-text-size: 19px;

--- a/components/tokens/custom-spectrum/custom-light-vars.css
+++ b/components/tokens/custom-spectrum/custom-light-vars.css
@@ -59,4 +59,8 @@ governing permissions and limitations under the License.
   --spectrum-assetcard-border-color-selected-down: var(--spectrum-blue-1000);
   --spectrum-assetcard-selectionindicator-background-color-ordered: var(--spectrum-blue-900);
   --spectrum-assestcard-focus-indicator-color: var(--spectrum-blue-800);
+
+  --spectrum-assetlist-item-background-color-selected-hover: rgba(var(--spectrum-blue-900-rgb),0.2);
+  --spectrum-assetlist-item-background-color-selected: rgba(var(--spectrum-blue-900-rgb),0.1);
+  --spectrum-assetlist-border-color-key-focus: var(--spectrum-blue-800);
 }

--- a/components/tokens/custom-spectrum/custom-light-vars.css
+++ b/components/tokens/custom-spectrum/custom-light-vars.css
@@ -21,7 +21,7 @@ governing permissions and limitations under the License.
   /* Drop Zone background color rgb */
   --spectrum-drop-zone-background-color-rgb: var(--spectrum-blue-800-rgb); /* var(--spectrum-accent-color-800);*/
 
-  /* Drop Indicator color rgb */  
+  /* Drop Indicator color rgb */
   --spectrum-dropindicator-color: var(--spectrum-blue-800);
 
   --spectrum-calendar-day-background-color-selected: rgba(var(--spectrum-blue-900-rgb), 0.1);

--- a/components/tokens/custom-spectrum/custom-light-vars.css
+++ b/components/tokens/custom-spectrum/custom-light-vars.css
@@ -38,7 +38,9 @@ governing permissions and limitations under the License.
   --spectrum-coach-indicator-ring-default-color: var(--spectrum-blue-800);
   --spectrum-coach-indicator-ring-dark-color: var(--spectrum-gray-900);
   --spectrum-coach-indicator-ring-light-color: var(--spectrum-gray-50);
+
   --spectrum-well-border-color: var(--spectrum-black-rgb);
+
   --spectrum-steplist-current-marker-color-key-focus: var(--spectrum-blue-800);
 
   --spectrum-treeview-item-background-color-quiet-selected: rgba(var(--spectrum-gray-900-rgb), 0.06);

--- a/components/tokens/custom-spectrum/custom-medium-vars.css
+++ b/components/tokens/custom-spectrum/custom-medium-vars.css
@@ -82,8 +82,9 @@ governing permissions and limitations under the License.
   --spectrum-treeview-item-indentation-large: 20px;
   --spectrum-treeview-item-indentation-extra-large: var(--spectrum-spacing-400);
   --spectrum-treeview-indicator-inset-block-start: 5px;
-  --spectrum-dialog-confirm-entry-animation-distance: 20px;
+  --spectrum-treeview-item-min-block-size-thumbnail-offset-medium: 0px;
 
+  --spectrum-dialog-confirm-entry-animation-distance: 20px;
   --spectrum-dialog-confirm-hero-height: 128px;
   --spectrum-dialog-confirm-border-radius: 4px;
   --spectrum-dialog-confirm-title-text-size: 18px;

--- a/components/tokens/custom-spectrum/custom-medium-vars.css
+++ b/components/tokens/custom-spectrum/custom-medium-vars.css
@@ -91,7 +91,6 @@ governing permissions and limitations under the License.
   --spectrum-dialog-confirm-padding-grid: 40px;
 
   --spectrum-datepicker-initial-width: 128px;
-  --spectrum-datepicker-initial-height: var(--spectrum-component-height-100);
   --spectrum-datepicker-generic-padding: var(--spectrum-spacing-200);
   --spectrum-datepicker-dash-line-height: 24px;
   --spectrum-datepicker-width-quiet-first: 72px;

--- a/components/tokens/custom-spectrum/custom-medium-vars.css
+++ b/components/tokens/custom-spectrum/custom-medium-vars.css
@@ -91,6 +91,7 @@ governing permissions and limitations under the License.
   --spectrum-dialog-confirm-padding-grid: 40px;
 
   --spectrum-datepicker-initial-width: 128px;
+  --spectrum-datepicker-initial-height: var(--spectrum-component-height-100);
   --spectrum-datepicker-generic-padding: var(--spectrum-spacing-200);
   --spectrum-datepicker-dash-line-height: 24px;
   --spectrum-datepicker-width-quiet-first: 72px;


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->

## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

Adds tokens from:
- [x] #2198 
- [x] #2211 
- [x] #2218 

<!--
  Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

### Regression testing

Validate:

1. A legacy documentation page (such as [accordion](https://pr-###--spectrum-css.netlify.app/accordion.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

2. A migrated documentation page (such as [action group](https://pr-###--spectrum-css.netlify.app/actiongroup.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [ ] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.

- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.

- [ ] ✨ This pull request is ready to merge. ✨
