### PR TITLE
fix: run mod-extractor on dist and support for multiple files

### DIFF
--- a/components/actionbutton/metadata/mods.md
+++ b/components/actionbutton/metadata/mods.md
@@ -47,4 +47,8 @@
 | `--mod-actionbutton-icon-size`                                    |
 | `--mod-actionbutton-label-color`                                  |
 | `--mod-actionbutton-min-width`                                    |
+| `--mod-actionbutton-static-content-color`                         |
 | `--mod-actionbutton-text-to-visual`                               |
+| `--mod-animation-duration-100`                                    |
+| `--mod-line-height-100`                                           |
+| `--mod-sans-font-family-stack`                                    |

--- a/components/button/metadata/mods.md
+++ b/components/button/metadata/mods.md
@@ -1,5 +1,6 @@
 | Modifiable Custom Properties               |
 | ------------------------------------------ |
+| `--mod-animation-duration-100`             |
 | `--mod-bold-font-weight`                   |
 | `--mod-button-animation-duration`          |
 | `--mod-button-background-color-default`    |
@@ -35,6 +36,9 @@
 | `--mod-button-margin-right`                |
 | `--mod-button-min-width`                   |
 | `--mod-button-padding-label-to-icon`       |
+| `--mod-button-static-content-color`        |
 | `--mod-button-top-to-text`                 |
 | `--mod-focus-indicator-gap`                |
+| `--mod-line-height-100`                    |
+| `--mod-sans-font-family-stack`             |
 | `--mod-static-black-focus-indicator-color` |

--- a/components/closebutton/metadata/mods.md
+++ b/components/closebutton/metadata/mods.md
@@ -1,5 +1,6 @@
 | Modifiable Custom Properties                        |
 | --------------------------------------------------- |
+| `--mod-animation-duration-100`                      |
 | `--mod-closebutton-align-self`                      |
 | `--mod-closebutton-animation-duraction`             |
 | `--mod-closebutton-animation-duration`              |
@@ -25,3 +26,5 @@
 | `--mod-closebutton-static-background-color-focus`   |
 | `--mod-closebutton-static-background-color-hover`   |
 | `--mod-closebutton-width`                           |
+| `--mod-line-height-100`                             |
+| `--mod-sans-font-family-stack`                      |

--- a/components/commons/metadata/mods.md
+++ b/components/commons/metadata/mods.md
@@ -1,4 +1,8 @@
 | Modifiable Custom Properties              |
 | ----------------------------------------- |
+| `--mod-animation-duration-100`            |
+| `--mod-focus-indicator-gap`               |
+| `--mod-line-height-100`                   |
 | `--mod-overlay-animation-distance`        |
 | `--mod-overlay-animation-duration-opened` |
+| `--mod-sans-font-family-stack`            |

--- a/components/logicbutton/metadata/mods.md
+++ b/components/logicbutton/metadata/mods.md
@@ -1,5 +1,8 @@
 | Modifiable Custom Properties                             |
 | -------------------------------------------------------- |
+| `--mod-animation-duration-100`                           |
+| `--mod-focus-indicator-gap`                              |
+| `--mod-line-height-100`                                  |
 | `--mod-logic-button-and-background-color`                |
 | `--mod-logic-button-and-background-color-disabled`       |
 | `--mod-logic-button-and-background-color-hover`          |
@@ -29,3 +32,4 @@
 | `--mod-logic-button-or-text-color`                       |
 | `--mod-logic-button-or-text-color-disabled`              |
 | `--mod-logic-button-padding`                             |
+| `--mod-sans-font-family-stack`                           |

--- a/components/modal/metadata/mods.md
+++ b/components/modal/metadata/mods.md
@@ -11,3 +11,4 @@
 | `--mod-modal-max-height`                       |
 | `--mod-modal-max-width`                        |
 | `--mod-modal-transition-animation-duration`    |
+| `--mod-overlay-animation-duration-opened`      |

--- a/components/picker/metadata/mods.md
+++ b/components/picker/metadata/mods.md
@@ -1,5 +1,7 @@
 | Modifiable Custom Properties                           |
 | ------------------------------------------------------ |
+| `--mod-animation-duration-100`                         |
+| `--mod-line-height-100`                                |
 | `--mod-picker-animation-duration`                      |
 | `--mod-picker-background-color-active`                 |
 | `--mod-picker-background-color-default`                |
@@ -62,3 +64,4 @@
 | `--mod-picker-spacing-top-to-disclosure-icon`          |
 | `--mod-picker-spacing-top-to-progress-circle`          |
 | `--mod-picker-spacing-top-to-text`                     |
+| `--mod-sans-font-family-stack`                         |

--- a/components/popover/metadata/mods.md
+++ b/components/popover/metadata/mods.md
@@ -1,5 +1,6 @@
 | Modifiable Custom Properties                  |
 | --------------------------------------------- |
+| `--mod-overlay-animation-duration-opened`     |
 | `--mod-popover-animation-distance`            |
 | `--mod-popover-background-color`              |
 | `--mod-popover-border-color`                  |

