### PR TITLE
chore(ci): correct the direction of diff equations

### DIFF
--- a/.github/actions/file-diff/README.md
+++ b/.github/actions/file-diff/README.md
@@ -4,11 +4,11 @@ A GitHub Action for comparing compiled assets between branches.
 
 ## Inputs
 
-### `path`
+### `head-path`
 
 **Required** Path to file or directory for file sizes analysis.
 
-### `diff-path`
+### `base-path`
 
 **Optional** Path to another directory against which to perform file comparisons.
 
@@ -44,8 +44,8 @@ Total size of all files for this branch in bytes.
 name: Compare compiled output file size
 uses: "spectrum-tools/gh-action-file-diff"
 with:
-    path: ${{ github.workspace }}/pull-request
-    diff-path: ${{ github.workspace }}/base-branch
+    head-path: ${{ github.workspace }}/pull-request
+    base-path: ${{ github.workspace }}/base-branch
     file-glob-pattern: |
         components/*/dist/*.{css,json}
         components/*/dist/themes/*.css

--- a/.github/actions/file-diff/action.yml
+++ b/.github/actions/file-diff/action.yml
@@ -2,11 +2,11 @@ name: "File comparisons"
 description: "Compares files between branches."
 author: "spectrum-tools"
 inputs:
-    path:
+    head-path:
         description: "Path to file or directory for file sizes analysis."
         required: false
         default: ${{ github.workspace }}
-    diff-path:
+    base-path:
         description: "Optional path to another directory to perform file size diff against the provided path."
         required: false
     token:

--- a/.github/actions/file-diff/index.js
+++ b/.github/actions/file-diff/index.js
@@ -26,8 +26,8 @@ async function run() {
 	try {
 		// --------------- Fetch user input values  ---------------
 		const token = core.getInput("token");
-		const path = core.getInput("path");
-		const diffPath = core.getInput("diff-path");
+		const headPath = core.getInput("head-path");
+		const basePath = core.getInput("base-path");
 		const fileGlobPattern = core.getMultilineInput("file-glob-pattern", {
 			trimWhitespace: true,
 		});
@@ -37,14 +37,14 @@ async function run() {
 
 		// --------------- Evaluate compiled assets  ---------------
 		/** @type Map<string, number> */
