### PR TITLE
docs(textarea): example text is more relevant to component

### DIFF
--- a/components/textfield/metadata/textarea.yml
+++ b/components/textfield/metadata/textarea.yml
@@ -1,6 +1,6 @@
 name: Text area
 status: Verified
-description: A multi-line text field (aka textarea)
+description: A multi-line text field using the `<textarea>` element.
 SpectrumSiteSlug: https://spectrum.adobe.com/page/text-field/
 sections:
   - name: Migration Guide
@@ -11,38 +11,38 @@ examples:
     name: Standard Sizes
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--sizeS spectrum-Textfield--multiline">
-        <label for="textfield-s" class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">Password</label>
+        <label for="textfield-s" class="spectrum-FieldLabel spectrum-FieldLabel--sizeS">Tell us your story</label>
         <span id="character-count-1" class="spectrum-Textfield-characterCount">50</span>
         <textarea id="textfield-s" name="field" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-1 character-count-1"></textarea>
         <div class="spectrum-HelpText spectrum-HelpText--sizeS spectrum-HelpText--neutral">
-          <div id="helptext-1" class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
+          <div id="helptext-1" class="spectrum-HelpText-text">50/50 characters remaining</div>
         </div>
       </div>
 
       <div class="spectrum-Textfield spectrum-Textfield--sizeM spectrum-Textfield--multiline">
-        <label for="textfield-m" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Password</label>
+        <label for="textfield-m" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Tell us your story</label>
         <span id="character-count-2" class="spectrum-Textfield-characterCount">50</span>
         <textarea id="textfield-m" name="field" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-2 character-count-2"></textarea>
         <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--neutral">
-          <div id="helptext-2" class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
+          <div id="helptext-2" class="spectrum-HelpText-text">50/50 characters remaining</div>
         </div>
       </div>
 
       <div class="spectrum-Textfield spectrum-Textfield--sizeL spectrum-Textfield--multiline">
-        <label for="textfield-l" class="spectrum-FieldLabel spectrum-FieldLabel--sizeL">Password</label>
+        <label for="textfield-l" class="spectrum-FieldLabel spectrum-FieldLabel--sizeL">Tell us your story</label>
         <span id="character-count-3" class="spectrum-Textfield-characterCount">50</span>
         <textarea id="textfield-l" name="field" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-3 character-count-3"></textarea>
         <div class="spectrum-HelpText spectrum-HelpText--sizeL spectrum-HelpText--neutral">
-          <div id="helptext-3" class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
+          <div id="helptext-3" class="spectrum-HelpText-text">50/50 characters remaining</div>
         </div>
       </div>
 
       <div class="spectrum-Textfield spectrum-Textfield--sizeXL spectrum-Textfield--multiline">
-        <label for="textfield-xl" class="spectrum-FieldLabel spectrum-FieldLabel--sizeXL">Password</label>
+        <label for="textfield-xl" class="spectrum-FieldLabel spectrum-FieldLabel--sizeXL">Tell us your story</label>
         <span id="character-count-4" class="spectrum-Textfield-characterCount">50</span>
         <textarea id="textfield-xl" name="field" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-4 character-count-4"></textarea>
         <div class="spectrum-HelpText spectrum-HelpText--sizeXL spectrum-HelpText--neutral">
-          <div id="helptext-4" class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
+          <div id="helptext-4" class="spectrum-HelpText-text">50/50 characters remaining</div>
         </div>
       </div>
 
@@ -50,10 +50,10 @@ examples:
     name: Textfield with Help Text
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline">
-        <label for="textfield-helptext" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Password</label>
+        <label for="textfield-helptext" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Tags</label>
         <textarea id="textfield-helptext" name="field" class="spectrum-Textfield-input" aria-describedby="helptext-5"></textarea>
         <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--neutral">
-          <div id="helptext-5" class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
+          <div id="helptext-5" class="spectrum-HelpText-text">Tags must be comma separated.</div>
         </div>
       </div>
 
@@ -61,7 +61,7 @@ examples:
     name: With Character Count
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline">
-        <label for="textfield-character-count" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
+        <label for="textfield-character-count" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Comments</label>
         <span id="character-count-5" class="spectrum-Textfield-characterCount">50</span>
         <textarea id="textfield-character-count" name="field" class="spectrum-Textfield-input" aria-describedby="character-count-5"></textarea>
       </div>
