### PR TITLE
chore(ci): add stricter timeouts to jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,7 @@ jobs:
                 node-version:
                     - ${{ inputs.node-version }}
         runs-on: ${{ matrix.system }}
+        timeout-minutes: 10
         outputs:
             head-sha: ${{ steps.set-SHAs.outputs.head }}
             base-sha: ${{ steps.set-SHAs.outputs.base }}

--- a/.github/workflows/compare-results.yml
+++ b/.github/workflows/compare-results.yml
@@ -38,6 +38,7 @@ jobs:
     compare:
         name: Compare compiled assets
         runs-on: ubuntu-latest
+        timeout-minutes: 10
         needs: [fetch-build-artifacts]
         outputs:
             has-changed: ${{ steps.compare.outputs.has-changed }}
@@ -102,6 +103,7 @@ jobs:
                     - ${{ inputs.head-sha }}
                     - ${{ inputs.base-sha }}
         runs-on: ubuntu-latest
+        timeout-minutes: 10
         steps:
             - name: Set the cache key for builds
               id: derive-key

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,6 +42,7 @@ jobs:
     lint:
         name: Lint
         runs-on: ubuntu-latest
+        timeout-minutes: 5
         steps:
             # install but don't build - we're linting pre-compiled assets
             - name: Check out code

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -53,6 +53,7 @@ jobs:
 
     todo_to_issue:
         runs-on: ubuntu-latest
+        timeout-minutes: 5
         steps:
             - name: Check out code
               uses: actions/checkout@v4
@@ -63,6 +64,7 @@ jobs:
     autoupdate:
       name: Auto-update pull requests
       runs-on: ubuntu-latest
+      timeout-minutes: 5
       permissions:
         contents: read
         pull-requests: write

--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -38,6 +38,7 @@ jobs:
     publish_site:
         name: Publish
         runs-on: ubuntu-latest
+        timeout-minutes: 10
         steps:
             ## --- SETUP --- ##
             - name: Check out code

--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -22,6 +22,7 @@ jobs:
     vrt:
         name: Chromatic
         runs-on: ubuntu-latest
+        timeout-minutes: 20
         outputs:
             storybook-url: ${{ steps.chromatic.outputs.storybookUrl }}
 


### PR DESCRIPTION
## Description

This sets stricter timeout limits on the updated CI tasks.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] ✨ This pull request is ready to merge. ✨
