### PR TITLE
build: minor typography fix to align with styleguide

### DIFF
--- a/components/accordion/metadata/mods.md
+++ b/components/accordion/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                          |
+| Modifiable custom properties                          |
 | ----------------------------------------------------- |
 | `--mod-accordion-background-color-default`            |
 | `--mod-accordion-background-color-down`               |

--- a/components/actionbar/metadata/mods.md
+++ b/components/actionbar/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                    |
+| Modifiable custom properties                    |
 | ----------------------------------------------- |
 | `--mod-actionbar-corner-radius`                 |
 | `--mod-actionbar-emphasized-background-color`   |

--- a/components/actionbutton/metadata/mods.md
+++ b/components/actionbutton/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                                      |
+| Modifiable custom properties                                      |
 | ----------------------------------------------------------------- |
 | `--mod-actionbutton-animation-duration`                           |
 | `--mod-actionbutton-background-color-default`                     |

--- a/components/actiongroup/metadata/mods.md
+++ b/components/actiongroup/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                   |
+| Modifiable custom properties                   |
 | ---------------------------------------------- |
 | `--mod-actiongroup-border-radius`              |
 | `--mod-actiongroup-border-radius-reset`        |

--- a/components/alertbanner/metadata/mods.md
+++ b/components/alertbanner/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                   |
+| Modifiable custom properties                   |
 | ---------------------------------------------- |
 | `--mod-alert-banner-bottom-text`               |
 | `--mod-alert-banner-close-button-spacing`      |

--- a/components/alertdialog/metadata/mods.md
+++ b/components/alertdialog/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                |
+| Modifiable custom properties                |
 | ------------------------------------------- |
 | `--mod-alert-dialog-body-color`             |
 | `--mod-alert-dialog-body-font-family`       |

--- a/components/assetcard/metadata/mods.md
+++ b/components/assetcard/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                                  |
+| Modifiable custom properties                                  |
 | ------------------------------------------------------------- |
 | `--mod-assectcard-border-color-selected-down`                 |
 | `--mod-assectcard-focus-indicator-color`                      |

--- a/components/assetlist/metadata/mods.md
+++ b/components/assetlist/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                           |
+| Modifiable custom properties                           |
 | ------------------------------------------------------ |
 | `--mod-assetlist-border-color-key-focus`               |
 | `--mod-assetlist-child-indicator-animation`            |

--- a/components/avatar/metadata/mods.md
+++ b/components/avatar/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties             |
+| Modifiable custom properties             |
 | ---------------------------------------- |
 | `--mod-avatar-block-size`                |
 | `--mod-avatar-border-radius`             |

--- a/components/badge/metadata/mods.md
+++ b/components/badge/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                |
+| Modifiable custom properties                |
 | ------------------------------------------- |
 | `--mod-badge-background-color-accent`       |
 | `--mod-badge-background-color-blue`         |

--- a/components/breadcrumb/metadata/mods.md
+++ b/components/breadcrumb/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                                      |
+| Modifiable custom properties                                      |
 | ----------------------------------------------------------------- |
 | `--mod-breadcrumbs-action-button-color`                           |
 | `--mod-breadcrumbs-action-button-color-disabled`                  |

--- a/components/button/metadata/mods.md
+++ b/components/button/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties               |
+| Modifiable custom properties               |
 | ------------------------------------------ |
 | `--mod-animation-duration-100`             |
 | `--mod-bold-font-weight`                   |

--- a/components/buttongroup/metadata/mods.md
+++ b/components/buttongroup/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties           |
+| Modifiable custom properties           |
 | -------------------------------------- |
 | `--mod-buttongroup-justify-content`    |
 | `--mod-buttongroup-spacing-horizontal` |

--- a/components/calendar/metadata/mods.md
+++ b/components/calendar/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                               |
+| Modifiable custom properties                               |
 | ---------------------------------------------------------- |
 | `--mod-calendar-border-radius-reset`                       |
 | `--mod-calendar-border-width-reset`                        |

--- a/components/card/metadata/mods.md
+++ b/components/card/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                  |
+| Modifiable custom properties                  |
 | --------------------------------------------- |
 | `--mod-animation-duration-100`                |
 | `--mod-card-actions-background-color-opacity` |

--- a/components/checkbox/metadata/mods.md
+++ b/components/checkbox/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                    |
+| Modifiable custom properties                    |
 | ----------------------------------------------- |
 | `--mod-checkbox-animation-duration`             |
 | `--mod-checkbox-border-width`                   |