@@ -70,11 +70,11 @@ examples:
     name: Textfield with Side Label
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--sideLabel">
-        <label for="textfield-m-sidelabel" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Password</label>
+        <label for="textfield-m-sidelabel" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Comments</label>
         <span id="character-count-6" class="spectrum-Textfield-characterCount">50</span>
         <textarea id="textfield-m-sidelabel" name="field" class="spectrum-Textfield-input" pattern=".{8,}" aria-describedby="helptext-6 character-count-6"></textarea>
         <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--neutral">
-          <div id="helptext-6" class="spectrum-HelpText-text">Create a password with at least 8 characters.</div>
+          <div id="helptext-6" class="spectrum-HelpText-text">50/50 characters remaining</div>
         </div>
       </div>
 
@@ -82,7 +82,7 @@ examples:
     name: Disabled
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline is-disabled">
-        <label for="textarea-disabled" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
+        <label for="textarea-disabled" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Comments</label>
         <textarea id="textarea-disabled" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+" disabled></textarea>
       </div>
 
@@ -90,7 +90,7 @@ examples:
     name: Valid
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline is-valid">
-        <label for="textarea-valid" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
+        <label for="textarea-valid" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Comments</label>
         <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-css-icon-Checkmark100" />
         </svg>
@@ -101,7 +101,7 @@ examples:
     name: Valid (disabled)
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline is-valid is-disabled">
-        <label for="textarea-valid-disabled" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
+        <label for="textarea-valid-disabled" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Comments</label>
         <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-css-icon-Checkmark100" />
         </svg>
@@ -114,7 +114,7 @@ examples:
       *Spectrum for Adobe Express uses a different icon. Use the `SX_Alert_18_N.svg` icon in the Express workflow icon set.*
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline is-invalid">
-        <label for="textarea-invalid" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
+        <label for="textarea-invalid" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Comments</label>
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>
@@ -125,7 +125,7 @@ examples:
     name: Invalid (disabled)
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline is-invalid is-disabled">
-        <label for="textarea-invalid-disabled" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
+        <label for="textarea-invalid-disabled" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Comments</label>
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>
@@ -136,7 +136,7 @@ examples:
     name: Focused
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline is-focused">
-        <label for="textarea-focused" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
+        <label for="textarea-focused" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Comments</label>
         <textarea id="textarea-focused" name="field" class="spectrum-Textfield-input"></textarea>
       </div>
 
@@ -144,7 +144,7 @@ examples:
     name: Keyboard Focused
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline is-keyboardFocused">
-        <label for="textarea-keyboard-focused" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
+        <label for="textarea-keyboard-focused" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Comments</label>
         <textarea id="textarea-keyboard-focused" name="field" class="spectrum-Textfield-input"></textarea>
       </div>
 
@@ -154,7 +154,7 @@ examples:
       *Spectrum for Adobe Express uses a different icon. Use the `SX_Alert_18_N.svg` icon in the Express workflow icon set.*
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline is-invalid is-focused">
-        <label for="textarea-focused-invalid" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
+        <label for="textarea-focused-invalid" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Comments</label>
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>
@@ -167,7 +167,7 @@ examples:
       *Spectrum for Adobe Express uses a different icon. Use the `SX_Alert_18_N.svg` icon in the Express workflow icon set.*
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline is-invalid is-keyboardFocused">
-        <label for="textarea-keyboard-focused-invalid" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
+        <label for="textarea-keyboard-focused-invalid" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Comments</label>
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>
@@ -178,7 +178,7 @@ examples:
     name: Quiet
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--quiet">
-        <label for="textarea-quiet" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Text area</label>
+        <label for="textarea-quiet" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Comments</label>
         <textarea id="textarea-quiet" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+"></textarea>
       </div>
 
@@ -186,7 +186,7 @@ examples:
     name: Quiet Disabled
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--quiet is-disabled">
-        <label for="textarea-quiet-disabled" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
+        <label for="textarea-quiet-disabled" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Comments</label>
         <textarea id="textarea-quiet-disabled" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+" disabled></textarea>
       </div>
 
@@ -196,7 +196,7 @@ examples:
       *Spectrum for Adobe Express uses a different icon. Use the `SX_Alert_18_N.svg` icon in the Express workflow icon set.*
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--quiet is-valid">
-        <label for="textarea-quiet-valid" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
+        <label for="textarea-quiet-valid" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Comments</label>
         <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-css-icon-Checkmark100" />
         </svg>
