### PR TITLE
docs: actionbar example and modal docs text update

### DIFF
--- a/components/actionbar/metadata/actionbar.yml
+++ b/components/actionbar/metadata/actionbar.yml
@@ -1,5 +1,5 @@
 name: Action bar
-description: Floating action bar that appears in selection mode.
+description: Floating Action bar that appears in selection mode.
 SpectrumSiteSlug: https://spectrum.adobe.com/page/action-bar/
 sections:
   - name: Custom Properties API
@@ -7,9 +7,6 @@ sections:
       This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/actionbar/metadata/mods.md">here</a>.
   - name: Migration Guide
     description: |
-      ### Change in Table example markup
-      In the Table example, the Action bar has been moved outside of the Table markup.
-
       ### Popover Dependency
       Action bar requires Popover, which is nested within Action bar. Action bar background, border, and corner radius are applied to the nested Popover component and can be overriden by Action bar.
 
@@ -33,7 +30,7 @@ sections:
 examples:
   - id: actionbar
     name: Standard
-    description: Standard Action Bars fill the width of their container.
+    description: Standard Action bars fill the width of their container.
     markup: |
       <div class="spectrum-ActionBar is-open">
         <div class="spectrum-Popover spectrum-ActionBar-popover is-open">
@@ -58,7 +55,6 @@ examples:
           </div>
         </div>
       </div>
-
 
       <div class="spectrum-ActionBar is-open">
         <div class="spectrum-Popover spectrum-ActionBar-popover is-open">
@@ -93,7 +89,6 @@ examples:
         </div>
       </div>
 
-
       <div class="spectrum-ActionBar is-open">
         <div class="spectrum-Popover spectrum-ActionBar-popover is-open">
           <button class="spectrum-CloseButton spectrum-CloseButton--sizeM" aria-label="Clear selection">
@@ -126,7 +121,7 @@ examples:
 
   - id: actionbar-emphasized
     name: Emphasized
-    description: Emphasized action bar.
+    description: Emphasized Action bar.
     markup: |
       <div class="spectrum-ActionBar spectrum-ActionBar--emphasized is-open">
         <div class="spectrum-Popover spectrum-ActionBar-popover is-open">
@@ -219,7 +214,7 @@ examples:
 
   - id: actionbar-flexible
     name: Flexible
-    description: Flexible Action Bars fit the width of their content.
+    description: Flexible Action bars fit the width of their content.
     markup: |
       <div class="spectrum-ActionBar spectrum-ActionBar--flexible is-open">
         <div class="spectrum-Popover spectrum-ActionBar-popover is-open">
@@ -246,207 +241,56 @@ examples:
         </div>
       </div>
 
-  - id: actionbar-table
-    name: Table with ActionBar
-    description: Example usage of sticky ActionBar within a table. 
+  - id: actionbar-sticky
+    name: Sticky
+    description: This example shows how the sticky Action bar looks within a scrollable element. Please see <a href="https://spectrum.adobe.com/page/action-bar/#Usage-guidelines">usage section of the guidelines</a>
+      for more information about using Action bar with underlying content.
     markup: |
