### PR TITLE
fix(opacitycheckerboard): align token version to latest release

### DIFF
--- a/components/opacitycheckerboard/package.json
+++ b/components/opacitycheckerboard/package.json
@@ -16,17 +16,15 @@
   "main": "dist/index-vars.css",
   "scripts": {
     "build": "gulp",
-    "clean": "rimraf dist",
-    "test": "nx test:scope @spectrum-css/previewopacitycheckerboard"
+    "clean": "rimraf dist"
   },
   "peerDependencies": {
-    "@spectrum-css/tokens": ">=10"
+    "@spectrum-css/tokens": ">=10 <=12"
   },
   "devDependencies": {
     "@spectrum-css/component-builder-simple": "^2.0.17",
-    "@spectrum-css/tokens": "^10.1.2",
+    "@spectrum-css/tokens": "^12.0.0",
     "gulp": "^4.0.0",
-    "nx": "^16.6.0",
     "rimraf": "^5.0.1"
   },
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2575,11 +2575,6 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/tokens/-/tokens-11.3.7.tgz#b4a32faa3febe1e0dc33a109e0ff5545a02bfac6"
   integrity sha512-WX0dPqwb2t9u9WBzIRzzYXL/ZJc0r/cSBb7eJxw1xCyg5NQnUKIhGtRT+cMTTCQP0SERFgCk9CZEJcJkZDphGw==
 
-"@spectrum-css/tokens@^10.1.2":
-  version "10.2.2"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/tokens/-/tokens-10.2.2.tgz#461697381575446542bbce8ae6d8ea948195ab3f"
-  integrity sha512-ljNXDPIJiS2q58dYn1EsXYF78gZaUCrLkOv8T8A5RBy/hM8fI85BghgiRkM0Dvsh87ej0juw3fO71Vkv3fuWlg==
-
 "@spectrum-css/underlay@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@spectrum-css/underlay/-/underlay-2.1.0.tgz#00a30d527d29e8e1ce1567765dab363738e16fb9"


### PR DESCRIPTION
## Description

Token version for opacitycheckerboard was out of sync causing an old version of tokens to be loaded as a dependency.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
