### PR TITLE
refactor(card): rename mod and refactor some usage of mods and vars

### DIFF
--- a/components/card/index.css
+++ b/components/card/index.css
@@ -52,6 +52,7 @@ governing permissions and limitations under the License.
 	--spectrum-card-actions-spacing: var(--spectrum-spacing-300);
 	--spectrum-card-actions-size: var(--spectrum-card-selection-background-size);
 	--spectrum-card-actions-border-radius: var(--spectrum-corner-radius-100);
+
 	/* TODO update to --spectrum-card-selection-background-color token once an RGB stripped value is available */
 	--spectrum-card-actions-background-color-rgb: var(--spectrum-gray-100-rgb);
 	--spectrum-card-actions-background-color-opacity: var(
@@ -70,14 +71,17 @@ governing permissions and limitations under the License.
 
 	/* Selected */
 	--spectrum-card-selected-background-opacity: 0.1; /* table-selected-row-background-opacity does not exist in tokens yet */
+
 	/* TODO: These are placeholder until recursive RGB is available */
 	.spectrum--light &,
 	.spectrum--lightest & {
 		--spectrum-card-selected-background-color-rgb: var(--spectrum-blue-900-rgb);
 	}
+
 	.spectrum--dark & {
 		--spectrum-card-selected-background-color-rgb: var(--spectrum-blue-500-rgb);
 	}
+
 	.spectrum--darkest & {
 		--spectrum-card-selected-background-color-rgb: var(--spectrum-blue-600-rgb);
 	}
@@ -86,29 +90,18 @@ governing permissions and limitations under the License.
 	&--quiet,
 	&--gallery {
 		--mod-card-content-margin-top: var(
-			--spectrum-card-content-margin-top-quiet,
+			--mod-card-content-margin-top-quiet,
 			var(--spectrum-spacing-100)
 		);
 		--mod-card-minimum-width: var(
-			--spectrum-card-minimum-width-quiet,
+			--mod-card-minimum-width-quiet,
 			var(--spectrum-card-minimum-width)
 		);
-
-		--spectrum-card-preview-border-width: var(--spectrum-border-width-100);
 	}
 
-	&--quiet,
-	&--gallery,
-	&--horizontal {
-		--mod-card-background-color: var(
-			--spectrum-card-background-color-quiet,
-			var(--spectrum-background-base-color)
-		);
-		--spectrum-card-background-color-hover: var(
-			--spectrum-card-background-color-hover-quiet,
-			var(--spectrum-gray-300)
-		);
-	}
+	--spectrum-card-preview-border-width-selected: var(--spectrum-border-width-100);
+	--spectrum-card-preview-background-color: var(--spectrum-background-base-color);
+	--spectrum-card-preview-background-color-hover: var(--spectrum-gray-300);
 
 	/* Horizontal */
 	--spectrum-card-horizontal-body-padding: var(--spectrum-spacing-300);
@@ -137,11 +130,17 @@ governing permissions and limitations under the License.
 		--highcontrast-card-border-color,
 		var(--mod-card-border-color, var(--spectrum-card-border-color))
 	);
+
+	/* @deprecation --mod-spectrum-card-background-color has been renamed to
+		--mod-card-background-color. The fallback will be removed in a future version. */
 	background-color: var(
 		--highcontrast-card-background-color,
 		var(
-			--mod-spectrum-card-background-color,
-			var(--spectrum-card-background-color)
+			--mod-card-background-color,
+			var(
+				--mod-spectrum-card-background-color,
+				var(--spectrum-card-background-color)
+			)
 		)
 	);
 
@@ -245,6 +244,7 @@ governing permissions and limitations under the License.
 				var(--spectrum-card-border-color-selected)
 			)
 		);
+
 		&::before {
 			background-color: rgba(
 				var(
@@ -294,7 +294,7 @@ governing permissions and limitations under the License.
     .spectrum-Card-actions {
       /* Ideally, this would simply apply is-open to the QuickActions component */
       visibility: visible;
-      opacity: 1;
+      opacity: 100%;
       pointer-events: all;
     }
   }
@@ -570,6 +570,7 @@ governing permissions and limitations under the License.
 			var(--mod-card-border-width, var(--spectrum-card-border-width))
 		)
 	);
