### PR TITLE
fix(picker): high contrast and other color fixes

### DIFF
--- a/components/picker/index.css
+++ b/components/picker/index.css
@@ -153,16 +153,17 @@ governing permissions and limitations under the License.
   .spectrum-Picker {
     --highcontrast-picker-focus-indicator-color: Highlight;
 
-    --highcontrast-picker-border-color-default: ButtonText;
-    --highcontrast-picker-border-color-active: ButtonText;
-    --highcontrast-picker-border-color-key-focus: ButtonText;
-    --highcontrast-picker-border-color-default-open: ButtonText;
+    --highcontrast-picker-border-color-default: ButtonBorder;
+    --highcontrast-picker-border-color-active: ButtonBorder;
+    --highcontrast-picker-border-color-key-focus: ButtonBorder;
+    --highcontrast-picker-border-color-default-open: ButtonBorder;
     --highcontrast-picker-border-color-hover-open: Highlight;
     --highcontrast-picker-border-color-hover: Highlight;
 
-    --highcontrast-picker-border-color-error-default-open: ButtonText;
-    --highcontrast-picker-border-color-error-hover: ButtonText;
-    --highcontrast-picker-border-color-error-active: ButtonText;
+    --highcontrast-picker-border-color-error-default-open: ButtonBorder;
+    --highcontrast-picker-border-color-error-hover: ButtonBorder;
+    --highcontrast-picker-border-color-error-active: ButtonBorder;
+    --highcontrast-picker-border-color-disabled: GrayText;
 
     --highcontrast-picker-font-color-default: ButtonText;
     --highcontrast-picker-font-color-default-open: ButtonText;
@@ -180,12 +181,6 @@ governing permissions and limitations under the License.
 
     --highcontrast-picker-icon-color-error-default: ButtonText;
 
-    &:disabled,
-    .is-disabled {
-      border-color: GrayText;
-      border-width: var(--mod-picker-border-width, var(--spectrum-picker-border-width));
-    }
-
     &:focus-visible,
     &.is-focused {
       --highcontrast-picker-border-color-hover-open: ButtonText;
@@ -196,12 +191,10 @@ governing permissions and limitations under the License.
       /* Make sure default transparent border stays transparent. */
       forced-color-adjust: none;
     }
-  }
-  .spectrum-Picker--quiet {
-    &:focus-visible,
-    &.is-focused {
+
+    .spectrum-Picker-label {
+      /* Remove additional text backplate added by WHCM. */
       forced-color-adjust: none;
-      outline: 0;
     }
   }
 }
@@ -296,8 +289,6 @@ governing permissions and limitations under the License.
     outline: none;
     background-color: var(--highcontrast-picker-background-color-default, var(--mod-picker-background-color-key-focus, var(--spectrum-picker-background-color-key-focus)));
     border-color: var(--highcontrast-picker-border-color-key-focus, var(--mod-picker-border-color-key-focus, var(--spectrum-picker-border-color-key-focus)));
-    border-width: var(--mod-picker-border-width, var(--spectrum-picker-border-width));
-
     color: var(--highcontrast-picker-font-color-key-focus, var(--mod-picker-font-color-key-focus, var(--spectrum-picker-font-color-key-focus)));
 
     /* Focus indicator */
