### PR TITLE
fix(picker)!: adjust position of quiet picker with side label 

### DIFF
--- a/components/fieldlabel/index.css
+++ b/components/fieldlabel/index.css
@@ -29,6 +29,7 @@ governing permissions and limitations under the License.
 
   --spectrum-fieldlabel-side-padding-top: var(--spectrum-component-top-to-text-75);
   --spectrum-fieldlabel-side-padding-right: var(--spectrum-spacing-100);
+  --spectrum-field-label-quiet-sidelabel-padding-block-start: 4px;
 
   --spectrum-field-label-text-to-asterisk: var(--spectrum-field-label-text-to-asterisk-small);
 }
@@ -41,6 +42,7 @@ governing permissions and limitations under the License.
 
   --spectrum-fieldlabel-side-padding-top: var(--spectrum-component-top-to-text-75);
   --spectrum-fieldlabel-side-padding-right: var(--spectrum-spacing-200);
+  --spectrum-field-label-quiet-sidelabel-padding-block-start: var(--spectrum-spacing-100);
 
   --spectrum-field-label-text-to-asterisk: var(--spectrum-field-label-text-to-asterisk-medium);
 }
@@ -53,6 +55,7 @@ governing permissions and limitations under the License.
 
   --spectrum-fieldlabel-side-padding-top: var(--spectrum-component-top-to-text-100);
   --spectrum-fieldlabel-side-padding-right: var(--spectrum-spacing-200);
+  --spectrum-field-label-quiet-sidelabel-padding-block-start: 11px;
 
   --spectrum-field-label-text-to-asterisk: var(--spectrum-field-label-text-to-asterisk-large);
 }
@@ -65,6 +68,7 @@ governing permissions and limitations under the License.
 
   --spectrum-fieldlabel-side-padding-top: var(--spectrum-component-top-to-text-200);
   --spectrum-fieldlabel-side-padding-right: var(--spectrum-spacing-200);
+  --spectrum-field-label-quiet-sidelabel-padding-block-start: 14px;
 
   --spectrum-field-label-text-to-asterisk: var(--spectrum-field-label-text-to-asterisk-extra-large);
 }
@@ -108,6 +112,20 @@ governing permissions and limitations under the License.
   padding-block: var(--mod-fieldlabel-side-padding-top, var(--spectrum-fieldlabel-side-padding-top)) 0;
   padding-inline: 0 var(--mod-fieldlabel-side-padding-right, var(--spectrum-fieldlabel-side-padding-right));
   padding-block: var(--mod-fieldlabel-side-padding-top, var(--spectrum-fieldlabel-side-padding-top)) 0;
+  &.spectrum-FieldLabel-quiet-picker-side-label {
+    &.spectrum-FieldLabel--sizeS {
+      --mod-fieldlabel-side-padding-top: var(--spectrum-fieldlabel-picker-side-label-quiet-padding-block-start-small);
+    }
+    &.spectrum-FieldLabel--sizeM {
+      --mod-fieldlabel-side-padding-top: var(--spectrum-fieldlabel-picker-side-label-quiet-padding-block-start-medium);
+    }
+    &.spectrum-FieldLabel--sizeL {
+      --mod-fieldlabel-side-padding-top: var(--spectrum-fieldlabel-picker-side-label-quiet-padding-block-start-large);
+    }
+    &.spectrum-FieldLabel--sizeXL{
+      --mod-fieldlabel-side-padding-top: var(--spectrum-fieldlabel-picker-side-label-quiet-padding-block-start-xlarge);
+    }
+  }
 }
 
 .spectrum-FieldLabel--right {
@@ -119,6 +137,7 @@ governing permissions and limitations under the License.
 }
 
 /********* Form *********/
+/* Form: two column alignment via display: table */
 .spectrum-Form {
   --spectrum-tableform-item-block-spacing: var(--spectrum-spacing-300);
 

--- a/components/fieldlabel/index.css
+++ b/components/fieldlabel/index.css
@@ -29,7 +29,6 @@ governing permissions and limitations under the License.
 
   --spectrum-fieldlabel-side-padding-top: var(--spectrum-component-top-to-text-75);
   --spectrum-fieldlabel-side-padding-right: var(--spectrum-spacing-100);
-  --spectrum-field-label-quiet-sidelabel-padding-block-start: 4px;
 
   --spectrum-field-label-text-to-asterisk: var(--spectrum-field-label-text-to-asterisk-small);
 }
@@ -42,7 +41,6 @@ governing permissions and limitations under the License.
 
   --spectrum-fieldlabel-side-padding-top: var(--spectrum-component-top-to-text-75);
   --spectrum-fieldlabel-side-padding-right: var(--spectrum-spacing-200);
-  --spectrum-field-label-quiet-sidelabel-padding-block-start: var(--spectrum-spacing-100);
 
   --spectrum-field-label-text-to-asterisk: var(--spectrum-field-label-text-to-asterisk-medium);
 }
@@ -55,7 +53,6 @@ governing permissions and limitations under the License.
 
   --spectrum-fieldlabel-side-padding-top: var(--spectrum-component-top-to-text-100);
   --spectrum-fieldlabel-side-padding-right: var(--spectrum-spacing-200);
-  --spectrum-field-label-quiet-sidelabel-padding-block-start: 11px;
 
   --spectrum-field-label-text-to-asterisk: var(--spectrum-field-label-text-to-asterisk-large);
 }
@@ -68,7 +65,6 @@ governing permissions and limitations under the License.
 
   --spectrum-fieldlabel-side-padding-top: var(--spectrum-component-top-to-text-200);
   --spectrum-fieldlabel-side-padding-right: var(--spectrum-spacing-200);
