### PR TITLE
fix(menu)!: reimplement text truncating

### DIFF
--- a/components/menu/index.css
+++ b/components/menu/index.css
@@ -537,8 +537,6 @@ governing permissions and limitations under the License.
 
 .spectrum-Menu-itemLabel {
   grid-area: labelArea;
-  display: flex;
-  align-items: flex-start;
   font-size: var(--mod-menu-item-label-font-size, var(--spectrum-menu-item-label-font-size));
   color: var(--highcontrast-menu-item-color-default, var(--mod-menu-item-label-content-color-default, var(--spectrum-menu-item-label-content-color-default)));
 }
@@ -641,7 +639,6 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Menu-itemLabel--truncate {
-  display: block;
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;

--- a/components/menu/index.css
+++ b/components/menu/index.css
@@ -537,7 +537,6 @@ governing permissions and limitations under the License.
   grid-area: iconArea;
 }
 
-
 .spectrum-Menu-checkmark {
   grid-area: checkmarkArea;
   align-self: start;

--- a/components/menu/index.css
+++ b/components/menu/index.css
@@ -377,7 +377,7 @@ governing permissions and limitations under the License.
   display: grid;
   /* stylelint-disable declaration-block-no-redundant-longhand-properties */
   grid-template-areas:
-    ".            chevronAreaCollapsible .             iconArea sectionHeadingArea  .         .           .                 "
+    ".            chevronAreaCollapsible .             headingIconArea  sectionHeadingArea  .         .           .                 "
     "selectedArea chevronAreaCollapsible checkmarkArea iconArea labelArea        valueArea actionsArea chevronAreaDrillIn"
     ".            .                      .             .        descriptionArea  .         .           .                 "
     ".            .                      .             .        submenuArea      .         .           .                 ";
@@ -525,6 +525,18 @@ governing permissions and limitations under the License.
   grid-area: iconArea;
   align-self: start;
 }
+
+.spectrum-Menu-item--collapsible .spectrum-Menu-itemIcon {
+  grid-area: headingIconArea;
+}
+
+.is-selectableMultiple .spectrum-Menu-item {
+  align-items: start;
+}
+.is-selectableMultiple .spectrum-Menu-itemCheckbox {
+  grid-area: iconArea;
+}
+
 
 .spectrum-Menu-checkmark {
   grid-area: checkmarkArea;

--- a/components/menu/index.css
+++ b/components/menu/index.css
@@ -16,7 +16,7 @@ governing permissions and limitations under the License.
   --spectrum-menu-item-icon-width: var(--spectrum-workflow-icon-size-100);
   --spectrum-menu-item-label-font-size: var(--spectrum-font-size-100);
   --spectrum-menu-item-label-text-to-visual: var(--spectrum-text-to-visual-100);
-  
+
   --spectrum-menu-item-label-inline-edge-to-content: var(--spectrum-component-edge-to-text-100);
   --spectrum-menu-item-top-edge-to-text: var(--spectrum-component-top-to-text-100);
   --spectrum-menu-item-bottom-edge-to-text: var(--spectrum-component-bottom-to-text-100);
@@ -71,7 +71,7 @@ governing permissions and limitations under the License.
   --spectrum-menu-section-header-font-weight: var(--spectrum-bold-font-weight);
   --spectrum-menu-section-header-color: var(--spectrum-gray-900);
   --spectrum-menu-collapsible-icon-color: var(--spectrum-gray-900);
-  
+
   --spectrum-menu-checkmark-icon-color-default: var(--spectrum-accent-color-900);
   --spectrum-menu-checkmark-icon-color-hover: var(--spectrum-accent-color-1000);
   --spectrum-menu-checkmark-icon-color-down: var(--spectrum-accent-color-1100);
@@ -120,7 +120,7 @@ governing permissions and limitations under the License.
   --spectrum-menu-item-icon-width: var(--spectrum-workflow-icon-size-75);
   --spectrum-menu-item-label-font-size: var(--spectrum-font-size-75);
   --spectrum-menu-item-label-text-to-visual: var(--spectrum-text-to-visual-75);
- 
+
   --spectrum-menu-item-label-inline-edge-to-content: var(--spectrum-component-edge-to-text-75);
   --spectrum-menu-item-top-edge-to-text: var(--spectrum-component-top-to-text-75);
   --spectrum-menu-item-bottom-edge-to-text: var(--spectrum-component-bottom-to-text-75);
@@ -147,7 +147,7 @@ governing permissions and limitations under the License.
   --spectrum-menu-item-icon-width: var(--spectrum-workflow-icon-size-200);
   --spectrum-menu-item-label-font-size: var(--spectrum-font-size-200);
   --spectrum-menu-item-label-text-to-visual: var(--spectrum-text-to-visual-200);
-  
+
   --spectrum-menu-item-label-inline-edge-to-content: var(--spectrum-component-edge-to-text-200);
   --spectrum-menu-item-top-edge-to-text: var(--spectrum-component-top-to-text-200);
   --spectrum-menu-item-bottom-edge-to-text: var(--spectrum-component-bottom-to-text-200);
@@ -174,7 +174,7 @@ governing permissions and limitations under the License.
   --spectrum-menu-item-icon-width: var(--spectrum-workflow-icon-size-300);
   --spectrum-menu-item-label-font-size: var(--spectrum-font-size-300);
   --spectrum-menu-item-label-text-to-visual: var(--spectrum-text-to-visual-300);
-  
+
   --spectrum-menu-item-label-inline-edge-to-content: var(--spectrum-component-edge-to-text-300);
   --spectrum-menu-item-top-edge-to-text: var(--spectrum-component-top-to-text-300);
   --spectrum-menu-item-bottom-edge-to-text: var(--spectrum-component-bottom-to-text-300);
@@ -227,7 +227,7 @@ governing permissions and limitations under the License.
         --highcontrast-checkbox-highlight-color-hover: ButtonText;
         --highcontrast-checkbox-highlight-color-default: ButtonText;
       }
