### PR TITLE
feat: add postcss-hover-media-feature plugin to build

### DIFF
--- a/components/menu/index.css
+++ b/components/menu/index.css
@@ -794,6 +794,16 @@ governing permissions and limitations under the License.
 
   &:hover {
     cursor: default;
+    background-color: transparent;
+
+    .spectrum-Menu-itemLabel,
+    .spectrum-Menu-sectionHeading {
+      color: var(--highcontrast-menu-item-color-disabled, var(--mod-menu-item-label-content-color-disabled, var(--spectrum-menu-item-label-content-color-disabled)));
+    }
+    
+    .spectrum-Menu-itemDescription {
+      color: var(--highcontrast-menu-item-color-disabled, var(--mod-menu-item-description-color-disabled, var(--spectrum-menu-item-description-color-disabled)));
+    }
 
     .spectrum-Menu-itemIcon {
       fill: var(--highcontrast-menu-item-color-disabled, var(--mod-menu-item-label-icon-color-disabled, var(--spectrum-menu-item-label-icon-color-disabled)));

--- a/components/tag/index.css
+++ b/components/tag/index.css
@@ -330,6 +330,7 @@ governing permissions and limitations under the License.
   &:hover {
     border-color: var(--highcontrast-tag-border-color-selected-hover, var(--mod-tag-border-color-selected-hover, var(--spectrum-tag-border-color-selected-hover)));
     background-color: var(--highcontrast-tag-background-color-selected-hover, var(--mod-tag-background-color-selected-hover, var(--spectrum-tag-background-color-selected-hover)));
+    color: var(--highcontrast-tag-content-color-selected, var(--mod-tag-content-color-selected, var(--spectrum-tag-content-color-selected)));
   }
 
   &:active {
@@ -373,6 +374,7 @@ governing permissions and limitations under the License.
     &:hover {
       border-color: var(--highcontrast-tag-border-color-invalid-selected-hover, var(--mod-tag-border-color-invalid-selected-hover, var(--spectrum-tag-border-color-invalid-selected-hover)));
       background-color: var(--highcontrast-tag-background-color-invalid-selected-hover, var(--mod-tag-background-color-invalid-selected-hover, var(--spectrum-tag-background-color-invalid-selected-hover)));
+      color: var(--highcontrast-tag-content-color-invalid-selected, var(--mod-tag-content-color-invalid-selected, var(--spectrum-tag-content-color-invalid-selected)));
     }
 
     &:active {
@@ -398,6 +400,7 @@ governing permissions and limitations under the License.
   &:hover {
     border-color: var(--highcontrast-tag-border-color-emphasized-hover, var(--mod-tag-border-color-emphasized-hover, var(--spectrum-tag-border-color-emphasized-hover)));
     background-color: var(--highcontrast-tag-background-color-emphasized-hover, var(--mod-tag-background-color-emphasized-hover, var(--spectrum-tag-background-color-emphasized-hover)));
+    color: var(--highcontrast-tag-content-color-emphasized, var(--mod-tag-content-color-emphasized, var(--spectrum-tag-content-color-emphasized)));
   }
 
   &:active {

--- a/components/tooltip/metadata/tooltip.yml
+++ b/components/tooltip/metadata/tooltip.yml
@@ -300,7 +300,7 @@ examples:
   - id: tooltip-showOnHover
     name: Show on hover
     status: Unverified
-    description: A tooltip that shows on hover using CSS only. Note that this approach does not support text wrapping.
+    description: A tooltip that shows on hover using CSS only. Note that this approach does not support text wrapping. Also, note that these Tooltips will likely not work on touch-enabled devices without additional client-side scripting.
     markup: |
       <div class="spectrum-Examples">
         <div class="spectrum-Examples-item">

--- a/tools/component-builder-simple/css/processors.js
+++ b/tools/component-builder-simple/css/processors.js
@@ -30,6 +30,7 @@ function getProcessors({ noFlatVariables = false, noSelectors = false, keepComme
 		require("postcss-dropunusedvars")({ fix: false }),
 		require("postcss-dropdupedvars"),
 		require("postcss-discard-empty"),
+    require("postcss-hover-media-feature"),
 		!keepComments ? require("postcss-discard-comments")({ removeAllButFirst: true }) : null,
 		require("autoprefixer")({}),
 	].filter(Boolean);

--- a/tools/component-builder-simple/css/processors.js
+++ b/tools/component-builder-simple/css/processors.js
@@ -26,11 +26,12 @@ function getProcessors({ noFlatVariables = false, noSelectors = false, keepComme
 			noSelectors,
 		}),
 		require("postcss-custom-properties-passthrough")(),
+		require("postcss-hover-media-feature"),
 		require("postcss-calc"),
 		require("postcss-dropunusedvars")({ fix: false }),
 		require("postcss-dropdupedvars"),
 		require("postcss-discard-empty"),
-    require("postcss-hover-media-feature"),
+		require("at-rule-packer"),
 		!keepComments ? require("postcss-discard-comments")({ removeAllButFirst: true }) : null,
 		require("autoprefixer")({}),
 	].filter(Boolean);

--- a/tools/component-builder-simple/package.json
+++ b/tools/component-builder-simple/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@spectrum-css/tokens": "^13.0.9",
+    "at-rule-packer": "^0.4.2",
     "autoprefixer": "^10.4.17",
     "colors": "^1.4.0",
     "gulp": "^4.0.0",

--- a/tools/component-builder-simple/package.json
+++ b/tools/component-builder-simple/package.json
@@ -28,6 +28,7 @@
     "postcss-dropdupedvars": "^2.0.0",
     "postcss-dropunusedvars": "^2.0.0",
     "postcss-extend": "^1.0.5",
+    "postcss-hover-media-feature": "1.0.2",
     "postcss-import": "^16.0.0",
     "postcss-nested": "^6.0.1",
     "postcss-selector-parser": "^6.0.15",

--- a/tools/component-builder/css/processors.js
+++ b/tools/component-builder/css/processors.js
@@ -85,6 +85,7 @@ function getProcessors(
 		require("postcss-droproot"),
 		secondNotNested ? require("postcss-notnested")() : null, // Second one to catch all stray &
 		require("postcss-discard-empty"),
+    require("postcss-hover-media-feature"),
 		require("postcss-discard-comments")({ removeAllButFirst: true }),
 		require("autoprefixer")({}),
 	].filter(Boolean);

--- a/tools/component-builder/css/processors.js
+++ b/tools/component-builder/css/processors.js
@@ -61,6 +61,7 @@ function getProcessors(
 		require("postcss-logical")(),
 		require("postcss-dir-pseudo-class")(),
 		require("postcss-custom-properties-passthrough")(),
+		require("postcss-hover-media-feature"),
 		require("postcss-calc"),
 		keepVars ? require("postcss-custom-properties-mapping")({
 			tokenDir: varDir,
@@ -85,7 +86,7 @@ function getProcessors(
 		require("postcss-droproot"),
 		secondNotNested ? require("postcss-notnested")() : null, // Second one to catch all stray &
 		require("postcss-discard-empty"),
-    require("postcss-hover-media-feature"),
+		require("at-rule-packer"),
 		require("postcss-discard-comments")({ removeAllButFirst: true }),
 		require("autoprefixer")({}),
 	].filter(Boolean);

--- a/tools/component-builder/package.json
+++ b/tools/component-builder/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@spectrum-css/tokens": "^13.0.9",
     "@spectrum-css/vars": "^9.0.8",
+    "at-rule-packer": "^0.4.2",
     "autoprefixer": "^10.4.17",
     "browser-sync": "^2.26.14",
     "colors": "^1.4.0",

--- a/tools/component-builder/package.json
+++ b/tools/component-builder/package.json
@@ -39,6 +39,7 @@
     "postcss-discard-empty": "^6.0.1",
     "postcss-droproot": "^2.0.0",
     "postcss-extend": "^1.0.5",
+    "postcss-hover-media-feature": "1.0.2",
     "postcss-import": "^16.0.0",
     "postcss-logical": "^7.0.1",
     "postcss-nested": "^6.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14481,6 +14481,13 @@ postcss-extend@^1.0.5:
   dependencies:
     postcss "^5.0.4"
 
+postcss-hover-media-feature@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/postcss-hover-media-feature/-/postcss-hover-media-feature-1.0.2.tgz#7c2046ddee1521148660195864b014d6c1d13b3c"
+  integrity sha512-o5xDUqCQ4xtilWOcvo5LKYxFVSLWcBN0IlTqa0IJwAwHTd4pxKmX4c0fGIpgLQCcBB/+aFizt2NVWNGJWG4Izg==
+  dependencies:
+    postcss-selector-parser "^6.0.4"
+
 postcss-import@^16.0.0:
   version "16.0.0"
   resolved "https://registry.yarnpkg.com/postcss-import/-/postcss-import-16.0.0.tgz#2be1c78391b3f43f129fccfe5cc0cc1a11baef54"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5791,6 +5791,11 @@ at-least-node@^1.0.0:
   resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
   integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
+at-rule-packer@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/at-rule-packer/-/at-rule-packer-0.4.2.tgz#24bd159e89466ee404d307ffff6e272e081331f9"
+  integrity sha512-UHzrnwrw2sZOOfnUKpoWwdVyJgU/ZAC6POTSW3NiNWxAApbb41Nz2KamlOKQMB6xS7I0WFvMJmZ6coudzmuEbQ==
+
 atob@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description
Adds the `postcss-hover-media-feature` [plugin](https://github.com/saulhardman/postcss-hover-media-feature) to the build. This extracts and wraps rules containing :hover pseudo-classes in `@media (hover: hover) {}` media queries.

Reasoning: certain mobile browsers apply `:hover` styles on 'tap', which (in most cases) isn't desirable. By wrapping `:hover` styles with a [Hover Media Feature](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/hover) Media Query these styles will only be applied on devices that support them.

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

This plugin will change the `dist` of every component where `:hover` is used, so we'll want to be sure that there are no visual defects after implementing this. A walk-through of the docs site and storybook in this PR deploy is recommended.

**Output before:**
```css
.spectrum-Accordion-item.is-disabled .spectrum-Accordion-itemHeader:hover{
			color:var(
				--mod-accordion-item-header-disabled-color,
				var(--spectrum-accordion-item-header-disabled-color)
			);
			background-color:transparent;
		}
```

**Output after:**
```css
@media (hover: hover) {
.spectrum-Accordion-item.is-disabled .spectrum-Accordion-itemHeader:hover{
			color:var(
				--mod-accordion-item-header-disabled-color,
				var(--spectrum-accordion-item-header-disabled-color)
			);
			background-color:transparent;
		}
}
```

1. Pick any 4 of the following components: accordion, actionbutton, assetlist, button, checkbox, combobox, infieldbutton, menu, picker, radio, search, slider, stepper, switch, table, tabs, tag, textfield, tooltip, treeview

2. Open the [storybook](https://pr-2467--spectrum-css.netlify.app/preview) for the button component:
    - Hover over the hoverable item in a desktop environment and ensure no regressions
    - Open the same component in a mobile virtualizer, ensure no hover state is applied on click

### Validation record

- [x] accordion @mdt2 
- [x] actionbutton @mdt2 
- [x] assetlist @mdt2 
- [x] button @mdt2 
- [x] checkbox @mdt2 
- [x] combobox @mdt2 
- [x] infieldbutton @mdt2 
- [x] menu @mdt2 - bug noted in Slack was fixed
- [x] picker @mdt2 
- [x] radio @mdt2 
- [x] search @mdt2 
- [x] slider @mdt2 
- [x] stepper @mdt2 
- [x] switch @mdt2 
- [x] table @mdt2 
- [x] tag @jenndiaz - bug noted in Slack, bug fix confirmed by @mdt2 
- [x] textfield @mdt2 
- [x] tooltip @mdt2 - bug noted in Slack is not really a bug, additional docs included on docs site
- [x] treeview @mdt2 

### Regression testing

Validate:
1. The documentation pages for at least two other components are still loading, including:
- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:
- [x] VRTs have been run and looked at.
- [N/A] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] ✨ This pull request is ready to merge. ✨
