### PR TITLE
docs(tag): invalid tags should always include icon

### DIFF
--- a/components/tag/metadata/tag.yml
+++ b/components/tag/metadata/tag.yml
@@ -21,6 +21,10 @@ sections:
       ```
       ### Icon size changed to small
       If you use an icon (`spectrum-Tag-itemIcon`) along with a tag, please replace `.spectrum-Icon--sizeXS` with `.spectrum-Icon--sizeS`.
+
+      ### Invalid
+      Docs updated to show invalid tags always including the alert icon. Invalid tags should have an icon to idenfity itself as invalid and not rely soley on the red background and border color.
+
 examples:
   - id: tag
     name: Standard
@@ -87,10 +91,6 @@ examples:
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Invalid</h4>
 
           <div class="spectrum-Tag spectrum-Tag--sizeS is-invalid" tabindex="0">
-            <span class="spectrum-Tag-itemLabel">Tag label</span>
-          </div>
-
-          <div class="spectrum-Tag spectrum-Tag--sizeS is-invalid" tabindex="0">
             <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-Tag-itemIcon" focusable="false" aria-hidden="true" aria-label="Tag">
               <use xlink:href="#spectrum-icon-24-Alert" />
             </svg>
@@ -98,9 +98,9 @@ examples:
           </div>
 
           <div class="spectrum-Tag spectrum-Tag--sizeS is-invalid" tabindex="0">
-            <div class="spectrum-Avatar spectrum-Avatar--size50">
-              <img class="spectrum-Avatar-image" src="img/example-ava.jpg" alt="Avatar">
-            </div>
+            <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-Tag-itemIcon" focusable="false" aria-hidden="true" aria-label="Tag">
+              <use xlink:href="#spectrum-icon-24-Alert" />
+            </svg>
             <span class="spectrum-Tag-itemLabel">Tag label</span>
             <button type="button" class="spectrum-ClearButton spectrum-ClearButton--sizeM spectrum-Tag-clearButton" tabindex="-1">
               <div class="spectrum-ClearButton-fill">
@@ -143,11 +143,6 @@ examples:
 
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Selected + Invalid</h4>
-
-          <div class="spectrum-Tag spectrum-Tag--sizeS is-selected is-invalid" tabindex="0">
-            <span class="spectrum-Tag-itemLabel">Tag label</span>
-          </div>
-
           <div class="spectrum-Tag spectrum-Tag--sizeS is-selected is-invalid" tabindex="0">
             <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-Tag-itemIcon" focusable="false" aria-hidden="true" aria-label="Tag">
               <use xlink:href="#spectrum-icon-24-Alert" />
@@ -156,9 +151,9 @@ examples:
           </div>
 
           <div class="spectrum-Tag spectrum-Tag--sizeS is-selected is-invalid" tabindex="0">
-            <div class="spectrum-Avatar spectrum-Avatar--size50">
-              <img class="spectrum-Avatar-image" src="img/example-ava.jpg" alt="Avatar">
-            </div>
+            <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-Tag-itemIcon" focusable="false" aria-hidden="true" aria-label="Tag">
+              <use xlink:href="#spectrum-icon-24-Alert" />
+            </svg>
             <span class="spectrum-Tag-itemLabel">Tag label</span>
             <button type="button" class="spectrum-ClearButton spectrum-ClearButton--sizeM spectrum-Tag-clearButton" tabindex="-1">
               <div class="spectrum-ClearButton-fill">
@@ -390,18 +385,6 @@ examples:
         </div>
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Invalid</h4>
-
-          <div class="spectrum-Tag spectrum-Tag--sizeS is-invalid spectrum-Tag--removable" tabindex="0">
-            <span class="spectrum-Tag-itemLabel">Tag label</span>
-            <button type="button" class="spectrum-ClearButton spectrum-ClearButton--sizeS spectrum-Tag-clearButton" tabindex="-1">
-              <div class="spectrum-ClearButton-fill">
-                <svg class="spectrum-Icon spectrum-ClearButton-icon spectrum-UIIcon-Cross75" focusable="false" aria-hidden="true">
-                  <use xlink:href="#spectrum-css-icon-Cross75" />
-                </svg>
-              </div>
-            </button>
-          </div>
-
           <div class="spectrum-Tag spectrum-Tag--sizeS is-invalid spectrum-Tag--removable" tabindex="0">
             <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-Tag-itemIcon" focusable="false" aria-hidden="true" aria-label="Tag">
               <use xlink:href="#spectrum-icon-24-Alert" />
@@ -447,17 +430,6 @@ examples:
         </div>
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Selected + Invalid</h4>
-
-          <div class="spectrum-Tag spectrum-Tag--sizeS is-selected is-invalid spectrum-Tag--removable" tabindex="0">
-            <span class="spectrum-Tag-itemLabel">Tag label</span>
-            <button type="button" class="spectrum-ClearButton spectrum-ClearButton--sizeS spectrum-Tag-clearButton" tabindex="-1">
-              <div class="spectrum-ClearButton-fill">
-                <svg class="spectrum-Icon spectrum-ClearButton-icon spectrum-UIIcon-Cross75" focusable="false" aria-hidden="true">
-                  <use xlink:href="#spectrum-css-icon-Cross75" />
-                </svg>
-              </div>
-            </button>
-          </div>
 
           <div class="spectrum-Tag spectrum-Tag--sizeS is-selected is-invalid spectrum-Tag--removable" tabindex="0">
             <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-Tag-itemIcon" focusable="false" aria-hidden="true" aria-label="Tag">

--- a/components/tag/stories/tag.stories.js
+++ b/components/tag/stories/tag.stories.js
@@ -70,6 +70,7 @@ export default {
 				category: "Component",
 			},
 			control: "boolean",
+			if: { arg: "isInvalid", truthy: false },
 		},
 		isInvalid: {
 			name: "Invalid",

--- a/components/tag/stories/template.js
+++ b/components/tag/stories/template.js
@@ -33,6 +33,10 @@ export const Template = ({
 		console.warn(e);
 	}
 
+	if(isInvalid) {
+		iconName = 'Alert'
+	}
+
 	return html`
 		<div
 			class=${classMap({
@@ -48,14 +52,14 @@ export const Template = ({
 			id=${ifDefined(id)}
 			tabindex=${isDisabled ? '-1' : '0'}
 		>
-			${avatarUrl
+			${avatarUrl && !isInvalid
 				? Avatar({
 						...globals,
 						image: avatarUrl,
 						size: "50",
 				  })
 				: ""}
-			${iconName
+			${iconName || isInvalid
 				? Icon({
 						...globals,
 						size,

--- a/components/taggroup/metadata/taggroup.yml
+++ b/components/taggroup/metadata/taggroup.yml
@@ -30,9 +30,6 @@ examples:
         <div class="spectrum-Tag spectrum-Tag--sizeS spectrum-TagGroup-item" role="listitem" tabindex="0">
           <span class="spectrum-Tag-itemLabel">Tag 1</span>
         </div>
-        <div class="spectrum-Tag spectrum-Tag--sizeS spectrum-TagGroup-item is-invalid" role="listitem" tabindex="0">
-          <span class="spectrum-Tag-itemLabel">Tag 2</span>
-        </div>
         <div class="spectrum-Tag spectrum-Tag--sizeS spectrum-TagGroup-item is-disabled" role="listitem">
           <span class="spectrum-Tag-itemLabel">Tag 2</span>
         </div>
@@ -42,12 +39,6 @@ examples:
 
       <div class= "spectrum-TagGroup" role="list" aria-label="Tags">
         <div class="spectrum-Tag spectrum-Tag--sizeS spectrum-TagGroup-item" role="listitem" tabindex="0">
-          <div class="spectrum-Avatar spectrum-Avatar--size50">
-            <img class="spectrum-Avatar-image" src="img/example-ava.jpg" alt="Avatar">
-          </div>
-          <span class="spectrum-Tag-itemLabel">Shantanu</span>
-        </div>
-        <div class="spectrum-Tag spectrum-Tag--sizeS spectrum-TagGroup-item is-invalid" role="listitem" tabindex="0">
           <div class="spectrum-Avatar spectrum-Avatar--size50">
             <img class="spectrum-Avatar-image" src="img/example-ava.jpg" alt="Avatar">
           </div>
@@ -71,9 +62,9 @@ examples:
           <span class="spectrum-Tag-itemLabel">Shantanu</span>
         </div>
         <div class="spectrum-Tag spectrum-Tag--sizeS spectrum-TagGroup-item is-invalid" role="listitem" tabindex="0">
-          <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-Tag-itemIcon" focusable="false" aria-hidden="true" aria-label="Tag">
-            <use xlink:href="#spectrum-icon-18-CheckmarkCircle" />
-          </svg>
+            <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-Tag-itemIcon" focusable="false" aria-hidden="true" aria-label="Tag">
+              <use xlink:href="#spectrum-icon-24-Alert" />
+            </svg>
           <span class="spectrum-Tag-itemLabel">Shantanu</span>
         </div>
         <div class="spectrum-Tag spectrum-Tag--sizeS spectrum-TagGroup-item is-disabled" role="listitem">
@@ -98,16 +89,6 @@ examples:
             </div>
           </button>
         </div>
-        <div class="spectrum-Tag spectrum-Tag--sizeS spectrum-TagGroup-item spectrum-Tag--removable is-invalid" tabindex="0" role="listitem">
-          <span class="spectrum-Tag-itemLabel">Tag 2</span>
-          <button type="button" class="spectrum-ClearButton spectrum-ClearButton--sizeS spectrum-Tag-clearButton" aria-label="Remove tag 2" tabindex="-1">
-            <div class="spectrum-ClearButton-fill">
-              <svg class="spectrum-ClearButton-icon spectrum-Icon spectrum-UIIcon-Cross75" focusable="false" aria-hidden="true">
-                <use xlink:href="#spectrum-css-icon-Cross75" />
-              </svg>
-            </div>
-          </button>
-        </div>
         <div class="spectrum-Tag spectrum-Tag--sizeS spectrum-TagGroup-item spectrum-Tag--removable is-disabled" role="listitem">
           <span class="spectrum-Tag-itemLabel">Tag 2</span>
           <button type="button" class="spectrum-ClearButton spectrum-ClearButton--sizeS spectrum-Tag-clearButton" aria-label="Remove tag 3" tabindex="-1" disabled>
@@ -124,19 +105,6 @@ examples:
 
       <div class= "spectrum-TagGroup" role="list" aria-label="Tags">
         <div class="spectrum-Tag spectrum-Tag--sizeS spectrum-TagGroup-item spectrum-Tag--removable" role="listitem" tabindex="0">
-          <div class="spectrum-Avatar spectrum-Avatar--size50">
-            <img class="spectrum-Avatar-image" src="img/example-ava.jpg" alt="Avatar">
-          </div>
-          <span class="spectrum-Tag-itemLabel">Shantanu</span>
-          <button type="button" class="spectrum-ClearButton spectrum-ClearButton--sizeS spectrum-Tag-clearButton" aria-label="Remove tag 2" tabindex="-1">
-            <div class="spectrum-ClearButton-fill">
-              <svg class="spectrum-ClearButton-icon spectrum-Icon spectrum-UIIcon-Cross75" focusable="false" aria-hidden="true">
-                <use xlink:href="#spectrum-css-icon-Cross75" />
-              </svg>
-            </div>
-          </button>
-        </div>
-        <div class="spectrum-Tag spectrum-Tag--sizeS spectrum-TagGroup-item spectrum-Tag--removable is-invalid" role="listitem" tabindex="0">
           <div class="spectrum-Avatar spectrum-Avatar--size50">
             <img class="spectrum-Avatar-image" src="img/example-ava.jpg" alt="Avatar">
           </div>
@@ -182,7 +150,7 @@ examples:
         </div>
         <div class="spectrum-Tag spectrum-Tag--sizeS spectrum-TagGroup-item spectrum-Tag--removable is-invalid" role="listitem" tabindex="0">
           <svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-Tag-itemIcon" focusable="false" aria-hidden="true" aria-label="Tag">
-            <use xlink:href="#spectrum-icon-18-CheckmarkCircle" />
+            <use xlink:href="#spectrum-icon-24-Alert" />
           </svg>
           <span class="spectrum-Tag-itemLabel">Shantanu</span>
           <button type="button" class="spectrum-ClearButton spectrum-ClearButton--sizeS spectrum-Tag-clearButton" aria-label="Remove tag Shantanu" tabindex="-1">


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

Removed all examples of invalid tags with out the correct icon from the docs site and storybook. 
Updated storybook controls so invalid tags always have the alert icon. 

[Design Docs](https://spectrum.adobe.com/page/tag/#Error) 

Addresses [SWC issue 3378]( https://github.com/adobe/spectrum-web-components/issues/3378)

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

@mdt2 
- [x] [Docs site for tag](https://pr-2341--spectrum-css.netlify.app/tag) only displays invalid tags with the alert icon 
- [x]  [Docs site for tag group](https://pr-2341--spectrum-css.netlify.app/tag) only displays invalid tags with the alert icon 
- [x] [Storybook controls for tag](https://pr-2341--spectrum-css.netlify.app/preview/?path=/docs/components-tag--docs) do not allow you to display and invalid tag without the alert icon
- [x] [Storybook controls for tag group](https://pr-2341--spectrum-css.netlify.app/preview/?path=/docs/components-tag-group--docs) do not allow you to display and invalid tag without the alert icon

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [ ] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