--- a/components/clearbutton/metadata/mods.md
+++ b/components/clearbutton/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                    |
+| Modifiable custom properties                    |
 | ----------------------------------------------- |
 | `--mod-clear-button-background-color`           |
 | `--mod-clear-button-background-color-disabled`  |

--- a/components/closebutton/metadata/mods.md
+++ b/components/closebutton/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                        |
+| Modifiable custom properties                        |
 | --------------------------------------------------- |
 | `--mod-animation-duration-100`                      |
 | `--mod-closebutton-align-self`                      |

--- a/components/coachindicator/metadata/mods.md
+++ b/components/coachindicator/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                                      |
+| Modifiable custom properties                                      |
 | ----------------------------------------------------------------- |
 | `--mod-coach-animation-indicator-ring-center-delay-multiple`      |
 | `--mod-coach-animation-indicator-ring-duration`                   |

--- a/components/coachmark/metadata/mods.md
+++ b/components/coachmark/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties               |
+| Modifiable custom properties               |
 | ------------------------------------------ |
 | `--mod-coachmark-body-to-footer`           |
 | `--mod-coachmark-border-radius`            |

--- a/components/colorarea/metadata/mods.md
+++ b/components/colorarea/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                |
+| Modifiable custom properties                |
 | ------------------------------------------- |
 | `--mod-colorarea-border-color`              |
 | `--mod-colorarea-border-radius`             |

--- a/components/colorhandle/metadata/mods.md
+++ b/components/colorhandle/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties              |
+| Modifiable custom properties              |
 | ----------------------------------------- |
 | `--mod-colorhandle-animation-duration`    |
 | `--mod-colorhandle-animation-easing`      |

--- a/components/colorloupe/metadata/mods.md
+++ b/components/colorloupe/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties          |
+| Modifiable custom properties          |
 | ------------------------------------- |
 | `--mod-colorloupe-animation-distance` |
 | `--mod-colorloupe-drop-shadow-blur`   |

--- a/components/colorslider/metadata/mods.md
+++ b/components/colorslider/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                      |
+| Modifiable custom properties                      |
 | ------------------------------------------------- |
 | `--mod-color-slider-background-color-disabled`    |
 | `--mod-color-slider-border-color`                 |

--- a/components/colorwheel/metadata/mods.md
+++ b/components/colorwheel/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                |
+| Modifiable custom properties                |
 | ------------------------------------------- |
 | `--mod-colorwheel-border-color`             |
 | `--mod-colorwheel-border-width`             |

--- a/components/combobox/metadata/mods.md
+++ b/components/combobox/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                           |
+| Modifiable custom properties                           |
 | ------------------------------------------------------ |
 | `--mod-combobox-alert-icon-color`                      |
 | `--mod-combobox-background-color-default`              |

--- a/components/contextualhelp/metadata/mods.md
+++ b/components/contextualhelp/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                     |
+| Modifiable custom properties                     |
 | ------------------------------------------------ |
 | `--mod-contextual-help-body-color`               |
 | `--mod-contextual-help-heading-color`            |

--- a/components/datepicker/metadata/mods.md
+++ b/components/datepicker/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                         |
+| Modifiable custom properties                         |
 | ---------------------------------------------------- |
 | `--mod-datepicker-border-color-disabled`             |
 | `--mod-datepicker-border-radius`                     |

--- a/components/dial/metadata/mods.md
+++ b/components/dial/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                 |
+| Modifiable custom properties                 |
 | -------------------------------------------- |
 | `--mod-dial-background-color-default`        |
 | `--mod-dial-border-color`                    |

--- a/components/dialog/metadata/mods.md
+++ b/components/dialog/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                        |
+| Modifiable custom properties                        |
 | --------------------------------------------------- |
 | `--mod-dialog-confirm-border-radius`                |
 | `--mod-dialog-confirm-buttongroup-padding-top`      |

--- a/components/divider/metadata/mods.md
+++ b/components/divider/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                         |
+| Modifiable custom properties                         |
 | ---------------------------------------------------- |
 | `--mod-divider-background-color`                     |
 | `--mod-divider-background-color-large-static-black`  |

--- a/components/dropindicator/metadata/mods.md
+++ b/components/dropindicator/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties       |
+| Modifiable custom properties       |
 | ---------------------------------- |
 | `--mod-dropindicator-border-color` |
 | `--mod-dropindicator-border-size`  |