@@ -351,11 +342,9 @@ governing permissions and limitations under the License.
 
   &:disabled,
   &.is-disabled {
-    border-width: var(--mod-picker-border-width, var(--spectrum-picker-border-width));
     cursor: default;
-
     background-color: var(--highcontrast-picker-background-color-disabled, var(--mod-picker-background-color-disabled, var(--spectrum-picker-background-color-disabled)));
-    border-color: transparent;
+    border-color: var(--highcontrast-picker-border-color-disabled, transparent);
     color: var(--highcontrast-picker-font-color-disabled, var(--mod-picker-font-color-disabled, var(--spectrum-picker-font-color-disabled)));
 
     .spectrum-Picker-icon,
@@ -487,7 +476,7 @@ governing permissions and limitations under the License.
   padding-inline: var(--mod-picker-spacing-edge-to-text-quiet, var(--spectrum-picker-spacing-edge-to-text-quiet));
   margin-block-start: calc( var(--mod-picker-spacing-label-to-picker-quiet, var(--spectrum-picker-spacing-label-to-picker-quiet)) + (1px));
   color: var(--highcontrast-picker-font-color-default, var(--mod-picker-font-color-default, var(--spectrum-picker-font-color-default)));
-  background-color: transparent;
+  background-color: var(--highcontrast-picker-background-color-default, transparent);
 
   &.spectrum-Picker--sideLabel {
     margin-block-start: calc(-1 * var(--spectrum-picker-spacing-top-to-text-side-label-quiet)); 
@@ -504,14 +493,14 @@ governing permissions and limitations under the License.
   }
 
   &:hover {
-    background-color: transparent;
+    background-color: var(--highcontrast-picker-background-color-default, transparent);
   }
 
   &:focus-visible,
   &.is-focused {
-    background-color: transparent;
+    background-color: var(--highcontrast-picker-background-color-default, transparent);
 
-    /* Focus indicator */
+    /* Focus indicator changes from a ring to a line underneath. */
     &::after {
       border: none;
       border-radius: 0;
@@ -522,12 +511,12 @@ governing permissions and limitations under the License.
 
   &:active,
   &.is-open {
-    background-color: transparent;
+    background-color: var(--highcontrast-picker-background-color-default, transparent);
   }
 
   &:disabled,
   &.is-disabled {
-    background-color: transparent;
+    background-color: var(--highcontrast-picker-background-color-default, transparent);
   }
 }
 

--- a/components/picker/index.css
+++ b/components/picker/index.css
@@ -364,18 +364,6 @@ governing permissions and limitations under the License.
   }
 }
 
-.spectrum-Picker--quiet {
-  inline-size: auto;
-  min-inline-size: 0;
-
-  &:disabled,
-  &.is-disabled {
-    &:focus-visible {
-      border-color: transparent;
-    }
-  }
-}
-
 .spectrum-Picker-label {
   /* Be the biggest, but also shrink! */
   flex: 1 1 auto;
@@ -451,6 +439,8 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Picker--quiet {
+  inline-size: auto;
+  min-inline-size: 0;
   border: none;
   border-radius: 0;
   padding-inline: var(--mod-picker-spacing-edge-to-text-quiet, var(--spectrum-picker-spacing-edge-to-text-quiet));

--- a/components/picker/index.css
+++ b/components/picker/index.css
@@ -154,36 +154,16 @@ governing permissions and limitations under the License.
     --highcontrast-picker-focus-indicator-color: Highlight;
 
     --highcontrast-picker-border-color-default: ButtonBorder;
-    --highcontrast-picker-border-color-active: ButtonBorder;
-    --highcontrast-picker-border-color-key-focus: ButtonBorder;
-    --highcontrast-picker-border-color-default-open: ButtonBorder;
-    --highcontrast-picker-border-color-hover-open: Highlight;
     --highcontrast-picker-border-color-hover: Highlight;
-
-    --highcontrast-picker-border-color-error-default-open: ButtonBorder;
-    --highcontrast-picker-border-color-error-hover: ButtonBorder;
-    --highcontrast-picker-border-color-error-active: ButtonBorder;
     --highcontrast-picker-border-color-disabled: GrayText;
 
-    --highcontrast-picker-font-color-default: ButtonText;
-    --highcontrast-picker-font-color-default-open: ButtonText;
-    --highcontrast-picker-font-color-key-focus: ButtonText;
-    --highcontrast-picker-font-color-disabled: GrayText;
-
-    --highcontrast-picker-background-color-default: ButtonFace;
-    --highcontrast-picker-background-color-disabled: ButtonFace;
-
-    --highcontrast-picker-icon-color-default: ButtonText;
-    --highcontrast-picker-icon-color-default-open: ButtonText;
-    --highcontrast-picker-icon-color-hover: ButtonText;
-    --highcontrast-picker-icon-color-hover-open: ButtonText;
-    --highcontrast-picker-icon-color-key-focus: ButtonText;
-
-    --highcontrast-picker-icon-color-error-default: ButtonText;
+    --highcontrast-picker-content-color-default: ButtonText;
+    --highcontrast-picker-content-color-disabled: GrayText;
+    --highcontrast-picker-background-color: ButtonFace;
 
     &:focus-visible,
     &.is-focused {
-      --highcontrast-picker-border-color-hover-open: ButtonText;
+      --highcontrast-picker-border-color-hover: ButtonText;
     }
 
     /* Focus indicator */
@@ -193,7 +173,7 @@ governing permissions and limitations under the License.
     }
 
     .spectrum-Picker-label {
-      /* Remove additional text backplate added by WHCM. */
+      /* Remove additional text backplate added in WHCM (Edge). */
       forced-color-adjust: none;
     }
   }
