### PR TITLE
refactor(site): programmatic focus is component-specific

### DIFF
--- a/site/resources/js/enhancement.js
+++ b/site/resources/js/enhancement.js
@@ -963,6 +963,49 @@ var NAVIGATION_KEYS = [
 	'Esc'
 ];
 
+var FOCUS_COMPONENTS = [
+	'assetlist',
+	'button',
+	'calendar',
+	'card',
+	'closebutton',
+	'colorarea',
+	'colorhandle',
+	'colorslider',
+	'colorwheel',
+	'combobox',
+	'menu',
+	'picker',
+	'pickerbutton',
+	'rating',
+	'sidenav',
+	'slider',
+	'steplist',
+	'stepper',
+	'table',
+	'tag',
+	'tooltip'
+];
+
+var KEYBOARD_FOCUS_COMPONENTS = [
+	'closebutton',
+	'combobox',
+	'datepicker',
+	'pickerbutton',
+	'sidenav',
+	'stepper',
+	'table',
+];
+
+// If pathname matches a component in the focus or keyboard focus arrays,
+// we know that component should get/is setup to handle the focus class
+function getsFocusClasses(componentArray) {
+	return componentArray.some((componentPath) => {
+		const currentPath = window.location.pathname;
+		return currentPath.includes(componentPath);
+	});
+}
+
 var keyboardFocus = false;
 
 function onKeydownHandler(event) {
@@ -971,25 +1014,26 @@ function onKeydownHandler(event) {
 	}
 	keyboardFocus = true;
 
-	if (document.activeElement &&
-		document.activeElement !== document.body) {
-					document.activeElement.classList.add('is-keyboardFocused');
+	if (getsFocusClasses(KEYBOARD_FOCUS_COMPONENTS)
+		&& document.activeElement
+		&& document.activeElement !== document.body) {
+			document.activeElement.classList.add('is-keyboardFocused');
 	}
 }
 
 function onMousedownHandler() {
 	keyboardFocus = false;
 
-	if (document.activeElement &&
-		document.activeElement !== document.body) {
-				document.activeElement.classList.add('is-focused');
+	if (getsFocusClasses(FOCUS_COMPONENTS)
+		&& document.activeElement
+		&& document.activeElement !== document.body) {
+			document.activeElement.classList.add('is-focused');
 	}
 }
 
-// Programmatic focus
 function onFocusHandler(event) {
 	var classList = event.target.classList;
-	if (classList && keyboardFocus) {
+	if (classList && keyboardFocus && getsFocusClasses(KEYBOARD_FOCUS_COMPONENTS)) {
 		classList.add('is-keyboardFocused');
 	}
 }


### PR DESCRIPTION
## Description

In some cases, we use `is-focused` and `is-keyboardFocused` classes in components where targeting `:focus` and/or `:focus-visible` aren’t enough to apply focus styles. This work aligns our docs site to limit application of those classes to components that need them and implement them in their CSS (vs before it was applying them to every component).

A couple interesting things that came up during this work:

- Some components (close button for instance) may not need to rely on `is-focused` and `is-keyboardFocused`. I’ll create a card in the backlog to evaluate this and adjust where needed.
- The mousedown functionality in enhacement.js seems a bit buggy. Sometimes when you mousedown on the element, it reports that you’re mousedown on the `<body>`, which must be why we have the check for whether the [activeElement is the body](https://github.com/adobe/spectrum-css/pull/2320/files#diff-0ca3b69929af0604381cde30c53cb81b0e8be463dbbcfe37852529e8b15e6690R1023). Since this might change with the move to 11ty, I decided to hold off on debugging this for now.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author: @jawinn 

### Validation steps

In the docs site, test that components that don't need the classes aren't getting them anymore:
- [x] Breadcrumbs should no longer receive `is-keyboardFocused` class on tab (though visually tabbing through will look the same)
- [x] Checkbox should no longer receive `is-keyboardFocused` class on tab (though visually tabbing through will look the same)

And test that components that do need the classes still receive them:
- [x] Table still receives `is-keyboardFocused` class on tab
- [x] Combobox still receives `is-focused` class on click

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [ ] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
