### PR TITLE
fix(infieldbutton): focus wont persist after mouse interaction

### DIFF
--- a/components/infieldbutton/index.css
+++ b/components/infieldbutton/index.css
@@ -24,8 +24,8 @@ governing permissions and limitations under the License.
 	);
 	--spectrum-infield-button-fill-padding: 0px;
 	--spectrum-infield-button-stacked-fill-padding-inline: var(--spectrum-in-field-button-edge-to-disclosure-icon-stacked-medium);
-	--spectrum-infield-button-stacked-fill-padding-outer: var(--spectrum-in-field-button-outer-edge-to-disclosure-icon-stacked-medium); 
-	--spectrum-infield-button-stacked-fill-padding-inner: var(--spectrum-in-field-button-inner-edge-to-disclosure-icon-stacked-medium); 
+	--spectrum-infield-button-stacked-fill-padding-outer: var(--spectrum-in-field-button-outer-edge-to-disclosure-icon-stacked-medium);
+	--spectrum-infield-button-stacked-fill-padding-inner: var(--spectrum-in-field-button-inner-edge-to-disclosure-icon-stacked-medium);
 
 	--spectrum-infield-button-animation-duration: var(
 		--spectrum-animation-duration-100
@@ -83,27 +83,27 @@ governing permissions and limitations under the License.
 	&.spectrum-InfieldButton--sizeS {
 		--spectrum-infield-button-height: var(--spectrum-component-height-75);
 		--spectrum-infield-button-width: var(--spectrum-component-height-75);
-		--spectrum-infield-button-stacked-fill-padding-inline: var(--spectrum-in-field-button-edge-to-disclosure-icon-stacked-small); 
-		--spectrum-infield-button-stacked-fill-padding-outer: var(--spectrum-in-field-button-outer-edge-to-disclosure-icon-stacked-small); 
-		--spectrum-infield-button-stacked-fill-padding-inner: var(--spectrum-in-field-button-inner-edge-to-disclosure-icon-stacked-small); 
+		--spectrum-infield-button-stacked-fill-padding-inline: var(--spectrum-in-field-button-edge-to-disclosure-icon-stacked-small);
+		--spectrum-infield-button-stacked-fill-padding-outer: var(--spectrum-in-field-button-outer-edge-to-disclosure-icon-stacked-small);
+		--spectrum-infield-button-stacked-fill-padding-inner: var(--spectrum-in-field-button-inner-edge-to-disclosure-icon-stacked-small);
 
 	}
 
 	&.spectrum-InfieldButton--sizeL {
 		--spectrum-infield-button-height: var(--spectrum-component-height-200);
 		--spectrum-infield-button-width: var(--spectrum-component-height-200);
-		--spectrum-infield-button-stacked-fill-padding-inline: var(--spectrum-in-field-button-edge-to-disclosure-icon-stacked-large); 
-		--spectrum-infield-button-stacked-fill-padding-outer: var(--spectrum-in-field-button-outer-edge-to-disclosure-icon-stacked-large); 
-		--spectrum-infield-button-stacked-fill-padding-inner: var(--spectrum-in-field-button-inner-edge-to-disclosure-icon-stacked-large); 
+		--spectrum-infield-button-stacked-fill-padding-inline: var(--spectrum-in-field-button-edge-to-disclosure-icon-stacked-large);
+		--spectrum-infield-button-stacked-fill-padding-outer: var(--spectrum-in-field-button-outer-edge-to-disclosure-icon-stacked-large);
+		--spectrum-infield-button-stacked-fill-padding-inner: var(--spectrum-in-field-button-inner-edge-to-disclosure-icon-stacked-large);
 
 	}
 
 	&.spectrum-InfieldButton--sizeXL {
 		--spectrum-infield-button-height: var(--spectrum-component-height-300);
 		--spectrum-infield-button-width: var(--spectrum-component-height-300);
-		--spectrum-infield-button-stacked-fill-padding-inline: var(--spectrum-in-field-button-edge-to-disclosure-icon-stacked-extra-large); 
-		--spectrum-infield-button-stacked-fill-padding-outer: var(--spectrum-in-field-button-outer-edge-to-disclosure-icon-stacked-extra-large); 
-		--spectrum-infield-button-stacked-fill-padding-inner: var(--spectrum-in-field-button-inner-edge-to-disclosure-icon-stacked-extra-large); 
+		--spectrum-infield-button-stacked-fill-padding-inline: var(--spectrum-in-field-button-edge-to-disclosure-icon-stacked-extra-large);
+		--spectrum-infield-button-stacked-fill-padding-outer: var(--spectrum-in-field-button-outer-edge-to-disclosure-icon-stacked-extra-large);
+		--spectrum-infield-button-stacked-fill-padding-inner: var(--spectrum-in-field-button-inner-edge-to-disclosure-icon-stacked-extra-large);
 
 	}
 
@@ -307,8 +307,7 @@ governing permissions and limitations under the License.
 		}
 	}
 
-	&:focus-visible,
-	&:focus {
+	&:focus-visible {
 		.spectrum-InfieldButton-fill {
 			background-color: var(
 				--mod-infield-button-background-color-key-focus,
@@ -340,7 +339,7 @@ governing permissions and limitations under the License.
 	block-size: calc(
 		var(--mod-infield-button-height, var(--spectrum-infield-button-height)) / 2
 	);
-	
+
 	.spectrum-InfieldButton-fill {
 		box-sizing: border-box;
 		padding-inline-start: calc(var(--mod-infield-button-stacked-fill-padding-inline, var(--spectrum-infield-button-stacked-fill-padding-inline)) - var(--mod-infield-button-edge-to-fill, var(--spectrum-infield-button-edge-to-fill)) - var(--mod-infield-button-border-width, var(--spectrum-infield-button-border-width)));


### PR DESCRIPTION
## Description

This work addresses issue #2233, which noted that focus shouldn't persist after mouse interaction.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps @jenndiaz 
- [x] Go to [the docs site](https://pr-2276--spectrum-css.netlify.app/infieldbutton) and click an infield button. After click, focus state should not persist
- [x] Keyboard focus remains unchanged

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
