### PR TITLE
fix: remove storybook-addon-pseudo-states

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -32,7 +32,6 @@ module.exports = {
 		"@whitespace/storybook-addon-html",
 		// https://storybook.js.org/addons/@etchteam/storybook-addon-status
 		"@etchteam/storybook-addon-status",
-    	"storybook-addon-pseudo-states",
 		// https://github.com/storybookjs/storybook/tree/next/code/addons/interactions
 		"@storybook/addon-interactions",
 		// https://www.chromatic.com/docs/visual-testing-addon/

--- a/.storybook/package.json
+++ b/.storybook/package.json
@@ -57,7 +57,6 @@
     "react-syntax-highlighter": "^15.5.0",
     "source-map-loader": "^4.0.1",
     "storybook": "^7.5.1",
-    "storybook-addon-pseudo-states": "^2.1.0",
     "style-loader": "3.3.3",
     "webpack": "^5.83.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -16053,11 +16053,6 @@ store2@^2.14.2:
   resolved "https://registry.yarnpkg.com/store2/-/store2-2.14.2.tgz#56138d200f9fe5f582ad63bc2704dbc0e4a45068"
   integrity sha512-siT1RiqlfQnGqgT/YzXVUNsom9S0H1OX+dpdGN1xkyYATo4I6sep5NmsRD/40s3IIOvlCq6akxkqG82urIZW1w==
 
-storybook-addon-pseudo-states@^2.1.0:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/storybook-addon-pseudo-states/-/storybook-addon-pseudo-states-2.1.2.tgz#9a04b8b97abecba69a47eca37966e297d15f924f"
-  integrity sha512-AHv6q1JiQEUnMyZE3729iV6cNmBW7bueeytc4Lga4+8W1En8YNea5VjqAdrDNJhXVU0QEEIGtxkD3EoC9aVWLw==
-
 storybook@^7.5.1:
   version "7.5.3"
   resolved "https://registry.yarnpkg.com/storybook/-/storybook-7.5.3.tgz#0003b072736b8b15c3b7205e9775d0c5ec898b4d"


### PR DESCRIPTION
## Description

Removes the Storybook addon `storybook-addon-pseudo-states`.

This addon for Storybook injects some CSS that results in components displaying differently. Resulting in incorrect component previews and VRTs. This was noticed in both Stepper and Combobox, especially with any styles containing `:not` selectors.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [ ] Storybook still builds with `yarn start`.
- [ ] Pseudo state selector is gone from the Storybook toolbar.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

An example of how this addon was causing components to render incorrectly in PR #2375 :

Addon enabled (Storybook):
![Screenshot 2024-01-04 at 11 26 57 AM](https://github.com/adobe/spectrum-css/assets/965114/36394265-5993-4f3d-8227-567cf78dc011)

Addon disabled (Storybook):
![Screenshot 2024-01-04 at 11 24 32 AM](https://github.com/adobe/spectrum-css/assets/965114/6a73286e-803d-48bb-b3af-0294887cf016)

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] ✨ This pull request is ready to merge. ✨
