### PR TITLE
build: hardening linter settings

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+site/resources

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,5 @@
 {
+	"root": true,
 	"env": {
 		"browser": true,
 		"node": true,
@@ -13,10 +14,137 @@
 		"func-call-spacing": ["warn", "never"],
 		"indent": ["warn", "tab", { "ignoredNodes": ["TemplateLiteral *"] }],
 		"linebreak-style": ["warn", "unix"],
-		"no-console": 0,
+		"no-console": ["warn", { "allow": ["warn", "error"] }],
 		"quotes": ["warn", "double"],
 		"semi": ["warn", "always"],
 		"space-before-blocks": ["warn", "always"]
 	},
-	"root": true
+	"overrides": [
+		{
+			"files": ["*.json"],
+			"parser": "jsonc-eslint-parser",
+			"extends": ["plugin:jsonc/recommended-with-jsonc"],
+			"rules": {
+				"jsonc/sort-keys": [
+					"warn",
+					{
+						"pathPattern": ".*", // Hits the all properties
+						"hasProperties": ["type"],
+						"order": [
+							"type",
+							"properties",
+							"items",
+							"required",
+							"minItems",
+							"additionalProperties",
+							"additionalItems"
+						]
+					},
+					{
+						"pathPattern": ".*",
+						"order": { "type": "asc" }
+					}
+				]
+			}
+		},
+		{
+			"files": ["project.json"],
+			"rules": {
+				"jsonc/sort-keys": [
+					"warn",
+					{
+						"pathPattern": "^$",
+						"order": [
+							"$schema",
+							"name",
+							"tags",
+							"implicitDependencies",
+							"targets"
+						]
+					},
+					{
+						"pathPattern": ".*",
+						"order": { "type": "asc" }
+					}
+				]
+			}
+		},
+		{
+			"files": ["package.json"],
+			"rules": {
+				"jsonc/sort-keys": [
+					"warn",
+					{
+						"pathPattern": "^$",
+						"order": [
+							"$schema",
+							"private",
+							"name",
+							"version",
+							"description",
+							"license",
+							"author",
+							"maintainers",
+							"contributors",
+							"homepage",
+							"repository",
+							"bugs",
+							"type",
+							"exports",
+							"main",
+							"module",
+							"browser",
+							"man",
+							"preferGlobal",
+							"bin",
+							"files",
+							"directories",
+							"scripts",
+							"config",
+							"sideEffects",
+							"types",
+							"typings",
+							"workspaces",
+							"resolutions",
+							"dependencies",
+							"bundleDependencies",
+							"bundledDependencies",
+							"peerDependencies",
+							"peerDependenciesMeta",
+							"optionalDependencies",
+							"devDependencies",
+							"keywords",
+							"engines",
+							"engineStrict",
+							"os",
+							"cpu",
+							"publishConfig"
+						]
+					},
+					{
+						"pathPattern": "^repository$",
+						"order": ["type", "url", "directory"]
+					},
+					{
+						"pathPattern": ".*",
+						"order": { "type": "asc" }
+					}
+				]
+			}
+		},
+		{
+			"files": [
+				"components/*/stories/*.js",
+				".storybook/*.js",
+				".storybook/**/*.js"
+			],
+			"parserOptions": {
+				"ecmaVersion": "latest",
+				"sourceType": "module",
+				"ecmaFeatures": {
+					"impliedStrict": true
+				}
+			}
+		}
+	]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ package-lock.json
 
 # Storybook build output
 .storybook/storybook-static
+storybook-static
 build-storybook.log
 
 # Chromatic
@@ -30,3 +31,6 @@ chromatic.config.json
 
 # Custom diff tool
 .diff-output
+
+.eslintcache
+.stylelintcache

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,17 +1,22 @@
+# Tooling config files
 **/.git
 **/.svn
 **/.hg
 **/node_modules
 
-components/*/dist
+# Static utility assets
 tokens/custom-*/*.css
-.storybook/storybook-static/**
-generator
-dist
-*.hbs
-
 site/includes/*.js
 
+# Compiled and generated files
+dist
+.storybook/storybook-static
+*-generated.css
+
+# Template files
+*.hbs
+
+# OS generated files
 .DS_Store*
 ehthumbs.db
 Icon?

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,11 +1,12 @@
+# Static utility assets
+tokens/custom-*/*.css
+generator
+
+# Compiled and generated files
+dist
+.storybook/storybook-static
 *-generated.css
 
-tokens/**/*.css
 node_modules/**/*.css
-
 plugins/*/expected/*
 plugins/*/fixtures/*
-dist/*
-
-components/*/dist/*
-components/*/node_modules/*

--- a/nx.json
+++ b/nx.json
@@ -16,6 +16,13 @@
 		"core": ["{projectRoot}/*.css", "{projectRoot}/themes/*.css"],
 		"scripts": ["{projectRoot}/stories/*.js"],
 		"docs": ["{projectRoot}/metadata/*.yml"],
+		"stylelint": [
+			"{workspaceRoot}/.stylelintignore",
+			"{workspaceRoot}/stylelint.config.js",
+			"{workspaceRoot}/plugins/stylelint-*/index.js"
+		],
+		"eslint": ["{workspaceRoot}/.eslintrc.js"],
+		"prettier": ["{workspaceRoot}/.prettierrc"],
 		"tools": [
 			"{projectRoot}/*.json",
 			"{workspaceRoot}/postcss.config.js",
@@ -25,7 +32,13 @@
 	"targetDefaults": {
 		"clean": {
 			"cache": true,
-			"inputs": ["{projectRoot}/dist", { "externalDependencies": ["rimraf"] }],
+			"inputs": [
+				"{projectRoot}/dist/*.{css,json}",
+				"{projectRoot}/dist/**/*.{css,json}",
+				"{projectRoot}/dist/*.map",
+				"{projectRoot}/dist/**/*.map",
+				{ "externalDependencies": ["rimraf"] }
+			],
 			"outputs": [],
 			"executor": "nx:run-commands",
 			"options": {
@@ -50,13 +63,18 @@
 				{ "externalDependencies": ["postcss"] },
 				{ "env": "NODE_ENV" }
 			],
-			"outputs": ["{projectRoot}/dist", "{projectRoot}/metadata/mods.md"],
+			"outputs": [
+				"{projectRoot}/dist/*.{css,json}",
+				"{projectRoot}/dist/themes/*.css",
+				"{projectRoot}/dist/*.map",
+				"{projectRoot}/dist/themes/*.css.map",
+				"{projectRoot}/metadata/mods.md"
+			],
 			"executor": "nx:run-commands",
 			"options": {
 				"commands": [
 					"node -e 'require(\"./tasks/component-builder.js\").default()'"
-				],
-				"parallel": false
+				]
 			}
 		},
 		"compare": {
@@ -90,35 +108,39 @@
 			}
 		},
 		"lint": {
-			"inputs": ["core", { "externalDependencies": ["stylelint", "eslint"] }],
-			"executor": "nx:run-commands",
-			"options": {
-				"commands": [
-					"stylelint {projectRoot}/*.css {projectRoot}/themes/*.css",
-					"eslint {projectRoot}/stories/*.js"
-				]
-			}
-		},
-		"format": {
-			"inputs": ["core", { "externalDependencies": ["stylelint", "eslint"] }],
-			"executor": "nx:run-commands",
-			"options": {
-				"commands": [
-					"stylelint --fix {projectRoot}/*.css {projectRoot}/themes/*.css",
-					"eslint --fix --no-error-on-unmatched-pattern {projectRoot}/stories/*.js"
-				]
-			}
-		},
-		"validate": {
+			"cache": true,
 			"inputs": [
-				"{workspaceRoot}/schemas/documentation.schema.json",
-				"docs",
-				{ "externalDependencies": ["pajv"] }
+				"core",
+				"scripts",
+				"stylelint",
+				"eslint",
+				"prettier",
+				{ "externalDependencies": ["stylelint", "eslint", "prettier"] }
 			],
 			"executor": "nx:run-commands",
 			"options": {
 				"commands": [
-					"test -e {projectRoot}/metadata && pajv validate -s ./schemas/documentation.schema.json -d \"{projectRoot}/metadata/*.yml\" || exit 0"
+					"stylelint --cache --allow-empty-input --report-descriptionless-disables --report-invalid-scope-disables --report-needless-disables {projectRoot}/*.css {projectRoot}/**/*.css --ignore-pattern {projectRoot}/dist",
+					"eslint --cache --no-error-on-unmatched-pattern --report-unused-disable-directives {projectRoot}/*.{js,json} {projectRoot}/**/*.{js,json} --ignore-pattern {projectRoot}/dist || exit 0"
+				]
+			}
+		},
+		"format": {
+			"cache": true,
+			"inputs": [
+				"core",
+				"scripts",
+				"stylelint",
+				"eslint",
+				"prettier",
+				{ "externalDependencies": ["stylelint", "eslint", "prettier"] }
+			],
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					"stylelint --fix --cache --allow-empty-input --quiet {projectRoot}/*.css {projectRoot}/**/*.css",
+					"eslint --fix --cache --no-error-on-unmatched-pattern --quiet {projectRoot}/*.json {projectRoot}/stories/*.js || exit 0",
+					"prettier --write --cache --loglevel error --ignore-unknown --no-error-on-unmatched-pattern {projectRoot}/*.{yml,md} {projectRoot}/**/*.{yml,md}"
 				]
 			}
 		},
