### PR TITLE
feat(assetcard)!: migrate to updated token system

### DIFF
--- a/components/assetcard/gulpfile.js
+++ b/components/assetcard/gulpfile.js
@@ -1,1 +1,1 @@
-module.exports = require("@spectrum-css/component-builder");
+module.exports = require("@spectrum-css/component-builder-simple");

--- a/components/assetcard/index.css
+++ b/components/assetcard/index.css
@@ -12,332 +12,509 @@ governing permissions and limitations under the License.
 
 /* outer container, unstyled */
 .spectrum-AssetCard {
-  /* todo: this isn't quite the size from the XD file as 232px is not a size token, so we use 224px */
-  --spectrum-assetcard-asset-size: var(--spectrum-global-dimension-static-size-2800);
+	--spectrum-assetcard-minimum-size: var(--spectrum-card-minimum-width);
+	--spectrum-assetcard-size: var(--spectrum-assetcard-asset-size, 224px);
 
-  --spectrum-assetcard-overlay-background-color: var(--spectrum-alias-assetcard-overlay-background-color);
-  --spectrum-assetcard-border-color-selected: var(--spectrum-alias-assetcard-border-color-selected);
-  --spectrum-assetcard-border-color-selected-hover: var(--spectrum-alias-assetcard-border-color-selected-hover);
-  --spectrum-assetcard-border-color-selected-down: var(--spectrum-alias-assetcard-border-color-selected-down);
-  --spectrum-assetcard-selectionindicator-background-color-ordered: var(--spectrum-alias-assetcard-selectionindicator-background-color-ordered);
+	--spectrum-assetcard-overlay-background-color: var(
+		--spectrum-alias-assetcard-overlay-background-color
+	);
+	--spectrum-assetcard-border-color-selected: var(
+		--spectrum-alias-assetcard-border-color-selected
+	);
+	--spectrum-assetcard-border-color-selected-hover: var(
+		--spectrum-alias-assetcard-border-color-selected-hover
+	);
+	--spectrum-assetcard-border-color-selected-down: var(
+		--spectrum-alias-assetcard-border-color-selected-down
+	);
+	--spectrum-assetcard-selectionindicator-background-color-ordered: var(
+		--spectrum-alias-assetcard-selectionindicator-background-color-ordered
+	);
 
-  --spectrum-assetcard-border-radius: var(--spectrum-alias-border-radius-regular);
-  --spectrum-assetcard-border-color: transparent;
-  --spectrum-assetcard-border-color-hover: var(--spectrum-alias-border-color-hover);
-  /* todo: this was hardcoded, it should reference --spectrum-alias-border-color-down once that becomes +200 */
-  --spectrum-assetcard-border-color-down: var(--spectrum-global-color-gray-600);
+	--spectrum-assetcard-border-radius: var(
+		--spectrum-alias-border-radius-regular
+	);
+	--spectrum-assetcard-border-color: transparent;
+	--spectrum-assetcard-border-color-hover: var(
+		--spectrum-alias-border-color-hover
+	);
+	/* todo: this was hardcoded, it should reference --spectrum-alias-border-color-down once that becomes +200 */
+	--spectrum-assetcard-border-color-down: var(--spectrum-gray-600);
 
-  --spectrum-assetcard-background-color: var(--spectrum-global-color-gray-200);
+	--spectrum-assetcard-background-color: var(--spectrum-gray-200);
 
-  --spectrum-assetcard-focus-ring-gap: var(--spectrum-global-dimension-static-size-65);
-  --spectrum-assetcard-focus-ring-border-radius: var(--spectrum-alias-focus-ring-border-radius-regular);
+	--spectrum-assetcard-focus-ring-opacity: 0;
+	--spectrum-assetcard-focus-ring-gap: var(--spectrum-focus-indicator-gap);
+	--spectrum-assetcard-focus-ring-border-radius: var(
+		--spectrum-alias-focus-ring-border-radius-regular
+	);
 
-  --spectrum-assetcard-selectionindicator-background-color-default: var(--spectrum-alias-background-color-quickactions);
-  --spectrum-assetcard-selectionindicator-margin: var(--spectrum-global-dimension-size-150);
-  --spectrum-assetcard-selectionindicator-size: var(--spectrum-global-dimension-static-size-500);
-  --spectrum-assetcard-selectionindicator-border-radius: var(--spectrum-alias-border-radius-regular);
+	--spectrum-assetcard-selectionindicator-background-color-default: var(
+		--spectrum-alias-background-color-quickactions
+	);
+	--spectrum-assetcard-selectionindicator-margin: var(--spectrum-spacing-200);
+	--spectrum-assetcard-selectionindicator-size: var(
+		--spectrum-card-selection-background-size
+	);
+	--spectrum-assetcard-selectionindicator-border-radius: var(
+		--spectrum-corner-radius-75
+	);
 
-  --spectrum-assetcard-heading-text-color: var(--spectrum-global-color-gray-900);
-  --spectrum-assetcard-content-text-color: var(--spectrum-global-color-gray-700);
+	--spectrum-assetcard-title-text-color: var(--spectrum-gray-900);
+	--spectrum-assetcard-header-content-text-color: var(--spectrum-gray-900);
+	--spectrum-assetcard-content-text-color: var(--spectrum-gray-700);
 
-  /* contain selection indicator */
-  position: relative;
+	/* Maps to .spectrum-Heading--sizeXS */
+	--spectrum-assetcard-title-font-size: var(--spectrum-heading-size-xs);
 
-  display: flex;
-  flex-direction: column;
+	--spectrum-assetcard-title-font-family: var(
+		--spectrum-sans-font-family-stack
+	);
+	--spectrum-assetcard-title-font-weight: var(
+		--spectrum-heading-sans-serif-font-weight
+	);
+	--spectrum-assetcard-title-font-style: var(
+		--spectrum-heading-sans-serif-font-style
+	);
+	--spectrum-assetcard-title-line-height: var(--spectrum-heading-line-height);
+	--spectrum-assetcard-title-letter-spacing: normal;
 
-  inline-size: var(--spectrum-assetcard-asset-size);
+	/* Maps to .spectrum-Body--sizeM */
+	--spectrum-assetcard-header-content-size: var(--spectrum-body-size-m);
 
-  cursor: pointer;
+	--spectrum-assetcard-header-content-font-family: var(
+		--spectrum-sans-font-family-stack
+	);
+	--spectrum-assetcard-header-content-font-weight: var(
+		--spectrum-body-sans-serif-font-weight
+	);
+	--spectrum-assetcard-header-content-font-style: var(
+		--spectrum-body-sans-serif-font-style
+	);
+	--spectrum-assetcard-heading-content-line-height: var(
+		--spectrum-body-line-height
+	);
+	--spectrum-assetcard-header-content-letter-spacing: normal;
 
-  &:hover {
-    .spectrum-AssetCard-assetContainer::after {
-      border-color: var(--spectrum-assetcard-border-color-hover);
-    }
-  }
+	/* Maps to .spectrum-Body--sizeS */
+	--spectrum-assetcard-content-size: var(--spectrum-body-size-s);
 
-  &:active {
-    .spectrum-AssetCard-assetContainer::after {
-      border-color: var(--spectrum-assetcard-border-color-down);
-    }
-  }
+	--spectrum-assetcard-content-font-family: var(
+		--spectrum-sans-font-family-stack
+	);
+	--spectrum-assetcard-content-font-weight: var(
+		--spectrum-body-sans-serif-font-weight
+	);
+	--spectrum-assetcard-content-line-height: var(--spectrum-body-line-height);
+	--spectrum-assetcard-content-font-style: var(
+		--spectrum-body-sans-serif-font-style
+	);
+	--spectrum-assetcard-content-line-height: var(--spectrum-body-line-height);
+	--spectrum-assetcard-content-letter-spacing: normal;
 
-  outline: none;
+	/* contain selection indicator */
+	position: relative;
 
-  &:focus-visible {
-    .spectrum-AssetCard-assetContainer::before {
-      opacity: 1;
-    }
-  }
+	display: flex;
+	flex-direction: column;
+
+	cursor: pointer;
+
+	outline: none;
+
+	font-family: var(
+		--mod-assetcard-content-font-family,
+		var(--spectrum-assetcard-content-font-family)
+	);
+	font-weight: var(
+		--mod-assetcard-content-font-weight,
+		var(--spectrum-assetcard-content-font-weight)
+	);
+	font-size: var(
+		--mod-assetcard-content-font-size,
+		var(--spectrum-assetcard-content-font-size)
+	);
+	line-height: var(
+		--mod-assetcard-content-line-height,
+		var(--spectrum-assetcard-content-line-height)
+	);
+	font-style: var(
+		--mod-assetcard-content-font-style,
+		var(--spectrum-assetcard-header-content-font-style)
+	);
+	letter-spacing: var(
+		--mod-assetcard-content-letter-spacing,
+		var(--spectrum-assetcard-content-letter-spacing)
+	);
+
+	&:hover {
+		--spectrum-assetcard-border-color: var(
+			--spectrum-assetcard-border-color-hover
+		);
+	}
+
+	&:active {
+		--spectrum-assetcard-border-color: var(
+			--spectrum-assetcard-border-color-down
+		);
+	}
+
+	&:focus-visible {
+		--spectrum-assetcard-focus-ring-opacity: 1;
+	}
+
+	&:lang(zh),
+	&:lang(ja),
+	&:lang(ko) {
+		--spectrum-assetcard-title-font-family: var(
+			--spectrum-cjk-font-family-stack
+		);
+		--spectrum-assetcard-title-font-style: var(
+			--spectrum-heading-cjk-font-style
+		);
+		--spectrum-assetcard-title-font-weight: var(
+			--spectrum-heading-cjk-font-weight
+		);
+		--spectrum-assetcard-title-font-size: var(
+			--spectrum-heading-cjk-font-size-xs
+		);
+
+		--spectrum-assetcard-title-line-height: var(
+			--spectrum-heading-cjk-line-height
+		);
+		--spectrum-assetcard-title-letter-spacing: var(
+			--spectrum-heading-cjk-letter-spacing
+		);
+
+		--spectrum-assetcard-header-content-font-family: var(
+			--spectrum-cjk-font-family-stack
+		);
+		--spectrum-assetcard-header-content-size: var(
+			--spectrum-body-cjk-font-size-m
+		);
+		--spectrum-assetcard-header-content-font-weight: var(
+			--spectrum-body-cjk-font-weight
+		);
+		--spectrum-assetcard-header-content-line-height: var(
+			--spectrum-body-cjk-line-height
+		);
+		--spectrum-assetcard-header-content-font-style: var(
+			--spectrum-body-cjk-font-style
+		);
+		--spectrum-assetcard-header-content-letter-spacing: var(
+			--spectrum-body-cjk-letter-spacing
+		);
+
+		--spectrum-assetcard-content-font-family: var(
+			--spectrum-cjk-font-family-stack
+		);
+		--spectrum-assetcard-content-font-size: var(
+			--spectrum-body-cjk-font-size-s
+		);
+		--spectrum-assetcard-content-font-weight: var(
+			--spectrum-body-cjk-font-weight
+		);
+		--spectrum-assetcard-content-line-height: var(
+			--spectrum-body-cjk-line-height
+		);
+		--spectrum-assetcard-content-font-style: var(
+			--spectrum-body-cjk-font-style
+		);
+		--spectrum-assetcard-content-letter-spacing: var(
+			--spectrum-body-cjk-letter-spacing
+		);
+	}
+
+	/* Sizing on large/mobile */
+	.spectrum--large & {
+		--spectrum-assetcard-title-font-size: var(--spectrum-heading-size-xxs);
+		--spectrum-assetcard-header-content-font-size: var(--spectrum-body-size-s);
+		--spectrum-assetcard-content-font-size: var(--spectrum-body-size-xs);
+	}
 }
 
 /* the container for the asset (background, border, etc) */
 .spectrum-AssetCard-assetContainer {
-  /* contain overlay */
-  position: relative;
+	/* contain overlay */
+	position: relative;
 
-  display: flex;
-  align-items: center;
-  justify-content: center;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 
-  inline-size: var(--spectrum-assetcard-asset-size);
-  block-size: var(--spectrum-assetcard-asset-size);
+	min-inline-size: var(--spectrum-assetcard-minimum-size);
+	inline-size: var(--spectrum-assetcard-size);
 
-  border-radius: var(--spectrum-assetcard-border-radius);
+	min-block-size: var(--spectrum-assetcard-minimum-size);
+	block-size: var(--spectrum-assetcard-size);
 
-  background-color: var(--spectrum-assetcard-background-color);
+	border-radius: var(--spectrum-assetcard-border-radius);
 
-  transition: border var(--spectrum-global-animation-duration-100) ease-in-out;
+	background-color: var(--spectrum-assetcard-background-color);
 
-  /* focus indicator */
-  &::before {
-    content: '';
+	transition: border var(--spectrum-animation-duration-100) ease-in-out;
 
-    position: absolute;
-    inset: calc(-1 * var(--spectrum-assetcard-focus-ring-gap));
+	/* focus indicator */
+	&::before {
+		content: "";
 
-    border: var(--spectrum-alias-border-size-thick) solid var(--spectrum-alias-focus-color);
-    border-radius: var(--spectrum-assetcard-focus-ring-border-radius);
+		position: absolute;
+		inset: calc(-1 * var(--spectrum-assetcard-focus-ring-gap));
 
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity var(--spectrum-global-animation-duration-100) ease-in-out;
-  }
+		border: var(--spectrum-focus-indicator-thickness) solid
+			var(--spectrum-alias-focus-color);
+		border-radius: var(--spectrum-assetcard-focus-ring-border-radius);
 
-  /* border */
-  &::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    z-index: 3;
+		opacity: var(--spectrum-assetcard-focus-ring-opacity);
+		pointer-events: none;
+		transition: opacity var(--spectrum-animation-duration-100) ease-in-out;
+	}
 
-    border: var(--spectrum-alias-border-size-thin) solid var(--spectrum-assetcard-border-color);
-    border-radius: calc(var(--spectrum-assetcard-border-radius) - 1px);
-  }
+	/* border */
+	&::after {
+		content: "";
+		position: absolute;
+		inset: 0;
+		z-index: 3;
+
+		border: var(--spectrum-alias-border-size-thin) solid
+			var(--spectrum-assetcard-border-color);
+		border-radius: calc(var(--spectrum-assetcard-border-radius) - 1px);
+	}
 }
 
 /* the actual asset */
 .spectrum-AssetCard-asset {
-  object-fit: contain;
+	object-fit: contain;
 
-  inline-size: 100%;
-  block-size: 100%;
+	inline-size: 100%;
+	block-size: 100%;
 
-  transition: inline-size var(--spectrum-global-animation-duration-100) ease-in-out,
-              block-size var(--spectrum-global-animation-duration-100) ease-in-out;
+	transition: inline-size var(--spectrum-animation-duration-100) ease-in-out,
+		block-size var(--spectrum-animation-duration-100) ease-in-out;
 
-  border-radius: calc(var(--spectrum-assetcard-border-radius) - 1px);
+	border-radius: calc(var(--spectrum-assetcard-border-radius) - 1px);
 }
 
 /* header area, contains the header and optional content */
 .spectrum-AssetCard-header {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-
-  /* space between the asset and the header, place it on the header so header can be optional */
-  margin-block-start: var(--spectrum-global-dimension-static-size-200);
+	display: flex;
+	flex-direction: row;
+	align-items: center;
 }
 
 /* bold title */
 .spectrum-AssetCard-title {
-  flex-grow: 1;
+	flex-grow: 1;
 
-  color: var(--spectrum-assetcard-heading-text-color);
+	/* space between the asset and the header */
+	margin-block-start: var(--spectrum-text-to-visual-300);
 
-  /* be a XS heading, size wise */
-  font-family: var(--spectrum-heading-xs-text-font-family);
-  font-weight: var(--spectrum-heading-xs-text-font-weight);
-  font-size: var(--spectrum-heading-xs-text-size);
-  line-height: var(--spectrum-heading-xs-text-line-height);
-  font-style: var(--spectrum-heading-xs-text-font-style);
-  letter-spacing: var(--spectrum-heading-xs-text-letter-spacing);
-}
+	color: var(
+		--mod-assetcard-header-text-color,
+		var(--spectrum-assetcard-title-text-color)
+	);
 
