### PR TITLE
fix(infieldbutton): no outline on focus-visible

### DIFF
--- a/components/infieldbutton/index.css
+++ b/components/infieldbutton/index.css
@@ -176,6 +176,14 @@ governing permissions and limitations under the License.
 			);
 		}
 	}
+
+	&:hover:not(:disabled),
+	&:active:not(:disabled),
+	&:focus-visible:not(:disabled) {
+		@media (forced-colors: active) {
+			--highcontrast-infield-button-border-color: Highlight;
+		}
+	}
 }
 
 .spectrum-InfieldButton {
@@ -216,8 +224,9 @@ governing permissions and limitations under the License.
 		);
 		border-style: solid;
 		border-color: var(
-			--mod-infield-button-border-color,
-			var(--spectrum-infield-button-border-color)
+			--highcontrast-infield-button-border-color,
+			var(--mod-infield-button-border-color,
+			var(--spectrum-infield-button-border-color))
 		);
 		border-end-end-radius: var(
 			--mod-infield-button-border-radius,
@@ -407,8 +416,6 @@ governing permissions and limitations under the License.
 		);
 	}
 }
-
-
 
 .spectrum-InfieldButton-icon {
 	display: initial;

--- a/components/infieldbutton/index.css
+++ b/components/infieldbutton/index.css
@@ -310,6 +310,8 @@ governing permissions and limitations under the License.
 	}
 
 	&:focus-visible {
+		outline: none;
+
 		.spectrum-InfieldButton-fill {
 			background-color: var(
 				--mod-infield-button-background-color-key-focus,


### PR DESCRIPTION
## Description

Addresses issue #2232. Per [the spec files](https://www.figma.com/file/nchxla8gD4CxWYwt9eiRrz/Token-definition-library?type=design&node-id=814-8857&mode=design&t=HifoxkguijiFSIM0-0), the In-field Button component shouldn't have an outline on keyboard focus. Keyboard focus also looks the same as hover focus for this component.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps @jenndiaz 

1. Open the component in [the docs site](https://pr-2288--spectrum-css.netlify.app/infieldbutton)
    - [x] When you tab through to apply keyboard focus, you should not see an outline
    - [x] Keyboard focus should look the same as the hover state
2. In the docs site, turn on WHCM
    - [x] You should see a border with the Highlight color when:
        - [x] Tabbing with keyboard
        - [x] You click and the button is active
        - [x] You hover a button
    - [x] You shouldn't see a border on hover, active, or focus on disabled infield buttons
    - [x] The border should have the same border radius as the component does when it's not hovered/focused/active
4. Open the component in [Storybook](https://pr-2288--spectrum-css.netlify.app/preview/?path=/story/components-in-field-button--default)
    - [x] When you tab through to apply keyboard focus, you should not see an outline
    - [x] Keyboard focus should look the same as the hover state

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

5. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
