### PR TITLE
fix(stepper): no longer touches InfieldButton classes

### DIFF
--- a/components/infieldbutton/index.css
+++ b/components/infieldbutton/index.css
@@ -44,6 +44,8 @@ governing permissions and limitations under the License.
 		--spectrum-neutral-content-color-key-focus
 	);
 
+	--spectrum-infield-button-fill-justify-content: center;
+
 	&:disabled {
 		--mod-infield-button-background-color: var(
 			--mod-infield-button-background-color-disabled,
@@ -327,7 +329,10 @@ governing permissions and limitations under the License.
   /* center icon */
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: var(
+		--mod-infield-button-fill-justify-content,
+		var(--spectrum-infield-button-fill-justify-content)
+	);
 
   transition: border-color var(--spectrum-global-animation-duration-100) ease-in-out;
 }
@@ -389,6 +394,14 @@ governing permissions and limitations under the License.
 		border-start-end-radius: var(
 			--mod-infield-button-stacked-border-radius-reset,
 			var(--spectrum-infield-button-stacked-border-radius-reset)
+		);
+		border-end-end-radius: var(
+			--mod-infield-button-stacked-bottom-border-radius-end-end,
+			var(--mod-infield-button-border-radius, var(--spectrum-infield-button-border-radius))
+		);
+		border-block-end-width: var(
+			--mod-infield-button-stacked-bottom-border-block-end-width,
+			var(--mod-infield-button-border-width, var(--spectrum-infield-button-border-width))
 		);
 	}
 }

--- a/components/infieldbutton/metadata/mods.md
+++ b/components/infieldbutton/metadata/mods.md
@@ -21,6 +21,7 @@
 | `--mod-infield-button-border-width`                           |
 | `--mod-infield-button-border-width-quiet`                     |
 | `--mod-infield-button-edge-to-fill`                           |
+| `--mod-infield-button-fill-justify-content`                   |
 | `--mod-infield-button-fill-padding`                           |
 | `--mod-infield-button-height`                                 |
 | `--mod-infield-button-icon-color`                             |
@@ -33,6 +34,8 @@
 | `--mod-infield-button-icon-color-key-focus-disabled`          |
 | `--mod-infield-button-inner-edge-to-fill`                     |
 | `--mod-infield-button-stacked-border-radius-reset`            |
+| `--mod-infield-button-stacked-bottom-border-block-end-width`  |
+| `--mod-infield-button-stacked-bottom-border-radius-end-end`   |
 | `--mod-infield-button-stacked-bottom-border-radius-end-start` |
 | `--mod-infield-button-stacked-fill-padding-inline`            |
 | `--mod-infield-button-stacked-fill-padding-inner`             |

--- a/components/stepper/index.css
+++ b/components/stepper/index.css
@@ -226,17 +226,11 @@ governing permissions and limitations under the License.
   }
 
   .spectrum-Stepper-button {
+    --mod-infield-button-border-block-end-width: var(--mod-stepper-border-width, var(--spectrum-stepper-border-width));
+    --mod-infield-button-stacked-bottom-border-radius-end-end: 0;
+    --mod-infield-button-stacked-bottom-border-radius-end-start: 0;
+    --mod-infield-button-fill-justify-content: flex-end;
     padding: 0;
-  }
-
-  .spectrum-Stepper-button.spectrum-InfieldButton--bottom .spectrum-InfieldButton-fill {
-    border-block-end-width: var(--mod-stepper-border-width, var(--spectrum-stepper-border-width));
-    border-end-end-radius: 0;
-    border-end-start-radius: 0;
-  }
-
-  .spectrum-Stepper-button .spectrum-InfieldButton-fill {
-    justify-content: flex-end;
   }
 
   .spectrum-Stepper-input,
@@ -305,14 +299,6 @@ governing permissions and limitations under the License.
 
   background-color: var(--highcontrast-stepper-buttons-background-color, var(--mod-stepper-buttons-background-color, var(--spectrum-stepper-buttons-background-color)));
   transition: border-color var(--mod-stepper-animation-duration, var(--spectrum-stepper-animation-duration)) ease-in-out;
-}
-
-.spectrum-Stepper-button.spectrum-InfieldButton--top {
-  padding-block-start: calc(var(--mod-stepper-button-padding, var(--spectrum-stepper-button-padding)) - var(--mod-stepper-border-width, var(--spectrum-stepper-border-width)));
-}
-
-.spectrum-Stepper-button.spectrum-InfieldButton--bottom {
-  padding-block-end: calc(var(--mod-stepper-button-padding, var(--spectrum-stepper-button-padding)) - var(--mod-stepper-border-width, var(--spectrum-stepper-border-width)));
 }
 
 /* hide-stepper */

--- a/components/stepper/index.css
+++ b/components/stepper/index.css
@@ -36,7 +36,7 @@ governing permissions and limitations under the License.
 
   /*** MODS for sub components ***/
   --mod-infield-button-border-color: var(--highcontrast-stepper-border-color, var(--mod-stepper-buttons-border-color, var(--spectrum-stepper-buttons-border-color)));