-/* be a XXS heading on large/mobile */
-.spectrum--large .spectrum-AssetCard-title {
-  font-family: var(--spectrum-heading-xxs-text-font-family);
-  font-weight: var(--spectrum-heading-xxs-text-font-weight);
-  font-size: var(--spectrum-heading-xxs-text-size);
-  line-height: var(--spectrum-heading-xxs-text-line-height);
-  font-style: var(--spectrum-heading-xxs-text-font-style);
-  letter-spacing: var(--spectrum-heading-xxs-text-letter-spacing);
+	font-family: var(
+		--mod-assetcard-title-font-family,
+		var(--spectrum-assetcard-title-font-family)
+	);
+	font-weight: var(
+		--mod-assetcard-title-font-weight,
+		var(--spectrum-assetcard-title-font-weight)
+	);
+	font-size: var(
+		--mod-assetcard-title-font-size,
+		var(--spectrum-assetcard-title-font-size)
+	);
+	line-height: var(
+		--mod-assetcard-title-line-height,
+		var(--spectrum-assetcard-title-line-height)
+	);
+	font-style: var(
+		--mod-assetcard-title-font-style,
+		var(--spectrum-assetcard-title-font-style)
+	);
+	letter-spacing: var(
+		--mod-assetcard-title-letter-spacing,
+		var(--spectrum-assetcard-title-letter-spacing)
+	);
 }
 
 /* optional content placed to the right of the title */
 .spectrum-AssetCard-headerContent {
-  color: var(--spectrum-assetcard-heading-text-color);
+	color: var(
+		--mod-assetcard-header-content-text-color,
+		var(--spectrum-assetcard-header-content-text-color)
+	);
 
-  /* be a M body */
-  font-family: var(--spectrum-body-m-text-font-family);
-  font-size: var(--spectrum-body-m-text-size);
-  font-weight: var(--spectrum-body-m-text-font-weight);
-  line-height: var(--spectrum-body-m-text-line-height);
-  font-style: var(--spectrum-body-m-text-font-style);
-  letter-spacing: var(--spectrum-body-m-text-letter-spacing);
+	font-family: var(
+		--mod-assetcard-header-content-font-family,
+		var(--spectrum-assetcard-header-content-font-family)
+	);
+	font-weight: var(
+		--mod-assetcard-header-content-font-weight,
+		var(--spectrum-assetcard-header-content-font-weight)
+	);
+	font-size: var(
+		--mod-assetcard-header-content-font-size,
+		var(--spectrum-assetcard-header-content-font-size)
+	);
+	line-height: var(
+		--mod-assetcard-header-content-line-height,
+		var(--spectrum-assetcard-header-content-line-height)
+	);
+	font-style: var(
+		--mod-assetcard-header-content-font-style,
+		var(--spectrum-assetcard-header-content-font-style)
+	);
+	letter-spacing: var(
+		--mod-assetcard-header-content-letter-spacing,
+		var(--spectrum-assetcard-header-content-letter-spacing)
+	);
 }
