### PR TITLE
fix(storybook): chromatic requires build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ package-lock.json
 build-storybook.log
 
 # Chromatic
+chromatic.log
 chromatic-build-*.xml
 chromatic-diagnostics*.json
 

--- a/.storybook/package.json
+++ b/.storybook/package.json
@@ -6,6 +6,9 @@
   "author": "Adobe",
   "homepage": "https://opensource.adobe.com/spectrum-css/preview",
   "main": "main.js",
+  "scripts": {
+    "build": "storybook build --config-dir . --output-dir ./storybook-static"
+  },
   "dependencies": {
     "@adobe/spectrum-css-workflow-icons": "^1.5.4",
     "@spectrum-css/expressvars": "^3.0.9",


### PR DESCRIPTION
## Description

In order to run the chromatic command locally, a build script must exist in the package.json. This brings back the build command so that the chromatic build continues to work locally.

<img width="894" alt="Screenshot 2023-12-12 at 8 51 07 AM" src="https://github.com/adobe/spectrum-css/assets/1840295/e0db3a75-01c9-4b46-a4e3-de7a83d95e64">

## How and where has this been tested?

- [x] `yarn test` - kicks off a full chromatic run with no error messages
- [x] `yarn test:scope Components/Table` - kicks off an isolated chromatic run for just the table

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] ✨ This pull request is ready to merge. ✨
