### PR TITLE
build: remove postcss-logical plugin

### DIFF
--- a/components/splitbutton/index.css
+++ b/components/splitbutton/index.css
@@ -131,6 +131,10 @@ governing permissions and limitations under the License.
     }
   }
 
+  & .spectrum-SplitButton-action .spectrum-Button-label + .spectrum-Icon {
+    margin-inline-start: var(--spectrum-splitbutton-icon-gap);
+  }
+
   &.spectrum-SplitButton--left {
     & .spectrum-SplitButton-action {
       border-start-start-radius: 0;
@@ -184,9 +188,5 @@ governing permissions and limitations under the License.
         border-inline-end-width: var(--spectrum-button-m-primary-outline-texticon-border-size);
       }
     }
-  }
-
-  & .spectrum-SplitButton-action .spectrum-Button-label + .spectrum-Icon {
-    margin-inline-start: var(--spectrum-splitbutton-icon-gap);
   }
 }

--- a/tools/component-builder/css/processors.js
+++ b/tools/component-builder/css/processors.js
@@ -58,7 +58,6 @@ function getProcessors(
 		require("postcss-extend"),
 		require("postcss-nested"),
 		diff ? require("postcss-varsonly")() : null,
-		require("postcss-logical")(),
 		require("postcss-dir-pseudo-class")(),
 		require("postcss-hover-media-feature"),
 		require("postcss-calc"),

--- a/tools/component-builder/package.json
+++ b/tools/component-builder/package.json
@@ -41,7 +41,6 @@
     "postcss-extend": "^1.0.5",
     "postcss-hover-media-feature": "1.0.2",
     "postcss-import": "^16.0.0",
-    "postcss-logical": "^7.0.1",
     "postcss-nested": "^6.0.1",
     "postcss-notnested": "^2.0.0",
     "postcss-selector-parser": "^6.0.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14526,13 +14526,6 @@ postcss-loader@^4.0.0:
     schema-utils "^3.0.0"
     semver "^7.3.4"
 
-postcss-logical@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/postcss-logical/-/postcss-logical-7.0.1.tgz#a3121f6510591b195321b16e65fbe13b1cfd3115"
-  integrity sha512-8GwUQZE0ri0K0HJHkDv87XOLC8DE0msc+HoWLeKdtjDZEwpZ5xuK3QdV6FhmHSQW40LPkg43QzvATRAI3LsRkg==
-  dependencies:
-    postcss-value-parser "^4.2.0"
-
 postcss-merge-rules@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/postcss-merge-rules/-/postcss-merge-rules-6.0.3.tgz#08fcf714faaad75b1980ecd961b080ae2f8ddeb3"


### PR DESCRIPTION
## Description

This plugin is no longer needed. It previously was adding support for logical properties when they were new to the CSS spec, but our dist CSS files are already making use of logical properties directly and not converting properties back to their non-logical alternatives.

This plugin affected the dist output of all un-migrated components still using `component-builder` rather than the newer `component-builder-simple`. It had replaced the use of logical properties with non-logical equivalents, for example creating additional style rules with `[dir="ltr"]` and `[dir="rtl"]` prepended, and replacing `min-inline-size` with `min-width`.

_Note: the difference in dist output can be compared locally be running `yarn compare` and clicking on each component._

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

The following components have not changed visually in LTR or RTL, in the docs and in Storybook.
- [x] Asset [@castastrophe]
- [x] CycleButton [@castastrophe]
- [x] Icon [@castastrophe]
- [x] QuickAction [@castastrophe]
- [x] SearchWithin [@castastrophe]
- [x] Site [@castastrophe]
- [x] SplitButton [@castastrophe]

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.  [@castastrophe]

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