-
-.spectrum--large .spectrum-AssetCard-headerContent {
-  /* be a S body */
-  font-family: var(--spectrum-body-s-text-font-family);
-  font-size: var(--spectrum-body-s-text-size);
-  font-weight: var(--spectrum-body-s-text-font-weight);
-  line-height: var(--spectrum-body-s-text-line-height);
-  font-style: var(--spectrum-body-s-text-font-style);
-  letter-spacing: var(--spectrum-body-s-text-letter-spacing);
-}
-
 
 /* content area, the last thing in the card */
 .spectrum-AssetCard-content {
-  flex-grow: 1;
+	flex-grow: 1;
 
-  /* space between the content and the header, place it on the content so content can be optional */
-  margin-block-start: var(--spectrum-global-dimension-static-size-50);
+	/* space between the content and the header */
+	margin-block-start: calc(
+		var(--spectrum-assetcard-title-font-size) *
+			var(--spectrum-heading-margin-bottom-multiplier)
+	);
 
-  color: var(--spectrum-assetcard-content-text-color);
-
-  /* be a S body, at least size-wise */
-  font-family: var(--spectrum-body-s-text-font-family);
-  font-size: var(--spectrum-body-s-text-size);
-  font-weight: var(--spectrum-body-s-text-font-weight);
-  line-height: var(--spectrum-body-s-text-line-height);
-  font-style: var(--spectrum-body-s-text-font-style);
-  letter-spacing: var(--spectrum-body-s-text-letter-spacing);
-}
-
-/* be a XS body on large/mobile */
-.spectrum--large .spectrum-AssetCard-content {
-  font-family: var(--spectrum-body-xs-text-font-family);
-  font-size: var(--spectrum-body-xs-text-size);
-  font-weight: var(--spectrum-body-xs-text-font-weight);
-  line-height: var(--spectrum-body-xs-text-line-height);
-  font-style: var(--spectrum-body-xs-text-font-style);
-  letter-spacing: var(--spectrum-body-xs-text-letter-spacing);
+	color: var(--spectrum-assetcard-content-text-color);
 }
 
 /*
   Selection styles
 */
 .spectrum-AssetCard-selectionOverlay {
-  position: absolute;
-  z-index: 1;
-  inset: 0;
+	position: absolute;
+	z-index: 1;
+	inset: 0;
 
-  background-color: transparent;
+	background-color: transparent;
 
-  pointer-events: none;
-  transition: background-color var(--spectrum-global-animation-duration-100) ease-in-out;
+	pointer-events: none;
+	transition: background-color var(--spectrum-animation-duration-100)
+		ease-in-out;
 
-  border-radius: calc(var(--spectrum-assetcard-border-radius) - 1px);
+	border-radius: calc(var(--spectrum-assetcard-border-radius) - 1px);
 }
 
 /* the checkbox or selection order indicator */
 .spectrum-AssetCard-selectionIndicator {
-  position: absolute;
-  z-index: 2;
-  inset-inline-start: var(--spectrum-assetcard-selectionindicator-margin);
-  inset-block-start: var(--spectrum-assetcard-selectionindicator-margin);
+	position: absolute;
+	z-index: 2;
+	inset-inline-start: var(--spectrum-assetcard-selectionindicator-margin);
+	inset-block-start: var(--spectrum-assetcard-selectionindicator-margin);
 
-  display: flex;
-  align-items: center;
-  justify-content: center;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 
-  inline-size: var(--spectrum-assetcard-selectionindicator-size);
-  block-size: var(--spectrum-assetcard-selectionindicator-size);
+	inline-size: var(--spectrum-assetcard-selectionindicator-size);
+	block-size: var(--spectrum-assetcard-selectionindicator-size);
 
-  border-radius: var(--spectrum-assetcard-selectionindicator-border-radius);
+	border-radius: var(--spectrum-assetcard-selectionindicator-border-radius);
 
-  box-shadow: 0 var(--spectrum-global-dimension-static-size-25) var(--spectrum-global-dimension-static-size-75) rgb(0, 0, 0, 0.15);
+	box-shadow: var(--spectrum-drop-shadow-x) var(--spectrum-drop-shadow-y)
+		var(--spectrum-drop-shadow-blur) var(--spectrum-drop-shadow-color);
 
-  color: var(--spectrum-global-color-static-white);
-  font-weight: var(--spectrum-global-font-weight-bold);
-  font-size: var(--spectrum-global-dimension-font-size-400);
+	color: var(--spectrum-gray-50);
+	font-weight: var(--spectrum-body-sans-serif-strong-font-style);
+	font-size: var(--spectrum-font-size-400);
 
-  visibility: hidden;
+	visibility: hidden;
 
-  opacity: 0;
-  transition: opacity var(--spectrum-global-animation-duration-100) ease-in-out;
+	opacity: 0;
+	transition: opacity var(--spectrum-animation-duration-100) ease-in-out;
 }
 
 .spectrum-AssetCard-selectionOrder {
-  line-height: 0;
+	line-height: 0;
 }
 
 /* base selection styles shared by every selection mode */