--- a/components/dropzone/metadata/mods.md
+++ b/components/dropzone/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                      |
+| Modifiable custom properties                      |
 | ------------------------------------------------- |
 | `--mod-drop-zone-background-color`                |
 | `--mod-drop-zone-background-color-opacity`        |

--- a/components/fieldlabel/metadata/mods.md
+++ b/components/fieldlabel/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                      |
+| Modifiable custom properties                      |
 | ------------------------------------------------- |
 | `--mod-disabled-content-color`                    |
 | `--mod-field-label-asterisk-vertical-align`       |

--- a/components/floatingactionbutton/metadata/mods.md
+++ b/components/floatingactionbutton/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                              |
+| Modifiable custom properties                              |
 | --------------------------------------------------------- |
 | `--mod-afloating-action-button-focus-ring-color`          |
 | `--mod-floating-action-button-background-color`           |

--- a/components/helptext/metadata/mods.md
+++ b/components/helptext/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties             |
+| Modifiable custom properties             |
 | ---------------------------------------- |
 | `--mod-helptext-bottom-to-text`          |
 | `--mod-helptext-bottom-to-workflow-icon` |

--- a/components/icon/metadata/mods.md
+++ b/components/icon/metadata/mods.md
@@ -1,3 +1,3 @@
-| Modifiable Custom Properties |
+| Modifiable custom properties |
 | ---------------------------- |
 | `--mod-icon-color`           |

--- a/components/illustratedmessage/metadata/mods.md
+++ b/components/illustratedmessage/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                            |
+| Modifiable custom properties                            |
 | ------------------------------------------------------- |
 | `--mod-illustrated-message-content-maximum-width`       |
 | `--mod-illustrated-message-description-color`           |

--- a/components/infieldbutton/metadata/mods.md
+++ b/components/infieldbutton/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                                  |
+| Modifiable custom properties                                  |
 | ------------------------------------------------------------- |
 | `--mod-infield-border-color-quiet`                            |
 | `--mod-infield-button-background-color`                       |

--- a/components/inlinealert/metadata/mods.md
+++ b/components/inlinealert/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                       |
+| Modifiable custom properties                       |
 | -------------------------------------------------- |
 | `--mod-inlinealert-background-color`               |
 | `--mod-inlinealert-border-and-icon-color`          |

--- a/components/link/metadata/mods.md
+++ b/components/link/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties              |
+| Modifiable custom properties              |
 | ----------------------------------------- |
 | `--mod-link-animation-duration`           |
 | `--mod-link-text-color-black`             |

--- a/components/logicbutton/metadata/mods.md
+++ b/components/logicbutton/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                             |
+| Modifiable custom properties                             |
 | -------------------------------------------------------- |
 | `--mod-animation-duration-100`                           |
 | `--mod-focus-indicator-gap`                              |

--- a/components/menu/metadata/mods.md
+++ b/components/menu/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                                       |
+| Modifiable custom properties                                       |
 | ------------------------------------------------------------------ |
 | `--mod-menu-back-heading-color`                                    |
 | `--mod-menu-back-icon-color-default`                               |

--- a/components/miller/metadata/mods.md
+++ b/components/miller/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties              |
+| Modifiable custom properties              |
 | ----------------------------------------- |
 | `--mod-millercolumns-inline-size`         |
 | `--mod-millercolumns-margin-inline-end`   |

--- a/components/modal/metadata/mods.md
+++ b/components/modal/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                   |
+| Modifiable custom properties                   |
 | ---------------------------------------------- |
 | `--mod-modal-background-color`                 |
 | `--mod-modal-confirm-border-radius`            |

--- a/components/opacitycheckerboard/metadata/mods.md
+++ b/components/opacitycheckerboard/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties          |
+| Modifiable custom properties          |
 | ------------------------------------- |
 | `--mod-opacity-checkerboard-dark`     |
 | `--mod-opacity-checkerboard-light`    |

--- a/components/pagination/metadata/mods.md
+++ b/components/pagination/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                   |
+| Modifiable custom properties                   |
 | ---------------------------------------------- |
 | `--mod-pagination-counter-color`               |
 | `--mod-pagination-counter-font-size`           |

--- a/components/picker/metadata/mods.md
+++ b/components/picker/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                           |
+| Modifiable custom properties                           |
 | ------------------------------------------------------ |
 | `--mod-animation-duration-100`                         |
 | `--mod-line-height-100`                                |

