### PR TITLE
refactor(combobox): use sub component mod properties

### DIFF
--- a/components/combobox/index.css
+++ b/components/combobox/index.css
@@ -36,25 +36,8 @@ governing permissions and limitations under the License.
 
   --spectrum-combobox-spacing-label-to-combobox: var(--spectrum-field-label-to-component);
 
-  --spectrum-combobox-font-family: var(--spectrum-sans-font-family-stack);
-  --spectrum-combobox-font-weight: var(--spectrum-regular-font-weight);
   --spectrum-combobox-font-style: var(--spectrum-default-font-style);
   --spectrum-combobox-line-height: var(--spectrum-line-height-100);
-  --spectrum-combobox-font-color-default: var(--spectrum-neutral-content-color-default);
-  --spectrum-combobox-font-color-hover: var(--spectrum-neutral-content-color-hover);
-  --spectrum-combobox-font-color-focus: var(--spectrum-neutral-content-color-focus);
-  --spectrum-combobox-font-color-focus-hover: var(--spectrum-neutral-content-color-focus-hover);
-  --spectrum-combobox-font-color-key-focus: var(--spectrum-neutral-content-color-key-focus);
-  --spectrum-combobox-font-color-placeholder: var(--spectrum-gray-600);
-
-  --spectrum-combobox-background-color-default: var(--spectrum-gray-50);
-  --spectrum-combobox-background-color-hover: var(--spectrum-gray-50);
-  --spectrum-combobox-background-color-focus: var(--spectrum-gray-50);
-  --spectrum-combobox-background-color-focus-hover: var(--spectrum-gray-50);
-  --spectrum-combobox-background-color-key-focus: var(--spectrum-gray-50);
-
-  --spectrum-combobox-background-color-disabled: var(--spectrum-disabled-background-color);
-  --spectrum-combobox-font-color-disabled: var(--spectrum-disabled-content-color);
 
   --spectrum-combobox-border-color-invalid-default: var(--spectrum-negative-border-color-default);
   --spectrum-combobox-border-color-invalid-hover: var(--spectrum-negative-border-color-hover);
@@ -62,12 +45,46 @@ governing permissions and limitations under the License.
   --spectrum-combobox-border-color-invalid-focus-hover: var(--spectrum-negative-border-color-focus-hover);
   --spectrum-combobox-border-color-invalid-key-focus: var(--spectrum-negative-border-color-key-focus);
 
-  --spectrum-combobox-alert-icon-color: var(--spectrum-negative-visual-color);
-
   /* Settings for nested Textfield component. */
   --mod-textfield-focus-indicator-gap: var(--mod-combobox-focus-indicator-gap, var(--spectrum-combobox-focus-indicator-gap));
   --mod-textfield-focus-indicator-width: var(--mod-combobox-focus-indicator-thickness, var(--spectrum-combobox-focus-indicator-thickness));
-  --mod-textfield-focus-indicator-color: var(--highcontrast-combobox-focus-indicator-color, var(--mod-combobox-focus-indicator-color, var(--spectrum-combobox-focus-indicator-color)));
+  --mod-textfield-focus-indicator-color: var(--mod-combobox-focus-indicator-color, var(--spectrum-combobox-focus-indicator-color));
+
+  --mod-textfield-background-color: var(--mod-combobox-background-color-default);
+  --mod-textfield-background-color-disabled: var(--mod-combobox-background-color-disabled);
+
+  --mod-textfield-font-family: var(--mod-combobox-font-family);
+  --mod-textfield-font-weight: var(--mod-combobox-font-weight);
+
+  --mod-textfield-text-color-default: var(--mod-combobox-font-color-default);
+  --mod-textfield-text-color-hover: var(--mod-combobox-font-color-hover);
+  --mod-textfield-text-color-focus: var(--mod-combobox-font-color-focus);
+  --mod-textfield-text-color-focus-hover: var(--mod-combobox-font-color-focus-hover);
+  --mod-textfield-text-color-keyboard-focus: var(--mod-combobox-font-color-key-focus);
+  --mod-textfield-text-color-disabled: var(--mod-combobox-font-color-disabled);
+
+  --mod-textfield-border-width: var(--mod-combobox-border-width, var(--spectrum-combobox-border-width));
+  --mod-textfield-border-color: var(--mod-combobox-border-color-default, var(--spectrum-combobox-border-color-default));
+  --mod-textfield-border-color-disabled: var(--mod-combobox-border-color-disabled);
+  --mod-textfield-border-color-focus: var(--mod-combobox-border-color-focus, var(--spectrum-combobox-border-color-focus));
+  --mod-textfield-border-color-focus-hover: var(--mod-combobox-border-color-focus-hover, var(--spectrum-combobox-border-color-focus-hover));
+  --mod-textfield-border-color-hover: var(--mod-combobox-border-color-hover, var(--spectrum-combobox-border-color-hover));
+  --mod-textfield-border-color-keyboard-focus: var(--mod-combobox-border-color-key-focus, var(--spectrum-combobox-border-color-key-focus));
+
+  --mod-textfield-border-color-invalid-default: var(--mod-combobox-border-color-invalid-default, var(--spectrum-combobox-border-color-invalid-default));
+  --mod-textfield-border-color-invalid-hover: var(--mod-combobox-border-color-invalid-hover, var(--spectrum-combobox-border-color-invalid-hover));
+  --mod-textfield-border-color-invalid-focus: var(--mod-combobox-border-color-invalid-focus, var(--spectrum-combobox-border-color-invalid-focus));
+  --mod-textfield-border-color-invalid-focus-hover: var(--mod-combobox-border-color-invalid-focus-hover, var(--spectrum-combobox-border-color-invalid-focus-hover));
+  --mod-textfield-border-color-invalid-keyboard-focus: var(--mod-combobox-border-color-invalid-key-focus, var(--spectrum-combobox-border-color-invalid-key-focus));
+
+  --mod-textfield-icon-color-invalid: var(--mod-combobox-alert-icon-color);
+
+  /* Settings for nested Picker Button component. */
+  --mod-picker-button-border-width: var(--mod-combobox-border-width, var(--spectrum-combobox-border-width));
+  --mod-picker-button-border-color: var(--mod-combobox-border-color-default, var(--spectrum-combobox-border-color-default));
+  --mod-picker-button-background-color: var(--mod-combobox-background-color-default);
+  --mod-picker-button-background-color-disabled: var(--mod-combobox-background-color-disabled);
+  --mod-picker-button-font-color-disabled: var(--mod-combobox-font-color-disabled);
 }
 
 .spectrum-Combobox--sizeS {
@@ -139,14 +156,6 @@ governing permissions and limitations under the License.
     (var(--mod-combobox-block-size, var(--spectrum-combobox-block-size)) / 2) - (var(--mod-combobox-icon-size, var(--spectrum-combobox-icon-size)) / 2)
   );
 