@@ -225,8 +205,8 @@ governing permissions and limitations under the License.
     box-shadow var(--mod-picker-animation-duration, var(--spectrum-picker-animation-duration)),
     border-color var(--mod-picker-animation-duration, var(--spectrum-picker-animation-duration)) ease-in-out;
 
-  color: var(--highcontrast-picker-font-color-default, var(--mod-picker-font-color-default, var(--spectrum-picker-font-color-default)));
-  background-color: var(--highcontrast-picker-background-color-default, var(--mod-picker-background-color-default, var(--spectrum-picker-background-color-default)));
+  color: var(--highcontrast-picker-content-color-default, var(--mod-picker-font-color-default, var(--spectrum-picker-font-color-default)));
+  background-color: var(--highcontrast-picker-background-color, var(--mod-picker-background-color-default, var(--spectrum-picker-background-color-default)));
   border-color: var(--highcontrast-picker-border-color-default, var(--mod-picker-border-color-default, var(--spectrum-picker-border-color-default)));
 
   /* Focus indicator */
@@ -261,18 +241,18 @@ governing permissions and limitations under the License.
   }
 
   &:hover {
-    color: var(--highcontrast-picker-font-color-default, var(--mod-picker-font-color-hover, var(--spectrum-picker-font-color-hover)));
-    background-color: var(--highcontrast-picker-background-color-default, var(--mod-picker-background-color-hover, var(--spectrum-picker-background-color-hover)));
+    color: var(--highcontrast-picker-content-color-default, var(--mod-picker-font-color-hover, var(--spectrum-picker-font-color-hover)));
+    background-color: var(--highcontrast-picker-background-color, var(--mod-picker-background-color-hover, var(--spectrum-picker-background-color-hover)));
     border-color: var(--highcontrast-picker-border-color-hover, var(--mod-picker-border-color-hover, var(--spectrum-picker-border-color-hover)));
 
     .spectrum-Picker-menuIcon {
-      color: var(--highcontrast-picker-icon-color-hover, var(--mod-picker-icon-color-hover, var(--spectrum-picker-icon-color-hover)));
+      color: var(--highcontrast-picker-content-color-default, var(--mod-picker-icon-color-hover, var(--spectrum-picker-icon-color-hover)));
     }
   }
 
   &:active {
-    background-color: var(--highcontrast-picker-background-active, var(--mod-picker-background-color-active, var(--spectrum-picker-background-color-active)));
-    border-color: var(--highcontrast-picker-border-color-active, var(--mod-picker-border-active, var(--spectrum-picker-border-color-active)));
+    background-color: var(--highcontrast-picker-background-color, var(--mod-picker-background-color-active, var(--spectrum-picker-background-color-active)));
+    border-color: var(--highcontrast-picker-border-color-default, var(--mod-picker-border-active, var(--spectrum-picker-border-color-active)));
 
     /* Focus indicator */
     &::after {
@@ -280,16 +260,16 @@ governing permissions and limitations under the License.
     }
 
     &.is-placeholder .spectrum-Picker-label {
-      color: var(--highcontrast-picker-font-color-default, var(--mod-picker-font-color-active, var(--spectrum-picker-font-color-active)));
+      color: var(--highcontrast-picker-content-color-default, var(--mod-picker-font-color-active, var(--spectrum-picker-font-color-active)));
     }
   }
 
   &:focus-visible,
   &.is-focused {
     outline: none;
-    background-color: var(--highcontrast-picker-background-color-default, var(--mod-picker-background-color-key-focus, var(--spectrum-picker-background-color-key-focus)));
-    border-color: var(--highcontrast-picker-border-color-key-focus, var(--mod-picker-border-color-key-focus, var(--spectrum-picker-border-color-key-focus)));
-    color: var(--highcontrast-picker-font-color-key-focus, var(--mod-picker-font-color-key-focus, var(--spectrum-picker-font-color-key-focus)));
+    background-color: var(--highcontrast-picker-background-color, var(--mod-picker-background-color-key-focus, var(--spectrum-picker-background-color-key-focus)));
+    border-color: var(--highcontrast-picker-border-color-default, var(--mod-picker-border-color-key-focus, var(--spectrum-picker-border-color-key-focus)));
+    color: var(--highcontrast-picker-content-color-default, var(--mod-picker-font-color-key-focus, var(--spectrum-picker-font-color-key-focus)));
 
     /* Focus indicator */
     &::after {
@@ -297,64 +277,64 @@ governing permissions and limitations under the License.
     }
 
     &.is-placeholder {
-      color: var(--highcontrast-picker-font-color-key-focus, var(--mod-picker-font-color-key-focus, var(--spectrum-picker-font-color-key-focus)));
+      color: var(--highcontrast-picker-content-color-default, var(--mod-picker-font-color-key-focus, var(--spectrum-picker-font-color-key-focus)));
     }
 
     .spectrum-Picker-menuIcon {
-      color: var(--highcontrast-picker-icon-color-key-focus, var(--mod-picker-icon-color-key-focus, var(--spectrum-picker-icon-color-key-focus)));
+      color: var(--highcontrast-picker-content-color-default, var(--mod-picker-icon-color-key-focus, var(--spectrum-picker-icon-color-key-focus)));
     }
   }
 
   &.is-invalid {
-    border-color: var(--highcontrast-picker-border-color-error-default, var(--mod-picker-border-color-error-default, var(--spectrum-picker-border-color-error-default)));
+    border-color: var(--highcontrast-picker-border-color-default, var(--mod-picker-border-color-error-default, var(--spectrum-picker-border-color-error-default)));
 
     .spectrum-Picker-validationIcon {
-      color: var(--highcontrast-picker-icon-color-error-default, var(--mod-picker-icon-color-error, var(--spectrum-picker-icon-color-error)));
+      color: var(--highcontrast-picker-content-color-default, var(--mod-picker-icon-color-error, var(--spectrum-picker-icon-color-error)));
     }
 
     &:hover {
-      border-color: var(--highcontrast-picker-border-color-error-hover, var(--mod-picker-border-color-error-hover, var(--spectrum-picker-border-color-error-hover)));
+      border-color: var(--highcontrast-picker-border-color-default, var(--mod-picker-border-color-error-hover, var(--spectrum-picker-border-color-error-hover)));
     }
 
     &:active {
-      border-color: var(--highcontrast-picker-border-color-error-active, var(--mod-picker-border-color-error-active, var(--spectrum-picker-border-color-error-active)));
+      border-color: var(--highcontrast-picker-border-color-default, var(--mod-picker-border-color-error-active, var(--spectrum-picker-border-color-error-active)));
     }
 
     &.is-open {
-      border-color: var(--highcontrast-picker-border-color-error-default-open, var(--mod-picker-border-color-error-default-open, var(--spectrum-picker-border-color-error-default-open)));
+      border-color: var(--highcontrast-picker-border-color-default, var(--mod-picker-border-color-error-default-open, var(--spectrum-picker-border-color-error-default-open)));
     }
 
     &.is-open:hover {
-      border-color: var(--highcontrast-picker-border-color-error-hover-open, var(--mod-picker-border-color-error-hover-open, var(--spectrum-picker-border-color-error-hover-open)));
+      border-color: var(--highcontrast-picker-border-color-default, var(--mod-picker-border-color-error-hover-open, var(--spectrum-picker-border-color-error-hover-open)));
     }
 
     &:focus-visible,
     &.is-focused {
-      border-color: var(--highcontrast-picker-border-color-error-default, var(--mod-picker-border-color-error-key-focus, var(--spectrum-picker-border-color-error-key-focus)));
+      border-color: var(--highcontrast-picker-border-color-default, var(--mod-picker-border-color-error-key-focus, var(--spectrum-picker-border-color-error-key-focus)));
     }
   }
 
   &.is-loading {
     .spectrum-Picker-menuIcon {
-      color: var(--highcontrast-picker-icon-color-disabled, var(--mod-picker-icon-color-disabled, var(--spectrum-picker-icon-color-disabled)));
+      color: var(--highcontrast-picker-content-color-disabled, var(--mod-picker-icon-color-disabled, var(--spectrum-picker-icon-color-disabled)));
     }
   }
 
   &:disabled,
   &.is-disabled {
     cursor: default;
-    background-color: var(--highcontrast-picker-background-color-disabled, var(--mod-picker-background-color-disabled, var(--spectrum-picker-background-color-disabled)));
+    background-color: var(--highcontrast-picker-background-color, var(--mod-picker-background-color-disabled, var(--spectrum-picker-background-color-disabled)));
     border-color: var(--highcontrast-picker-border-color-disabled, transparent);
-    color: var(--highcontrast-picker-font-color-disabled, var(--mod-picker-font-color-disabled, var(--spectrum-picker-font-color-disabled)));
+    color: var(--highcontrast-picker-content-color-disabled, var(--mod-picker-font-color-disabled, var(--spectrum-picker-font-color-disabled)));
 
     .spectrum-Picker-icon,
     .spectrum-Picker-menuIcon,
     .spectrum-Picker-validationIcon {
-      color: var(--highcontrast-picker-icon-color-disabled, var(--mod-picker-icon-color-disabled, var(--spectrum-picker-icon-color-disabled)));
+      color: var(--highcontrast-picker-content-color-disabled, var(--mod-picker-icon-color-disabled, var(--spectrum-picker-icon-color-disabled)));
     }
 
     .spectrum-Picker-label.is-placeholder {
-      color: var(--highcontrast-picker-font-color-disabled, var(--mod-picker-font-color-disabled, var(--spectrum-picker-font-color-disabled)));
+      color: var(--highcontrast-picker-content-color-disabled, var(--mod-picker-font-color-disabled, var(--spectrum-picker-font-color-disabled)));
     }
   }
 
