### PR TITLE
fix(card): gap between preview and horizontal card border

### DIFF
--- a/components/card/index.css
+++ b/components/card/index.css
@@ -814,22 +814,10 @@ governing permissions and limitations under the License.
 		align-items: center;
 		justify-content: center;
 
-		border-start-start-radius: var(
-			--mod-card-corner-radius,
-			var(--spectrum-card-corner-radius)
-		);
+		border-start-start-radius: calc(var(--mod-card-corner-radius, var(--spectrum-card-corner-radius)) - var(--mod-card-border-width, var(--spectrum-card-border-width)));
 		border-start-end-radius: 0;
-		border-end-start-radius: var(
-			--mod-card-corner-radius,
-			var(--spectrum-card-corner-radius)
-		);
+		border-end-start-radius: calc(var(--mod-card-corner-radius, var(--spectrum-card-corner-radius)) - var(--mod-card-border-width, var(--spectrum-card-border-width)));
 		border-end-end-radius: 0;
-
-		border-inline-end: var(
-				--mod-card-border-width,
-				var(--spectrum-card-border-width)
-			)
-			solid transparent;
 
 		padding: var(
 			--mod-card-horizontal-preview-padding,


### PR DESCRIPTION
## Description

Address [issue 3843](https://github.com/adobe/spectrum-web-components/issues/3843) by adjusting border-radius of horizontal card's preview.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
- [ ] In the docs site, the horizontal card should not have any gaps between the gray preview background and the border of the card
- [ ] In Storybook, the horizontal card should not have any gaps between the gray preview background and the border of the card

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

Before fix:
![image](https://github.com/adobe/spectrum-css/assets/23404383/50c985f1-1745-479d-938c-59b4e7f046ad)

After fix:
![Screen Shot 2024-01-19 at 1 52 48 PM](https://github.com/adobe/spectrum-css/assets/23404383/56078f60-a406-467f-9631-8217ce10c082)

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
