### PR TITLE
docs: storybook wrap, truncate examples part 2

### DIFF
--- a/components/dropzone/stories/dropzone.stories.js
+++ b/components/dropzone/stories/dropzone.stories.js
@@ -1,4 +1,6 @@
-// Import the component markup template
+import { Template as Link } from "@spectrum-css/link/stories/template.js";
+import isChromatic from "chromatic/isChromatic";
+import { html } from "lit";
 import { Template } from "./template";
 
 export default {
@@ -44,7 +46,33 @@ export default {
 	},
 };
 
-export const Default = Template.bind({});
+export const Default = ({
+	customHeading,
+	customDescription,
+	...args
+}) => {
+	return html`
+		<div>
+			${Template({
+				...args
+			})}
+
+			${isChromatic() ?
+				Template({
+					...args,
+					customHeading: 'Drag and drop your file to upload',
+					customDescription: [
+						() => {
+							return html`You can also ${Link({ url: "#", text: "select a file" })} from your computer.`
+						}
+					],
+					customLabel: 'Drag and drop to replace file upload'
+				})
+			: null
+		}
+		</div>
+	`;
+};
 Default.args = {};
 
 export const Dragged = Template.bind({});

--- a/components/dropzone/stories/template.js
+++ b/components/dropzone/stories/template.js
@@ -2,9 +2,9 @@ import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
+import { Template as ActionButton } from "@spectrum-css/actionbutton/stories/template.js";
 import { AccentColor as IllustratedMessageStory } from "@spectrum-css/illustratedmessage/stories/illustratedmessage.stories.js";
 import { Template as IllustratedMessage } from "@spectrum-css/illustratedmessage/stories/template.js";
-import { Template as ActionButton } from "@spectrum-css/actionbutton/stories/template.js";
 
 import "../index.css";
 
