### PR TITLE
fix(table): replace leftover global color token

### DIFF
--- a/components/table/index.css
+++ b/components/table/index.css
@@ -802,7 +802,7 @@ governing permissions and limitations under the License.
 /********* SCROLLABLE *********/
 /* Wrapper that allows a scrollable body and sticky column header. */
 .spectrum-Table-scroller {
-  --spectrum-table-header-background-color: var(--mod-table-header-background-color-scrollable, var(--spectrum-background-layer-1-color, var(--spectrum-global-color-gray-100)));
+  --spectrum-table-header-background-color: var(--mod-table-header-background-color-scrollable, var(--spectrum-background-layer-1-color, var(--spectrum-gray-100)));
 
   box-sizing: border-box;
   display: inline-block;
@@ -818,7 +818,7 @@ governing permissions and limitations under the License.
     var(--highcontrast-table-border-color, var(--mod-table-border-color, var(--spectrum-table-border-color)));
   
   &.spectrum-Table--quiet {
-    --mod-table-header-background-color--quiet: var(--mod-table-header-background-color-scrollable, var(--spectrum-background-layer-1-color, var(--spectrum-global-color-gray-100)));
+    --mod-table-header-background-color--quiet: var(--mod-table-header-background-color-scrollable, var(--spectrum-background-layer-1-color, var(--spectrum-gray-100)));
     border-block-start: none;
   }
 


### PR DESCRIPTION
## Description

Replace one leftover token value referencing a _--spectrum-global_ token with the new token value.
This change should not affect anything visually as it's a fallback value.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [x] Visuals have not changed in the scroller variant. 
- [x] No more references to "--spectrum-global" exist in the CSS for this component.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] ✨ This pull request is ready to merge. ✨