-      <div class="spectrum-Table-scroller spectrum-Table spectrum-Table--emphasized spectrum-Table--quiet" style="height: 200px; width: 100%;">
-        <div class="spectrum-Table-main" role="grid" style="width: 100%;">
-          <div class="spectrum-Table-head" role="row">
-            <div class="spectrum-Table-headCell spectrum-Table-checkboxCell" role="columnheader">
-              <label class="spectrum-Checkbox spectrum-Checkbox--sizeM is-indeterminate">
-                <input type="checkbox" class="spectrum-Checkbox-input">
-                <span class="spectrum-Checkbox-box">
-                  <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-                    <use xlink:href="#spectrum-css-icon-Checkmark100" />
-                  </svg>
-                  <svg class="spectrum-Icon spectrum-UIIcon-Dash100 spectrum-Checkbox-partialCheckmark" focusable="false" aria-hidden="true">
-                    <use xlink:href="#spectrum-css-icon-Dash100" />
-                  </svg>
-                </span>
-              </label>
-            </div>
-            <div class="spectrum-Table-headCell is-sortable is-sorted-desc" role="columnheader" aria-sort="descending" tabindex="0">
-              <svg class="spectrum-Icon spectrum-UIIcon-ArrowDown100 spectrum-Table-sortedIcon" focusable="false" aria-hidden="true">
-                <use xlink:href="#spectrum-css-icon-Arrow100" />
-              </svg><span class="spectrum-Table-columnTitle">Column title</span>
-            </div>
-            <div class="spectrum-Table-headCell is-sortable" role="columnheader" aria-sort="none" tabindex="0">
-              <svg class="spectrum-Icon spectrum-UIIcon-ArrowDown100 spectrum-Table-sortedIcon" focusable="false" aria-hidden="true">
-                <use xlink:href="#spectrum-css-icon-Arrow100" />
-              </svg><span class="spectrum-Table-columnTitle">Column title</span>
-            </div>
-            <div class="spectrum-Table-headCell" role="columnheader">Column Title</div>
-          </div>
-          <div class="spectrum-Table-body" role="rowgroup">
-            <div class="spectrum-Table-row" role="row">
-              <div class="spectrum-Table-cell spectrum-Table-checkboxCell" role="gridcell">
-                <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-Table-checkbox">
-                  <input type="checkbox" class="spectrum-Checkbox-input" title="Select" checked>
-                  <span class="spectrum-Checkbox-box">
-                    <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-                      <use xlink:href="#spectrum-css-icon-Checkmark100" />
-                    </svg>
-                  </span>
-                </label>
-              </div>
-              <div class="spectrum-Table-cell" role="gridcell">Row Item Alpha</div>
-              <div class="spectrum-Table-cell" role="gridcell">Row Item Alpha</div>
-              <div class="spectrum-Table-cell" role="gridcell">Row Item Alpha</div>
-            </div>
-            <div class="spectrum-Table-row" role="row">
-              <div class="spectrum-Table-cell spectrum-Table-checkboxCell" role="gridcell">
-                <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-Table-checkbox">
-                  <input type="checkbox" class="spectrum-Checkbox-input" title="Select" checked>
-                  <span class="spectrum-Checkbox-box">
-                    <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-                      <use xlink:href="#spectrum-css-icon-Checkmark100" />
-                    </svg>
-                  </span>
-                </label>
-              </div>
-              <div class="spectrum-Table-cell" role="gridcell">Row Item Bravo</div>
-              <div class="spectrum-Table-cell" role="gridcell">Row Item Bravo</div>
-              <div class="spectrum-Table-cell" role="gridcell">Row Item Bravo</div>
-            </div>
-            <div class="spectrum-Table-row" role="row">
-              <div class="spectrum-Table-cell spectrum-Table-checkboxCell" role="gridcell">
-                <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-Table-checkbox">
-                  <input type="checkbox" class="spectrum-Checkbox-input" title="Select" checked>
-                  <span class="spectrum-Checkbox-box">
-                    <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-                      <use xlink:href="#spectrum-css-icon-Checkmark100" />
-                    </svg>
-                  </span>
-                </label>
-              </div>
-              <div class="spectrum-Table-cell" role="gridcell">Row Item Charlie</div>
-              <div class="spectrum-Table-cell" role="gridcell">Row Item Charlie</div>
-              <div class="spectrum-Table-cell" role="gridcell">Row Item Charlie</div>
-            </div>
-            <div class="spectrum-Table-row" role="row">
-              <div class="spectrum-Table-cell spectrum-Table-checkboxCell" role="gridcell">
-                <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-Table-checkbox">
-                  <input type="checkbox" class="spectrum-Checkbox-input" title="Select">
-                  <span class="spectrum-Checkbox-box">
-                    <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-                      <use xlink:href="#spectrum-css-icon-Checkmark100" />
-                    </svg>
-                  </span>
-                </label>
-              </div>
-              <div class="spectrum-Table-cell" role="gridcell">Row Item Delta</div>
-              <div class="spectrum-Table-cell" role="gridcell">Row Item Delta</div>
-              <div class="spectrum-Table-cell" role="gridcell">Row Item Delta</div>
-            </div>
-            <div class="spectrum-Table-row" role="row">
-              <div class="spectrum-Table-cell spectrum-Table-checkboxCell" role="gridcell">
-                <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-Table-checkbox">
-                  <input type="checkbox" class="spectrum-Checkbox-input" title="Select" checked>
-                  <span class="spectrum-Checkbox-box">
-                    <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-                      <use xlink:href="#spectrum-css-icon-Checkmark100" />
-                    </svg>
-                  </span>
-                </label>
-              </div>
-              <div class="spectrum-Table-cell" role="gridcell">Row Item Echo</div>
-              <div class="spectrum-Table-cell" role="gridcell">Row Item Echo</div>
-              <div class="spectrum-Table-cell" role="gridcell">Row Item Echo</div>
-            </div>
-            <div class="spectrum-Table-row" role="row">
-              <div class="spectrum-Table-cell spectrum-Table-checkboxCell" role="gridcell">
-                <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-Table-checkbox">
-                  <input type="checkbox" class="spectrum-Checkbox-input" title="Select">
-                  <span class="spectrum-Checkbox-box">
-                    <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-                      <use xlink:href="#spectrum-css-icon-Checkmark100" />
-                    </svg>
-                  </span>
-                </label>
-              </div>
-              <div class="spectrum-Table-cell" role="gridcell">Row Item Frank</div>
-              <div class="spectrum-Table-cell" role="gridcell">Row Item Frank</div>
-              <div class="spectrum-Table-cell" role="gridcell">Row Item Frank</div>
-            </div>
-            <div class="spectrum-Table-row" role="row">
-              <div class="spectrum-Table-cell spectrum-Table-checkboxCell" role="gridcell">
-                <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-Table-checkbox">
-                  <input type="checkbox" class="spectrum-Checkbox-input" title="Select">
-                  <span class="spectrum-Checkbox-box">
-                    <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-                      <use xlink:href="#spectrum-css-icon-Checkmark100" />
-                    </svg>
-                  </span>
-                </label>
-              </div>
-              <div class="spectrum-Table-cell" role="gridcell">Row Item George</div>
-              <div class="spectrum-Table-cell" role="gridcell">Row Item George</div>
-              <div class="spectrum-Table-cell" role="gridcell">Row Item George</div>
-            </div>
-            <div class="spectrum-Table-row" role="row">
-              <div class="spectrum-Table-cell spectrum-Table-checkboxCell" role="gridcell">
-                <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-Table-checkbox">
-                  <input type="checkbox" class="spectrum-Checkbox-input" title="Select">
-                  <span class="spectrum-Checkbox-box">
-                    <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-                      <use xlink:href="#spectrum-css-icon-Checkmark100" />
-                    </svg>
-                  </span>
-                </label>
-              </div>
-              <div class="spectrum-Table-cell" role="gridcell">Row Item Henry</div>
-              <div class="spectrum-Table-cell" role="gridcell">Row Item Henry</div>
-              <div class="spectrum-Table-cell" role="gridcell">Row Item Henry</div>
-            </div>
-            <div class="spectrum-Table-row" role="row">
-              <div class="spectrum-Table-cell spectrum-Table-checkboxCell" role="gridcell">
-                <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-Table-checkbox">
-                  <input type="checkbox" class="spectrum-Checkbox-input" title="Select">
-                  <span class="spectrum-Checkbox-box">
-                    <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-                      <use xlink:href="#spectrum-css-icon-Checkmark100" />
-                    </svg>
-                  </span>
-                </label>
-              </div>
-              <div class="spectrum-Table-cell" role="gridcell">Row Item Jake</div>
-              <div class="spectrum-Table-cell" role="gridcell">Row Item Jake</div>
-              <div class="spectrum-Table-cell" role="gridcell">Row Item Jake</div>
+      <section style="position: relative; max-height: 8em; overflow: auto;">
+        <h4>Scroll down to view sticky behavior</h4>
+        <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in
+            reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt
+            in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+            tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+            aliquip ex ea commodo consequat.
+        </p>
+        <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in
+            reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+        </p>
+        <div class="spectrum-ActionBar spectrum-ActionBar--sticky is-open">
+          <div class="spectrum-Popover spectrum-ActionBar-popover is-open">
+            <button class="spectrum-CloseButton spectrum-CloseButton--sizeM" aria-label="Clear selection">
+              <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-css-icon-Cross100" />
+              </svg>
+            </button>
+
+            <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">3 Selected</label>
+
+            <div class="spectrum-ActionGroup">
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+                <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-label="Edit" aria-hidden="true">
+                  <use xlink:href="#spectrum-icon-18-Edit"></use>
+                </svg>
+                <span class="spectrum-ActionButton-label">Edit</span>
+              </button>
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+                <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-label="Copy" aria-hidden="true">
+                  <use xlink:href="#spectrum-icon-18-Copy"></use>
+                </svg>
+                <span class="spectrum-ActionButton-label">Copy</span>
+              </button>
+              <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
+                <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-label="Delete" aria-hidden="true">
+                  <use xlink:href="#spectrum-icon-18-Delete"></use>
+                </svg>
+                <span class="spectrum-ActionButton-label">Delete</span>
+              </button>
             </div>
           </div>
         </div>
