### PR TITLE
chore(modal): custom properties documentation

### DIFF
--- a/components/modal/metadata/modal.yml
+++ b/components/modal/metadata/modal.yml
@@ -1,5 +1,9 @@
 name: Modal
 description: A modal component used primarily by Dialog
+sections:
+  - name: Custom Properties API
+    description: |
+      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/modal/metadata/mods.md">here</a>.
 examples:
   - id: modal
     name: Modal


### PR DESCRIPTION
## Description

Missing the custom properties link in the modal documentation.

## How and where has this been tested?

- [x] Does the Custom properties API section appear on the modal docs page?

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
