### PR TITLE
fix(commons): rename and deprecate mods referencing global tokens

### DIFF
--- a/components/actionbutton/metadata/mods.md
+++ b/components/actionbutton/metadata/mods.md
@@ -50,5 +50,8 @@
 | `--mod-actionbutton-static-content-color`                         |
 | `--mod-actionbutton-text-to-visual`                               |
 | `--mod-animation-duration-100`                                    |
+| `--mod-button-animation-duration`                                 |
+| `--mod-button-font-family`                                        |
+| `--mod-button-line-height`                                        |
 | `--mod-line-height-100`                                           |
 | `--mod-sans-font-family-stack`                                    |

--- a/components/button/metadata/mods.md
+++ b/components/button/metadata/mods.md
@@ -24,10 +24,12 @@
 | `--mod-button-edge-to-text`                |
 | `--mod-button-edge-to-visual`              |
 | `--mod-button-edge-to-visual-only`         |
+| `--mod-button-focus-indicator-gap`         |
 | `--mod-button-focus-ring-border-radius`    |
 | `--mod-button-focus-ring-color`            |
 | `--mod-button-focus-ring-gap`              |
 | `--mod-button-focus-ring-thickness`        |
+| `--mod-button-font-family`                 |
 | `--mod-button-font-size`                   |
 | `--mod-button-height`                      |
 | `--mod-button-line-height`                 |

--- a/components/closebutton/metadata/mods.md
+++ b/components/closebutton/metadata/mods.md
@@ -1,6 +1,9 @@
 | Modifiable custom properties                        |
 | --------------------------------------------------- |
 | `--mod-animation-duration-100`                      |
+| `--mod-button-animation-duration`                   |
+| `--mod-button-font-family`                          |
+| `--mod-button-line-height`                          |
 | `--mod-closebutton-align-self`                      |
 | `--mod-closebutton-animation-duraction`             |
 | `--mod-closebutton-animation-duration`              |

--- a/components/commons/basebutton-coretokens.css
+++ b/components/commons/basebutton-coretokens.css
@@ -40,15 +40,19 @@ governing permissions and limitations under the License.
   /* Adjacent buttons should be aligned correctly */
   vertical-align: top;
 
-  transition: background var(--mod-animation-duration-100, var(--spectrum-animation-duration-100)) ease-out,
-    border-color var(--mod-animation-duration-100, var(--spectrum-animation-duration-100)) ease-out,
-    color var(--mod-animation-duration-100, var(--spectrum-animation-duration-100)) ease-out,
-    box-shadow var(--mod-animation-duration-100, var(--spectrum-animation-duration-100)) ease-out;
+  /* @deprecation --mod-animation-duration-100 has been renamed and will be removed in a future version. */
+  transition: background var(--mod-button-animation-duration, var(--mod-animation-duration-100, var(--spectrum-animation-duration-100))) ease-out,
+    border-color var(--mod-button-animation-duration, var(--mod-animation-duration-100, var(--spectrum-animation-duration-100))) ease-out,
+    color var(--mod-button-animation-duration, var(--mod-animation-duration-100, var(--spectrum-animation-duration-100))) ease-out,
+    box-shadow var(--mod-button-animation-duration, var(--mod-animation-duration-100, var(--spectrum-animation-duration-100))) ease-out;
 
   text-decoration: none;
-  font-family: var(--mod-sans-font-family-stack, var(--spectrum-sans-font-family-stack));
 
-  line-height: var(--mod-line-height-100, var(--spectrum-line-height-100));
+  /* @deprecation --mod-sans-font-family-stack has been renamed and will be removed in a future version. */
+  font-family: var(--mod-button-font-family, var(--mod-sans-font-family-stack, var(--spectrum-sans-font-family-stack)));
+
+  /* @deprecation --mod-line-height-100 has been renamed and will be removed in a future version. */
+  line-height: var(--mod-button-line-height, var(--mod-line-height-100, var(--spectrum-line-height-100)));
 
   user-select: none;
   -webkit-user-select: none;
