### PR TITLE
feat(backgroundlayers): class based implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,3 +395,7 @@ Occasionally, you may want to run a prerelease for an individual package and ski
 - You **must** run a build **before** continuing with the prerelease. An npm task for cleaning, building, and beta publishing is available, and it can be run via the following command: `yarn release:beta-from-package`. This command will perform a full `clean` (via the `clean` task), a full `build` (via the `build` task), and will attempt to publish the package (via `lerna publish --conventional-prerelease --preid beta --pre-dist-tag beta --no-private`).
 - Depending on the severity of your change(s), and before publishing to npm, Lerna should show a preview of the affected package version number that looks something like: `@spectrum-css/switch: 1.0.23 => 2.0.0-beta.0`. Additionally, at this time, Lerna will ask if you would like to continue with publishing the changes or cancel.
 - Selecting `y` to publish will publish the affected package(s) to npm.
+
+## Spectrum 2
+
+More information coming soon!

--- a/components/alertdialog/metadata/alertdialog.yml
+++ b/components/alertdialog/metadata/alertdialog.yml
@@ -8,7 +8,7 @@ examples:
     markup: |
       <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--outline spectrum-Button--staticWhite spectrum-CSSExample-overlayShowButton" onclick="openDialog(this.nextElementSibling)"><span class="spectrum-Button-label">Open Alert Dialog</span></button>
       <div class="spectrum-Modal-wrapper spectrum-CSSExample-dialog">
-        <div class="spectrum-Modal is-open" data-testid="modal">
+        <div class="spectrum-Modal is-open spectrum-BackgroundLayers--elevated" data-testid="modal">
           <section class="spectrum-AlertDialog spectrum-AlertDialog--confirmation" role="dialog" tabindex="-1" aria-modal="true" aria-labelledby="dialog_label">
             <div class="spectrum-AlertDialog-grid">
               <h1 class="spectrum-AlertDialog-heading" id="dialog_label">Enable Smart Filters?</h1>
@@ -34,7 +34,7 @@ examples:
       <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--outline spectrum-Button--staticWhite spectrum-CSSExample-overlayShowButton" onclick="openDialog(this.nextElementSibling)"><span class="spectrum-Button-label">Open Alert Dialog</span></button>
 
       <div class="spectrum-Modal-wrapper spectrum-CSSExample-dialog">
-        <div class="spectrum-Modal is-open" data-testid="modal">
+        <div class="spectrum-Modal is-open spectrum-BackgroundLayers--elevated" data-testid="modal">
           <section class="spectrum-AlertDialog spectrum-AlertDialog--information" role="dialog" tabindex="-1" aria-modal="true" aria-labelledby="dialog_label">
             <div class="spectrum-AlertDialog-grid">
               <h1 class="spectrum-AlertDialog-heading" id="dialog_label">Connect to wifi</h1>
@@ -60,7 +60,7 @@ examples:
       <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--outline spectrum-Button--staticWhite spectrum-CSSExample-overlayShowButton" onclick="openDialog(this.nextElementSibling)"><span class="spectrum-Button-label">Open Alert Dialog</span></button>
 
       <div class="spectrum-Modal-wrapper spectrum-CSSExample-dialog">
-        <div class="spectrum-Modal is-open" data-testid="modal">
+        <div class="spectrum-Modal is-open spectrum-BackgroundLayers--elevated" data-testid="modal">
           <section class="spectrum-AlertDialog spectrum-AlertDialog--warning" role="dialog" tabindex="-1" aria-modal="true" aria-labelledby="dialog_label">
             <div class="spectrum-AlertDialog-grid">
             <div class="spectrum-AlertDialog-header">
@@ -92,7 +92,7 @@ examples:
       <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--outline spectrum-Button--staticWhite spectrum-CSSExample-overlayShowButton" onclick="openDialog(this.nextElementSibling)"><span class="spectrum-Button-label">Open Alert Dialog</span></button>
 
       <div class="spectrum-Modal-wrapper spectrum-CSSExample-dialog">
-        <div class="spectrum-Modal spectrum-AlertDialog-modal is-open" data-testid="modal">
+        <div class="spectrum-Modal spectrum-AlertDialog-modal is-open spectrum-BackgroundLayers--elevated" data-testid="modal">
           <section class="spectrum-AlertDialog spectrum-AlertDialog--error"  role="dialog" tabindex="-1" aria-modal="true" aria-labelledby="dialog_label">
             <div class="spectrum-AlertDialog-grid">
               <div class="spectrum-AlertDialog-header">
@@ -120,7 +120,7 @@ examples:
       <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--outline spectrum-Button--staticWhite spectrum-CSSExample-overlayShowButton" onclick="openDialog(this.nextElementSibling)"><span class="spectrum-Button-label">Open Alert Dialog</span></button>
 
       <div class="spectrum-Modal-wrapper spectrum-CSSExample-dialog">
-        <div class="spectrum-Modal is-open" data-testid="modal">
+        <div class="spectrum-Modal is-open spectrum-BackgroundLayers--elevated" data-testid="modal">
           <section class="spectrum-AlertDialog spectrum-AlertDialog--destructive" role="dialog" tabindex="-1" aria-modal="true" aria-labelledby="dialog_label">
             <div class="spectrum-AlertDialog-grid">
               <div class="spectrum-AlertDialog-header">
@@ -149,7 +149,7 @@ examples:
       <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--outline spectrum-Button--staticWhite spectrum-CSSExample-overlayShowButton" onclick="openDialog(this.nextElementSibling)"><span class="spectrum-Button-label">Open Alert Dialog</span></button>
 
       <div class="spectrum-Modal-wrapper spectrum-CSSExample-dialog">
-        <div class="spectrum-Modal is-open" data-testid="modal">
+        <div class="spectrum-Modal is-open spectrum-BackgroundLayers--elevated" data-testid="modal">
           <section class="spectrum-AlertDialog spectrum-AlertDialog--information" role="dialog" tabindex="-1" aria-modal="true" aria-labelledby="dialog_label">
             <div class="spectrum-AlertDialog-grid">
               <h1 class="spectrum-AlertDialog-heading" id="dialog_label">Rate this app</h1>
@@ -177,7 +177,7 @@ examples:
       <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--outline spectrum-Button--staticWhite spectrum-CSSExample-overlayShowButton" onclick="openDialog(this.nextElementSibling)"><span class="spectrum-Button-label">Open Alert Dialog</span></button>
 
       <div class="spectrum-Modal-wrapper spectrum-CSSExample-dialog">
-        <div class="spectrum-Modal is-open" data-testid="modal">
+        <div class="spectrum-Modal is-open spectrum-BackgroundLayers--elevated" data-testid="modal">
           <section class="spectrum-AlertDialog spectrum-AlertDialog--information" role="dialog" tabindex="-1" aria-modal="true" aria-labelledby="dialog_label">
             <div class="spectrum-AlertDialog-grid">
               <h1 class="spectrum-AlertDialog-heading" id="dialog_label">Lorem Ipsum</h1>

--- a/components/alertdialog/package.json
+++ b/components/alertdialog/package.json
@@ -20,6 +20,7 @@
   },
   "peerDependencies": {
     "@spectrum-css/button": ">=11",
+    "@spectrum-css/backgroundlayers": ">=1",,
     "@spectrum-css/buttongroup": ">=6",
     "@spectrum-css/divider": ">=1 <=2",
     "@spectrum-css/icon": ">=4",
@@ -36,6 +37,7 @@
     "@spectrum-css/modal": "^4.0.4",
     "@spectrum-css/tokens": "^13.0.5",
     "@spectrum-css/underlay": "^3.0.12",
+    "@spectrum-css/backgroundlayers": "^1.0.0-alpha.0",
     "gulp": "^4.0.0"
   },
   "publishConfig": {

--- a/components/alertdialog/package.json
+++ b/components/alertdialog/package.json
@@ -19,8 +19,8 @@
     "clean": "rimraf dist"
   },
   "peerDependencies": {
+    "@spectrum-css/backgroundlayers": ">=1",
     "@spectrum-css/button": ">=11",
-    "@spectrum-css/backgroundlayers": ">=1",,
     "@spectrum-css/buttongroup": ">=6",
     "@spectrum-css/divider": ">=1 <=2",
     "@spectrum-css/icon": ">=4",

--- a/components/backgroundlayers/README.md
+++ b/components/backgroundlayers/README.md
@@ -1,0 +1,7 @@
+# @spectrum-css/backgroundlayers
+
+> The Spectrum CSS background layers component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/backgroundlayers).

--- a/components/backgroundlayers/README.md
+++ b/components/backgroundlayers/README.md
@@ -1,6 +1,20 @@
 # @spectrum-css/backgroundlayers
 
-> The Spectrum CSS background layers component
+> The Spectrum CSS background layers is a set of utility classes used to apply Spectrum 2 app framing. Consult design documentation for further usage and infomation.
+
+To use these classes add the approproate layers and contexts class to the element that the background styling should be applied. Make note of the context when determing the correct class to use.
+
+Editing Context Classes:
+- `spectrum-BackgroundLayers--elevated`
+- `spectrum-BackgroundLayers--layer2`
+- `spectrum-BackgroundLayers--layer1`
+- `spectrum-BackgroundLayers--pasteboard`
+
+Browsing Context Classes:
+- `spectrum-BackgroundLayers--elevated`
+- `spectrum-BackgroundLayers--layer1`
+- `spectrum-BackgroundLayers--base`
+
 
 This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
 