@@ -365,22 +345,22 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Picker.is-open {
-  color: var(--highcontrast-picker-font-color-default-open, var(--mod-picker-font-color-default-open, var(--spectrum-picker-font-color-default-open)));
-  background-color: var(--highcontrast-picker-background-default-open, var(--mod-picker-background-color-default-open, var(--spectrum-picker-background-color-default-open)));
-  border-color: var(--highcontrast-picker-border-color-default-open, var(--mod-picker-border-default-open, var(--spectrum-picker-border-color-default-open)));
+  color: var(--highcontrast-picker-content-color-default, var(--mod-picker-font-color-default-open, var(--spectrum-picker-font-color-default-open)));
+  background-color: var(--highcontrast-picker-background-color, var(--mod-picker-background-color-default-open, var(--spectrum-picker-background-color-default-open)));
+  border-color: var(--highcontrast-picker-border-color-default, var(--mod-picker-border-default-open, var(--spectrum-picker-border-color-default-open)));
   
   &:hover {
-    color: var(--highcontrast-picker-font-color-default, var(--mod-picker-font-color-hover-open, var(--spectrum-picker-font-color-hover-open)));
-    background-color: var(--highcontrast-picker-background-color-hover-open, var(--mod-picker-background-color-hover-open, var(--spectrum-picker-background-color-hover-open)));
-    border-color: var(--highcontrast-picker-border-color-hover-open, var(--mod-picker-border-color-hover-open, var(--spectrum-picker-border-color-hover-open)));
+    color: var(--highcontrast-picker-content-color-default, var(--mod-picker-font-color-hover-open, var(--spectrum-picker-font-color-hover-open)));
+    background-color: var(--highcontrast-picker-background-color, var(--mod-picker-background-color-hover-open, var(--spectrum-picker-background-color-hover-open)));
+    border-color: var(--highcontrast-picker-border-color-hover, var(--mod-picker-border-color-hover-open, var(--spectrum-picker-border-color-hover-open)));
 
     .spectrum-Picker-menuIcon {
-      color: var(--highcontrast-picker-icon-color-hover-open, var(--mod-picker-icon-color-hover-open, var(--spectrum-picker-icon-color-hover-open)));
+      color: var(--highcontrast-picker-content-color-default, var(--mod-picker-icon-color-hover-open, var(--spectrum-picker-icon-color-hover-open)));
     }
   }
 
   .spectrum-Picker-menuIcon {
-    color: var(--highcontrast-picker-icon-color-default-open, var(--mod-picker-icon-color-default-open, var(--spectrum-picker-icon-color-default-open)));
+    color: var(--highcontrast-picker-content-color-default, var(--mod-picker-icon-color-default-open, var(--spectrum-picker-icon-color-default-open)));
   }
 }
 
