### PR TITLE
fix(calendar, swatch): use display instead of visibility

### DIFF
--- a/components/calendar/index.css
+++ b/components/calendar/index.css
@@ -200,7 +200,7 @@ governing permissions and limitations under the License.
   }
 
   &.is-outsideMonth {
-    visibility: hidden;
+    display: none;
   }
 
   &::before {

--- a/components/swatch/index.css
+++ b/components/swatch/index.css
@@ -173,7 +173,7 @@ governing permissions and limitations under the License.
 
     .spectrum-Swatch-mixedValueIcon {
       color: var(--spectrum-swatch-dash-icon-color);
-      visibility: visible;
+      display: block;
     }
   }
 
@@ -215,7 +215,7 @@ governing permissions and limitations under the License.
   &[disabled],
   &.is-disabled {
     .spectrum-Swatch-disabledIcon {
-      visibility: visible;
+      display: block;
     }
   }
 
@@ -303,7 +303,7 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Swatch-mixedValueIcon {
-  visibility: hidden;
+  display: none;
   pointer-events: none;
   /* Undefined variable allows custom stylesheet or JS to pass the value to this element */
   color: var(--spectrum-picked-color, transparent);
@@ -313,7 +313,7 @@ governing permissions and limitations under the License.
   position: relative;
   z-index: 2;
 
-  visibility: hidden;
+  display: none;
   pointer-events: none;
 
   color: var(--highcontrast-swatch-disabled-icon-color, var(--mod-swatch-disabled-icon-color, var(--spectrum-swatch-disabled-icon-color)));


### PR DESCRIPTION
## Description

Adjusting a couple components to use display instead of visibility. This can help improve performance by removing the unused elements from the DOM.

- Calendar days that aren't in the month being shown are hidden with display instead of visibility
- Swatch icons for disabled and mixedValue use display instead of visibility

A note: Overlay uses visibility in order to utilize the CSS transition property on visibility and opacity. This animation won’t work if we use the display property. This effects Modal and the use of Quick Actions in the Card component, which is why we aren't changing the visibility property in those components.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps @jenndiaz 

Evaluate the **Calendar component**, it should look the same as prod in:
- [x] [Storybook](https://pr-2327--spectrum-css.netlify.app/preview/?path=/docs/components-calendar--docs)
- [x] [Docs Site](https://pr-2327--spectrum-css.netlify.app/calendar)

Evaluate the **Swatch component**, it should look the same as prod in:
- [x] [Storybook](https://pr-2327--spectrum-css.netlify.app/preview/?path=/docs/components-swatch--docs)
- [x] [Docs Site](https://pr-2327--spectrum-css.netlify.app/swatch)

Also check that the **Swatch Group component** still looks good:
- [x] [Storybook](https://pr-2327--spectrum-css.netlify.app/preview/?path=/docs/components-swatch-group--docs)
- [x] [Docs Site](https://pr-2327--spectrum-css.netlify.app/swatchgroup)

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
