### PR TITLE
fix(card): rename misnamed instance of background color mod

### DIFF
--- a/components/card/index.css
+++ b/components/card/index.css
@@ -137,11 +137,16 @@ governing permissions and limitations under the License.
 		--highcontrast-card-border-color,
 		var(--mod-card-border-color, var(--spectrum-card-border-color))
 	);
+	/* @deprecation --mod-spectrum-card-background-color has been renamed to
+		--mod-card-background-color. The fallback will be removed in a future version. */
 	background-color: var(
 		--highcontrast-card-background-color,
 		var(
-			--mod-spectrum-card-background-color,
-			var(--spectrum-card-background-color)
+			--mod-card-background-color,
+			var(
+				--mod-spectrum-card-background-color,
+				var(--spectrum-card-background-color)
+			)
 		)
 	);
 


### PR DESCRIPTION
## Description

The custom mod property for the background color was named incorrectly as `--mod-spectrum-card-background-color` in one of the declarations. The correct mod name `--mod-card-background-color` already exists and is used by the rest of the file, so this is more of a bug fix than an overall renaming. A fallback and deprecation notice were left in case of existing usage of the old mod name.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps @jenndiaz 

- [x] Set `--mod-card-background-color` to a color and it should change the background color (does not in prod). Setting the deprecated fallback `--mod-spectrum-card-background-color` should also change it.
- [x] Existing variants of Card look the same on docs and in Storybook. Double-check quiet, gallery, horizontal, and drop target

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