-  --spectrum-field-label-quiet-sidelabel-padding-block-start: 14px;
 
   --spectrum-field-label-text-to-asterisk: var(--spectrum-field-label-text-to-asterisk-extra-large);
 }

--- a/components/fieldlabel/index.css
+++ b/components/fieldlabel/index.css
@@ -105,19 +105,22 @@ governing permissions and limitations under the License.
 .spectrum-FieldLabel--right {
   display: inline-block;
   vertical-align: top;
-  padding-block: var(--mod-fieldlabel-side-padding-top, var(--spectrum-fieldlabel-side-padding-top)) 0;
   padding-inline: 0 var(--mod-fieldlabel-side-padding-right, var(--spectrum-fieldlabel-side-padding-right));
   padding-block: var(--mod-fieldlabel-side-padding-top, var(--spectrum-fieldlabel-side-padding-top)) 0;
+
   &.spectrum-FieldLabel-quiet-picker-side-label {
     &.spectrum-FieldLabel--sizeS {
       --mod-fieldlabel-side-padding-top: var(--spectrum-fieldlabel-picker-side-label-quiet-padding-block-start-small);
     }
+
     &.spectrum-FieldLabel--sizeM {
       --mod-fieldlabel-side-padding-top: var(--spectrum-fieldlabel-picker-side-label-quiet-padding-block-start-medium);
     }
+
     &.spectrum-FieldLabel--sizeL {
       --mod-fieldlabel-side-padding-top: var(--spectrum-fieldlabel-picker-side-label-quiet-padding-block-start-large);
     }
+
     &.spectrum-FieldLabel--sizeXL{
       --mod-fieldlabel-side-padding-top: var(--spectrum-fieldlabel-picker-side-label-quiet-padding-block-start-xlarge);
     }
@@ -126,10 +129,6 @@ governing permissions and limitations under the License.
 
 .spectrum-FieldLabel--right {
   text-align: end;
-}
-
-.spectrum-FieldLabel-picker--quiet {
-  padding-block: 8px 0;
 }
 
 /********* Form *********/

--- a/components/fieldlabel/index.css
+++ b/components/fieldlabel/index.css
@@ -111,6 +111,12 @@ governing permissions and limitations under the License.
 
 .spectrum-FieldLabel--right {
   text-align: end;
+  padding-block: var(--mod-fieldlabel-side-padding-top, var(--spectrum-fieldlabel-side-padding-top)) 0;
+}
+
+.spectrum-FieldLabel--left {
+  text-align: end;
+  padding-block: 8px 0;
 }
 
 /********* Form *********/

--- a/components/fieldlabel/index.css
+++ b/components/fieldlabel/index.css
@@ -107,15 +107,14 @@ governing permissions and limitations under the License.
   vertical-align: top;
   padding-block: var(--mod-fieldlabel-side-padding-top, var(--spectrum-fieldlabel-side-padding-top)) 0;
   padding-inline: 0 var(--mod-fieldlabel-side-padding-right, var(--spectrum-fieldlabel-side-padding-right));
+  padding-block: var(--mod-fieldlabel-side-padding-top, var(--spectrum-fieldlabel-side-padding-top)) 0;
 }
 
 .spectrum-FieldLabel--right {
   text-align: end;
-  padding-block: var(--mod-fieldlabel-side-padding-top, var(--spectrum-fieldlabel-side-padding-top)) 0;
 }
 
-.spectrum-FieldLabel--left {
-  text-align: end;
+.spectrum-FieldLabel-picker--quiet {
   padding-block: 8px 0;
 }
 

--- a/components/picker/index.css
+++ b/components/picker/index.css
@@ -449,7 +449,8 @@ governing permissions and limitations under the License.
   background-color: var(--highcontrast-picker-background-color, transparent);
 
   &.spectrum-Picker--sideLabel {
-    margin-block-start: calc(-1 * var(--spectrum-picker-spacing-top-to-text-side-label-quiet));
+    margin-block-start: 1px;
+    /* margin-block-start: calc(-1 * var(--spectrum-picker-spacing-top-to-text-side-label-quiet)); */
   }
 
   .spectrum-Picker-menuIcon {

--- a/components/picker/index.css
+++ b/components/picker/index.css
@@ -31,7 +31,6 @@ governing permissions and limitations under the License.
   --spectrum-picker-spacing-bottom-to-text: var(--spectrum-component-bottom-to-text-100);
   --spectrum-picker-spacing-edge-to-text: var(--spectrum-component-edge-to-text-100);
   --spectrum-picker-spacing-edge-to-text-quiet: var(--spectrum-field-edge-to-text-quiet);
-  --spectrum-picker-spacing-top-to-text-side-label-quiet: 1px;
   --spectrum-picker-spacing-label-to-picker: var(--spectrum-field-label-to-component);
 
   --spectrum-picker-spacing-text-to-icon: var(--spectrum-text-to-visual-100);
@@ -88,7 +87,6 @@ governing permissions and limitations under the License.
 .spectrum-Picker--sizeS {
   --spectrum-picker-font-size: var(--spectrum-font-size-75);
   --spectrum-picker-block-size: var(--spectrum-component-height-75);
-  --spectrum-picker-spacing-top-to-text-side-label-quiet: 0px;
   --spectrum-picker-spacing-top-to-text: var(--spectrum-component-top-to-text-75);
   --spectrum-picker-spacing-bottom-to-text: var(--spectrum-component-bottom-to-text-75);
   --spectrum-picker-spacing-edge-to-text: var(--spectrum-component-edge-to-text-75);
@@ -109,7 +107,6 @@ governing permissions and limitations under the License.
 .spectrum-Picker--sizeL {
   --spectrum-picker-font-size: var(--spectrum-font-size-200);
   --spectrum-picker-block-size: var(--spectrum-component-height-200);
-  --spectrum-picker-spacing-top-to-text-side-label-quiet: 1px;
   --spectrum-picker-spacing-top-to-text: var(--spectrum-component-top-to-text-200);
   --spectrum-picker-spacing-bottom-to-text: var(--spectrum-component-bottom-to-text-200);
   --spectrum-picker-spacing-edge-to-text: var(--spectrum-component-edge-to-text-200);
@@ -130,7 +127,6 @@ governing permissions and limitations under the License.
 .spectrum-Picker--sizeXL {
   --spectrum-picker-font-size: var(--spectrum-font-size-300);
   --spectrum-picker-block-size: var(--spectrum-component-height-300);
-  --spectrum-picker-spacing-top-to-text-side-label-quiet: 1px;
   --spectrum-picker-spacing-top-to-text: var(--spectrum-component-top-to-text-300);
   --spectrum-picker-spacing-bottom-to-text: var(--spectrum-component-bottom-to-text-300);
   --spectrum-picker-spacing-edge-to-text: var(--spectrum-component-edge-to-text-300);

--- a/components/picker/index.css
+++ b/components/picker/index.css
@@ -31,7 +31,7 @@ governing permissions and limitations under the License.
   --spectrum-picker-spacing-bottom-to-text: var(--spectrum-component-bottom-to-text-100);
   --spectrum-picker-spacing-edge-to-text: var(--spectrum-component-edge-to-text-100);
   --spectrum-picker-spacing-edge-to-text-quiet: var(--spectrum-field-edge-to-text-quiet);
-  --spectrum-picker-spacing-top-to-text-side-label-quiet: var(--spectrum-field-label-top-margin-medium);
+  --spectrum-picker-spacing-top-to-text-side-label-quiet: 1px;
   --spectrum-picker-spacing-label-to-picker: var(--spectrum-field-label-to-component);
 
   --spectrum-picker-spacing-text-to-icon: var(--spectrum-text-to-visual-100);
@@ -88,7 +88,7 @@ governing permissions and limitations under the License.
 .spectrum-Picker--sizeS {
   --spectrum-picker-font-size: var(--spectrum-font-size-75);
   --spectrum-picker-block-size: var(--spectrum-component-height-75);
-  --spectrum-picker-spacing-top-to-text-side-label-quiet: var(--spectrum-field-label-top-margin-small);
+  --spectrum-picker-spacing-top-to-text-side-label-quiet: 0px;
   --spectrum-picker-spacing-top-to-text: var(--spectrum-component-top-to-text-75);
   --spectrum-picker-spacing-bottom-to-text: var(--spectrum-component-bottom-to-text-75);
   --spectrum-picker-spacing-edge-to-text: var(--spectrum-component-edge-to-text-75);
@@ -109,7 +109,7 @@ governing permissions and limitations under the License.
 .spectrum-Picker--sizeL {
   --spectrum-picker-font-size: var(--spectrum-font-size-200);
   --spectrum-picker-block-size: var(--spectrum-component-height-200);
-  --spectrum-picker-spacing-top-to-text-side-label-quiet: var(--spectrum-field-label-top-margin-large);
+  --spectrum-picker-spacing-top-to-text-side-label-quiet: 1px;
   --spectrum-picker-spacing-top-to-text: var(--spectrum-component-top-to-text-200);
   --spectrum-picker-spacing-bottom-to-text: var(--spectrum-component-bottom-to-text-200);
   --spectrum-picker-spacing-edge-to-text: var(--spectrum-component-edge-to-text-200);
@@ -130,7 +130,7 @@ governing permissions and limitations under the License.
 .spectrum-Picker--sizeXL {
   --spectrum-picker-font-size: var(--spectrum-font-size-300);
   --spectrum-picker-block-size: var(--spectrum-component-height-300);
-  --spectrum-picker-spacing-top-to-text-side-label-quiet: var(--spectrum-field-label-top-margin-extra-large);
+  --spectrum-picker-spacing-top-to-text-side-label-quiet: 1px;
   --spectrum-picker-spacing-top-to-text: var(--spectrum-component-top-to-text-300);
   --spectrum-picker-spacing-bottom-to-text: var(--spectrum-component-bottom-to-text-300);
   --spectrum-picker-spacing-edge-to-text: var(--spectrum-component-edge-to-text-300);
@@ -449,8 +449,18 @@ governing permissions and limitations under the License.
   background-color: var(--highcontrast-picker-background-color, transparent);
 
   &.spectrum-Picker--sideLabel {
-    margin-block-start: 1px;
-    /* margin-block-start: calc(-1 * var(--spectrum-picker-spacing-top-to-text-side-label-quiet)); */
+    &.spectrum-Picker--sizeS{
+      --mod-picker-spacing-label-to-picker-quiet: var(--spectrum-picker-side-label-quiet-padding-block-start-small);
+    }
+    &.spectrum-Picker--sizeM{
+      --mod-picker-spacing-label-to-picker-quiet: var(--spectrum-picker-side-label-quiet-padding-block-start-medium);
+    }
+    &.spectrum-Picker--sizeL{
+      --mod-picker-spacing-label-to-picker-quiet: var(--spectrum-picker-side-label-quiet-padding-block-start-large);
+    }
+    &.spectrum-Picker--sizeXL{
+      --mod-picker-spacing-label-to-picker-quiet: var(--spectrum-picker-side-label-quiet-padding-block-start-xlarge);
+    }
   }
 
   .spectrum-Picker-menuIcon {

--- a/components/picker/index.css
+++ b/components/picker/index.css
@@ -348,7 +348,7 @@ governing permissions and limitations under the License.
   color: var(--highcontrast-picker-content-color-default, var(--mod-picker-font-color-default-open, var(--spectrum-picker-font-color-default-open)));
   background-color: var(--highcontrast-picker-background-color, var(--mod-picker-background-color-default-open, var(--spectrum-picker-background-color-default-open)));
   border-color: var(--highcontrast-picker-border-color-default, var(--mod-picker-border-default-open, var(--spectrum-picker-border-color-default-open)));
-  
+
   &:hover {
     color: var(--highcontrast-picker-content-color-default, var(--mod-picker-font-color-hover-open, var(--spectrum-picker-font-color-hover-open)));
     background-color: var(--highcontrast-picker-background-color, var(--mod-picker-background-color-hover-open, var(--spectrum-picker-background-color-hover-open)));
@@ -449,7 +449,7 @@ governing permissions and limitations under the License.
   background-color: var(--highcontrast-picker-background-color, transparent);
 
   &.spectrum-Picker--sideLabel {
-    margin-block-start: calc(-1 * var(--spectrum-picker-spacing-top-to-text-side-label-quiet)); 
+    margin-block-start: calc(-1 * var(--spectrum-picker-spacing-top-to-text-side-label-quiet));
   }
 
   .spectrum-Picker-menuIcon {

--- a/components/picker/metadata/picker.yml
+++ b/components/picker/metadata/picker.yml
@@ -49,6 +49,56 @@ sections:
       ### Remove focus-ring class
       We've migrated away from the focus-ring class in favor of the native `:focus-visible` pseudo-class due to changes in browser support.
 examples:
+  - id: picker-sizing
+    name: With other Elements
+    markup: |
+      <div style="display:flex; gap:15px;">
+        <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left">Spectrum</div>
+        <button type="button" class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet spectrum-Picker--sideLabel" aria-haspopup="listbox">
+          <span class="spectrum-Picker-label is-placeholder">Classis</span>
+          <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
+            <use xlink:href="#spectrum-css-icon-Chevron100" />
+          </svg>
+        </button>
+        <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left">Theme</div>
+        <button type="button" class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet spectrum-Picker--sideLabel" aria-haspopup="listbox">
+          <span class="spectrum-Picker-label is-placeholder">Light</span>
+          <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
+            <use xlink:href="#spectrum-css-icon-Chevron100" />
+          </svg>
+        </button>
+        <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left">Scale</div>
+        <button type="button" class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet spectrum-Picker--sideLabel" aria-haspopup="listbox">
+          <span class="spectrum-Picker-label is-placeholder">Medium</span>
+          <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
+            <use xlink:href="#spectrum-css-icon-Chevron100" />
+          </svg>
+        </button>
+        <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left">Direction</div>
+        <button type="button" class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet spectrum-Picker--sideLabel" aria-haspopup="listbox">
+          <span class="spectrum-Picker-label is-placeholder">LTR</span>
+          <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
+            <use xlink:href="#spectrum-css-icon-Chevron100" />
+          </svg>
+        </button>
+        <div class="spectrum-Switch spectrum-Switch--sizeM">
+          <input type="checkbox" class="spectrum-Switch-input" id="switch-onoff-0">
+          <span class="spectrum-Switch-switch"></span>
+          <label class="spectrum-Switch-label" for="switch-onoff-0">Switch Off</label>
+        </div>
+      </div>
+      <div style="display:flex; gap:15px; padding-block-start: 30px;">
+        <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left">Spectrum</div>
+        <button type="button" class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet spectrum-Picker--sideLabel" aria-haspopup="listbox">
+          <span class="spectrum-Picker-label is-placeholder">Classis</span>
+          <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
+            <use xlink:href="#spectrum-css-icon-Chevron100" />
+          </svg>
+        </button>
+        <button class="spectrum-Button spectrum-Button--fill spectrum-Button--accent spectrum-Button--sizeM">
+          <span class="spectrum-Button-label">Edit</span>
+        </button>
+      </div>
   - id: picker-standard
     name: Standard
     markup: |
@@ -58,7 +108,7 @@ examples:
         <div class="spectrum-Examples-item">
           <h4>Closed</h4>
           <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Country</div>
-          <button type="button" class="spectrum-Picker spectrum-Picker--sizeM" aria-haspopup="listbox" style="width: 240px">
+          <button type="button" class="spectrum-Picker spectrum-Picker--sizeM " aria-haspopup="listbox" style="width: 240px">
             <span class="spectrum-Picker-label is-placeholder">Select a Country with a very long label, too long in fact</span>
             <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
               <use xlink:href="#spectrum-css-icon-Chevron100" />

--- a/components/picker/metadata/picker.yml
+++ b/components/picker/metadata/picker.yml
@@ -53,7 +53,7 @@ examples:
     name: With other Elements
     markup: |
       <div style="display:flex;">
-        <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left" style="margin-left: 32px;">Direction</div>
+        <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left spectrum-FieldLabel-picker--quiet" style="margin-left: 32px;">Direction</div>
         <button type="button" class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet spectrum-Picker--sideLabel" aria-haspopup="listbox">
           <span class="spectrum-Picker-label is-placeholder">LTR</span>
           <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
@@ -67,7 +67,7 @@ examples:
         </div>
       </div>
       <div style=" padding-block-start: 30px;">
-        <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left" style="margin-left: 32px;">Spectrum</div>
+        <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left spectrum-FieldLabel-picker--quiet" style="margin-left: 32px;">Spectrum</div>
         <button type="button" class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet spectrum-Picker--sideLabel" aria-haspopup="listbox">
           <span class="spectrum-Picker-label is-placeholder">Classic</span>
           <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
@@ -79,7 +79,7 @@ examples:
         </button>
       </div>
       <div style="display: flex;  padding-block-start: 30px;">
-        <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left" style="margin-left: 32px;">Theme</div>
+        <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left spectrum-FieldLabel-picker--quiet" style="margin-left: 32px;">Theme</div>
         <button type="button" class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet spectrum-Picker--sideLabel" aria-haspopup="listbox">
           <span class="spectrum-Picker-label is-placeholder">Light</span>
           <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
@@ -93,7 +93,7 @@ examples:
         </div>
       </div>
       <div style="display: flex;  padding-block-start: 30px;">
-        <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left" style="margin-left: 32px;">Theme</div>
+        <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left spectrum-FieldLabel-picker--quiet" style="margin-left: 32px;">Theme</div>
         <button type="button" class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet spectrum-Picker--sideLabel" aria-haspopup="listbox">
           <span class="spectrum-Picker-label is-placeholder">Light</span>
           <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">

--- a/components/picker/metadata/picker.yml
+++ b/components/picker/metadata/picker.yml
@@ -100,8 +100,8 @@ examples:
             <use xlink:href="#spectrum-css-icon-Chevron100" />
           </svg>
         </button>
-          <label class="spectrum-Checkbox spectrum-Checkbox--sizeM">
-            <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-0" style="margin-left: 32px;"">
+          <label class="spectrum-Checkbox spectrum-Checkbox--sizeM"  style="margin-left: 32px;">
+            <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-0">
             <span class="spectrum-Checkbox-box">
               <svg class="spectrum-Icon spectrum-UIIcon-Checkmark75 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
                 <use xlink:href="#spectrum-css-icon-Checkmark75" />

--- a/components/picker/metadata/picker.yml
+++ b/components/picker/metadata/picker.yml
@@ -52,50 +52,50 @@ examples:
   - id: picker-sizing
     name: With other Elements
     markup: |
-      <div style="display:flex; gap:15px;">
-        <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left">Spectrum</div>
+      <div style="display:flex;">
+        <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left" style="margin-left: 32px;">Spectrum</div>
         <button type="button" class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet spectrum-Picker--sideLabel" aria-haspopup="listbox">
-          <span class="spectrum-Picker-label is-placeholder">Classis</span>
+          <span class="spectrum-Picker-label is-placeholder">Classic</span>
           <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
             <use xlink:href="#spectrum-css-icon-Chevron100" />
           </svg>
         </button>
-        <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left">Theme</div>
+        <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left" style="margin-left: 32px;">Theme</div>
         <button type="button" class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet spectrum-Picker--sideLabel" aria-haspopup="listbox">
           <span class="spectrum-Picker-label is-placeholder">Light</span>
           <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
             <use xlink:href="#spectrum-css-icon-Chevron100" />
           </svg>
         </button>
-        <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left">Scale</div>
+        <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left" style="margin-left: 32px;">Scale</div>
         <button type="button" class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet spectrum-Picker--sideLabel" aria-haspopup="listbox">
           <span class="spectrum-Picker-label is-placeholder">Medium</span>
           <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
             <use xlink:href="#spectrum-css-icon-Chevron100" />
           </svg>
         </button>
-        <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left">Direction</div>
+        <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left" style="margin-left: 32px;">Direction</div>
         <button type="button" class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet spectrum-Picker--sideLabel" aria-haspopup="listbox">
           <span class="spectrum-Picker-label is-placeholder">LTR</span>
           <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
             <use xlink:href="#spectrum-css-icon-Chevron100" />
           </svg>
         </button>
-        <div class="spectrum-Switch spectrum-Switch--sizeM">
+        <div class="spectrum-Switch spectrum-Switch--sizeM" style="margin-left: 32px;">
           <input type="checkbox" class="spectrum-Switch-input" id="switch-onoff-0">
           <span class="spectrum-Switch-switch"></span>
           <label class="spectrum-Switch-label" for="switch-onoff-0">Switch Off</label>
         </div>
       </div>
-      <div style="display:flex; gap:15px; padding-block-start: 30px;">
-        <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left">Spectrum</div>
+      <div style=" padding-block-start: 30px;">
+        <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left" style="margin-left: 32px;">Spectrum</div>
         <button type="button" class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet spectrum-Picker--sideLabel" aria-haspopup="listbox">
-          <span class="spectrum-Picker-label is-placeholder">Classis</span>
+          <span class="spectrum-Picker-label is-placeholder">Classic</span>
           <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
             <use xlink:href="#spectrum-css-icon-Chevron100" />
           </svg>
         </button>
-        <button class="spectrum-Button spectrum-Button--fill spectrum-Button--accent spectrum-Button--sizeM">
+        <button class="spectrum-Button spectrum-Button--fill spectrum-Button--accent spectrum-Button--sizeM" style="margin-left: 32px;">
           <span class="spectrum-Button-label">Edit</span>
         </button>
       </div>

--- a/components/picker/metadata/picker.yml
+++ b/components/picker/metadata/picker.yml
@@ -53,27 +53,6 @@ examples:
     name: With other Elements
     markup: |
       <div style="display:flex;">
-        <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left" style="margin-left: 32px;">Spectrum</div>
-        <button type="button" class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet spectrum-Picker--sideLabel" aria-haspopup="listbox">
-          <span class="spectrum-Picker-label is-placeholder">Classic</span>
-          <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Chevron100" />
-          </svg>
-        </button>
-        <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left" style="margin-left: 32px;">Theme</div>
-        <button type="button" class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet spectrum-Picker--sideLabel" aria-haspopup="listbox">
-          <span class="spectrum-Picker-label is-placeholder">Light</span>
-          <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Chevron100" />
-          </svg>
-        </button>
-        <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left" style="margin-left: 32px;">Scale</div>
-        <button type="button" class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet spectrum-Picker--sideLabel" aria-haspopup="listbox">
-          <span class="spectrum-Picker-label is-placeholder">Medium</span>
-          <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
-            <use xlink:href="#spectrum-css-icon-Chevron100" />
-          </svg>
-        </button>
         <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left" style="margin-left: 32px;">Direction</div>
         <button type="button" class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet spectrum-Picker--sideLabel" aria-haspopup="listbox">
           <span class="spectrum-Picker-label is-placeholder">LTR</span>
@@ -98,6 +77,41 @@ examples:
         <button class="spectrum-Button spectrum-Button--fill spectrum-Button--accent spectrum-Button--sizeM" style="margin-left: 32px;">
           <span class="spectrum-Button-label">Edit</span>
         </button>
+      </div>
+      <div style="display: flex;  padding-block-start: 30px;">
+        <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left" style="margin-left: 32px;">Theme</div>
+        <button type="button" class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet spectrum-Picker--sideLabel" aria-haspopup="listbox">
+          <span class="spectrum-Picker-label is-placeholder">Light</span>
+          <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
+            <use xlink:href="#spectrum-css-icon-Chevron100" />
+          </svg>
+        </button>
+        <div class="spectrum-Radio spectrum-Radio--sizeS">
+          <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-0" style="margin-left: 32px;">
+          <span class="spectrum-Radio-button spectrum-Radio-button--sizeS"></span>
+          <label class="spectrum-Radio-label spectrum-Radio-label--sizeS" for="radio-0">Kittens</label>
+        </div>
+      </div>
+      <div style="display: flex;  padding-block-start: 30px;">
+        <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left" style="margin-left: 32px;">Theme</div>
+        <button type="button" class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet spectrum-Picker--sideLabel" aria-haspopup="listbox">
+          <span class="spectrum-Picker-label is-placeholder">Light</span>
+          <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
+            <use xlink:href="#spectrum-css-icon-Chevron100" />
+          </svg>
+        </button>
+          <label class="spectrum-Checkbox spectrum-Checkbox--sizeM">
+            <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-0" style="margin-left: 32px;"">
+            <span class="spectrum-Checkbox-box">
+              <svg class="spectrum-Icon spectrum-UIIcon-Checkmark75 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-Checkmark75" />
+              </svg>
+              <svg class="spectrum-Icon spectrum-UIIcon-Dash75 spectrum-Checkbox-partialCheckmark" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-Dash75" />
+              </svg>
+            </span>
+            <span class="spectrum-Checkbox-label">Checkbox</span>
+          </label>
       </div>
   - id: picker-standard
     name: Standard

--- a/components/picker/metadata/picker.yml
+++ b/components/picker/metadata/picker.yml
@@ -52,8 +52,22 @@ examples:
   - id: picker-sizing
     name: With other Elements
     markup: |
-      <div style="display:flex;">
-        <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left spectrum-FieldLabel-picker--quiet" style="margin-left: 32px;">Direction</div>
+      <div>
+        <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeS spectrum-FieldLabel--left spectrum-FieldLabel-quiet-picker-side-label" style="margin-left: 32px;">Direction</div>
+        <button type="button" class="spectrum-Picker spectrum-Picker--sizeS spectrum-Picker--quiet spectrum-Picker--sideLabel" aria-haspopup="listbox">
+          <span class="spectrum-Picker-label is-placeholder">LTR</span>
+          <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
+            <use xlink:href="#spectrum-css-icon-Chevron100" />
+          </svg>
+        </button>
+        <div class="spectrum-Switch spectrum-Switch--sizeS" style="margin-left: 32px;">
+          <input type="checkbox" class="spectrum-Switch-input" id="switch-onoff-0">
+          <span class="spectrum-Switch-switch"></span>
+          <label class="spectrum-Switch-label" for="switch-onoff-0">Switch Off</label>
+        </div>
+      </div>
+      <div>
+        <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left spectrum-FieldLabel-quiet-picker-side-label" style="margin-left: 32px;">Direction</div>
         <button type="button" class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet spectrum-Picker--sideLabel" aria-haspopup="listbox">
           <span class="spectrum-Picker-label is-placeholder">LTR</span>
           <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
@@ -66,8 +80,37 @@ examples:
           <label class="spectrum-Switch-label" for="switch-onoff-0">Switch Off</label>
         </div>
       </div>
+      <div>
+        <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeL spectrum-FieldLabel--left spectrum-FieldLabel-quiet-picker-side-label" style="margin-left: 32px;">Direction</div>
+        <button type="button" class="spectrum-Picker spectrum-Picker--sizeL spectrum-Picker--quiet spectrum-Picker--sideLabel" aria-haspopup="listbox">
+          <span class="spectrum-Picker-label is-placeholder">LTR</span>
+          <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
+            <use xlink:href="#spectrum-css-icon-Chevron100" />
+          </svg>
+        </button>
+        <div class="spectrum-Switch spectrum-Switch--sizeL" style="margin-left: 32px;">
+          <input type="checkbox" class="spectrum-Switch-input" id="switch-onoff-0">
+          <span class="spectrum-Switch-switch"></span>
+          <label class="spectrum-Switch-label" for="switch-onoff-0">Switch Off</label>
+        </div>
+      </div>
+      <div>
+        <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeXL spectrum-FieldLabel--left spectrum-FieldLabel-quiet-picker-side-label" style="margin-left: 32px;">Direction</div>
+        <button type="button" class="spectrum-Picker spectrum-Picker--sizeXL spectrum-Picker--quiet spectrum-Picker--sideLabel" aria-haspopup="listbox">
+          <span class="spectrum-Picker-label is-placeholder">LTR</span>
+          <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
+            <use xlink:href="#spectrum-css-icon-Chevron100" />
+          </svg>
+        </button>
+        <div class="spectrum-Switch spectrum-Switch--sizeXL" style="margin-left: 32px;">
+          <input type="checkbox" class="spectrum-Switch-input" id="switch-onoff-0">
+          <span class="spectrum-Switch-switch"></span>
+          <label class="spectrum-Switch-label" for="switch-onoff-0">Switch Off</label>
+        </div>
+      </div>
+
       <div style=" padding-block-start: 30px;">
-        <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left spectrum-FieldLabel-picker--quiet" style="margin-left: 32px;">Spectrum</div>
+        <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left spectrum-FieldLabel-quiet-picker-side-label" style="margin-left: 32px;">Spectrum</div>
         <button type="button" class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet spectrum-Picker--sideLabel" aria-haspopup="listbox">
           <span class="spectrum-Picker-label is-placeholder">Classic</span>
           <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
@@ -79,21 +122,21 @@ examples:
         </button>
       </div>
       <div style="display: flex;  padding-block-start: 30px;">
-        <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left spectrum-FieldLabel-picker--quiet" style="margin-left: 32px;">Theme</div>
+        <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left spectrum-FieldLabel-quiet-picker-side-label" style="margin-left: 32px;">Theme</div>
         <button type="button" class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet spectrum-Picker--sideLabel" aria-haspopup="listbox">
           <span class="spectrum-Picker-label is-placeholder">Light</span>
           <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
             <use xlink:href="#spectrum-css-icon-Chevron100" />
           </svg>
         </button>
-        <div class="spectrum-Radio spectrum-Radio--sizeS">
+        <div class="spectrum-Radio spectrum-Radio--sizeM">
           <input type="radio" name="pets" class="spectrum-Radio-input" id="radio-0" style="margin-left: 32px;">
-          <span class="spectrum-Radio-button spectrum-Radio-button--sizeS"></span>
-          <label class="spectrum-Radio-label spectrum-Radio-label--sizeS" for="radio-0">Kittens</label>
+          <span class="spectrum-Radio-button spectrum-Radio-button--sizeM"></span>
+          <label class="spectrum-Radio-label spectrum-Radio-label--sizeM" for="radio-0">Kittens</label>
         </div>
       </div>
       <div style="display: flex;  padding-block-start: 30px;">
-        <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left spectrum-FieldLabel-picker--quiet" style="margin-left: 32px;">Theme</div>
+        <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left spectrum-FieldLabel-quiet-picker-side-label" style="margin-left: 32px;">Theme</div>
         <button type="button" class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet spectrum-Picker--sideLabel" aria-haspopup="listbox">
           <span class="spectrum-Picker-label is-placeholder">Light</span>
           <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
@@ -521,7 +564,7 @@ examples:
       <div class="dummy-spacing"></div>
 
       <h4>Side Label</h4>
-      <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left">Country</div>
+      <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-FieldLabel--left spectrum-FieldLabel-quiet-picker-side-label">Country</div>
       <button type="button" class="spectrum-Picker spectrum-Picker--sizeM spectrum-Picker--quiet spectrum-Picker--sideLabel is-open" aria-haspopup="listbox">
         <span class="spectrum-Picker-label">Ballard</span>
         <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">

--- a/components/picker/metadata/picker.yml
+++ b/components/picker/metadata/picker.yml
@@ -165,7 +165,7 @@ examples:
         <div class="spectrum-Examples-item">
           <h4>Closed</h4>
           <div class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Country</div>
-          <button type="button" class="spectrum-Picker spectrum-Picker--sizeM " aria-haspopup="listbox" style="width: 240px">
+          <button type="button" class="spectrum-Picker spectrum-Picker--sizeM" aria-haspopup="listbox" style="width: 240px">
             <span class="spectrum-Picker-label is-placeholder">Select a Country with a very long label, too long in fact</span>
             <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 spectrum-Picker-menuIcon" focusable="false" aria-hidden="true">
               <use xlink:href="#spectrum-css-icon-Chevron100" />

--- a/components/picker/stories/picker.stories.js
+++ b/components/picker/stories/picker.stories.js
@@ -158,6 +158,15 @@ Quiet.args = {
 	],
 };
 
+export const QuietSideLabel = Template.bind({});
+QuietSideLabel.args = {
+	isQuiet: true,
+	content: [
+		() => MenuStories(MenuStories.args)
+	],
+	labelPosition: "left"
+};
+
 export const Loading = Template.bind({});
 Loading.args = {
 	isLoading: true,

--- a/components/picker/stories/template.js
+++ b/components/picker/stories/template.js
@@ -141,6 +141,7 @@ export const Template = ({
 					label,
 					isDisabled,
 					alignment: labelPosition,
+					customClasses: [`${isQuiet && labelPosition == "left" ? "spectrum-FieldLabel-quiet-picker-side-label" : ''}`],
 			  })
 			: ""}
 		${labelPosition == "left" ?

--- a/tokens/custom-spectrum/custom-large-vars.css
+++ b/tokens/custom-spectrum/custom-large-vars.css
@@ -120,4 +120,14 @@ governing permissions and limitations under the License.
 	--spectrum-assetcard-content-font-size: var(--spectrum-body-size-xs);
 
   --spectrum-tooltip-animation-distance: 5px;
+
+  --spectrum-picker-side-label-quiet-padding-block-start-small: -1px;
+  --spectrum-picker-side-label-quiet-padding-block-start-medium: -1px;
+  --spectrum-picker-side-label-quiet-padding-block-start-large: -1px;
+  --spectrum-picker-side-label-quiet-padding-block-start-xlarge: 0px;
+
+  --spectrum-fieldlabel-picker-side-label-quiet-padding-block-start-small: 5px;
+  --spectrum-fieldlabel-picker-side-label-quiet-padding-block-start-medium: 11px;
+  --spectrum-fieldlabel-picker-side-label-quiet-padding-block-start-large: 14px;
+  --spectrum-fieldlabel-picker-side-label-quiet-padding-block-start-xlarge: 18px;
 }

--- a/tokens/custom-spectrum/custom-medium-vars.css
+++ b/tokens/custom-spectrum/custom-medium-vars.css
@@ -119,4 +119,14 @@ governing permissions and limitations under the License.
 	--spectrum-assetcard-content-font-size: var(--spectrum-body-size-s);
 
   --spectrum-tooltip-animation-distance: var(--spectrum-spacing-75);
+
+  --spectrum-picker-side-label-quiet-padding-block-start-small: -1px;
+  --spectrum-picker-side-label-quiet-padding-block-start-medium: 0px;
+  --spectrum-picker-side-label-quiet-padding-block-start-large: -1px;
+  --spectrum-picker-side-label-quiet-padding-block-start-xlarge: 0px;
+
+  --spectrum-fieldlabel-picker-side-label-quiet-padding-block-start-small: 4px;
+  --spectrum-fieldlabel-picker-side-label-quiet-padding-block-start-medium: 8px;
+  --spectrum-fieldlabel-picker-side-label-quiet-padding-block-start-large: 11px;
+  --spectrum-fieldlabel-picker-side-label-quiet-padding-block-start-xlarge: 14px;
 }

--- a/tokens/custom-spectrum/custom-medium-vars.css
+++ b/tokens/custom-spectrum/custom-medium-vars.css
@@ -125,8 +125,8 @@ governing permissions and limitations under the License.
   --spectrum-picker-side-label-quiet-padding-block-start-large: -1px;
   --spectrum-picker-side-label-quiet-padding-block-start-xlarge: 0px;
 
-  --spectrum-fieldlabel-picker-side-label-quiet-padding-block-start-small: 4px;
-  --spectrum-fieldlabel-picker-side-label-quiet-padding-block-start-medium: 8px;
+  --spectrum-fieldlabel-picker-side-label-quiet-padding-block-start-small: var(--spectrum-spacing-75);
+  --spectrum-fieldlabel-picker-side-label-quiet-padding-block-start-medium: var(--spectrum-spacing-100);
   --spectrum-fieldlabel-picker-side-label-quiet-padding-block-start-large: 11px;
   --spectrum-fieldlabel-picker-side-label-quiet-padding-block-start-xlarge: 14px;
 }


### PR DESCRIPTION
## Description

BREAKING CHANGE - does require a change to the classes used on the field label 

Addresses concerned raised in [SWC Github issue 2963]( https://github.com/adobe/spectrum-web-components/issues/2963) where the quiet picker and it's associated side label does not align with text of other components, making it appear incorrect when used with other components. 

For before look at #2231 


### Proposed fix: 
Adjust the top padding or margin for both the FieldLabel and Picker when the Picker is Quiet and has a side label.
#### Field Label

- add a class to the Field Label for this particular use case `spectrum-FieldLabel-quiet-picker-side-label`
- this class to position the field label text using custom properties: 
`--spectrum-fieldlabel-picker-side-label-quiet-padding-block-start-small`
`--spectrum-fieldlabel-picker-side-label-quiet-padding-block-start-medium`
`--spectrum-fieldlabel-picker-side-label-quiet-padding-block-start-large` 
`--spectrum-fieldlabel-picker-side-label-quiet-padding-block-start-xlarge`

#### Picker 
- using the already in place `spectrum-Picker--sideLabel`  class position the Picker using the custom properties: 
  `--spectrum-picker-side-label-quiet-padding-block-start-small` 
 ` --spectrum-picker-side-label-quiet-padding-block-start-medium`
  `--spectrum-picker-side-label-quiet-padding-block-start-large`
  `--spectrum-picker-side-label-quiet-padding-block-start-xlarge`
  
  #### Potential Token Changes: 
  - add component specific tokens for each of the custom properties, including different values for Large scale
  
  
## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps


### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

![Screenshot 2023-11-22 at 11 51 37 AM](https://github.com/adobe/spectrum-css/assets/63808889/8feca2b9-90bc-44f7-b5fb-e0d417f31d28)


## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
