### PR TITLE
refactor(fieldlabel): form - replace table layout with grid

### DIFF
--- a/components/fieldgroup/metadata/fieldgroup.yml
+++ b/components/fieldgroup/metadata/fieldgroup.yml
@@ -25,8 +25,7 @@ examples:
       <div class="spectrum-Examples">
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Radio</h4>
-
-          <form class="spectrum-Form">
+          <form>
             <div class="spectrum-FieldGroup" role="radiogroup" aria-labelledby="radiogroup-label-1">
               <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="radiogroup-label-1">Radio Group Label</div>
 
@@ -53,8 +52,7 @@ examples:
 
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Radio</h4>
-
-          <form class="spectrum-Form">
+          <form>
             <div class="spectrum-FieldGroup spectrum-FieldGroup--toplabel spectrum-FieldGroup--vertical" role="radiogroup" aria-labelledby="radiogroup-label-1">
               <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="radiogroup-label-1">Radio Group Label</div>
 
@@ -81,8 +79,7 @@ examples:
 
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Checkbox</h4>
-
-          <form class="spectrum-Form">
+          <form>
             <div class="spectrum-FieldGroup spectrum-FieldGroup--toplabel spectrum-FieldGroup--vertical" role="group" aria-labelledby="checkboxgroup-label-1">
               <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="checkboxgroup-label-1">Checkbox Group Label</div>
 
@@ -124,8 +121,7 @@ examples:
       <div class="spectrum-Examples">
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Radio</h4>
-
-          <form class="spectrum-Form">
+          <form>
             <div class="spectrum-FieldGroup spectrum-FieldGroup--toplabel spectrum-FieldGroup--horizontal" role="radiogroup" aria-labelledby="radiogroup-label-2">
               <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="radiogroup-label-2">Radio Group Label</div>
 
@@ -152,8 +148,7 @@ examples:
 
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Checkbox</h4>
-
-          <form class="spectrum-Form">
+          <form>
             <div class="spectrum-FieldGroup spectrum-FieldGroup--toplabel spectrum-FieldGroup--horizontal" role="group" aria-labelledby="checkboxgroup-label-2">
               <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="checkboxgroup-label-2">Checkbox Group Label</div>
 
@@ -196,8 +191,7 @@ examples:
       <div class="spectrum-Examples">
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Radio</h4>
-
-          <form class="spectrum-Form">
+          <form>
             <div
               class="spectrum-FieldGroup spectrum-FieldGroup--toplabel spectrum-FieldGroup--horizontal"
               role="radiogroup"
@@ -233,8 +227,7 @@ examples:
 
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Checkbox</h4>
-
-          <form class="spectrum-Form">
+          <form>
             <div class="spectrum-FieldGroup spectrum-FieldGroup--toplabel spectrum-FieldGroup--horizontal" role="group" aria-labelledby="checkboxgroup-label-3">
               <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="checkboxgroup-label-3">Checkbox Group Label</div>
 
@@ -279,7 +272,7 @@ examples:
       <div class="spectrum-Examples">
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Required</h4>
-          <form class="spectrum-Form">
+          <form>
             <div class="spectrum-FieldGroup spectrum-FieldGroup--toplabel spectrum-FieldGroup--vertical" role="radiogroup" aria-labelledby="radiogroup-label-4">
               <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="radiogroup-label-4">Radio Group Label (required)</div>
 
@@ -306,7 +299,7 @@ examples:
 
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Required Asterisk</h4>
-          <form class="spectrum-Form">
+          <form>
             <div class="spectrum-FieldGroup spectrum-FieldGroup--toplabel spectrum-FieldGroup--vertical" role="radiogroup" aria-labelledby="radiogroup-label-5">
               <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="radiogroup-label-5">Radio Group Label
                 <svg class="spectrum-Icon spectrum-UIIcon-Asterisk100 spectrum-FieldLabel-requiredIcon" focusable="false" aria-hidden="true">
@@ -337,7 +330,7 @@ examples:
 
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Optional</h4>
-          <form class="spectrum-Form">
+          <form>
             <div class="spectrum-FieldGroup spectrum-FieldGroup--toplabel spectrum-FieldGroup--vertical" role="radiogroup" aria-labelledby="radiogroup-label-6">
               <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM" id="radiogroup-label-6">Radio Group Label (optional)</div>
 
@@ -366,8 +359,7 @@ examples:
 
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Side Label Vertical Radio</h4>
-
-          <form class="spectrum-Form">
+          <form>
             <div class="spectrum-FieldGroup spectrum-FieldGroup--sidelabel spectrum-FieldGroup--vertical" role="radiogroup" aria-labelledby="radiogroup-label-7">
               <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--right" id="radiogroup-label-7">Radio Group Label</div>
 