@@ -207,7 +207,7 @@ examples:
     name: Quiet Valid (disabled)
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--quiet is-valid is-disabled">
-        <label for="textarea-valid-disabled" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
+        <label for="textarea-valid-disabled" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Comments</label>
         <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-css-icon-Checkmark100" />
         </svg>
@@ -220,7 +220,7 @@ examples:
       *Spectrum for Adobe Express uses a different icon. Use the `SX_Alert_18_N.svg` icon in the Express workflow icon set.*
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--quiet is-invalid">
-        <label for="textarea-quiet-invalid" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
+        <label for="textarea-quiet-invalid" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Comments</label>
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>
@@ -231,7 +231,7 @@ examples:
     name: Quiet Invalid (disabled)
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--quiet is-invalid is-disabled">
-        <label for="textarea-quiet-invalid-disabled" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
+        <label for="textarea-quiet-invalid-disabled" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Comments</label>
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>
@@ -242,7 +242,7 @@ examples:
     name: Quiet Focused
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--quiet is-focused">
-        <label for="textarea-quiet-focused" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
+        <label for="textarea-quiet-focused" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Comments</label>
         <textarea id="textarea-quiet-focused" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+"></textarea>
       </div>
 
@@ -250,7 +250,7 @@ examples:
     name: Quiet Keyboard Focused
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--quiet is-keyboardFocused">
-        <label for="textarea-quiet-keyboard-focused" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
+        <label for="textarea-quiet-keyboard-focused" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Comments</label>
         <textarea id="textarea-quiet-keyboard-focused" name="field" class="spectrum-Textfield-input" pattern="[\w\s]+"></textarea>
       </div>
 
@@ -260,7 +260,7 @@ examples:
       *Spectrum for Adobe Express uses a different icon. Use the `SX_Alert_18_N.svg` icon in the Express workflow icon set.*
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--quiet is-invalid is-focused">
-        <label for="textarea-quiet-focused-invalid" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
+        <label for="textarea-quiet-focused-invalid" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Comments</label>
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>
@@ -273,7 +273,7 @@ examples:
       *Spectrum for Adobe Express uses a different icon. Use the `SX_Alert_18_N.svg` icon in the Express workflow icon set.*
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--quiet is-invalid is-keyboardFocused">
-        <label for="textarea-quiet-keyboard-focused-invalid" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Enter your name</label>
+        <label for="textarea-quiet-keyboard-focused-invalid" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Comments</label>
         <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-icon-18-Alert" />
         </svg>

--- a/components/textfield/metadata/textfield.yml
+++ b/components/textfield/metadata/textfield.yml
@@ -1,6 +1,6 @@
 name: Text field
 status: Verified
-description: A single-line text field (aka textfield)
+description: A single-line text field using the `<input>` element with a `type="text"`.
 SpectrumSiteSlug: https://spectrum.adobe.com/page/text-field/
 sections:
   - name: Migration Guide

--- a/components/textfield/metadata/textfield.yml
+++ b/components/textfield/metadata/textfield.yml
@@ -1,6 +1,6 @@
 name: Text field
 status: Verified
-description: A single-line text field using the `<input>` element with a `type="text"`.
+description: A single-line text field using the `<input>` element`.
 SpectrumSiteSlug: https://spectrum.adobe.com/page/text-field/
 sections:
   - name: Migration Guide

--- a/components/textfield/metadata/textfield.yml
+++ b/components/textfield/metadata/textfield.yml
@@ -1,6 +1,6 @@
 name: Text field
 status: Verified
-description: A single-line text field using the `<input>` element`.
+description: A single-line text field using the `<input>` element.
 SpectrumSiteSlug: https://spectrum.adobe.com/page/text-field/
 sections:
   - name: Migration Guide


### PR DESCRIPTION
## Description

Adjusting the example text in the TextArea docs page to be more realistic for what the component is used for.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
- [ ] Open the [TextArea docs site page](https://pr-2477--spectrum-css.netlify.app/textarea) and confirm that the example labels and help text make more sense in regards to the type of info a TextArea might be used to gather. (open to suggestions, you'd think I'd never used a textarea before with how difficult I found it to think of applicable labels 😂)

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.


## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