-  /* drop target looks identical to selected */
+/* drop target looks identical to selected */
 .spectrum-AssetCard.is-drop-target,
 .spectrum-AssetCard.is-selected {
-  .spectrum-AssetCard-assetContainer::after {
-    border-color: var(--spectrum-assetcard-border-color-selected);
-  }
+	.spectrum-AssetCard-assetContainer::after {
+		border-color: var(--spectrum-assetcard-border-color-selected);
+	}
 
-  .spectrum-AssetCard-selectionOverlay {
-    background-color: var(--spectrum-assetcard-overlay-background-color);
-  }
+	.spectrum-AssetCard-selectionOverlay {
+		background-color: var(--spectrum-assetcard-overlay-background-color);
+	}
 
-  &:hover {
-    .spectrum-AssetCard-assetContainer::after {
-      border-color: var(--spectrum-assetcard-border-color-selected-hover);
-    }
-  }
+	&:hover {
+		.spectrum-AssetCard-assetContainer::after {
+			border-color: var(--spectrum-assetcard-border-color-selected-hover);
+		}
+	}
 
-  &:active {
-    .spectrum-AssetCard-assetContainer::after {
-      border-color: var(--spectrum-assetcard-border-color-selected-down);
-    }
-  }
+	&:active {
+		.spectrum-AssetCard-assetContainer::after {
+			border-color: var(--spectrum-assetcard-border-color-selected-down);
+		}
+	}
 }
 
 /* highlight */
 .spectrum-AssetCard--highlightSelection {
-  &.is-selected {
-    .spectrum-AssetCard-asset {
-      inline-size: 90%;
-      block-size: 90%;
+	&.is-selected {
+		.spectrum-AssetCard-asset {
+			inline-size: 90%;
+			block-size: 90%;
 
-      /* no radius, otherwise square assets get rounded */
-      border-radius: 0;
-    }
-  }
+			/* no radius, otherwise square assets get rounded */
+			border-radius: 0;
+		}
+	}
 }
 
 /* with a checkbox */
 .spectrum-AssetCard--checkboxSelection {
-  .spectrum-AssetCard-selectionIndicator {
-    background-color: var(--spectrum-assetcard-selectionindicator-background-color-default);
+	.spectrum-AssetCard-selectionIndicator {
+		background-color: var(
+			--spectrum-assetcard-selectionindicator-background-color-default
+		);
 
-    .spectrum-AssetCard-selectionOrder {
-      display: none;
-    }
-  }
+		.spectrum-AssetCard-selectionOrder {
+			display: none;
+		}
+	}
 
-  &.is-selected,
-  &:focus,
-  &:hover {
-    .spectrum-AssetCard-selectionIndicator {
-      visibility: visible;
-      opacity: 1;
-      pointer-events: all;
-    }
-  }
+	&.is-selected,
+	&:focus,
+	&:hover {
+		.spectrum-AssetCard-selectionIndicator {
+			visibility: visible;
+			opacity: 1;
+			pointer-events: all;
+		}
+	}
 }
 
 /* with the little order flag that shows the selection order */
 .spectrum-AssetCard--orderedSelection {
-  .spectrum-AssetCard-selectionIndicator {
-    background-color: var(--spectrum-assetcard-selectionindicator-background-color-ordered);
+	.spectrum-AssetCard-selectionIndicator {
+		background-color: var(
+			--spectrum-assetcard-selectionindicator-background-color-ordered
+		);
 
-    .spectrum-AssetCard-checkbox {
-      display: none;
-    }
-  }
+		.spectrum-AssetCard-checkbox {
+			display: none;
+		}
+	}
 
-  &.is-selected {
-    .spectrum-AssetCard-selectionIndicator {
-      visibility: visible;
-      opacity: 1;
-      pointer-events: all;
-    }
-  }
+	&.is-selected {
+		.spectrum-AssetCard-selectionIndicator {
+			visibility: visible;
+			opacity: 1;
+			pointer-events: all;
+		}
+	}
 }

