### PR TITLE
fix(quickaction): storybook using wrong root class 

### DIFF
--- a/components/quickaction/stories/quickaction.stories.js
+++ b/components/quickaction/stories/quickaction.stories.js
@@ -37,7 +37,7 @@ export default {
 		},
 	},
 	args: {
-		rootClass: "spectrum-QuickAction",
+		rootClass: "spectrum-QuickActions",
 		isOpen: true,
 		textOnly: false,
 	},


### PR DESCRIPTION
## Description

The wrong root class for quickaction was being used in Storybook, resulting in missing styles. This updates the args to use the correct class, which is plural: `spectrum-QuickActions`.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [x] Quick actions Storybook: Quick actions CSS is present in Storybook; including horizontal margin that appears between buttons, as seen on the docs page

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [ ] ✨ This pull request is ready to merge. ✨