@@ -394,9 +386,8 @@ examples:
 
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Side Label Vertical Checkbox</h4>
-
-          <form class="spectrum-Form">
-            <div class="spectrum-FieldGroup spectrum-FieldGroup--sidelabel spectrum-FieldGroup--vertical" role="radiogroup" aria-labelledby="checkboxgroup-label-4">
+          <form>
+            <div class="spectrum-FieldGroup spectrum-FieldGroup--sidelabel spectrum-FieldGroup--vertical" role="group" aria-labelledby="checkboxgroup-label-4">
               <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--right" id="checkboxgroup-label-4">Checkbox Group Label</div>
 
               <div class="spectrum-FieldGroupInputLayout" aria-describedby="helptext-checkbox-4">
@@ -429,8 +420,7 @@ examples:
 
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Side Label Horizontal Radio</h4>
-
-          <form class="spectrum-Form">
+          <form>
             <div class="spectrum-FieldGroup spectrum-FieldGroup--sidelabel spectrum-FieldGroup--horizontal" role="radiogroup" aria-labelledby="radiogroup-label-8">
               <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--right" id="radiogroup-label-8">Radio Group Label</div>
 
@@ -457,9 +447,8 @@ examples:
           <hr>
 
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Side Label Horizontal Checkbox</h4>
-
-          <form class="spectrum-Form">
-            <div class="spectrum-FieldGroup spectrum-FieldGroup--sidelabel spectrum-FieldGroup--horizontal" role="radiogroup" aria-labelledby="checkboxgroup-label-5">
+          <form>
+            <div class="spectrum-FieldGroup spectrum-FieldGroup--sidelabel spectrum-FieldGroup--horizontal" role="group" aria-labelledby="checkboxgroup-label-5">
               <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--right" id="checkboxgroup-label-5">Checkbox Group Label</div>
 
               <div class="spectrum-FieldGroupInputLayout" aria-describedby="helptext-checkbox-5">

--- a/components/fieldlabel/index.css
+++ b/components/fieldlabel/index.css
@@ -82,16 +82,12 @@ governing permissions and limitations under the License.
 
   line-height: var(--mod-fieldlabel-line-height, var(--spectrum-fieldlabel-line-height));
 
-  vertical-align: top;
-
   -webkit-font-smoothing: subpixel-antialiased;
   -moz-osx-font-smoothing: auto;
 
   color: var(--spectrum-fieldlabel-color);
-}
 
-/* international lang support */
-.spectrum-FieldLabel {
+  /* CJK (Chinese, Japanese, and Korean) language support */
   &:lang(ja),
   &:lang(zh),
   &:lang(ko) {
@@ -108,6 +104,7 @@ governing permissions and limitations under the License.
 .spectrum-FieldLabel--left,
 .spectrum-FieldLabel--right {
   display: inline-block;
+  vertical-align: top;
   padding-block: var(--mod-fieldlabel-side-padding-top, var(--spectrum-fieldlabel-side-padding-top)) 0;
   padding-inline: 0 var(--mod-fieldlabel-side-padding-right, var(--spectrum-fieldlabel-side-padding-right));
 }
@@ -116,25 +113,37 @@ governing permissions and limitations under the License.
   text-align: end;
 }
 
-/* Form: two column alignment via display: table */
+/********* Form *********/
 .spectrum-Form {
   --spectrum-tableform-item-block-spacing: var(--spectrum-spacing-300);
-  --spectrum-tableform-border-spacing: 0 var(--mod-tableform-item-block-spacing, var(--spectrum-tableform-item-block-spacing));
-  --spectrum-tableform-margin: calc(var(--mod-tableform-item-block-spacing, var(--spectrum-tableform-item-block-spacing)) * -1) 0;
 
-  display: table;
-  border-collapse: separate;
-  border-spacing: var(--mod-tableform-border-spacing, var(--spectrum-tableform-border-spacing));
-  margin: var(--mod-tableform-margin, var(--spectrum-tableform-margin));
+  margin: 0;
+  display: grid;
+  grid-template-columns: var(--mod-form-grid-template-columns, auto auto);
+  inline-size: var(--mod-form-inline-size, fit-content);
+  justify-content: start;
+
+  /* @deprecation --mod-tableform-item-block-spacing has been renamed to
+     --mod-form-item-block-spacing. The fallback will be removed in a future version. */
+  row-gap: var(--mod-form-item-block-spacing, var(--mod-tableform-item-block-spacing, var(--spectrum-tableform-item-block-spacing)));
 }
 
+/* Row */
 .spectrum-Form-item {
-  display: table-row;
+  display: contents;
+}
+
+@supports(grid-template-columns: subgrid){
+  .spectrum-Form-item {
+    display: grid;
+    grid-column: span 2;
+    grid-template-columns: subgrid;
+  }
 }
 
 .spectrum-Form-itemLabel,
 .spectrum-Form-itemField {
-  display: table-cell;
+  display: block;
 }
 
 /* Fix extra space after inline-flex elements such as stepper. */
@@ -142,28 +151,19 @@ governing permissions and limitations under the License.
   vertical-align: top;
 }
 
