### PR TITLE
fix(picker): quiet side label picker positioning

### DIFF
--- a/components/fieldlabel/index.css
+++ b/components/fieldlabel/index.css
@@ -105,7 +105,7 @@ governing permissions and limitations under the License.
 .spectrum-FieldLabel--right {
   display: inline-block;
 
-  margin-block-start: var(--spectrum-fieldlabel-side-margin-block-start);
+  margin-block-start: var(--mod-fieldlabel-side-margin-block-start, var(--spectrum-fieldlabel-side-margin-block-start));
   margin-block-end: 0;
   margin-inline-end: var(--mod-fieldlabel-side-padding-right, var(--spectrum-fieldlabel-side-padding-right));
 

--- a/components/fieldlabel/index.css
+++ b/components/fieldlabel/index.css
@@ -27,7 +27,7 @@ governing permissions and limitations under the License.
   --spectrum-fieldlabel-bottom-to-text: var(--spectrum-component-bottom-to-text-75);
   --spectrum-fieldlabel-font-size: var(--spectrum-font-size-75);
 
-  --spectrum-fieldlabel-side-padding-top: var(--spectrum-component-top-to-text-75);
+  --spectrum-fieldlabel-side-margin-block-start: var(--spectrum-field-label-top-margin-small);
   --spectrum-fieldlabel-side-padding-right: var(--spectrum-spacing-100);
 
   --spectrum-field-label-text-to-asterisk: var(--spectrum-field-label-text-to-asterisk-small);
@@ -39,7 +39,7 @@ governing permissions and limitations under the License.
   --spectrum-fieldlabel-bottom-to-text: var(--spectrum-component-bottom-to-text-75);
   --spectrum-fieldlabel-font-size: var(--spectrum-font-size-75);
 
-  --spectrum-fieldlabel-side-padding-top: var(--spectrum-component-top-to-text-75);
+  --spectrum-fieldlabel-side-margin-block-start: var(--spectrum-field-label-top-margin-medium);
   --spectrum-fieldlabel-side-padding-right: var(--spectrum-spacing-200);
 
   --spectrum-field-label-text-to-asterisk: var(--spectrum-field-label-text-to-asterisk-medium);
@@ -51,7 +51,7 @@ governing permissions and limitations under the License.
   --spectrum-fieldlabel-bottom-to-text: var(--spectrum-component-bottom-to-text-100);
   --spectrum-fieldlabel-font-size: var(--spectrum-font-size-100);
 
-  --spectrum-fieldlabel-side-padding-top: var(--spectrum-component-top-to-text-100);
+  --spectrum-fieldlabel-side-margin-block-start: var(--spectrum-field-label-top-margin-large);
   --spectrum-fieldlabel-side-padding-right: var(--spectrum-spacing-200);
 
   --spectrum-field-label-text-to-asterisk: var(--spectrum-field-label-text-to-asterisk-large);
@@ -63,7 +63,7 @@ governing permissions and limitations under the License.
   --spectrum-fieldlabel-bottom-to-text: var(--spectrum-component-bottom-to-text-200);
   --spectrum-fieldlabel-font-size: var(--spectrum-font-size-200);
 
-  --spectrum-fieldlabel-side-padding-top: var(--spectrum-component-top-to-text-200);
+  --spectrum-fieldlabel-side-margin-block-start: var(--spectrum-field-label-top-margin-extra-large);
   --spectrum-fieldlabel-side-padding-right: var(--spectrum-spacing-200);
 
   --spectrum-field-label-text-to-asterisk: var(--spectrum-field-label-text-to-asterisk-extra-large);
@@ -104,9 +104,12 @@ governing permissions and limitations under the License.
 .spectrum-FieldLabel--left,
 .spectrum-FieldLabel--right {
   display: inline-block;
+
+  margin-block-start: var(--spectrum-fieldlabel-side-margin-block-start);
+  margin-block-end: 0;
+  margin-inline-end: var(--mod-fieldlabel-side-padding-right, var(--spectrum-fieldlabel-side-padding-right));
+
   vertical-align: top;
-  padding-block: var(--mod-fieldlabel-side-padding-top, var(--spectrum-fieldlabel-side-padding-top)) 0;
-  padding-inline: 0 var(--mod-fieldlabel-side-padding-right, var(--spectrum-fieldlabel-side-padding-right));
 }
 
 .spectrum-FieldLabel--right {

--- a/components/fieldlabel/metadata/mods.md
+++ b/components/fieldlabel/metadata/mods.md
@@ -10,8 +10,8 @@
 | `--mod-fieldlabel-line-height`                    |
 | `--mod-fieldlabel-line-height-cjk`                |
 | `--mod-fieldlabel-min-height`                     |
+| `--mod-fieldlabel-side-margin-block-start`        |
 | `--mod-fieldlabel-side-padding-right`             |
-| `--mod-fieldlabel-side-padding-top`               |
 | `--mod-form-grid-template-columns`                |
 | `--mod-form-grid-template-columns-labels-above`   |
 | `--mod-form-inline-size`                          |

--- a/components/fieldlabel/stories/form-template.js
+++ b/components/fieldlabel/stories/form-template.js
@@ -27,7 +27,7 @@ export const Template = ({
             ${FieldLabel({
                 label: 'Company Title',
                 forInput: 'form-example-company',
-                alignment: 'left',
+                alignment: labelsAbove ? undefined : 'left',
             })}
             <div class="spectrum-Form-itemField">
                 ${TextField({

--- a/components/picker/index.css
+++ b/components/picker/index.css
@@ -31,7 +31,7 @@ governing permissions and limitations under the License.
   --spectrum-picker-spacing-bottom-to-text: var(--spectrum-component-bottom-to-text-100);
   --spectrum-picker-spacing-edge-to-text: var(--spectrum-component-edge-to-text-100);
   --spectrum-picker-spacing-edge-to-text-quiet: var(--spectrum-field-edge-to-text-quiet);
-  --spectrum-picker-spacing-top-to-text-side-label-quiet: var(--spectrum-field-label-top-margin-medium);
+  --spectrum-picker-spacing-top-to-text-side-label-quiet: var(--spectrum-component-top-to-text-100);
   --spectrum-picker-spacing-label-to-picker: var(--spectrum-field-label-to-component);
 
   --spectrum-picker-spacing-text-to-icon: var(--spectrum-text-to-visual-100);
@@ -88,7 +88,7 @@ governing permissions and limitations under the License.
 .spectrum-Picker--sizeS {
   --spectrum-picker-font-size: var(--spectrum-font-size-75);
   --spectrum-picker-block-size: var(--spectrum-component-height-75);
-  --spectrum-picker-spacing-top-to-text-side-label-quiet: var(--spectrum-field-label-top-margin-small);
+  --spectrum-picker-spacing-top-to-text-side-label-quiet: var(--spectrum-component-top-to-text-75);
   --spectrum-picker-spacing-top-to-text: var(--spectrum-component-top-to-text-75);
   --spectrum-picker-spacing-bottom-to-text: var(--spectrum-component-bottom-to-text-75);
   --spectrum-picker-spacing-edge-to-text: var(--spectrum-component-edge-to-text-75);
@@ -109,7 +109,7 @@ governing permissions and limitations under the License.
 .spectrum-Picker--sizeL {
   --spectrum-picker-font-size: var(--spectrum-font-size-200);
   --spectrum-picker-block-size: var(--spectrum-component-height-200);
-  --spectrum-picker-spacing-top-to-text-side-label-quiet: var(--spectrum-field-label-top-margin-large);
+  --spectrum-picker-spacing-top-to-text-side-label-quiet: var(--spectrum-component-top-to-text-200);
   --spectrum-picker-spacing-top-to-text: var(--spectrum-component-top-to-text-200);
   --spectrum-picker-spacing-bottom-to-text: var(--spectrum-component-bottom-to-text-200);
   --spectrum-picker-spacing-edge-to-text: var(--spectrum-component-edge-to-text-200);
@@ -130,7 +130,7 @@ governing permissions and limitations under the License.
 .spectrum-Picker--sizeXL {
   --spectrum-picker-font-size: var(--spectrum-font-size-300);
   --spectrum-picker-block-size: var(--spectrum-component-height-300);
-  --spectrum-picker-spacing-top-to-text-side-label-quiet: var(--spectrum-field-label-top-margin-extra-large);
+  --spectrum-picker-spacing-top-to-text-side-label-quiet: var(--spectrum-component-top-to-text-300);
   --spectrum-picker-spacing-top-to-text: var(--spectrum-component-top-to-text-300);
   --spectrum-picker-spacing-bottom-to-text: var(--spectrum-component-bottom-to-text-300);
   --spectrum-picker-spacing-edge-to-text: var(--spectrum-component-edge-to-text-300);
@@ -449,7 +449,7 @@ governing permissions and limitations under the License.
   background-color: var(--highcontrast-picker-background-color, transparent);
 
   &.spectrum-Picker--sideLabel {
-    margin-block-start: calc(-1 * var(--spectrum-picker-spacing-top-to-text-side-label-quiet));
+    margin-block-start: 0;
   }
 
   .spectrum-Picker-menuIcon {

--- a/components/picker/stories/picker.stories.js
+++ b/components/picker/stories/picker.stories.js
@@ -200,6 +200,17 @@ const ChromaticPickerGroup = ({
 			</div>
 			<div>
 				${Template({
+					labelPosition: "left",
+					...args,
+					isOpen: false,
+					withSwitch: true,
+					fieldLabelStyle: {'max-width': '90px'},
+					label: "Enter country, text should wrap",
+					placeholder: "Select Your State Or Province"
+				})}
+			</div>
+			<div>
+				${Template({
 						labelPosition: "left",
 						...args,
 						isOpen: false,
@@ -207,6 +218,18 @@ const ChromaticPickerGroup = ({
 						placeholder: "Select Your State Or Province",
 						isQuiet: true,
 					})}
+			</div>
+			<div>
+				${Template({
+					labelPosition: "left",
+					...args,
+					isOpen: false,
+					withSwitch: true,
+					isQuiet: true,
+					fieldLabelStyle: {'max-width': '90px'},
+					label: "Enter country, text should wrap",
+					placeholder: "Select Your State Or Province"
+				})}
 			</div>
 		</div>
 	`;

--- a/components/picker/stories/picker.stories.js
+++ b/components/picker/stories/picker.stories.js
@@ -1,6 +1,5 @@
 import { Default as MenuStories } from "@spectrum-css/menu/stories/menu.stories.js";
 import { html } from "lit";
-import isChromatic from "chromatic/isChromatic";
 import { Template } from "./template";
 
 export default {
@@ -235,7 +234,7 @@ const ChromaticPickerGroup = ({
 	`;
 };
 
-export const Default = (args) => isChromatic() ? ChromaticPickerGroup(args) : Template(args);
+export const Default = (args) => window.isChromatic() ? ChromaticPickerGroup(args) : Template(args);
 Default.args = {
 	content: [
 		() => MenuStories(MenuStories.args)
@@ -250,14 +249,13 @@ Open.args = {
 	],
 };
 
-export const WithForcedColors = Template.bind({
-  parameters: {
+export const WithForcedColors = (args) => window.isChromatic() ? ChromaticPickerGroup(args) : Template(args);
+WithForcedColors.parameters = {
     // Sets the forced-colors media feature for a specific story.
     chromatic: { forcedColors: 'active' },
-  },
-});
+}
 WithForcedColors.args = {
 	content: [
 		() => MenuStories(MenuStories.args)
-	],
+	]
 }

--- a/components/picker/stories/picker.stories.js
+++ b/components/picker/stories/picker.stories.js
@@ -45,6 +45,7 @@ export default {
 				category: "Component",
 			},
 			control: "boolean",
+			if: { arg: "labelPosition", eq: "left" },
 		},
 		placeholder: {
 			name: "Placeholder",

--- a/components/picker/stories/picker.stories.js
+++ b/components/picker/stories/picker.stories.js
@@ -1,4 +1,6 @@
 import { Default as MenuStories } from "@spectrum-css/menu/stories/menu.stories.js";
+import { html } from "lit";
+import isChromatic from "chromatic/isChromatic";
 import { Template } from "./template";
 
 export default {
@@ -134,7 +136,82 @@ export default {
 	},
 };
 
-export const Default = Template.bind({});
+
+const ChromaticPickerGroup = ({
+	customStyles = {},
+	...args
+}) => {
+	return html`
+		<div style="display: grid; gap: 20px;">
+			<div>
+				${Template({
+					labelPosition: "top",
+					...args,
+					isOpen: false,
+					placeholder: "Select Your State Or Province"
+				})}
+			</div>
+			<div>
+				${Template({
+					labelPosition: "top",
+					...args,
+					isOpen: false,
+					isQuiet: true,
+					placeholder: "Select Your State Or Province"
+				})}
+			</div>
+			<div>
+				${Template({
+					labelPosition: "top",
+					...args,
+					isOpen: false,
+					isLoading: true,
+					placeholder: "Select Your State Or Province"
+				})}
+			</div>
+			<div>
+				${Template({
+					labelPosition: "top",
+					...args,
+					isOpen: false,
+					isInvalid: true,
+					placeholder: "Select Your State Or Province"
+				})}
+			</div>
+			<div>
+				${Template({
+					labelPosition: "top",
+					...args,
+					isOpen: false,
+					isKeyboardFocused: true,
+					helpText: "Please select a country",
+					placeholder: "Select Your State Or Province"
+				})}
+			</div>
+			<div>
+				${Template({
+					labelPosition: "left",
+					...args,
+					isOpen: false,
+					withSwitch: true,
+					placeholder: "Select Your State Or Province"
+				})}
+			</div>
+			<div>
+				${Template({
+						labelPosition: "left",
+						...args,
+						isOpen: false,
+						withSwitch: true,
+						placeholder: "Select Your State Or Province",
+						isQuiet: true,
+					})}
+			</div>
+		</div>
+	`;
+};
+
+export const Default = (args) => isChromatic() ? ChromaticPickerGroup(args) : Template(args);
 Default.args = {
 	content: [
 		() => MenuStories(MenuStories.args)
@@ -144,50 +221,6 @@ Default.args = {
 export const Open = Template.bind({});
 Open.args = {
 	isOpen: true,
-	content: [
-		() => MenuStories(MenuStories.args)
-	],
-};
-
-export const SideLabel = Template.bind({});
-SideLabel.args = {
-	content: [
-		() => MenuStories(MenuStories.args)
-	],
-	labelPosition: "left",
-	placeholder: "Select Your State Or Province"
-};
-
-export const Quiet = Template.bind({});
-Quiet.args = {
-	isQuiet: true,
-	content: [
-		() => MenuStories(MenuStories.args)
-	],
-};
-
-export const Loading = Template.bind({});
-Loading.args = {
-	isLoading: true,
-	content: [
-		() => MenuStories(MenuStories.args)
-	],
-};
-
-export const Invalid = Template.bind({});
-Invalid.args = {
-	helpText: "Please select a country",
-	isInvalid: true,
-	content: [
-		() => MenuStories(MenuStories.args)
-	],
-};
-
-export const Focused = Template.bind({});
-Focused.storyName = "Keyboard Focused";
-Focused.args = {
-	helpText: "Please select a country",
-	isKeyboardFocused: true,
 	content: [
 		() => MenuStories(MenuStories.args)
 	],

--- a/components/picker/stories/picker.stories.js
+++ b/components/picker/stories/picker.stories.js
@@ -35,6 +35,15 @@ export default {
 			options: ["top", "left"],
 			control: { type: "select" },
 		},
+		withSwitch: {
+			name: "Display with a switch component",
+			type: { name: "boolean" },
+			table: {
+				type: { summary: "boolean" },
+				category: "Component",
+			},
+			control: "boolean",
+		},
 		placeholder: {
 			name: "Placeholder",
 			type: { name: "string" },
@@ -111,6 +120,7 @@ export default {
 		isDisabled: false,
 		isInvalid: false,
 		isOpen: false,
+		withSwitch: false,
 	},
 	parameters: {
 		actions: {

--- a/components/picker/stories/picker.stories.js
+++ b/components/picker/stories/picker.stories.js
@@ -149,7 +149,7 @@ const ChromaticPickerGroup = ({
 					labelPosition: "top",
 					...args,
 					isOpen: false,
-					placeholder: "Select Your State Or Province"
+					placeholder: "Select your country of origin"
 				})}
 			</div>
 			<div>
@@ -158,7 +158,7 @@ const ChromaticPickerGroup = ({
 					...args,
 					isOpen: false,
 					isQuiet: true,
-					placeholder: "Select Your State Or Province"
+					placeholder: "Select your country of origin"
 				})}
 			</div>
 			<div>
@@ -167,7 +167,7 @@ const ChromaticPickerGroup = ({
 					...args,
 					isOpen: false,
 					isLoading: true,
-					placeholder: "Select Your State Or Province"
+					placeholder: "Select your country of origin"
 				})}
 			</div>
 			<div>
@@ -176,7 +176,7 @@ const ChromaticPickerGroup = ({
 					...args,
 					isOpen: false,
 					isInvalid: true,
-					placeholder: "Select Your State Or Province"
+					placeholder: "Select your country of origin"
 				})}
 			</div>
 			<div>
@@ -186,7 +186,7 @@ const ChromaticPickerGroup = ({
 					isOpen: false,
 					isKeyboardFocused: true,
 					helpText: "Please select a country",
-					placeholder: "Select Your State Or Province"
+					placeholder: "Select your country of origin"
 				})}
 			</div>
 			<div>
@@ -195,7 +195,7 @@ const ChromaticPickerGroup = ({
 					...args,
 					isOpen: false,
 					withSwitch: true,
-					placeholder: "Select Your State Or Province"
+					placeholder: "Select your country of origin"
 				})}
 			</div>
 			<div>
@@ -206,7 +206,7 @@ const ChromaticPickerGroup = ({
 					withSwitch: true,
 					fieldLabelStyle: {'max-width': '90px'},
 					label: "Enter country, text should wrap",
-					placeholder: "Select Your State Or Province"
+					placeholder: "Select your country of origin"
 				})}
 			</div>
 			<div>
@@ -215,7 +215,7 @@ const ChromaticPickerGroup = ({
 						...args,
 						isOpen: false,
 						withSwitch: true,
-						placeholder: "Select Your State Or Province",
+						placeholder: "Select your contry of origin",
 						isQuiet: true,
 					})}
 			</div>
@@ -228,7 +228,7 @@ const ChromaticPickerGroup = ({
 					isQuiet: true,
 					fieldLabelStyle: {'max-width': '90px'},
 					label: "Enter country, text should wrap",
-					placeholder: "Select Your State Or Province"
+					placeholder: "Select your contry of origin"
 				})}
 			</div>
 		</div>

--- a/components/picker/stories/template.js
+++ b/components/picker/stories/template.js
@@ -106,6 +106,8 @@ export const Template = ({
 	isDisabled = false,
 	isReadOnly = false,
 	withSwitch = false,
+	fieldLabelStyle = {},
+	fieldLabelText,
 	customClasses = [],
 	customStyles = {},
 	customPopoverStyles = {},
@@ -144,6 +146,7 @@ export const Template = ({
 					size,
 					label,
 					isDisabled,
+					style: fieldLabelStyle,
 					alignment: labelPosition,
 			  })
 			: ""}

--- a/components/picker/stories/template.js
+++ b/components/picker/stories/template.js
@@ -3,6 +3,7 @@ import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { styleMap } from "lit/directives/style-map.js";
+import { when } from 'lit/directives/when.js';
 
 import { Template as FieldLabel } from "@spectrum-css/fieldlabel/stories/template.js";
 import { Template as HelpText } from "@spectrum-css/helptext/stories/template.js";
@@ -207,15 +208,13 @@ export const Template = ({
 			customStyles: customPopoverStyles,
 			content,
 		})}
-		${withSwitch ?
-			Switch({
+		${when (withSwitch, () => Switch({
 				...globals,
 				size,
 				label: "Toggle switch",
 				customStyles: {
 					"padding-inline-start": "15px"
 				}
-			})
-			: null}
+			})) }
 	`;
 };

--- a/components/picker/stories/template.js
+++ b/components/picker/stories/template.js
@@ -9,6 +9,7 @@ import { Template as HelpText } from "@spectrum-css/helptext/stories/template.js
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 import { Template as Popover } from "@spectrum-css/popover/stories/template.js";
 import { Template as ProgressCircle } from "@spectrum-css/progresscircle/stories/template.js";
+import { Template as Switch } from "@spectrum-css/switch/stories/template.js";
 
 import "../index.css";
 
@@ -103,6 +104,7 @@ export const Template = ({
 	isLoading = false,
 	isDisabled = false,
 	isReadOnly = false,
+	withSwitch = false,
 	customClasses = [],
 	customStyles = {},
 	customPopoverStyles = {},
@@ -205,5 +207,15 @@ export const Template = ({
 			customStyles: customPopoverStyles,
 			content,
 		})}
+		${withSwitch ?
+			Switch({
+				...globals,
+				size,
+				label: "Toggle switch",
+				customStyles: {
+					"padding-inline-start": "15px"
+				}
+			})
+			: null}
 	`;
 };


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

Addresses concerned raised in https://github.com/adobe/spectrum-web-components/issues/2963 where the quiet picker and it's associated side label does not align with text of other components, making it appear incorrect when used with other components.

For before look at https://github.com/adobe/spectrum-css/pull/2231

### Changes: 
FieldLabel: 
- use `--spectrum-field-label-top-margin-*` tokens and margin to adjust position of side label to match design specs 

Picker
- Remove negative top margin from the quiet side label 
- Use correct tokens for picker side label margins 
- add displaying with the switch component to controls for picker storybook


## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

On the docs site for picker and field label 
- [x] side field labels match design specs (side label positioning is slightly lower, 4px for medium, than previously)

Storybook for picker 
- [x] controls should all work as expected, particularly looking at quiet with a side label and a switch at various t-shirt sizes 

Chromatic
- [x] displays kitchen sink grouping of picker which includes, a standard, standard quiet, loading, invalid, keyboard focused, standard with side label and switch, and quiet with side field label and switch


### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

### T-shirt sizing with other components
![Screenshot 2024-01-26 at 10 28 58 AM](https://github.com/adobe/spectrum-css/assets/63808889/c7a0f365-d412-4964-aa5a-fe16270380f4)

### Storybook Kitchen Sink
![Screenshot 2024-02-01 at 11 48 22 AM](https://github.com/adobe/spectrum-css/assets/63808889/55e820a8-3111-451f-a9c1-969bc8a3d167)

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