-      </div>
-
-      <div class="spectrum-ActionBar spectrum-ActionBar--sticky is-open">
-        <div class="spectrum-Popover spectrum-ActionBar-popover is-open">
-          <button class="spectrum-CloseButton spectrum-CloseButton--sizeM" aria-label="Clear selection">
-            <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
-              <use xlink:href="#spectrum-css-icon-Cross100" />
-            </svg>
-          </button>
-
-          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">3 Selected</label>
-
-          <div class="spectrum-ActionGroup">
-            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-label="Edit" aria-hidden="true">
-                <use xlink:href="#spectrum-icon-18-Edit"></use>
-              </svg>
-              <span class="spectrum-ActionButton-label">Edit</span>
-            </button>
-            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-label="Copy" aria-hidden="true">
-                <use xlink:href="#spectrum-icon-18-Copy"></use>
-              </svg>
-              <span class="spectrum-ActionButton-label">Copy</span>
-            </button>
-            <button class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-ActionGroup-item">
-              <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-ActionButton-icon" focusable="false" aria-label="Delete" aria-hidden="true">
-                <use xlink:href="#spectrum-icon-18-Delete"></use>
-              </svg>
-              <span class="spectrum-ActionButton-label">Delete</span>
-            </button>
-          </div>
-        </div>
-      </div>
+      </section>