--- a/components/assetcard/metadata/mods.md
+++ b/components/assetcard/metadata/mods.md
@@ -1,0 +1,22 @@
+| Modifiable Custom Properties                    |
+| ----------------------------------------------- |
+| `--mod-assetcard-content-font-family`           |
+| `--mod-assetcard-content-font-size`             |
+| `--mod-assetcard-content-font-style`            |
+| `--mod-assetcard-content-font-weight`           |
+| `--mod-assetcard-content-letter-spacing`        |
+| `--mod-assetcard-content-line-height`           |
+| `--mod-assetcard-header-content-font-family`    |
+| `--mod-assetcard-header-content-font-size`      |
+| `--mod-assetcard-header-content-font-style`     |
+| `--mod-assetcard-header-content-font-weight`    |
+| `--mod-assetcard-header-content-letter-spacing` |
+| `--mod-assetcard-header-content-line-height`    |
+| `--mod-assetcard-header-content-text-color`     |
+| `--mod-assetcard-header-text-color`             |
+| `--mod-assetcard-title-font-family`             |
+| `--mod-assetcard-title-font-size`               |
+| `--mod-assetcard-title-font-style`              |
+| `--mod-assetcard-title-font-weight`             |
+| `--mod-assetcard-title-letter-spacing`          |
+| `--mod-assetcard-title-line-height`             |