--- a/components/pickerbutton/metadata/mods.md
+++ b/components/pickerbutton/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                           |
+| Modifiable custom properties                           |
 | ------------------------------------------------------ |
 | `--mod-picker-button-background-animation-duration`    |
 | `--mod-picker-button-background-color`                 |

--- a/components/popover/metadata/mods.md
+++ b/components/popover/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                  |
+| Modifiable custom properties                  |
 | --------------------------------------------- |
 | `--mod-overlay-animation-duration-opened`     |
 | `--mod-popover-animation-distance`            |

--- a/components/progressbar/metadata/mods.md
+++ b/components/progressbar/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                            |
+| Modifiable custom properties                            |
 | ------------------------------------------------------- |
 | `--mod-meter-inline-size`                               |
 | `--mod-meter-max-width`                                 |

--- a/components/progresscircle/metadata/mods.md
+++ b/components/progresscircle/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                               |
+| Modifiable custom properties                               |
 | ---------------------------------------------------------- |
 | `--mod-progress-circle-fill-border-color`                  |
 | `--mod-progress-circle-fill-border-color-over-background`  |

--- a/components/quickaction/metadata/mods.md
+++ b/components/quickaction/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties              |
+| Modifiable custom properties              |
 | ----------------------------------------- |
 | `--mod-overlay-animation-distance`        |
 | `--mod-overlay-animation-duration-opened` |

--- a/components/radio/metadata/mods.md
+++ b/components/radio/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                      |
+| Modifiable custom properties                      |
 | ------------------------------------------------- |
 | `--mod-radio-animation-duration`                  |
 | `--mod-radio-border-width`                        |

--- a/components/rating/metadata/mods.md
+++ b/components/rating/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                   |
+| Modifiable custom properties                   |
 | ---------------------------------------------- |
 | `--mod-rating-border-radius`                   |
 | `--mod-rating-emphasized-icon-color-default`   |

--- a/components/search/metadata/mods.md
+++ b/components/search/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties             |
+| Modifiable custom properties             |
 | ---------------------------------------- |
 | `--mod-search-background-color`          |
 | `--mod-search-background-color-disabled` |

--- a/components/sidenav/metadata/mods.md
+++ b/components/sidenav/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                            |
+| Modifiable custom properties                            |
 | ------------------------------------------------------- |
 | `--mod-sidenav-background-default`                      |
 | `--mod-sidenav-background-disabled`                     |

--- a/components/slider/metadata/mods.md
+++ b/components/slider/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                           |
+| Modifiable custom properties                           |
 | ------------------------------------------------------ |
 | `--mod-animation-duration-100`                         |
 | `--mod-disabled-border-color`                          |

--- a/components/splitview/metadata/mods.md
+++ b/components/splitview/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                      |
+| Modifiable custom properties                      |
 | ------------------------------------------------- |
 | `--mod-splitview-background-color`                |
 | `--mod-splitview-gripper-border-radius`           |

--- a/components/statuslight/metadata/mods.md
+++ b/components/statuslight/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                      |
+| Modifiable custom properties                      |
 | ------------------------------------------------- |
 | `--mod-statuslight-border-width`                  |
 | `--mod-statuslight-content-color-default`         |

--- a/components/steplist/metadata/mods.md
+++ b/components/steplist/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                               |
+| Modifiable custom properties                               |
 | ---------------------------------------------------------- |
 | `--mod-steplist-complete-label-text-color`                 |
 | `--mod-steplist-complete-marker-background-color`          |

--- a/components/stepper/metadata/mods.md
+++ b/components/stepper/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                        |
+| Modifiable custom properties                        |
 | --------------------------------------------------- |
 | `--mod-stepper-animation-duration`                  |
 | `--mod-stepper-border-color`                        |

--- a/components/swatch/metadata/mods.md
+++ b/components/swatch/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                 |
+| Modifiable custom properties                 |
 | -------------------------------------------- |
 | `--mod-animation-duration-100`               |
 | `--mod-swatch-border-color`                  |

--- a/components/swatchgroup/metadata/mods.md
+++ b/components/swatchgroup/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties         |
+| Modifiable custom properties         |
 | ------------------------------------ |
 | `--mod-swatchgroup-spacing-compact`  |
 | `--mod-swatchgroup-spacing-regular`  |

