### PR TITLE
ci: allow spectrum-two PRs

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -12,6 +12,7 @@ on:
     pull_request:
         branches:
             - main
+            - spectrum-two
             # Allow us to run tests for PRs updating github actions
             - chore-*ci*
             - chore-*github-actions*

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -10,7 +10,7 @@ name: Build and verify production
 
 on:
     push:
-        branches: [main]
+        branches: [main, spectrum-two]
 
 permissions:
     contents: read


### PR DESCRIPTION
## Description

Set up the `spectrum-two` branch as a base branch for CI. Allows PRs to be opened against it and have all CI run to validate.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] ✨ This pull request is ready to merge. ✨