-/* Form: stacked alignment via display: flex */
+/* Rows with stacked alignment */
 .spectrum-Form--labelsAbove {
-  --mod-tableform-margin: var(--mod-tableform-margin-labels-above, 0);
-  display: flex;
-  flex-direction: column;
+  /* @deprecation --mod-tableform-item-block-spacing-labels-above has been renamed to
+     --mod-form-item-block-spacing-labels-above. The fallback will be removed in a future version. */
+  --mod-form-item-block-spacing: var(--mod-form-item-block-spacing-labels-above, var(--mod-tableform-item-block-spacing-labels-above, var(--spectrum-spacing-200)));
+  --mod-form-grid-template-columns: var(--mod-form-grid-template-columns-labels-above, auto);
 
   .spectrum-Form-item {
-    display: flex;
-    flex-direction: column;
-
-    .spectrum-Form-itemLabel,
-    .spectrum-Form-itemField {
-      display: block;
-    }
-
-    & + .spectrum-Form-item {
-      margin-block-start: var(--mod-tableform-item-block-spacing-labels-above, var(--spectrum-spacing-200));
-    }
+    display: block;
   }
 }
 
-/* Disabled state */
+/********* Disabled state *********/
 .spectrum-FieldLabel,
 .spectrum-Form-itemLabel {
   &.is-disabled {

--- a/components/fieldlabel/metadata/form.yml
+++ b/components/fieldlabel/metadata/form.yml
@@ -18,7 +18,7 @@ examples:
           <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Form-itemLabel spectrum-FieldLabel--left" for="fieldLabelExample-emailaddress">Email Address</label>
           <div class="spectrum-Form-itemField">
             <div class="spectrum-Textfield">
-              <input class="spectrum-Textfield-input" aria-invalid="false" type="text" placeholder="Enter your e-mail address" id="fieldLabelExample-emailaddress">
+              <input class="spectrum-Textfield-input" aria-invalid="false" type="text" id="fieldLabelExample-emailaddress">
             </div>
           </div>
         </div>
@@ -65,7 +65,7 @@ examples:
           <div class="spectrum-Form-itemField">
             <div class="spectrum-Stepper">
               <div class="spectrum-Textfield spectrum-Stepper-textfield">
-                <input type="number" class="spectrum-Textfield-input spectrum-Stepper-input" placeholder="Enter a number" min="-2" max="2" step="0.5" id="fieldLabelExample-stepper">
+                <input type="number" class="spectrum-Textfield-input spectrum-Stepper-input" min="-2" max="2" step="0.5" id="fieldLabelExample-stepper">
               </div>
               <span class="spectrum-Stepper-buttons">
                 <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-Stepper-stepUp" tabindex="-1">
@@ -92,7 +92,7 @@ examples:
           <label for="fieldLabelExample-lifestory" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Form-itemLabel spectrum-FieldLabel--right">Company Title</label>
           <div class="spectrum-Form-itemField">
             <div class="spectrum-Textfield spectrum-Textfield--multiline">
-              <textarea id="fieldLabelExample-lifestory" placeholder="Enter your life story" name="field" class="spectrum-Textfield-input"></textarea>
+              <textarea id="fieldLabelExample-lifestory" name="field" class="spectrum-Textfield-input"></textarea>
             </div>
           </div>
         </div>
@@ -100,7 +100,7 @@ examples:
           <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Form-itemLabel spectrum-FieldLabel--right" for="fieldLabelExample-emailaddress">Email Address</label>
           <div class="spectrum-Form-itemField">
             <div class="spectrum-Textfield">
-              <input class="spectrum-Textfield-input" aria-invalid="false" type="text" placeholder="Enter your e-mail address" id="fieldLabelExample-emailaddress">
+              <input class="spectrum-Textfield-input" aria-invalid="false" type="text" id="fieldLabelExample-emailaddress">
             </div>
           </div>
         </div>
@@ -147,7 +147,7 @@ examples:
           <div class="spectrum-Form-itemField">
             <div class="spectrum-Stepper">
               <div class="spectrum-Textfield spectrum-Stepper-textfield">
-                <input type="number" class="spectrum-Textfield-input spectrum-Stepper-input" placeholder="Enter a number" min="-2" max="2" step="0.5" id="fieldLabelExample-stepper">
+                <input type="number" class="spectrum-Textfield-input spectrum-Stepper-input" min="-2" max="2" step="0.5" id="fieldLabelExample-stepper">
               </div>
               <span class="spectrum-Stepper-buttons">
                 <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-Stepper-stepUp" tabindex="-1">
@@ -174,7 +174,7 @@ examples:
           <label for="fieldLabelExample-lifestory" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Form-itemLabel">Company Title</label>
           <div class="spectrum-Form-itemField">
             <div class="spectrum-Textfield spectrum-Textfield--multiline">
-              <textarea id="fieldLabelExample-lifestory" placeholder="Enter your life story" name="field" class="spectrum-Textfield-input"></textarea>
+              <textarea id="fieldLabelExample-lifestory" name="field" class="spectrum-Textfield-input"></textarea>
             </div>
           </div>
         </div>
@@ -182,7 +182,7 @@ examples:
           <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Form-itemLabel" for="fieldLabelExample-emailaddress">Email Address</label>
           <div class="spectrum-Form-itemField">
             <div class="spectrum-Textfield">
-              <input class="spectrum-Textfield-input" aria-invalid="false" type="text" placeholder="Enter your e-mail address" id="fieldLabelExample-emailaddress">
+              <input class="spectrum-Textfield-input" aria-invalid="false" type="text" id="fieldLabelExample-emailaddress">
             </div>
           </div>
         </div>
@@ -229,7 +229,7 @@ examples:
           <div class="spectrum-Form-itemField">
             <div class="spectrum-Stepper">
               <div class="spectrum-Textfield spectrum-Stepper-textfield">
-                <input type="number" class="spectrum-Textfield-input spectrum-Stepper-input" placeholder="Enter a number" min="-2" max="2" step="0.5" id="fieldLabelExample-stepper">
+                <input type="number" class="spectrum-Textfield-input spectrum-Stepper-input" min="-2" max="2" step="0.5" id="fieldLabelExample-stepper">
               </div>
               <span class="spectrum-Stepper-buttons">
                 <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-Stepper-stepUp" tabindex="-1">

--- a/components/fieldlabel/metadata/form.yml
+++ b/components/fieldlabel/metadata/form.yml
@@ -23,9 +23,9 @@ examples:
           </div>
         </div>
         <div class="spectrum-Form-item">
-          <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Form-itemLabel spectrum-FieldLabel--left">Country</div>
+          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Form-itemLabel spectrum-FieldLabel--left" for="fieldLabelExample-country-1">Country</label>
           <div class="spectrum-Form-itemField">
-            <button type="button" class="spectrum-Picker spectrum-Picker--sizeM" aria-haspopup="listbox">
+            <button type="button" class="spectrum-Picker spectrum-Picker--sizeM" aria-haspopup="listbox" id="fieldLabelExample-country-1">
               <span class="spectrum-Picker-label is-placeholder">Select a Country</span>
               <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
                 <use xlink:href="#spectrum-css-icon-Chevron100" />
@@ -109,9 +109,9 @@ examples:
           </div>
         </div>
         <div class="spectrum-Form-item">
-          <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Form-itemLabel spectrum-FieldLabel--right">Country</div>
+          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Form-itemLabel spectrum-FieldLabel--right" for="fieldLabelExample-country-2">Country</label>
           <div class="spectrum-Form-itemField">
-            <button type="button" class="spectrum-Picker spectrum-Picker--sizeM" aria-haspopup="listbox">
+            <button type="button" class="spectrum-Picker spectrum-Picker--sizeM" aria-haspopup="listbox" id="fieldLabelExample-country-2">
               <span class="spectrum-Picker-label is-placeholder">Select a Country</span>
               <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
                 <use xlink:href="#spectrum-css-icon-Chevron100" />
@@ -195,9 +195,9 @@ examples:
           </div>
         </div>
         <div class="spectrum-Form-item">
-          <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Form-itemLabel">Country</div>
+          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Form-itemLabel" for="fieldLabelExample-country-3">Country</label>
           <div class="spectrum-Form-itemField">
-            <button type="button" class="spectrum-Picker spectrum-Picker--sizeM" aria-haspopup="listbox">
+            <button type="button" class="spectrum-Picker spectrum-Picker--sizeM" aria-haspopup="listbox" id="fieldLabelExample-country-3">
               <span class="spectrum-Picker-label is-placeholder">Select a Country</span>
               <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
                 <use xlink:href="#spectrum-css-icon-Chevron100" />

--- a/components/fieldlabel/metadata/form.yml
+++ b/components/fieldlabel/metadata/form.yml
@@ -7,25 +7,25 @@ examples:
     markup: |
       <form class="spectrum-Form">
         <div class="spectrum-Form-item">
-          <label for="fieldLabelExample-lifestory" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Form-itemLabel spectrum-FieldLabel--left">Company Title</label>
+          <label for="fieldLabelExample-company-1" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Form-itemLabel spectrum-FieldLabel--left">Company Title</label>
           <div class="spectrum-Form-itemField">
             <div class="spectrum-Textfield spectrum-Textfield--multiline">
-              <textarea id="fieldLabelExample-lifestory" placeholder="Enter your life story" name="field" class="spectrum-Textfield-input"></textarea>
+              <textarea id="fieldLabelExample-company-1" name="field" class="spectrum-Textfield-input"></textarea>
             </div>
           </div>
         </div>
         <div class="spectrum-Form-item">
-          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Form-itemLabel spectrum-FieldLabel--left" for="fieldLabelExample-emailaddress">Email Address</label>
+          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Form-itemLabel spectrum-FieldLabel--left" for="fieldLabelExample-emailaddress-1">Email Address</label>
           <div class="spectrum-Form-itemField">
             <div class="spectrum-Textfield">
-              <input class="spectrum-Textfield-input" aria-invalid="false" type="text" id="fieldLabelExample-emailaddress">
+              <input class="spectrum-Textfield-input" aria-invalid="false" type="text" id="fieldLabelExample-emailaddress-1">
             </div>
           </div>
         </div>
         <div class="spectrum-Form-item">
-          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Form-itemLabel spectrum-FieldLabel--left" for="spectrum-textinput-instance">Country</label>
+          <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Form-itemLabel spectrum-FieldLabel--left">Country</div>
           <div class="spectrum-Form-itemField">
-            <button class="spectrum-Picker spectrum-Picker--sizeM" aria-haspopup="true">
+            <button type="button" class="spectrum-Picker spectrum-Picker--sizeM" aria-haspopup="listbox">
               <span class="spectrum-Picker-label is-placeholder">Select a Country</span>
               <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
                 <use xlink:href="#spectrum-css-icon-Chevron100" />
@@ -39,7 +39,7 @@ examples:
           <div class="spectrum-Form-itemField">
             <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical">
               <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
-                <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-0">
+                <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-1-0">
                 <span class="spectrum-Checkbox-box">
                   <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
                     <use xlink:href="#spectrum-css-icon-Checkmark100" />
@@ -48,7 +48,7 @@ examples:
                 <span class="spectrum-Checkbox-label">Kittens</span>
               </label>
               <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
-                <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-1" checked>
+                <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-1-1" checked>
                 <span class="spectrum-Checkbox-box">
                   <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
                     <use xlink:href="#spectrum-css-icon-Checkmark100" />
@@ -61,24 +61,28 @@ examples:
         </div>
 
         <div class="spectrum-Form-item">
-          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Form-itemLabel spectrum-FieldLabel--left" for="fieldLabelExample-stepper">Age</label>
+          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Form-itemLabel spectrum-FieldLabel--left" for="fieldLabelExample-stepper-1">Age</label>
           <div class="spectrum-Form-itemField">
             <div class="spectrum-Stepper">
               <div class="spectrum-Textfield spectrum-Stepper-textfield">
-                <input type="number" class="spectrum-Textfield-input spectrum-Stepper-input" min="-2" max="2" step="0.5" id="fieldLabelExample-stepper">
+                <input type="number" class="spectrum-Textfield-input spectrum-Stepper-input" min="-2" max="2" step="0.5" id="fieldLabelExample-stepper-1">
               </div>
-              <span class="spectrum-Stepper-buttons">
-                <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-Stepper-stepUp" tabindex="-1">
-                  <svg class="spectrum-Icon spectrum-UIIcon-ChevronUp75 spectrum-Stepper-stepUpIcon" focusable="false" aria-hidden="true">
-                    <use xlink:href="#spectrum-css-icon-Chevron75" />
-                  </svg>
+              <div class="spectrum-Stepper-buttons">
+                <button type="button" class="spectrum-InfieldButton spectrum-InfieldButton--top spectrum-Stepper-button" aria-haspopup="listbox" aria-label="Add">
+                  <div class="spectrum-InfieldButton-fill">
+                    <svg class="spectrum-Icon spectrum-UIIcon-ChevronUp75 spectrum-InfieldButton-icon" focusable="false" aria-hidden="true">
+                        <use xlink:href="#spectrum-css-icon-Chevron75" />
+                      </svg>
+                  </div>
                 </button>
-                <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-Stepper-stepDown" tabindex="-1">
-                  <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown75 spectrum-Stepper-stepDownIcon" focusable="false" aria-hidden="true">
-                    <use xlink:href="#spectrum-css-icon-Chevron75" />
-                  </svg>
+                <button type="button" class="spectrum-InfieldButton spectrum-InfieldButton--bottom spectrum-Stepper-button" aria-haspopup="listbox" aria-label="Add">
+                  <div class="spectrum-InfieldButton-fill">
+                    <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown75 spectrum-InfieldButton-icon" focusable="false" aria-hidden="true">
+                      <use xlink:href="#spectrum-css-icon-Chevron75" />
+                    </svg>
+                  </div>
                 </button>
-              </span>
+              </div>
             </div>
           </div>
         </div>
@@ -89,25 +93,25 @@ examples:
     markup: |
       <form class="spectrum-Form">
         <div class="spectrum-Form-item">
-          <label for="fieldLabelExample-lifestory" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Form-itemLabel spectrum-FieldLabel--right">Company Title</label>
+          <label for="fieldLabelExample-company-2" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Form-itemLabel spectrum-FieldLabel--right">Company Title</label>
           <div class="spectrum-Form-itemField">
             <div class="spectrum-Textfield spectrum-Textfield--multiline">
-              <textarea id="fieldLabelExample-lifestory" name="field" class="spectrum-Textfield-input"></textarea>
+              <textarea id="fieldLabelExample-company-2" name="field" class="spectrum-Textfield-input"></textarea>
             </div>
           </div>
         </div>
         <div class="spectrum-Form-item">
-          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Form-itemLabel spectrum-FieldLabel--right" for="fieldLabelExample-emailaddress">Email Address</label>
+          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Form-itemLabel spectrum-FieldLabel--right" for="fieldLabelExample-emailaddress-2">Email Address</label>
           <div class="spectrum-Form-itemField">
             <div class="spectrum-Textfield">
-              <input class="spectrum-Textfield-input" aria-invalid="false" type="text" id="fieldLabelExample-emailaddress">
+              <input class="spectrum-Textfield-input" aria-invalid="false" type="text" id="fieldLabelExample-emailaddress-2">
             </div>
           </div>
         </div>
         <div class="spectrum-Form-item">
-          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Form-itemLabel spectrum-FieldLabel--right" for="spectrum-textinput-instance">Country</label>
+          <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Form-itemLabel spectrum-FieldLabel--right">Country</div>
           <div class="spectrum-Form-itemField">
-            <button class="spectrum-Picker spectrum-Picker--sizeM" aria-haspopup="true">
+            <button type="button" class="spectrum-Picker spectrum-Picker--sizeM" aria-haspopup="listbox">
               <span class="spectrum-Picker-label is-placeholder">Select a Country</span>
               <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
                 <use xlink:href="#spectrum-css-icon-Chevron100" />
@@ -121,7 +125,7 @@ examples:
           <div class="spectrum-Form-itemField">
             <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical">
               <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
-                <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-0">
+                <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-2-0">
                 <span class="spectrum-Checkbox-box">
                   <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
                     <use xlink:href="#spectrum-css-icon-Checkmark100" />
@@ -130,7 +134,7 @@ examples:
                 <span class="spectrum-Checkbox-label">Kittens</span>
               </label>
               <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
-                <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-1" checked>
+                <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-2-1" checked>
                 <span class="spectrum-Checkbox-box">
                   <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
                     <use xlink:href="#spectrum-css-icon-Checkmark100" />
@@ -143,24 +147,28 @@ examples:
         </div>
 
         <div class="spectrum-Form-item">
-          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Form-itemLabel spectrum-FieldLabel--right" for="fieldLabelExample-stepper">Age</label>
+          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Form-itemLabel spectrum-FieldLabel--right" for="fieldLabelExample-stepper-2">Age</label>
           <div class="spectrum-Form-itemField">
             <div class="spectrum-Stepper">
               <div class="spectrum-Textfield spectrum-Stepper-textfield">
-                <input type="number" class="spectrum-Textfield-input spectrum-Stepper-input" min="-2" max="2" step="0.5" id="fieldLabelExample-stepper">
+                <input type="number" class="spectrum-Textfield-input spectrum-Stepper-input" min="-2" max="2" step="0.5" id="fieldLabelExample-stepper-2">
               </div>
-              <span class="spectrum-Stepper-buttons">
-                <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-Stepper-stepUp" tabindex="-1">
-                  <svg class="spectrum-Icon spectrum-UIIcon-ChevronUp75 spectrum-Stepper-stepUpIcon" focusable="false" aria-hidden="true">
-                    <use xlink:href="#spectrum-css-icon-Chevron75" />
-                  </svg>
+              <div class="spectrum-Stepper-buttons">
+                <button type="button" class="spectrum-InfieldButton spectrum-InfieldButton--top spectrum-Stepper-button" aria-haspopup="listbox" aria-label="Add">
+                  <div class="spectrum-InfieldButton-fill">
+                    <svg class="spectrum-Icon spectrum-UIIcon-ChevronUp75 spectrum-InfieldButton-icon" focusable="false" aria-hidden="true">
+                        <use xlink:href="#spectrum-css-icon-Chevron75" />
+                      </svg>
+                  </div>
                 </button>
-                <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-Stepper-stepDown" tabindex="-1">
-                  <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown75 spectrum-Stepper-stepDownIcon" focusable="false" aria-hidden="true">
-                    <use xlink:href="#spectrum-css-icon-Chevron75" />
-                  </svg>
+                <button type="button" class="spectrum-InfieldButton spectrum-InfieldButton--bottom spectrum-Stepper-button" aria-haspopup="listbox" aria-label="Add">
+                  <div class="spectrum-InfieldButton-fill">
+                    <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown75 spectrum-InfieldButton-icon" focusable="false" aria-hidden="true">
+                      <use xlink:href="#spectrum-css-icon-Chevron75" />
+                    </svg>
+                  </div>
                 </button>
-              </span>
+              </div>
             </div>
           </div>
         </div>
@@ -171,25 +179,25 @@ examples:
     markup: |
       <form class="spectrum-Form spectrum-Form--labelsAbove">
         <div class="spectrum-Form-item">
-          <label for="fieldLabelExample-lifestory" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Form-itemLabel">Company Title</label>
+          <label for="fieldLabelExample-company-3" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Form-itemLabel">Company Title</label>
           <div class="spectrum-Form-itemField">
             <div class="spectrum-Textfield spectrum-Textfield--multiline">
-              <textarea id="fieldLabelExample-lifestory" name="field" class="spectrum-Textfield-input"></textarea>
+              <textarea id="fieldLabelExample-company-3" name="field" class="spectrum-Textfield-input"></textarea>
             </div>
           </div>
         </div>
         <div class="spectrum-Form-item">
-          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Form-itemLabel" for="fieldLabelExample-emailaddress">Email Address</label>
+          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Form-itemLabel" for="fieldLabelExample-emailaddress-3">Email Address</label>
           <div class="spectrum-Form-itemField">
             <div class="spectrum-Textfield">
-              <input class="spectrum-Textfield-input" aria-invalid="false" type="text" id="fieldLabelExample-emailaddress">
+              <input class="spectrum-Textfield-input" aria-invalid="false" type="text" id="fieldLabelExample-emailaddress-3">
             </div>
           </div>
         </div>
         <div class="spectrum-Form-item">
-          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Form-itemLabel" for="spectrum-textinput-instance">Country</label>
+          <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Form-itemLabel">Country</div>
           <div class="spectrum-Form-itemField">
-            <button class="spectrum-Picker spectrum-Picker--sizeM" aria-haspopup="true">
+            <button type="button" class="spectrum-Picker spectrum-Picker--sizeM" aria-haspopup="listbox">
               <span class="spectrum-Picker-label is-placeholder">Select a Country</span>
               <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
                 <use xlink:href="#spectrum-css-icon-Chevron100" />
@@ -203,7 +211,7 @@ examples:
           <div class="spectrum-Form-itemField">
             <div class="spectrum-FieldGroup spectrum-FieldGroup--vertical" id="checkboxgroup-label-3">
               <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
-                <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-0">
+                <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-3-0">
                 <span class="spectrum-Checkbox-box">
                   <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
                     <use xlink:href="#spectrum-css-icon-Checkmark100" />
@@ -212,7 +220,7 @@ examples:
                 <span class="spectrum-Checkbox-label">Kittens</span>
               </label>
               <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
-                <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-1" checked>
+                <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-3-1" checked>
                 <span class="spectrum-Checkbox-box">
                   <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
                     <use xlink:href="#spectrum-css-icon-Checkmark100" />
@@ -225,24 +233,28 @@ examples:
         </div>
 
         <div class="spectrum-Form-item">
-          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Form-itemLabel" for="fieldLabelExample-stepper">Age</label>
+          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Form-itemLabel" for="fieldLabelExample-stepper-3">Age</label>
           <div class="spectrum-Form-itemField">
             <div class="spectrum-Stepper">
               <div class="spectrum-Textfield spectrum-Stepper-textfield">
-                <input type="number" class="spectrum-Textfield-input spectrum-Stepper-input" min="-2" max="2" step="0.5" id="fieldLabelExample-stepper">
+                <input type="number" class="spectrum-Textfield-input spectrum-Stepper-input" min="-2" max="2" step="0.5" id="fieldLabelExample-stepper-3">
               </div>
-              <span class="spectrum-Stepper-buttons">
-                <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-Stepper-stepUp" tabindex="-1">
-                  <svg class="spectrum-Icon spectrum-UIIcon-ChevronUp75 spectrum-Stepper-stepUpIcon" focusable="false" aria-hidden="true">
-                    <use xlink:href="#spectrum-css-icon-Chevron75" />
-                  </svg>
+              <div class="spectrum-Stepper-buttons">
+                <button type="button" class="spectrum-InfieldButton spectrum-InfieldButton--top spectrum-Stepper-button" aria-haspopup="listbox" aria-label="Add">
+                  <div class="spectrum-InfieldButton-fill">
+                    <svg class="spectrum-Icon spectrum-UIIcon-ChevronUp75 spectrum-InfieldButton-icon" focusable="false" aria-hidden="true">
+                        <use xlink:href="#spectrum-css-icon-Chevron75" />
+                      </svg>
+                  </div>
                 </button>
-                <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-Stepper-stepDown" tabindex="-1">
-                  <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown75 spectrum-Stepper-stepDownIcon" focusable="false" aria-hidden="true">
-                    <use xlink:href="#spectrum-css-icon-Chevron75" />
-                  </svg>
+                <button type="button" class="spectrum-InfieldButton spectrum-InfieldButton--bottom spectrum-Stepper-button" aria-haspopup="listbox" aria-label="Add">
+                  <div class="spectrum-InfieldButton-fill">
+                    <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown75 spectrum-InfieldButton-icon" focusable="false" aria-hidden="true">
+                      <use xlink:href="#spectrum-css-icon-Chevron75" />
+                    </svg>
+                  </div>
                 </button>
-              </span>
+              </div>
             </div>
           </div>
         </div>

--- a/components/fieldlabel/metadata/mods.md
+++ b/components/fieldlabel/metadata/mods.md
@@ -12,8 +12,10 @@
 | `--mod-fieldlabel-min-height`                     |
 | `--mod-fieldlabel-side-padding-right`             |
 | `--mod-fieldlabel-side-padding-top`               |
-| `--mod-tableform-border-spacing`                  |
+| `--mod-form-grid-template-columns`                |
+| `--mod-form-grid-template-columns-labels-above`   |
+| `--mod-form-inline-size`                          |
+| `--mod-form-item-block-spacing`                   |
+| `--mod-form-item-block-spacing-labels-above`      |
 | `--mod-tableform-item-block-spacing`              |
 | `--mod-tableform-item-block-spacing-labels-above` |
-| `--mod-tableform-margin`                          |
-| `--mod-tableform-margin-labels-above`             |

--- a/components/fieldlabel/stories/form-template.js
+++ b/components/fieldlabel/stories/form-template.js
@@ -79,7 +79,7 @@ export const Template = ({
             <div class="spectrum-Form-item">
                 ${FieldLabel({
                     label: 'Amount',
-                    forInput: 'form-example-amount',
+                    forInput: 'form-example-amount-input',
                     alignment: labelsAbove ? undefined : 'left',
                 })}
                 <div class="spectrum-Form-itemField">

--- a/components/fieldlabel/stories/form-template.js
+++ b/components/fieldlabel/stories/form-template.js
@@ -1,12 +1,11 @@
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
-import { styleMap } from "lit/directives/style-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
 import { Template as FieldLabel } from "@spectrum-css/fieldlabel/stories/template.js";
-import { Template as TextField } from "@spectrum-css/textfield/stories/template.js";
 import { Template as Picker } from "@spectrum-css/picker/stories/template.js";
 import { Template as Stepper } from "@spectrum-css/stepper/stories/template.js";
+import { Template as TextField } from "@spectrum-css/textfield/stories/template.js";
 
 import "../index.css";
 
@@ -44,7 +43,6 @@ export const Template = ({
                 <div class="spectrum-Form-itemField">
                     ${TextField({  
                         multiline: true,
-                        placeholder: 'Enter your company name',
                         name: 'field',
                         id: 'form-example-company',
                     })}
@@ -57,8 +55,7 @@ export const Template = ({
                     alignment: labelsAbove ? undefined : 'left',
                 })}
                 <div class="spectrum-Form-itemField">
-                    ${TextField({  
-                        placeholder: 'Enter your email address',
+                    ${TextField({
                         name: 'email',
                         type: 'email',
                         id: 'form-example-email',


### PR DESCRIPTION
## Description

### Use CSS grid in Form component
Refactors `.spectrum-Form` (which currently exists within the FieldLabel component) to modernize its layout. This changes the display to use CSS `grid` instead of `table`, which helps get rid of the need for negative margins and different ways of handling spacing between the two variants. 

### Mod property Changes
Deprecates some Form --mod properties:
- `--mod-tableform-border-spacing` has been renamed to `--mod-form-item-block-spacing` and has a temporary fallback for the old name.
- `--mod-tableform-item-block-spacing-labels-above` has been renamed to `--mod-form-item-block-spacing-labels-above` and has a temporary fallback for the old name.
- `--mod-tableform-margin`
- `--mod-tableform-margin-labels-above`

Additional mods have been added for modifying the size of the the grid tracks.

### Docs updates
**FieldGroup**: Removes the `.spectrum-Form` class from the Field group examples, as this currently is not being used for alignment or with the correct markup for Form (e.g. there is no .spectrumForm-item used, etc). It is not needed here  to demonstrate the Field group markup and CSS, which has its own flex alignment used.

**Form**: General cleanup of the example docs, including
 - Use updated component markup for Stepper
 - Use updated component markup for Picker
 - Replace duplicate IDs with unique IDs

CSS-591

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [x] Form in the docs site still has the same spacing and layout as production (Chrome, FF, Safari, and Edge). _There will be a slight improvement in the appearance of Stepper, as its markup was previously outdated._
- [x] Form in Storybook still has the same spacing.
- [x] Confirm that Field group docs examples look the same as production.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
