### PR TITLE
feat(button): pending state

### DIFF
--- a/components/button/index.css
+++ b/components/button/index.css
@@ -56,6 +56,11 @@ governing permissions and limitations under the License.
   --spectrum-button-padding-label-to-icon: var(--spectrum-text-to-visual-100);
   --spectrum-button-top-to-text: var(--spectrum-button-top-to-text-medium);
   --spectrum-button-bottom-to-text: var(--spectrum-button-bottom-to-text-medium);
+
+  &[pending],
+  &.is-pending {
+    --mod-button-edge-to-visual-only: calc(1px + var(--spectrum-button-edge-to-visual-only));
+  }
 }
 
 .spectrum-Button--sizeL {
@@ -72,6 +77,12 @@ governing permissions and limitations under the License.
   --spectrum-button-padding-label-to-icon: var(--spectrum-text-to-visual-200);
   --spectrum-button-top-to-text: var(--spectrum-button-top-to-text-large);
   --spectrum-button-bottom-to-text: var(--spectrum-button-bottom-to-text-large);
+
+
+  &[pending],
+  &.is-pending {
+    --mod-button-edge-to-visual-only: calc(2px + var(--spectrum-button-edge-to-visual-only));
+  }
 }
 
 .spectrum-Button--sizeXL {
@@ -89,6 +100,15 @@ governing permissions and limitations under the License.
   --spectrum-button-top-to-text: var(--spectrum-button-top-to-text-extra-large);
   --spectrum-button-bottom-to-text: var(--spectrum-button-bottom-to-text-extra-large);
 
+  .spectrum--medium &[pending],
+  .spectrum--medium &.is-pending {
+    --mod-button-edge-to-visual-only: calc(3px + var(--spectrum-button-edge-to-visual-only));
+  }
+
+  .spectrum--large &[pending],
+  .spectrum--large &.is-pending {
+    --mod-button-edge-to-visual-only: calc(4px + var(--spectrum-button-edge-to-visual-only));
+  }
 }
 
 .spectrum-Button {
@@ -229,10 +249,22 @@ a.spectrum-Button {
   }
 
   &:disabled,
-  &.is-disabled {
+  &.is-disabled,
+  &[pending],
+  &.is-pending {
     background-color: var(--highcontrast-button-background-color-disabled, var(--mod-button-background-color-disabled, var(--spectrum-button-background-color-disabled)));
     border-color: var(--highcontrast-button-border-color-disabled, var(--mod-button-border-color-disabled, var(--spectrum-button-border-color-disabled)));
     color: var(--highcontrast-button-content-color-disabled, var(--mod-button-content-color-disabled, var(--spectrum-button-content-color-disabled)));
+  }
+
+  &[pending],
+  &.is-pending {
+    cursor: default;
+
+    .spectrum-Icon,
+    .spectrum-Button-label {
+      display: none;
+    }
   }
 }
 
@@ -241,6 +273,9 @@ a.spectrum-Button {
   .spectrum-Button {
     --highcontrast-button-content-color-disabled: GrayText;
     --highcontrast-button-border-color-disabled: GrayText;
+    --mod-progress-circle-track-border-color: ButtonText;
+    --mod-progress-circle-track-border-color-over-background: ButtonText;
+    --mod-progress-circle-thickness: var(--spectrum-progress-circle-thickness-medium);
 
     &:focus-visible {
       &::after {

--- a/components/button/metadata/button-pending.yml
+++ b/components/button/metadata/button-pending.yml
@@ -1,0 +1,651 @@
+name: Button - pending
+status: Verified
+description: The pending button is for indicating that a quick progress action is taking place. In this case, the label and optional icon disappear and a progress circle appears. The progress circle always shows an indeterminate progress. We recommend the use of the `.is-pending` class on the component's parent container, but there is also an option to use an attribute of `pending` instead. Buttons should have the `disabled` attribute when the pending state is applied.
+SpectrumSiteSlug: https://spectrum.adobe.com/page/button/#Pending
+examples:
+  - id: button-pending
+    name: Default (accent, negative, primary, and secondary)
+    markup: |
+      <div class="spectrum-Examples">
+        <div class="spectrum-Examples-item">
+          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">S</h4>
+          <button class="spectrum-Button spectrum-Button--fill spectrum-Button--accent spectrum-Button--sizeS is-pending" disabled>
+            <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small">
+              <div class="spectrum-ProgressCircle-track"></div>
+              <div class="spectrum-ProgressCircle-fills">
+                <div class="spectrum-ProgressCircle-fillMask1">
+                  <div class="spectrum-ProgressCircle-fillSubMask1">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+                <div class="spectrum-ProgressCircle-fillMask2">
+                  <div class="spectrum-ProgressCircle-fillSubMask2">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </button>
+
+          <button class="spectrum-Button spectrum-Button--fill spectrum-Button--accent spectrum-Button--iconOnly spectrum-Button--sizeS is-pending" disabled>
+            <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small">
+              <div class="spectrum-ProgressCircle-track"></div>
+              <div class="spectrum-ProgressCircle-fills">
+                <div class="spectrum-ProgressCircle-fillMask1">
+                  <div class="spectrum-ProgressCircle-fillSubMask1">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+                <div class="spectrum-ProgressCircle-fillMask2">
+                  <div class="spectrum-ProgressCircle-fillSubMask2">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </button>
+        </div>
+
+        <div class="spectrum-Examples-item">
+          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">M (default)</h4>
+          <button class="spectrum-Button spectrum-Button--fill spectrum-Button--negative spectrum-Button--sizeM is-pending" disabled>
+            <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small">
+              <div class="spectrum-ProgressCircle-track"></div>
+              <div class="spectrum-ProgressCircle-fills">
+                <div class="spectrum-ProgressCircle-fillMask1">
+                  <div class="spectrum-ProgressCircle-fillSubMask1">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+                <div class="spectrum-ProgressCircle-fillMask2">
+                  <div class="spectrum-ProgressCircle-fillSubMask2">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </button>
+
+          <button class="spectrum-Button spectrum-Button--fill spectrum-Button--negative spectrum-Button--iconOnly spectrum-Button--sizeM is-pending" disabled>
+            <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small">
+              <div class="spectrum-ProgressCircle-track"></div>
+              <div class="spectrum-ProgressCircle-fills">
+                <div class="spectrum-ProgressCircle-fillMask1">
+                  <div class="spectrum-ProgressCircle-fillSubMask1">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+                <div class="spectrum-ProgressCircle-fillMask2">
+                  <div class="spectrum-ProgressCircle-fillSubMask2">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </button>
+        </div>
+
+        <div class="spectrum-Examples-item">
+          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">L</h4>
+          <button class="spectrum-Button spectrum-Button--fill spectrum-Button--primary spectrum-Button--sizeL is-pending" disabled>
+            <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small">
+              <div class="spectrum-ProgressCircle-track"></div>
+              <div class="spectrum-ProgressCircle-fills">
+                <div class="spectrum-ProgressCircle-fillMask1">
+                  <div class="spectrum-ProgressCircle-fillSubMask1">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+                <div class="spectrum-ProgressCircle-fillMask2">
+                  <div class="spectrum-ProgressCircle-fillSubMask2">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </button>
+
+          <button class="spectrum-Button spectrum-Button--fill spectrum-Button--primary spectrum-Button--iconOnly spectrum-Button--sizeL is-pending" disabled>
+            <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small">
+              <div class="spectrum-ProgressCircle-track"></div>
+              <div class="spectrum-ProgressCircle-fills">
+                <div class="spectrum-ProgressCircle-fillMask1">
+                  <div class="spectrum-ProgressCircle-fillSubMask1">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+                <div class="spectrum-ProgressCircle-fillMask2">
+                  <div class="spectrum-ProgressCircle-fillSubMask2">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </button>
+        </div>
+
+        <div class="spectrum-Examples-item">
+          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">XL</h4>
+          <button class="spectrum-Button spectrum-Button--fill spectrum-Button--secondary spectrum-Button--sizeXL is-pending" disabled>
+            <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small">
+              <div class="spectrum-ProgressCircle-track"></div>
+              <div class="spectrum-ProgressCircle-fills">
+                <div class="spectrum-ProgressCircle-fillMask1">
+                  <div class="spectrum-ProgressCircle-fillSubMask1">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+                <div class="spectrum-ProgressCircle-fillMask2">
+                  <div class="spectrum-ProgressCircle-fillSubMask2">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </button>
+
+          <button class="spectrum-Button spectrum-Button--fill spectrum-Button--secondary spectrum-Button--iconOnly spectrum-Button--sizeXL is-pending" disabled>
+            <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small">
+              <div class="spectrum-ProgressCircle-track"></div>
+              <div class="spectrum-ProgressCircle-fills">
+                <div class="spectrum-ProgressCircle-fillMask1">
+                  <div class="spectrum-ProgressCircle-fillSubMask1">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+                <div class="spectrum-ProgressCircle-fillMask2">
+                  <div class="spectrum-ProgressCircle-fillSubMask2">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </button>
+        </div>
+      </div>
+  - id: button-pending-outline
+    name: Outline (accent, negative, primary, and secondary)
+    markup: |
+      <div class="spectrum-Examples">
+        <div class="spectrum-Examples-item">
+          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">S</h4>
+          <button class="spectrum-Button spectrum-Button--accent spectrum-Button--outline spectrum-Button--sizeS is-pending" disabled>
+            <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small">
+              <div class="spectrum-ProgressCircle-track"></div>
+              <div class="spectrum-ProgressCircle-fills">
+                <div class="spectrum-ProgressCircle-fillMask1">
+                  <div class="spectrum-ProgressCircle-fillSubMask1">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+                <div class="spectrum-ProgressCircle-fillMask2">
+                  <div class="spectrum-ProgressCircle-fillSubMask2">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </button>
+
+          <button class="spectrum-Button spectrum-Button--accent spectrum-Button--outline spectrum-Button--iconOnly spectrum-Button--sizeS is-pending" disabled>
+            <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small">
+              <div class="spectrum-ProgressCircle-track"></div>
+              <div class="spectrum-ProgressCircle-fills">
+                <div class="spectrum-ProgressCircle-fillMask1">
+                  <div class="spectrum-ProgressCircle-fillSubMask1">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+                <div class="spectrum-ProgressCircle-fillMask2">
+                  <div class="spectrum-ProgressCircle-fillSubMask2">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </button>
+        </div>
+
+        <div class="spectrum-Examples-item">
+          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">M (default)</h4>
+          <button class="spectrum-Button spectrum-Button--negative spectrum-Button--outline spectrum-Button--sizeM is-pending" disabled>
+            <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small">
+              <div class="spectrum-ProgressCircle-track"></div>
+              <div class="spectrum-ProgressCircle-fills">
+                <div class="spectrum-ProgressCircle-fillMask1">
+                  <div class="spectrum-ProgressCircle-fillSubMask1">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+                <div class="spectrum-ProgressCircle-fillMask2">
+                  <div class="spectrum-ProgressCircle-fillSubMask2">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </button>
+
+          <button class="spectrum-Button spectrum-Button--negative spectrum-Button--outline spectrum-Button--iconOnly spectrum-Button--sizeM is-pending" disabled>
+            <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small">
+              <div class="spectrum-ProgressCircle-track"></div>
+              <div class="spectrum-ProgressCircle-fills">
+                <div class="spectrum-ProgressCircle-fillMask1">
+                  <div class="spectrum-ProgressCircle-fillSubMask1">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+                <div class="spectrum-ProgressCircle-fillMask2">
+                  <div class="spectrum-ProgressCircle-fillSubMask2">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </button>
+        </div>
+
+        <div class="spectrum-Examples-item">
+          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">L</h4>
+          <button class="spectrum-Button spectrum-Button--primary spectrum-Button--outline spectrum-Button--sizeL is-pending" disabled>
+            <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small">
+              <div class="spectrum-ProgressCircle-track"></div>
+              <div class="spectrum-ProgressCircle-fills">
+                <div class="spectrum-ProgressCircle-fillMask1">
+                  <div class="spectrum-ProgressCircle-fillSubMask1">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+                <div class="spectrum-ProgressCircle-fillMask2">
+                  <div class="spectrum-ProgressCircle-fillSubMask2">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </button>
+
+          <button class="spectrum-Button spectrum-Button--primary spectrum-Button--outline spectrum-Button--iconOnly spectrum-Button--sizeL is-pending" disabled>
+            <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small">
+              <div class="spectrum-ProgressCircle-track"></div>
+              <div class="spectrum-ProgressCircle-fills">
+                <div class="spectrum-ProgressCircle-fillMask1">
+                  <div class="spectrum-ProgressCircle-fillSubMask1">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+                <div class="spectrum-ProgressCircle-fillMask2">
+                  <div class="spectrum-ProgressCircle-fillSubMask2">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </button>
+        </div>
+
+        <div class="spectrum-Examples-item">
+          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">XL</h4>
+          <button class="spectrum-Button spectrum-Button--secondary spectrum-Button--outline spectrum-Button--sizeXL is-pending" disabled>
+            <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small">
+              <div class="spectrum-ProgressCircle-track"></div>
+              <div class="spectrum-ProgressCircle-fills">
+                <div class="spectrum-ProgressCircle-fillMask1">
+                  <div class="spectrum-ProgressCircle-fillSubMask1">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+                <div class="spectrum-ProgressCircle-fillMask2">
+                  <div class="spectrum-ProgressCircle-fillSubMask2">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </button>
+
+          <button class="spectrum-Button spectrum-Button--secondary spectrum-Button--outline spectrum-Button--iconOnly spectrum-Button--sizeXL is-pending" disabled>
+            <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small">
+              <div class="spectrum-ProgressCircle-track"></div>
+              <div class="spectrum-ProgressCircle-fills">
+                <div class="spectrum-ProgressCircle-fillMask1">
+                  <div class="spectrum-ProgressCircle-fillSubMask1">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+                <div class="spectrum-ProgressCircle-fillMask2">
+                  <div class="spectrum-ProgressCircle-fillSubMask2">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </button>
+        </div>
+      </div>
+  - id: button-pending-static
+    name: Static white
+    description: Pending button state is only supported for static white, not for static black.
+    markup: |
+      <div style="background-color: rgb(15, 121, 125); color: rgb(15, 121, 125); --spectrum-alias-heading-text-color: white; padding: 15px 20px;">
+        <div class="spectrum-Examples">
+          <div class="spectrum-Examples-item">
+            <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">S</h4>
+            <button class="spectrum-Button spectrum-Button--fill spectrum-Button--staticWhite spectrum-Button--sizeS is-pending" disabled>
+              <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small spectrum-ProgressCircle--staticWhite">
+                <div class="spectrum-ProgressCircle-track"></div>
+                <div class="spectrum-ProgressCircle-fills">
+                  <div class="spectrum-ProgressCircle-fillMask1">
+                    <div class="spectrum-ProgressCircle-fillSubMask1">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                  <div class="spectrum-ProgressCircle-fillMask2">
+                    <div class="spectrum-ProgressCircle-fillSubMask2">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </button>
+
+            <button class="spectrum-Button spectrum-Button--fill spectrum-Button--staticWhite spectrum-Button--iconOnly spectrum-Button--sizeS is-pending" disabled>
+              <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small spectrum-ProgressCircle--staticWhite">
+                <div class="spectrum-ProgressCircle-track"></div>
+                <div class="spectrum-ProgressCircle-fills">
+                  <div class="spectrum-ProgressCircle-fillMask1">
+                    <div class="spectrum-ProgressCircle-fillSubMask1">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                  <div class="spectrum-ProgressCircle-fillMask2">
+                    <div class="spectrum-ProgressCircle-fillSubMask2">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </button>
+          </div>
+
+          <div class="spectrum-Examples-item">
+            <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">M (default)</h4>
+            <button class="spectrum-Button spectrum-Button--fill spectrum-Button--staticWhite spectrum-Button--sizeM is-pending" disabled>
+              <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small spectrum-ProgressCircle--staticWhite">
+                <div class="spectrum-ProgressCircle-track"></div>
+                <div class="spectrum-ProgressCircle-fills">
+                  <div class="spectrum-ProgressCircle-fillMask1">
+                    <div class="spectrum-ProgressCircle-fillSubMask1">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                  <div class="spectrum-ProgressCircle-fillMask2">
+                    <div class="spectrum-ProgressCircle-fillSubMask2">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </button>
+
+            <button class="spectrum-Button spectrum-Button--fill spectrum-Button--staticWhite spectrum-Button--iconOnly spectrum-Button--sizeM is-pending" disabled>
+              <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small spectrum-ProgressCircle--staticWhite">
+                <div class="spectrum-ProgressCircle-track"></div>
+                <div class="spectrum-ProgressCircle-fills">
+                  <div class="spectrum-ProgressCircle-fillMask1">
+                    <div class="spectrum-ProgressCircle-fillSubMask1">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                  <div class="spectrum-ProgressCircle-fillMask2">
+                    <div class="spectrum-ProgressCircle-fillSubMask2">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </button>
+          </div>
+
+          <div class="spectrum-Examples-item">
+            <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">L</h4>
+            <button class="spectrum-Button spectrum-Button--fill spectrum-Button--staticWhite spectrum-Button--sizeL is-pending" disabled>
+              <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small spectrum-ProgressCircle--staticWhite">
+                <div class="spectrum-ProgressCircle-track"></div>
+                <div class="spectrum-ProgressCircle-fills">
+                  <div class="spectrum-ProgressCircle-fillMask1">
+                    <div class="spectrum-ProgressCircle-fillSubMask1">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                  <div class="spectrum-ProgressCircle-fillMask2">
+                    <div class="spectrum-ProgressCircle-fillSubMask2">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </button>
+
+            <button class="spectrum-Button spectrum-Button--fill spectrum-Button--staticWhite spectrum-Button--iconOnly spectrum-Button--sizeL is-pending" disabled>
+              <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small spectrum-ProgressCircle--staticWhite">
+                <div class="spectrum-ProgressCircle-track"></div>
+                <div class="spectrum-ProgressCircle-fills">
+                  <div class="spectrum-ProgressCircle-fillMask1">
+                    <div class="spectrum-ProgressCircle-fillSubMask1">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                  <div class="spectrum-ProgressCircle-fillMask2">
+                    <div class="spectrum-ProgressCircle-fillSubMask2">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </button>
+          </div>
+
+          <div class="spectrum-Examples-item">
+            <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">XL</h4>
+            <button class="spectrum-Button spectrum-Button--fill spectrum-Button--staticWhite spectrum-Button--sizeXL is-pending" disabled>
+              <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small spectrum-ProgressCircle--staticWhite">
+                <div class="spectrum-ProgressCircle-track"></div>
+                <div class="spectrum-ProgressCircle-fills">
+                  <div class="spectrum-ProgressCircle-fillMask1">
+                    <div class="spectrum-ProgressCircle-fillSubMask1">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                  <div class="spectrum-ProgressCircle-fillMask2">
+                    <div class="spectrum-ProgressCircle-fillSubMask2">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </button>
+
+            <button class="spectrum-Button spectrum-Button--fill spectrum-Button--staticWhite spectrum-Button--iconOnly spectrum-Button--sizeXL is-pending" disabled>
+              <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small spectrum-ProgressCircle--staticWhite">
+                <div class="spectrum-ProgressCircle-track"></div>
+                <div class="spectrum-ProgressCircle-fills">
+                  <div class="spectrum-ProgressCircle-fillMask1">
+                    <div class="spectrum-ProgressCircle-fillSubMask1">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                  <div class="spectrum-ProgressCircle-fillMask2">
+                    <div class="spectrum-ProgressCircle-fillSubMask2">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </button>
+          </div>
+        </div>
+      </div>
+  - id: button-pending-static-outline
+    name: Outline on Static White
+    description: Pending button state is only supported for static white, not for static black.
+    markup: |
+      <div style="background-color: rgb(15, 121, 125); color: rgb(15, 121, 125); --spectrum-alias-heading-text-color: white; padding: 15px 20px;">
+        <div class="spectrum-Examples">
+          <div class="spectrum-Examples-item">
+            <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">S</h4>
+            <button class="spectrum-Button spectrum-Button--staticWhite spectrum-Button--outline spectrum-Button--sizeS is-pending" disabled>
+              <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small spectrum-ProgressCircle--staticWhite">
+                <div class="spectrum-ProgressCircle-track"></div>
+                <div class="spectrum-ProgressCircle-fills">
+                  <div class="spectrum-ProgressCircle-fillMask1">
+                    <div class="spectrum-ProgressCircle-fillSubMask1">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                  <div class="spectrum-ProgressCircle-fillMask2">
+                    <div class="spectrum-ProgressCircle-fillSubMask2">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </button>
+
+            <button class="spectrum-Button spectrum-Button--staticWhite spectrum-Button--outline spectrum-Button--iconOnly spectrum-Button--sizeS is-pending" disabled>
+              <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small spectrum-ProgressCircle--staticWhite">
+                <div class="spectrum-ProgressCircle-track"></div>
+                <div class="spectrum-ProgressCircle-fills">
+                  <div class="spectrum-ProgressCircle-fillMask1">
+                    <div class="spectrum-ProgressCircle-fillSubMask1">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                  <div class="spectrum-ProgressCircle-fillMask2">
+                    <div class="spectrum-ProgressCircle-fillSubMask2">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </button>
+          </div>
+
+          <div class="spectrum-Examples-item">
+            <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">M (default)</h4>
+            <button class="spectrum-Button spectrum-Button--staticWhite spectrum-Button--outline spectrum-Button--sizeM is-pending" disabled>
+              <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small spectrum-ProgressCircle--staticWhite">
+                <div class="spectrum-ProgressCircle-track"></div>
+                <div class="spectrum-ProgressCircle-fills">
+                  <div class="spectrum-ProgressCircle-fillMask1">
+                    <div class="spectrum-ProgressCircle-fillSubMask1">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                  <div class="spectrum-ProgressCircle-fillMask2">
+                    <div class="spectrum-ProgressCircle-fillSubMask2">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </button>
+
+            <button class="spectrum-Button spectrum-Button--staticWhite spectrum-Button--outline spectrum-Button--iconOnly spectrum-Button--sizeM is-pending" disabled>
+              <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small spectrum-ProgressCircle--staticWhite">
+                <div class="spectrum-ProgressCircle-track"></div>
+                <div class="spectrum-ProgressCircle-fills">
+                  <div class="spectrum-ProgressCircle-fillMask1">
+                    <div class="spectrum-ProgressCircle-fillSubMask1">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                  <div class="spectrum-ProgressCircle-fillMask2">
+                    <div class="spectrum-ProgressCircle-fillSubMask2">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </button>
+          </div>
+
+          <div class="spectrum-Examples-item">
+            <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">L</h4>
+            <button class="spectrum-Button spectrum-Button--staticWhite spectrum-Button--outline spectrum-Button--sizeL is-pending" disabled>
+              <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small spectrum-ProgressCircle--staticWhite">
+                <div class="spectrum-ProgressCircle-track"></div>
+                <div class="spectrum-ProgressCircle-fills">
+                  <div class="spectrum-ProgressCircle-fillMask1">
+                    <div class="spectrum-ProgressCircle-fillSubMask1">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                  <div class="spectrum-ProgressCircle-fillMask2">
+                    <div class="spectrum-ProgressCircle-fillSubMask2">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </button>
+
+            <button class="spectrum-Button spectrum-Button--staticWhite spectrum-Button--outline spectrum-Button--iconOnly spectrum-Button--sizeL is-pending" disabled>
+              <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small spectrum-ProgressCircle--staticWhite">
+                <div class="spectrum-ProgressCircle-track"></div>
+                <div class="spectrum-ProgressCircle-fills">
+                  <div class="spectrum-ProgressCircle-fillMask1">
+                    <div class="spectrum-ProgressCircle-fillSubMask1">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                  <div class="spectrum-ProgressCircle-fillMask2">
+                    <div class="spectrum-ProgressCircle-fillSubMask2">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </button>
+          </div>
+
+          <div class="spectrum-Examples-item">
+            <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">XL</h4>
+            <button class="spectrum-Button spectrum-Button--staticWhite spectrum-Button--outline spectrum-Button--sizeXL is-pending" disabled>
+              <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small spectrum-ProgressCircle--staticWhite">
+                <div class="spectrum-ProgressCircle-track"></div>
+                <div class="spectrum-ProgressCircle-fills">
+                  <div class="spectrum-ProgressCircle-fillMask1">
+                    <div class="spectrum-ProgressCircle-fillSubMask1">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                  <div class="spectrum-ProgressCircle-fillMask2">
+                    <div class="spectrum-ProgressCircle-fillSubMask2">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </button>
+
+            <button class="spectrum-Button spectrum-Button--staticWhite spectrum-Button--outline spectrum-Button--iconOnly spectrum-Button--sizeXL is-pending" disabled>
+              <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small spectrum-ProgressCircle--staticWhite">
+                <div class="spectrum-ProgressCircle-track"></div>
+                <div class="spectrum-ProgressCircle-fills">
+                  <div class="spectrum-ProgressCircle-fillMask1">
+                    <div class="spectrum-ProgressCircle-fillSubMask1">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                  <div class="spectrum-ProgressCircle-fillMask2">
+                    <div class="spectrum-ProgressCircle-fillSubMask2">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </button>
+          </div>
+        </div>
+      </div>

--- a/components/button/package.json
+++ b/components/button/package.json
@@ -16,10 +16,14 @@
   "main": "dist/index-vars.css",
   "peerDependencies": {
     "@spectrum-css/icon": ">=4",
+    "@spectrum-css/progresscircle": ">=2",
     "@spectrum-css/tokens": ">=13"
   },
   "peerDependenciesMeta": {
     "@spectrum-css/icon": {
+      "optional": true
+    },
+    "@spectrum-css/progresscircle": {
       "optional": true
     }
   },

--- a/components/button/stories/button.stories.js
+++ b/components/button/stories/button.stories.js
@@ -2,6 +2,7 @@ import { html } from "lit";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { styleMap } from "lit/directives/style-map.js";
 
+import { Template as Typography } from "@spectrum-css/typography/stories/template.js";
 import { Template } from "./template";
 
 import { default as IconStories } from "@spectrum-css/icon/stories/icon.stories.js";
@@ -69,6 +70,16 @@ export default {
 			},
 			control: "boolean",
 		},
+		isPending: {
+			name: "Pending",
+			type: { name: "boolean" },
+			table: {
+				type: { summary: "boolean" },
+				category: "State",
+			},
+			control: "boolean",
+			if: { arg: "staticColor", neq: "black" }
+		},
 		staticColor: {
 			name: "Static color",
 			type: { name: "string" },
@@ -78,7 +89,7 @@ export default {
 			},
 			options: ["white", "black"],
 			control: "select",
-		},
+		}
 	},
 	args: {
 		rootClass: "spectrum-Button",
@@ -87,6 +98,7 @@ export default {
 		variant: "accent",
 		treatment: "fill",
 		isDisabled: false,
+		isPending: false,
 	},
 	parameters: {
 		actions: {
@@ -105,40 +117,107 @@ const CustomButton = ({
 	staticColor,
 	customStyles = {},
 	...args
-}) => {
-	return html`
-		<div
-      		style=${ifDefined(styleMap({
-				padding: "1rem",
-				backgroundColor: staticColor === "white" ? "rgb(15, 121, 125)" : staticColor === "black" ? "rgb(181, 209, 211)" : undefined,
-				...customStyles
-			}))}
-		>
-			${Template({
-				...args,
-				staticColor,
-				iconName: undefined,
+}) => html`
+	<div
+				style=${ifDefined(styleMap({
+			padding: "1rem",
+			backgroundColor: staticColor === "white" ? "rgb(15, 121, 125)" : staticColor === "black" ? "rgb(181, 209, 211)" : undefined,
+			...customStyles
+		}))}
+	>
+		${Template({
+			...args,
+			staticColor,
+			iconName: undefined,
+		})}
+		${Template({
+			...args,
+			staticColor,
+			iconName: undefined,
+			treatment: "outline",
+		})}
+		${Template({
+			...args,
+			staticColor,
+			iconName: iconName ?? "Edit",
+		})}
+		${Template({
+			...args,
+			staticColor,
+			hideLabel: true,
+			iconName: iconName ?? "Edit",
+		})}
+	</div>
+`;
+
+const PendingButton = ({
+	staticColor,
+	customStyles = {},
+	...args
+}) => html`
+	<div style=${styleMap({
+		display: "flex",
+		flexDirection: "column",
+		gap: ".3rem",
+	})}>
+		<div>
+		${Typography({
+				semantics: "heading",
+				size: "xxs",
+				content: ["Default"],
 			})}
-			${Template({
+			${CustomButton({
 				...args,
-				staticColor,
-				iconName: undefined,
-				treatment: "outline",
-			})}
-			${Template({
-				...args,
-				staticColor,
-				iconName: iconName ?? "Edit",
-			})}
-			${Template({
-				...args,
-				staticColor,
-				hideLabel: true,
-				iconName: iconName ?? "Edit",
 			})}
 		</div>
-	`;
-};
+		<div>
+			${Typography({
+				semantics: "heading",
+				size: "xxs",
+				content: ["Static White"],
+			})}
+			${CustomButton({
+				...args,
+				staticColor: "white",
+			})}
+		</div>
+	</div>
+`;
+
+const ButtonsWithForcedColors = ({
+	customStyles = {},
+	...args
+}) => html`
+	<div style=${styleMap({
+		display: "flex",
+		flexDirection: "column",
+		gap: ".3rem",
+	})}>
+		<div>
+		${Typography({
+				semantics: "heading",
+				size: "xxs",
+				content: ["Default"],
+			})}
+			${CustomButton({
+				...args,
+				variant: "accent"
+			})}
+		</div>
+		<div>
+			${Typography({
+				semantics: "heading",
+				size: "xxs",
+				content: ["Pending State"],
+			})}
+			${CustomButton({
+				...args,
+				isDisabled: true,
+				isPending: true,
+			})}
+		</div>
+	</div>
+`;
 
 export const Accent = CustomButton.bind({});
 Accent.args = {
@@ -177,7 +256,13 @@ Disabled.args = {
 	iconName: "Actions",
 };
 
-export const WithForcedColors = CustomButton.bind({});
+export const Pending = PendingButton.bind({});
+Pending.args = {
+	isDisabled: true,
+	isPending: true,
+};
+
+export const WithForcedColors = ButtonsWithForcedColors.bind({});
 WithForcedColors.parameters = {
   chromatic: { forcedColors: "active" },
 };

--- a/components/button/stories/template.js
+++ b/components/button/stories/template.js
@@ -7,6 +7,7 @@ import { when } from "lit/directives/when.js";
 import { capitalize, lowerCase } from "lodash-es";
 
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
+import { Template as ProgressCircle } from "@spectrum-css/progresscircle/stories/template.js";
 
 import "../index.css";
 
@@ -25,6 +26,7 @@ export const Template = ({
   treatment,
   onclick,
   isDisabled = false,
+  isPending = false,
   ariaExpanded,
   ariaControls,
   ...globals
@@ -46,6 +48,7 @@ export const Template = ({
         [`${rootClass}--size${size?.toUpperCase()}`]: typeof size !== "undefined",
         [`${rootClass}--static${capitalize(lowerCase(staticColor))}`]: typeof staticColor !== "undefined",
         [`${rootClass}--iconOnly`]: hideLabel,
+        "is-pending": isPending,
         ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
       })}
       id=${ifDefined(id)}
@@ -61,6 +64,11 @@ export const Template = ({
         () => html`<span class=${`${rootClass}-label`}>${label}</span>`
       )}
       ${when(iconName && iconAfterLabel, () => Icon({ ...globals, iconName, size }))}
+      ${when(isPending, () => {
+          const isOverBackground = staticColor === 'white';
+          return ProgressCircle({ ...globals, size: 's', overBackground: isOverBackground, isIndeterminate: true, addStaticBackground: false })
+        }
+      )}
     </button>
   `;
 };

--- a/components/progresscircle/stories/progresscircle.stories.js
+++ b/components/progresscircle/stories/progresscircle.stories.js
@@ -1,4 +1,5 @@
-// Import the component markup template
+import isChromatic from "chromatic/isChromatic";
+import { html } from "lit";
 import { Template } from "./template";
 
 export default {
@@ -54,5 +55,22 @@ export default {
 	},
 };
 
-export const Default = Template.bind({});
+const chromaticKitchenSink = (args) => html`
+	${Template(args)}
+	${Template({
+		...args,
+		isIndeterminate: true,
+	})}
+	${Template({
+		...args,
+		overBackground: true,
+	})}
+	${Template({
+		...args,
+		isIndeterminate: true,
+		overBackground: true,
+	})}
+`;
+
+export const Default = (args) => isChromatic() ? chromaticKitchenSink(args) : Template(args);
 Default.args = {};

--- a/components/progresscircle/stories/template.js
+++ b/components/progresscircle/stories/template.js
@@ -9,6 +9,7 @@ export const Template = ({
 	size = "m",
 	overBackground = false,
 	isIndeterminate = false,
+	addStaticBackground = overBackground,
 }) => {
 	let sizeClassName = "medium";
 	switch (size) {
@@ -52,5 +53,5 @@ export const Template = ({
 		<div style="background-color: #0F797D;">${componentMarkup}</div>
 	`;
 
-	return overBackground ? decoratedMarkup : componentMarkup;
+	return overBackground && addStaticBackground ? decoratedMarkup : componentMarkup;
 };


### PR DESCRIPTION
## Description

Add pending state variant to the existing button

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
#### New/additional validation steps
- [ ] The "iconOnly" version of the button (aka the circular one) remains a perfect circle when the pending state is applied. Check that the height and width match and that the iconOnly pending state button has the same height as other variants of the button. This is best checked in the docs site but can be tested in Storybook as well.
- [ ] In Storybook, Pending has it's own story that shows pending state default and static white with labels (Cassondra recommended this and is implementing similar things in her [decorator PR](https://github.com/adobe/spectrum-css/pull/2420/files#diff-b965736461e30accd067d0f9fe09aa0e60ac58b4910b6dfb39c194bbb5200f5a))
- [ ] WithForcedColors story includes Pending state
- [ ] Test WHCM. Buttons should look like this per chats with the accessibility team:
![Screen Shot 2024-01-23 at 2 25 48 PM](https://github.com/adobe/spectrum-css/assets/23404383/737624c4-367b-41c6-a8c3-731fbc8737cc)


#### Original validation steps
- [x] Design approval @mdt2 
  - Outstanding design questions [and answers](https://adobedesign.slack.com/archives/G019JTYMT6H/p1705609053178079?thread_ts=1705006780.231489&cid=G019JTYMT6H):
    - [x] Should the pending button be disabled to prevent user interaction and hover/focus states? **yes**
    - [x] Assuming it is disabled, the background color and border should be the same no matter what background color variant the button originally was, correct? For example even if it is a negative variant button, when it is pending it should look like the pending spec with the disabled gray background/border and the default blue for the progress circle? **yes, it can use disabled-background-color and disabled-border-color**
    - [x] What size Progress Circle (PC) should I use for each size of the button? **small for all size buttons, including desktop and mobile**
    - [x] What should the pending state look like against static white or black backgrounds? Should we use a different version of the Progress Circle in either case? **Static white uses the static white progress circle. Design is continuing to not support static black for progress circle, which means buttons on static black aren't eligible for pending state.**

- [x] Pending state has storybook representation @jenndiaz 
- [x] Pending state has docs site representation @jenndiaz 
- [x] Pending state matches [the spec](https://spectrum.adobe.com/page/button/#Pending) @jenndiaz 
- [x] ProgressCircle has increased chromatic coverage for indeterminate and static white variants @jenndiaz 

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.


## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