--- a/components/assetcard/package.json
+++ b/components/assetcard/package.json
@@ -20,15 +20,13 @@
   "peerDependencies": {
     "@spectrum-css/checkbox": ">=7",
     "@spectrum-css/icon": ">=3",
-    "@spectrum-css/typography": ">=4 <=5",
-    "@spectrum-css/vars": ">=9"
+    "@spectrum-css/tokens": ">=11 <=12"
   },
   "devDependencies": {
     "@spectrum-css/checkbox": "^7.0.16",
-    "@spectrum-css/component-builder": "^4.0.14",
+    "@spectrum-css/component-builder-simple": "^2.0.17",
     "@spectrum-css/icon": "^4.0.3",
-    "@spectrum-css/typography": "^5.0.45",
-    "@spectrum-css/vars": "^9.0.8",
+    "@spectrum-css/tokens": "^12.0.0",
     "gulp": "^4.0.0"
   },
   "publishConfig": {

--- a/components/assetcard/themes/express.css
+++ b/components/assetcard/themes/express.css
@@ -1,0 +1,15 @@
+/*!
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+@container (--system: express) {
+
+}

--- a/components/assetcard/themes/spectrum.css
+++ b/components/assetcard/themes/spectrum.css
@@ -1,0 +1,15 @@
+/*!
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+@container (--system: spectrum) {
+
+}


### PR DESCRIPTION
## Description

Patching the assetcard diff during the build rework led to most of the properties being updated to @spectrum-css/tokens so I took the couple of extra steps to fully migrate it.

I thought we could possibly merge this separately so it has it's own distinct PR to reference later.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

<!--
  Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

### Regression testing

Validate:

1. A legacy documentation page (such as [accordion](https://pr-###--spectrum-css.netlify.app/accordion.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

2. A migrated documentation page (such as [action group](https://pr-###--spectrum-css.netlify.app/actiongroup.html)), including:

- [ ] The page renders correctly
- [ ] The page is accessible
- [ ] The page is responsive

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