-  --spectrum-combobox-border-color-disabled: var(--spectrum-disabled-border-color);
-  --spectrum-combobox-background-color-default: var(--spectrum-transparent-white-100);
-  --spectrum-combobox-background-color-hover: var(--spectrum-transparent-white-100);
-  --spectrum-combobox-background-color-focus: var(--spectrum-transparent-white-100);
-  --spectrum-combobox-background-color-focus-hover: var(--spectrum-transparent-white-100);
-  --spectrum-combobox-background-color-key-focus: var(--spectrum-transparent-white-100);
-  --spectrum-combobox-background-color-disabled: var(--spectrum-transparent-white-100);
-
   &.spectrum-Combobox--sizeS {
     --spectrum-combobox-spacing-label-to-combobox: var(--spectrum-field-label-to-component-quiet-small);
   }
@@ -162,24 +171,32 @@ governing permissions and limitations under the License.
   &.spectrum-Combobox--sizeXL {
     --spectrum-combobox-spacing-label-to-combobox: var(--spectrum-field-label-to-component-quiet-extra-large);
   }
+
+  /* Settings for nested Picker Button component. */
+  --mod-picker-button-background-color-quiet: transparent;
+  --mod-picker-button-border-color-quiet: transparent;
 }
 
 @media (forced-colors: active) {
   .spectrum-Combobox {
-    --highcontrast-combobox-focus-indicator-color: Highlight;
-    --highcontrast-combobox-border-color: ButtonText;
-    --highcontrast-combobox-font-color: CanvasText;
-    --highcontrast-combobox-font-color-disabled: GrayText;
-    --highcontrast-combobox-icon-color: ButtonText;
-    --highcontrast-combobox-background-color: Background;
-    --highcontrast-combobox-border-color-disabled: GrayText;
-    --highcontrast-combobox-font-color-placeholder: CanvasText;
+    --highcontrast-combobox-border-color-highlight: Highlight;
+    --highcontrast-combobox-border-color-invalid: Highlight;
+
+    .spectrum-Combobox-button.spectrum-PickerButton--quiet {
+      .spectrum-PickerButton-fill {
+        forced-color-adjust: none;
+      }
+
+      .spectrum-PickerButton-icon {
+        /* Should match foreground color of the Textfield. */
+        color: CanvasText;
+      }
+    }
   }
 }
 
 .spectrum-Combobox {
   position: relative;
-
   display: inline-flex;
   flex-flow: row nowrap;
 
@@ -214,102 +231,74 @@ governing permissions and limitations under the License.
   }
 }
 
-/* stylelint-disable max-nesting-depth */
 
 /* PICKER BUTTON */