@@ -139,7 +161,6 @@
 					]
 				},
 				"plugins": {
-					"dependsOn": [],
 					"inputs": [
 						"{projectRoot}/index.js",
 						"{projectRoot}/test.js",
@@ -149,6 +170,19 @@
 					"cwd": "{projectRoot}",
 					"commands": ["ava test.js"]
 				}
+			}
+		},
+		"validate": {
+			"inputs": [
+				"{workspaceRoot}/schemas/documentation.schema.json",
+				"docs",
+				{ "externalDependencies": ["pajv"] }
+			],
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					"test -e {projectRoot}/metadata && pajv validate -s ./schemas/documentation.schema.json -d \"{projectRoot}/metadata/*.yml\" || exit 0"
+				]
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "compare": "cross-env NODE_ENV=production node ./tasks/compare-compiled-output.js",
     "dev": "cross-env NODE_ENV=production nx run storybook:build:docs && nx start docs",
     "format": "yarn formatter tag:component",
-    "formatter": "nx run-many --target format --verbose --projects",
+    "formatter": "nx run-many --target format --projects",
     "preinstall": "command -v nvm >/dev/null 2>&1 && nvm use || exit 0",
     "lint": "yarn linter tag:component",
     "linter": "nx run-many --target lint --verbose --projects",
@@ -73,9 +73,12 @@
     "diff": "^5.1.0",
     "diff2html": "^3.4.45",
     "eslint": "^8.57.0",
+    "eslint-plugin-jsonc": "^2.13.0",
+    "eslint-plugin-prettier": "^5.1.3",
     "fast-glob": "^3.3.2",
     "gh-pages": "^6.1.1",
     "husky": "^9.0.11",
+    "jsonc-eslint-parser": "^2.4.0",
     "lerna": "^6.6.2",
     "lint-staged": "^15.2.2",
     "lodash": "^4.17.21",
@@ -123,11 +126,27 @@
     "package.json": [
       "prettier-package-json --write"
     ],
+    "components/*/*.css": [
+      "stylelint --fix --cache --allow-empty-input --quiet"
+    ],
+    "*.json": [
+      "eslint --fix --cache --no-error-on-unmatched-pattern --quiet"
+    ],
+    "components/*/stories/*.js": [
+      "eslint --fix --cache --no-error-on-unmatched-pattern --quiet"
+    ],
+    "plugins/*/*.js": [
+      "eslint --fix --cache --no-error-on-unmatched-pattern --quiet"
+    ],
     "dist/*.css": [
       "prettier --no-config --no-error-on-unmatched-pattern --ignore-unknown --loglevel silent --write"
     ],
     "components/*/metadata/*.{yml,yaml}": [
-      "pajv test --valid -s ./schemas/documentation.schema.json -d "
+      "pajv test --valid -s ./schemas/documentation.schema.json -d ",
+      "prettier --no-config --no-error-on-unmatched-pattern --ignore-unknown --loglevel silent --write"
+    ],
+    "*.md": [
+      "prettier --no-config --no-error-on-unmatched-pattern --ignore-unknown --loglevel silent --write"
     ]
   }
 }

