### PR TITLE
fix(button): support for wrapping text

### DIFF
--- a/components/button/index.css
+++ b/components/button/index.css
@@ -146,6 +146,7 @@ governing permissions and limitations under the License.
       var(--mod-button-edge-to-text, var(--spectrum-button-edge-to-text))
     );
     color: inherit;
+    flex-shrink: 0;
   }
 
   /* correct focus indicator radius for t-shirt sizing */
@@ -176,7 +177,6 @@ a.spectrum-Button {
   @extend %spectrum-ButtonLabel;
   padding-block-start: calc(var(--mod-button-top-to-text, var(--spectrum-button-top-to-text)) - var(--mod-button-border-width, var(--spectrum-button-border-width)));
   padding-block-end: calc(var(--mod-button-bottom-to-text, var(--spectrum-button-bottom-to-text)) - var(--mod-button-border-width, var(--spectrum-button-border-width)));
-  white-space: nowrap;
   line-height: var(--mod-button-line-height, var(--spectrum-button-line-height));
   align-self: start;
 }

--- a/components/button/index.css
+++ b/components/button/index.css
@@ -155,10 +155,12 @@ governing permissions and limitations under the License.
       var(--spectrum-icon-block-size, var(--spectrum-button-intended-icon-size))
     );
 
-    margin-block-start: max(0px,
-      var(--mod-button-top-to-icon, var(--spectrum-button-top-to-icon)) - 
-      var(--mod-button-border-width, var(--spectrum-button-border-width)) +
-      (var(--_icon-size-difference, 0px) / 2)
+    margin-block-start: var(--mod-button-icon-margin-block-start,
+      max(0px,
+        var(--mod-button-top-to-icon, var(--spectrum-button-top-to-icon)) - 
+        var(--mod-button-border-width, var(--spectrum-button-border-width)) +
+        (var(--_icon-size-difference, 0px) / 2)
+      )
     );
 
     margin-inline-start: calc(

--- a/components/button/index.css
+++ b/components/button/index.css
@@ -23,6 +23,7 @@ governing permissions and limitations under the License.
   --spectrum-button-focus-ring-border-radius: calc(var(--spectrum-button-border-radius) + var(--spectrum-button-focus-ring-gap));
   --spectrum-button-focus-ring-thickness: var(--spectrum-focus-indicator-thickness);
   --spectrum-button-focus-indicator-color: var(--spectrum-focus-indicator-color);
+  --spectrum-button-intended-icon-size: var(--spectrum-workflow-icon-size-50);
 }
 
 .spectrum-Button--sizeS {
@@ -40,6 +41,7 @@ governing permissions and limitations under the License.
   --spectrum-button-top-to-text: var(--spectrum-button-top-to-text-small);
   --spectrum-button-bottom-to-text: var(--spectrum-button-bottom-to-text-small);
   --spectrum-button-top-to-icon: var(--spectrum-component-top-to-workflow-icon-75);
+  --spectrum-button-intended-icon-size: var(--spectrum-workflow-icon-size-75);
 }
 
 .spectrum-Button--sizeM {
@@ -57,6 +59,7 @@ governing permissions and limitations under the License.
   --spectrum-button-top-to-text: var(--spectrum-button-top-to-text-medium);
   --spectrum-button-bottom-to-text: var(--spectrum-button-bottom-to-text-medium);
   --spectrum-button-top-to-icon: var(--spectrum-component-top-to-workflow-icon-100);
+  --spectrum-button-intended-icon-size: var(--spectrum-workflow-icon-size-100);
 
   &[pending],
   &.is-pending {
@@ -79,6 +82,7 @@ governing permissions and limitations under the License.
   --spectrum-button-top-to-text: var(--spectrum-button-top-to-text-large);
   --spectrum-button-bottom-to-text: var(--spectrum-button-bottom-to-text-large);
   --spectrum-button-top-to-icon: var(--spectrum-component-top-to-workflow-icon-200);
+  --spectrum-button-intended-icon-size: var(--spectrum-workflow-icon-size-200);
 
   &[pending],
   &.is-pending {
@@ -101,6 +105,7 @@ governing permissions and limitations under the License.
   --spectrum-button-top-to-text: var(--spectrum-button-top-to-text-extra-large);
   --spectrum-button-bottom-to-text: var(--spectrum-button-bottom-to-text-extra-large);
   --spectrum-button-top-to-icon: var(--spectrum-component-top-to-workflow-icon-300);
+  --spectrum-button-intended-icon-size: var(--spectrum-workflow-icon-size-300);
 
   .spectrum--medium &[pending],
   .spectrum--medium &.is-pending {
@@ -143,10 +148,19 @@ governing permissions and limitations under the License.
   }
 
   .spectrum-Icon {
+    /* Any block-size difference between the intended workflow icon size and actual icon used.
+       Helps support any existing use of smaller UI icons instead of intended Workflow icons. */
+    --_icon-size-difference: max(0px,
+      var(--spectrum-button-intended-icon-size) - 
+      var(--spectrum-icon-block-size, var(--spectrum-button-intended-icon-size))
+    );
+
     margin-block-start: max(0px,
       var(--mod-button-top-to-icon, var(--spectrum-button-top-to-icon)) - 
-      var(--mod-button-border-width, var(--spectrum-button-border-width))
+      var(--mod-button-border-width, var(--spectrum-button-border-width)) +
+      (var(--_icon-size-difference, 0px) / 2)
     );
+
     margin-inline-start: calc(
       var(--mod-button-edge-to-visual, var(--spectrum-button-edge-to-visual)) -
       var(--mod-button-edge-to-text, var(--spectrum-button-edge-to-text))

--- a/components/button/index.css
+++ b/components/button/index.css
@@ -25,7 +25,6 @@ governing permissions and limitations under the License.
   --spectrum-button-focus-indicator-color: var(--spectrum-focus-indicator-color);
 }
 
-
 .spectrum-Button--sizeS {
   --spectrum-button-min-width: calc(var(--spectrum-component-height-75) * var(--spectrum-button-minimum-width-multiplier));
 
@@ -40,6 +39,7 @@ governing permissions and limitations under the License.
   --spectrum-button-padding-label-to-icon: var(--spectrum-text-to-visual-75);
   --spectrum-button-top-to-text: var(--spectrum-button-top-to-text-small);
   --spectrum-button-bottom-to-text: var(--spectrum-button-bottom-to-text-small);
+  --spectrum-button-top-to-icon: var(--spectrum-component-top-to-workflow-icon-75);
 }
 
 .spectrum-Button--sizeM {
@@ -56,6 +56,7 @@ governing permissions and limitations under the License.
   --spectrum-button-padding-label-to-icon: var(--spectrum-text-to-visual-100);
   --spectrum-button-top-to-text: var(--spectrum-button-top-to-text-medium);
   --spectrum-button-bottom-to-text: var(--spectrum-button-bottom-to-text-medium);
+  --spectrum-button-top-to-icon: var(--spectrum-component-top-to-workflow-icon-100);
 
   &[pending],
   &.is-pending {
@@ -77,7 +78,7 @@ governing permissions and limitations under the License.
   --spectrum-button-padding-label-to-icon: var(--spectrum-text-to-visual-200);
   --spectrum-button-top-to-text: var(--spectrum-button-top-to-text-large);
   --spectrum-button-bottom-to-text: var(--spectrum-button-bottom-to-text-large);
-
+  --spectrum-button-top-to-icon: var(--spectrum-component-top-to-workflow-icon-200);
 
   &[pending],
   &.is-pending {
@@ -99,6 +100,7 @@ governing permissions and limitations under the License.
   --spectrum-button-padding-label-to-icon: var(--spectrum-text-to-visual-300);
   --spectrum-button-top-to-text: var(--spectrum-button-top-to-text-extra-large);
   --spectrum-button-bottom-to-text: var(--spectrum-button-bottom-to-text-extra-large);
+  --spectrum-button-top-to-icon: var(--spectrum-component-top-to-workflow-icon-300);
 
   .spectrum--medium &[pending],
   .spectrum--medium &.is-pending {
@@ -141,12 +143,17 @@ governing permissions and limitations under the License.
   }
 
   .spectrum-Icon {
+    margin-block-start: max(0px,
+      var(--mod-button-top-to-icon, var(--spectrum-button-top-to-icon)) - 
+      var(--mod-button-border-width, var(--spectrum-button-border-width))
+    );
     margin-inline-start: calc(
       var(--mod-button-edge-to-visual, var(--spectrum-button-edge-to-visual)) -
       var(--mod-button-edge-to-text, var(--spectrum-button-edge-to-text))
     );
     color: inherit;
     flex-shrink: 0;
+    align-self: flex-start;
   }
 
   /* correct focus indicator radius for t-shirt sizing */
@@ -160,7 +167,9 @@ governing permissions and limitations under the License.
     border-radius: 50%;
 
     .spectrum-Icon {
+      align-self: center;
       margin-inline-start: 0;
+      margin-block-start: 0;
     }
 
     &::after {
@@ -179,6 +188,11 @@ a.spectrum-Button {
   padding-block-end: calc(var(--mod-button-bottom-to-text, var(--spectrum-button-bottom-to-text)) - var(--mod-button-border-width, var(--spectrum-button-border-width)));
   line-height: var(--mod-button-line-height, var(--spectrum-button-line-height));
   align-self: start;
+  text-align: var(--mod-button-text-align, center);
+}
+
+.spectrum-Button .spectrum-Icon + .spectrum-Button-label {
+  text-align: var(--mod-button-text-align-with-icon, start);
 }
 
 .spectrum-Button {
@@ -190,26 +204,22 @@ a.spectrum-Button {
   }
 }
 
-/* special cases for focus-ring */
+/* Special cases for focus indicator */
 .spectrum-Button {
   transition: border-color var(--mod-button-animation-duration, var(--spectrum-button-animation-duration)) ease-in-out;
 
   &::after {
     position: absolute;
     inset: 0;
-
     margin: calc((var(--mod-button-focus-ring-gap, var(--spectrum-button-focus-ring-gap)) + var(--mod-button-border-width, var(--spectrum-button-border-width))) * -1);
-
     border-radius: var(--mod-button-focus-ring-border-radius, var(--spectrum-button-focus-ring-border-radius));
-
     transition: box-shadow var(--mod-button-animation-duration, var(--spectrum-button-animation-duration)) ease-in-out;
-
     pointer-events: none;
     content: '';
   }
 
   &:focus-visible {
-    /* kill the default ring */
+    /* Remove the default focus outline */
     box-shadow: none;
     outline: none;
 
@@ -222,7 +232,6 @@ a.spectrum-Button {
 
 /* Core Token Theming */
 /* former skin.css, applied / copied from actionbutton/index.css  */
-
 .spectrum-Button {
   @extend %spectrum-BaseButton;
 
@@ -268,7 +277,16 @@ a.spectrum-Button {
   }
 }
 
-/* windows high contrast mode over-writes for accent variant */
+/* Static color variants */
+.spectrum-Button--staticWhite {
+  --spectrum-button-focus-indicator-color: var(--mod-static-black-focus-indicator-color, var(--spectrum-static-black-focus-indicator-color));
+}
+
+.spectrum-Button--staticBlack {
+  --spectrum-button-focus-indicator-color: var(--mod-static-black-focus-indicator-color, var(--spectrum-static-black-focus-indicator-color));
+}
+
+/* Windows High Contrast Mode */
 @media (forced-colors: active) {
   .spectrum-Button {
     --highcontrast-button-content-color-disabled: GrayText;
@@ -301,13 +319,4 @@ a.spectrum-Button {
       }
     }
   }
-}
-
-/* static variants */
-.spectrum-Button--staticWhite {
-  --spectrum-button-focus-indicator-color: var(--mod-static-black-focus-indicator-color, var(--spectrum-static-black-focus-indicator-color));
-}
-
-.spectrum-Button--staticBlack {
-  --spectrum-button-focus-indicator-color: var(--mod-static-black-focus-indicator-color, var(--spectrum-static-black-focus-indicator-color));
 }

--- a/components/button/metadata/mods.md
+++ b/components/button/metadata/mods.md
@@ -32,6 +32,7 @@
 | `--mod-button-font-family`                 |
 | `--mod-button-font-size`                   |
 | `--mod-button-height`                      |
+| `--mod-button-icon-margin-block-start`     |
 | `--mod-button-line-height`                 |
 | `--mod-button-margin-block`                |
 | `--mod-button-margin-left`                 |

--- a/components/button/metadata/mods.md
+++ b/components/button/metadata/mods.md
@@ -39,6 +39,9 @@
 | `--mod-button-min-width`                   |
 | `--mod-button-padding-label-to-icon`       |
 | `--mod-button-static-content-color`        |
+| `--mod-button-text-align`                  |
+| `--mod-button-text-align-with-icon`        |
+| `--mod-button-top-to-icon`                 |
 | `--mod-button-top-to-text`                 |
 | `--mod-focus-indicator-gap`                |
 | `--mod-line-height-100`                    |

--- a/components/button/package.json
+++ b/components/button/package.json
@@ -15,7 +15,7 @@
   },
   "main": "dist/index-vars.css",
   "peerDependencies": {
-    "@spectrum-css/icon": ">=4",
+    "@spectrum-css/icon": ">=6",
     "@spectrum-css/progresscircle": ">=2",
     "@spectrum-css/tokens": ">=13"
   },

--- a/components/button/stories/button.stories.js
+++ b/components/button/stories/button.stories.js
@@ -82,6 +82,7 @@ export default {
 		},
 		staticColor: {
 			name: "Static color",
+			description: "Variants that can be used when a button needs to be placed on top of a colored background or a visual.",
 			type: { name: "string" },
 			table: {
 				type: { summary: "string" },

--- a/components/button/stories/button.stories.js
+++ b/components/button/stories/button.stories.js
@@ -89,7 +89,17 @@ export default {
 			},
 			options: ["white", "black"],
 			control: "select",
-		}
+		},
+		showIconOnlyButton: {
+			table: {
+				disable: true,
+			},
+		},
+		showOneButtonPerLine: {
+			table: {
+				disable: true,
+			},
+		},
 	},
 	args: {
 		rootClass: "spectrum-Button",
@@ -99,6 +109,8 @@ export default {
 		treatment: "fill",
 		isDisabled: false,
 		isPending: false,
+		showIconOnlyButton: true,
+		showOneButtonPerLine: false,
 	},
 	parameters: {
 		actions: {
@@ -112,43 +124,60 @@ export default {
 	},
 };
 
+/**
+ * Multiple button variations displayed in one story template.
+ * Used as the base template for the stories.
+ */
 const CustomButton = ({
 	iconName,
 	staticColor,
+	showOneButtonPerLine,
+	showIconOnlyButton,
 	customStyles = {},
 	...args
-}) => html`
-	<div
-				style=${ifDefined(styleMap({
-			padding: "1rem",
-			backgroundColor: staticColor === "white" ? "rgb(15, 121, 125)" : staticColor === "black" ? "rgb(181, 209, 211)" : undefined,
-			...customStyles
-		}))}
-	>
-		${Template({
-			...args,
-			staticColor,
-			iconName: undefined,
-		})}
-		${Template({
-			...args,
-			staticColor,
-			iconName: undefined,
-			treatment: "outline",
-		})}
-		${Template({
-			...args,
-			staticColor,
-			iconName: iconName ?? "Edit",
-		})}
-		${Template({
-			...args,
-			staticColor,
-			hideLabel: true,
-			iconName: iconName ?? "Edit",
-		})}
-	</div>
-`;
+}) => {
+	// Optional wrapper for each button, to assist with the testing of wrapping text.
+	const ButtonWrap = (content) => {
+		const buttonWrapStyles = {
+			'margin-block': '15px',
+			'max-width': '480px',
+		};
+		return showOneButtonPerLine ? html`<div style=${styleMap(buttonWrapStyles)}>${content}</div>` : content;
+	};
+
+	return html`
+		<div
+			style=${ifDefined(styleMap({
+				padding: "1rem",
+				backgroundColor: staticColor === "white" ? "rgb(15, 121, 125)" : staticColor === "black" ? "rgb(181, 209, 211)" : undefined,
+				...customStyles
+			}))}
+		>
+			${ButtonWrap(Template({
+				...args,
+				staticColor,
+				iconName: undefined,
+			}))}
+			${ButtonWrap(Template({
+				...args,
+				staticColor,
+				iconName: undefined,
+				treatment: "outline",
+			}))}
+			${ButtonWrap(Template({
+				...args,
+				staticColor,
+				iconName: iconName ?? "Edit",
+			}))}
+			${showIconOnlyButton ? ButtonWrap(Template({
+				...args,
+				staticColor,
+				hideLabel: true,
+				iconName: iconName ?? "Edit",
+			})) : ''}
+		</div>
+	`;
+};
 
 const PendingButton = ({
 	staticColor,
@@ -161,7 +190,7 @@ const PendingButton = ({
 		gap: ".3rem",
 	})}>
 		<div>
-		${Typography({
+			${Typography({
 				semantics: "heading",
 				size: "xxs",
 				content: ["Default"],
@@ -194,7 +223,7 @@ const ButtonsWithForcedColors = ({
 		gap: ".3rem",
 	})}>
 		<div>
-		${Typography({
+			${Typography({
 				semantics: "heading",
 				size: "xxs",
 				content: ["Default"],
@@ -268,4 +297,12 @@ WithForcedColors.parameters = {
 };
 WithForcedColors.args = {
 	iconName: "Actions",
+};
+
+export const Wrapping = CustomButton.bind({});
+Wrapping.args = {
+	showOneButtonPerLine: true,
+	showIconOnlyButton: false,
+	variant: "accent",
+	label: "An example of text overflow behavior within the button component. When the button text is too long for the horizontal space available, it wraps to form another line.",
 };

--- a/components/button/stories/button.stories.js
+++ b/components/button/stories/button.stories.js
@@ -96,10 +96,16 @@ export default {
 				disable: true,
 			},
 		},
-		showOneButtonPerLine: {
-			table: {
-				disable: true,
+		layout: {
+		    name: "Layout",
+		    description: "How the buttons align in the preview (Storybook only).",
+		    type: { name: "string" },
+			table: { 
+			    type: { summary: "string" },
+			    category: "Advanced"
 			},
+			options: ["stacked","inline"],
+			control: "radio"
 		},
 	},
 	args: {
@@ -111,7 +117,7 @@ export default {
 		isDisabled: false,
 		isPending: false,
 		showIconOnlyButton: true,
-		showOneButtonPerLine: false,
+		layout: "inline",
 	},
 	parameters: {
 		actions: {
@@ -132,7 +138,7 @@ export default {
 const CustomButton = ({
 	iconName,
 	staticColor,
-	showOneButtonPerLine,
+	layout,
 	showIconOnlyButton,
 	customStyles = {},
 	...args
@@ -143,7 +149,7 @@ const CustomButton = ({
 			'margin-block': '15px',
 			'max-width': '480px',
 		};
-		return showOneButtonPerLine ? html`<div style=${styleMap(buttonWrapStyles)}>${content}</div>` : content;
+		return layout === "stacked" ? html`<div style=${styleMap(buttonWrapStyles)}>${content}</div>` : content;
 	};
 
 	return html`
@@ -302,7 +308,7 @@ WithForcedColors.args = {
 
 export const Wrapping = CustomButton.bind({});
 Wrapping.args = {
-	showOneButtonPerLine: true,
+	layout: "stacked",
 	showIconOnlyButton: false,
 	variant: "accent",
 	label: "An example of text overflow behavior within the button component. When the button text is too long for the horizontal space available, it wraps to form another line.",


### PR DESCRIPTION
## Description

This update allows text wrapping within the **Button** component and updates the alignment of the label and icon when wrapping to conform with the design specs.

- Fixes a previously introduced bug that disabled wrapping of lengthy text inside a Button. This removes the white-space property that prevented wrapping.
- BREAKING CHANGE: Updates styles so that buttons that contain a workflow icon have the correct icon and text alignment. Previously everything was vertically aligned center and the text was aligned center, which did not match the design in the case of wrapping text. See screenshots for reference to the design.

  This is a significant change as the vertical flex alignment of the icon is now to the top/start instead of the center, and the design defined _--spectrum-component-top-to-workflow-icon-_* tokens are used for the spacing between the icon and the top of the component. While button is intended to be used with workflow icons, there were not previously any guidelines around _not_ using UI icons and even SplitButton was using one---in order to support vertical alignment of any existing usage of UI icons, some additional CSS calculations were included to add some margin based on the difference between the height of the intended workflow icon size and the actual icon size used (now accessible through `--spectrum-icon-block-size` since the 6.0 core tokens migration of _Icon_).
- Adds a "Wrapping" example to Storybook. This also has a Chromatic-only version with additional variations displayed.

CSS-621

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

  - [x] Verify changes with design team [@jawinn]
  - [x] Button wrapping example exists in Storybook.
  - [x] Button without icon wraps and has centered text (like [guidelines](https://spectrum.adobe.com/page/button/#Text-overflow)).
  - [x] Button with icon has icon aligned to the top of the component and text aligned to the left/start of the component. Matching "Design spec for wrapping behavior with icon" in screenshots.
  - [x] Wrapping behavior looks correct in right-to-left text direction.
  - [ ] Non-wrapping examples of the button with an icon have no visual changes.

### Regression testing

Validate:

1. A legacy documentation page (such as [accordion](https://pr-###--spectrum-css.netlify.app/accordion.html)), including:

- [x] The page renders correctly
- [x] The page is accessible
- [x] The page is responsive

2. A migrated documentation page (such as [action group](https://pr-###--spectrum-css.netlify.app/actiongroup.html)), including:

- [x] The page renders correctly
- [x] The page is accessible
- [x] The page is responsive

## Screenshots

Updated wrapping behavior (Storybook):
![Screenshot 2023-10-31 at 3 48 35 PM](https://github.com/adobe/spectrum-css/assets/965114/d8c923f4-dc87-41fe-9561-df21d3f458a0)

Chromatic view of Wrapping story that includes showing backwards compatible alignment of differently sized UI icons
![Screenshot 2024-02-08 at 11 57 21 AM](https://github.com/adobe/spectrum-css/assets/965114/9b992309-1099-4a53-9378-5b7f61202a07)

Reference: design spec for wrapping behavior with icon
![Screenshot 2023-10-31 at 4 02 40 PM](https://github.com/adobe/spectrum-css/assets/965114/00992b74-7e39-4be2-bc32-afad8158fbbb)
Previous behavior:
![Screenshot 2024-02-08 at 2 14 28 PM](https://github.com/adobe/spectrum-css/assets/965114/6454e1d7-4775-47e7-8fac-93ae59f5885e)

Reference: design spec for wrapping behavior without icon
![button_behaviors_text-overflow@2x_1649295070805](https://github.com/adobe/spectrum-css/assets/965114/e0f53614-1890-4a8b-bcbd-8dd8b12d3594)


## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] VRTs have been run and reviewed.
- [ ] ✨ This pull request is ready to merge. ✨
