### PR TITLE
chore: update build script used in chromatic config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 CHROMATIC_PROJECT_TOKEN=1234abcd
 CHROMATIC_PROJECT_ID="Project:64762974a45b8bc5ca1705a2"
-CHROMATIC_BUILD_SCRIPT_NAME="ci:storybook"
+# Note: the build script here should be defined in .storybook/package.json
+# this is used by the chromatic storybook addon to build the storybook on the fly
+CHROMATIC_BUILD_SCRIPT_NAME="build"
 
 # NX settings
 NX_PREFER_TS_NODE=true


### PR DESCRIPTION
## Description

Chromatic's config is looking for a build script in the .storybook config folder but the current script defined is one that exists at the root package. This corrects this and thus allows us to re-run baselines from the UI in a local storybook instance.

## How and where has this been tested?

### Setup

1. Delete any existing `.env` files and `.storybook/chromatic.config.json` files.
2. `yarn install` - after the install, this runs the config script which generates a new set of the above files.
  - [x] Expect the `chromatic.config.json` to look like (with **** being replaced by your personal chromatic token):

```
{
  "projectToken": "********",
  "projectId": "Project:64762974a45b8bc5ca1705a2",
  "buildScriptName": "build"
}
```

  - [x] Expect the .env file to now include:

```
CHROMATIC_PROJECT_ID="Project:64762974a45b8bc5ca1705a2"
# Note: the build script here should be defined in .storybook/package.json
# this is used by the chromatic storybook addon to build the storybook on the fly
CHROMATIC_BUILD_SCRIPT_NAME="build"
```

### Validate

1. `yarn start`
2. Go to a story (not a docs page) and click the `Visual Tests` tab in the panel.
3. Click the `Sign in with Chromatic` button.
4. Click the `Go to Chromatic` button and verify the matching code. (sign-in if necessary)

  - [x] Expect not to have to select a project (this should be read in from the config
  - [x] By clicking the `build started` button the Visual Tests panel, it should successfully kick off a chromatic run

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] ✨ This pull request is ready to merge. ✨