--- a/components/backgroundlayers/gulpfile.js
+++ b/components/backgroundlayers/gulpfile.js
@@ -1,0 +1,1 @@
+module.exports = require('@spectrum-css/component-builder-simple');

--- a/components/backgroundlayers/index.css
+++ b/components/backgroundlayers/index.css
@@ -21,16 +21,25 @@ governing permissions and limitations under the License.
   --spectrum-backgroundlayers-shadow-vertical: 0;
   --spectrum-backgroundlayers-shadow-blur: 5px;
   --spectrum-backgroundlayers-shadow-color: var(--spectrum-gray-200);
-
+    .spectrum--dark & {
+      --spectum-backgroundlayers-background-color: var(--spectrum-gray-75);
+      --spectrum-backgroundlayers-shadow-color: var(--spectrum-gray-100);
+    }
 }
 .spectrum-BackgroundLayers--layer2 {
   --spectum-backgroundlayers-background-color: var(--spectrum-gray-25);
+  .spectrum--dark & {
+    --spectum-backgroundlayers-background-color: var(--spectrum-gray-75);
+	}
 }
 .spectrum-BackgroundLayers--layer1 {
   --spectum-backgroundlayers-background-color: var(--spectrum-gray-50);
 }
 .spectrum-BackgroundLayers--pasteboard {
   --spectum-backgroundlayers-background-color: var(--spectrum-gray-100);
+  .spectrum--dark & {
+    --spectum-backgroundlayers-background-color: var(--spectrum-gray-25);
+	}
 }
 .spectrum-BackgroundLayers--base {
   --spectum-backgroundlayers-background-color: var(--spectrum-gray-25);

--- a/components/backgroundlayers/index.css
+++ b/components/backgroundlayers/index.css
@@ -12,10 +12,16 @@ governing permissions and limitations under the License.
 
 .spectrum-BackgroundLayers {
   --spectum-backgroundlayers-background-color: var(--spectrum-gray-25);
+  --spectrum-backgroundlayers-drop-shadow:
 }
 
 .spectrum-BackgroundLayers--elevated {
   --spectum-backgroundlayers-background-color: var(--spectrum-gray-25);
+  --spectrum-backgroundlayers-shadow-horizontal: 0;
+  --spectrum-backgroundlayers-shadow-vertical: 0;
+  --spectrum-backgroundlayers-shadow-blur: 5px;
+  --spectrum-backgroundlayers-shadow-color: var(--spectrum-gray-200);
+
 }
 .spectrum-BackgroundLayers--layer2 {
   --spectum-backgroundlayers-background-color: var(--spectrum-gray-25);
@@ -28,9 +34,10 @@ governing permissions and limitations under the License.
 }
 .spectrum-BackgroundLayers--base {
   --spectum-backgroundlayers-background-color: var(--spectrum-gray-25);
-  border: 2px solid gray;
+  border: 2px solid rgba(180, 180, 180, 0.25);
 }
 
 .spectrum-BackgroundLayers {
   background-color: var(--spectum-backgroundlayers-background-color);
+  filter: drop-shadow(var(--spectrum-backgroundlayers-shadow-horizontal) var(--spectrum-backgroundlayers-shadow-vertical) var(--spectrum-backgroundlayers-shadow-blur) var(--spectrum-backgroundlayers-shadow-color));
 }

--- a/components/backgroundlayers/index.css
+++ b/components/backgroundlayers/index.css
@@ -43,6 +43,7 @@ governing permissions and limitations under the License.
 		--spectum-backgroundlayers-background-color: var(--spectrum-gray-75);
 	}
 	background-color: var(--spectum-backgroundlayers-background-color);