--- a/plugins/stylelint-no-missing-var/index.js
+++ b/plugins/stylelint-no-missing-var/index.js
@@ -11,53 +11,53 @@
  */
 
 const {
-  createPlugin,
-  utils: { report, ruleMessages, validateOptions }
+	createPlugin,
+	utils: { report, ruleMessages, validateOptions }
 } = require("stylelint");
 
 require("colors");
 
 const ruleName = "spectrum-tools/no-missing-var";
 const messages = ruleMessages(ruleName, {
-    expected: (property) => `Missing ${'var'.yellow} function around custom property ${property.magenta}`,
+	expected: (property) => `Missing ${"var".yellow} function around custom property ${property.magenta}`,
 });
 
 /** @type {import('stylelint').Plugin} */
 const ruleFunction = (enabled, _options, context) => {
-    return (root, result) => {
-        const validOptions = validateOptions(
-            result,
-            ruleName,
-            {
-                actual: enabled,
-                possible: [true],
-            },
-        );
+	return (root, result) => {
+		const validOptions = validateOptions(
+			result,
+			ruleName,
+			{
+				actual: enabled,
+				possible: [true],
+			},
+		);
 
-        if (!validOptions) return;
+		if (!validOptions) return;
 
-        root.walkDecls((decl) => {
-            const value = decl.value.replace(/\s/g, ""); // Remove whitespace
-            if (!value) return;
+		root.walkDecls((decl) => {
+			const value = decl.value.replace(/\s/g, ""); // Remove whitespace
+			if (!value) return;
 
-            const regex = /(?<!var\(\S*)--\S+\b/;
-            if (regex.test(value)) {
-                if (context.fix) {
-                    decl.value = value.replace(regex, `var(${value.match(regex)[0]})`);
-                } else {
-                    const prop = value.match(regex)?.[0];
-                    if (!prop) return;
+			const regex = /(?<!var\(\S*)--\S+\b/;
+			if (regex.test(value)) {
+				if (context.fix) {
+					decl.value = value.replace(regex, `var(${value.match(regex)[0]})`);
+				} else {
+					const prop = value.match(regex)?.[0];
+					if (!prop) return;
 
-                    report({
-                        message: messages.expected(prop),
-                        node: decl,
-                        result,
-                        ruleName,
-                    });
-                }
-            }
-        });
-    };
+					report({
+						message: messages.expected(prop),
+						node: decl,
+						result,
+						ruleName,
+					});
+				}
+			}
+		});
+	};
 };
 
 module.exports.ruleName = ruleName;

--- a/plugins/stylelint-no-missing-var/project.json
+++ b/plugins/stylelint-no-missing-var/project.json
@@ -1,8 +1,14 @@
 {
 	"$schema": "../../node_modules/nx/schemas/project-schema.json",
-	"tags": ["tooling", "stylelint"],
 	"name": "stylelint-no-missing-var",
+	"tags": ["tooling", "stylelint"],
 	"targets": {
+		"format": {
+			"defaultConfiguration": "plugins"
+		},
+		"lint": {
+			"defaultConfiguration": "plugins"
+		},
 		"test": {
 			"defaultConfiguration": "plugins"
 		}

--- a/plugins/stylelint-no-missing-var/test.js
+++ b/plugins/stylelint-no-missing-var/test.js
@@ -8,38 +8,38 @@ const plugin = require("./index");
 const { ruleName } = require("./index");
 
 async function compare(_, fixtureFilePath) {
-    const code = readFile(`./fixtures/${fixtureFilePath}`);
-    return stylelint.lint({
-        code,
-        config: {
-            plugins: [plugin],
-            rules: {
-                [ruleName]: true,
-            },
-        },
-    });
+	const code = readFile(`./fixtures/${fixtureFilePath}`);
+	return stylelint.lint({
+		code,
+		config: {
+			plugins: [plugin],
+			rules: {
+				[ruleName]: true,
+			},
+		},
+	});
 }
 
 function readFile(filename) {
-    return fs.readFileSync(join(__dirname, filename), "utf8");
+	return fs.readFileSync(join(__dirname, filename), "utf8");
 }
 
-test(`should throw an error for missing "var" before custom properties`, async (t) => {
-    const { results } = await compare(t, "missing-var.css");
+test("should throw an error for missing \"var\" before custom properties", async (t) => {
+	const { results } = await compare(t, "missing-var.css");
 
-    const warnings = results[0].warnings;
+	const warnings = results[0].warnings;
 
-    t.is(warnings.length, 2);
-    t.is(warnings[0].rule, ruleName);
+	t.is(warnings.length, 2);
+	t.is(warnings[0].rule, ruleName);
 
-    // @todo Validate specific messages
-    // t.is(warnings[0].text, messages.expected("--spectrum-well-color"));
-    // t.is(warnings[1].text, messages.expected("--spectrum-well-background-color"));
+	// @todo Validate specific messages
+	// t.is(warnings[0].text, messages.expected("--spectrum-well-color"));
+	// t.is(warnings[1].text, messages.expected("--spectrum-well-background-color"));
 });
 
-test(`should not throw an error`, async (t) => {
-    const { results } = await compare(t, "passing.css");
+test("should not throw an error for \"var\" usage", async (t) => {
+	const { results } = await compare(t, "passing.css");
 
-    const warnings = results[0].warnings;
-    t.is(warnings.length, 0);
+	const warnings = results[0].warnings;
+	t.is(warnings.length, 0);
 });

--- a/plugins/stylelint-no-unknown-custom-properties/index.js
+++ b/plugins/stylelint-no-unknown-custom-properties/index.js
@@ -14,8 +14,8 @@ const path = require("path");
 const fs = require("fs");
 
 const {
-  createPlugin,
-  utils: { report, ruleMessages, validateOptions }
+	createPlugin,
+	utils: { report, ruleMessages, validateOptions }
 } = require("stylelint");
 
 const { isString, isRegExp, isBoolean } = require("stylelint/lib/utils/validateTypes");
@@ -24,7 +24,7 @@ require("colors");
 
 const ruleName = "spectrum-tools/no-unknown-custom-properties";
 const messages = ruleMessages(ruleName, {
-    expected: (prop) => `Custom property ${prop.magenta} not defined`,
+	expected: (prop) => `Custom property ${prop.magenta} not defined`,
 });
 
 const fg = require("fast-glob");
@@ -33,136 +33,136 @@ const valueParser = require("postcss-value-parser");
 
 /** @type {import('stylelint').Plugin} */
 const ruleFunction = (enabled, options = {}) => {
-    return (root, result) => {
-        const validOptions = validateOptions(
-            result,
-            ruleName,
-            {
-                actual: enabled,
-                possible: [true],
-            },
-            {
-                actual: options,
-                possible: {
-                    ignoreList: [isString, isRegExp],
-                    skipDependencies: isBoolean,
-                },
+	return (root, result) => {
+		const validOptions = validateOptions(
+			result,
+			ruleName,
+			{
+				actual: enabled,
+				possible: [true],
+			},
+			{
+				actual: options,
+				possible: {
+					ignoreList: [isString, isRegExp],
+					skipDependencies: isBoolean,
+				},
 				optional: true,
-            },
-        );
+			},
+		);
 
-        if (!validOptions) return;
+		if (!validOptions) return;
 
-        const { ignoreList = [], skipDependencies = true } = options;
+		const { ignoreList = [], skipDependencies = true } = options;
 
-        /** @type {Set<string>} */
-        const localDefinitions = new Set();
-        root.walkDecls(/^--/, ({ prop }) => {
-            localDefinitions.add(prop);
-        });
+		/** @type {Set<string>} */
+		const localDefinitions = new Set();
+		root.walkDecls(/^--/, ({ prop }) => {
+			localDefinitions.add(prop);
+		});
 
-        const sourceFile = root.source.input.file;
-        const parts = sourceFile ? sourceFile.split(path.sep) : [];
+		const sourceFile = root.source.input.file;
+		const parts = sourceFile ? sourceFile.split(path.sep) : [];
 
-        // @todo this is a hard-coded assumption that the components directory is the root before the component name
-        const rootIdx = parts.indexOf("components");
-        const componentRoot = parts.slice(0, rootIdx + 2).join(path.sep);
+		// @todo this is a hard-coded assumption that the components directory is the root before the component name
+		const rootIdx = parts.indexOf("components");
+		const componentRoot = parts.slice(0, rootIdx + 2).join(path.sep);
 
-        const sharedDefinitions = new Set();
+		const sharedDefinitions = new Set();
 
-        for (const themePath of fg.sync(["themes/*.css"], { cwd: componentRoot, absolute: true })) {
-            const content = fs.readFileSync(themePath, "utf8");
-            if (!content) continue;
-            postcss.parse(content).walkDecls(/^--/, ({ prop }) => {
-                sharedDefinitions.add(prop);
-            });
-        }
+		for (const themePath of fg.sync(["themes/*.css"], { cwd: componentRoot, absolute: true })) {
+			const content = fs.readFileSync(themePath, "utf8");
+			if (!content) continue;
+			postcss.parse(content).walkDecls(/^--/, ({ prop }) => {
+				sharedDefinitions.add(prop);
+			});
+		}
 
-        function fetchResolutions(depName) {
-            let req;
-            try {
-                req = require.resolve(depName, {
-                    paths: [
-                        path.join(componentRoot, "node_modules"), path.join(__dirname, "../../node_modules")
-                    ]
-                });
-            } catch (e) {
-                /* allow quiet failure for peer dependencies */
-            }
+		function fetchResolutions(depName) {
+			let req;
+			try {
+				req = require.resolve(depName, {
+					paths: [
+						path.join(componentRoot, "node_modules"), path.join(__dirname, "../../node_modules")
+					]
+				});
+			} catch (e) {
+				/* allow quiet failure for peer dependencies */
+			}
 
-            // @note: if this is failing, it's likely b/c the dependency isn't built locally
-            if (!fs.existsSync(req)) return;
+			// @note: if this is failing, it's likely b/c the dependency isn't built locally
+			if (!fs.existsSync(req)) return;
 
-            const content = fs.readFileSync(req, "utf8");
-            if (!content) return;
+			const content = fs.readFileSync(req, "utf8");
+			if (!content) return;
 
-            // Fetch all defined custom properties
-            postcss.parse(content).walkDecls(/^--/, ({ prop }) => {
-                sharedDefinitions.add(prop);
-            });
-        }
+			// Fetch all defined custom properties
+			postcss.parse(content).walkDecls(/^--/, ({ prop }) => {
+				sharedDefinitions.add(prop);
+			});
+		}
 
-        // Check dependencies for custom properties
-        if (!skipDependencies && rootIdx > -1) {
-            // @todo this is a hard-coded assumption
-            const pkg = require(path.join(componentRoot, "package.json"));
+		// Check dependencies for custom properties
+		if (!skipDependencies && rootIdx > -1) {
+			// @todo this is a hard-coded assumption
+			const pkg = require(path.join(componentRoot, "package.json"));
 
-            if (!pkg) return;
+			if (!pkg) return;
 
-            const allDependencies = new Set([
-                ...(Object.keys(pkg.peerDependencies ?? {}) ?? []),
-                ...(Object.keys(pkg.dependencies ?? {}) ?? []),
-            ]);
+			const allDependencies = new Set([
+				...(Object.keys(pkg.peerDependencies ?? {}) ?? []),
+				...(Object.keys(pkg.dependencies ?? {}) ?? []),
+			]);
 
-            if (allDependencies.size === 0) return;
+			if (allDependencies.size === 0) return;
 
-            // @todo this is a hard-coded assumption that we only care about spectrum-css dependencies
-            for (const dep of [...allDependencies].filter(dep => dep.startsWith("@spectrum-css"))) {
-                try {
-                    if (!dep.endsWith("vars")) fetchResolutions(dep);
-                    else {
-                        for (const d of ["spectrum-global.css", "components/index.css"]) {
-                            fetchResolutions(`${dep}/dist/${d}`);
-                        }
-                    }
-                } catch (e) {
-                    /* allow quiet failure for peer dependencies */
-                }
-            }
-        }
+			// @todo this is a hard-coded assumption that we only care about spectrum-css dependencies
+			for (const dep of [...allDependencies].filter(dep => dep.startsWith("@spectrum-css"))) {
+				try {
+					if (!dep.endsWith("vars")) fetchResolutions(dep);
+					else {
+						for (const d of ["spectrum-global.css", "components/index.css"]) {
+							fetchResolutions(`${dep}/dist/${d}`);
+						}
+					}
+				} catch (e) {
+					/* allow quiet failure for peer dependencies */
+				}
+			}
+		}
 
-        /* Collect variable use information */
-        root.walkDecls((decl) => {
-            // Parse value and get a list of variables used
-            const parsed = valueParser(decl.value);
-            parsed.walk((node) => {
-                if (node.type !== "function" || node.value !== "var") {
-                    return;
-                }
+		/* Collect variable use information */
+		root.walkDecls((decl) => {
+			// Parse value and get a list of variables used
+			const parsed = valueParser(decl.value);
+			parsed.walk((node) => {
+				if (node.type !== "function" || node.value !== "var") {
+					return;
+				}
 
-                const [firstNode, secondNode] = node.nodes;
+				const [firstNode, secondNode] = node.nodes;
 
-                if (!firstNode) return;
+				if (!firstNode) return;
 
-                const isIgnored = ignoreList && ignoreList.length > 0 && ignoreList.some((regex) => regex.test(firstNode.value));
-                if (isIgnored) return;
+				const isIgnored = ignoreList && ignoreList.length > 0 && ignoreList.some((regex) => regex.test(firstNode.value));
+				if (isIgnored) return;
 
-                if (localDefinitions.has(firstNode.value)) return;
-                if (sharedDefinitions.has(firstNode.value)) return;
+				if (localDefinitions.has(firstNode.value)) return;
+				if (sharedDefinitions.has(firstNode.value)) return;
 
-                // Second node (div) indicates fallback exists in all cases
-                if (secondNode && secondNode.type === "div") return;
+				// Second node (div) indicates fallback exists in all cases
+				if (secondNode && secondNode.type === "div") return;
 
-                return report({
-                    message: messages.expected,
-                    messageArgs: [firstNode.value],
-                    node: decl,
-                    result,
-                    ruleName,
-                });
-            });
-        });
-    };
+				return report({
+					message: messages.expected,
+					messageArgs: [firstNode.value],
+					node: decl,
+					result,
+					ruleName,
+				});
+			});
+		});
+	};
 };
 
 module.exports.ruleName = ruleName;

--- a/plugins/stylelint-no-unknown-custom-properties/project.json
+++ b/plugins/stylelint-no-unknown-custom-properties/project.json
@@ -1,8 +1,14 @@
 {
 	"$schema": "../../node_modules/nx/schemas/project-schema.json",
-	"tags": ["tooling", "stylelint"],
 	"name": "stylelint-no-unknown-custom-properties",
+	"tags": ["tooling", "stylelint"],
 	"targets": {
+		"format": {
+			"defaultConfiguration": "plugins"
+		},
+		"lint": {
+			"defaultConfiguration": "plugins"
+		},
 		"test": {
 			"defaultConfiguration": "plugins"
 		}

--- a/plugins/stylelint-no-unknown-custom-properties/test.js
+++ b/plugins/stylelint-no-unknown-custom-properties/test.js
@@ -8,34 +8,34 @@ const plugin = require("./index");
 const { ruleName } = require("./index");
 
 async function compare(t, fixtureFilePath, options = {}) {
-    const code = readFile(`./fixtures/${fixtureFilePath}`);
-    return stylelint.lint({
-        code,
-        config: {
-            plugins: [plugin],
-            rules: {
-                [ruleName]: [true, options],
-            },
-        },
-    });
+	const code = readFile(`./fixtures/${fixtureFilePath}`);
+	return stylelint.lint({
+		code,
+		config: {
+			plugins: [plugin],
+			rules: {
+				[ruleName]: [true, options],
+			},
+		},
+	});
 }
 
 function readFile(filename) {
-    return fs.readFileSync(join(__dirname, filename), "utf8");
+	return fs.readFileSync(join(__dirname, filename), "utf8");
 }
 
 test("should throw an error for unknown custom properties", async (t) => {
-    const { results } = await compare(t, "unknown-prop.css");
+	const { results } = await compare(t, "unknown-prop.css");
 
-    const warnings = results[0].warnings;
+	const warnings = results[0].warnings;
 
-    t.is(warnings.length, 2);
-    t.is(warnings[0].rule, ruleName);
+	t.is(warnings.length, 2);
+	t.is(warnings[0].rule, ruleName);
 });
 
-test(`should not throw an error for unknown custom properties`, async (t) => {
-    const { results } = await compare(t, "passing.css");
+test("should not throw an error for unknown custom properties", async (t) => {
+	const { results } = await compare(t, "passing.css");
 
-    const warnings = results[0].warnings;
-    t.is(warnings.length, 0);
+	const warnings = results[0].warnings;
+	t.is(warnings.length, 0);
 });

--- a/plugins/stylelint-no-unused-custom-properties/expected/unused.css
+++ b/plugins/stylelint-no-unused-custom-properties/expected/unused.css
@@ -1,0 +1,13 @@
+:root {
+  --prefix-component-background-color: blue;
+  --prefix-component-border-color: blue;
+  --prefix-component-width: 10px;
+  --prefix-component-height: 10px;
+}
+
+.component {
+  inline-size: var(--prefix-component-width);
+  block-size: var(--prefix-component-height);
+  background-color: var(--prefix-component-background-color);
+  border-color: var(--other-color, var(--prefix-component-border-color));
+}

--- a/plugins/stylelint-no-unused-custom-properties/expected/varRefs.css
+++ b/plugins/stylelint-no-unused-custom-properties/expected/varRefs.css
@@ -1,0 +1,19 @@
+:root {
+  --gray: gray;
+  --blue: blue;
+  --orange: orange;
+  --default: var(--gray);
+  --focus: var(--blue);
+}
+
+.component {
+  background-color: var(--default);
+}
+
+.component:focus {
+  background-color: var(--focus);
+}
+
+.component:active {
+  background-color: var(--orange);
+}

--- a/plugins/stylelint-no-unused-custom-properties/index.js
+++ b/plugins/stylelint-no-unused-custom-properties/index.js
@@ -11,8 +11,8 @@
  */
 
 const {
-  createPlugin,
-  utils: { report, ruleMessages, validateOptions }
+	createPlugin,
+	utils: { report, ruleMessages, validateOptions }
 } = require("stylelint");
 
 const { isString, isRegExp } = require("stylelint/lib/utils/validateTypes");
@@ -21,157 +21,157 @@ require("colors");
 
 const ruleName = "spectrum-tools/no-unused-custom-properties";
 const messages = ruleMessages(ruleName, {
-    expected: (prop) => `Unused custom property ${prop.magenta} defined`,
-    referenced: (prop) => `Custom property ${prop.magenta}'s references have been removed`,
+	expected: (prop) => `Unused custom property ${prop.magenta} defined`,
+	referenced: (prop) => `Custom property ${prop.magenta}'s references have been removed`,
 });
 
 const valueParser = require("postcss-value-parser");
 
 /** @type {import('stylelint').Plugin} */
 const ruleFunction = (enabled, { ignoreList = [] } = {}, context) => {
-    return (root, result) => {
-        const validOptions = validateOptions(
-            result,
-            ruleName,
-            {
-                actual: enabled,
-                possible: [true],
-            },
-            {
-                actual: ignoreList,
-                possible: [isString, isRegExp],
-                optional: true
-            },
-        );
+	return (root, result) => {
+		const validOptions = validateOptions(
+			result,
+			ruleName,
+			{
+				actual: enabled,
+				possible: [true],
+			},
+			{
+				actual: ignoreList,
+				possible: [isString, isRegExp],
+				optional: true
+			},
+		);
 
-        if (!validOptions) return;
+		if (!validOptions) return;
 
-        // Convert strings to regexes if necessary
-        if (ignoreList.length) {
-            ignoreList = ignoreList.map((regex) => regex instanceof RegExp ? regex : new RegExp(regex));
-        }
+		// Convert strings to regexes if necessary
+		if (ignoreList.length) {
+			ignoreList = ignoreList.map((regex) => regex instanceof RegExp ? regex : new RegExp(regex));
+		}
 
-        /* A list of all custom properties used anywhere in the file */
-        const usedAnywhere = new Set();
-        /* A list of custom properties that are used by a CSS property (NOT a variable) */
-        const usedInProps = new Set();
-        /* A map keyed by custom property name, with a list of all variables that use it */
-        const relationships = new Map();
+		/* A list of all custom properties used anywhere in the file */
+		const usedAnywhere = new Set();
+		/* A list of custom properties that are used by a CSS property (NOT a variable) */
+		const usedInProps = new Set();
+		/* A map keyed by custom property name, with a list of all variables that use it */
+		const relationships = new Map();
 
-        function trackRelationships(decl) {
-            const isCustomProperty = decl.prop.startsWith("--");
-            const usedInDecl = new Set();
+		function trackRelationships(decl) {
+			const isCustomProperty = decl.prop.startsWith("--");
+			const usedInDecl = new Set();
 
-            // Parse value and get a list of variables used
-            const parsed = valueParser(decl.value);
-            parsed.walk((node) => {
-                if (node.type !== "function" || node.value !== "var" || !node.nodes.length) {
-                    return;
-                }
+			// Parse value and get a list of variables used
+			const parsed = valueParser(decl.value);
+			parsed.walk((node) => {
+				if (node.type !== "function" || node.value !== "var" || !node.nodes.length) {
+					return;
+				}
 
-                const varName = node.nodes[0].value;
+				const varName = node.nodes[0].value;
 
-                usedInDecl.add(varName);
-                usedAnywhere.add(varName);
+				usedInDecl.add(varName);
+				usedAnywhere.add(varName);
 
-                if (!isCustomProperty) {
-                    usedInProps.add(varName);
-                }
-            });
+				if (!isCustomProperty) {
+					usedInProps.add(varName);
+				}
+			});
 
-            // Store every variable referenced by this var
-            if (isCustomProperty && usedInDecl.size > 0) {
-                for (let varName of usedInDecl) {
-                    const previous = relationships.has(varName) ? relationships.get(varName) : [];
-                    relationships.set(varName, [...new Set([...previous, decl.prop])]);
-                }
-            }
-        }
+			// Store every variable referenced by this var
+			if (isCustomProperty && usedInDecl.size > 0) {
+				for (let varName of usedInDecl) {
+					const previous = relationships.has(varName) ? relationships.get(varName) : [];
+					relationships.set(varName, [...new Set([...previous, decl.prop])]);
+				}
+			}
+		}
 
-        function cleanOrReport(decl, message = messages.expected) {
-            if (context.fix) {
-                decl.remove();
-            } else {
-                report({
-                    message,
-                    messageArgs: [decl.prop],
-                    node: decl,
-                    result,
-                    ruleName,
-                });
-            }
-        }
+		function cleanOrReport(decl, message = messages.expected) {
+			if (context.fix) {
+				decl.remove();
+			} else {
+				report({
+					message,
+					messageArgs: [decl.prop],
+					node: decl,
+					result,
+					ruleName,
+				});
+			}
+		}
 
-        /* Collect a set of all allowed passthroughs */
-        const allowedPassthroughs = new Set();
-        root.walkComments((comment) => {
-            const startRegex = /^\s*@passthroughs?(\s+start)?/g;
-            const endRegex = /^\s*@passthroughs?\s+end/g;
+		/* Collect a set of all allowed passthroughs */
+		const allowedPassthroughs = new Set();
+		root.walkComments((comment) => {
+			const startRegex = /^\s*@passthroughs?(\s+start)?/g;
+			const endRegex = /^\s*@passthroughs?\s+end/g;
 
-            if (!/@passthrough/g.test(comment.text)) return;
+			if (!/@passthrough/g.test(comment.text)) return;
 
-            // Look for a start or end indicator
-            const start = startRegex.test(comment.text);
-            const end = endRegex.test(comment.text);
+			// Look for a start or end indicator
+			const start = startRegex.test(comment.text);
+			const end = endRegex.test(comment.text);
 
-            let nextLine = comment.next();
+			let nextLine = comment.next();
 
-            // If there is neither a start, nor end identifier, capture the next line
-            if (!start && !end && nextLine && nextLine.type === "declaration" && nextLine.prop.startsWith("--")) {
-                allowedPassthroughs.add(nextLine.prop);
-            }
+			// If there is neither a start, nor end identifier, capture the next line
+			if (!start && !end && nextLine && nextLine.type === "declaration" && nextLine.prop.startsWith("--")) {
+				allowedPassthroughs.add(nextLine.prop);
+			}
 
-            if (!start || end) return;
+			if (!start || end) return;
 
-            // If this comment is a start indicator, capture the declarations after it until the end indicator
-            while (nextLine) {
-                if (nextLine.type === "decl" && nextLine.prop.startsWith("--")) {
-                    allowedPassthroughs.add(nextLine.prop);
-                } else if (nextLine.type === "comment" && /^\s*@passthroughs?\s*(\s+end)?$/.test(nextLine.text)) {
-                    break;
-                }
+			// If this comment is a start indicator, capture the declarations after it until the end indicator
+			while (nextLine) {
+				if (nextLine.type === "decl" && nextLine.prop.startsWith("--")) {
+					allowedPassthroughs.add(nextLine.prop);
+				} else if (nextLine.type === "comment" && /^\s*@passthroughs?\s*(\s+end)?$/.test(nextLine.text)) {
+					break;
+				}
 
-                nextLine = nextLine.next();
-            }
-        });
+				nextLine = nextLine.next();
+			}
+		});
 
-        /* Collect variable use information */
-        root.walkDecls((decl) => trackRelationships(decl));
+		/* Collect variable use information */
+		root.walkDecls((decl) => trackRelationships(decl));
 
-        root.walkDecls(/^--/, (decl) => {
-            const isIgnored = ignoreList.length ? ignoreList.some((regex) => regex.test(decl.prop)) : false;
-            const isPassthrough = allowedPassthroughs.has(decl.prop);
+		root.walkDecls(/^--/, (decl) => {
+			const isIgnored = ignoreList.length ? ignoreList.some((regex) => regex.test(decl.prop)) : false;
+			const isPassthrough = allowedPassthroughs.has(decl.prop);
 
-            if (isIgnored || isPassthrough) return;
+			if (isIgnored || isPassthrough) return;
 
-            // Check if this variable is not used anywhere in the file
-            // or is used by a CSS property (NOT a variable)
-            if (!usedAnywhere.has(decl.prop) || (!usedInProps.has(decl.prop) && !relationships.has(decl.prop))) {
-                cleanOrReport(decl);
-                return;
-            }
+			// Check if this variable is not used anywhere in the file
+			// or is used by a CSS property (NOT a variable)
+			if (!usedAnywhere.has(decl.prop) || (!usedInProps.has(decl.prop) && !relationships.has(decl.prop))) {
+				cleanOrReport(decl);
+				return;
+			}
 
-            if (usedInProps.has(decl.prop)) return;
+			if (usedInProps.has(decl.prop)) return;
 
-            // Check if this variable is not used by another variable
-            if (!relationships.has(decl.prop)) return;
+			// Check if this variable is not used by another variable
+			if (!relationships.has(decl.prop)) return;
 
-            // Then iterate through all the variables that use it and check if they are used anywhere
-            const relatives = relationships.get(decl.prop);
-            // Check if everything that references this variable has been removed
-            const keep = relatives.reduce((keep, relatedVar) => {
-                if (usedAnywhere.has(relatedVar)) return true;
-                if (allowedPassthroughs.has(relatedVar)) return true;
-                if(usedInProps.has(relatedVar)) return true;
+			// Then iterate through all the variables that use it and check if they are used anywhere
+			const relatives = relationships.get(decl.prop);
+			// Check if everything that references this variable has been removed
+			const keep = relatives.reduce((keep, relatedVar) => {
+				if (usedAnywhere.has(relatedVar)) return true;
+				if (allowedPassthroughs.has(relatedVar)) return true;
+				if(usedInProps.has(relatedVar)) return true;
 
-                return keep;
-            }, false);
+				return keep;
+			}, false);
 
-            if (keep) return;
+			if (keep) return;
 
-            cleanOrReport(decl, messages.referenced);
-        });
-    };
+			cleanOrReport(decl, messages.referenced);
+		});
+	};
 };
 
 module.exports.ruleName = ruleName;

--- a/plugins/stylelint-no-unused-custom-properties/project.json
+++ b/plugins/stylelint-no-unused-custom-properties/project.json
@@ -1,8 +1,14 @@
 {
 	"$schema": "../../node_modules/nx/schemas/project-schema.json",
-	"tags": ["tooling", "stylelint"],
 	"name": "stylelint-no-unused-custom-properties",
+	"tags": ["tooling", "stylelint"],
 	"targets": {
+		"format": {
+			"defaultConfiguration": "plugins"
+		},
+		"lint": {
+			"defaultConfiguration": "plugins"
+		},
 		"test": {
 			"defaultConfiguration": "plugins"
 		}

--- a/plugins/stylelint-no-unused-custom-properties/test.js
+++ b/plugins/stylelint-no-unused-custom-properties/test.js
@@ -8,67 +8,67 @@ const plugin = require("./index");
 const { ruleName } = require("./index");
 
 function compare(t, fixtureFilePath, options = {}) {
-    const code = readFile(`./fixtures/${fixtureFilePath}`);
-    return stylelint.lint({
-        code,
-        config: {
-            plugins: [plugin],
-            rules: {
-                [ruleName]: [true, options],
-            },
-        },
-    });
+	const code = readFile(`./fixtures/${fixtureFilePath}`);
+	return stylelint.lint({
+		code,
+		config: {
+			plugins: [plugin],
+			rules: {
+				[ruleName]: [true, options],
+			},
+		},
+	});
 }
 
 function readFile(filename) {
-    return fs.readFileSync(join(__dirname, filename), "utf8");
+	return fs.readFileSync(join(__dirname, filename), "utf8");
 }
 
 test("should throw an error for unused custom properties", async (t) => {
-    const { results } = await compare(t, "unused.css");
+	const { results } = await compare(t, "unused.css");
 
-    const warnings = results[0].warnings;
-    t.is(warnings.length, 1);
-    t.is(warnings[0].rule, ruleName);
+	const warnings = results[0].warnings;
+	t.is(warnings.length, 1);
+	t.is(warnings[0].rule, ruleName);
 });
 
-test(`should not throw an error for unused custom properties`, async (t) => {
-    const { results } = await compare(t, "passing.css");
+test("should not throw an error for unused custom properties", async (t) => {
+	const { results } = await compare(t, "passing.css");
 
-    const warnings = results[0].warnings;
-    t.is(warnings.length, 0);
+	const warnings = results[0].warnings;
+	t.is(warnings.length, 0);
 });
 
 test("should throw an error for unused custom properties with deep references", async (t) => {
-    const { results } = await compare(t, "varRefs.css");
+	const { results } = await compare(t, "varRefs.css");
 
-    // Should check warnings to ensure each of these failures was caught
-    const expectedFailures = ["--selected", "--active", "--green"];
+	// Should check warnings to ensure each of these failures was caught
+	const expectedFailures = ["--selected", "--active", "--green"];
 
-    const warnings = results[0].warnings;
-    t.is(warnings.length, 3);
-    t.is(warnings[0].rule, ruleName);
+	const warnings = results[0].warnings;
+	t.is(warnings.length, 3);
+	t.is(warnings[0].rule, ruleName);
 
-    // Check that each of the expected failures was caught
-    expectedFailures.forEach((failure) => {
-        t.true(warnings.some((warning) => warning.text.includes(failure)));
-    });
+	// Check that each of the expected failures was caught
+	expectedFailures.forEach((failure) => {
+		t.true(warnings.some((warning) => warning.text.includes(failure)));
+	});
 });
 
 test("should not throw an error for unused custom properties in ignore list", async (t) => {
-    const { results } = await compare(t, "unused.css", {
-        ignoreList: ["--prefix-component-size"],
-    });
+	const { results } = await compare(t, "unused.css", {
+		ignoreList: ["--prefix-component-size"],
+	});
 
-    const warnings = results[0].warnings;
-    t.is(warnings.length, 0);
+	const warnings = results[0].warnings;
+	t.is(warnings.length, 0);
 });
 
 test("should not throw an error for unused custom properties wrapped in passthrough syntax", async (t) => {
-    const { results } = await compare(t, "passthrough.css");
+	const { results } = await compare(t, "passthrough.css");
 
-    const warnings = results[0].warnings;
-    t.is(warnings.length, 0);
+	const warnings = results[0].warnings;
+	t.is(warnings.length, 0);
 });
 
 // @todo add tests for fix mode

--- a/yarn.lock
+++ b/yarn.lock
@@ -3041,6 +3041,11 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
+"@pkgr/core@^0.1.0":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.1.1.tgz#1ec17e2edbec25c8306d424ecfbf13c7de1aaa31"
+  integrity sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==
+
 "@protobuf-ts/plugin-framework@^2.0.7", "@protobuf-ts/plugin-framework@^2.9.3":
   version "2.9.3"
   resolved "https://registry.yarnpkg.com/@protobuf-ts/plugin-framework/-/plugin-framework-2.9.3.tgz#b4af125a5444a8377d27d99bb7c0214cbf0bbfdc"
@@ -5138,7 +5143,7 @@ acorn@^8.10.0, acorn@^8.4.1, acorn@^8.7.1, acorn@^8.8.2:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.11.2.tgz#ca0d78b51895be5390a5903c5b3bdcdaf78ae40b"
   integrity sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==
 
-acorn@^8.11.3, acorn@^8.6.0, acorn@^8.9.0:
+acorn@^8.11.3, acorn@^8.5.0, acorn@^8.6.0, acorn@^8.9.0:
   version "8.11.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.11.3.tgz#71e0b14e13a4ec160724b38fb7b0f233b1b81d7a"
   integrity sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==
@@ -8338,12 +8343,40 @@ escape-string-regexp@^5.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz#4683126b500b61762f2dbebace1806e8be31b1c8"
   integrity sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==
 
+eslint-compat-utils@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/eslint-compat-utils/-/eslint-compat-utils-0.5.0.tgz#f7b2eb2befec25a370fac76934d3f9189f312a65"
+  integrity sha512-dc6Y8tzEcSYZMHa+CMPLi/hyo1FzNeonbhJL7Ol0ccuKQkwopJcJBA9YL/xmMTLU1eKigXo9vj9nALElWYSowg==
+  dependencies:
+    semver "^7.5.4"
+
 eslint-plugin-jest@^27.2.2:
   version "27.6.3"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-27.6.3.tgz#8acb8b1e45597fe1f4d4cf25163d90119efc12be"
   integrity sha512-+YsJFVH6R+tOiO3gCJon5oqn4KWc+mDq2leudk8mrp8RFubLOo9CVyi3cib4L7XMpxExmkmBZQTPDYVBzgpgOA==
   dependencies:
     "@typescript-eslint/utils" "^5.10.0"
+
+eslint-plugin-jsonc@^2.13.0:
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsonc/-/eslint-plugin-jsonc-2.15.0.tgz#3d6e329ae37a4240e2647c0e71f77ec6725a6897"
+  integrity sha512-wAphMVgTQPAKAYV8d/QEkEYDg8uer9nMQ85N17IUiJcAWLxJs83/Exe59dEH9yKUpvpLf46H+wR7/U7lZ3/NpQ==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.2.0"
+    eslint-compat-utils "^0.5.0"
+    espree "^9.6.1"
+    graphemer "^1.4.0"
+    jsonc-eslint-parser "^2.0.4"
+    natural-compare "^1.4.0"
+    synckit "^0.6.0"
+
+eslint-plugin-prettier@^5.1.3:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-5.1.3.tgz#17cfade9e732cef32b5f5be53bd4e07afd8e67e1"
+  integrity sha512-C9GCVAs4Eq7ZC/XFQHITLiHJxQngdtraXaM+LoUFoFp/lHNl2Zn8f3WQbe9HvTBBQ9YnKFB0/2Ajdqwo5D1EAw==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
+    synckit "^0.8.6"
 
 eslint-scope@5.1.1, eslint-scope@^5.1.1:
   version "5.1.1"
@@ -8361,7 +8394,7 @@ eslint-scope@^7.2.2:
     esrecurse "^4.3.0"
     estraverse "^5.2.0"
 
-eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4.3:
+eslint-visitor-keys@^3.0.0, eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4.3:
   version "3.4.3"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz#0cd72fe8550e3c2eae156a96a4dddcd1c8ac5800"
   integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
@@ -8410,7 +8443,7 @@ eslint@^8.57.0:
     strip-ansi "^6.0.1"
     text-table "^0.2.0"
 
-espree@^9.6.0, espree@^9.6.1:
+espree@^9.0.0, espree@^9.6.0, espree@^9.6.1:
   version "9.6.1"
   resolved "https://registry.yarnpkg.com/espree/-/espree-9.6.1.tgz#a2a17b8e434690a5432f2f8018ce71d331a48c6f"
   integrity sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==
@@ -8655,7 +8688,7 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-diff@^1.2.0:
+fast-diff@^1.1.2, fast-diff@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.3.0.tgz#ece407fa550a64d638536cd727e129c61616e0f0"
   integrity sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==
@@ -11027,6 +11060,16 @@ json5@^2.1.2, json5@^2.2.2, json5@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
+
+jsonc-eslint-parser@^2.0.4, jsonc-eslint-parser@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/jsonc-eslint-parser/-/jsonc-eslint-parser-2.4.0.tgz#74ded53f9d716e8d0671bd167bf5391f452d5461"
+  integrity sha512-WYDyuc/uFcGp6YtM2H0uKmUwieOuzeE/5YocFJLnLfclZ4inf3mRn8ZVy1s7Hxji7Jxm6Ss8gqpexD/GlKoGgg==
+  dependencies:
+    acorn "^8.5.0"
+    eslint-visitor-keys "^3.0.0"
+    espree "^9.0.0"
+    semver "^7.3.5"
 
 jsonc-parser@3.2.0, jsonc-parser@^3.0.0:
   version "3.2.0"
@@ -14172,6 +14215,13 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
+  dependencies:
+    fast-diff "^1.1.2"
+
 prettier-package-json@^2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/prettier-package-json/-/prettier-package-json-2.8.0.tgz#70aba2b4f7aeb4e294ae2191fb64b7d8fdea0398"
@@ -16363,6 +16413,21 @@ synchronous-promise@^2.0.15:
   resolved "https://registry.yarnpkg.com/synchronous-promise/-/synchronous-promise-2.0.17.tgz#38901319632f946c982152586f2caf8ddc25c032"
   integrity sha512-AsS729u2RHUfEra9xJrE39peJcc2stq2+poBXX8bcM08Y6g9j/i/PUzwNQqkaJde7Ntg1TO7bSREbR5sdosQ+g==
 
+synckit@^0.6.0:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/synckit/-/synckit-0.6.2.tgz#e1540b97825f2855f7170b98276e8463167f33eb"
+  integrity sha512-Vhf+bUa//YSTYKseDiiEuQmhGCoIF3CVBhunm3r/DQnYiGT4JssmnKQc44BIyOZRK2pKjXXAgbhfmbeoC9CJpA==
+  dependencies:
+    tslib "^2.3.1"
+
+synckit@^0.8.6:
+  version "0.8.8"
+  resolved "https://registry.yarnpkg.com/synckit/-/synckit-0.8.8.tgz#fe7fe446518e3d3d49f5e429f443cf08b6edfcd7"
+  integrity sha512-HwOKAP7Wc5aRGYdKH+dw0PRRpbO841v2DENBtjnR5HFWoiNByAl7vrx3p0G/rCyYXQsrxqtX48TImFtPcIHSpQ==
+  dependencies:
+    "@pkgr/core" "^0.1.0"
+    tslib "^2.6.2"
+
 table@^6.8.1:
   version "6.8.1"
   resolved "https://registry.yarnpkg.com/table/-/table-6.8.1.tgz#ea2b71359fe03b017a5fbc296204471158080bdf"
@@ -16740,7 +16805,7 @@ tslib@^1.13.0, tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.2.0, tslib@^2.3.0, tslib@^2.4.0:
+tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.2.0, tslib@^2.3.0, tslib@^2.3.1, tslib@^2.4.0, tslib@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==


### PR DESCRIPTION
## Description

Set up a more detailed JS-linter with support for JSON assets with a structured formatting order to reduce unnecessary re-ordering diffs in PRs.

Improve the prettier, stylelint, and eslint ignore rules for wider coverage.

Add lint assets to the nx dependency inputs to ensure accurate caching when changes are made to supporting configurations.

Add lint fixing to the lint-staged workflow.

Apply linting updates to the plugins and support the lint and format commands for them as well.

## Validate

Do not commit the changes from the below tests:

- [x] `yarn linter card`: in addition to the CSS errors previously reported, you should now see errors for storybook assets and JSON assets
- [x] `yarn linter tag:stylelint`: reports on linting changes needed in the stylelint plugins

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