@@ -418,14 +398,14 @@ governing permissions and limitations under the License.
     font-style: var(--mod-picker-placeholder-font-style, var(--spectrum-picker-placeholder-font-style));
     transition: color var(--mod-picker-animation-duration, var(--spectrum-picker-animation-duration)) ease-in-out;
 
-    color: var(--highcontrast-picker-font-color-default, var(--mod-picker-font-color-default, var(--spectrum-picker-font-color-default)));
+    color: var(--highcontrast-picker-content-color-default, var(--mod-picker-font-color-default, var(--spectrum-picker-font-color-default)));
 
     &:hover {
-      color: var(--highcontrast-picker-font-color-default, var(--mod-picker-font-color-hover, var(--spectrum-picker-font-color-hover)));
+      color: var(--highcontrast-picker-content-color-default, var(--mod-picker-font-color-hover, var(--spectrum-picker-font-color-hover)));
     }
 
     &:active {
-      color: var(--highcontrast-picker-font-color-default, var(--mod-picker-font-color-active, var(--spectrum-picker-font-color-active)));
+      color: var(--highcontrast-picker-content-color-default, var(--mod-picker-font-color-active, var(--spectrum-picker-font-color-active)));
     }
   }
 }
@@ -441,10 +421,10 @@ governing permissions and limitations under the License.
   margin-inline-start: var(--mod-picker-spacing-icon-to-disclosure-icon, var(--spectrum-picker-spacing-icon-to-disclosure-icon));
   margin-block: var(--mod-picker-spacing-top-to-disclosure-icon, var(--spectrum-picker-spacing-top-to-disclosure-icon));
 