--- a/components/switch/metadata/mods.md
+++ b/components/switch/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                        |
+| Modifiable custom properties                        |
 | --------------------------------------------------- |
 | `--mod-animation-duration-100`                      |
 | `--mod-animation-duration-200`                      |

--- a/components/table/metadata/mods.md
+++ b/components/table/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                                     |
+| Modifiable custom properties                                     |
 | ---------------------------------------------------------------- |
 | `--mod-table-border-color`                                       |
 | `--mod-table-border-radius`                                      |

--- a/components/tabs/metadata/mods.md
+++ b/components/tabs/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                          |
+| Modifiable custom properties                          |
 | ----------------------------------------------------- |
 | `--mod-tabs-animation-duration`                       |
 | `--mod-tabs-animation-ease`                           |

--- a/components/tag/metadata/mods.md
+++ b/components/tag/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                         |
+| Modifiable custom properties                         |
 | ---------------------------------------------------- |
 | `--mod-avatar-opacity-disabled`                      |
 | `--mod-clearbutton-fill-background-color`            |

--- a/components/taggroup/metadata/mods.md
+++ b/components/taggroup/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties         |
+| Modifiable custom properties         |
 | ------------------------------------ |
 | `--mod-tag-group-item-margin-block`  |
 | `--mod-tag-group-item-margin-inline` |

--- a/components/textfield/metadata/mods.md
+++ b/components/textfield/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                            |
+| Modifiable custom properties                            |
 | ------------------------------------------------------- |
 | `--mod-texfield-animation-duration`                     |
 | `--mod-text-area-min-block-size`                        |

--- a/components/thumbnail/metadata/mods.md
+++ b/components/thumbnail/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                |
+| Modifiable custom properties                |
 | ------------------------------------------- |
 | `--mod-thumbnail-border-color`              |
 | `--mod-thumbnail-border-color-selected`     |

--- a/components/toast/metadata/mods.md
+++ b/components/toast/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                            |
+| Modifiable custom properties                            |
 | ------------------------------------------------------- |
 | `--mod-toast-background-color-default`                  |
 | `--mod-toast-block-size`                                |

--- a/components/tooltip/metadata/mods.md
+++ b/components/tooltip/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                 |
+| Modifiable custom properties                 |
 | -------------------------------------------- |
 | `--mod-overlay-animation-duration-opened`    |
 | `--mod-tooltip-animation-distance`           |

--- a/components/tray/metadata/mods.md
+++ b/components/tray/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                |
+| Modifiable custom properties                |
 | ------------------------------------------- |
 | `--mod-tray-background-color`               |
 | `--mod-tray-bottom-to-content-area`         |

--- a/components/treeview/metadata/mods.md
+++ b/components/treeview/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                          |
+| Modifiable custom properties                          |
 | ----------------------------------------------------- |
 | `--mod-treeview-font-size`                            |
 | `--mod-treeview-heading-bottom-to-text`               |

--- a/components/typography/metadata/mods.md
+++ b/components/typography/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                                   |
+| Modifiable custom properties                                   |
 | -------------------------------------------------------------- |
 | `--mod-body-cjk-emphasized-font-style`                         |
 | `--mod-body-cjk-emphasized-font-weight`                        |

--- a/components/underlay/metadata/mods.md
+++ b/components/underlay/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties                         |
+| Modifiable custom properties                         |
 | ---------------------------------------------------- |
 | `--mod-overlay-animation-duration-opened`            |
 | `--mod-underlay-background-color`                    |

--- a/components/well/metadata/mods.md
+++ b/components/well/metadata/mods.md
@@ -1,4 +1,4 @@
-| Modifiable Custom Properties  |
+| Modifiable custom properties  |
 | ----------------------------- |
 | `--mod-well-background-color` |
 | `--mod-well-border-color`     |


### PR DESCRIPTION
## Description

Super-small update to the mods script to use sentence case for the heading as outlined in the [style guide](https://spectrum.adobe.com/page/grammar-and-mechanics/#Sentence-case).

It also adds reporting to the console as the script completes each task.

## How and where has this been tested?

- [x] After running `yarn build`, expect all table headings to use `Modifiable custom properties` instead of `Modifiable Custom Properties`
- [x] Expect the console output when running `yarn build --verbose` to reflect:

```
[mod-extractor] 🔍 @spectrum-css/slider
Found 55 modifiable custom properties
✓ metadata/mods.md written
✓ dist/mods.json written
```

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] ✨ This pull request is ready to merge. ✨
