### PR TITLE
fix: focus outlines only on keyboard focus

### DIFF
--- a/components/breadcrumb/metadata/breadcrumb.yml
+++ b/components/breadcrumb/metadata/breadcrumb.yml
@@ -35,7 +35,7 @@ examples:
           </li>
         </ul>
       </nav>
-  - id: breadcrumb
+  - id: breadcrumb-dragged
     name: Dragged
     status: Verified
     markup: |
@@ -58,7 +58,7 @@ examples:
           </li>
         </ul>
       </nav>
-  - id: breadcrumb
+  - id: breadcrumb-nested
     name: Nested
     status: Verified
     markup: |
@@ -91,7 +91,7 @@ examples:
           </li>
         </ul>
       </nav>
-  - id: breadcrumb
+  - id: breadcrumb-nested-root
     name: Nested (root visible)
     status: Verified
     markup: |
@@ -147,7 +147,7 @@ examples:
           </li>
         </ul>
       </nav>
-  - id: breadcrumb-multiline
+  - id: breadcrumb-multiline-dragged
     name: Multiline (dragged)
     status: Verified
     markup: |
@@ -170,7 +170,7 @@ examples:
           </li>
         </ul>
       </nav>
-  - id: breadcrumb-multiline
+  - id: breadcrumb-multiline-nested
     name: Multiline Nested
     status: Verified
     markup: |
@@ -203,7 +203,7 @@ examples:
           </li>
         </ul>
       </nav>
-  - id: breadcrumb-multiline
+  - id: breadcrumb-multiline-nested-root
     name: Multiline Nested (root visible)
     status: Verified
     markup: |
@@ -259,7 +259,7 @@ examples:
           </li>
         </ul>
       </nav>
-  - id: breadcrumb-compact
+  - id: breadcrumb-compact-nested
     name: Compact Nested
     status: Verified
     markup: |
@@ -292,7 +292,7 @@ examples:
           </li>
         </ul>
       </nav>
-  - id: breadcrumb-compact
+  - id: breadcrumb-compact-nested-root
     name: Compact Nested (root visible)
     status: Verified
     markup: |

--- a/components/breadcrumb/stories/breadcrumb.stories.js
+++ b/components/breadcrumb/stories/breadcrumb.stories.js
@@ -18,9 +18,19 @@ export default {
 			options: ["compact", "multiline"],
 			control: "inline-radio",
 		},