--- a/components/tooltip/metadata/mods.md
+++ b/components/tooltip/metadata/mods.md
@@ -1,5 +1,6 @@
 | Modifiable Custom Properties                 |
 | -------------------------------------------- |
+| `--mod-overlay-animation-duration-opened`    |
 | `--mod-tooltip-animation-distance`           |
 | `--mod-tooltip-background-color-default`     |
 | `--mod-tooltip-background-color-informative` |

--- a/components/underlay/metadata/mods.md
+++ b/components/underlay/metadata/mods.md
@@ -1,5 +1,6 @@
 | Modifiable Custom Properties                         |
 | ---------------------------------------------------- |
+| `--mod-overlay-animation-duration-opened`            |
 | `--mod-underlay-background-color`                    |
 | `--mod-underlay-background-entry-animation-delay`    |
 | `--mod-underlay-background-entry-animation-duration` |

--- a/tasks/mod-extractor.js
+++ b/tasks/mod-extractor.js
@@ -14,8 +14,16 @@ const { writeFile, readFile } = require("fs").promises;
 const path = require("path");
 const fg = require("fast-glob");
 
-async function main(dir = path.join(__dirname, "../components")) {
-	/* Loop over the directories in the components folder and find all the first-level css files */
+/**
+ * Parse first-level CSS files to extract "--mod" custom properties.
+ *
+ * @param {string} dir Parent components directory. 
+ * @returns Array of objects containing the component directory and the list of mod names.
+ */
+async function collectMods(dir = path.join(__dirname, "../components")) {
+	let modsPerPath = [];
+
+	// Loop over the directories in the components folder and find all the first-level CSS files.
 	for (const filepath of await fg("*/*.css", {
 		cwd: dir,
 		absolute: true,
@@ -37,53 +45,88 @@ async function main(dir = path.join(__dirname, "../components")) {
 		 */
 		const regex = /(--mod-(?:\w|-)+)(?!:|\w|-)/g;
 
-		/* Read the file and find all the matches */
+		// Read the file and find all the matches.
 		const matches = await readFile(filepath, "utf-8")
 			.then((content) => {
-				// assign the matches to an array through the spread operator and map the results to the first capture group
+				// Assign the matches to an array through the spread operator
+				// and map the results to the first capture group.
 				return [...content.matchAll(regex)].map((match) => match[1]);
 			})
 			.catch((err) => {
 				console.log(err);
 			});
 
-		// If there are no matches, skip this file and continue to the next one
+		// If there are no matches, skip this file and continue to the next one.
 		if (!matches || matches.length === 0) continue;
 
-		/* Remove duplicates using a Set and sort the results (default is alphabetical) */
-		const found = [...new Set(matches)].sort();
-		/* -- Markdown Output -- */
-		/* Output as a markdown table in the metadata folder for site rendering */
-		let destPath = `${path.dirname(filepath)}/metadata`;
-		// If the metadata folder doesn't exist, create it
-		if (!existsSync(destPath)) mkdirSync(destPath);
-
-		let formattedResults = [
-			"| Modifiable Custom Properties |\n| --- |",
-			...found.map((result) => `| \`${result}\` |`),
-		];
-
-		// Write the results to a markdown file in the metadata folder
-		await writeFile(
-			`${destPath}/mods.md`,
-			formattedResults.join("\n"),
-			(err) => {
-				if (err) throw err;
-			}
-		);
-
-		/* -- JSON Output -- */
-		destPath = `${path.dirname(filepath)}/dist`;
-		// If the dist folder doesn't exist yet, create it
-		if (!existsSync(destPath)) mkdirSync(destPath);
-
-		formattedResults = JSON.stringify({ mods: found }, null, 2);
-
-		// Write the JSON output to the dist folder
-		await writeFile(`${destPath}/mods.json`, formattedResults, (err) => {
-			if (err) throw err;
-		});
+		// Add matches to list of mods associated with this component (directory).
+		// Append to existing array or add new object to array.
+		const directory = path.dirname(filepath);
+		existingPathIndex = modsPerPath.findIndex(obj => obj.directory == directory);
+		if (existingPathIndex != -1){
+			modsPerPath[existingPathIndex].matches.push(...matches);
+		} else {
+			modsPerPath.push({ directory, matches });
+		}
 	}
+
+	return modsPerPath;
 }
 
-main();
+/**
+ * Output list of mods to a markdown file and a JSON file in the metadata directory.
+ * Sorts list and exludes any duplicates.
+ * 
+ * @param {String} directory Directory to write the metadata folder with mods files.
+ * @param {Array} mods Array of custom properties starting with "--mod".
+ */
+async function outputMods(directory, mods = []){
+	if (!mods || mods.length === 0 || !directory) return;
+
+	// Remove duplicates using a Set and sort the results (default is alphabetical).
+	const found = [...new Set(mods)].sort();
+
+	/* -- Markdown Output -- */
+	/* Output as a markdown table in the metadata folder for site rendering */
+	let destPath = `${directory}/metadata`;
+	// If the metadata folder doesn't exist, create it.
+	if (!existsSync(destPath)) mkdirSync(destPath);
+
+	let formattedResults = [
+		"| Modifiable Custom Properties |\n| --- |",
+		...found.map((result) => `| \`${result}\` |`),
+	];
+
+	// Write the results to a markdown file in the metadata folder.
+	await writeFile(
+		`${destPath}/mods.md`,
+		formattedResults.join("\n"),
+		(err) => {
+			if (err) throw err;
+		}
+	);
+
+	/* -- JSON Output -- */
+	destPath = `${directory}/dist`;
+	// If the dist folder doesn't exist yet, create it.
+	if (!existsSync(destPath)) mkdirSync(destPath);
+
+	formattedResults = JSON.stringify({ mods: found }, null, 2);
+
+	// Write the JSON output to the dist folder.
+	await writeFile(`${destPath}/mods.json`, formattedResults, (err) => {
+		if (err) throw err;
+	});
+}
+
+/**
+ * Parse CSS files to extract "--mod" custom properties, and export the list of mods
+ * to both a markdown file and a JSON file for each component.
+ */
+(async () => {
+	const modsPerPath = await collectMods();
+	// Output mods list for each component (directory).
+	modsPerPath.forEach(m => {
+		outputMods(m.directory, m.matches);
+	});
+})();

--- a/tasks/mod-extractor.js
+++ b/tasks/mod-extractor.js
@@ -15,7 +15,7 @@ const path = require("path");
 const fg = require("fast-glob");
 
 /**
- * Parse first-level CSS files to extract "--mod" custom properties.
+ * Parse CSS files to extract "--mod" custom properties.
  *
  * @param {string} dir Parent components directory. 
  * @returns Array of objects containing the component directory and the list of mod names.
@@ -23,14 +23,14 @@ const fg = require("fast-glob");
 async function collectMods(dir = path.join(__dirname, "../components")) {
 	let modsPerPath = [];
 
-	// Loop over the directories in the components folder and find all the first-level CSS files.
-	for (const filepath of await fg("*/*.css", {
+	// Loop over the directories in the components folder and find the built
+	// CSS file(s) that might contain mods.
+	for (const filepath of await fg("*/dist/index.css", {
 		cwd: dir,
 		absolute: true,
 		/* Skip the vars and tokens files */
 		ignore: [
 			"**/node_modules/**",
-			"**/dist/**",
 			"**/metadata/**",
 			"**/*vars/*.css",
 			"**/tokens/*.css",
@@ -59,14 +59,17 @@ async function collectMods(dir = path.join(__dirname, "../components")) {
 		// If there are no matches, skip this file and continue to the next one.
 		if (!matches || matches.length === 0) continue;
 
-		// Add matches to list of mods associated with this component (directory).
+		// Add matches to list of mods associated with this component directory.
 		// Append to existing array or add new object to array.
-		const directory = path.dirname(filepath);
-		existingPathIndex = modsPerPath.findIndex(obj => obj.directory == directory);
+		let componentDirectory = path.dirname(filepath).replace('/dist','');
+		existingPathIndex = modsPerPath.findIndex(obj => obj.directory == componentDirectory);
 		if (existingPathIndex != -1){
 			modsPerPath[existingPathIndex].matches.push(...matches);
 		} else {
-			modsPerPath.push({ directory, matches });
+			modsPerPath.push({
+				directory: componentDirectory,
+				matches
+			});
 		}
 	}
 


### PR DESCRIPTION
## Description

An update for the`yarn docs:mod` utility:
If there were multiple CSS files in the root, such as with the icon component and commons, only the mods from the last file found were being included. Basically the mods.md and mods.json were being overwritten each time a CSS file was processed. During migration changes to Icon (CSS-511), some mods were being left out of the metadata when the utility was run. This fixes that issue.

The utility now bundles all parsed mods per component directory into an array before exporting them. It also splits the utility into two functions `collectMods` and `exportMods` as it was quite large and the functionality was already very independent. This also makes it easier to add unit tests in the future.

_Per PR discussions, this also now runs the utility on dist files instead of source files to make sure all mods are being included, such as those coming in through inherits or extends. It also improves console logging output (see screenshot), and allows the utility to be run on a single component._

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
- [x] Pull down the branch locally and run `docs:mod`. There should not be any changes.
- [x] Delete all markdown and json files locally `rm -R ./components/*/metadata/mods.md && rm -R ./components/*/dist/mods.json`, see that files have been deleted and run `docs:mod` again. All files should be regenerated and there are no changes except for searchwithin mods.md being deleted because it has no mods in its CSS.
- [x] Add the following CSS to the icon component's **workflow-icons.css** file .spectrum-Icon `color: var(--mod-test);` and run `docs:mod`. The mods.md for icon should show both `--mod-test` and `--mod-icon-color`

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

## Screenshots

![Screenshot 2023-12-07 at 6 49 05 PM](https://github.com/adobe/spectrum-css/assets/965114/ace939dc-fc90-438d-8bac-9eecda638e5d)

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