-  color: var(--highcontrast-picker-icon-color-default, var(--mod-picker-icon-color-default, var(--spectrum-picker-icon-color-default)));
+  color: var(--highcontrast-picker-content-color-default, var(--mod-picker-icon-color-default, var(--spectrum-picker-icon-color-default)));
 
   &:active {
-    color: var(--highcontrast-picker-icon-color-default, var(--mod-picker-icon-color-active, var(--spectrum-picker-icon-color-active)));
+    color: var(--highcontrast-picker-content-color-default, var(--mod-picker-icon-color-active, var(--spectrum-picker-icon-color-active)));
   }
 }
 
@@ -475,8 +455,8 @@ governing permissions and limitations under the License.
   border-radius: 0;
   padding-inline: var(--mod-picker-spacing-edge-to-text-quiet, var(--spectrum-picker-spacing-edge-to-text-quiet));
   margin-block-start: calc( var(--mod-picker-spacing-label-to-picker-quiet, var(--spectrum-picker-spacing-label-to-picker-quiet)) + (1px));
-  color: var(--highcontrast-picker-font-color-default, var(--mod-picker-font-color-default, var(--spectrum-picker-font-color-default)));
-  background-color: var(--highcontrast-picker-background-color-default, transparent);
+  color: var(--highcontrast-picker-content-color-default, var(--mod-picker-font-color-default, var(--spectrum-picker-font-color-default)));
+  background-color: var(--highcontrast-picker-background-color, transparent);
 
   &.spectrum-Picker--sideLabel {
     margin-block-start: calc(-1 * var(--spectrum-picker-spacing-top-to-text-side-label-quiet)); 
@@ -493,12 +473,12 @@ governing permissions and limitations under the License.
   }
 
   &:hover {
-    background-color: var(--highcontrast-picker-background-color-default, transparent);
+    background-color: var(--highcontrast-picker-background-color, transparent);
   }
 
   &:focus-visible,
   &.is-focused {
-    background-color: var(--highcontrast-picker-background-color-default, transparent);
+    background-color: var(--highcontrast-picker-background-color, transparent);
 
     /* Focus indicator changes from a ring to a line underneath. */
     &::after {
@@ -511,12 +491,12 @@ governing permissions and limitations under the License.
 
   &:active,
   &.is-open {
-    background-color: var(--highcontrast-picker-background-color-default, transparent);
+    background-color: var(--highcontrast-picker-background-color, transparent);
   }
 
   &:disabled,
   &.is-disabled {
-    background-color: var(--highcontrast-picker-background-color-default, transparent);
+    background-color: var(--highcontrast-picker-background-color, transparent);
   }
 }
 

--- a/components/picker/index.css
+++ b/components/picker/index.css
@@ -344,7 +344,7 @@ governing permissions and limitations under the License.
   }
 }
 
