### PR TITLE
fix(slider): high contrast improvements for filled track

### DIFF
--- a/components/slider/index.css
+++ b/components/slider/index.css
@@ -429,6 +429,7 @@ governing permissions and limitations under the License.
   .spectrum-Slider-handle {
     background-color: var(--highcontrast-slider-tick-handle-background-color, var(--mod-slider-tick-handle-background-color, var(--spectrum-slider-tick-handle-background-color)));
   }
+
   .spectrum-Slider-controls {
     margin-block-start:
       calc(
@@ -542,13 +543,19 @@ governing permissions and limitations under the License.
   overflow: hidden;
 }
 
-
+/* Applies to the filled-offset variant to keep track the same color for highcontrast mode */
 .spectrum-Slider-track {
+  &::before {
+    background: var(--highcontrast-slider-track-color-static, var(--mod-slider-track-color, var(--spectrum-slider-track-color)));
+  }
+}
+
+/* All variants other than filled-offset get a new track color for highcontrast mode */
+.spectrum-Slider-track:not(:has(~ .spectrum-Slider-fill)) {
   &::before {
     background: var(--highcontrast-slider-track-color, var(--mod-slider-track-color, var(--spectrum-slider-track-color)));
   }
 }
-
 
 .spectrum-Slider-labelContainer {
   color: var(--highcontrast-slider-label-text-color, var(--mod-slider-label-text-color, var(--spectrum-slider-label-text-color)));
@@ -558,14 +565,14 @@ governing permissions and limitations under the License.
 .spectrum-Slider--filled {
   .spectrum-Slider-track:first-child {
     &::before {
-      background: var(--highcontrast-slider-track-fill-color, var(--mod-slider-track-fill-color, var(--spectrum-slider-track-fill-color)));
+      background: var(--highcontrast-slider-filled-track-fill-color, var(--mod-slider-track-fill-color, var(--spectrum-slider-track-fill-color)));
     }
   }
 }
 
 .spectrum-Slider-fill {
   &::before {
-    background: var(--highcontrast-slider-track-fill-color, var(--mod-slider-track-fill-color, var(--spectrum-slider-track-fill-color)));
+    background: var(--highcontrast-slider-filled-track-fill-color, var(--mod-slider-track-fill-color, var(--spectrum-slider-track-fill-color)));
   }
 }
 
@@ -626,8 +633,8 @@ governing permissions and limitations under the License.
 
 .spectrum-Slider--range {
   .spectrum-Slider-track {
-    &:not(:first-of-type):not(:last-of-type)::before {
-      background: var(--highcontrast-slider-track-fill-icolor, var(--mod-slider-track-fill-color, var(--spectrum-slider-track-fill-color)));
+    &:not(:first-of-type, :last-of-type)::before {
+      background: var(--highcontrast-slider-filled-track-fill-color, var(--mod-slider-track-fill-color, var(--spectrum-slider-track-fill-color)));
     }
   }
 }
@@ -691,18 +698,19 @@ governing permissions and limitations under the License.
   }
 
   &.spectrum-Slider--range {
-    .spectrum-Slider-track:not(:first-of-type):not(:last-of-type)::before {
+    .spectrum-Slider-track:not(:first-of-type, :last-of-type)::before {
       background: var(--highcontrast-slider-track-color-disabled, var(--mod-slider-track-color-disabled, var(--spectrum-slider-track-color-disabled)));
     }
   }
 }
 
 @media (forced-colors: active) {
-
   .spectrum-Slider {
     /*  over-writes */
     --highcontrast-slider-track-color: ButtonText;
+    --highcontrast-slider-track-color-static: ButtonText;
     --highcontrast-slider-track-fill-color: ButtonText;
+    --highcontrast-slider-filled-track-fill-color: Highlight;
     --highcontrast-slider-ramp-track-color: ButtonText;
     --highcontrast-slider-ramp-track-color-disabled: GrayText;
     --highcontrast-slider-tick-mark-color: ButtonText;
@@ -753,7 +761,8 @@ governing permissions and limitations under the License.
     }
 
     /* Slider control hover and focus colors for high contrast mode */
-    &:not(.is-disabled) {
+    /* Filled and range variants are excluded since the filled portion of the track uses Highlight */
+    &:not(.is-disabled, .spectrum-Slider--filled, .spectrum-Slider--range) {
       .spectrum-Slider-controls:hover,
       .spectrum-Slider-controls:active,
       .spectrum-Slider-controls:focus-within,


### PR DESCRIPTION
## Description

Filled sections of the track get the Highlight color when in high contrast mode to differentiate them from the rest of the track, which remains the ButtonText color (even on hover/focus/keyboard focus/active state). Slack receipts [in this thread](https://adobedesign.slack.com/archives/GQ09RCBA5/p1697227853534239).

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
- [x] Design approval (@mdt2)
- [x] Open the Slider in the docs site and turn on high contrast @jenndiaz 
- [x] The filled portion of the track should be the Highlight color to differentiate them from the rest of the track for: @jenndiaz 
    - [x] Filled
    - [x] Filled-offset
    - [x] Range

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.


## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
