### PR TITLE
feat(storybook): custom decorators for chromatic coverage

### DIFF
--- a/.storybook/decorators/index.js
+++ b/.storybook/decorators/index.js
@@ -2,6 +2,7 @@ import { makeDecorator, useEffect } from "@storybook/preview-api";
 import isChromatic from "chromatic/isChromatic";
 import { html } from "lit";
 import { styleMap } from "lit/directives/style-map.js";
+import { isFullscreen, isPopover } from "./utilities.js";
 
 export { withContextWrapper } from "./contextsWrapper.js";
 
@@ -28,7 +29,10 @@ export const withTextDirectionWrapper = makeDecorator({
 		};
 		const showBothDirections = textDirection === DIRECTIONS.both;
 
-		if (showBothDirections) {
+		const componentIsFullscreen = isFullscreen(context);
+		const componentHasPopover = isPopover(context);
+
+		if (showBothDirections && !componentIsFullscreen && !componentHasPopover) {
 			return html`
 				<div style="margin-bottom: 4rem" dir=${DIRECTIONS.left}>
 					${StoryFn(context)}
@@ -36,6 +40,14 @@ export const withTextDirectionWrapper = makeDecorator({
 				<div dir=${DIRECTIONS.right}>
 					${StoryFn(context)}
 				</div>
+			`;
+		};
+
+		if (showBothDirections && (componentIsFullscreen || componentHasPopover)) {
+			return html`
+				<h4 class="spectrum-Detail spectrum-Detail--sizeXS spectrum-Examples-itemHeading" style="text-transform: none; background-color: var(--spectrum-negative-color-900); color: var(--spectrum-white); padding: 1rem;">
+					⚠️ Sorry, feature is unavailable for this component. Choose a single-setting option in the toolbar to view the component, or try changing the setting in the control panel.
+				</h4>
 			`;
 		};
 
@@ -106,6 +118,9 @@ export const withPlatformScaleWrapper = makeDecorator({
 	parameterName: "context",
 	wrapper: (StoryFn, context) => {
 		const { args, globals, argTypes } = context;
+		const componentIsFullscreen = isFullscreen(context);
+		const componentHasPopover = isPopover(context);
+
 		const bodyEl = document.body;
     const bodyElClasses = bodyEl.classList;
 		const mediumClass = 'spectrum--medium';
@@ -116,7 +131,7 @@ export const withPlatformScaleWrapper = makeDecorator({
 			both: 'both',
 		};
 		const defaultScale = SCALES.medium;
-		const scale = globals.platformScale || argTypes.scale || args.scale || defaultScale;
+		let scale = globals.platformScale || argTypes.scale || args.scale || defaultScale;
 		const showBothScales = scale === 'both';
 
 		const updateBodyClasses = () => {
@@ -132,7 +147,7 @@ export const withPlatformScaleWrapper = makeDecorator({
 			};
 		}, [scale]);
 
-		if (showBothScales) {
+		if (showBothScales && !componentIsFullscreen && !componentHasPopover) {
 			return html`
 				<div style="margin-bottom: 1rem" class=${mediumClass}>
 					<h4 class="spectrum-Detail spectrum-Detail--sizeXS spectrum-Examples-itemHeading">
@@ -148,6 +163,15 @@ export const withPlatformScaleWrapper = makeDecorator({
 				</div>
 			`;
 		};
+
+		if (showBothScales && (componentIsFullscreen || componentHasPopover)) {
+			scale = defaultScale;
+			return html`
+				<h4 class="spectrum-Detail spectrum-Detail--sizeXS spectrum-Examples-itemHeading" style="text-transform: none; padding: 1rem;">
+					⚠️ Sorry, feature is unavailable for this component. Choose a single-setting option in the toolbar to view the component, or try changing the setting in the control panel.
+				</h4>
+			`;
+		}
 
 		return StoryFn(context);
 }});
@@ -248,6 +272,17 @@ export const withBackgroundColorDisplayWrapper = makeDecorator({
         padding: '2rem',
       },
     };
+
+		const componentIsFullscreen = isFullscreen(context);
+		const componentHasPopover = isPopover(context);
+
+		if (componentIsFullscreen || componentHasPopover) {
+			return html`
+				<h4 class="spectrum-Detail spectrum-Detail--sizeXS spectrum-Examples-itemHeading" style="text-transform: none; background-color: var(--spectrum-negative-color-900); color: var(--spectrum-white); padding: 1rem;">
+					⚠️ Sorry, feature is unavailable for this component. Choose a single-setting option in the toolbar to view the component, or try changing the setting in the control panel.
+				</h4>
+			`;
+		};
 
     return html`
       <div style=${styleMap(styles.grid)}>

--- a/.storybook/decorators/index.js
+++ b/.storybook/decorators/index.js
@@ -1,5 +1,7 @@
-import { useEffect, makeDecorator } from "@storybook/preview-api";
+import { makeDecorator, useEffect } from "@storybook/preview-api";
+import isChromatic from "chromatic/isChromatic";
 import { html } from "lit";
+import { styleMap } from "lit/directives/style-map.js";
 
 export { withContextWrapper } from "./contextsWrapper.js";
 
@@ -15,21 +17,27 @@ export const withTextDirectionWrapper = makeDecorator({
     const defaultDirection = "ltr"
 		const textDirection = parameters.textDirection || globals.textDirection || defaultDirection;
 
-		// Shortkeys for the global types
-		document.addEventListener("keydown", (e) => {
-			switch (e.key || e.keyCode) {
-				case "r":
-					document.documentElement.dir = "rtl";
-					break;
-				case "n":
-					document.documentElement.dir = defaultDirection;
-					break;
-			}
-		});
-
 		useEffect(() => {
 			if (textDirection) document.documentElement.dir = textDirection;
 		}, [textDirection]);
+
+		const DIRECTIONS = {
+			left: 'ltr',
+			right: 'rtl',
+			both: 'both',
+		};
+		const showBothDirections = textDirection === DIRECTIONS.both;
+
+		if (showBothDirections) {
+			return html`
+				<div style="margin-bottom: 4rem" dir=${DIRECTIONS.left}>
+					${StoryFn(context)}
+				</div>
+				<div dir=${DIRECTIONS.right}>
+					${StoryFn(context)}
+				</div>
+			`;
+		};
 
 		return StoryFn(context);
 	},
@@ -93,6 +101,57 @@ export const withLanguageWrapper = makeDecorator({
 /**
  * @type import('@storybook/csf').DecoratorFunction<import('@storybook/web-components').WebComponentsFramework>
  **/
+export const withPlatformScaleWrapper = makeDecorator({
+	name: "withPlatformScaleWrapper",
+	parameterName: "context",
+	wrapper: (StoryFn, context) => {
+		const { args, globals, argTypes } = context;
+		const bodyEl = document.body;
+    const bodyElClasses = bodyEl.classList;
+		const mediumClass = 'spectrum--medium';
+		const largeClass = 'spectrum--large';
+		const SCALES = {
+			medium: 'medium',
+			large: 'large',
+			both: 'both',
+		};
+		const defaultScale = SCALES.medium;
+		const scale = globals.platformScale || argTypes.scale || args.scale || defaultScale;
+		const showBothScales = scale === 'both';
+
+		const updateBodyClasses = () => {
+			bodyElClasses.remove(mediumClass, largeClass);
+			bodyElClasses.add(`spectrum--${scale}`);
+		};
+
+		useEffect(() => {
+			if (scale) {
+				setTimeout(() => {
+					updateBodyClasses();
+        }, 100);
+			};
+		}, [scale]);
+
+		if (showBothScales) {
+			return html`
+				<div style="margin-bottom: 1rem" class=${mediumClass}>
+					<h4 class="spectrum-Detail spectrum-Detail--sizeXS spectrum-Examples-itemHeading">
+						Platform Scale: Medium
+					</h4>
+					${StoryFn(context)}
+				</div>
+				<div class=${largeClass}>
+					<h4 class="spectrum-Detail spectrum-Detail--sizeXS spectrum-Examples-itemHeading">
+						Platform Scale: Large
+					</h4>
+					${StoryFn(context)}
+				</div>
+			`;
+		};
+
+		return StoryFn(context);
+}});
+
 export const withSizingWrapper = makeDecorator({
 	name: "withSizingWrapper",
 	parameterName: "context",
@@ -123,20 +182,83 @@ export const withSizingWrapper = makeDecorator({
 			disable: true,
 		};
 
-		return html` <div class="spectrum-Examples">
-			${sizes.map((size) => {
-				context.args.size = size;
-				return html` <div class="spectrum-Examples-item" data-value=${size}>
-					<div class="spectrum-Examples-itemGroup" id="scoped-root">
-						${StoryFn(context)}
-					</div>
-					<h4
-						class="spectrum-Detail spectrum-Detail--sizeXS spectrum-Examples-itemHeading"
-					>
-						${printSize(size)}
-					</h4>
-				</div>`;
-			})}
-		</div>`;
+		return isChromatic()
+			? html` <div class="spectrum-Examples">
+					${sizes.map((size) => {
+						context.args.size = size;
+						return html` <div class="spectrum-Examples-item" data-value=${size}>
+								<h4
+									class="spectrum-Detail spectrum-Detail--sizeXS spectrum-Examples-itemHeading"
+								>
+									${printSize(size)}
+								</h4>
+							<div class="spectrum-Examples-itemGroup" id="scoped-root">
+								${StoryFn(context)}
+							</div>
+						</div>`;
+					})}
+				</div>`
+			: StoryFn(context);
 	},
+});
+
+export const withBackgroundColorDisplayWrapper = makeDecorator({
+  name: "withBackgroundColorDisplayWrapper",
+  parameterName: "context",
+  wrapper: (StoryFn, context) => {
+    const { globals, args, parameters } = context;
+    const defaultBackgroundColor = 'default';
+    const backgroundColorDisplay = parameters.backgroundColorDisplay || globals.backgroundColorDisplay || defaultBackgroundColor;
+    const isDefault = backgroundColorDisplay === defaultBackgroundColor;
+    const isStacked = backgroundColorDisplay === 'stacked';
+    const bodyEl = document.body;
+    const bodyElClasses = bodyEl.classList;
+
+    // remove the classes from the Storybook body element
+    // use a timeout here to make it wait for other addons to modify classes first and then remove them after that
+    useEffect(() => {
+      if (isDefault) {
+        setTimeout(() => {
+          bodyEl.className = bodyElClasses;
+        }, 1000);
+      } else {
+        setTimeout(() => {
+          bodyEl.classList.remove(...backgroundColorClassNames);
+        }, 1000);
+      }
+    }, [bodyEl]);
+
+    // is it the "default" display option? Return early
+    if (isDefault) return StoryFn(context);
+
+    // prep the display areas with the correct classes
+    const isExpress = args.express;
+
+    const backgroundColorClassNames = ['spectrum--light', 'spectrum--dark', 'spectrum--darkest'];
+    const styles = {
+      grid: {
+        display: 'grid',
+        gridTemplateColumns: isStacked ? '1fr' : 'repeat(auto-fit, minmax(0px, 1fr))',
+        height: 'auto',
+      },
+      gridItem: {
+        backgroundColor: 'var(--spectrum-alias-background-color-default)',
+        color: 'var(--spectrum-alias-text-color-default)',
+        outline: '2px solid var(--spectrum-blue-background-color-default)',
+        padding: '2rem',
+      },
+    };
+
+    return html`
+      <div style=${styleMap(styles.grid)}>
+        ${backgroundColorClassNames.map((backgroundColorClassName) => {
+          return html`
+            <div class="spectrum ${backgroundColorClassName} ${isExpress ? `spectrum--express` : null}" style=${styleMap(styles.gridItem)}>
+              ${StoryFn(context)}
+            </div>
+          `;
+        })}
+      </div>
+    `;
+  },
 });

--- a/.storybook/decorators/utilities.js
+++ b/.storybook/decorators/utilities.js
@@ -1,0 +1,32 @@
+const FULLSCREEN_COMPONENT_IDS = [
+	'components-alert-dialog',
+	'components-dialog',
+	'components-modal',
+	'components-ray',
+	'components-underlay',
+	'components-menu--tray-submenu'
+];
+
+export const isFullscreen = (context) => {
+	const { id } = context;
+	const isFullscreenComponent = FULLSCREEN_COMPONENT_IDS.find((componentName) => id.includes(componentName));
+	return (isFullscreenComponent) ? true : false;
+};
+
+const POPOVER_COMPONENT_IDS = [
+	'components-alert-banner',
+	'components-coach-mark',
+	'components-color-loupe',
+	'components-combobox',
+	'components-contextual-help',
+	'components-datepicker',
+	'components-picker',
+	'components-popover',
+	'components-search-within'
+];
+
+export const isPopover = (context) => {
+	const { id } = context;
+	const isPopoverComponent = POPOVER_COMPONENT_IDS.find((componentName) => id.includes(componentName));
+	return (isPopoverComponent) ? true : false;
+};

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -85,9 +85,9 @@ export const globalTypes = {
     defaultValue: isChromatic() ? "side-by-side" : "default",
     toolbar: {
       items: [
-        {value: "default", icon: "photo", title: "default bg color", right: "default"},
-        {value: "stacked", icon: "stacked", title: "stacked bg colors", right: "stacked"},
-        {value: "side-by-side", icon: "sidebyside", title: "side-by-side bg colors", right: "side-by-side"}
+        { value: "default", icon: "photo", title: "default bg color", right: "default" },
+        { value: "stacked", icon: "stacked", title: "stacked bg colors", right: "stacked" },
+        { value: "side-by-side", icon: "sidebyside", title: "side-by-side bg colors", right: "side-by-side" }
       ],
       dynamicTitle: true,
     }
@@ -99,9 +99,9 @@ export const globalTypes = {
     defaultValue: isChromatic() ? "both" : "medium",
     toolbar: {
       items: [
-        {value: "medium", icon: "browser", title: "medium - desktop", right: "medium"},
-        {value: "large", icon: "mobile", title: "large - mobile", right: "large"},
-        {value: "both", icon: "tablet", title: "medium + large", right: "both"}
+        { value: "medium", icon: "browser", title: "medium - desktop", right: "medium" },
+        { value: "large", icon: "mobile", title: "large - mobile", right: "large" },
+        { value: "both", icon: "tablet", title: "medium + large", right: "both" }
       ],
       dynamicTitle: true,
     }

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -3,10 +3,13 @@ import isChromatic from "chromatic/isChromatic";
 import { withActions } from "@storybook/addon-actions/decorator";
 import DocumentationTemplate from './DocumentationTemplate.mdx';
 import {
+	withBackgroundColorDisplayWrapper,
 	withContextWrapper,
 	withLanguageWrapper,
+	withPlatformScaleWrapper,
 	withReducedMotionWrapper,
-	withTextDirectionWrapper,
+	withSizingWrapper,
+	withTextDirectionWrapper
 } from "./decorators/index.js";
 
 // https://github.com/storybookjs/storybook-addon-console
@@ -49,11 +52,12 @@ export const globalTypes = {
 		title: "Text Direction",
 		description: "Direction of the content flow",
 		showName: true,
-		defaultValue: "ltr",
+		defaultValue: isChromatic() ? "both" : "ltr",
 		toolbar: {
 			items: [
 				{ value: "ltr", title: "ltr", right: "left to right" },
 				{ value: "rtl", title: "rtl", right: "right to left" },
+				{ value: "both", title: "ltr + rtl", right: "ltr and rtl" },
 			],
 			dynamicTitle: true,
 		},
@@ -74,6 +78,34 @@ export const globalTypes = {
 			dynamicTitle: true,
 		},
 	},
+	backgroundColorDisplay: {
+    title: "Background Color Display",
+    description: "Show default background or all background colors at once",
+    showName: true,
+    defaultValue: isChromatic() ? "side-by-side" : "default",
+    toolbar: {
+      items: [
+        {value: "default", icon: "photo", title: "default bg color", right: "default"},
+        {value: "stacked", icon: "stacked", title: "stacked bg colors", right: "stacked"},
+        {value: "side-by-side", icon: "sidebyside", title: "side-by-side bg colors", right: "side-by-side"}
+      ],
+      dynamicTitle: true,
+    }
+  },
+	platformScale: {
+		title: "Platform Scale",
+    description: "Show medium (desktop), large (mobile), or both scales at once",
+    showName: true,
+    defaultValue: isChromatic() ? "both" : "medium",
+    toolbar: {
+      items: [
+        {value: "medium", icon: "browser", title: "medium - desktop", right: "medium"},
+        {value: "large", icon: "mobile", title: "large - mobile", right: "large"},
+        {value: "both", icon: "tablet", title: "medium + large", right: "both"}
+      ],
+      dynamicTitle: true,
+    }
+	}
 };
 
 // Global properties added to each component;
@@ -97,6 +129,7 @@ export const argTypes = {
 				darkest: "Darkest",
 			},
 		},
+		if: { global: "backgroundColorDisplay", eq: "default" },
 	},
 	scale: {
 		name: "Platform scale",
@@ -115,6 +148,7 @@ export const argTypes = {
 				large: "Large",
 			},
 		},
+		if: { global: "platformScale", eq: "medium" },
 	},
 	// @todo https://jira.corp.adobe.com/browse/CSS-314
 	reducedMotion: {
@@ -244,7 +278,9 @@ export const decorators = [
 	withReducedMotionWrapper,
 	withContextWrapper,
 	withActions,
-	// ...[isChromatic() ? withSizingWrapper : false].filter(Boolean),
+	withBackgroundColorDisplayWrapper,
+	withPlatformScaleWrapper,
+	withSizingWrapper,
 ];
 
 export default {


### PR DESCRIPTION
## Description

Overall, this work will increase our Chromatic coverage without increasing our number of snapshots by showing LTR and RTL, all three background colors, both platform sizes, and every available size of component to Chromatic by default.

- Implement custom decorators for background color, platform scale, and text direction
- Turn off controls when custom decorators are in use in the toolbar (because the controls don't work unless the global value in the toolbar is set to "default," so removing them to avoid confusion of which to use)
- Turn on size decorator so Chromatic tests components at each size in one snapshot

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

**Text direction** @jenndiaz 
- [x] When `ltr` is active (the default), the component has the ltr direction
- [x] When `rtl` is active, the component have the rtl direction
- [x] When `ltr + rtl` is active, there are two components showing, one is ltr and the other is rtl

**Background color** @jenndiaz 
- [x] When `default bg color` is active, the background is Light
- [x] When `default bg color` is active, the background color can be changed in the control panel
- [x] When `stacked bg colors` is active, the background color cannot be changed in the control panel (it shouldn't even show as a control)
- [x] When `stacked bg colors` is active, the component shows three times with our three different background colors, stacked one on top of the other
- [x] When `side-by-side bg colors` is active, the background color cannot be changed in the control panel (it shouldn't even show as a control)
- [x] When `side-by-side bg colors` is active, the component shows three times with our three different background colors, side by side
- [x] If you go back to the default `default bg color`, the control should show back up in the control panel. If you adjust it, the component adjusts accordingly.

**Platform sizes** @jenndiaz 
- [x] When `medium - desktop` is active, the component shows at the medium platform size
- [x] When `medium - desktop` is active, the platform size can be changed in the control panel
- [x] When `large - mobile` is active, the component shows at the large platform size (usually a bit bigger visually)
- [x] When `large - mobile` is active, the platform size cannot be changed in the control panel (it shouldn't even show as a control)
- [x] When `medium + large` is active, two components show, with a heading of "Platform Size: Size", and one is medium and the other is large (in alignment with their heading)
- [x] When `medium + large` is active, the platform size cannot be changed in the control panel (it shouldn't even show as a control)
- [x] If you go back to the default `medium - desktop`, the control should show back up in the control panel. If you adjust it, the component adjusts accordingly.

**Testing together!**
Try some combinations of the controls:
- [ ] Set `ltr + rtl`, `side-by-side bg colors`, and `medium + large` to see what Chromatic will see
- [ ] Try all sorts of combinations. Try to break it. Adjust control panel controls and then their toolbar counterparts, etc.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.


## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