-.spectrum-Picker.is-open {
+.spectrum-Picker.is-open:not(.spectrum-Picker--quiet) {
   color: var(--highcontrast-picker-content-color-default, var(--mod-picker-font-color-default-open, var(--spectrum-picker-font-color-default-open)));
   background-color: var(--highcontrast-picker-background-color, var(--mod-picker-background-color-default-open, var(--spectrum-picker-background-color-default-open)));
   border-color: var(--highcontrast-picker-border-color-default, var(--mod-picker-border-default-open, var(--spectrum-picker-border-color-default-open)));

--- a/components/picker/index.css
+++ b/components/picker/index.css
@@ -151,11 +151,14 @@ governing permissions and limitations under the License.
 /* Windows high contrast mode */
 @media (forced-colors: active) {
   .spectrum-Picker {
-    --highcontrast-picker-focus-indicator-color: CanvasText;
+    --highcontrast-picker-focus-indicator-color: Highlight;
 
     --highcontrast-picker-border-color-default: ButtonText;
     --highcontrast-picker-border-color-active: ButtonText;
-    --highcontrast-picker-border-color-key-focus: Highlight;
+    --highcontrast-picker-border-color-key-focus: ButtonText;
+    --highcontrast-picker-border-color-default-open: ButtonText;
+    --highcontrast-picker-border-color-hover-open: Highlight;
+    --highcontrast-picker-border-color-hover: Highlight;
 
     --highcontrast-picker-border-color-error-default-open: ButtonText;
     --highcontrast-picker-border-color-error-hover: ButtonText;
@@ -173,7 +176,7 @@ governing permissions and limitations under the License.
     --highcontrast-picker-icon-color-default-open: ButtonText;
     --highcontrast-picker-icon-color-hover: ButtonText;
     --highcontrast-picker-icon-color-hover-open: ButtonText;
-    --highcontrast-picker-icon-color-key-focus: Highlight;
+    --highcontrast-picker-icon-color-key-focus: ButtonText;
 
     --highcontrast-picker-icon-color-error-default: ButtonText;
 
@@ -181,6 +184,17 @@ governing permissions and limitations under the License.
     .is-disabled {
       border-color: GrayText;
       border-width: var(--mod-picker-border-width, var(--spectrum-picker-border-width));
+    }
+
+    &:focus-visible,
+    &.is-focused {
+      --highcontrast-picker-border-color-hover-open: ButtonText;
+    }
+
+    /* Focus indicator */
+    &::after {
+      /* Make sure default transparent border stays transparent. */
+      forced-color-adjust: none;
     }
   }
   .spectrum-Picker--quiet {
@@ -222,6 +236,7 @@ governing permissions and limitations under the License.
   background-color: var(--highcontrast-picker-background-color-default, var(--mod-picker-background-color-default, var(--spectrum-picker-background-color-default)));
   border-color: var(--highcontrast-picker-border-color-default, var(--mod-picker-border-color-default, var(--spectrum-picker-border-color-default)));
 
+  /* Focus indicator */
   &::after {
     pointer-events: none;
     content: '';
@@ -255,7 +270,7 @@ governing permissions and limitations under the License.
   &:hover {
     color: var(--highcontrast-picker-font-color-default, var(--mod-picker-font-color-hover, var(--spectrum-picker-font-color-hover)));
     background-color: var(--highcontrast-picker-background-color-default, var(--mod-picker-background-color-hover, var(--spectrum-picker-background-color-hover)));
-    border-color: var(--highcontrast-picker-border-color-default, var(--mod-picker-border-color-hover, var(--spectrum-picker-border-color-hover)));
+    border-color: var(--highcontrast-picker-border-color-hover, var(--mod-picker-border-color-hover, var(--spectrum-picker-border-color-hover)));
 
     .spectrum-Picker-menuIcon {
       color: var(--highcontrast-picker-icon-color-hover, var(--mod-picker-icon-color-hover, var(--spectrum-picker-icon-color-hover)));
@@ -266,6 +281,7 @@ governing permissions and limitations under the License.
     background-color: var(--highcontrast-picker-background-active, var(--mod-picker-background-color-active, var(--spectrum-picker-background-color-active)));
     border-color: var(--highcontrast-picker-border-color-active, var(--mod-picker-border-active, var(--spectrum-picker-border-color-active)));
 
+    /* Focus indicator */
     &::after {
       border-color: transparent;
     }
@@ -284,7 +300,7 @@ governing permissions and limitations under the License.
 
     color: var(--highcontrast-picker-font-color-key-focus, var(--mod-picker-font-color-key-focus, var(--spectrum-picker-font-color-key-focus)));
 
-    /* Focus ring */
+    /* Focus indicator */
     &::after {
       border-color: var(--highcontrast-picker-focus-indicator-color, var(--mod-picker-focus-indicator-color, var(--spectrum-picker-focus-indicator-color)));
     }
@@ -495,6 +511,7 @@ governing permissions and limitations under the License.
   &.is-focused {
     background-color: transparent;
 
+    /* Focus indicator */
     &::after {
       border: none;
       border-radius: 0;

--- a/components/picker/index.css
+++ b/components/picker/index.css
@@ -285,7 +285,7 @@ governing permissions and limitations under the License.
     }
   }
 
-  &.is-invalid {
+  &.is-invalid:not(:disabled, .is-disabled) {
     border-color: var(--highcontrast-picker-border-color-default, var(--mod-picker-border-color-error-default, var(--spectrum-picker-border-color-error-default)));
 
     .spectrum-Picker-validationIcon {
@@ -293,7 +293,7 @@ governing permissions and limitations under the License.
     }
 
     &:hover {
-      border-color: var(--highcontrast-picker-border-color-default, var(--mod-picker-border-color-error-hover, var(--spectrum-picker-border-color-error-hover)));
+      border-color: var(--highcontrast-picker-border-color-hover, var(--mod-picker-border-color-error-hover, var(--spectrum-picker-border-color-error-hover)));
     }
 
     &:active {
@@ -305,7 +305,7 @@ governing permissions and limitations under the License.
     }
 
     &.is-open:hover {
-      border-color: var(--highcontrast-picker-border-color-default, var(--mod-picker-border-color-error-hover-open, var(--spectrum-picker-border-color-error-hover-open)));
+      border-color: var(--highcontrast-picker-border-color-hover, var(--mod-picker-border-color-error-hover-open, var(--spectrum-picker-border-color-error-hover-open)));
     }
 
     &:focus-visible,

--- a/components/picker/index.css
+++ b/components/picker/index.css
@@ -169,8 +169,8 @@ governing permissions and limitations under the License.
     --highcontrast-picker-font-color-key-focus: ButtonText;
     --highcontrast-picker-font-color-disabled: GrayText;
 
-    --highcontrast-picker-background-color-default: Background;
-    --highcontrast-picker-background-color-disabled: Background;
+    --highcontrast-picker-background-color-default: ButtonFace;
+    --highcontrast-picker-background-color-disabled: ButtonFace;
 
     --highcontrast-picker-icon-color-default: ButtonText;
     --highcontrast-picker-icon-color-default-open: ButtonText;


### PR DESCRIPTION
## Description

**Picker**: A few fixes for forced-colors/Windows High Contrast Mode to address the bugs in CSS-636, along with a few more discovered when working on it. Along with some cleanup work.

- The focus indicator ring now only shows on keyboard focus. It was showing all the time by default.
- The color of the focus indicator and the border are no longer reversed. This now matches the visual behavior that was decided upon for Text field, where the indicator is blue and the border color inside it is the default grey (keyboard focused).
- The hover `Highlight` border color now appears on hover (except when keyboard focused).
- Proper [matching foreground/background pairs](https://www.w3.org/TR/css-color-4/#css-system-colors) are now used for the system colors defined. The `ButtonText` foreground needed a `ButtonFace` background to ensure appropriate contrast. The `ButtonBorder` system color is also now used.
- Some cleanup of a few things including removing some unnecessary declarations, organizing some styles, and slimming down the list of _highcontrast_ custom properties as a lot were unnecessary and repeating the same values.

In this work, I discovered and fixed these additional issues (not WHCM):
- Fixes invalid red border color appearing on docs example "Closed and Disabled with Thumbnails", on hover.
- Fixes issue with dark grey background color appearing on hover for quiet picker (open + side label).

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [x] WHCM: Focus indicator ring only shows when you tab focus with the keyboard, and is the `Highlight` color
- [x] WHCM: When the focus indicator is visible, the border color is the same as the default and not `Highlight`
- [x] WHCM: The border color shows as `Highlight` when hovering over the picker, except when the focus indicator is visible
- [x] On docs example "Closed and Disabled with Thumbnails", hover does not show a red border (or any change in border color)
- [x] Hover on quiet picker, including w/ open & side label on the docs, does not show a grey background

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have tested these changes in Windows High Contrast mode.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
