### PR TITLE
ci: separate build matrix from workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,9 @@ on:
             node-version:
                 required: false
                 default: "18"
+            experimental:
+                required: false
+                default: "false"
             ref:
                 description: "The branch or tag to checkout"
                 required: false
@@ -35,6 +38,10 @@ on:
                 required: false
                 type: string
                 default: "18"
+            experimental:
+                required: false
+                type: boolean
+                default: false
             ref:
                 description: "The branch or tag to checkout"
                 required: false
@@ -62,7 +69,10 @@ jobs:
                     - ${{ inputs.system }}
                 node-version:
                     - ${{ inputs.node-version }}
+                experimental:
+                    - ${{ inputs.experimental }}
         runs-on: ${{ matrix.system }}
+        continue-on-error: ${{ matrix.experimental }}
         timeout-minutes: 10
         outputs:
             head-sha: ${{ steps.set-SHAs.outputs.head }}
@@ -129,6 +139,7 @@ jobs:
                   if-no-files-found: error
 
             # This step will evaluate the repo status and report the change
+            # If there are changes, capture the changes and upload them as an artifact
             - name: Check if there are changes
               shell: bash
               run: |
@@ -138,5 +149,14 @@ jobs:
                 else
                     echo "Changes detected"
                     git status
+                    git add .
+                    git diff > changes.diff
                     exit 1
                 fi
+
+            - name: Upload changes
+              if: ${{ failure() }}
+              uses: actions/upload-artifact@v4
+              with:
+                path: changes.diff
+                name: changes.diff

--- a/.github/workflows/compare-results.yml
+++ b/.github/workflows/compare-results.yml
@@ -20,10 +20,6 @@ on:
                 required: false
                 type: string
                 default: ${{ github.event.workflow_call.head.ref }}
-            artifact-id:
-                description: The artifact id to use for the build artifacts
-                required: false
-                type: string
         outputs:
             has-changed:
                 value: ${{ jobs.compare.outputs.has-changed }}

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -46,23 +46,29 @@ jobs:
     # -------------------------------------------------------------
     # Validate build for various environments
     # -------------------------------------------------------------
-    build:
-        name: Build
+    verify_builds:
+        name: Verify
         # Check that the PR is not in draft mode (or if it is, that it has the run_ci label to force a build)
-        # if: ${{ github.event.pull_request.draft != 'true' || contains(github.event.pull_request.labels.*.name, 'run_ci') }}
+        if: ${{ github.event.pull_request.draft != 'true' || contains(github.event.pull_request.labels.*.name, 'run_ci') }}
         strategy:
             fail-fast: false
             matrix:
                 system:
                     - macos-latest
                     - ubuntu-latest
-                    # - windows-latest
+                    # - windows-latest # todo: debug token style-dictionary failures on windows
                 node-version:
                     - 18
+                experimental:
+                    - false
+                include:
+                    - node-version: 20
+                      experimental: true
         uses: ./.github/workflows/build.yml
         with:
             system: ${{ matrix.system }}
             node-version: ${{ matrix.node-version }}
+            experimental: ${{ matrix.experimental }}
         secrets: inherit
 
     # -------------------------------------------------------------
@@ -70,13 +76,9 @@ jobs:
     # -------------------------------------------------------------
     compare:
         name: Compare
-        needs: [build]
         # Check that the PR is not in draft mode (or if it is, that it has the run_ci label to force a build)
         if: ${{ github.event.pull_request.draft != 'true' || contains(github.event.pull_request.labels.*.name, 'run_ci') }}
         uses: ./.github/workflows/compare-results.yml
-        with:
-            base-sha: ${{ needs.build.outputs.base-sha }}
-            head-sha: ${{ needs.build.outputs.head-sha }}
         secrets: inherit
 
     # -------------------------------------------------------------
@@ -136,7 +138,6 @@ jobs:
     # -------------------------------------------------------------
     vrt:
         name: Testing
-        needs: [build]
         if: ${{ contains(github.event.pull_request.labels.*.name, 'run_vrt') || ((github.event.pull_request.draft != true || contains(github.event.pull_request.labels.*.name, 'run_ci')) && github.event.pull_request.mergeable == true) }}
         uses: ./.github/workflows/vrt.yml
         with:
@@ -150,9 +151,9 @@ jobs:
     publish_site:
         name: Publish
         # The build step ensures we are leveraging the cache for the build
-        needs: [build, vrt]
+        needs: [vrt]
         # Note: the goal here is to allow vrt to be skipped but still require the build to succeed
-        if: ${{ always() && (needs.vrt.result == 'success' || needs.vrt.result == 'skipped') && needs.build.result == 'success' }}
+        if: ${{ always() && (needs.vrt.result == 'success' || needs.vrt.result == 'skipped') }}
         uses: ./.github/workflows/publish-site.yml
         with:
             deploy-message: ${{ github.event.pull_request.title }}

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -36,7 +36,6 @@ jobs:
                 system:
                     - macos-latest
                     - ubuntu-latest
-                    # - windows-latest
                 node-version:
                     - 18
         uses: ./.github/workflows/build.yml


### PR DESCRIPTION
## Description

Separate the build matrix testing from the CI workflows.

### Why?

The macos environments build a minute or two slower than ubuntu. As the ubuntu environment is used for the rest of the CI workflow, it would speed up the overall run-time to allow these tasks to run separately.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [ ] Expect to see CI run all defined environments and pass

<img width="739" alt="Screenshot 2024-02-08 at 11 22 54 AM" src="https://github.com/adobe/spectrum-css/assets/1840295/1b08446f-3ea3-4eda-8222-94915e46a6b8">
(Note that Matrix: Compare & fetch are separate from Matrix: Verify)

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] ✨ This pull request is ready to merge. ✨
