### PR TITLE
refactor(opacitycheckerboard): address concerns about inclusion order

### DIFF
--- a/components/opacitycheckerboard/README.md
+++ b/components/opacitycheckerboard/README.md
@@ -1,6 +1,7 @@
 # @spectrum-css/opacitycheckerboard
 
-> Opacity checkerboard
+> Opacity checkerboard is a class used to highlight background color opacity.
+
 
 This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
 

--- a/components/opacitycheckerboard/index.css
+++ b/components/opacitycheckerboard/index.css
@@ -21,8 +21,6 @@ permissions and limitations under the License. */
 }
 
 .spectrum-OpacityCheckerboard {
-	inline-size: 100%;
-	block-size: 100%;
 	background: repeating-conic-gradient(
 			var(
 					--mod-opacity-checkerboard-light,

--- a/components/opacitycheckerboard/metadata/opacitycheckerboard.yml
+++ b/components/opacitycheckerboard/metadata/opacitycheckerboard.yml
@@ -1,15 +1,15 @@
-name: Opacity Checkerboard
-description: Opacity checkerboard is used with other components to highlight opacity.
+name: Opacity checkerboard
+description: Opacity checkerboard is a class used to highlight background color opacity.
 examples:
   - id: opacity-checkerboard
-    name: Opacity Checkerboard
+    name: Opacity checkerboard
     markup: |
       <div style="inline-size: 100px; block-size: 100px;">
-        <div class="spectrum-OpacityCheckerboard">
+        <div class="spectrum-OpacityCheckerboard" style="inline-size: 100%; block-size: 100%;">
         </div>
       </div>
   - id: opacity-checkerboard
-    name: Opacity Checkerboard with color overlay
+    name: Opacity checkerboard with color overlay
     markup: |
       <div style="inline-size: 100px; block-size: 100px;">
         <div class="spectrum-OpacityCheckerboard" style="inline-size: 100%; block-size: 100%;"></div>

--- a/components/opacitycheckerboard/metadata/opacitycheckerboard.yml
+++ b/components/opacitycheckerboard/metadata/opacitycheckerboard.yml
@@ -12,6 +12,6 @@ examples:
     name: Opacity Checkerboard with color overlay
     markup: |
       <div style="inline-size: 100px; block-size: 100px;">
-        <div class="spectrum-OpacityCheckerboard"></div>
+        <div class="spectrum-OpacityCheckerboard" style="inline-size: 100%; block-size: 100%;"></div>
         <div style="background-color: rgba(255, 0, 0, 0.5); inline-size: 100%; block-size: 100%; position: relative; inset-block: -100%"></div>
       </div>

--- a/components/opacitycheckerboard/stories/opacitycheckerboard.stories.js
+++ b/components/opacitycheckerboard/stories/opacitycheckerboard.stories.js
@@ -22,7 +22,7 @@ export default {
 	},
 	args: {
 		rootClass: "spectrum-OpacityCheckerboard",
-		backgroundPosition: "top left"
+		backgroundPosition: "left top"
 	},
 	parameters: {
 		actions: {
@@ -39,11 +39,20 @@ export default {
 	],
 };
 export const Default = Template.bind({});
-Default.args = {};
+Default.args = {
+	customStyles: {
+		"inline-size": "100%",
+		"block-size": "100%"
+	}
+};
 
 export const CheckerboardPosition = Template.bind({});
 CheckerboardPosition.args = {
 	backgroundPosition: 'center center',
+	customStyles: {
+		"inline-size": "100%",
+		"block-size": "100%"
+	}
 };
 CheckerboardPosition.parameters = {
 	docs: {

--- a/components/opacitycheckerboard/stories/opacitycheckerboard.stories.js
+++ b/components/opacitycheckerboard/stories/opacitycheckerboard.stories.js
@@ -5,7 +5,7 @@ import { styleMap } from "lit/directives/style-map.js";
 import { Template } from "./template";
 
 export default {
-	title: "Components/Opacity checkerboard",
+	title: "Utilities/Opacity checkerboard",
 	description:
 		"Opacity checkerboard is used with other components to highlight opacity.",
 	component: "OpacityCheckerboard",

--- a/components/opacitycheckerboard/stories/opacitycheckerboard.stories.js
+++ b/components/opacitycheckerboard/stories/opacitycheckerboard.stories.js
@@ -5,7 +5,7 @@ import { styleMap } from "lit/directives/style-map.js";
 import { Template } from "./template";
 
 export default {
-	title: "Utilities/Opacity checkerboard",
+	title: "Components/Opacity checkerboard",
 	description:
 		"Opacity checkerboard is used with other components to highlight opacity.",
 	component: "OpacityCheckerboard",

--- a/components/opacitycheckerboard/stories/template.js
+++ b/components/opacitycheckerboard/stories/template.js
@@ -22,6 +22,8 @@ export const Template = ({
 			})}
 			style=${ifDefined(styleMap({
 				"--mod-opacity-checkerboard-position": backgroundPosition,
+				"inline-size": "100%",
+				"block-size": "100%",
 				...customStyles,
 			}))}
 			role=${ifDefined(role)}

--- a/components/opacitycheckerboard/stories/template.js
+++ b/components/opacitycheckerboard/stories/template.js
@@ -7,7 +7,7 @@ import "../index.css";
 
 export const Template = ({
 	rootClass = "spectrum-OpacityCheckerboard",
-	backgroundPosition = "top left",
+	backgroundPosition,
 	customClasses = [],
 	customStyles = {},
 	id,
@@ -22,8 +22,6 @@ export const Template = ({
 			})}
 			style=${ifDefined(styleMap({
 				"--mod-opacity-checkerboard-position": backgroundPosition,
-				"inline-size": "100%",
-				"block-size": "100%",
 				...customStyles,
 			}))}
 			role=${ifDefined(role)}


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description
Addresses: #2139 

> "With both the spectrum-ColorHandle and the spectrum-OpacityCheckerboard classes applied to the host element the rules within those selectors will race depending on how CSS is deployed in a consuming application. Specifically, the size rules for .spectrum-OpacityCheckerboard
> Can overwrite those of .spectrum-ColorHandle:"
> 

Changes: 
- removes "inline-size": "100%", "block-size": "100%", since the background should be used with a component with these properties already set, this is not needed with in this classes CSS
- move from components in storybook into utilities 
- improve docs for component and update storybook 

These changes as well as the SWC documentation improvements merged in with [SWC PR 3651 ](https://github.com/adobe/spectrum-web-components/pull/3651) addresses concerns around inclusion order when using the opacity checkerboard. 

Alternative approach to now closed [PR #2350](https://github.com/adobe/spectrum-css/pull/2350)

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

tested by @mdt2 

On the [docs site](https://pr-2382--spectrum-css.netlify.app/opacitycheckerboard):
- [x] opacity checkerboard displayed with no changes 
- [x] no changes to opacity checkerboard within Colorhandle, Colorslider, Swatch, or Thumbnail

In [storybook](https://pr-2382--spectrum-css.netlify.app/preview/?path=/docs/utilities-opacity-checkerboard--docs): 
- [x] no changes to opacity checkerboard within Colorhandle, Colorslider, Swatch, or Thumbnail
- [x] opacity checkerboard moved to Utilities folder in the side nav


### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