@@ -13,6 +13,9 @@ export const Template = ({
 	isDragged = false,
 	isFilled = false,
 	customClasses = [],
+	customHeading,
+	customDescription,
+	customLabel,
 	id,
 	...globals
 }) => {
@@ -31,13 +34,13 @@ export const Template = ({
 		>
 			${IllustratedMessage({
 				...globals,
-				heading: IllustratedMessageStory.args.heading,
-				description: IllustratedMessageStory.args.description,
+				heading: customHeading ?? IllustratedMessageStory.args.heading,
+				description: customDescription ?? IllustratedMessageStory.args.description,
 			})}
 
 			<div class="${rootClass}-content">
 				${ActionButton({
-					label: "Drop file to replace",
+					label: customLabel ?? "Drop file to replace",
 					customClasses: [`${rootClass}-button`],
 				})}
 			</div>

--- a/components/illustratedmessage/stories/illustratedmessage.stories.js
+++ b/components/illustratedmessage/stories/illustratedmessage.stories.js
@@ -1,8 +1,9 @@
+import isChromatic from "chromatic/isChromatic";
 import { html } from "lit";
 
 // Import the component markup template
-import { Template } from "./template";
 import { Template as Link } from "@spectrum-css/link/stories/template.js";
+import { Template } from "./template";
 
 export default {
 	title: "Components/Illustrated message",
@@ -51,13 +52,34 @@ export default {
 	},
 };
 
-export const Default = Template.bind({});
-Default.args = {
-	heading: "Error 404: Page not found",
-	description: [
-		"This page isn't available. Try checking the URL or visit a different page.",
-	],
-	useAccentColor: false,
+export const Default = ({
+	heading,
+	description,
+	...args
+}) => {
+	return html`
+		<div>
+			${Template({
+				...args,
+				heading: "Error 404: Page not found",
+				description: [
+					"This page isn't available. Try checking the URL or visit a different page.",
+				],
+				useAccentColor: false,
+			})}
+			${isChromatic() ?
+				Template({
+					...args,
+					heading: "Error 404: This is not the page you're looking for",
+					description: [
+						"This page isn't available.",
+					],
+					useAccentColor: false,
+				})
+				: null
+			}
+		</div>
+	`;
 };
 
 export const AccentColor = Template.bind({});

--- a/components/inlinealert/stories/inlinealert.stories.js
+++ b/components/inlinealert/stories/inlinealert.stories.js
@@ -1,4 +1,5 @@
-// Import the component markup template
+import isChromatic from "chromatic/isChromatic";
+import { html } from "lit";
 import { Template } from "./template";
 
 export default {
@@ -66,5 +67,34 @@ export default {
 	},
 };
 
-export const Default = Template.bind({});
-Default.args = {};
+export const Default = ({
+	...args
+}) => {
+	return html`
+		<div>
+			${Template({
+				...args
+			})}
+
+			${
+				isChromatic() ?
+					Template({
+						...args,
+						headerText: 'in-line alert header announcing something very long and in-line',
+						text: 'this is a very urgent alert with a lot of context, so the text has to wrap',
+						customStyles: {"max-width": "400px"}
+					})
+					&&
+					Template({
+						...args,
+						headerText: 'in-line alert header announcing something very long and in-line',
+						text: 'this is a very urgent alert with a lot of context, so the text has to wrap',
+						customStyles: {"max-width": "400px"},
+						variant: 'notice',
+						isClosable: true,
+					})
+				: null
+			}
+		</div>
+	`;
+};

--- a/components/inlinealert/stories/template.js
+++ b/components/inlinealert/stories/template.js
@@ -1,15 +1,17 @@
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
-// import { ifDefined } from 'lit/directives/if-definedjs';
+import { ifDefined } from "lit/directives/if-defined.js";
+import { styleMap } from "lit/directives/style-map.js";
 
-import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 import { Template as Button } from "@spectrum-css/button/stories/template.js";
+import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 
 import "../index.css";
 
 export const Template = ({
 	rootClass = "spectrum-InLineAlert",
 	customClasses = [],
+	customStyles = {},
 	headerText,
 	text,
 	variant = "neutral",
@@ -75,6 +77,8 @@ export const Template = ({
 				[`${rootClass}--${variant}`]: typeof variant !== "undefined",
 				...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
 			})}
+			style=${ifDefined(styleMap(customStyles))}
+
 		>
 			<div class="${rootClass}-header">
 				${variant.charAt(0).toUpperCase() + variant.slice(1)} ${headerText}

--- a/components/menu/stories/menu.stories.js
+++ b/components/menu/stories/menu.stories.js
@@ -147,7 +147,7 @@ IconsAndDescriptions.args = {
           isFocused: true
         },
         {
-          label: "A Menu Item With a Longer Label That Causes The Text to Wrap",
+          label: "A Menu Item With a Longer Label That Causes The Text to Wrap to The Next Line",
           iconName: "Share",
         },
         {
@@ -172,7 +172,7 @@ IconsAndDescriptions.args = {
           isFocused: true,
         },
         {
-          label: "A Menu Item With a Longer Label That Causes The Text to Wrap",
+          label: "A Menu Item With a Longer Label That Causes The Text to Wrap to The Next Line",
           description: "A description that is longer than average and is forced to wrap with an example max width.",
         },
         {
@@ -199,7 +199,7 @@ IconsAndDescriptions.args = {
           isFocused: true,
         },
         {
-          label: "A Menu Item With a Longer Label That Causes The Text to Wrap",
+          label: "A Menu Item With a Longer Label That Causes The Text to Wrap to The Next Line",
           iconName: "Share",
           description: "A description that is longer than average and is forced to wrap with an example max width.",
         },

--- a/components/miller/stories/miller.stories.js
+++ b/components/miller/stories/miller.stories.js
@@ -130,7 +130,7 @@ FilesSelectable.args = {
 					isSelected: false,
 				},
 				{
-					label: "File 2.2",
+					label: "File 2.2 Shows Text Truncation For Long Names",
 					isBranch: false,
 					isSelectable: false,
 					isSelected: false,

--- a/components/picker/stories/picker.stories.js
+++ b/components/picker/stories/picker.stories.js
@@ -146,7 +146,8 @@ SideLabel.args = {
 	content: [
 		() => MenuStories(MenuStories.args)
 	],
-	labelPosition: "left"
+	labelPosition: "left",
+	placeholder: "Select Your State Or Province"
 };
 
 export const Quiet = Template.bind({});

--- a/components/progressbar/stories/meter.stories.js
+++ b/components/progressbar/stories/meter.stories.js
@@ -66,27 +66,32 @@ export default {
 
 export const Default = Template.bind({});
 Default.args = {
-	meterFill: "default",
-};
-
-export const Large = Template.bind({});
-Large.args = {
-	meterFill: "default",
-	size: "l",
-};
-
-
-export const Postive = Template.bind({});
-Postive.args = {
-	meterFill: "positive",
-};
-
-export const Negative = Template.bind({});
-Negative.args = {
-	meterFill: "negative",
-};
-
-export const Notice = Template.bind({});
-Notice.args = {
-	meterFill: "notice",
+	items: [
+		{
+			heading: "Default",
+			meterFill: "default",
+		},
+		{
+			heading: "Large",
+			meterFill: "default",
+			size: "l",
+		},
+		{
+			heading: "Positive",
+			meterFill: "positive",
+		},
+		{
+			heading: "Negative",
+			meterFill: "negative",
+		},
+		{
+			heading: "Notice",
+			meterFill: "notice",
+		},
+		{
+			heading: "Text Overflow",
+			meterFill: "notice",
+			label: "Storage Space Remaining for XYZ User"
+		}
+	]
 };

--- a/components/progressbar/stories/metertemplate.js
+++ b/components/progressbar/stories/metertemplate.js
@@ -1,28 +1,35 @@
+import { Template as FieldLabel } from "@spectrum-css/fieldlabel/stories/template.js";
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
-import { Template as FieldLabel } from "@spectrum-css/fieldlabel/stories/template.js";
 
 import "../index.css";
 
 export const Template = ({
 	rootClass = "spectrum-ProgressBar",
 	customClasses = [],
-	label,
+	items = [],
+	label = "Storage Space",
 	value,
 	meterFill,
 	size = "s",
 	...globals
 }) => {
+	return items.map((meter) => {
+		const {heading, meterFill} = meter;
+		const meterSize = meter.size ?? size;
+		const meterLabel = meter.label ?? label;
 
-	return html`
+		return html`
+		<p style="text-decoration: underline;">${heading}</p>
 		<div
 			class=${classMap({
 				[rootClass]: true,
 				["spectrum-Meter"]: true,
-				[`spectrum-Meter--size${size?.toUpperCase()}`]: size,
+				[`spectrum-Meter--size${meterSize?.toUpperCase()}`]: meterSize,
 				[`is-${meterFill}`]: meterFill !== "default",
 				...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
 			})}
+			style="margin-block-end: 2rem;"
 			value="${value}%"
 			role="progressbar"
 			aria-valuenow="${value}%"
@@ -31,14 +38,14 @@ export const Template = ({
 		>
 			${FieldLabel({
 				...globals,
-				size,
-				label,
+				size: meterSize,
+				label: meterLabel,
 				alignment: "",
 				customClasses: [`${rootClass}-label`],
 			})}
 			${FieldLabel({
 				...globals,
-				size,
+				size: meterSize,
 				label: `${value}%`,
 				alignment: "",
 				customClasses: [`${rootClass}-percentage`],
@@ -47,5 +54,6 @@ export const Template = ({
 				<div class="${rootClass}-fill" style="width: ${value}%;"></div>
 			</div>
 		</div>
-	`;
+		`;
+	});
 };

--- a/components/progressbar/stories/progressbar.stories.js
+++ b/components/progressbar/stories/progressbar.stories.js
@@ -86,4 +86,5 @@ export const StaticWhite = Template.bind({});
 StaticWhite.args = {
 	backgroundColor: "rgb(15, 121, 125)",
 	staticWhite: "staticWhite",
+	label: "Loading your fonts, images, and icons"
 };

--- a/components/radio/stories/radio.stories.js
+++ b/components/radio/stories/radio.stories.js
@@ -1,4 +1,4 @@
-// Import the component markup template
+import { html } from "lit";
 import { Template } from "./template";
 
 export default {
@@ -94,24 +94,39 @@ export default {
 	},
 };
 
-export const Default = Template.bind({});
-Default.args = {};
-
-export const Emphasized = Template.bind({});
-Emphasized.args = {
-	isEmphasized: true,
-	isChecked: true,
+// export const Default = Template.bind({});
+// Default.args = {};
+export const Default = ({
+	customHeading,
+	customDescription,
+	...args
+}) => {
+	return html`
+		<div style="display: flex; flex-direction: column; align-items: flex-start;">
+			${Template({
+				...args,
+				label: "Default"
+			})}
+			${Template({
+				...args,
+				isEmphasized: true,
+				isChecked: true,
+				label: "Emphasized radio button label that is so long it has to wrap",
+				customStyles: {
+					"max-width": "220px",
+				}
+			})}
+			${Template({
+				...args,
+				isDisabled: true,
+				label: "Disabled"
+			})}
+			${Template({
+				...args,
+				isDisabled: true,
+				isReadOnly: true,
+				label: "Read only"
+			})}
+		</div>
+	`;
 };
-
-export const Disabled = Template.bind({});
-Disabled.args = {
-	isDisabled: true,
-};
-
-export const ReadOnly = Template.bind({});
-ReadOnly.args = {
-	isDisabled: true,
-	isReadOnly: true,
-};
-
-

--- a/components/radio/stories/template.js
+++ b/components/radio/stories/template.js
@@ -1,6 +1,7 @@
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
+import { styleMap } from "lit/directives/style-map.js";
 
 import "../index.css";
 
@@ -15,6 +16,7 @@ export const Template = ({
 	isReadOnly,
 	id,
 	customClasses = [],
+	customStyles = {},
 	...globals
 }) => {
 	const { express } = globals;
@@ -36,6 +38,7 @@ export const Template = ({
 				"is-readOnly" : isReadOnly,
 				...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
 			})}
+			style=${ifDefined(styleMap(customStyles))}
 			id=${ifDefined(id)}
 		>
 			<input


### PR DESCRIPTION
## Description

Adjusts some components in Storybook to include wrapping and truncation examples, visually where needed and for Chromatic otherwise.

- **Dropzone**: Adds a Chromatic-only instance with wrapping heading and description. I chose Chromatic-only on this one since it uses Illustrated Message, a component that already shows a wrapping description as a visual example.
- **Illustrated Message**: Adds a Chromatic-only instance with a wrapping heading since we already have a visual example (also tested in Chromatic) with a wrapping description.
- **In-Line Alert**: Adds a Chromatic-only instance with wrapping heading and description.
- **Menu**: Adjusts existing labels to wrap to the next line.
- **Miller Columns**: Adjusts an existing label to truncate.
- **Meter**: Updates the template to a "kitchen sink" style display (like the Accent Button for example) to show all variants within one story. Adds a "text overflow" instance to show wrapping text.
- **Progress Bar**: Adjusts an existing label to show wrapping text.
- **Radio**: Adjusts an existing label to show wrapping text.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
- Dropzone:
    - [x] [Storybook](https://pr-2330--spectrum-css.netlify.app/preview/?path=/story/components-drop-zone--default) should look the same
    - [x] VRT tests include a screenshot of a Dropzone with wrapping heading and description
- Illustrated Message:
    - [x] [Storybook](https://pr-2330--spectrum-css.netlify.app/preview/?path=/story/components-illustrated-message--default) should look the same
    - [x] VRT tests include a screenshot of an Illustrated Message with a wrapping heading
- In-Line Alert:
    - [x] [Storybook](https://pr-2330--spectrum-css.netlify.app/preview/?path=/story/components-in-line-alert--default) should look the same
    - [x] VRT tests include a screenshot of an In-Line Alert with wrapping heading and description
- Menu:
    - [x] [Storybook](https://pr-2330--spectrum-css.netlify.app/preview/?path=/story/components-menu--icons-and-descriptions) Icons and Descriptions story shows wrapping labels
- Miller Columns:
    - [x] [Storybook](https://pr-2330--spectrum-css.netlify.app/preview/?path=/story/components-miller-columns--files-selectable) Files Selectable story shows truncating example
- Meter:
    - [x] [Storybook](https://pr-2330--spectrum-css.netlify.app/preview/?path=/story/components-meter--default) All meter variants are displayed, with headings, in the Default story
    - [x] Also in Storybook, there is a "text overflow" variant to show wrapping text
- Progress Bar:
    - [x] [Storybook](https://pr-2330--spectrum-css.netlify.app/preview/?path=/story/components-progress-bar--static-white) Static White story has been updated with a wrapping label
- Radio:
    - [x] [Storybook](https://pr-2330--spectrum-css.netlify.app/preview/?path=/story/components-radio--emphasized) Emphasized story has been updated with a wrapping label


### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [ ] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
