### PR TITLE
build: allow empty theme assets during build step

### DIFF
--- a/tools/component-builder-simple/css/index.js
+++ b/tools/component-builder-simple/css/index.js
@@ -22,7 +22,9 @@ function buildCSS() {
 			"index.css",
 			"themes/spectrum.css", // spectrum comes first
 			"themes/*.css",
-		])
+		], {
+			allowEmpty: true,
+		})
 		.pipe(concat("index.css"))
 		.pipe(
 			postcss(processors, {
@@ -38,7 +40,9 @@ function buildCSSWithoutThemes() {
 			"index.css",
 			"themes/spectrum.css", // spectrum comes first
 			"themes/*.css",
-		])
+		], {
+			allowEmpty: true,
+		})
 		.pipe(concat("index-base.css"))
 		.pipe(
 			postcss(processorsFunction({ noFlatVariables: true }), {
@@ -53,7 +57,9 @@ function buildCSSThemeIndex() {
 		.src([
 			"themes/spectrum.css", // spectrum comes first
 			"themes/*.css",
-		])
+		], {
+			allowEmpty: true,
+		})
 		.pipe(concat("index-theme.css"))
 		.pipe(postcss(processorsFunction({ noSelectors: true })))
 		.pipe(gulp.dest("dist/"));
@@ -61,7 +67,9 @@ function buildCSSThemeIndex() {
 
 function buildCSSThemes() {
 	return gulp
-		.src(["themes/*.css"])
+		.src(["themes/*.css"], {
+			allowEmpty: true,
+		})
 		.pipe(postcss(processorsFunction({ noSelectors: true })))
 		.pipe(gulp.dest("dist/themes/"));
 }
@@ -71,7 +79,9 @@ function buildCSSThemes() {
 */
 function buildExpressTheme() {
 	return gulp
-		.src(["dist/index-theme.css"])
+		.src(["dist/index-theme.css"], {
+			allowEmpty: true,
+		})
 		.pipe(concat("express.css"))
 		.pipe(postcss(processorsFunction().concat(require("postcss-combininator"))))
 		.pipe(gulp.dest("dist/themes/"));

--- a/tools/component-builder/css/lib/varUtils.js
+++ b/tools/component-builder/css/lib/varUtils.js
@@ -169,7 +169,9 @@ function getAllVars() {
 				`${varDir}/css/globals/*.css`,
 				`${varDir}/custom.css`,
 				coreTokensFile,
-			])
+			], {
+				allowEmpty: true,
+			})
 			.pipe(concat("everything.css"))
 			.pipe(
 				through.obj(function getAllVars(file, enc, cb) {
@@ -194,7 +196,9 @@ function getAllComponentVars() {
 				`${varDir}/css/components/*.css`,
 				`${varDir}/css/globals/*.css`,
 				`${varDir}/custom.css`,
-			])
+			], {
+				allowEmpty: true,
+			})
 			.pipe(concat("everything.css"))
 			.pipe(
 				through.obj(function getAllVars(file, enc, cb) {

--- a/tools/component-builder/css/vars.js
+++ b/tools/component-builder/css/vars.js
@@ -12,17 +12,11 @@ governing permissions and limitations under the License.
 
 const gulp = require("gulp");
 const through = require("through2");
-const postcss = require("postcss");
 const logger = require("gulplog");
 const fsp = require("fs").promises;
 const path = require("path");
 
 const varUtils = require("./lib/varUtils");
-
-// Todo: get these values from a common place?
-let colorStops = ["darkest", "dark", "light", "lightest"];
-
-let scales = ["medium", "large"];
 
 function bakeVars() {
 	return gulp


### PR DESCRIPTION
## Description

Currently, whether a package uses the themes/*.css assets for styling or not, those placeholder files must exist in order for the build to work. If you remove empty theme files, the build for that component will fail even though the files are not needed.

This fix removes that requirement so that we can delete theme assets when they are not needed and clean-up technical cruft.

## How and where has this been tested?

### Setup

- Remove the themes folder in `components/accordion` (**note** do not commit this change to the branch)

### Validation steps

- [x] Run `yarn builder accordion`; expect the build to complete successfully and not output any warnings or errors regarding missing theme files. No dist/themes assets should be generated.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] ✨ This pull request is ready to merge. ✨
