### PR TITLE
chore(ci): correct data formatting for diff comment

### DIFF
--- a/.github/actions/file-diff/index.js
+++ b/.github/actions/file-diff/index.js
@@ -149,33 +149,31 @@ async function run() {
 								]
 								: []),
 						],
-						...fileMap.entries(),
-					]
-						.reduce(
-							(
-								table,
-								[readableFilename, { byteSize = 0, diffByteSize = 0 }]
-							) => {
-								// @todo readable filename can be linked to html diff of the file?
-								// https://github.com/adobe/spectrum-css/pull/2093/files#diff-6badd53e481452b5af234953767029ef2e364427dd84cdeed25f5778b6fca2e6
-								const row = [
-									readableFilename,
-									byteSize === 0 ? "**removed**" : bytesToSize(byteSize),
-									diffByteSize === 0 ? "" : bytesToSize(diffByteSize),
-								];
+					].map((row) => `| ${row.join(" | ")} |`),
+					...fileMap.entries().reduce(
+						(
+							table,
+							[readableFilename, { byteSize = 0, diffByteSize = 0 }]
+						) => {
+							// @todo readable filename can be linked to html diff of the file?
+							// https://github.com/adobe/spectrum-css/pull/2093/files#diff-6badd53e481452b5af234953767029ef2e364427dd84cdeed25f5778b6fca2e6
+							const row = [
+								readableFilename,
+								byteSize === 0 ? "**removed**" : bytesToSize(byteSize),
+								diffByteSize === 0 ? "" : bytesToSize(diffByteSize),
+							];
 
-								if (hasDiff && diffByteSize > 0) {
-									if (byteSize === 0) row.push("", "");
-									else {
-										row.push(printChange(diffByteSize - byteSize), "");
-									}
+							if (hasDiff && diffByteSize > 0) {
+								if (byteSize === 0) row.push("", "");
+								else {
+									row.push(printChange(diffByteSize - byteSize), "");
 								}
+							}
 
-								return [...table, row];
-							},
-							[]
-						)
-						.map((row) => `| ${row.join(" | ")} |`),
+							return [...table, row];
+						},
+						[]
+					).map((row) => `| ${row.join(" | ")} |`),
 				);
 
 				markdown.push(...md);

--- a/.github/actions/file-diff/utilities.js
+++ b/.github/actions/file-diff/utilities.js
@@ -62,12 +62,20 @@ function debugEmptyDirectory(path, pattern, { core }) {
  * @returns {string} The size in human readable format
  */
 exports.bytesToSize = function (bytes) {
+    if (!bytes) return "-";
     if (bytes === 0) return "0";
 
     const sizes = ["bytes", "KB", "MB", "GB", "TB"];
+
     // Determine the size identifier to use (KB, MB, etc)
     const i = parseInt(Math.floor(Math.log(bytes) / Math.log(1024)));
-    if (i === 0) return (bytes / 1000).toFixed(2) + " " + sizes[1];
+
+    if (i === 0) {
+        const value = (bytes / 1000).toFixed(2);
+        if (value === "0.00") return "< 0.01 KB";
+        return value + " " + sizes[1];
+    }
+
     return (bytes / Math.pow(1024, i)).toFixed(2) + " " + sizes[i];
 };
 


### PR DESCRIPTION
## Description

A small patch to the details table formatting in the CI diff output comment and a clarification of values with less than 0.01KB difference.

You can see these issues in the screenshots below from https://github.com/adobe/spectrum-css/pull/2338#issuecomment-1841084699

<img width="433" alt="Screenshot 2023-12-06 at 12 16 28 PM" src="https://github.com/adobe/spectrum-css/assets/1840295/ff19d6f6-f7fc-49b1-a183-940b37b1fe70">

<img width="606" alt="Screenshot 2023-12-06 at 12 16 35 PM" src="https://github.com/adobe/spectrum-css/assets/1840295/bd635318-ce26-4f1a-bf7f-0df2b98290f1">


## How and where has this been tested?

Should see these fixes in the comments of this PR.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] ✨ This pull request is ready to merge. ✨
