### PR TITLE
fix(card): revert misnamed instance of background color mod

### DIFF
--- a/components/card/index.css
+++ b/components/card/index.css
@@ -137,16 +137,11 @@ governing permissions and limitations under the License.
 		--highcontrast-card-border-color,
 		var(--mod-card-border-color, var(--spectrum-card-border-color))
 	);
-	/* @deprecation --mod-spectrum-card-background-color has been renamed to
-		--mod-card-background-color. The fallback will be removed in a future version. */
 	background-color: var(
 		--highcontrast-card-background-color,
 		var(
-			--mod-card-background-color,
-			var(
-				--mod-spectrum-card-background-color,
-				var(--spectrum-card-background-color)
-			)
+			--mod-spectrum-card-background-color,
+			var(--spectrum-card-background-color)
 		)
 	);
 


### PR DESCRIPTION
Reverts adobe/spectrum-css#2417