-  --mod-infield-button-border-width: var(--mod-stepper-border-width, var(--spectrum-stepper-border-width));
+  --mod-infield-button-border-width: var(--mod-stepper-button-border-width, var(--spectrum-stepper-button-border-width));
   --mod-textfield-border-width: var(--mod-stepper-border-width, var(--spectrum-stepper-border-width));
 
   &.spectrum-Stepper--sizeS {
@@ -227,6 +227,7 @@ governing permissions and limitations under the License.
 
   .spectrum-Stepper-button {
     --mod-infield-button-border-block-end-width: var(--mod-stepper-border-width, var(--spectrum-stepper-border-width));
+    --mod-infield-button-stacked-bottom-border-block-end-width: var(--mod-stepper-border-width, var(--spectrum-stepper-border-width));
     --mod-infield-button-stacked-bottom-border-radius-end-end: 0;
     --mod-infield-button-stacked-bottom-border-radius-end-start: 0;
     --mod-infield-button-fill-justify-content: flex-end;

--- a/components/stepper/metadata/mods.md
+++ b/components/stepper/metadata/mods.md
@@ -15,6 +15,7 @@
 | `--mod-stepper-border-width`                           |
 | `--mod-stepper-button-background-color-focus`          |
 | `--mod-stepper-button-background-color-keyboard-focus` |
+| `--mod-stepper-button-border-width`                    |
 | `--mod-stepper-button-width`                           |
 | `--mod-stepper-button-width-quiet`                     |
 | `--mod-stepper-buttons-background-color`               |

--- a/components/stepper/metadata/mods.md
+++ b/components/stepper/metadata/mods.md
@@ -15,7 +15,6 @@
 | `--mod-stepper-border-width`                           |
 | `--mod-stepper-button-background-color-focus`          |
 | `--mod-stepper-button-background-color-keyboard-focus` |
-| `--mod-stepper-button-padding`                         |
 | `--mod-stepper-button-width`                           |
 | `--mod-stepper-button-width-quiet`                     |
 | `--mod-stepper-buttons-background-color`               |

--- a/components/stepper/themes/express.css
+++ b/components/stepper/themes/express.css
@@ -23,6 +23,7 @@ governing permissions and limitations under the License.
     --spectrum-stepper-buttons-border-color-keyboard-focus: transparent;
 
     --spectrum-stepper-button-border-radius-reset: var(--spectrum-in-field-button-fill-stacked-inner-border-rounding);
+    --spectrum-stepper-button-border-width: 0;
 
     --spectrum-stepper-border-color: var(--spectrum-gray-400);
     --spectrum-stepper-border-color-hover: var(--spectrum-gray-500);

--- a/components/stepper/themes/spectrum.css
+++ b/components/stepper/themes/spectrum.css
@@ -22,6 +22,9 @@ governing permissions and limitations under the License.
     --spectrum-stepper-buttons-border-color-focus: var(--spectrum-gray-800);
     --spectrum-stepper-buttons-border-color-keyboard-focus: var(--spectrum-gray-900);
 
+    --spectrum-stepper-button-border-radius-reset: 0px;
+    --spectrum-stepper-button-border-width: var(--spectrum-border-width-100);
+
     --spectrum-stepper-border-color: var(--spectrum-gray-500);
     --spectrum-stepper-border-color-hover: var(--spectrum-gray-600);
     --spectrum-stepper-border-color-focus: var(--spectrum-gray-800);
@@ -32,8 +35,6 @@ governing permissions and limitations under the License.
     --spectrum-stepper-border-color-focus-invalid: var(--spectrum-negative-border-color-focus);
     --spectrum-stepper-border-color-focus-hover-invalid: var(--spectrum-negative-border-color-focus-hover);
     --spectrum-stepper-border-color-keyboard-focus-invalid: var(--spectrum-negative-border-color-key-focus);
-
-    --spectrum-stepper-button-border-radius-reset: 0px;
 
     --spectrum-stepper-button-background-color-focus: var(--spectrum-gray-300);
     --spectrum-stepper-button-background-color-keyboard-focus: var(--spectrum-gray-200);


### PR DESCRIPTION
## Description

Per issue #2234, Stepper shouldn't be using classes that it doesn't own. This PR adds some properties to InfieldButton and uses their mods to modify them for Stepper so that we no longer touch InfieldButton classes inside our Stepper component. There should be no visual differences to the components.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

**Note:** When reviewing the code, [filter commits](https://github.com/adobe/spectrum-css/pull/2300/files/2c9965dd3b7b93eeeb21ba83f37964fac5863d61..4dc140f81210b5b36020899df381c25c229d4e7b) so that you aren't reviewing separate changes made in PR #2234.

1. Stepper variants match prod:
  - [x] on the [docs site](https://pr-2300--spectrum-css.netlify.app/stepper) in every state (focus, hover, active, keyboard focus)
  - [x] in [Storybook](https://pr-2300--spectrum-css.netlify.app/preview/?path=/docs/components-stepper--docs) in every state (focus, hover, active, keyboard focus)
2. InfieldButton variants match prod:
  - [x] on the [docs site](https://pr-2300--spectrum-css.netlify.app/infieldbutton) in every state (focus, hover, active, keyboard focus)
  - [x] in [Storybook](https://pr-2300--spectrum-css.netlify.app/preview/?path=/docs/components-in-field-button--docs) in every state (focus, hover, active, keyboard focus)
3. The naming of the custom props in [the code](https://github.com/adobe/spectrum-css/pull/2300/commits/3596b3c3e2d6bf83a3d2f55134a3305971727b02):
  - [x] makes sense
  - [x] aligns with existing conventions

Tested by @jawinn 

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.


## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [ ] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
