### PR TITLE
fix(asset): add whcm values for asset background color

### DIFF
--- a/components/asset/skin.css
+++ b/components/asset/skin.css
@@ -25,7 +25,7 @@ governing permissions and limitations under the License.
 
 @media (forced-colors: active) {
 	.spectrum-Asset {
-    --highcontrast-asset-folder-background-color: CanvasText;
-    --highcontrast-asset-file-background-color: CanvasText;
+    --highcontrast-asset-folder-background-color: currentColor;
+    --highcontrast-asset-file-background-color: currentColor;
   	}
 }

--- a/components/asset/skin.css
+++ b/components/asset/skin.css
@@ -11,14 +11,21 @@ governing permissions and limitations under the License.
 */
 
 .spectrum-Asset-folderBackground {
-  fill: var(--spectrum-asset-folder-background-color);
+  fill: var(--highcontrast-asset-folder-background-color, var(--spectrum-asset-folder-background-color));
 }
 
 .spectrum-Asset-fileBackground {
-  fill: var(--spectrum-asset-file-background-color);
+  fill: var(--highcontrast-asset-file-background-color, var(--spectrum-asset-file-background-color));
 }
 
 .spectrum-Asset-folderOutline,
 .spectrum-Asset-fileOutline {
   fill: var(--spectrum-asset-icon-outline-color);
+}
+
+@media (forced-colors: active) {
+	.spectrum-Asset {
+    --highcontrast-asset-folder-background-color: CanvasText;
+    --highcontrast-asset-file-background-color: CanvasText;
+  	}
 }


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

Addresses SWC issue [3376](https://github.com/adobe/spectrum-web-components/issues/3376)
"When running in high contrast mode the file and folder asset types should use the high contrast mode colours so they are always visible no matter the theme chosen"

Fix: 
- use `currentColor` on the background fill of the file and folder background when `forced-colors: active` 
- `currentColor` matches the inherited color property which unlike svg fill is overwritten with WHCM values 



<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

Open the docs site and emulate WHCM 
- [x] asset Folder and File are visible in a dark color scheme 
- [x]  asset Folder and File are visible in a light color scheme 

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

### Before 

**Light**
![Screenshot 2023-12-15 at 1 38 07 PM](https://github.com/adobe/spectrum-css/assets/63808889/1a230e3a-6cb9-45ac-839e-89e2254c3c54)

**Dark**
![Screenshot 2023-12-15 at 1 38 20 PM](https://github.com/adobe/spectrum-css/assets/63808889/0a77637b-d644-410b-81bb-624b7deaf90e)


### After

**Light** 
![Screenshot 2023-12-15 at 1 37 41 PM](https://github.com/adobe/spectrum-css/assets/63808889/bcf18c46-f26e-4c5c-9d0d-4b7f8d67bbb4)

**Dark** 
![Screenshot 2023-12-15 at 1 37 52 PM](https://github.com/adobe/spectrum-css/assets/63808889/0175dfc9-fa3a-4860-b99c-92ec679611c2)

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [ ] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
