### PR TITLE
chore(ci): error if uncomitted changes found on build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,6 +142,6 @@ jobs:
                     exit 0
                 else
                     echo "Changes detected"
-                    echo "$(git status)"
+                    git status
                     exit 1
                 fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,3 +132,16 @@ jobs:
                   # this is important, it lets us catch if the build failed silently
                   # by alterting us that no compiled assets were generated
                   if-no-files-found: error
+
+            # This step will evaluate the repo status and report the change
+            - name: Check if there are changes
+              shell: bash
+              run: |
+                if [[ -z $(git status --porcelain) ]]; then
+                    echo "No changes detected"
+                    exit 0
+                else
+                    echo "Changes detected"
+                    echo "$(git status)"
+                    exit 1
+                fi


### PR DESCRIPTION
## Description

This addition will fail the CI workflow if any uncommitted assets are found at the end of the build process.

## How and where has this been tested?

On a fork branch of this PR, remove one or more of the mods.md assets from any component.

- [x] Expect CI to fail after the build step with a note that the mods.md assets are missing. Said note will exist in the log for the GitHub Action workflow.  https://github.com/adobe/spectrum-css/pull/2340

<img width="740" alt="Screenshot 2023-12-05 at 11 30 33 AM" src="https://github.com/adobe/spectrum-css/assets/1840295/22e3da50-c479-4307-a8b7-bbc69875bf35">

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] ✨ This pull request is ready to merge. ✨
