### PR TITLE
chore: swap gulp dev for gulp devHeavy

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "cleaner": "nx run-many --target clean --projects",
     "compare": "node ./tasks/compare-compiled-output.js",
     "predev": "nx run-many --projects ui-icons,tokens --target build",
-    "dev": "NODE_ENV=development BROWSERSYNC_OPEN=true gulp dev",
+    "dev": "NODE_ENV=development BROWSERSYNC_OPEN=true gulp devHeavy",
     "preinstall": "command -v nvm >/dev/null 2>&1 && nvm use || exit 0",
     "lint": "yarn linter tag:component --verbose",
     "linter": "nx run-many --target lint --verbose --projects",


### PR DESCRIPTION
## Description

Swap dev command to use the `gulp devHeavy` for building the local docs site.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [ ] `yarn dev`: should build components and compile the templates, then spin up a localhost server and open it in a browser.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] ✨ This pull request is ready to merge. ✨