+/* stylelint-disable max-nesting-depth */
 .spectrum-Combobox-button {
   position: absolute;
   inset-inline-end: calc(-1 * var(--mod-combobox-button-inline-offset, var(--spectrum-combobox-button-inline-offset, 0px)));
-  color: var(--highcontrast-combobox-font-color, var(--mod-combobox-font-color-default, var(--spectrum-combobox-font-color-default)));
-
-  .spectrum-PickerButton-fill {
-    border-width: var(--mod-combobox-border-width, var(--spectrum-combobox-border-width));
-  }
 
   /* Default */
-  &:not(:disabled):not(.is-invalid) {
-    .spectrum-PickerButton-fill {
-      border-color: var(--highcontrast-combobox-border-color, var(--mod-combobox-border-color-default, var(--spectrum-combobox-border-color-default)));
-    }
+  &:not(:disabled, .is-invalid, .spectrum-PickerButton--quiet) {
+    --mod-picker-button-border-color: var(--mod-combobox-border-color-default, var(--spectrum-combobox-border-color-default));
 
     &.is-focused,
-    &:focus {
-      color: var(--highcontrast-combobox-font-color, var(--mod-combobox-font-color-focus, var(--spectrum-combobox-font-color-focus)));
-      .spectrum-PickerButton-fill {
-        border-color: var(--highcontrast-combobox-focus-indicator-color, var(--mod-combobox-border-color-focus, var(--spectrum-combobox-border-color-focus)));
-      }
+    &:focus,
+    .spectrum-Combobox.is-focused &,
+    .spectrum-Combobox:has(:focus) & {
+      --mod-picker-button-border-color: var(--highcontrast-combobox-border-color-highlight, var(--mod-combobox-border-color-focus, var(--spectrum-combobox-border-color-focus)));
     }
 
     &.is-keyboardFocused,
-    &:focus-visible {
-      color: var(--highcontrast-combobox-font-color, var(--mod-combobox-font-color-key-focus, var(--spectrum-combobox-font-color-key-focus)));
-      .spectrum-PickerButton-fill {
-        border-color: var(--highcontrast-combobox-border-color, var(--mod-combobox-border-color-key-focus, var(--spectrum-combobox-border-color-key-focus)));
-      }
+    &:focus-visible,
+    .spectrum-Combobox.is-keyboardFocused & {
+      --mod-picker-button-border-color: var(--mod-combobox-border-color-key-focus, var(--spectrum-combobox-border-color-key-focus));
     }
 
     &:hover,
-    &:active {
-      color: var(--highcontrast-combobox-font-color, var(--mod-combobox-font-color-hover, var(--spectrum-combobox-font-color-hover)));
-      .spectrum-PickerButton-fill {
-        border-color: var(--highcontrast-combobox-focus-indicator-color, var(--mod-combobox-border-color-hover, var(--spectrum-combobox-border-color-hover)));
-      }
+    &:active,
+    .spectrum-Combobox:hover &,
+    .spectrum-Combobox:has(:active) & {
+      --mod-picker-button-border-color: var(--highcontrast-combobox-border-color-highlight, var(--mod-combobox-border-color-hover, var(--spectrum-combobox-border-color-hover)));
     }
 
     &:focus:hover,
-    &.is-focused:hover {
-      color: var(--highcontrast-combobox-font-color, var(--mod-combobox-font-color-focus-hover, var(--spectrum-combobox-font-color-focus-hover)));
-      .spectrum-PickerButton-fill {
-        border-color: var(--highcontrast-combobox-focus-indicator-color, var(--mod-combobox-border-color-focus-hover, var(--spectrum-combobox-border-color-focus-hover)));
-      }
+    &.is-focused:hover,
+    .spectrum-Combobox:hover:has(:focus) &,
+    .spectrum-Combobox.is-focused:hover & {
+      --mod-picker-button-border-color: var(--highcontrast-combobox-border-color-highlight, var(--mod-combobox-border-color-focus-hover, var(--spectrum-combobox-border-color-focus-hover)));
     }
   }
 
   /* Invalid */
-  &.is-invalid:not(:disabled) {
-    .spectrum-PickerButton-fill {
-      border-color: var(--highcontrast-combobox-focus-indicator-color, var(--mod-combobox-border-color-invalid-default, var(--spectrum-combobox-border-color-invalid-default)));
-    }
+  &.is-invalid:not(:disabled, .spectrum-PickerButton--quiet) {
+    --mod-picker-button-border-color: var(--highcontrast-combobox-border-color-invalid, var(--mod-combobox-border-color-invalid-default, var(--spectrum-combobox-border-color-invalid-default)));
 
     &.is-focused,
-    &:focus {
-      color: var(--highcontrast-combobox-font-color, var(--mod-combobox-font-color-focus, var(--spectrum-combobox-font-color-focus)));
-      .spectrum-PickerButton-fill {
-        border-color: var(--highcontrast-combobox-focus-indicator-color, var(--mod-combobox-border-color-invalid-focus, var(--spectrum-combobox-border-color-invalid-focus)));
-      }
+    &:focus,
+    .spectrum-Combobox.is-focused &,
+    .spectrum-Combobox:has(:focus) & {
+      --mod-picker-button-border-color: var(--highcontrast-combobox-border-color-invalid, var(--mod-combobox-border-color-invalid-focus, var(--spectrum-combobox-border-color-invalid-focus)));
     }
 
     &.is-keyboardFocused,
-    &:focus-visible {
-      color: var(--highcontrast-combobox-font-color, var(--mod-combobox-font-color-key-focus, var(--spectrum-combobox-font-color-key-focus)));
-      .spectrum-PickerButton-fill {
-        border-color: var(--highcontrast-combobox-focus-indicator-color, var(--mod-combobox-border-color-invalid-key-focus, var(--spectrum-combobox-border-color-invalid-key-focus)));
-      }
+    &:focus-visible,
+    .spectrum-Combobox.is-keyboardFocused & {
+      --mod-picker-button-border-color: var(--highcontrast-combobox-border-color-invalid, var(--mod-combobox-border-color-invalid-key-focus, var(--spectrum-combobox-border-color-invalid-key-focus)));
     }
 
     &:hover,
-    &:active {
-      color: var(--highcontrast-combobox-font-color, var(--mod-combobox-font-color-hover, var(--spectrum-combobox-font-color-hover)));
-      .spectrum-PickerButton-fill {
-        border-color: var(--highcontrast-combobox-focus-indicator-color, var(--mod-combobox-border-color-invalid-hover, var(--spectrum-combobox-border-color-invalid-hover)));
-      }
+    &:active,
+    .spectrum-Combobox:hover &,
+    .spectrum-Combobox:has(:active) & {
+      --mod-picker-button-border-color: var(--highcontrast-combobox-border-color-invalid, var(--mod-combobox-border-color-invalid-hover, var(--spectrum-combobox-border-color-invalid-hover)));
     }
 
     &:focus:hover,
-    &.is-focused:hover {
-      color: var(--highcontrast-combobox-font-color, var(--mod-combobox-font-color-focus-hover, var(--spectrum-combobox-font-color-focus-hover)));
-      .spectrum-PickerButton-fill {
-        border-color: var(--highcontrast-combobox-focus-indicator-color, var(--mod-combobox-border-color-invalid-focus-hover, var(--spectrum-combobox-border-color-invalid-focus-hover)));
-      }
-    }
-  }
-
-  /* Disabled */
-  .spectrum-Combobox.is-disabled &,
-  &:disabled {
-    color: var(--highcontrast-combobox-font-color-disabled, var(--mod-combobox-font-color-disabled, var(--spectrum-combobox-font-color-disabled)));
-    .spectrum-PickerButton-fill {
-      background-color: var(--highcontrast-combobox-background-color, var(--mod-combobox-background-color-disabled, var(--spectrum-combobox-background-color-disabled)));
+    &.is-focused:hover,
+    .spectrum-Combobox:hover:has(:focus) &,
+    .spectrum-Combobox.is-focused:hover & {
+      --mod-picker-button-border-color: var(--highcontrast-combobox-border-color-invalid, var(--mod-combobox-border-color-invalid-focus-hover, var(--spectrum-combobox-border-color-invalid-focus-hover)));
     }
   }
 }
@@ -339,62 +328,36 @@ governing permissions and limitations under the License.
     var(--mod-combobox-spacing-inline-end-edge-to-text, var(--spectrum-combobox-spacing-inline-end-edge-to-text)) -
     (var(--mod-combobox-border-width, var(--spectrum-combobox-border-width)) * 2)
   );
-
-  background-color: var(--highcontrast-combobox-background-color, var(--mod-combobox-background-color-default, var(--spectrum-combobox-background-color-default)));
-  border-color: var(--highcontrast-combobox-border-color, var(--mod-combobox-border-color-default, var(--spectrum-combobox-border-color-default)));
-  border-width: var(--mod-combobox-border-width, var(--spectrum-combobox-border-width));
   backface-visibility: hidden;
-
+  line-height: var(--mod-combobox-line-height, var(--spectrum-combobox-line-height));  
   font-size: var(--mod-combobox-font-size, var(--spectrum-combobox-font-size));
-  font-family: var(--mod-combobox-font-family, var(--spectrum-combobox-font-family));
-  font-weight: var(--mod-combobox-font-weight, var(--spectrum-combobox-font-weight));
-  line-height: var(--mod-combobox-line-height, var(--spectrum-combobox-line-height));
   font-style: var(--mod-combobox-font-style, var(--spectrum-combobox-font-style));
-  color: var(--highcontrast-combobox-font-color, var(--mod-combobox-font-color-default, var(--spectrum-combobox-font-color-default)));
 
   &::placeholder {
-    color: var(--highcontrast-combobox-font-color-placeholder, var(--mod-combobox-font-color-placeholder, var(--spectrum-combobox-font-color-placeholder)));
+    --mod-textfield-text-color-default: var(--mod-combobox-font-color-placeholder);
   }
 
   /* Hover */
   .spectrum-Combobox-textfield:hover &,
   &:hover,
   &:active {
-    background-color: var(--highcontrast-combobox-background-color, var(--mod-combobox-background-color-hover, var(--spectrum-combobox-background-color-hover)));
-    border-color: var(--highcontrast-combobox-focus-indicator-color, var(--mod-combobox-border-color-hover, var(--spectrum-combobox-border-color-hover)));
-    color: var(--highcontrast-combobox-font-color, var(--mod-combobox-font-color-hover, var(--spectrum-combobox-font-color-hover)));
-
-    &::placeholder {
-      color: var(--highcontrast-combobox-font-color-placeholder, var(--mod-combobox-font-color-hover, var(--spectrum-combobox-font-color-hover)));
-    }
+    --mod-textfield-background-color: var(--mod-combobox-background-color-hover);
   }
 
   /* Focus */
   .spectrum-Combobox-textfield.is-focused &,
-  .spectrum-Combobox-textfield:focus-within &,
   &:focus {
-    background-color: var(--highcontrast-combobox-background-color, var(--mod-combobox-background-color-focus, var(--spectrum-combobox-background-color-focus)));
-    border-color: var(--highcontrast-combobox-focus-indicator-color, var(--mod-combobox-border-color-focus, var(--spectrum-combobox-border-color-focus)));
-    color: var(--highcontrast-combobox-font-color, var(--mod-combobox-font-color-focus, var(--spectrum-combobox-font-color-focus)));
-
-    &::placeholder {
-      color: var(--highcontrast-combobox-font-color-placeholder, var(--mod-combobox-font-color-focus, var(--spectrum-combobox-font-color-focus)));
-    }
+    --mod-textfield-background-color: var(--mod-combobox-background-color-focus);
 
     /* Focus + Hover */
     &:hover {
-      background-color: var(--highcontrast-combobox-background-color, var(--mod-combobox-background-color-focus-hover, var(--spectrum-combobox-background-color-focus-hover)));
-      border-color: var(--highcontrast-combobox-focus-indicator-color, var(--mod-combobox-border-color-focus-hover, var(--spectrum-combobox-border-color-focus-hover)));
-      color: var(--highcontrast-combobox-font-color, var(--mod-combobox-font-color-focus-hover, var(--spectrum-combobox-font-color-focus-hover)));
+      --mod-textfield-background-color: var(--mod-combobox-background-color-focus-hover);
     }
   }
 
   /* Keyboard Focus */
-  .spectrum-Combobox-textfield.is-keyboardFocused &,
-  &:focus-visible {
-    background-color: var(--highcontrast-combobox-background-color, var(--mod-combobox-background-color-key-focus, var(--spectrum-combobox-background-color-key-focus)));
-    border-color: var(--highcontrast-combobox-border-color, var(--mod-combobox-border-color-key-focus, var(--spectrum-combobox-border-color-key-focus)));
-    color: var(--highcontrast-combobox-font-color, var(--mod-combobox-font-color-key-focus, var(--spectrum-combobox-font-color-key-focus)));
+  .spectrum-Combobox-textfield.is-keyboardFocused & {
+    --mod-textfield-background-color: var(--mod-combobox-background-color-key-focus);
   }
 
   /* ****** Invalid & Loading ****** */
@@ -408,49 +371,6 @@ governing permissions and limitations under the License.
       var(--mod-combobox-button-inline-offset, var(--spectrum-combobox-button-inline-offset, 0px)) -
       (var(--mod-combobox-border-width, var(--spectrum-combobox-border-width)) * 2)
     );
-  }
-
-  /* ****** Invalid ******* */
-  .spectrum-Combobox-textfield.is-invalid {
-    border-color: var(--highcontrast-combobox-focus-indicator-color, var(--mod-combobox-border-color-invalid-default, var(--spectrum-combobox-border-color-invalid-default)));
-  }
-
-  /* Invalid - Hover */
-  .spectrum-Combobox-textfield.is-invalid:hover &,
-  .spectrum-Combobox-textfield.is-invalid &:hover,
-  .spectrum-Combobox-textfield.is-invalid &:active {
-    border-color: var(--highcontrast-combobox-focus-indicator-color, var(--mod-combobox-border-color-invalid-hover, var(--spectrum-combobox-border-color-invalid-hover)));
-  }
-
-  /* Invalid - Focus */
-  .spectrum-Combobox-textfield.is-invalid.is-focused &,
-  .spectrum-Combobox-textfield.is-invalid:focus-within &,
-  .spectrum-Combobox-textfield.is-invalid &:focus {
-    border-color: var(--highcontrast-combobox-focus-indicator-color, var(--mod-combobox-border-color-invalid-focus, var(--spectrum-combobox-border-color-invalid-focus)));
-
-    /* Invalid - Focus + Hover */
-    &:hover {
-      border-color: var(--highcontrast-combobox-focus-indicator-color, var(--mod-combobox-border-color-invalid-focus-hover, var(--spectrum-combobox-border-color-invalid-focus-hover)));
-    }
-  }
-
-  /* Invalid - Keyboard Focus */
-  .spectrum-Combobox-textfield.is-invalid.is-keyboardFocused &,
-  .spectrum-Combobox-textfield.is-invalid &:focus-visible {
-    border-color: var(--highcontrast-combobox-focus-indicator-color, var(--mod-combobox-border-color-invalid-key-focus, var(--spectrum-combobox-border-color-invalid-key-focus)));
-  }
-
-  /* ****** Disabled ****** */
-  .spectrum-Combobox.is-disabled .spectrum-Combobox-textfield &,
-  .spectrum-Combobox-textfield.is-disabled &,
-  &:disabled {
-    border-color: var(--highcontrast-combobox-border-color-disabled, var(--mod-combobox-background-color-disabled, var(--spectrum-combobox-background-color-disabled)));
-    background-color: var(--highcontrast-combobox-background-color, var(--mod-combobox-background-color-disabled, var(--spectrum-combobox-background-color-disabled)));
-    color: var(--highcontrast-combobox-font-color-disabled, var(--mod-combobox-font-color-disabled, var(--spectrum-combobox-font-color-disabled)));
-
-    &::placeholder {
-      color: var(--highcontrast-combobox-font-color-disabled, var(--mod-combobox-font-color-disabled, var(--spectrum-combobox-font-color-disabled)));
-    }
   }
 }
 
@@ -466,28 +386,18 @@ governing permissions and limitations under the License.
       var(--mod-combobox-spacing-inline-icon-to-button, var(--spectrum-combobox-spacing-inline-icon-to-button)) +
       var(--mod-combobox-button-width, var(--spectrum-combobox-button-width))
     );
-
-    color: var(--highcontrast-combobox-icon-color, var(--mod-combobox-alert-icon-color, var(--spectrum-combobox-alert-icon-color)));
   }
 
   .spectrum-Textfield.is-disabled &,
   .spectrum-Textfield.is-readOnly &,
   .spectrum-Textfield.is-loading & {
-    color: transparent;
+    display: none;
   }
 }
 
 /* QUIET VARIATION (no visible background) */
 .spectrum-Combobox--quiet {
   border-radius: 0;
-
-  &.spectrum-Combobox .spectrum-Combobox-button:not(:disabled):not(.is-invalid),
-  &.spectrum-Combobox .spectrum-Combobox-button.is-invalid:not(:disabled) {
-    .spectrum-PickerButton-fill {
-      background: transparent;
-      border-color: transparent;
-    }
-  }
 
   .spectrum-Combobox-textfield {
     &.is-invalid .spectrum-Textfield-validationIcon {
@@ -521,12 +431,5 @@ governing permissions and limitations under the License.
       var(--mod-combobox-spacing-inline-end-edge-to-text, var(--spectrum-combobox-spacing-inline-end-edge-to-text)) -
       var(--mod-combobox-button-inline-offset, var(--spectrum-combobox-button-inline-offset, 0px))
     );
-  }
-
-  /* Disabled */
-  &.is-disabled .spectrum-Combobox-textfield .spectrum-Combobox-input,
-  .spectrum-Combobox-textfield.is-disabled .spectrum-Combobox-input,
-  .spectrum-Combobox-input:disabled {
-    border-block-end-color: var(--highcontrast-combobox-border-color-disabled, var(--mod-combobox-border-color-disabled, var(--spectrum-combobox-border-color-disabled)));
   }
 }

--- a/components/combobox/metadata/combobox.yml
+++ b/components/combobox/metadata/combobox.yml
@@ -59,7 +59,7 @@ examples:
 
               <button tabindex="-1" class="spectrum-PickerButton spectrum-PickerButton--sizeM spectrum-PickerButton--uiicononly spectrum-PickerButton--right spectrum-Combobox-button" aria-haspopup="listbox">
                 <div class="spectrum-PickerButton-fill">
-                  <svg class="spectrum-PickerButton-UIIcon spectrum-Icon spectrum-UIIcon-ChevronDown200" focusable="false" aria-hidden="true">
+                  <svg class="spectrum-PickerButton-icon spectrum-Icon spectrum-UIIcon-ChevronDown200" focusable="false" aria-hidden="true">
                     <use xlink:href="#spectrum-css-icon-Chevron200" />
                   </svg>
                 </div>
@@ -80,7 +80,7 @@ examples:
 
               <button tabindex="-1" class="spectrum-PickerButton spectrum-PickerButton--sizeM spectrum-PickerButton--uiicononly spectrum-PickerButton--right spectrum-Combobox-button" aria-haspopup="listbox">
                 <div class="spectrum-PickerButton-fill">
-                  <svg class="spectrum-PickerButton-UIIcon spectrum-Icon spectrum-UIIcon-ChevronDown200" focusable="false" aria-hidden="true">
+                  <svg class="spectrum-PickerButton-icon spectrum-Icon spectrum-UIIcon-ChevronDown200" focusable="false" aria-hidden="true">
                     <use xlink:href="#spectrum-css-icon-Chevron200" />
                   </svg>
                 </div>
@@ -99,7 +99,7 @@ examples:
 
               <button tabindex="-1" class="spectrum-PickerButton spectrum-PickerButton--sizeM spectrum-PickerButton--uiicononly spectrum-PickerButton--right spectrum-Combobox-button" disabled aria-haspopup="listbox">
                 <div class="spectrum-PickerButton-fill">
-                  <svg class="spectrum-PickerButton-UIIcon spectrum-Icon spectrum-UIIcon-ChevronDown200" focusable="false" aria-hidden="true">
+                  <svg class="spectrum-PickerButton-icon spectrum-Icon spectrum-UIIcon-ChevronDown200" focusable="false" aria-hidden="true">
                     <use xlink:href="#spectrum-css-icon-Chevron200" />
                   </svg>
                 </div>
@@ -118,7 +118,7 @@ examples:
 
               <button tabindex="-1" class="spectrum-PickerButton spectrum-PickerButton--sizeM spectrum-PickerButton--uiicononly spectrum-PickerButton--right spectrum-Combobox-button is-open" aria-haspopup="listbox">
                 <div class="spectrum-PickerButton-fill">
-                  <svg class="spectrum-PickerButton-UIIcon spectrum-Icon spectrum-UIIcon-ChevronDown200" focusable="false" aria-hidden="true">
+                  <svg class="spectrum-PickerButton-icon spectrum-Icon spectrum-UIIcon-ChevronDown200" focusable="false" aria-hidden="true">
                     <use xlink:href="#spectrum-css-icon-Chevron200" />
                   </svg>
                 </div>
@@ -161,7 +161,7 @@ examples:
 
               <button tabindex="-1" class="spectrum-PickerButton spectrum-PickerButton--sizeM spectrum-PickerButton--uiicononly spectrum-PickerButton--quiet spectrum-PickerButton--right spectrum-Combobox-button" aria-haspopup="listbox">
                 <div class="spectrum-PickerButton-fill">
-                  <svg class="spectrum-PickerButton-UIIcon spectrum-Icon spectrum-UIIcon-ChevronDown200" focusable="false" aria-hidden="true">
+                  <svg class="spectrum-PickerButton-icon spectrum-Icon spectrum-UIIcon-ChevronDown200" focusable="false" aria-hidden="true">
                     <use xlink:href="#spectrum-css-icon-Chevron200" />
                   </svg>
                 </div>
@@ -182,7 +182,7 @@ examples:
 
               <button tabindex="-1" class="spectrum-PickerButton spectrum-PickerButton--sizeM spectrum-PickerButton--uiicononly spectrum-PickerButton--quiet spectrum-PickerButton--right spectrum-Combobox-button" aria-haspopup="listbox">
                 <div class="spectrum-PickerButton-fill">
-                  <svg class="spectrum-PickerButton-UIIcon spectrum-Icon spectrum-UIIcon-ChevronDown200" focusable="false" aria-hidden="true">
+                  <svg class="spectrum-PickerButton-icon spectrum-Icon spectrum-UIIcon-ChevronDown200" focusable="false" aria-hidden="true">
                     <use xlink:href="#spectrum-css-icon-Chevron200" />
                   </svg>
                 </div>
@@ -201,7 +201,7 @@ examples:
 
               <button tabindex="-1" class="spectrum-PickerButton spectrum-PickerButton--sizeM spectrum-PickerButton--uiicononly spectrum-PickerButton--quiet spectrum-PickerButton--right spectrum-Combobox-button" disabled aria-haspopup="listbox">
                 <div class="spectrum-PickerButton-fill">
-                  <svg class="spectrum-PickerButton-UIIcon spectrum-Icon spectrum-UIIcon-ChevronDown200" focusable="false" aria-hidden="true">
+                  <svg class="spectrum-PickerButton-icon spectrum-Icon spectrum-UIIcon-ChevronDown200" focusable="false" aria-hidden="true">
                     <use xlink:href="#spectrum-css-icon-Chevron200" />
                   </svg>
                 </div>
@@ -220,7 +220,7 @@ examples:
 
               <button tabindex="-1" class="spectrum-PickerButton spectrum-PickerButton--sizeM spectrum-PickerButton--uiicononly spectrum-PickerButton--quiet spectrum-PickerButton--right spectrum-Combobox-button" aria-haspopup="listbox">
                 <div class="spectrum-PickerButton-fill">
-                  <svg class="spectrum-PickerButton-UIIcon spectrum-Icon spectrum-UIIcon-ChevronDown200" focusable="false" aria-hidden="true">
+                  <svg class="spectrum-PickerButton-icon spectrum-Icon spectrum-UIIcon-ChevronDown200" focusable="false" aria-hidden="true">
                     <use xlink:href="#spectrum-css-icon-Chevron200" />
                   </svg>
                 </div>
@@ -266,7 +266,7 @@ examples:
 
               <button tabindex="-1" class="spectrum-PickerButton spectrum-PickerButton--sizeM spectrum-PickerButton--uiicononly spectrum-PickerButton--right spectrum-Combobox-button is-invalid" aria-haspopup="listbox">
                 <div class="spectrum-PickerButton-fill">
-                  <svg class="spectrum-PickerButton-UIIcon spectrum-Icon spectrum-UIIcon-ChevronDown200" focusable="false" aria-hidden="true">
+                  <svg class="spectrum-PickerButton-icon spectrum-Icon spectrum-UIIcon-ChevronDown200" focusable="false" aria-hidden="true">
                     <use xlink:href="#spectrum-css-icon-Chevron200" />
                   </svg>
                 </div>
@@ -288,7 +288,7 @@ examples:
 
               <button tabindex="-1" class="spectrum-PickerButton spectrum-PickerButton--sizeM spectrum-PickerButton--uiicononly spectrum-PickerButton--quiet spectrum-PickerButton--right spectrum-Combobox-button is-invalid" aria-haspopup="listbox">
                 <div class="spectrum-PickerButton-fill">
-                  <svg class="spectrum-PickerButton-UIIcon spectrum-Icon spectrum-UIIcon-ChevronDown200" focusable="false" aria-hidden="true">
+                  <svg class="spectrum-PickerButton-icon spectrum-Icon spectrum-UIIcon-ChevronDown200" focusable="false" aria-hidden="true">
                     <use xlink:href="#spectrum-css-icon-Chevron200" />
                   </svg>
                 </div>
@@ -329,7 +329,7 @@ examples:
 
               <button tabindex="-1" class="spectrum-PickerButton spectrum-PickerButton--sizeM spectrum-PickerButton--uiicononly spectrum-PickerButton--right spectrum-Combobox-button is-loading" aria-haspopup="listbox">
                 <div class="spectrum-PickerButton-fill">
-                  <svg class="spectrum-PickerButton-UIIcon spectrum-Icon spectrum-UIIcon-ChevronDown200" focusable="false" aria-hidden="true">
+                  <svg class="spectrum-PickerButton-icon spectrum-Icon spectrum-UIIcon-ChevronDown200" focusable="false" aria-hidden="true">
                     <use xlink:href="#spectrum-css-icon-Chevron200" />
                   </svg>
                 </div>
@@ -365,7 +365,7 @@ examples:
 
               <button tabindex="-1" class="spectrum-PickerButton spectrum-PickerButton--sizeM spectrum-PickerButton--uiicononly spectrum-PickerButton--quiet spectrum-PickerButton--right spectrum-Combobox-button is-loading" aria-haspopup="listbox">
                 <div class="spectrum-PickerButton-fill">
-                  <svg class="spectrum-PickerButton-UIIcon spectrum-Icon spectrum-UIIcon-ChevronDown200" focusable="false" aria-hidden="true">
+                  <svg class="spectrum-PickerButton-icon spectrum-Icon spectrum-UIIcon-ChevronDown200" focusable="false" aria-hidden="true">
                     <use xlink:href="#spectrum-css-icon-Chevron200" />
                   </svg>
                 </div>

--- a/components/combobox/stories/template.js
+++ b/components/combobox/stories/template.js
@@ -2,11 +2,11 @@ import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
-import { Template as Menu } from "@spectrum-css/menu/stories/template.js";
-import { Template as TextField } from "@spectrum-css/textfield/stories/template.js";
-import { Template as Popover } from "@spectrum-css/popover/stories/template.js";
-import { Template as PickerButton } from "@spectrum-css/pickerbutton/stories/template.js";
 import { Template as FieldLabel } from "@spectrum-css/fieldlabel/stories/template.js";
+import { Template as Menu } from "@spectrum-css/menu/stories/template.js";
+import { Template as PickerButton } from "@spectrum-css/pickerbutton/stories/template.js";
+import { Template as Popover } from "@spectrum-css/popover/stories/template.js";
+import { Template as TextField } from "@spectrum-css/textfield/stories/template.js";
 
 import { useArgs, useGlobals } from "@storybook/client-api";
 
@@ -98,14 +98,16 @@ export const Template = ({
 				}),
 				PickerButton({
 					...globals,
-					customClasses: [`${rootClass}-button`],
+					customClasses: [
+						`${rootClass}-button`,
+						... isInvalid ? ['is-invalid'] : [],
+						... isValid ? ['is-valid'] : [],
+					],
 					size,
 					iconType: "workflow",
 					iconName: "ChevronDown",
 					isQuiet,
 					isOpen,
-					isInvalid,
-					isValid,
 					isFocused,
 					isKeyboardFocused,
 					isDisabled,

--- a/site/resources/js/enhancement.js
+++ b/site/resources/js/enhancement.js
@@ -157,33 +157,43 @@ governing permissions and limitations under the License.
 	});
 })();
 
-// Textfield
+// Textfield and Combobox
+// -- Bubble up focus classes to component's parent element.
 (function () {
-	function setFocus(textfield, input, focused) {
-		var focusClass = input.classList.contains("is-keyboardFocused")
+	// Add or remove focused or keyboard focused classes on element.
+	function setFocusClasses(element, eventTarget, focused) {
+		var focusClass = eventTarget.classList.contains("is-keyboardFocused")
 			? "is-keyboardFocused"
 			: "is-focused";
 		if (focused) {
-			textfield.classList.add(focusClass);
+			element.classList.add(focusClass);
 		} else {
-			textfield.classList.remove("is-keyboardFocused");
-			textfield.classList.remove("is-focused");
+			element.classList.remove("is-keyboardFocused");
+			element.classList.remove("is-focused");
 		}
 	}
 
 	document.addEventListener("focusin", function (event) {
 		var textfield = event.target.closest(".spectrum-Textfield");
+		var combobox = event.target.closest(".spectrum-Combobox");
 
 		if (textfield) {
-			setFocus(textfield, event.target, true);
+			setFocusClasses(textfield, event.target, true);
+		}
+		if (combobox) {
+			setFocusClasses(combobox, event.target, true);
 		}
 	});
 
 	document.addEventListener("focusout", function (event) {
 		var textfield = event.target.closest(".spectrum-Textfield");
+		var combobox = event.target.closest(".spectrum-Combobox");
 
 		if (textfield) {
-			setFocus(textfield, event.target, false);
+			setFocusClasses(textfield, event.target, false);
+		}
+		if (combobox) {
+			setFocusClasses(combobox, event.target, false);
 		}
 	});
 })();


### PR DESCRIPTION
## Description

Combobox was migrated to core tokens before Textfield's migration was finished and we started using passthrough mod properties for the sub-components. This is a broad stroke refactor of the CSS to simplify much of it by using the mods available in Textfield and Picker Button. Removing mods was avoided in this PR to avoid breaking changes.

- Refactors much of the CSS to use mod properties for its sub components Textfield and Picker Button. 
- Includes some additional selectors to fix the border styles around the picker button so they match when interacting with the textfield, which is in more alignment with the gifs shown in the Guidelines. Previously when the textfield was focused for example, the focus border color did not extend around the whole combobox because the picker button border color was not changing as well. This was hard to notice because of the subtle gray border color changes; tips for testing are included in the validation steps.
- Improves WHCM appearance of quiet _Picker Button_ to not show a border (aligns with _Picker_ WHCM quiet design):
![Screenshot 2023-12-18 at 3 03 13 PM](https://github.com/adobe/spectrum-css/assets/965114/7e8f10b9-b6de-4f25-ad32-b08822fc11cf)

CSS-602

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

Overall validation
- [x] Docs variations look and act like production
- [x] Storybook variations look and act like production
- [ ] No mod properties have been lost from list of available mods

Border color fix validation

Try setting the follow mod values on the body element in your inspector, to better test how the border colors change. Note: if you try this on prod, you'll see the difference where only the left side of the combobox shows the color change.
```
--mod-combobox-border-color-default: blue;
--mod-combobox-border-color-hover: red;
--mod-combobox-border-color-focus-hover: cyan;
--mod-combobox-border-color-key-focus: seagreen;
--mod-combobox-border-color-focus: orange;
```
- [x] Hovered textfield shows red border
- [x] Focused and hovered textfield shows cyan border
- [x] Focused textfield shows orange border
- [x] Keyboard focused (tab) textfield shows green border

WHCM validation
- [x] High contrast styles have not regressed and show improvement to the quiet variation as noted in description.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have tested these changes in Windows High Contrast mode.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