@@ -92,18 +96,19 @@ governing permissions and limitations under the License.
     inset-block-end: 0;
     inset-inline-start: 0;
     inset-inline-end: 0;
-    margin: calc(var(--mod-focus-indicator-gap, var(--spectrum-focus-indicator-gap)) * -1);
-    transition: opacity var(--mod-animation-duration-100, var(--spectrum-animation-duration-100)) ease-out,
-                margin var(--mod-animation-duration-100, var(--spectrum-animation-duration-100)) ease-out;
+    /* @deprecation --mod-focus-indicator-gap has been renamed and will be removed in a future version. */
+    margin: calc(var(--mod-button-focus-indicator-gap, var(--mod-focus-indicator-gap, var(--spectrum-focus-indicator-gap))) * -1);
+    /* @deprecation --mod-animation-duration-100 has been renamed and will be removed in a future version. */
+    transition: opacity var(--mod-button-animation-duration, var(--mod-animation-duration-100, var(--spectrum-animation-duration-100))) ease-out,
+                margin var(--mod-button-animation-duration, var(--mod-animation-duration-100, var(--spectrum-animation-duration-100))) ease-out;
   }
 
   &:focus-visible {
     &::after {
-      margin: calc(var(--mod-focus-indicator-gap, var(--spectrum-focus-indicator-gap)) * -2);
+      margin: calc(var(--mod-button-focus-indicator-gap, var(--mod-focus-indicator-gap, var(--spectrum-focus-indicator-gap))) * -2);
     }
   }
 }
-
 
 %spectrum-AnchorButton {
   /* Remove appearance for clickable types in iOS and Safari. */
@@ -118,9 +123,6 @@ governing permissions and limitations under the License.
 
   /* Fixes horizontal alignment of text in anchor buttons */
   text-align: center;
-
-  /* @safari10 Workaround for https://bugs.webkit.org/show_bug.cgi?id=169700 */
-  /*inline-size: 100%;*/
 
   &:empty {
     display: none;

--- a/components/logicbutton/metadata/mods.md
+++ b/components/logicbutton/metadata/mods.md
@@ -1,6 +1,10 @@
 | Modifiable custom properties                             |
 | -------------------------------------------------------- |
 | `--mod-animation-duration-100`                           |
+| `--mod-button-animation-duration`                        |
+| `--mod-button-focus-indicator-gap`                       |
+| `--mod-button-font-family`                               |
+| `--mod-button-line-height`                               |
 | `--mod-focus-indicator-gap`                              |
 | `--mod-line-height-100`                                  |
 | `--mod-logic-button-and-background-color`                |

--- a/components/picker/metadata/mods.md
+++ b/components/picker/metadata/mods.md
@@ -1,6 +1,9 @@
 | Modifiable custom properties                           |
 | ------------------------------------------------------ |
 | `--mod-animation-duration-100`                         |
+| `--mod-button-animation-duration`                      |
+| `--mod-button-font-family`                             |
+| `--mod-button-line-height`                             |
 | `--mod-line-height-100`                                |
 | `--mod-picker-animation-duration`                      |
 | `--mod-picker-background-color-active`                 |


### PR DESCRIPTION
## Description

Some mod properties had been misnamed with reference to the global tokens. This adds the renamed mods to the _commons_ styles, with the old mods as a fallback, and adds deprecation notice comments. 

- `--mod-animation-duration-100` is now `--mod-button-animation-duration`
- `--mod-sans-font-family-stack` is now `--mod-button-font-family`
- `--mod-line-height-100` is now `--mod-button-line-height`
- `--mod-focus-indicator-gap` is now `--mod-button-focus-indicator-gap`

CSS-651

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps @jenndiaz 

 - [x] The mods listed in the description have the new mod name first in the fallback chain

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
