### PR TITLE
chore(ci): fix workspace path for storybook build

### DIFF
--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -90,7 +90,7 @@ jobs:
             - name: Build storybook site
               if: ${{ github.event.inputs.storybook-url == '' }}
               shell: bash
-              run: yarn ci:storybook --output-dir {{ .github.workspace }}/dist/preview
+              run: yarn ci:storybook --output-dir ../dist/preview
 
             - name: Build docs site
               shell: bash


### PR DESCRIPTION
## Description

When chromatic isn’t run as part of the ci workflow, the site should kick off a local storybook build. This fixes the path to that build.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

For a build without vrt, validate storybook is built locally to the dist/preview path.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md)
- [x] ✨ This pull request is ready to merge. ✨