+
 	/* @deprecation --mod-card-footer-margin-top has been renamed to --mod-card-footer-padding-block-start
 	   and will be removed in a future version. */
 	padding-block-start: var(
@@ -623,6 +624,7 @@ governing permissions and limitations under the License.
 		&::after {
 			border-width: 0;
 		}
+
 		.spectrum-Card-preview::after {
 			border-color: var(
 				--mod-card-focus-indicator-color,
@@ -633,9 +635,14 @@ governing permissions and limitations under the License.
 
 	&.is-selected {
 		.spectrum-Card-preview {
+			/* @deprecation --mod-card-preview-border-width has been renamed to --mod-card-preview-border-width-selected
+				and the fallback will be removed in a future version. */
 			border: var(
-					--mod-card-preview-border-width,
-					var(--spectrum-card-preview-border-width)
+					--mod-card-preview-border-width-selected,
+					var(
+						--mod-card-preview-border-width,
+						var(--spectrum-card-preview-border-width-selected)
+					)
 				)
 				solid;
 			border-color: var(
@@ -672,8 +679,11 @@ governing permissions and limitations under the License.
 			var(--spectrum-card-corner-radius)
 		);
 		background-color: var(
-			--mod-card-background-color,
-			var(--spectrum-card-background-color)
+			--mod-card-preview-background-color, 
+			var(
+				--mod-card-background-color, 
+				var(--spectrum-card-preview-background-color)
+			)
 		);
 		min-block-size: var(
 			--mod-card-preview-minimum-height,
@@ -684,8 +694,9 @@ governing permissions and limitations under the License.
 		margin: 0 auto;
 		box-sizing: border-box;
 		position: relative;
+		/* @deprecation --mod-animation-duration-100 has been renamed and will be removed in a future version. */
 		transition: background-color
-			var(--mod-animation-duration-100, var(--spectrum-animation-duration-100));
+			var(--mod-card-animation-duration, var(--mod-animation-duration-100, var(--spectrum-animation-duration-100)));
 		overflow: visible;
 
 		/* Use ::before to show the selected overlay */
@@ -729,10 +740,14 @@ governing permissions and limitations under the License.
 
 	&:hover {
 		border-color: transparent;
+
 		.spectrum-Card-preview {
 			background-color: var(
-				--mod-card-background-color-hover,
-				var(--spectrum-card-background-color-hover)
+				--mod-card-preview-background-color-hover,
+				var(
+					--mod-card-background-color-hover,
+					var(--spectrum-card-preview-background-color-hover)
+				)
 			);
 		}
 	}
@@ -745,8 +760,11 @@ governing permissions and limitations under the License.
 		.spectrum-Card-preview {
 			transition: none;
 			background-color: var(
-				--mod-card-background-color,
-				var(--spectrum-card-background-color)
+				--mod-card-preview-background-color, 
+				var(
+					--mod-card-background-color, 
+					var(--spectrum-card-preview-background-color)
+				)
 			);
 		}
 
@@ -796,7 +814,7 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Card--horizontal {
-  flex-direction: row;
+	flex-direction: row;
 
 	&:hover {
 		.spectrum-Card-preview {
@@ -824,21 +842,20 @@ governing permissions and limitations under the License.
 			var(--spectrum-card-horizontal-preview-padding)
 		);
 		background-color: var(
-			--mod-card-background-color,
-			var(--spectrum-card-background-color)
+			--mod-card-preview-background-color,
+			var(--spectrum-card-preview-background-color)
 		);
-
 		border-color: var(
 			--mod-card-border-color,
 			var(--spectrum-card-border-color)
 		);
 	}
 
-  .spectrum-Card-header,
-  .spectrum-Card-content {
-    margin-block-start: 0;
-    block-size: auto;
-  }
+	.spectrum-Card-header,
+	.spectrum-Card-content {
+		margin-block-start: 0;
+		block-size: auto;
+	}
 
 	.spectrum-Card-content {
 		margin-block-end: 0;
@@ -848,12 +865,11 @@ governing permissions and limitations under the License.
 		padding-inline-end: 0;
 	}
 
-  .spectrum-Card-body {
-    flex-shrink: 0;
-    display: flex;
-    justify-content: center;
-    flex-direction: column;
-
+	.spectrum-Card-body {
+		flex-shrink: 0;
+		display: flex;
+		justify-content: center;
+		flex-direction: column;
 		padding-block: 0;
 		padding-inline: var(
 			--mod-card-horizontal-body-padding,

--- a/components/card/metadata/mods.md
+++ b/components/card/metadata/mods.md
@@ -10,6 +10,7 @@
 | `--mod-card-actions-drop-shadow-y`            |
 | `--mod-card-actions-size`                     |
 | `--mod-card-actions-spacing`                  |
+| `--mod-card-animation-duration`               |
 | `--mod-card-background-color`                 |
 | `--mod-card-background-color-hover`           |
 | `--mod-card-body-font-color`                  |
@@ -29,6 +30,7 @@
 | `--mod-card-border-width`                     |
 | `--mod-card-content-margin-bottom`            |
 | `--mod-card-content-margin-top`               |
+| `--mod-card-content-margin-top-quiet`         |
 | `--mod-card-corner-radius`                    |
 | `--mod-card-divider-color`                    |
 | `--mod-card-focus-indicator-color`            |
@@ -42,7 +44,11 @@
 | `--mod-card-horizontal-body-padding`          |
 | `--mod-card-horizontal-preview-padding`       |
 | `--mod-card-minimum-width`                    |
+| `--mod-card-minimum-width-quiet`              |
+| `--mod-card-preview-background-color`         |
+| `--mod-card-preview-background-color-hover`   |
 | `--mod-card-preview-border-width`             |
+| `--mod-card-preview-border-width-selected`    |
 | `--mod-card-preview-minimum-height`           |
 | `--mod-card-selected-background-color-rgb`    |
 | `--mod-card-selected-background-opacity`      |


### PR DESCRIPTION
## Description

fix(card): rename misnamed instance of background color mod

The custom mod property for the background color was named incorrectly in one of the declarations.
This mod renaming was made in the reverted PR #2417 , which had some issues with the Horizontal variant. This does an additional bit of refactoring cleanup to address this:

refactor(card): cleanup mods and vars around use of preview bg

The custom properties and mods were not differentiating between the card background and the preview div background used in the quiet, gallery, and horizontal variations. This did not work well with the horizontal variant which has both a card background and a preview background, when some of the mis-named mods were fixed.

A few unset custom properties with spectrum prefixed naming also appeared to be intended as mods, and now have mod equivalents. These did not exist in the repo or in the tokens package, and have been removed/replaced:
--spectrum-card-background-color-quiet
--spectrum-card-background-color-hover-quiet
--spectrum-card-content-margin-top-quiet
--spectrum-card-minimum-width-quiet

This PR creates new custom properties for the preview background colors, that were previously being set through changing a mod value. It also renames `--spectrum-card-preview-border-width` to `--spectrum-card-preview-border-width-selected` to match with its usage.

A fallback was kept to maintain the use of `--mod-card-background-color` for the quiet variants. The horizontal variant now uses `--mod-card-preview-background-color`, as it has both a card background color and a "preview" element background color.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [x] No visual changes to Card variations in docs site, including focus and hover
- [x] No visual changes to Card in Storybook, including focus, hover, selected
- [x] Set `--mod-card-background-color` to a color and it should change the background color (does not in prod). Setting the deprecated fallback `--mod-spectrum-card-background-color` should also change it.
- [x] Setting `--mod-card-preview-background-color` should change the preview area bg color for quiet, and horizontal variants
- [x] Setting `--mod-card-preview-background-color-hover` should change the preview area bg color for quiet variants

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
