### PR TITLE
chore: patch storybook build for ci

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -117,11 +117,12 @@ module.exports = {
 								options: {
 									name: "[path][name].[ext][query]",
 									outputPath: (url) => {
+										const cleanURL = url.replace(/_\//g, "");
 										if (/node_modules\/@spectrum-css/.test(url)) {
-											return `assets/css/${url.replace(/^_\/_\/node_modules\/@spectrum-css\//g, "")}`;
+											return `assets/css/${cleanURL.replace(/node_modules\/@spectrum-css\//g, "")}`;
 										}
 
-										return `assets/css/${url.replace(/_\//g, "")}`;
+										return `assets/css/${cleanURL}`;
 									},
 									esModule: false,
 								},


### PR DESCRIPTION
## Description

When building the static storybook, a stray `../` (which is represented in webpack with `_/`) is messing with the pathing to the vars & expressvars.  This should correct for that.

## How and where has this been tested?

CI 🎈 

### Validation steps

- [ ] CI successfully build storybook

### Regression testing

- [x] No local storybook regressions

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