-  
+
       .spectrum-Menu-itemSwitch {
         --highcontrast-switch-handle-border-color-hover: ButtonText;
         --highcontrast-switch-handle-border-color-selected-default: ButtonText;
@@ -281,7 +281,7 @@ governing permissions and limitations under the License.
   .spectrum-Menu-divider {
     --spectrum-menu-divider-thickness: var(--spectrum-divider-thickness-medium);
     &.spectrum-Divider--sizeS {
-      --spectrum-menu-divider-thickness: var(--spectrum-divider-thickness-small); 
+      --spectrum-menu-divider-thickness: var(--spectrum-divider-thickness-small);
     }
 
     overflow: visible;
@@ -339,14 +339,14 @@ governing permissions and limitations under the License.
   box-sizing: border-box;
 
   background-color: var(--highcontrast-menu-item-background-color-default, var(--mod-menu-item-background-color-default, var(--spectrum-menu-item-background-color-default)));
-  
+
   line-height: var(--mod-menu-item-label-line-height, var(--spectrum-menu-item-label-line-height));
 
   min-block-size: var(--mod-menu-item-min-height, var(--spectrum-menu-item-min-height));
   padding-block-start: var(--mod-menu-item-top-edge-to-text, var(--spectrum-menu-item-top-edge-to-text));
   padding-block-end: var(--mod-menu-item-bottom-edge-to-text, var(--spectrum-menu-item-bottom-edge-to-text));
   padding-inline: var(--mod-menu-item-label-inline-edge-to-content, var(--spectrum-menu-item-label-inline-edge-to-content));
-  
+
   margin: 0;
   text-decoration: none;
 
@@ -365,7 +365,7 @@ governing permissions and limitations under the License.
 
   .spectrum-Menu-itemSwitch {
     min-block-size: 0;
-    
+
     .spectrum-Switch-switch {
       margin-block-start: var(--mod-menu-item-top-to-action, var(--spectrum-menu-item-top-to-action));;
       margin-block-end: 0;
@@ -381,7 +381,7 @@ governing permissions and limitations under the License.
     "selectedArea chevronAreaCollapsible checkmarkArea iconArea labelArea        valueArea actionsArea chevronAreaDrillIn"
     ".            .                      .             .        descriptionArea  .         .           .                 "
     ".            .                      .             .        submenuArea      .         .           .                 ";
-  
+
   grid-template-columns: auto auto auto auto 1fr auto auto auto;
   grid-template-rows: 1fr auto;
 }
@@ -422,7 +422,7 @@ governing permissions and limitations under the License.
   > .spectrum-Menu-itemValue {
     color: var(--highcontrast-menu-item-color-focus, var(--mod-menu-item-value-color-focus, var(--spectrum-menu-item-value-color-focus)));
   }
-  
+
   > .spectrum-Menu-itemIcon:not(.spectrum-Menu-chevron, .spectrum-Menu-checkmark) {
     fill: var(--highcontrast-menu-item-color-focus, var(--mod-menu-item-label-icon-color-focus, var(--spectrum-menu-item-label-icon-color-focus)));
     color: var(--highcontrast-menu-item-color-focus, var(--mod-menu-item-label-icon-color-focus, var(--spectrum-menu-item-label-icon-color-focus)));
@@ -469,7 +469,7 @@ governing permissions and limitations under the License.
   > .spectrum-Menu-itemValue {
     color: var(--highcontrast-menu-item-color-focus, var(--mod-menu-item-value-color-hover, var(--spectrum-menu-item-value-color-hover)));
   }
-  
+
   > .spectrum-Menu-itemIcon:not(.spectrum-Menu-chevron, .spectrum-Menu-checkmark) {
     fill: var(--highcontrast-menu-item-color-focus, var(--mod-menu-item-label-icon-color-hover, var(--spectrum-menu-item-label-icon-color-hover)));
     color: var(--highcontrast-menu-item-color-focus, var(--mod-menu-item-label-icon-color-hover, var(--spectrum-menu-item-label-icon-color-hover)));
@@ -492,7 +492,7 @@ governing permissions and limitations under the License.
   > .spectrum-Menu-itemLabel {
     color: var(--highcontrast-menu-item-color-focus, var(--mod-menu-item-label-content-color-down, var(--spectrum-menu-item-label-content-color-down)));
   }
-  
+
   > .spectrum-Menu-sectionHeading {
     color: var(--highcontrast-menu-item-color-focus, var(--mod-menu-section-header-color, var(--spectrum-menu-section-header-color)));
   }
@@ -504,7 +504,7 @@ governing permissions and limitations under the License.
   > .spectrum-Menu-itemValue {
     color: var(--highcontrast-menu-item-color-focus, var(--mod-menu-item-value-color-down, var(--spectrum-menu-item-value-color-down)));
   }
-  
+
   > .spectrum-Menu-itemIcon:not(.spectrum-Menu-chevron, .spectrum-Menu-checkmark) {
     fill: var(--highcontrast-menu-item-color-focus, var(--mod-menu-item-label-icon-color-down, var(--spectrum-menu-item-label-icon-color-down)));
     color: var(--highcontrast-menu-item-color-focus, var(--mod-menu-item-label-icon-color-down, var(--spectrum-menu-item-label-icon-color-down)));
@@ -640,7 +640,8 @@ governing permissions and limitations under the License.
   margin-inline-start: var(--mod-menu-item-label-to-value-area-min-spacing, var(--spectrum-menu-item-label-to-value-area-min-spacing));
 }
 
-.spectrum-Menu-itemLabel--wrapping {
+.spectrum-Menu-itemLabel--truncate {
+  display: block;
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
@@ -694,11 +695,11 @@ governing permissions and limitations under the License.
 }
 
 [dir="rtl"] .spectrum-Menu-chevron {
-  transform: rotate(-180deg); 
+  transform: rotate(-180deg);
 }
 
 /*
-  assume that if an item is collapsible, it will 
+  assume that if an item is collapsible, it will
   have a chevron and we need to adjust position of submenu items to account for that
 */
 .spectrum-Menu-item--collapsible .spectrum-Menu {
@@ -745,7 +746,7 @@ governing permissions and limitations under the License.
     .spectrum-Menu-chevron {
       fill: var(--highcontrast-menu-item-color-focus, var(--mod-menu-drillin-icon-color-hover, var(--spectrum-menu-drillin-icon-color-hover)));
       color: var(--highcontrast-menu-item-color-focus, var(--mod-menu-drillin-icon-color-hover, var(--spectrum-menu-drillin-icon-color-hover)));
-    }    
+    }
   }
 
   &:focus,
@@ -753,14 +754,14 @@ governing permissions and limitations under the License.
     .spectrum-Menu-chevron {
       fill: var(--highcontrast-menu-item-color-focus, var(--mod-menu-drillin-icon-color-focus, var(--spectrum-menu-drillin-icon-color-focus)));
       color: var(--highcontrast-menu-item-color-focus, var(--mod-menu-drillin-icon-color-focus, var(--spectrum-menu-drillin-icon-color-focus)));
-    }    
+    }
   }
 
   &:active {
     .spectrum-Menu-chevron {
       fill: var(--highcontrast-menu-item-color-focus, var(--mod-menu-drillin-icon-color-down, var(--spectrum-menu-drillin-icon-color-down)));
       color: var(--highcontrast-menu-item-color-focus, var(--mod-menu-drillin-icon-color-down, var(--spectrum-menu-drillin-icon-color-down)));
-    }    
+    }
   }
 }
 
@@ -773,11 +774,11 @@ governing permissions and limitations under the License.
   .spectrum-Menu-sectionHeading {
     color: var(--highcontrast-menu-item-color-disabled, var(--mod-menu-item-label-content-color-disabled, var(--spectrum-menu-item-label-content-color-disabled)));
   }
-  
+
   .spectrum-Menu-itemDescription {
     color: var(--highcontrast-menu-item-color-disabled, var(--mod-menu-item-description-color-disabled, var(--spectrum-menu-item-description-color-disabled)));
   }
-  
+
   .spectrum-Menu-itemIcon {
     fill: var(--highcontrast-menu-item-color-disabled, var(--mod-menu-item-label-icon-color-disabled, var(--spectrum-menu-item-label-icon-color-disabled)));
     color: var(--highcontrast-menu-item-color-disabled, var(--mod-menu-item-label-icon-color-disabled, var(--spectrum-menu-item-label-icon-color-disabled)));

--- a/components/menu/metadata/menu.yml
+++ b/components/menu/metadata/menu.yml
@@ -1265,10 +1265,10 @@ examples:
           <div class="spectrum-Examples-itemGroup">
             <ul class="spectrum-Menu" role="menu">
               <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
-                <label class="spectrum-Switch-label spectrum-Menu-itemLabel" for="switch-onoff-3">
                   <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Menu-itemIcon spectrum-Menu-itemIcon--workflowIcon" focusable="false" aria-hidden="true" aria-label="Selection Icon">
                     <use xlink:href="#spectrum-icon-18-Selection"></use>
                   </svg>
+                <label class="spectrum-Switch-label spectrum-Menu-itemLabel" for="switch-onoff-3">
                   Marquee
                 </label>
                 <div class="spectrum-Menu-itemActions">
@@ -1279,10 +1279,10 @@ examples:
                 </div>
               </li>
               <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
+                <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Menu-itemIcon spectrum-Menu-itemIcon--workflowIcon" focusable="false" aria-hidden="true" aria-label="Select Add Icon">
+                  <use xlink:href="#spectrum-icon-18-SelectAdd"></use>
+                </svg>
                 <label class="spectrum-Switch-label spectrum-Menu-itemLabel" for="switch-onoff-4">
-                  <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Menu-itemIcon spectrum-Menu-itemIcon--workflowIcon" focusable="false" aria-hidden="true" aria-label="Select Add Icon">
-                    <use xlink:href="#spectrum-icon-18-SelectAdd"></use>
-                  </svg>
                   Add
                 </label>
                 <div class="spectrum-Menu-itemActions">
@@ -1293,10 +1293,10 @@ examples:
                 </div>
               </li>
               <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
+                <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Menu-itemIcon spectrum-Menu-itemIcon--workflowIcon" focusable="false" aria-hidden="true" aria-label="Select Subtract Icon">
+                  <use xlink:href="#spectrum-icon-18-SelectSubtract"></use>
+                </svg>
                 <label class="spectrum-Switch-label spectrum-Menu-itemLabel" for="switch-onoff-5">
-                  <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Menu-itemIcon spectrum-Menu-itemIcon--workflowIcon" focusable="false" aria-hidden="true" aria-label="Select Subtract Icon">
-                    <use xlink:href="#spectrum-icon-18-SelectSubtract"></use>
-                  </svg>
                   Subtract
                 </label>
                 <div class="spectrum-Menu-itemActions">
@@ -1383,7 +1383,7 @@ examples:
     name: Menu with truncating text
     description: To truncate menu items, use the class `spectrum-Menu-itemLabel--truncate` along with a fixed inline size on the item that should truncate
     markup: |
-      <div class="spectrum-Examples">
+      <div class="spectrum-Examples" style="justify-content: flex-start; gap: 25%;">
         <div class="spectrum-Examples-item">
           <ul class="spectrum-Menu spectrum-Menu--sizeM" role="menu" style="inline-size: 100px;">
             <li class="spectrum-Menu-item" role="menuitem" tabindex="0">

--- a/components/menu/metadata/menu.yml
+++ b/components/menu/metadata/menu.yml
@@ -1017,7 +1017,7 @@ examples:
               <span class="spectrum-Menu-itemLabel">Feather Effect </span>
             </li>
             <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
-              <span class="spectrum-Menu-itemLabel">Select and Mask Effectspan>
+              <span class="spectrum-Menu-itemLabel">Select and Mask </span>
             </li>
             <li class="spectrum-Divider spectrum-Divider--sizeS spectrum-Menu-divider" role="separator"></li>
             <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
@@ -1381,7 +1381,7 @@ examples:
               </ul>
   - id: menu-truncate
     name: Menu with truncating text
-    description: spectrum-Menu-itemLabel--truncate along with a fix width, can be used to truncate menu items
+    description: To truncate menu items, use the class `spectrum-Menu-itemLabel--truncate` along with a fixed inline size on the item that should truncate
     markup: |
       <div class="spectrum-Examples">
         <div class="spectrum-Examples-item">
@@ -1393,7 +1393,7 @@ examples:
               <span class="spectrum-Menu-itemLabel">Select Inverse</span>
             </li>
             <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
-              <span class="spectrum-Menu-itemLabel spectrum-Menu-itemLabel--truncate">Select and Mask Items that are too long to fit</span>
+              <span class="spectrum-Menu-itemLabel spectrum-Menu-itemLabel--truncate">Truncate this menu item</span>
             </li>
             <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
               <span class="spectrum-Menu-itemLabel">Save Selection</span>

--- a/components/menu/metadata/menu.yml
+++ b/components/menu/metadata/menu.yml
@@ -1383,6 +1383,9 @@ examples:
                   <span class="spectrum-Menu-itemLabel">Subtract</span>
                 </li>
               </ul>
+          </div>
+        </div>
+
   - id: menu-truncate
     name: Menu with truncating text
     description: Use the class `spectrum-Menu-itemLabel--truncate` on the item label or section heading that should truncate with in a menu with a set `inline-size` or `max-inline-size`

--- a/components/menu/metadata/menu.yml
+++ b/components/menu/metadata/menu.yml
@@ -1014,10 +1014,10 @@ examples:
               <span class="spectrum-Menu-itemLabel">Select Inverse</span>
             </li>
             <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
-              <span class="spectrum-Menu-itemLabel">Feather Effect </span>
+              <span class="spectrum-Menu-itemLabel">Feather Effect</span>
             </li>
             <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
-              <span class="spectrum-Menu-itemLabel">Select and Mask </span>
+              <span class="spectrum-Menu-itemLabel">Select and Mask</span>
             </li>
             <li class="spectrum-Divider spectrum-Divider--sizeS spectrum-Menu-divider" role="separator"></li>
             <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
@@ -1381,7 +1381,7 @@ examples:
               </ul>
   - id: menu-truncate
     name: Menu with truncating text
-    description: To truncate menu items, use the class `spectrum-Menu-itemLabel--truncate` along with a fixed inline size on the item that should truncate
+    description: Use the class `spectrum-Menu-itemLabel--truncate` on the item label or section heading that should truncate with in a menu with a set `inline-size` or `max-inline-size`
     markup: |
       <div class="spectrum-Examples" style="justify-content: flex-start; gap: 25%;">
         <div class="spectrum-Examples-item">

--- a/components/menu/metadata/menu.yml
+++ b/components/menu/metadata/menu.yml
@@ -14,6 +14,10 @@ sections:
 
       ### Change workflow icon size to medium
       Please replace `.spectrum-Icon--sizeS` with `.spectrum-Icon--sizeM`.
+
+      ### Menu item with switch mark up ###
+      In the case of a menu item that includes an icon and a switch, the label and icon should be seperate elements. As opposed to the icon SVG being with in the label. This matches the pattern of other variants with icons within the menu item.
+
 examples:
   - id: sizing
     name: Sizing

--- a/components/menu/metadata/menu.yml
+++ b/components/menu/metadata/menu.yml
@@ -1312,7 +1312,7 @@ examples:
       </div>
   - id: submenu-drillin
     name: Drill-in for submenu
-    description: When a menu item contains a submenu, a drill-in chevron will appear at the end of the menu item to show that a submenu is available. See the guidelines for more info on how to display submenus.
+    description: Use the class `spectrum-Menu-itemLabel--truncate` on the item label or section heading that should truncate within a menu. When text would typically overflow beyond the available horizontal space and wrap (default behavior), ellipsis will appear instead. This is demonstrated here by setting an `inline-size` on the menu.
     markup: |
       <div class="spectrum-Examples">
         <div class="spectrum-Examples-item">

--- a/components/menu/metadata/menu.yml
+++ b/components/menu/metadata/menu.yml
@@ -8,10 +8,10 @@ sections:
     description: |
       ### T-shirt sizing
       Menu now supports t-shirt sizing and requires that you specify the size by adding a `.spectrum-Menu--size*` class.
-      
+
       ### Use small divider classes
       When using a section divider, add `.spectrum-Divider` and `spectrum-Divider--sizeS` classes to `spectrum-Menu-divider`. The divider has also changed from medium to small.
-      
+
       ### Change workflow icon size to medium
       Please replace `.spectrum-Icon--sizeS` with `.spectrum-Icon--sizeM`.
 examples:
@@ -551,7 +551,7 @@ examples:
                 <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-UIIcon-ChevronRight75 spectrum-Menu-chevron spectrum-Menu-itemIcon" focusable="false" aria-hidden="true" aria-label="Next">
                   <use xlink:href="#spectrum-css-icon-Chevron75" />
                 </svg>
-                
+
                 <span class="spectrum-Menu-sectionHeading" id="ex1-menu-heading-2" aria-hidden="true">Mobile</span>
                 <ul id="spectrum-menu-item-1-submenu" class="spectrum-Menu spectrum-Menu--sizeS is-open" aria-labelledby="ex1-menu-heading-2" role="menu">
                   <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
@@ -671,7 +671,7 @@ examples:
                 <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-UIIcon-ChevronRight100 spectrum-Menu-chevron spectrum-Menu-itemIcon" focusable="false" aria-hidden="true" aria-label="Next">
                   <use xlink:href="#spectrum-css-icon-Chevron100" />
                 </svg>
-                
+
                 <span class="spectrum-Menu-sectionHeading" id="ex2-menu-heading-2" aria-hidden="true">Mobile</span>
                 <ul id="spectrum-menu-item-1-submenu" class="spectrum-Menu is-open" aria-labelledby="ex2-menu-heading-2" role="menu">
                   <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
@@ -791,7 +791,7 @@ examples:
                 <svg class="spectrum-Icon spectrum-Icon--sizeL spectrum-UIIcon-ChevronRight200 spectrum-Menu-chevron spectrum-Menu-itemIcon" focusable="false" aria-hidden="true" aria-label="Next">
                   <use xlink:href="#spectrum-css-icon-Chevron200" />
                 </svg>
-                
+
                 <span class="spectrum-Menu-sectionHeading" id="ex3-menu-heading-2" aria-hidden="true">Mobile</span>
                 <ul id="spectrum-menu-item-1-submenu" class="spectrum-Menu spectrum-Menu--sizeL is-open" aria-labelledby="ex3-menu-heading-2" role="menu">
                   <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
@@ -911,7 +911,7 @@ examples:
                 <svg class="spectrum-Icon spectrum-Icon--sizeXL spectrum-UIIcon-Chevron300 spectrum-Menu-chevron spectrum-Menu-itemIcon" focusable="false" aria-hidden="true" aria-label="Next">
                   <use xlink:href="#spectrum-css-icon-Chevron300" />
                 </svg>
-                
+
                 <span class="spectrum-Menu-sectionHeading" id="ex4-menu-heading-2" aria-hidden="true">Mobile</span>
                 <ul id="spectrum-menu-item-1-submenu" class="spectrum-Menu spectrum-Menu--sizeXL is-open" aria-labelledby="ex4-menu-heading-2" role="menu">
                   <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
@@ -1014,10 +1014,10 @@ examples:
               <span class="spectrum-Menu-itemLabel">Select Inverse</span>
             </li>
             <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
-              <span class="spectrum-Menu-itemLabel">Feather...</span>
+              <span class="spectrum-Menu-itemLabel">Feather Effect </span>
             </li>
             <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
-              <span class="spectrum-Menu-itemLabel">Select and Mask...</span>
+              <span class="spectrum-Menu-itemLabel">Select and Mask Effectspan>
             </li>
             <li class="spectrum-Divider spectrum-Divider--sizeS spectrum-Menu-divider" role="separator"></li>
             <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
@@ -1379,6 +1379,24 @@ examples:
                   <span class="spectrum-Menu-itemLabel">Subtract</span>
                 </li>
               </ul>
+  - id: menu-truncate
+    name: Menu with truncating text
+    description: spectrum-Menu-itemLabel--truncate along with a fix width, can be used to truncate menu items
+    markup: |
+      <div class="spectrum-Examples">
+        <div class="spectrum-Examples-item">
+          <ul class="spectrum-Menu spectrum-Menu--sizeM" role="menu" style="inline-size: 100px;">
+            <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
+              <span class="spectrum-Menu-itemLabel">Deselect</span>
+            </li>
+            <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
+              <span class="spectrum-Menu-itemLabel">Select Inverse</span>
+            </li>
+            <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
+              <span class="spectrum-Menu-itemLabel spectrum-Menu-itemLabel--truncate">Select and Mask Items that are too long to fit</span>
+            </li>
+            <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
+              <span class="spectrum-Menu-itemLabel">Save Selection</span>
             </li>
           </ul>
         </div>

--- a/components/menu/metadata/menu.yml
+++ b/components/menu/metadata/menu.yml
@@ -1330,7 +1330,7 @@ examples:
               </svg>
             </li>
             <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
-              <span class="spectrum-Menu-itemLabel">Select and Mask...</span>
+              <span class="spectrum-Menu-itemLabel">Select and Mask</span>
             </li>
             <li class="spectrum-Menu-item" role="menuitem" tabindex="0">
               <span class="spectrum-Menu-itemLabel">Save Selection</span>

--- a/components/menu/stories/menu.stories.js
+++ b/components/menu/stories/menu.stories.js
@@ -39,7 +39,7 @@ export default {
         type: { summary: "text" },
         category: "Component",
       },
-      control: "number",
+      control: "text",
       if: { arg: "shouldTruncate", truthy: true },
     },
     hasActions: { table: { disable: true } },
@@ -53,7 +53,7 @@ export default {
     selectionMode: "none",
     size: "m",
     shouldTruncate: false,
-    maxInlineSize: "150"
+    maxInlineSize: "150px"
   },
   parameters: {
     actions: {
@@ -93,7 +93,7 @@ Truncate.args = {
     { label: "Make Work Path", isDisabled: true },
   ],
   shouldTruncate: true,
-  maxInlineSize: '100',
+  maxInlineSize: '100px',
 };
 
 export const MenuWithSections = Template.bind({});

--- a/components/menu/stories/menu.stories.js
+++ b/components/menu/stories/menu.stories.js
@@ -33,15 +33,15 @@ export default {
       control: "boolean",
     },
     maxInlineSize: {
-			name: "Max Inline Size",
-			type: { name: "text", required: true },
-			table: {
-				type: { summary: "text" },
-				category: "Component",
-			},
-			control: "number",
+      name: "Max Inline Size",
+      type: { name: "text", required: true },
+      table: {
+        type: { summary: "text" },
+        category: "Component",
+      },
+      control: "number",
       if: { arg: "shouldTruncate", truthy: true },
-		},
+    },
     hasActions: { table: { disable: true } },
     labelledby: { table: { disable: true } },
     items: { table: { disable: true } },

--- a/components/menu/stories/menu.stories.js
+++ b/components/menu/stories/menu.stories.js
@@ -23,6 +23,25 @@ export default {
 			options: ["s", "m", "l", "xl"],
 			control: "select",
 		},
+    shouldTruncate: {
+      name: "Truncate menu item label",
+      type: { name: "boolean" },
+      table: {
+        type: { summary: "boolean" },
+        category: "Component",
+      },
+      control: "boolean",
+    },
+    maxInlineSize: {
+			name: "Max Inline Size",
+			type: { name: "text", required: true },
+			table: {
+				type: { summary: "text" },
+				category: "Component",
+			},
+			control: "number",
+      if: { arg: "shouldTruncate", truthy: true },
+		},
     hasActions: { table: { disable: true } },
     labelledby: { table: { disable: true } },
     items: { table: { disable: true } },
@@ -33,6 +52,8 @@ export default {
     rootClass: "spectrum-Menu",
     selectionMode: "none",
     size: "m",
+    shouldTruncate: false,
+    maxInlineSize: "150"
   },
   parameters: {
     actions: {
@@ -72,7 +93,7 @@ Truncate.args = {
     { label: "Make Work Path", isDisabled: true },
   ],
   shouldTruncate: true,
-  inlineSize: '100px',
+  maxInlineSize: '100',
 };
 
 export const MenuWithSections = Template.bind({});
@@ -361,6 +382,7 @@ DrillInSubmenu.args = {
 
 export const Collapsible = Template.bind({});
 Collapsible.args = {
+  shouldTruncate: true,
   items: [
     {
       label: "Web Design",

--- a/components/menu/stories/menu.stories.js
+++ b/components/menu/stories/menu.stories.js
@@ -13,16 +13,16 @@ export default {
       table: { disable: true },
       options: ["none", "single", "multiple"],
     },
-		size: {
-			name: "Size",
-			type: { name: "string", required: true },
-			table: {
-				type: { summary: "string" },
-				category: "Component",
-			},
-			options: ["s", "m", "l", "xl"],
-			control: "select",
-		},
+    size: {
+      name: "Size",
+      type: { name: "string", required: true },
+      table: {
+        type: { summary: "string" },
+        category: "Component",
+      },
+      options: ["s", "m", "l", "xl"],
+      control: "select",
+    },
     shouldTruncate: {
       name: "Truncate menu item label",
       type: { name: "boolean" },

--- a/components/menu/stories/menu.stories.js
+++ b/components/menu/stories/menu.stories.js
@@ -52,12 +52,27 @@ Default.args = {
   items: [
     { label: "Deselect" },
     { label: "Select Inverse" },
-    { label: "Feather..." },
-    { label: "Select and Mask..." },
+    { label: "Feather" },
+    { label: "Select and Mask" },
     { type: "divider" },
     { label: "Save Selection" },
     { label: "Make Work Path", isDisabled: true },
   ],
+};
+
+export const Truncate = Template.bind({});
+Truncate.args = {
+  items: [
+    { label: "Deselect", },
+    { label: "Select Inverse" },
+    { label: "Feather" },
+    { label: "Select and Mask" },
+    { type: "divider" },
+    { label: "Save Selection" },
+    { label: "Make Work Path", isDisabled: true },
+  ],
+  shouldTruncate: true,
+  inlineSize: '100px',
 };
 
 export const MenuWithSections = Template.bind({});
@@ -335,7 +350,7 @@ DrillInSubmenu.args = {
       isOpen: true,
     },
     {
-      label: "Select and Mask...",
+      label: "Select and Mask",
       isDrillIn: true,
       isDisabled: true,
       isOpen: true,

--- a/components/menu/stories/template.js
+++ b/components/menu/stories/template.js
@@ -1,5 +1,6 @@
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
+import { styleMap } from "lit/directives/style-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { when } from "lit/directives/when.js";
 
@@ -258,7 +259,7 @@ export const Template = ({
       role=${ifDefined(role)}
       aria-labelledby=${ifDefined(labelledby)}
       aria-disabled=${isDisabled ? "true" : "false"}
-      style=${maxInlineSize ? `max-inline-size: ${maxInlineSize}px;` : ""}
+      style=${maxInlineSize ? `max-inline-size: ${maxInlineSize};` : styleMap(customStyles)}
     >
       ${items.map((i, idx) => {
         if (i.type === "divider")

--- a/components/menu/stories/template.js
+++ b/components/menu/stories/template.js
@@ -2,6 +2,7 @@ import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { styleMap } from "lit/directives/style-map.js";
+import { when } from "lit/directives/when.js";
 
 import { Template as Checkbox } from "@spectrum-css/checkbox/stories/template.js";
 import { Template as Divider } from "@spectrum-css/divider/stories/template.js";
@@ -25,8 +26,8 @@ export const MenuItem = ({
   isDrillIn = false,
   isCollapsible = false,
   isOpen = false,
-  shouldTruncate = false,
-  inlineSize = false,
+  shouldTruncate,
+  maxInlineSize,
   role = "menuitem",
   items = [],
   size,
@@ -37,6 +38,7 @@ export const MenuItem = ({
   value,
   ...globals
 }) => {
+  console.log('menu item', label, shouldTruncate)
   return html`
     <li
       class=${classMap({
@@ -54,7 +56,6 @@ export const MenuItem = ({
       role=${ifDefined(role)}
       aria-selected=${isSelected ? "true" : "false"}
       aria-disabled=${isDisabled ? "true" : "false"}
-      style=${ifDefined(inlineSize) ? `inline-size: ${inlineSize};` : ""}
       tabindex=${ifDefined(!isDisabled ? "0" : undefined)}>
       ${isCollapsible
         ? Icon({
@@ -77,7 +78,7 @@ export const MenuItem = ({
             ]
           }) : ''}
       ${isCollapsible
-        ? html`<span class="spectrum-Menu-sectionHeading">${label}</span>`
+        ? html`<span class="spectrum-Menu-sectionHeading ${shouldTruncate ? "spectrum-Menu-itemLabel--truncate" : "" }">${label}</span>`
         : ''
       }
       ${selectionMode != "multiple" && !isCollapsible
@@ -103,8 +104,8 @@ export const MenuItem = ({
             ],
           })
         : ''}
-      ${selectionMode == "multiple"
-        ? Checkbox({
+      ${when(selectionMode == "multiple", () =>  html`
+        ${Checkbox({
           ...globals,
           size,
           isEmphasized: true,
@@ -114,9 +115,10 @@ export const MenuItem = ({
           customClasses: [
             `${rootClass}Checkbox`,
           ],
-        })
-      : ''}
-      ${isChecked && selectionMode == "single"
+        })}
+         <span  class="spectrum-Menu-itemLabel ${shouldTruncate ? "spectrum-Menu-itemLabel--truncate" : "" }">${label}</span>
+         `)}
+        ${isChecked && selectionMode == "single"
         ? Icon({
             ...globals,
             iconName: "Checkmark100",
@@ -144,7 +146,7 @@ export const MenuItem = ({
             })}
             </div>`
           : ''}
-      ${isCollapsible && items.length > 0 ? Template({ ...globals, items, isOpen, size }) : ''}
+      ${isCollapsible && items.length > 0 ? Template({ ...globals, items, isOpen, size, shouldTruncate }) : ''}
     </li>
   `
 };
@@ -173,6 +175,8 @@ export const MenuGroup = ({
   isDisabled = false,
   isSelectable = false,
   isTraySubmenu = false,
+  shouldTruncate,
+  maxInlineSize,
   subrole,
   size,
   ...globals
@@ -196,11 +200,15 @@ export const MenuGroup = ({
               customClasses: [`spectrum-Menu-backIcon`]
             })}
           </button>
-          <span
-            class="spectrum-Menu-backHeading"
-            id=${id ?? `menu-heading-category-${idx}`}
-            aria-hidden="true"
-          >${heading}</span>
+          ${heading
+          ? html`<span
+              class="spectrum-Menu-sectionHeading ${shouldTruncate ? "spectrum-Menu-itemLabel--truncate" : "" }"
+              style=${maxInlineSize ? `max-inline-size: ${maxInlineSize}px;` : ""}
+              id=${id ?? `menu-heading-category-${idx}`}
+              aria-hidden="true"
+              >${heading}</span
+            >`
+          : ""}
         </div>`
     }
     ${Template({
@@ -211,10 +219,13 @@ export const MenuGroup = ({
       items,
       isDisabled,
       isSelectable,
+      shouldTruncate: true,
+      maxInlineSize,
       size,
     })}
   </li>
 `;
+
 
 export const Template = ({
   rootClass = "spectrum-Menu",
@@ -223,6 +234,8 @@ export const Template = ({
   customStyles = {},
   size,
   isDisabled = false,
+  maxInlineSize,
+  shouldTruncate,
   selectionMode = "none",
   isOpen = false,
   hasActions = false,
@@ -247,9 +260,10 @@ export const Template = ({
       role=${ifDefined(role)}
       aria-labelledby=${ifDefined(labelledby)}
       aria-disabled=${isDisabled ? "true" : "false"}
-      style=${ifDefined(styleMap(customStyles))}
+      style=${maxInlineSize ? `max-inline-size: ${maxInlineSize}px;` : ""}
     >
       ${items.map((i, idx) => {
+        console.log('template items', i)
         if (i.type === "divider")
           return Divider({
             ...globals,
@@ -265,6 +279,7 @@ export const Template = ({
             size,
             selectionMode,
             isTraySubmenu,
+            shouldTruncate
           });
         else
           return MenuItem({
@@ -275,6 +290,7 @@ export const Template = ({
             role: subrole,
             size,
             selectionMode,
+            shouldTruncate,
             hasActions,
           });
       })}

--- a/components/menu/stories/template.js
+++ b/components/menu/stories/template.js
@@ -109,7 +109,6 @@ export const MenuItem = ({
           size,
           isEmphasized: true,
           isChecked: isSelected,
-          label: label,
           id: `menu-checkbox-${idx}`,
           customClasses: [
             `${rootClass}Checkbox`,
@@ -186,7 +185,7 @@ export const MenuGroup = ({
   >
     ${!isTraySubmenu
       ? html`<span
-          class="spectrum-Menu-sectionHeading"
+          class="spectrum-Menu-sectionHeading ${shouldTruncate ? "spectrum-Menu-itemLabel--truncate" : "" }"
           id=${id ?? `menu-heading-category-${idx}`}
           aria-hidden="true"
         >${heading}</span>`

--- a/components/menu/stories/template.js
+++ b/components/menu/stories/template.js
@@ -25,6 +25,8 @@ export const MenuItem = ({
   isDrillIn = false,
   isCollapsible = false,
   isOpen = false,
+  shouldTruncate = false,
+  inlineSize = false,
   role = "menuitem",
   items = [],
   size,
@@ -52,6 +54,7 @@ export const MenuItem = ({
       role=${ifDefined(role)}
       aria-selected=${isSelected ? "true" : "false"}
       aria-disabled=${isDisabled ? "true" : "false"}
+      style=${ifDefined(inlineSize) ? `inline-size: ${inlineSize};` : ""}
       tabindex=${ifDefined(!isDisabled ? "0" : undefined)}>
       ${isCollapsible
         ? Icon({
@@ -79,8 +82,9 @@ export const MenuItem = ({
       }
       ${selectionMode != "multiple" && !isCollapsible
         ? html`<span class=${classMap({
-            [`${rootClass}Label`]: true,
-            ['spectrum-Switch-label']: hasActions,
+          [`${rootClass}Label`]: true,
+          ['spectrum-Switch-label']: hasActions,
+          [`spectrum-Menu-itemLabel--truncate`]: shouldTruncate,
           })}>
           ${label}
         </span>`
@@ -177,7 +181,7 @@ export const MenuGroup = ({
     id=${ifDefined(id)}
     role="presentation"
   >
-    ${!isTraySubmenu 
+    ${!isTraySubmenu
       ? html`<span
           class="spectrum-Menu-sectionHeading"
           id=${id ?? `menu-heading-category-${idx}`}
@@ -189,7 +193,7 @@ export const MenuGroup = ({
               ...globals,
               iconName: backArrowWithScale(size),
               size,
-              customClasses: [`spectrum-Menu-backIcon`] 
+              customClasses: [`spectrum-Menu-backIcon`]
             })}
           </button>
           <span
@@ -254,7 +258,7 @@ export const Template = ({
             customClasses: [`${rootClass}-divider`],
           });
         else if (i.heading || i.isTraySubmenu)
-          return MenuGroup({ 
+          return MenuGroup({
             ...i,
             ...globals,
             subrole,

--- a/components/menu/stories/template.js
+++ b/components/menu/stories/template.js
@@ -1,7 +1,6 @@
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
-import { styleMap } from "lit/directives/style-map.js";
 import { when } from "lit/directives/when.js";
 
 import { Template as Checkbox } from "@spectrum-css/checkbox/stories/template.js";
@@ -38,7 +37,6 @@ export const MenuItem = ({
   value,
   ...globals
 }) => {
-  console.log('menu item', label, shouldTruncate)
   return html`
     <li
       class=${classMap({
@@ -263,7 +261,6 @@ export const Template = ({
       style=${maxInlineSize ? `max-inline-size: ${maxInlineSize}px;` : ""}
     >
       ${items.map((i, idx) => {
-        console.log('template items', i)
         if (i.type === "divider")
           return Divider({
             ...globals,


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

BREAKING CHANGE

"Previously the spectrum-Menu-itemLabel--wrapping class could be added to the spectrum-Menu-itemLabel element in a Menu Item to prevent it from wrapping and force it to use an ellipsis instead."

Fix: 
- the css to truncate was not able to be applied because `spectrum-Menu-itemLabel` had `display: flex;`
[read more about flex causing issues with truncate](https://css-tricks.com/flexbox-truncated-text/)
- I was able to remove this by changing the mark up of the Multi Selection with icons example which had the SVG with in the label 
- Rename classes to indicate truncating and not wrapping
- removed any html that was making it appear that the text with truncating `...`
 
Docs: 
- added example to docs site 
- added example to Storybook 
- added control to Storybook to toggle on all variants

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [ ] truncating example visible on docs page 
- [ ] storybook has truncate story with each menu item over 150px truncates and displays `...`
- [ ] each story for menu has a truncate control which adds a max width to the menu and adds `spectrum-Menu-itemLabel--truncate` to each menu item or heading

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [ ] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