+    isDragged: {
+      name: "Dragged",
+      type: { name: "boolean" },
+      table: {
+        type: { summary: "boolean" },
+        category: "State",
+      },
+      control: "boolean"
+    },
 	},
 	args: {
 		rootClass: "spectrum-Breadcrumbs",
+		isDragged: false,
 	},
 	parameters: {
 		actions: {
@@ -63,6 +73,7 @@ NestedMultiline.args = {
 		},
 		{
 			label: "Trend",
+			isDragged: true,
 		},
 		{
 			label: "January 2019 Assets",

--- a/components/breadcrumb/stories/template.js
+++ b/components/breadcrumb/stories/template.js
@@ -2,8 +2,8 @@ import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { when } from "lit/directives/when.js";
 
-import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 import { Template as ActionButton } from "@spectrum-css/actionbutton/stories/template.js";
+import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 
 import "../index.css";
 
@@ -12,6 +12,7 @@ export const Template = ({
 	customClasses = [],
 	items = [],
 	variant,
+	isDragged = false,
 	...globals
 }) => {
 	const { express } = globals;
@@ -33,12 +34,12 @@ export const Template = ({
 				})}
 			>
 				${items.map((item, idx, arr) => {
-					const { label, isDisabled, isDragged, iconName } = item;
+					const { label, isDisabled, iconName } = item;
 					return html` <li
 						class=${classMap({
 							[`${rootClass}-item`]: true,
 							"is-disabled": isDisabled,
-							"is-dragged": isDragged,
+							"is-dragged": isDragged && item.isDragged,
 						})}
 					>
 						${when(

--- a/components/card/index.css
+++ b/components/card/index.css
@@ -178,8 +178,7 @@ governing permissions and limitations under the License.
 		);
 	}
 
-	&:focus,
-	&.is-focused {
+	&:focus-visible {
 		outline: none;
 
 		&::after {
@@ -411,7 +410,7 @@ governing permissions and limitations under the License.
 	/* @deprecation --mod-card-title-padding-top has been renamed to --mod-card-body-padding-block-start
 	   and will be removed in a future version. */
 	padding-block-start: var(
-		--mod-card-body-padding-block-start, 
+		--mod-card-body-padding-block-start,
 		var(
 			--mod-card-title-padding-top,
 			var(--spectrum-card-title-padding-top)
@@ -425,7 +424,7 @@ governing permissions and limitations under the License.
 		)
 	);
 	padding-inline-start: var(
-		--mod-card-body-padding-inline-start, 
+		--mod-card-body-padding-inline-start,
 		calc(
 			var(--mod-card-body-spacing, var(--spectrum-card-body-spacing)) -
 			var(--mod-card-border-width, var(--spectrum-card-border-width))

--- a/components/card/metadata/card.yml
+++ b/components/card/metadata/card.yml
@@ -8,10 +8,10 @@ sections:
 
       ### Change workflow icon size to medium
       Please replace `.spectrum-Icon--sizeS` with `.spectrum-Icon--sizeM`.
-      ### Use Spectrum Heading for title 
+      ### Use Spectrum Heading for title
       To make the card component more flexible, products can have more fine control over the typography by using the Heading component with its corresponding sizes. To be more consistent with previous card designs you can use the following:
         * Add the `spectrum-Heading` and `spectrum-Heading--sizeXS` or `spectrum-Heading--sizeXXS` to the `spectrum-Card-title` element.
-      ### Subtitle deprecated 
+      ### Subtitle deprecated
       For this first Card iteration, the `subtitle` option has been removed.
       ### Small Card deprecated
       Card only has one size moving forward and the minimum width has been updated to allow for smaller card widths if needed. There is no longer a need for the `spectrum-Card--sizeM` class on this component.
@@ -170,7 +170,7 @@ examples:
           </div>
         </div>
       </div>
-  - id: card
+  - id: card-selected
     name: Standard (selected)
     markup: |
       <div role="grid">

--- a/components/dropzone/index.css
+++ b/components/dropzone/index.css
@@ -122,8 +122,7 @@ governing permissions and limitations under the License.
     --mod-drop-zone-content-display: flex;
   }
 
-  &:focus,
-  &:focus-within {
+  &:focus-visible {
     --mod-drop-zone-border-style: solid;
     --spectrum-drop-zone-border-color: var(--highcontrast-drop-zone-border-color-hover, var(--mod-drop-zone-border-color-hover, var(--spectrum-drop-zone-border-color-hover)));
     outline: 0;

--- a/components/dropzone/metadata/dropzone.yml
+++ b/components/dropzone/metadata/dropzone.yml
@@ -2,7 +2,7 @@ name: Drop zone
 description: 'A Drop Zone is an area on the screen into a which an object can be dragged and dropped to accomplish a task. For example, a Drop Zone might be used in an upload workflow to enable the user to simply drop a file from their operating system into the Drop Zone, which is a more efficient and intuitive action, rather than utilize the standard "Choose File" dialog.'
 examples:
   - id: dropzone
-    name: Drop Zone (default)
+    name: Default
     markup: |
       <div class="spectrum-DropZone" role="region" tabindex="0">
         <div class="spectrum-IllustratedMessage">
@@ -12,7 +12,7 @@ examples:
         </div>
       </div>
   - id: dropzone-dragged
-    name: Drop Zone (dragged)
+    name: Dragged
     markup: |
       <div class="spectrum-DropZone is-dragged" role="region" tabindex="0">
         <div class="spectrum-IllustratedMessage">
@@ -22,7 +22,7 @@ examples:
         </div>
       </div>
   - id: dropzone-filled
-    name: Drop Zone (filled, dragged)
+    name: Filled and dragged
     markup: |
       <div class="spectrum-DropZone is-filled is-dragged" role="region" tabindex="0" style="height: 200px; background-image:url(img/example-card-portrait.jpg)">
         <div class="spectrum-DropZone-content">

--- a/components/floatingactionbutton/index.css
+++ b/components/floatingactionbutton/index.css
@@ -96,11 +96,10 @@ governing permissions and limitations under the License.
     }
   }
 
-  &:focus, 
-  &:focus-within {
+  &:focus-visible {
     background-color: var(--highcontrast-floating-action-button-background-color-key-focus, var(--mod-floating-action-button-background-color-key-focus, var(--spectrum-floating-action-button-background-color-key-focus)));
     outline: 0;
-    
+
     .spectrum-FloatingActionButton-icon {
       fill: var(--highcontrast-floating-action-button-icon-color-key-focus, var(--mod-floating-action-button-icon-color-key-focus, var(--spectrum-floating-action-button-icon-color-key-focus)));
     }

--- a/components/tabs/index.css
+++ b/components/tabs/index.css
@@ -80,13 +80,13 @@ governing permissions and limitations under the License.
 		--spectrum-tabs-start-to-edge: var(--spectrum-tab-item-start-to-edge-small);
 		--spectrum-tabs-top-to-text: var(--spectrum-tab-item-top-to-text-small);
 		--spectrum-tabs-bottom-to-text: var(--spectrum-tab-item-bottom-to-text-small);
-	
+
 		--spectrum-tabs-icon-size: var(--spectrum-workflow-icon-size-50);
 		--spectrum-tabs-icon-to-text: var(--spectrum-text-to-visual-75);
 		--spectrum-tabs-top-to-icon: var(
 			--spectrum-tab-item-top-to-workflow-icon-small
 		);
-	
+
 		--spectrum-tabs-focus-indicator-gap: var(
 			--spectrum-tab-item-focus-indicator-gap-small
 		);
@@ -104,13 +104,13 @@ governing permissions and limitations under the License.
 		--spectrum-tabs-start-to-edge: var(--spectrum-tab-item-start-to-edge-large);
 		--spectrum-tabs-top-to-text: var(--spectrum-tab-item-top-to-text-large);
 		--spectrum-tabs-bottom-to-text: var(--spectrum-tab-item-bottom-to-text-large);
-	
+
 		--spectrum-tabs-icon-size: var(--spectrum-workflow-icon-size-100);
 		--spectrum-tabs-icon-to-text: var(--spectrum-text-to-visual-200);
 		--spectrum-tabs-top-to-icon: var(
 			--spectrum-tab-item-top-to-workflow-icon-large
 		);
-	
+
 		--spectrum-tabs-focus-indicator-gap: var(
 			--spectrum-tab-item-focus-indicator-gap-large
 		);
@@ -132,13 +132,13 @@ governing permissions and limitations under the License.
 		--spectrum-tabs-bottom-to-text: var(
 			--spectrum-tab-item-bottom-to-text-extra-large
 		);
-	
+
 		--spectrum-tabs-icon-size: var(--spectrum-workflow-icon-size-200);
 		--spectrum-tabs-icon-to-text: var(--spectrum-text-to-visual-300);
 		--spectrum-tabs-top-to-icon: var(
 			--spectrum-tab-item-top-to-workflow-icon-extra-large
 		);
-	
+
 		--spectrum-tabs-focus-indicator-gap: var(
 			--spectrum-tab-item-focus-indicator-gap-extra-large
 		);
@@ -158,7 +158,7 @@ governing permissions and limitations under the License.
 			--mod-tabs-color-key-focus-emphasized,
 			var(--spectrum-accent-content-color-key-focus)
 		);
-	
+
 		--mod-tabs-selection-indicator-color: var(
 			--mod-tabs-selection-indicator-color-emphasized,
 			var(--spectrum-accent-content-color-default)
@@ -408,7 +408,6 @@ governing permissions and limitations under the License.
 		}
 	}
 
-	&:focus,
 	&:focus-visible {
 		color: var(
 			--highcontrast-tabs-color-key-focus,
@@ -572,7 +571,7 @@ governing permissions and limitations under the License.
 	}
 }
 
-.spectrum-Tabs--vertical-right { 
+.spectrum-Tabs--vertical-right {
 	.spectrum-Tabs-selectionIndicator {
 		inset-inline: auto 0;
 	}

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -475,9 +475,7 @@ governing permissions and limitations under the License.
 		);
 	}
 
-	&.is-keyboardFocused,
-	&:focus-visible,
-	&:focus-within {
+	&.is-keyboardFocused {
 		&::after {
 			background-color: var(
 				--highcontrast-textfield-focus-indicator-color,
@@ -965,8 +963,7 @@ governing permissions and limitations under the License.
 	}
 
 	/* keyboard focus */
-	.is-keyboardFocused &,
-	&:focus-visible {
+	.is-keyboardFocused & {
 		border-color: var(
 			--highcontrast-textfield-border-color-keyboard-focus,
 			var(

--- a/components/textfield/metadata/textfield.yml
+++ b/components/textfield/metadata/textfield.yml
@@ -152,7 +152,23 @@ examples:
         </div>
       </div>
 
-  - id: textfield
+  - id: textfield-focused
+    name: Focused
+    markup: |
+      <div class="spectrum-Textfield is-focused">
+        <label for="textfield-focused" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
+        <input id="textfield-focused" type="text" name="field" value="" class="spectrum-Textfield-input">
+      </div>
+
+  - id: textfield-keyboard-focused
+    name: Keyboard Focused
+    markup: |
+      <div class="spectrum-Textfield is-keyboardFocused">
+        <label for="textfield-keyboard-focused" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
+        <input id="textfield-keyboard-focused" type="text" name="field" value="" class="spectrum-Textfield-input">
+      </div>
+
+  - id: textfield-disabled
     name: Disabled
     markup: |
       <div class="spectrum-Textfield is-disabled">
@@ -168,7 +184,7 @@ examples:
         <input id="textfield-readonly" type="text" name="field" value="This text is read-only" class="spectrum-Textfield-input" pattern="[\w\s]+" readonly="readonly">
       </div>
 
-  - id: textfield
+  - id: textfield-valid
     name: Valid
     description: |
       *Spectrum for Adobe Express uses a different icon. Use the `SX_Alert_18_N.svg` icon in the Express workflow icon set.*
@@ -205,7 +221,7 @@ examples:
         <input id="textfield-xl-valid" type="text" name="field" value="A valid input" class="spectrum-Textfield-input" pattern="[\w\s]+" required>
       </div>
 
-  - id: textfield
+  - id: textfield-valid-disabled
     name: Valid (disabled)
     markup: |
       <div class="spectrum-Textfield is-valid is-disabled">
@@ -216,7 +232,7 @@ examples:
         <input id="textfield-valid-disabled" type="text" name="field" value="A valid input" class="spectrum-Textfield-input" pattern="[\w\s]+" required disabled>
       </div>
 
-  - id: textfield
+  - id: textfield-invalid
     name: Invalid
     description: |
       *Spectrum for Adobe Express uses a different icon. Use the `SX_Alert_18_N.svg` icon in the Express workflow icon set.*
@@ -265,7 +281,7 @@ examples:
         </div>
       </div>
 
-  - id: textfield
+  - id: textfield-invalid-disabled
     name: Invalid (disabled)
     markup: |
       <div class="spectrum-Textfield is-invalid is-disabled">
@@ -276,23 +292,7 @@ examples:
         <input id="textfield-invalid-disabled" type="text" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern="[\w\s]+" disabled>
       </div>
 
-  - id: textfield
-    name: Focused
-    markup: |
-      <div class="spectrum-Textfield is-focused">
-        <label for="textfield-focused" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <input id="textfield-focused" type="text" name="field" value="" class="spectrum-Textfield-input">
-      </div>
-
-  - id: textfield
-    name: Keyboard Focused
-    markup: |
-      <div class="spectrum-Textfield is-keyboardFocused">
-        <label for="textfield-keyboard-focused" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
-        <input id="textfield-keyboard-focused" type="text" name="field" value="" class="spectrum-Textfield-input">
-      </div>
-
-  - id: textfield
+  - id: textfield-focused-invalid
     name: Focused (invalid)
     description: |
       *Spectrum for Adobe Express uses a different icon. Use the `SX_Alert_18_N.svg` icon in the Express workflow icon set.*
@@ -305,7 +305,7 @@ examples:
         <input id="textfield-focused-invalid" type="text" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern="[\w\s]+" required>
       </div>
 
-  - id: textfield
+  - id: textfield-keyboard-focused-invalid
     name: Keyboard Focused (invalid)
     description: |
       *Spectrum for Adobe Express uses a different icon. Use the `SX_Alert_18_N.svg` icon in the Express workflow icon set.*
@@ -326,7 +326,7 @@ examples:
         <input id="textfield-quiet" type="text" name="field" value="" class="spectrum-Textfield-input">
       </div>
 
-  - id: textfield-quiet
+  - id: textfield-quiet-disabled
     name: Quiet Disabled
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--quiet is-disabled">
@@ -334,7 +334,7 @@ examples:
         <input id="textfield-quiet-disabled" type="text" name="field" value="" class="spectrum-Textfield-input" disabled>
       </div>
 
-  - id: textfield-quiet
+  - id: textfield-quiet-valid
     name: Quiet Valid
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--quiet is-valid">
@@ -345,7 +345,7 @@ examples:
         <input id="textfield-quiet-valid" type="text" name="field" value="A valid input" class="spectrum-Textfield-input" required>
       </div>
 
-  - id: textfield-quiet
+  - id: textfield-quiet-valid-disabled
     name: Quiet Valid (disabled)
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--quiet is-valid is-disabled">
@@ -390,7 +390,7 @@ examples:
         <input id="textfield-quiet-focused" type="text" name="field" value="" class="spectrum-Textfield-input">
       </div>
 
-  - id: textfield-quiet
+  - id: textfield-quiet-keyboard-focused
     name: Quiet Keyboard Focused
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--quiet is-keyboardFocused">
@@ -398,7 +398,7 @@ examples:
         <input id="textfield-quiet-keyboard-focused" type="text" name="field" value="" class="spectrum-Textfield-input">
       </div>
 
-  - id: textfield-focused-invalid
+  - id: textfield-quiet-focused-invalid
     name: Quiet Focused (invalid)
     description: |
       *Spectrum for Adobe Express uses a different icon. Use the `SX_Alert_18_N.svg` icon in the Express workflow icon set.*
@@ -411,7 +411,7 @@ examples:
         <input id="textfield-focused-invalid" type="text" name="field" value="Invalid input" class="spectrum-Textfield-input" pattern="[\w\s]+" required>
       </div>
 
-  - id: textfield-keyboard-focused-invalid
+  - id: textfield-quiet-keyboard-focused-invalid
     name: Quiet Keyboard Focused (invalid)
     description: |
       *Spectrum for Adobe Express uses a different icon. Use the `SX_Alert_18_N.svg` icon in the Express workflow icon set.*

--- a/components/textfield/stories/textfield.stories.js
+++ b/components/textfield/stories/textfield.stories.js
@@ -140,7 +140,6 @@ export default {
 		rootClass: "spectrum-Textfield",
 		isValid: false,
 		isInvalid: false,
-		isValid: false,
 		isDisabled: false,
 		isRequired: false,
 		isReadOnly: false,


### PR DESCRIPTION
## Description

Some of our components (breadcrumb, card, dropzone, floatingactionbutton, tabs, textfield) were showing and persisting a keyboard focus indicator on mouse focus. This PR adjusts those components to show the correct focus indicators for keyboard and mouse.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

#### Breadcrumb component
- [x] Focus outline only shows on keyboard focus

In [Storybook](https://pr-2306--spectrum-css.netlify.app/preview/?path=/story/components-breadcrumbs--default):
- [x] Focus outline only shows on keyboard focus (manually tab through, compare to prod to see behavior before changes)

#### Card component
- [x] Focus outline only shows on keyboard focus

In [Storybook](https://pr-2306--spectrum-css.netlify.app/preview/?path=/story/components-card--default):
- [x] Has a focused control
- [x] Focus outline only shows on keyboard focus (manually tab through, compare to prod to see behavior before changes)

[Docs site](https://pr-2306--spectrum-css.netlify.app/card) includes:
- [x] Example of focus

#### Dropzone component
- [x] Focus outline only shows on keyboard focus

In [Storybook](https://pr-2306--spectrum-css.netlify.app/preview/?path=/story/components-drop-zone--default):
- [x] Focus outline only shows on keyboard focus (manually tab through, compare to prod to see behavior before changes)

#### Floatingactionbutton component
- [x] Focus outline only shows on keyboard focus

In [Storybook](https://pr-2306--spectrum-css.netlify.app/preview/?path=/story/components-floating-action-button--default):
- [x] Focus outline only shows on keyboard focus (manually tab through, compare to prod to see behavior before changes)

#### Tabs component
- [x] Focus outline only shows on keyboard focus

In [Storybook](https://pr-2306--spectrum-css.netlify.app/preview/?path=/story/components-tabs-horizontal--default):
- [x] Focus outline only shows on keyboard focus (manually tab through, compare to prod to see behavior before changes)

#### Textfield component
- [x] Focus outline only shows on keyboard focus

In [Storybook](https://pr-2306--spectrum-css.netlify.app/preview/?path=/story/components-text-field--default):
- [x] Has a focused control
- [x] Has a keyboard focused control
- [x] Focus outline only shows on keyboard focus (compare to prod to see behavior before changes)

[Docs site](https://pr-2306--spectrum-css.netlify.app/textfield) includes:
- [x] Example of focus
- [x] Example of keyboard focus

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [ ] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
