### PR TITLE
chore: incorporate ui-icons build into prerelease task

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "refresh:config": "test -n $BASH_VERSION && bash ./tasks/chromatic-config-creation.sh || exit 0",
     "refresh:directory": "test -n $BASH_VERSION && bash ./tasks/clean-up-after-migration.sh || exit 0",
     "refresh:env": "test -n $BASH_VERSION && bash ./tasks/copy-env-from-root.sh || exit 0",
-    "prerelease": "nx reset && yarn build",
+    "prerelease": "nx reset && yarn builder tag:component,ui-icons",
     "release": "lerna publish --no-private",
     "release:beta-from-package": "yarn release from-package --conventional-prerelease --preid beta --pre-dist-tag beta",
     "prerelease:site": "yarn build:site",


### PR DESCRIPTION
## Description

The @spectrum-css/ui-icons package was missing from the pre-release build task. This PR adds it to prevent any missing dist output for future ui-icons releases.

## How and where has this been tested?

- [x] `yarn release`: before the lerna command is run, we expect the nx cache to reset and all components, tokens, and the ui-icons package to be built with valid dist output. Cancel before the release.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] ✨ This pull request is ready to merge. ✨