+	border: 2px solid rgba(180, 180, 180, 0.25);
 }
 
 .spectrum-BackgroundLayers--pasteboard {

--- a/components/backgroundlayers/index.css
+++ b/components/backgroundlayers/index.css
@@ -9,44 +9,52 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-
 .spectrum-BackgroundLayers {
-  --spectum-backgroundlayers-background-color: var(--spectrum-gray-25);
-  --spectrum-backgroundlayers-drop-shadow:
+	--spectrum-gray-25: rgb(255, 255, 255);
+	--spectrum-gray-50: rgb(248, 248, 248);
+	--spectrum-gray-75: rgb(243, 243, 243);
+	--spectrum-gray-100: rgb(233, 233, 233);
+	--spectum-backgroundlayers-background-color: var(--spectrum-gray-25);
+
 }
 
 .spectrum-BackgroundLayers--elevated {
-  --spectum-backgroundlayers-background-color: var(--spectrum-gray-25);
-  --spectrum-backgroundlayers-shadow-horizontal: 0;
-  --spectrum-backgroundlayers-shadow-vertical: 0;
-  --spectrum-backgroundlayers-shadow-blur: 5px;
-  --spectrum-backgroundlayers-shadow-color: var(--spectrum-gray-200);
-    .spectrum--dark & {
-      --spectum-backgroundlayers-background-color: var(--spectrum-gray-75);
-      --spectrum-backgroundlayers-shadow-color: var(--spectrum-gray-100);
-    }
+	--spectum-backgroundlayers-background-color: var(--spectrum-gray-25);
+	--spectrum-backgroundlayers-shadow-horizontal: 0;
+	--spectrum-backgroundlayers-shadow-vertical: 0;
+	--spectrum-backgroundlayers-shadow-blur: 5px;
+	--spectrum-backgroundlayers-shadow-color: var(--spectrum-gray-200);
+	.spectrum--dark & {
+		--spectum-backgroundlayers-background-color: var(--spectrum-gray-75);
+		--spectrum-backgroundlayers-shadow-color: var(--spectrum-gray-100);
+	}
 }
 .spectrum-BackgroundLayers--layer2 {
-  --spectum-backgroundlayers-background-color: var(--spectrum-gray-25);
-  .spectrum--dark & {
-    --spectum-backgroundlayers-background-color: var(--spectrum-gray-75);
+	--spectum-backgroundlayers-background-color: var(--spectrum-gray-25);
+	.spectrum--dark & {
+		--spectum-backgroundlayers-background-color: var(--spectrum-gray-75);
 	}
 }
 .spectrum-BackgroundLayers--layer1 {
-  --spectum-backgroundlayers-background-color: var(--spectrum-gray-50);
+	--spectum-backgroundlayers-background-color: var(--spectrum-gray-50);
 }
 .spectrum-BackgroundLayers--pasteboard {
-  --spectum-backgroundlayers-background-color: var(--spectrum-gray-100);
-  .spectrum--dark & {
-    --spectum-backgroundlayers-background-color: var(--spectrum-gray-25);
+	--spectum-backgroundlayers-background-color: var(--spectrum-gray-100);
+	.spectrum--dark & {
+		--spectum-backgroundlayers-background-color: var(--spectrum-gray-25);
 	}
 }
 .spectrum-BackgroundLayers--base {
-  --spectum-backgroundlayers-background-color: var(--spectrum-gray-25);
-  border: 2px solid rgba(180, 180, 180, 0.25);
+	--spectum-backgroundlayers-background-color: var(--spectrum-gray-25);
+	border: 2px solid rgba(180, 180, 180, 0.25);
 }
 
 .spectrum-BackgroundLayers {
-  background-color: var(--spectum-backgroundlayers-background-color);
-  filter: drop-shadow(var(--spectrum-backgroundlayers-shadow-horizontal) var(--spectrum-backgroundlayers-shadow-vertical) var(--spectrum-backgroundlayers-shadow-blur) var(--spectrum-backgroundlayers-shadow-color));
+	background-color: var(--spectum-backgroundlayers-background-color);
+	filter: drop-shadow(
+		var(--spectrum-backgroundlayers-shadow-horizontal)
+			var(--spectrum-backgroundlayers-shadow-vertical)
+			var(--spectrum-backgroundlayers-shadow-blur)
+			var(--spectrum-backgroundlayers-shadow-color)
+	);
 }

--- a/components/backgroundlayers/index.css
+++ b/components/backgroundlayers/index.css
@@ -16,7 +16,7 @@ governing permissions and limitations under the License.
 	--spectrum-backgroundlayers-shadow-horizontal: 0;
 	--spectrum-backgroundlayers-shadow-vertical: 0;
 	--spectrum-backgroundlayers-shadow-blur: 5px;
-	--spectrum-backgroundlayers-shadow-color: var(--spectrum-gray-200);
+	--spectrum-backgroundlayers-shadow-color: var(--spectrum-gray-600);
 	.spectrum--dark & {
 		--spectum-backgroundlayers-background-color: var(--spectrum-gray-75);
 		--spectrum-backgroundlayers-shadow-color: var(--spectrum-gray-100);

--- a/components/backgroundlayers/index.css
+++ b/components/backgroundlayers/index.css
@@ -9,15 +9,8 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-.spectrum-BackgroundLayers {
-	--spectrum-gray-25: rgb(255, 255, 255);
-	--spectrum-gray-50: rgb(248, 248, 248);
-	--spectrum-gray-75: rgb(243, 243, 243);
-	--spectrum-gray-100: rgb(233, 233, 233);
-	--spectum-backgroundlayers-background-color: var(--spectrum-gray-25);
 
-}
-
+/* used in editing and browsing contexts */
 .spectrum-BackgroundLayers--elevated {
 	--spectum-backgroundlayers-background-color: var(--spectrum-gray-25);
 	--spectrum-backgroundlayers-shadow-horizontal: 0;
@@ -28,28 +21,7 @@ governing permissions and limitations under the License.
 		--spectum-backgroundlayers-background-color: var(--spectrum-gray-75);
 		--spectrum-backgroundlayers-shadow-color: var(--spectrum-gray-100);
 	}
-}
-.spectrum-BackgroundLayers--layer2 {
-	--spectum-backgroundlayers-background-color: var(--spectrum-gray-25);
-	.spectrum--dark & {
-		--spectum-backgroundlayers-background-color: var(--spectrum-gray-75);
-	}
-}
-.spectrum-BackgroundLayers--layer1 {
-	--spectum-backgroundlayers-background-color: var(--spectrum-gray-50);
-}
-.spectrum-BackgroundLayers--pasteboard {
-	--spectum-backgroundlayers-background-color: var(--spectrum-gray-100);
-	.spectrum--dark & {
-		--spectum-backgroundlayers-background-color: var(--spectrum-gray-25);
-	}
-}
-.spectrum-BackgroundLayers--base {
-	--spectum-backgroundlayers-background-color: var(--spectrum-gray-25);
-	border: 2px solid rgba(180, 180, 180, 0.25);
-}
 
-.spectrum-BackgroundLayers {
 	background-color: var(--spectum-backgroundlayers-background-color);
 	filter: drop-shadow(
 		var(--spectrum-backgroundlayers-shadow-horizontal)
@@ -58,3 +30,33 @@ governing permissions and limitations under the License.
 			var(--spectrum-backgroundlayers-shadow-color)
 	);
 }
+
+.spectrum-BackgroundLayers--layer1 {
+	--spectum-backgroundlayers-background-color: var(--spectrum-gray-50);
+	background-color: var(--spectum-backgroundlayers-background-color);
+}
+
+/* only used in browsing contexts */
+.spectrum-BackgroundLayers--layer2 {
+	--spectum-backgroundlayers-background-color: var(--spectrum-gray-25);
+	.spectrum--dark & {
+		--spectum-backgroundlayers-background-color: var(--spectrum-gray-75);
+	}
+	background-color: var(--spectum-backgroundlayers-background-color);
+}
+
+.spectrum-BackgroundLayers--pasteboard {
+	--spectum-backgroundlayers-background-color: var(--spectrum-gray-100);
+	.spectrum--dark & {
+		--spectum-backgroundlayers-background-color: var(--spectrum-gray-25);
+	}
+	background-color: var(--spectum-backgroundlayers-background-color);
+}
+
+/* only used in editing contexts */
+.spectrum-BackgroundLayers--base {
+	--spectum-backgroundlayers-background-color: var(--spectrum-gray-25);
+	border: 2px solid rgba(180, 180, 180, 0.25);
+	background-color: var(--spectum-backgroundlayers-background-color);
+}
+

--- a/components/backgroundlayers/index.css
+++ b/components/backgroundlayers/index.css
@@ -1,0 +1,36 @@
+/*!
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+.spectrum-BackgroundLayers {
+  --spectum-backgroundlayers-background-color: var(--spectrum-gray-25);
+}
+
+.spectrum-BackgroundLayers--elevated {
+  --spectum-backgroundlayers-background-color: var(--spectrum-gray-25);
+}
+.spectrum-BackgroundLayers--layer2 {
+  --spectum-backgroundlayers-background-color: var(--spectrum-gray-25);
+}
+.spectrum-BackgroundLayers--layer1 {
+  --spectum-backgroundlayers-background-color: var(--spectrum-gray-50);
+}
+.spectrum-BackgroundLayers--pasteboard {
+  --spectum-backgroundlayers-background-color: var(--spectrum-gray-100);
+}
+.spectrum-BackgroundLayers--base {
+  --spectum-backgroundlayers-background-color: var(--spectrum-gray-25);
+  border: 2px solid gray;
+}
+
+.spectrum-BackgroundLayers {
+  background-color: var(--spectum-backgroundlayers-background-color);
+}

--- a/components/backgroundlayers/index.css
+++ b/components/backgroundlayers/index.css
@@ -10,8 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-/* used in editing and browsing contexts */
-.spectrum-BackgroundLayers--elevated {
+/* for use only in editing contexts */
+.spectrum-BackgroundLayers-edit-elevated {
 	--spectrum-backgroundlayers-background-color: var(--spectrum-gray-25);
 	--spectrum-backgroundlayers-shadow-horizontal: 0;
 	--spectrum-backgroundlayers-shadow-vertical: 0;
@@ -30,12 +30,6 @@ governing permissions and limitations under the License.
 		var(--spectrum-backgroundlayers-shadow-color)
 }
 
-.spectrum-BackgroundLayers--layer1 {
-	--spectrum-backgroundlayers-background-color: var(--spectrum-gray-50);
-	background-color: var(--spectrum-backgroundlayers-background-color);
-}
-
-/* only used in browsing contexts */
 .spectrum-BackgroundLayers--layer2 {
 	--spectrum-backgroundlayers-background-color: var(--spectrum-gray-25);
 
@@ -46,7 +40,12 @@ governing permissions and limitations under the License.
 	border: 2px solid rgba(180, 180, 180, 25%);
 }
 
-.spectrum-BackgroundLayers--pasteboard {
+.spectrum-BackgroundLayers-edit-layer1 {
+	--spectrum-backgroundlayers-background-color: var(--spectrum-gray-50);
+	background-color: var(--spectrum-backgroundlayers-background-color);
+}
+
+.spectrum-BackgroundLayers-edit-pasteboard {
 	--spectrum-backgroundlayers-background-color: var(--spectrum-gray-100);
 
 	.spectrum--dark & {
@@ -55,10 +54,33 @@ governing permissions and limitations under the License.
 	background-color: var(--spectrum-backgroundlayers-background-color);
 }
 
-/* only used in editing contexts */
-.spectrum-BackgroundLayers--base {
+/* only used in browsing contexts */
+.spectrum-BackgroundLayers-browse-elevated {
+	--spectrum-backgroundlayers-background-color: var(--spectrum-gray-25);
+	--spectrum-backgroundlayers-shadow-horizontal: 0;
+	--spectrum-backgroundlayers-shadow-vertical: 0;
+	--spectrum-backgroundlayers-shadow-blur: 5px;
+	--spectrum-backgroundlayers-shadow-color: var(--spectrum-gray-600);
+
+	.spectrum--dark & {
+		--spectrum-backgroundlayers-background-color: var(--spectrum-gray-75);
+		--spectrum-backgroundlayers-shadow-color: var(--spectrum-gray-100);
+	}
+	background-color: var(--spectrum-backgroundlayers-background-color);
+	box-shadow:
+		var(--spectrum-backgroundlayers-shadow-horizontal)
+		var(--spectrum-backgroundlayers-shadow-vertical)
+		var(--spectrum-backgroundlayers-shadow-blur)
+		var(--spectrum-backgroundlayers-shadow-color)
+}
+
+.spectrum-BackgroundLayers-browse-layer1 {
+	--spectrum-backgroundlayers-background-color: var(--spectrum-gray-50);
+	background-color: var(--spectrum-backgroundlayers-background-color);
+}
+
+.spectrum-BackgroundLayers-browse-base {
 	--spectrum-backgroundlayers-background-color: var(--spectrum-gray-25);
 	border: 2px solid rgba(180, 180, 180, 25%);
 	background-color: var(--spectrum-backgroundlayers-background-color);
 }
-

--- a/components/backgroundlayers/index.css
+++ b/components/backgroundlayers/index.css
@@ -12,52 +12,53 @@ governing permissions and limitations under the License.
 
 /* used in editing and browsing contexts */
 .spectrum-BackgroundLayers--elevated {
-	--spectum-backgroundlayers-background-color: var(--spectrum-gray-25);
+	--spectrum-backgroundlayers-background-color: var(--spectrum-gray-25);
 	--spectrum-backgroundlayers-shadow-horizontal: 0;
 	--spectrum-backgroundlayers-shadow-vertical: 0;
 	--spectrum-backgroundlayers-shadow-blur: 5px;
 	--spectrum-backgroundlayers-shadow-color: var(--spectrum-gray-600);
+
 	.spectrum--dark & {
-		--spectum-backgroundlayers-background-color: var(--spectrum-gray-75);
+		--spectrum-backgroundlayers-background-color: var(--spectrum-gray-75);
 		--spectrum-backgroundlayers-shadow-color: var(--spectrum-gray-100);
 	}
-
-	background-color: var(--spectum-backgroundlayers-background-color);
-	filter: drop-shadow(
+	background-color: var(--spectrum-backgroundlayers-background-color);
+	box-shadow:
 		var(--spectrum-backgroundlayers-shadow-horizontal)
-			var(--spectrum-backgroundlayers-shadow-vertical)
-			var(--spectrum-backgroundlayers-shadow-blur)
-			var(--spectrum-backgroundlayers-shadow-color)
-	);
+		var(--spectrum-backgroundlayers-shadow-vertical)
+		var(--spectrum-backgroundlayers-shadow-blur)
+		var(--spectrum-backgroundlayers-shadow-color)
 }
 
 .spectrum-BackgroundLayers--layer1 {
-	--spectum-backgroundlayers-background-color: var(--spectrum-gray-50);
-	background-color: var(--spectum-backgroundlayers-background-color);
+	--spectrum-backgroundlayers-background-color: var(--spectrum-gray-50);
+	background-color: var(--spectrum-backgroundlayers-background-color);
 }
 
 /* only used in browsing contexts */
 .spectrum-BackgroundLayers--layer2 {
-	--spectum-backgroundlayers-background-color: var(--spectrum-gray-25);
+	--spectrum-backgroundlayers-background-color: var(--spectrum-gray-25);
+
 	.spectrum--dark & {
-		--spectum-backgroundlayers-background-color: var(--spectrum-gray-75);
+		--spectrum-backgroundlayers-background-color: var(--spectrum-gray-75);
 	}
-	background-color: var(--spectum-backgroundlayers-background-color);
-	border: 2px solid rgba(180, 180, 180, 0.25);
+	background-color: var(--spectrum-backgroundlayers-background-color);
+	border: 2px solid rgba(180, 180, 180, 25%);
 }
 
 .spectrum-BackgroundLayers--pasteboard {
-	--spectum-backgroundlayers-background-color: var(--spectrum-gray-100);
+	--spectrum-backgroundlayers-background-color: var(--spectrum-gray-100);
+
 	.spectrum--dark & {
-		--spectum-backgroundlayers-background-color: var(--spectrum-gray-25);
+		--spectrum-backgroundlayers-background-color: var(--spectrum-gray-25);
 	}
-	background-color: var(--spectum-backgroundlayers-background-color);
+	background-color: var(--spectrum-backgroundlayers-background-color);
 }
 
 /* only used in editing contexts */
 .spectrum-BackgroundLayers--base {
-	--spectum-backgroundlayers-background-color: var(--spectrum-gray-25);
-	border: 2px solid rgba(180, 180, 180, 0.25);
-	background-color: var(--spectum-backgroundlayers-background-color);
+	--spectrum-backgroundlayers-background-color: var(--spectrum-gray-25);
+	border: 2px solid rgba(180, 180, 180, 25%);
+	background-color: var(--spectrum-backgroundlayers-background-color);
 }
 

--- a/components/backgroundlayers/metadata/backgroundlayers.yml
+++ b/components/backgroundlayers/metadata/backgroundlayers.yml
@@ -5,14 +5,24 @@ examples:
   - id: backgroundlayers-browsing
     name: Browsing Contexts
     markup: |
-      <div class="spectrum-Examples">
-      <div class="spectrum-BackgroundLayers spectrum-BackgroundLayers--pasteboard" style="inline-size: 100px; block-size: 100px; border-radius: 10px;">
-      </div>
+      <div class="spectrum-Examples" style="justify-content: flex-start; position: relative; height: 150px;">
+        <div class="spectrum-BackgroundLayers spectrum-BackgroundLayers--elevated" style="inline-size: 100px; block-size: 100px; border-radius: 10px; position: absolute; z-index: 4;">
+        </div>
+        <div class="spectrum-BackgroundLayers spectrum-BackgroundLayers--layer2" style="inline-size: 100px; block-size: 100px; border-radius: 10px; position: absolute; left: 15px; top: 15px; z-index: 3;">
+        </div>
+        <div class="spectrum-BackgroundLayers spectrum-BackgroundLayers--layer1" style="inline-size: 100px; block-size: 100px; border-radius: 10px; position: absolute; left: 30px; top: 30px; z-index: 2;">
+        </div>
+        <div class="spectrum-BackgroundLayers spectrum-BackgroundLayers--pasteboard" style="inline-size: 100px; block-size: 100px; border-radius: 10px; position: absolute; left: 40px; top: 40px; z-index: 1;">
+        </div>
       </div>
   - id: backgroundlayers-editting
     name: Editting Contexts
     markup: |
-      <div class="spectrum-Examples">
-      <div class="spectrum-BackgroundLayers spectrum-BackgroundLayers--base" style="inline-size: 100px; block-size: 100px; border-radius: 10px;">
-      </div>
+      <div class="spectrum-Examples" style="justify-content: flex-start; position: relative; height: 150px;">
+        <div class="spectrum-BackgroundLayers spectrum-BackgroundLayers--elevated" style="inline-size: 100px; block-size: 100px; border-radius: 10px; position: absolute; z-index: 3;">
+        </div>
+        <div class="spectrum-BackgroundLayers spectrum-BackgroundLayers--layer1" style="inline-size: 100px; block-size: 100px; border-radius: 10px; position: absolute; left: 15px; top: 15px; z-index: 2;">
+        </div>
+        <div class="spectrum-BackgroundLayers spectrum-BackgroundLayers--base"  style="inline-size: 100px; block-size: 100px; border-radius: 10px; position: absolute; left: 20px; top: 20px; z-index: 1;">
+        </div>
       </div>

--- a/components/backgroundlayers/metadata/backgroundlayers.yml
+++ b/components/backgroundlayers/metadata/backgroundlayers.yml
@@ -1,0 +1,18 @@
+name: Background layers
+status: Verified
+SpectrumSiteSlug: https://spectrum.adobe.com/page/background-layers/
+examples:
+  - id: backgroundlayers-browsing
+    name: Browsing Contexts
+    markup: |
+      <div class="spectrum-Examples">
+      <div class="spectrum-BackgroundLayers spectrum-BackgroundLayers--pasteboard" style="inline-size: 100px; block-size: 100px; border-radius: 10px;">
+      </div>
+      </div>
+  - id: backgroundlayers-editting
+    name: Editting Contexts
+    markup: |
+      <div class="spectrum-Examples">
+      <div class="spectrum-BackgroundLayers spectrum-BackgroundLayers--base" style="inline-size: 100px; block-size: 100px; border-radius: 10px;">
+      </div>
+      </div>

--- a/components/backgroundlayers/metadata/backgroundlayers.yml
+++ b/components/backgroundlayers/metadata/backgroundlayers.yml
@@ -15,8 +15,8 @@ examples:
         <div class="spectrum-BackgroundLayers--pasteboard" style="inline-size: 100px; block-size: 100px; border-radius: 10px; position: absolute; left: 40px; top: 40px; z-index: 1;">
         </div>
       </div>
-  - id: backgroundlayers-editting
-    name: Editting Contexts
+  - id: backgroundlayers-editing
+    name: Editing Contexts
     markup: |
       <div class="spectrum-Examples" style="justify-content: flex-start; position: relative; height: 150px;">
         <div class="spectrum-BackgroundLayers--elevated" style="inline-size: 100px; block-size: 100px; border-radius: 10px; position: absolute; z-index: 3;">

--- a/components/backgroundlayers/metadata/backgroundlayers.yml
+++ b/components/backgroundlayers/metadata/backgroundlayers.yml
@@ -6,23 +6,23 @@ examples:
     name: Browsing Contexts
     markup: |
       <div class="spectrum-Examples" style="justify-content: flex-start; position: relative; height: 150px;">
-        <div class="spectrum-BackgroundLayers spectrum-BackgroundLayers--elevated" style="inline-size: 100px; block-size: 100px; border-radius: 10px; position: absolute; z-index: 4;">
+        <div class="spectrum-BackgroundLayers--elevated" style="inline-size: 100px; block-size: 100px; border-radius: 10px; position: absolute; z-index: 4;">
         </div>
-        <div class="spectrum-BackgroundLayers spectrum-BackgroundLayers--layer2" style="inline-size: 100px; block-size: 100px; border-radius: 10px; position: absolute; left: 15px; top: 15px; z-index: 3;">
+        <div class="spectrum-BackgroundLayers--layer2" style="inline-size: 100px; block-size: 100px; border-radius: 10px; position: absolute; left: 15px; top: 15px; z-index: 3;">
         </div>
-        <div class="spectrum-BackgroundLayers spectrum-BackgroundLayers--layer1" style="inline-size: 100px; block-size: 100px; border-radius: 10px; position: absolute; left: 30px; top: 30px; z-index: 2;">
+        <div class="spectrum-BackgroundLayers--layer1" style="inline-size: 100px; block-size: 100px; border-radius: 10px; position: absolute; left: 30px; top: 30px; z-index: 2;">
         </div>
-        <div class="spectrum-BackgroundLayers spectrum-BackgroundLayers--pasteboard" style="inline-size: 100px; block-size: 100px; border-radius: 10px; position: absolute; left: 40px; top: 40px; z-index: 1;">
+        <div class="spectrum-BackgroundLayers--pasteboard" style="inline-size: 100px; block-size: 100px; border-radius: 10px; position: absolute; left: 40px; top: 40px; z-index: 1;">
         </div>
       </div>
   - id: backgroundlayers-editting
     name: Editting Contexts
     markup: |
       <div class="spectrum-Examples" style="justify-content: flex-start; position: relative; height: 150px;">
-        <div class="spectrum-BackgroundLayers spectrum-BackgroundLayers--elevated" style="inline-size: 100px; block-size: 100px; border-radius: 10px; position: absolute; z-index: 3;">
+        <div class="spectrum-BackgroundLayers--elevated" style="inline-size: 100px; block-size: 100px; border-radius: 10px; position: absolute; z-index: 3;">
         </div>
-        <div class="spectrum-BackgroundLayers spectrum-BackgroundLayers--layer1" style="inline-size: 100px; block-size: 100px; border-radius: 10px; position: absolute; left: 15px; top: 15px; z-index: 2;">
+        <div class="spectrum-BackgroundLayers--layer1" style="inline-size: 100px; block-size: 100px; border-radius: 10px; position: absolute; left: 15px; top: 15px; z-index: 2;">
         </div>
-        <div class="spectrum-BackgroundLayers spectrum-BackgroundLayers--base"  style="inline-size: 100px; block-size: 100px; border-radius: 10px; position: absolute; left: 20px; top: 20px; z-index: 1;">
+        <div class="spectrum-BackgroundLayers--base"  style="inline-size: 100px; block-size: 100px; border-radius: 10px; position: absolute; left: 20px; top: 20px; z-index: 1;">
         </div>
       </div>

--- a/components/backgroundlayers/metadata/mods.md
+++ b/components/backgroundlayers/metadata/mods.md
@@ -1,0 +1,3 @@
+| Modifiable Custom Properties                   |
+| ---------------------------------------------- |
+| `--mod-backgroundlayers-content-color-default` |

--- a/components/backgroundlayers/metadata/mods.md
+++ b/components/backgroundlayers/metadata/mods.md
@@ -1,3 +1,0 @@
-| Modifiable Custom Properties                   |
-| ---------------------------------------------- |
-| `--mod-backgroundlayers-content-color-default` |

--- a/components/backgroundlayers/package.json
+++ b/components/backgroundlayers/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@spectrum-css/backgroundlayers",
+  "version": "1.0.0-alpha.0",
+  "description": "The Spectrum CSS backgroundlayers component",
+  "license": "Apache-2.0",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/backgroundlayers"
+  },
+  "bugs": {
+    "url": "https://github.com/adobe/spectrum-css/issues"
+  },
+  "main": "dist/index-vars.css",
+  "scripts": {
+    "build": "gulp",
+    "clean": "rimraf dist",
+    "test": "nx test:scope @spectrum-css/preview backgroundlayers"
+  },
+  "peerDependencies": {
+    "@spectrum-css/tokens": ">=12"
+  },
+  "devDependencies": {
+    "@spectrum-css/component-builder-simple": "^2.0.17",
+    "@spectrum-css/tokens": "^12.0.0",
+    "gulp": "^4.0.0",
+    "nx": "^17.0.3",
+    "rimraf": "^5.0.1"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/components/backgroundlayers/stories/backgroundlayers.stories.js
+++ b/components/backgroundlayers/stories/backgroundlayers.stories.js
@@ -2,7 +2,7 @@ import { Template } from "./template";
 import { html } from 'lit';
 
 export default {
-  title: "UtilitityClasses/Background layers",
+  title: "UtilityClasses/Background layers",
   description: "The background layers is a series of classes used to style background layers.",
   component: "BackgroundLayers",
   argTypes: {},

--- a/components/backgroundlayers/stories/backgroundlayers.stories.js
+++ b/components/backgroundlayers/stories/backgroundlayers.stories.js
@@ -1,0 +1,39 @@
+// Import the component markup template
+import { Template } from "./template";
+
+// More on default export: https://storybook.js.org/docs/web-components/writing-stories/introduction#default-export
+export default {
+  title: "Components/background layers",
+  description: "The background layers component is...",
+  component: "BackgroundLayers",
+  argTypes: {
+    size: {
+      name: "Size",
+      type: { name: "string", required: true },
+      defaultValue: "m",
+      table: {
+        type: { summary: "string" },
+        category: "Component",
+        defaultValue: { summary: "m" }
+      },
+      options: ["s", "m", "l", "xl"],
+      control: "select"
+    },
+  },
+  // More on args: https://storybook.js.org/docs/web-components/writing-stories/args
+  args: {
+    rootClass: "spectrum-BackgroundLayers",
+    size: "m",
+  },
+  parameters: {
+    actions: {
+      handles: []
+    },
+    status: {
+      type: process.env.MIGRATED_PACKAGES.includes('backgroundlayers') ? 'migrated' : undefined
+    }
+  }
+};
+
+export const Default = Template.bind({});
+Default.args = {};

--- a/components/backgroundlayers/stories/backgroundlayers.stories.js
+++ b/components/backgroundlayers/stories/backgroundlayers.stories.js
@@ -2,7 +2,7 @@ import { Template } from "./template";
 import { html } from 'lit';
 
 export default {
-  title: "Elements/Background layers",
+  title: "UtilitityClasses/Background layers",
   description: "The background layers is a series of classes used to style background layers.",
   component: "BackgroundLayers",
   argTypes: {},
@@ -24,19 +24,19 @@ const EditingContext = ({
 	return html`
 		<div style="display: flex; justify-content: flex-start; position: relative; block-size: 150px;">
 			${Template({
-        style: "z-index: 4;",
+        style: "z-index: 4; inset-inline-start: 10px; inset-block-start: 10px;",
 				layer: 'elevated',
 			})}
 			${Template({
-        style: "z-index: 3; inset-inline-start: 15px; inset-block-start: 15px;",
+        style: "z-index: 3; inset-inline-start: 20px; inset-block-start: 20px;",
 				layer: 'layer2',
 			})}
 			${Template({
-        style: "z-index: 2; inset-inline-start: 25px; inset-block-start: 25px;",
+        style: "z-index: 2; inset-inline-start: 30px; inset-block-start: 30px;",
 				layer: 'layer1',
 			})}
 			${Template({
-        style: "z-index: 1; inset-inline-start: 35px; inset-block-start: 35px;",
+        style: "z-index: 1; inset-inline-start: 40px; inset-block-start: 40px;",
 				layer: "pasteboard",
 			})}
 		</div>
@@ -48,15 +48,15 @@ const BrowsingContext = ({
 	return html`
 		<div style="display: flex; justify-content: flex-start; position: relative; block-size: 150px;">
 			${Template({
-        style: "z-index: 3;",
+        style: "z-index: 3; inset-inline-start: 10px; inset-block-start: 10px;",
 				layer: 'elevated',
 			})}
 			${Template({
-        style: "z-index: 2; inset-inline-start: 15px; inset-block-start: 15px;",
+        style: "z-index: 2; inset-inline-start: 20px; inset-block-start: 20px;",
 				layer: 'layer1',
 			})}
 			${Template({
-        style: "z-index: 1; inset-inline-start: 25px; inset-block-start: 25px;",
+        style: "z-index: 1; inset-inline-start: 30px; inset-block-start: 30px;",
 				layer: "base",
 			})}
 		</div>

--- a/components/backgroundlayers/stories/backgroundlayers.stories.js
+++ b/components/backgroundlayers/stories/backgroundlayers.stories.js
@@ -5,20 +5,7 @@ export default {
   title: "Elements/Background layers",
   description: "The background layers is a series of classes used to style background layers.",
   component: "BackgroundLayers",
-  argTypes: {
-    context: {
-      name: "Context",
-      type: { name: "string", required: true },
-      defaultValue: "Browsing",
-      table: {
-        type: { summary: "string" },
-        category: "Component",
-        defaultValue: { summary: "browsing" }
-      },
-      options: ["browsing", "editing"],
-      control: "select"
-    },
-  },
+  argTypes: {},
   args: {
     rootClass: "spectrum-BackgroundLayers",
   },
@@ -35,7 +22,7 @@ export default {
 const EditingContext = ({
 }) => {
 	return html`
-		<div style="display: flex; justify-content: flex-start; position: relative;">
+		<div style="display: flex; justify-content: flex-start; position: relative; block-size: 150px;">
 			${Template({
         style: "z-index: 4;",
 				layer: 'elevated',
@@ -59,7 +46,7 @@ const EditingContext = ({
 const BrowsingContext = ({
 }) => {
 	return html`
-		<div style="display: flex; justify-content: flex-start; position: relative;">
+		<div style="display: flex; justify-content: flex-start; position: relative; block-size: 150px;">
 			${Template({
         style: "z-index: 3;",
 				layer: 'elevated',

--- a/components/backgroundlayers/stories/backgroundlayers.stories.js
+++ b/components/backgroundlayers/stories/backgroundlayers.stories.js
@@ -1,29 +1,26 @@
-// Import the component markup template
 import { Template } from "./template";
+import { html } from 'lit';
 
-// More on default export: https://storybook.js.org/docs/web-components/writing-stories/introduction#default-export
 export default {
-  title: "Components/background layers",
-  description: "The background layers component is...",
+  title: "Elements/Background layers",
+  description: "The background layers is a series of classes used to style background layers.",
   component: "BackgroundLayers",
   argTypes: {
-    size: {
-      name: "Size",
+    context: {
+      name: "Context",
       type: { name: "string", required: true },
-      defaultValue: "m",
+      defaultValue: "Browsing",
       table: {
         type: { summary: "string" },
         category: "Component",
-        defaultValue: { summary: "m" }
+        defaultValue: { summary: "browsing" }
       },
-      options: ["s", "m", "l", "xl"],
+      options: ["browsing", "editing"],
       control: "select"
     },
   },
-  // More on args: https://storybook.js.org/docs/web-components/writing-stories/args
   args: {
     rootClass: "spectrum-BackgroundLayers",
-    size: "m",
   },
   parameters: {
     actions: {
@@ -35,5 +32,51 @@ export default {
   }
 };
 
-export const Default = Template.bind({});
-Default.args = {};
+const EditingContext = ({
+}) => {
+	return html`
+		<div style="display: flex; justify-content: flex-start; position: relative;">
+			${Template({
+        style: "z-index: 4;",
+				layer: 'elevated',
+			})}
+			${Template({
+        style: "z-index: 3; inset-inline-start: 15px; inset-block-start: 15px;",
+				layer: 'layer2',
+			})}
+			${Template({
+        style: "z-index: 2; inset-inline-start: 25px; inset-block-start: 25px;",
+				layer: 'layer1',
+			})}
+			${Template({
+        style: "z-index: 1; inset-inline-start: 35px; inset-block-start: 35px;",
+				layer: "pasteboard",
+			})}
+		</div>
+	`;
+};
+
+const BrowsingContext = ({
+}) => {
+	return html`
+		<div style="display: flex; justify-content: flex-start; position: relative;">
+			${Template({
+        style: "z-index: 3;",
+				layer: 'elevated',
+			})}
+			${Template({
+        style: "z-index: 2; inset-inline-start: 15px; inset-block-start: 15px;",
+				layer: 'layer1',
+			})}
+			${Template({
+        style: "z-index: 1; inset-inline-start: 25px; inset-block-start: 25px;",
+				layer: "base",
+			})}
+		</div>
+	`;
+};
+export const Editing = EditingContext.bind({});
+Editing.args = {};
+
+export const Browsing = BrowsingContext.bind({});
+Browsing.args = {};

--- a/components/backgroundlayers/stories/template.js
+++ b/components/backgroundlayers/stories/template.js
@@ -1,0 +1,24 @@
+import { html } from 'lit';
+import { classMap } from 'lit/directives/class-map.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
+
+import "../index.css";
+
+// More on component templates: https://storybook.js.org/docs/web-components/writing-stories/introduction#using-args
+export const Template = ({
+  rootClass = "spectrum-BackgroundLayers",
+  size,
+  id,
+  customClasses = [],
+  ...globals
+}) => {
+  return html`
+    <div class=${classMap({
+      [rootClass]: true,
+      [`${rootClass}--size${size.toUpperCase()}`]: true,
+      ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
+    })} id=${ifDefined(id)}>
+      <!-- Component mark-up goes here -->
+    </div>
+  `;
+}

--- a/components/backgroundlayers/stories/template.js
+++ b/components/backgroundlayers/stories/template.js
@@ -1,24 +1,22 @@
 import { html } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
-import { ifDefined } from 'lit/directives/if-defined.js';
 
 import "../index.css";
 
-// More on component templates: https://storybook.js.org/docs/web-components/writing-stories/introduction#using-args
 export const Template = ({
   rootClass = "spectrum-BackgroundLayers",
-  size,
+  style,
+  layer,
   id,
   customClasses = [],
-  ...globals
 }) => {
   return html`
     <div class=${classMap({
       [rootClass]: true,
-      [`${rootClass}--size${size.toUpperCase()}`]: true,
+      [`${rootClass}--${layer}`]: true,
       ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
-    })} id=${ifDefined(id)}>
-      <!-- Component mark-up goes here -->
+    })}
+      style="${style} inline-size: 100px; block-size: 100px; border-radius: 10px; position: absolute;">
     </div>
   `;
 }

--- a/components/backgroundlayers/stories/template.js
+++ b/components/backgroundlayers/stories/template.js
@@ -16,7 +16,7 @@ export const Template = ({
       [`${rootClass}--${layer}`]: true,
       ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
     })}
-      style="${style} inline-size: 100px; block-size: 100px; border-radius: 10px; position: absolute;">
+      style="${style} inline-size: 150px; block-size: 150px; border-radius: 10px; position: absolute;">
     </div>
   `;
 }

--- a/components/backgroundlayers/themes/express.css
+++ b/components/backgroundlayers/themes/express.css
@@ -1,0 +1,13 @@
+/*!
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+@container (--system: express) {}

--- a/components/backgroundlayers/themes/spectrum.css
+++ b/components/backgroundlayers/themes/spectrum.css
@@ -1,0 +1,13 @@
+/*!
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+@container (--system: spectrum) {}

--- a/components/infieldbutton/index.css
+++ b/components/infieldbutton/index.css
@@ -44,6 +44,8 @@ governing permissions and limitations under the License.
 		--spectrum-neutral-content-color-key-focus
 	);
 
+	--spectrum-infield-button-fill-justify-content: center;
+
 	&:disabled {
 		--mod-infield-button-background-color: var(
 			--mod-infield-button-background-color-disabled,
@@ -327,7 +329,10 @@ governing permissions and limitations under the License.
   /* center icon */
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: var(
+		--mod-infield-button-fill-justify-content,
+		var(--spectrum-infield-button-fill-justify-content)
+	);
 
   transition: border-color var(--spectrum-global-animation-duration-100) ease-in-out;
 }
@@ -389,6 +394,14 @@ governing permissions and limitations under the License.
 		border-start-end-radius: var(
 			--mod-infield-button-stacked-border-radius-reset,
 			var(--spectrum-infield-button-stacked-border-radius-reset)
+		);
+		border-end-end-radius: var(
+			--mod-infield-button-stacked-bottom-border-radius-end-end,
+			var(--mod-infield-button-border-radius, var(--spectrum-infield-button-border-radius))
+		);
+		border-block-end-width: var(
+			--mod-infield-button-stacked-bottom-border-block-end-width,
+			var(--mod-infield-button-border-width, var(--spectrum-infield-button-border-width))
 		);
 	}
 }

--- a/components/infieldbutton/metadata/mods.md
+++ b/components/infieldbutton/metadata/mods.md
@@ -21,6 +21,7 @@
 | `--mod-infield-button-border-width`                           |
 | `--mod-infield-button-border-width-quiet`                     |
 | `--mod-infield-button-edge-to-fill`                           |
+| `--mod-infield-button-fill-justify-content`                   |
 | `--mod-infield-button-fill-padding`                           |
 | `--mod-infield-button-height`                                 |
 | `--mod-infield-button-icon-color`                             |
@@ -33,6 +34,8 @@
 | `--mod-infield-button-icon-color-key-focus-disabled`          |
 | `--mod-infield-button-inner-edge-to-fill`                     |
 | `--mod-infield-button-stacked-border-radius-reset`            |
+| `--mod-infield-button-stacked-bottom-border-block-end-width`  |
+| `--mod-infield-button-stacked-bottom-border-radius-end-end`   |
 | `--mod-infield-button-stacked-bottom-border-radius-end-start` |
 | `--mod-infield-button-stacked-fill-padding-inline`            |
 | `--mod-infield-button-stacked-fill-padding-inner`             |

--- a/components/modal/index.css
+++ b/components/modal/index.css
@@ -80,7 +80,7 @@ governing permissions and limitations under the License.
 	max-block-size: var(--mod-modal-max-height, var(--spectrum-modal-max-height));
 	max-inline-size: var(--mod-modal-max-width, var(--spectrum-modal-max-width));
 
-	background: var(--mod-modal-background-color, var(--spectrum-modal-background-color));
+	/* TESTING BackgroundLayers background: var(--mod-modal-background-color, var(--spectrum-modal-background-color)); */
 
 	/* border-radius includes legacy token fallback, which can be deprecated once component is migrated */
 	border-radius: var(--mod-modal-confirm-border-radius, var(--spectrum-modal-confirm-border-radius));

--- a/components/modal/metadata/modal.yml
+++ b/components/modal/metadata/modal.yml
@@ -9,6 +9,6 @@ examples:
     name: Modal
     demoClassName: spectrum-CSSExample-example--overlay
     markup: |
-      <div class="spectrum-Modal-wrapper spectrum-CSSExample-dialog">
+      <div class="spectrum-Modal-wrapper spectrum-CSSExample-dialog spectrum-BackgroundLayers--elevated">
         <div class="spectrum-Modal is-open">This is a modal. Don't use it like this; get yourself a Modal.</div>
       </div>

--- a/components/stepper/index.css
+++ b/components/stepper/index.css
@@ -36,7 +36,7 @@ governing permissions and limitations under the License.
 
   /*** MODS for sub components ***/
   --mod-infield-button-border-color: var(--highcontrast-stepper-border-color, var(--mod-stepper-buttons-border-color, var(--spectrum-stepper-buttons-border-color)));
-  --mod-infield-button-border-width: var(--mod-stepper-border-width, var(--spectrum-stepper-border-width));
+  --mod-infield-button-border-width: var(--mod-stepper-button-border-width, var(--spectrum-stepper-button-border-width));
   --mod-textfield-border-width: var(--mod-stepper-border-width, var(--spectrum-stepper-border-width));
 
   &.spectrum-Stepper--sizeS {
@@ -226,17 +226,12 @@ governing permissions and limitations under the License.
   }
 
   .spectrum-Stepper-button {
+    --mod-infield-button-border-block-end-width: var(--mod-stepper-border-width, var(--spectrum-stepper-border-width));
+    --mod-infield-button-stacked-bottom-border-block-end-width: var(--mod-stepper-border-width, var(--spectrum-stepper-border-width));
+    --mod-infield-button-stacked-bottom-border-radius-end-end: 0;
+    --mod-infield-button-stacked-bottom-border-radius-end-start: 0;
+    --mod-infield-button-fill-justify-content: flex-end;
     padding: 0;
-  }
-
-  .spectrum-Stepper-button.spectrum-InfieldButton--bottom .spectrum-InfieldButton-fill {
-    border-block-end-width: var(--mod-stepper-border-width, var(--spectrum-stepper-border-width));
-    border-end-end-radius: 0;
-    border-end-start-radius: 0;
-  }
-
-  .spectrum-Stepper-button .spectrum-InfieldButton-fill {
-    justify-content: flex-end;
   }
 
   .spectrum-Stepper-input,
@@ -305,14 +300,6 @@ governing permissions and limitations under the License.
 
   background-color: var(--highcontrast-stepper-buttons-background-color, var(--mod-stepper-buttons-background-color, var(--spectrum-stepper-buttons-background-color)));
   transition: border-color var(--mod-stepper-animation-duration, var(--spectrum-stepper-animation-duration)) ease-in-out;
-}
-
-.spectrum-Stepper-button.spectrum-InfieldButton--top {
-  padding-block-start: calc(var(--mod-stepper-button-padding, var(--spectrum-stepper-button-padding)) - var(--mod-stepper-border-width, var(--spectrum-stepper-border-width)));
-}
-
-.spectrum-Stepper-button.spectrum-InfieldButton--bottom {
-  padding-block-end: calc(var(--mod-stepper-button-padding, var(--spectrum-stepper-button-padding)) - var(--mod-stepper-border-width, var(--spectrum-stepper-border-width)));
 }
 
 /* hide-stepper */

--- a/components/stepper/metadata/mods.md
+++ b/components/stepper/metadata/mods.md
@@ -15,7 +15,7 @@
 | `--mod-stepper-border-width`                           |
 | `--mod-stepper-button-background-color-focus`          |
 | `--mod-stepper-button-background-color-keyboard-focus` |
-| `--mod-stepper-button-padding`                         |
+| `--mod-stepper-button-border-width`                    |
 | `--mod-stepper-button-width`                           |
 | `--mod-stepper-button-width-quiet`                     |
 | `--mod-stepper-buttons-background-color`               |

--- a/components/stepper/themes/express.css
+++ b/components/stepper/themes/express.css
@@ -23,6 +23,7 @@ governing permissions and limitations under the License.
     --spectrum-stepper-buttons-border-color-keyboard-focus: transparent;
 
     --spectrum-stepper-button-border-radius-reset: var(--spectrum-in-field-button-fill-stacked-inner-border-rounding);
+    --spectrum-stepper-button-border-width: 0;
 
     --spectrum-stepper-border-color: var(--spectrum-gray-400);
     --spectrum-stepper-border-color-hover: var(--spectrum-gray-500);

--- a/components/stepper/themes/spectrum.css
+++ b/components/stepper/themes/spectrum.css
@@ -22,6 +22,9 @@ governing permissions and limitations under the License.
     --spectrum-stepper-buttons-border-color-focus: var(--spectrum-gray-800);
     --spectrum-stepper-buttons-border-color-keyboard-focus: var(--spectrum-gray-900);
 
+    --spectrum-stepper-button-border-radius-reset: 0px;
+    --spectrum-stepper-button-border-width: var(--spectrum-border-width-100);
+
     --spectrum-stepper-border-color: var(--spectrum-gray-500);
     --spectrum-stepper-border-color-hover: var(--spectrum-gray-600);
     --spectrum-stepper-border-color-focus: var(--spectrum-gray-800);
@@ -32,8 +35,6 @@ governing permissions and limitations under the License.
     --spectrum-stepper-border-color-focus-invalid: var(--spectrum-negative-border-color-focus);
     --spectrum-stepper-border-color-focus-hover-invalid: var(--spectrum-negative-border-color-focus-hover);
     --spectrum-stepper-border-color-keyboard-focus-invalid: var(--spectrum-negative-border-color-key-focus);
-
-    --spectrum-stepper-button-border-radius-reset: 0px;
 
     --spectrum-stepper-button-background-color-focus: var(--spectrum-gray-300);
     --spectrum-stepper-button-background-color-keyboard-focus: var(--spectrum-gray-200);

--- a/tokens/package.json
+++ b/tokens/package.json
@@ -27,7 +27,7 @@
     "format:results": "prettier --no-config --no-error-on-unmatched-pattern --ignore-unknown --loglevel silent --write dist/"
   },
   "devDependencies": {
-    "@adobe/spectrum-tokens": "12.23.1",
+    "@adobe/spectrum-tokens": "13.0.0-beta.5",
     "concat-cli": "^4.0.0",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2687,10 +2687,40 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/expressvars/-/expressvars-3.0.9.tgz#72678e0845c240bc9cb6b4d828f20806810f4cab"
   integrity sha512-mnxdnF2NGNdba+3OomwFURPG0XqNRD+S2cmX0ARYnia9lv84HpzhbSoGuqmQO4+4+dXe46zYjnKRe2L8oJM/zw==
 
-"@spectrum-css/vars@^9.0.8":
-  version "9.0.8"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/vars/-/vars-9.0.8.tgz#6af3bcdace903b8461f5fcd4c9aa23e70128a456"
-  integrity sha512-rGfd7jqXOdR69bEjrRP58ynuIeJU0czPfwQvzhtCzg7jKVukV+efNHqrs086sC6xutB3W4TF71K/dZMr3oyTyg==
+"@spectrum-css/clearbutton@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/clearbutton/-/clearbutton-2.0.0.tgz#ad638dd4bd021f42c0b020ae024f487aa64198ca"
+  integrity sha512-hdJFgBVnzRPe9jne5iaGE6NFuynUpwFuNtKRB4LJ1Yt0IqDK+bXhdak9NxMnvHEFjUr4NGDdBoXFUiBHPYYlSQ==
+
+"@spectrum-css/icon@^3.1.0-alpha.0":
+  version "3.1.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/icon/-/icon-3.1.0-alpha.0.tgz#5aa819f4078dd899aaed4a301014eb17b2998bc1"
+  integrity sha512-qokLJ1FvEFS/0ef6I1cKFCZr3JLfBLCPdRmAimrElocUx6hBbzwfBOVoRm0tHSZM9VIxHVMugziTA2IbSdH2EA==
+
+"@spectrum-css/menu@^4.0.50":
+  version "4.0.50"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/menu/-/menu-4.0.50.tgz#d72467542b0cab858062c6fd5cb2950e8bbb0bc4"
+  integrity sha512-CBg8mUe4BFR0pKsMLWkAQW9/7tOp1V9QQkQzc8ZnT3Ayz5uFGy9saEErN5mSWxf2+22Ab5UftMU2uzgFo762eA==
+
+"@spectrum-css/stepper@^4.0.59":
+  version "4.0.59"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/stepper/-/stepper-4.0.59.tgz#e5501abd0755e0032277604e9196299279dced44"
+  integrity sha512-bE1T3+kHDPY4xPKtYd7cpFtS7odRiAlenZWU0HLNPhEZBfXou/jt86PQaDfZvD6smG3aiZOyuFGy7go2aoGhlQ==
+
+"@spectrum-css/tokens@11.3.7":
+  version "11.3.7"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/tokens/-/tokens-11.3.7.tgz#b4a32faa3febe1e0dc33a109e0ff5545a02bfac6"
+  integrity sha512-WX0dPqwb2t9u9WBzIRzzYXL/ZJc0r/cSBb7eJxw1xCyg5NQnUKIhGtRT+cMTTCQP0SERFgCk9CZEJcJkZDphGw==
+
+"@spectrum-css/tokens@^11.3.6", "@spectrum-css/tokens@^11.3.7":
+  version "11.4.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/tokens/-/tokens-11.4.0.tgz#381e163c5cae2f8483b47c380a75d1dbaf60b933"
+  integrity sha512-emJOFG/rYO+bE4X+6/CBZApGgdQ8fAp8fQpd1NwF5dW0kwOYGib2XjaQXsVvuXNb64eo/2sjyD8JrB5LCOnVKw==
+
+"@spectrum-css/underlay@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/underlay/-/underlay-2.1.0.tgz#00a30d527d29e8e1ce1567765dab363738e16fb9"
+  integrity sha512-KlOV7uel4C8HhYAoPlBvCReI+BIKpOmgRLLPo2XFVM4rTsFa1xxFVkmeP74uEPuVLcRtXGG3/6cL2+0OArhZmA==
 
 "@storybook/addon-a11y@^7.5.1":
   version "7.5.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -61,10 +61,10 @@
   resolved "https://registry.yarnpkg.com/@adobe/spectrum-css-workflow-icons/-/spectrum-css-workflow-icons-1.5.4.tgz#0e09ff519c36139176c3ba3ce617a995c9032f67"
   integrity sha512-sZ19YOLGw5xTZzCEkVXPjf53lXVzo063KmDTJjpSjy/XLVsF+RaX0b436SfSM4hsIUZ7n27+UsbOvzFaFjcYXw==
 
-"@adobe/spectrum-tokens@12.23.1":
-  version "12.23.1"
-  resolved "https://registry.yarnpkg.com/@adobe/spectrum-tokens/-/spectrum-tokens-12.23.1.tgz#60bce03365850508bc3d36aa5dfc9b77533f0008"
-  integrity sha512-PQnZ7KRsOA7M8AsEE5ajEmfSjnmo1/1tiUymFPFcGrWnV0jNYO/6n16LA3925KJo/+IbmNrYNpdHhpBGpXjhcQ==
+"@adobe/spectrum-tokens@13.0.0-beta.5":
+  version "13.0.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@adobe/spectrum-tokens/-/spectrum-tokens-13.0.0-beta.5.tgz#a84cfe1250adadb3985a15a0ebabdbcc870db2dc"
+  integrity sha512-u2cqkNcszFw4IHWnvOSfv7++Wt67wHL7Sj1QmUZCpBSp7fLGdjixiGf/eLXEwXbur65qNcFOsI3yC5pS9Ns4/Q==
 
 "@ampproject/remapping@^2.2.0":
   version "2.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2682,45 +2682,49 @@
   resolved "https://registry.yarnpkg.com/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz#96116f2a912e0c02817345b3c10751069920d553"
   integrity sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==
 
+"@spectrum-css/component-builder-simple@^2.0.17":
+  version "2.0.18"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/component-builder-simple/-/component-builder-simple-2.0.18.tgz#975ab1402f76b4d38fcd55005fef0ce83ddf884c"
+  integrity sha512-j3zi7x++COMoChWUFajbh6nD9fyNUEfh59JghcJ3WssaPp/dGlyjQ7DKb4KzzImdOlkXJYj04CHeeOiDufN8dA==
+  dependencies:
+    "@spectrum-css/tokens" "^13.0.3"
+    autoprefixer "^6.5.3"
+    colors "^1.4.0"
+    del "^5.0.0"
+    gulp "^4.0.0"
+    gulp-concat "^2.6.1"
+    gulp-postcss "^7.0.0"
+    gulp-rename "^1.4.0"
+    gulplog "^2.0.1"
+    postcss "^7.0.36"
+    postcss-calc "^6.0.0"
+    postcss-combininator "^1.0.2"
+    postcss-discard-comments "^4.0.0"
+    postcss-discard-empty "^4.0.1"
+    postcss-dropdupedvars "^1.1.2"
+    postcss-dropunusedvars "^1.2.1"
+    postcss-import "^10.0.0"
+    postcss-inherit "^4.0.3"
+    postcss-nested "^3.0.0"
+    postcss-selector-parser "^6.0.2"
+    postcss-splitinator "^1.0.2"
+    postcss-values-parser "^3.1.1"
+    through2 "^3.0.1"
+
 "@spectrum-css/expressvars@^3.0.9":
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/@spectrum-css/expressvars/-/expressvars-3.0.9.tgz#72678e0845c240bc9cb6b4d828f20806810f4cab"
   integrity sha512-mnxdnF2NGNdba+3OomwFURPG0XqNRD+S2cmX0ARYnia9lv84HpzhbSoGuqmQO4+4+dXe46zYjnKRe2L8oJM/zw==
 
-"@spectrum-css/clearbutton@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/clearbutton/-/clearbutton-2.0.0.tgz#ad638dd4bd021f42c0b020ae024f487aa64198ca"
-  integrity sha512-hdJFgBVnzRPe9jne5iaGE6NFuynUpwFuNtKRB4LJ1Yt0IqDK+bXhdak9NxMnvHEFjUr4NGDdBoXFUiBHPYYlSQ==
+"@spectrum-css/tokens@^12.0.0":
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/tokens/-/tokens-12.0.0.tgz#dccc297cf62be60ddc23c15e9805acf664b38613"
+  integrity sha512-P4+AieUf60i3TRa4fnD+rlSH52ZQtimsEUMCdHReYO3wUGdLWdLln7rtZ0fVh4mXJ4z3o75MEbE4PYYklqtOmA==
 
-"@spectrum-css/icon@^3.1.0-alpha.0":
-  version "3.1.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/icon/-/icon-3.1.0-alpha.0.tgz#5aa819f4078dd899aaed4a301014eb17b2998bc1"
-  integrity sha512-qokLJ1FvEFS/0ef6I1cKFCZr3JLfBLCPdRmAimrElocUx6hBbzwfBOVoRm0tHSZM9VIxHVMugziTA2IbSdH2EA==
-
-"@spectrum-css/menu@^4.0.50":
-  version "4.0.50"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/menu/-/menu-4.0.50.tgz#d72467542b0cab858062c6fd5cb2950e8bbb0bc4"
-  integrity sha512-CBg8mUe4BFR0pKsMLWkAQW9/7tOp1V9QQkQzc8ZnT3Ayz5uFGy9saEErN5mSWxf2+22Ab5UftMU2uzgFo762eA==
-
-"@spectrum-css/stepper@^4.0.59":
-  version "4.0.59"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/stepper/-/stepper-4.0.59.tgz#e5501abd0755e0032277604e9196299279dced44"
-  integrity sha512-bE1T3+kHDPY4xPKtYd7cpFtS7odRiAlenZWU0HLNPhEZBfXou/jt86PQaDfZvD6smG3aiZOyuFGy7go2aoGhlQ==
-
-"@spectrum-css/tokens@11.3.7":
-  version "11.3.7"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/tokens/-/tokens-11.3.7.tgz#b4a32faa3febe1e0dc33a109e0ff5545a02bfac6"
-  integrity sha512-WX0dPqwb2t9u9WBzIRzzYXL/ZJc0r/cSBb7eJxw1xCyg5NQnUKIhGtRT+cMTTCQP0SERFgCk9CZEJcJkZDphGw==
-
-"@spectrum-css/tokens@^11.3.6", "@spectrum-css/tokens@^11.3.7":
-  version "11.4.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/tokens/-/tokens-11.4.0.tgz#381e163c5cae2f8483b47c380a75d1dbaf60b933"
-  integrity sha512-emJOFG/rYO+bE4X+6/CBZApGgdQ8fAp8fQpd1NwF5dW0kwOYGib2XjaQXsVvuXNb64eo/2sjyD8JrB5LCOnVKw==
-
-"@spectrum-css/underlay@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/underlay/-/underlay-2.1.0.tgz#00a30d527d29e8e1ce1567765dab363738e16fb9"
-  integrity sha512-KlOV7uel4C8HhYAoPlBvCReI+BIKpOmgRLLPo2XFVM4rTsFa1xxFVkmeP74uEPuVLcRtXGG3/6cL2+0OArhZmA==
+"@spectrum-css/vars@^9.0.8":
+  version "9.0.8"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/vars/-/vars-9.0.8.tgz#6af3bcdace903b8461f5fcd4c9aa23e70128a456"
+  integrity sha512-rGfd7jqXOdR69bEjrRP58ynuIeJU0czPfwQvzhtCzg7jKVukV+efNHqrs086sC6xutB3W4TF71K/dZMr3oyTyg==
 
 "@storybook/addon-a11y@^7.5.1":
   version "7.5.3"


### PR DESCRIPTION
## Description

Experimental PR to look at adding Background Layers 

This approach creates utility classes which can be used by adding background layers to the dependencies for the component and then using the classes where needed. 

Changes: 
- Created a utility like "component" for background layers. This should eventually live in it's own section of the docs site. I didn't focus too much on navigation for the docs site or editing the `nav.pug` file. 
- This "component" has classes for each of the layers specified in the specs for background layers which can be used directly; `spectrum-BackgroundLayers--elevated`, `spectrum-BackgroundLayers--layer2`, `spectrum-BackgroundLayers--layer1`, `spectrum-BackgroundLayers--pasteboard`, and `spectrum-BackgroundLayers--base`
- this allows these classes to be used by including it in the dependencies for the component where you intend to use it 
- For an example look at Alert Dialog
- In storybook background layers is in it's own section "utility classes"

Look at the [docs site for Alert Dialog ](https://pr-2274--spectrum-css.netlify.app/alertdialog) to see the elevated class in use

[Storybook ](https://pr-2274--spectrum-css.netlify.app/preview/?path=/story/utilityclasses-background-layers--editing)