-		const pathOutput = await fetchFilesAndSizes(path, fileGlobPattern, {
+		const headOutput = await fetchFilesAndSizes(headPath, fileGlobPattern, {
 			core,
 		});
 		/**
 		 * If a diff path is provided, get the diff files and their sizes
 		 * @type Map<string, number>
 		 **/
-		const diffOutput = await fetchFilesAndSizes(diffPath, fileGlobPattern, {
+		const baseOutput = await fetchFilesAndSizes(basePath, fileGlobPattern, {
 			core,
 		});
 		/**
@@ -52,24 +52,28 @@ async function run() {
 		 * and not just reporting on the overall size of the compiled assets
 		 * @type boolean
 		 */
-		const hasDiff = diffOutput.size > 0;
+		const hasDiff = baseOutput.size > 0;
 		// --------------- End evaluation  ---------------
 
 		/** Split the data by component package */
-		const { filePath, PACKAGES } = splitDataByPackage(pathOutput, path, diffOutput);
-		const sections = makeTable(PACKAGES, filePath, path);
+		const { filePath, PACKAGES } = splitDataByPackage(headOutput, headPath, baseOutput);
+		const sections = makeTable(PACKAGES, filePath, headPath);
 
-		const overallSize = [...pathOutput.values()].reduce(
+		/** Calculate the total size of the pull request's assets */
+		const overallHeadSize = [...headOutput.values()].reduce(
 			(acc, size) => acc + size,
 			0
 		);
 
-		/** Calculate the overall size of the updated assets */
-		const overallDiffSize = hasDiff
-			? [...diffOutput.values()].reduce((acc, size) => acc + size, 0)
+		/** Calculate the overall size of the base branch's assets */
+		const overallBaseSize = hasDiff
+			? [...baseOutput.values()].reduce((acc, size) => acc + size, 0)
 			: undefined;
 
+		const hasChange = overallHeadSize !== overallBaseSize;
+
 		/** If no diff map data provided, we're going to report on the overall size */
+
 		/**
 		 * If the updated assets are the same as the original,
 		 * report no change
@@ -78,89 +82,98 @@ async function run() {
 		const markdown = [];
 		const summary = [
 			"### Summary",
-			`**Total size**: ${bytesToSize(overallDiffSize)}<sup>*</sup>`
+			`**Total size**: ${bytesToSize(overallHeadSize)}<sup>*</sup>`,
 		];
-		const summaryTable = [];
+
+		let summaryTable = [];
 
 		if (sections.length === 0) {
 			summary.push(...["", " 🎉 No changes detected in any packages"]);
 		} else {
-			if (diffOutput.size > 0 && hasDiff) {
-				let changeSummary = `**Total change (Δ)**: ${printChange(
-					overallDiffSize - overallSize
-				)}`;
-
-				if (overallSize === overallDiffSize) changeSummary += " 🎉";
-				else
-					changeSummary += ` (${printPercentChange(
-						(overallDiffSize - overallSize) / overallSize
-					)})`;
-
-				summary.push(...[changeSummary, ""]);
+			/**
+			 * Calculate the change in size
+			 * PR - base / base = change
+			 */
+			let changeSummary = "";
+			if (baseOutput.size > 0 && hasDiff && hasChange) {
+				changeSummary = `**Total change (Δ)**: ${printChange(overallHeadSize, overallBaseSize)} (${printPercentChange(overallHeadSize, overallBaseSize)})`;
+			} else if (baseOutput.size > 0 && hasDiff && !hasChange) {
+				changeSummary = `No change in file sizes`;
 			}
 
-			summaryTable.push(
-				["Package", "Size", ...(hasDiff ? ["Δ"] : [])],
-				["-", "-", ...(hasDiff ? ["-"] : [])]
-			);
+			if (changeSummary !== "") {
+				summary.push(...[
+					changeSummary,
+					"<small><em>Table reports on changes to a package's main file. Other changes can be found in the collapsed \"Details\" below.</em></small>",
+					""
+				]);
+			}
 
 			markdown.push(`<details>`, `<summary><b>Details</b></summary>`, "");
 
-			sections.map(({ name, filePath, totalSize, totalDiffSize, hasChange, fileMap }) => {
-				const md = ["", `#### ${name}`, ""];
-				const data = [name, bytesToSize(totalDiffSize)];
-
+			sections.map(({ name, filePath, headMainSize, baseMainSize, hasChange, mainFile, fileMap }) => {
 				if (!hasChange) return;
 
+				const data = [];
+
+				/** We only evaluate changes if there is a diff branch being used and this is the main file for the package */
 				if (hasDiff) {
-					// If a diff path was provided and the component folder doesn't exist,
-					// report that the compiled assets were removed
+					/**
+					 * If: the component folder exists in the original branch but not the PR
+					 * Or: the pull request file size is 0 or empty but the original branch has a size
+					 * Then: report that it was removed, moved, or renamed
+					 *
+					 * Else if: the component folder exists in the PR but not the original branch
+					 * Or: the pull request file has size but the original branch does not
+					 * Then: report that it's new
+					 *
+					 * Else if: the difference between the two sizes is not 0 (i.e. there is a change)
+					 * Then: report the change
+					 *
+					 * Else: report that there is no change
+					 */
 					if (
-						!existsSync(join(diffPath, filePath, name)) ||
-						(totalSize === 0 && totalDiffSize > 0)
+						(existsSync(join(basePath, filePath, name)) && !existsSync(join(headPath, filePath, name)))
 					) {
 						data.push("🚨 deleted, moved, or renamed");
-						summaryTable.push(data);
-					} else if (totalSize > 0 && totalDiffSize === 0) {
+					} else if (
+						(existsSync(join(headPath, filePath, name)) && !existsSync(join(basePath, filePath, name)))
+					) {
 						data.push("🎉 new");
-						summaryTable.push(data);
-					} else if (bytesToSize(Math.abs(totalDiffSize - totalSize)) !== "< 0.01 KB") {
-						data.push(printChange(totalDiffSize - totalSize));
-						summaryTable.push(data);
+					} else if (
+						((Math.abs(difference(headMainSize, baseMainSize))) / 1000) >= 0.001
+					) {
+						data.push(printChange(headMainSize, baseMainSize));
+					}
+
+					if (data.length > 0) {
+						summaryTable.push([name, bytesToSize(headMainSize), data]);
 					}
 				}
 
+
+				const md = ["", `#### ${name}`, ""];
 				md.push(
 					...[
-						["File", "Size", ...(hasDiff ? ["Base", "Δ"] : [])],
+						["File", "Head", ...(hasDiff ? ["Base", "Δ"] : [])],
 						[" - ", " - ", ...(hasDiff ? [" - ", " - "] : [])],
-						[
-							"**Total**",
-							bytesToSize(totalSize),
-							...(hasDiff
-								? [
-									bytesToSize(totalDiffSize),
-									`${printChange(totalDiffSize - totalSize)}${totalDiffSize - totalSize !== 0 ? ` (${printPercentChange((totalDiffSize - totalSize) / totalSize)})` : ""}`,
-								]
-								: []),
-						],
 					].map((row) => `| ${row.join(" | ")} |`),
 					...[...fileMap.entries()]
 						.reduce(
 							(
-								table,
-								[readableFilename, { byteSize = 0, diffByteSize = 0 }]
+								table, // accumulator
+								[readableFilename, { headByteSize = 0, baseByteSize = 0 }] // deconstructed filemap entry; i.e., Map<key, { ...values }> = [key, { ...values }]
 							) => {
 								// @todo readable filename can be linked to html diff of the file?
 								// https://github.com/adobe/spectrum-css/pull/2093/files#diff-6badd53e481452b5af234953767029ef2e364427dd84cdeed25f5778b6fca2e6
 								return [
 									...table,
 									[
-										readableFilename,
-										byteSize === 0 && diffByteSize > 0 ? "**removed**" : bytesToSize(byteSize),
+										readableFilename === mainFile ? `**${readableFilename}**` : readableFilename,
+										isRemoved(headByteSize, baseByteSize) ? "**removed**" : isNew(headByteSize, baseByteSize) ? "**new**" : bytesToSize(headByteSize),
 										...(hasDiff ? [
-											bytesToSize(diffByteSize),
-											`${printChange(diffByteSize - byteSize)}${diffByteSize - byteSize !== 0 ? ` (${printPercentChange((diffByteSize - byteSize) / byteSize)})` : ""}`,
+											bytesToSize(baseByteSize),
+											`${printChange(headByteSize, baseByteSize)}${difference(headByteSize, baseByteSize) !== 0 ? ` (${printPercentChange(headByteSize , baseByteSize)})` : ""}`,
 										] : []),
 									]
 								];
@@ -176,7 +189,14 @@ async function run() {
 			markdown.push("", `</details>`);
 		}
 
-		if (summaryTable.length > 1) {
+		if (summaryTable.length > 0) {
+			// Add the headings to the summary table if it contains data
+			summaryTable = [
+				["Package", "Size", ...(hasDiff ? ["Δ"] : [])],
+				["-", "-", ...(hasDiff ? ["-"] : [])],
+				...summaryTable,
+			];
+
 			summary.push(...summaryTable.map((row) => `| ${row.join(" | ")} |`));
 		}
 
@@ -210,22 +230,22 @@ async function run() {
 		core.summary = summary.join("\n");
 
 		// --------------- Set output variables  ---------------
-		if (pathOutput.size > 0) {
-			const totalSize = [...pathOutput.entries()].reduce(
+		if (headOutput.size > 0) {
+			const headMainSize = [...headOutput.entries()].reduce(
 				(acc, [_, size]) => acc + size,
 				0
 			);
-			core.setOutput("total-size", totalSize);
+			core.setOutput("total-size", headMainSize);
 
 			if (hasDiff) {
-				const totalDiffSize = [...diffOutput.entries()].reduce(
+				const baseMainSize = [...baseOutput.entries()].reduce(
 					(acc, [_, size]) => acc + size,
 					0
 				);
 
 				core.setOutput(
 					"has-changed",
-					hasDiff && totalSize !== totalDiffSize ? "true" : "false"
+					hasDiff && headMainSize !== baseMainSize ? "true" : "false"
 				);
 			}
 		} else {
@@ -239,16 +259,23 @@ async function run() {
 
 run();
 
+/** A few helpful utility functions; v1 == PR (change); v0 == base (initial) */
+const difference = (v1, v0) => v1 - v0;
+const isRemoved = (v1, v0) => (!v1 || v1 === 0) && (v0 && v0 > 0);
+const isNew = (v1, v0) => (v1 && v1 > 0) && (!v0 || v0 === 0);
+
 /**
  * Convert the provided difference between file sizes into a human
  * readable representation of the change.
  * @param {number} difference
  * @returns {string}
  */
-const printChange = function (difference) {
-	return difference === 0
+const printChange = function (v1, v0) {
+	/** Calculate the change in size: v1 - v0 = change */
+	const d = difference(v1, v0);
+	return d === 0
 		? `-`
-		: `${difference > 0 ? "⬆" : "⬇"} ${bytesToSize(Math.abs(difference))}`;
+		: `${d > 0 ? "⬆" : "⬇"} ${bytesToSize(Math.abs(d))}`;
 };
 
 /**
@@ -258,17 +285,18 @@ const printChange = function (difference) {
  * @param {number} original
  * @returns {string}
  */
-const printPercentChange = function (delta) {
+const printPercentChange = function (v1, v0) {
+	const delta = ((v1 - v0) / v0) * 100;
 	if (delta === 0) return `no change`;
-	return `${Math.abs(delta * 100).toFixed(2)}%`;
+	return `${delta.toFixed(2)}%`;
 };
 
 /**
  *
- * @param {Map<string, Map<string, { byteSize: number, diffByteSize: number }>>} PACKAGES
+ * @param {Map<string, Map<string, { headByteSize: number, baseByteSize: number }>>} PACKAGES
  * @param {string} filePath - The path to the component's dist folder from the root of the repo
  * @param {string} path - The path from the github workspace to the root of the repo
- * @returns {Array<{ name: string, filePath: string, totalSize: number, totalDiffSize: number, hasChange: boolean, fileMap: Map<string, { byteSize: number, diffByteSize: number }>}>}
+ * @returns {Array<{ name: string, filePath: string, headMainSize: number, baseMainSize: number, hasChange: boolean, fileMap: Map<string, { headByteSize: number, baseByteSize: number }>}>}
  */
 const makeTable = function (PACKAGES, filePath, path) {
 	const sections = [];
@@ -280,38 +308,41 @@ const makeTable = function (PACKAGES, filePath, path) {
 
 		let mainFile = "index.css";
 		if (existsSync(packagePath)) {
-			mainFile = require(join(path, filePath, packageName, "package.json"))?.main;
+			const { main } = require(packagePath) ?? {};
+			if (main) mainFile = main.replace(/^.*\/dist\//, "");
 		}
 
 		const mainFileOnly = [...fileMap.keys()].filter((file) => file.endsWith(mainFile));
-		const totalSize = mainFileOnly.reduce(
+		const headMainSize = mainFileOnly.reduce(
 			(acc, filename) => {
-				const { byteSize = 0 } = fileMap.get(filename);
-				return acc + byteSize;
-			},
-			0
-		);
-		const totalDiffSize = mainFileOnly.reduce(
-			(acc, filename) => {
-				const { diffByteSize = 0 } = fileMap.get(filename);
-				return acc + diffByteSize;
+				const { headByteSize = 0 } = fileMap.get(filename);
+				return acc + headByteSize;
 			},
 			0
 		);
 
-		const hasChange = fileMap.size > 0 && [...fileMap.values()].some(({ byteSize, diffByteSize }) => byteSize !== diffByteSize);
+		const baseMainSize = mainFileOnly.reduce(
+			(acc, filename) => {
+				const { baseByteSize = 0 } = fileMap.get(filename);
+				return acc + baseByteSize;
+			},
+			0
+		);
+
+		const hasChange = fileMap.size > 0 && [...fileMap.values()].some(({ headByteSize, baseByteSize }) => headByteSize !== baseByteSize);
 
 		/**
 		 * We don't need to report on components that haven't changed unless they're new or removed
 		 */
-		if (totalSize === totalDiffSize) return;
+		if (headMainSize === baseMainSize) return;
 
 		sections.push({
 			name: packageName,
 			filePath,
-			totalSize,
-			totalDiffSize,
+			headMainSize,
+			baseMainSize,
 			hasChange,
+			mainFile: mainFileOnly?.[0],
 			fileMap
 		});
 	});
@@ -323,14 +354,14 @@ const makeTable = function (PACKAGES, filePath, path) {
  * Split out the data indexed by filename into groups by component
  * @param {Map<string, number>} dataMap
  * @param {string} path
- * @param {Map<string, number>} diffMap
- * @returns {{ filePath: string, PACKAGES: Map<string, Map<string, { byteSize: number, diffByteSize: number }>>}}
+ * @param {Map<string, number>} baseMap
+ * @returns {{ filePath: string, PACKAGES: Map<string, Map<string, { headByteSize: number, baseByteSize: number }>>}}
  */
-const splitDataByPackage = function (dataMap, path, diffMap = new Map()) {
+const splitDataByPackage = function (dataMap, path, baseMap = new Map()) {
 	const PACKAGES = new Map();
 
 	let filePath;
-	[...dataMap.entries()].forEach(([file, byteSize]) => {
+	[...dataMap.entries()].forEach(([file, headByteSize]) => {
 		// Determine the name of the component
 		const parts = file.split(sep);
 		const componentIdx = parts.findIndex((part) => part === "dist") - 1;
@@ -348,8 +379,8 @@ const splitDataByPackage = function (dataMap, path, diffMap = new Map()) {
 
 		if (!fileMap.has(readableFilename)) {
 			fileMap.set(readableFilename, {
-				byteSize,
-				diffByteSize: diffMap.get(file),
+				headByteSize: headByteSize,
+				baseByteSize: baseMap.get(file),
 			});
 		} else {
 			throw new Error(`The file ${file} was found twice in the dataset`);

--- a/.github/workflows/compare-results.yml
+++ b/.github/workflows/compare-results.yml
@@ -90,8 +90,8 @@ jobs:
               uses: ./.github/actions/file-diff
               # uses: spectrum-tools/gh-action-file-diff@v1
               with:
-                  path: ${{ github.workspace }}/${{ inputs.head-sha }}/
-                  diff-path: ${{ github.workspace }}/${{ inputs.base-sha }}/
+                  head-path: ${{ github.workspace }}/${{ inputs.head-sha }}/
+                  base-path: ${{ github.workspace }}/${{ inputs.base-sha }}/
                   file-glob-pattern: |
                     components/*/dist/**
                     tokens/dist/**

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,7 @@
 	},
 	"[javascript]": {
 		"editor.codeActionsOnSave": {
-			"source.organizeImports": true
+			"source.organizeImports": "explicit"
 		},
 		"editor.colorDecorators": true,
 		"editor.defaultFormatter": "dbaeumer.vscode-eslint"


### PR DESCRIPTION
## Description

This is clarifying some of the equations used to determine file diffs and creates a clearer variable naming for the head and base branches being evaluated.

* path renamed to head-path
* diff-path renamed to base-path
* this same renaming is carried throughout the file-diff/index.js file
* before the summary table, I added the following note: `Table below reports only on changes to a package's main file. Other changes can be found in the collapsed "Details" below.`
* fixed the summary table to report on changes to the main file (before it was reported whatever the last file in the list was)
* more comments throughout

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

- [x] Pulled into #2398 to verify diff reporting 

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