--- a/components/modal/metadata/modal.yml
+++ b/components/modal/metadata/modal.yml
@@ -1,5 +1,5 @@
 name: Modal
-description: A modal component used primarily by Dialog
+description: A modal component that is used primarily by Dialog.
 sections:
   - name: Custom Properties API
     description: |
@@ -8,7 +8,9 @@ examples:
   - id: modal
     name: Modal
     demoClassName: spectrum-CSSExample-example--overlay
+    description: This is a base component used by other components, and should not be used on its own like the following example. If you need a full-featured modal for
+      displaying content, take a look at the <a href="https://opensource.adobe.com/spectrum-css/dialog.html">Dialog</a> component instead.
     markup: |
       <div class="spectrum-Modal-wrapper spectrum-CSSExample-dialog">
-        <div class="spectrum-Modal is-open">This is a modal. Don't use it like this; get yourself a Modal.</div>
+        <div class="spectrum-Modal is-open">A basic example of the Modal markup.</div>
       </div>

--- a/components/modal/stories/modal.stories.js
+++ b/components/modal/stories/modal.stories.js
@@ -49,5 +49,5 @@ export default {
 
 export const Default = Template.bind({});
 Default.args = {
-	content: ["This is a modal. Don't use it like this; get yourself a Modal."],
+	content: ["Modal is a base component used by other components, and should not be used on its own."],
 };


### PR DESCRIPTION
## Description

**docs(actionbar): change table example to demonstrate sticky variant**
The table example was no longer showing sticky behavior. Adjusts example to be similar to SWC. The Table component was causing problems in the build of this docs page and was missing CSS because it's not a dependency of action bar. This solves both issues.
    
**docs(modal): improve docs language around not using a modal**
Improves some slightly confusing and short docs text for Modal. Open to more suggestions here for those who may have some more context!

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [x] Proofread docs text changes for Action bar "sticky" example
- [x] Action bar "Sticky" example displays sticky behavior when scrolling
- [x] Proofread docs text changes for Modal

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- ~~VRTs have been run and looked at.~~
- ~~Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.~~

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
