### PR TITLE
fix: docs watch unable to find package.json

### DIFF
--- a/tools/bundle-builder/dev/index.js
+++ b/tools/bundle-builder/dev/index.js
@@ -191,7 +191,8 @@ function watch() {
 					},
 					function buildDocs_forDep() {
 						logger.debug(`Building docs for ${package}`);
-						return docs.buildDocs_forDep(package);
+						let packageDir = path.dirname(require.resolve(`@spectrum-css/${package}/package.json`));
+						return docs.buildDocs_forDep(packageDir);
 					}
 				)();
 				// this catches yaml parsing errors


### PR DESCRIPTION
## Description

Fixes the below described bug:

When `yarn dev` was already running and changes were made to any component .yml file, we would get a console error: `'buildDocs_forDep' errored after 9.74 ms. Error: Cannot find module '...component-name/package.json'`. The issue was that on initial docs site build, `buildDocs_forDep` was receiving the correct path `@spectrum-css/component-name/package.json`, but on handleFileChanged, the path would come back without `@spectrum-css`, causing the error because it couldn't find the package.json, which is one of the first things the function needs.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
- [ ] Pull down the branch and run `yarn dev`
- [ ] Once the docs site spins up, make an html change to a component's .yml file. The change shouldn't cause an error and the docs site should be updated, either by hot reload or manual reload (you might see this change hot reload instead of having to manually reload, I've seen it work intermittently. We've always had to manually reload on html change before so it's fine if that's still the case)
- [ ] Now make an easily visible change to a component index.css. The change should be applied to the docs site and it should hot reload

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.


## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
