### PR TITLE
feat(tokens): add icon xxl and xxs tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 dist
 dist-site
+!tokens/dist
 
 # Recommended update re:https://docs.netlify.com/integrations/frameworks/eleventy/
 **/node_modules/**

--- a/tokens/custom-spectrum/custom-large-vars.css
+++ b/tokens/custom-spectrum/custom-large-vars.css
@@ -77,6 +77,9 @@ governing permissions and limitations under the License.
   --spectrum-well-border-radius: 5px;
 
   --spectrum-icon-chevron-size-50: 8px;
+  /* XXL and XXS icon sizes are not within the design spec and are planned to be deprecated in Spectrum 2. */
+  --spectrum-workflow-icon-size-xxl: 40px;
+  --spectrum-workflow-icon-size-xxs: 15px;
 
   --spectrum-treeview-item-indentation-medium: 20px;
   --spectrum-treeview-item-indentation-small: 15px;
@@ -117,7 +120,10 @@ governing permissions and limitations under the License.
   --spectrum-assetcard-selectionindicator-margin: 15px;
   --spectrum-assetcard-title-font-size: var(--spectrum-heading-size-xxs);
   --spectrum-assetcard-header-content-font-size: var(--spectrum-heading-size-xxs);
-	--spectrum-assetcard-content-font-size: var(--spectrum-body-size-xs);
+  --spectrum-assetcard-content-font-size: var(--spectrum-body-size-xs);
 
   --spectrum-tooltip-animation-distance: 5px;
+
+  --spectrum-ui-icon-medium-display: none;
+  --spectrum-ui-icon-large-display: block;
 }

--- a/tokens/custom-spectrum/custom-medium-vars.css
+++ b/tokens/custom-spectrum/custom-medium-vars.css
@@ -76,6 +76,9 @@ governing permissions and limitations under the License.
   --spectrum-well-border-radius: var(--spectrum-spacing-75);
 
   --spectrum-icon-chevron-size-50: 6px;
+  /* XXL and XXS icon sizes are not within the design spec and are planned to be deprecated in Spectrum 2. */
+  --spectrum-workflow-icon-size-xxl: 32px;
+  --spectrum-workflow-icon-size-xxs: 12px;
 
   --spectrum-treeview-item-indentation-medium: var(--spectrum-spacing-300);
   --spectrum-treeview-item-indentation-small: var(--spectrum-spacing-200);
@@ -114,9 +117,12 @@ governing permissions and limitations under the License.
 
   --spectrum-assetcard-focus-ring-border-radius: 8px;
   --spectrum-assetcard-selectionindicator-margin: 12px;
-	--spectrum-assetcard-title-font-size: var(--spectrum-heading-size-xs);
+  --spectrum-assetcard-title-font-size: var(--spectrum-heading-size-xs);
   --spectrum-assetcard-header-content-font-size: var(--spectrum-heading-size-xs);
-	--spectrum-assetcard-content-font-size: var(--spectrum-body-size-s);
+  --spectrum-assetcard-content-font-size: var(--spectrum-body-size-s);
 
   --spectrum-tooltip-animation-distance: var(--spectrum-spacing-75);
+
+  --spectrum-ui-icon-medium-display: block;
+  --spectrum-ui-icon-large-display: none;
 }

--- a/tokens/dist/css/spectrum/custom-large-vars.css
+++ b/tokens/dist/css/spectrum/custom-large-vars.css
@@ -63,6 +63,9 @@
   --spectrum-well-border-radius:5px;
 
   --spectrum-icon-chevron-size-50:8px;
+  /* XXL and XXS icon sizes are not within the design spec and are planned to be deprecated in Spectrum 2. */
+  --spectrum-workflow-icon-size-xxl:40px;
+  --spectrum-workflow-icon-size-xxs:15px;
 
   --spectrum-treeview-item-indentation-medium:20px;
   --spectrum-treeview-item-indentation-small:15px;
@@ -103,7 +106,10 @@
   --spectrum-assetcard-selectionindicator-margin:15px;
   --spectrum-assetcard-title-font-size:var(--spectrum-heading-size-xxs);
   --spectrum-assetcard-header-content-font-size:var(--spectrum-heading-size-xxs);
-	--spectrum-assetcard-content-font-size:var(--spectrum-body-size-xs);
+  --spectrum-assetcard-content-font-size:var(--spectrum-body-size-xs);
 
   --spectrum-tooltip-animation-distance:5px;
+
+  --spectrum-ui-icon-medium-display:none;
+  --spectrum-ui-icon-large-display:block;
 }

--- a/tokens/dist/css/spectrum/custom-medium-vars.css
+++ b/tokens/dist/css/spectrum/custom-medium-vars.css
@@ -62,6 +62,9 @@
   --spectrum-well-border-radius:var(--spectrum-spacing-75);
 
   --spectrum-icon-chevron-size-50:6px;
+  /* XXL and XXS icon sizes are not within the design spec and are planned to be deprecated in Spectrum 2. */
+  --spectrum-workflow-icon-size-xxl:32px;
+  --spectrum-workflow-icon-size-xxs:12px;
 
   --spectrum-treeview-item-indentation-medium:var(--spectrum-spacing-300);
   --spectrum-treeview-item-indentation-small:var(--spectrum-spacing-200);
@@ -100,9 +103,12 @@
 
   --spectrum-assetcard-focus-ring-border-radius:8px;
   --spectrum-assetcard-selectionindicator-margin:12px;
-	--spectrum-assetcard-title-font-size:var(--spectrum-heading-size-xs);
+  --spectrum-assetcard-title-font-size:var(--spectrum-heading-size-xs);
   --spectrum-assetcard-header-content-font-size:var(--spectrum-heading-size-xs);
-	--spectrum-assetcard-content-font-size:var(--spectrum-body-size-s);
+  --spectrum-assetcard-content-font-size:var(--spectrum-body-size-s);
 
   --spectrum-tooltip-animation-distance:var(--spectrum-spacing-75);
+
+  --spectrum-ui-icon-medium-display:block;
+  --spectrum-ui-icon-large-display:none;
 }

--- a/tokens/dist/index.css
+++ b/tokens/dist/index.css
@@ -2225,6 +2225,9 @@
   --spectrum-well-border-radius:5px;
 
   --spectrum-icon-chevron-size-50:8px;
+  /* XXL and XXS icon sizes are not within the design spec and are planned to be deprecated in Spectrum 2. */
+  --spectrum-workflow-icon-size-xxl:40px;
+  --spectrum-workflow-icon-size-xxs:15px;
 
   --spectrum-treeview-item-indentation-medium:20px;
   --spectrum-treeview-item-indentation-small:15px;
@@ -2265,9 +2268,12 @@
   --spectrum-assetcard-selectionindicator-margin:15px;
   --spectrum-assetcard-title-font-size:var(--spectrum-heading-size-xxs);
   --spectrum-assetcard-header-content-font-size:var(--spectrum-heading-size-xxs);
-	--spectrum-assetcard-content-font-size:var(--spectrum-body-size-xs);
+  --spectrum-assetcard-content-font-size:var(--spectrum-body-size-xs);
 
   --spectrum-tooltip-animation-distance:5px;
+
+  --spectrum-ui-icon-medium-display:none;
+  --spectrum-ui-icon-large-display:block;
   --spectrum-checkbox-control-size-small:16px;
   --spectrum-checkbox-control-size-medium:18px;
   --spectrum-checkbox-control-size-large:20px;
@@ -3396,6 +3402,9 @@
   --spectrum-well-border-radius:var(--spectrum-spacing-75);
 
   --spectrum-icon-chevron-size-50:6px;
+  /* XXL and XXS icon sizes are not within the design spec and are planned to be deprecated in Spectrum 2. */
+  --spectrum-workflow-icon-size-xxl:32px;
+  --spectrum-workflow-icon-size-xxs:12px;
 
   --spectrum-treeview-item-indentation-medium:var(--spectrum-spacing-300);
   --spectrum-treeview-item-indentation-small:var(--spectrum-spacing-200);
@@ -3434,11 +3443,14 @@
 
   --spectrum-assetcard-focus-ring-border-radius:8px;
   --spectrum-assetcard-selectionindicator-margin:12px;
-	--spectrum-assetcard-title-font-size:var(--spectrum-heading-size-xs);
+  --spectrum-assetcard-title-font-size:var(--spectrum-heading-size-xs);
   --spectrum-assetcard-header-content-font-size:var(--spectrum-heading-size-xs);
-	--spectrum-assetcard-content-font-size:var(--spectrum-body-size-s);
+  --spectrum-assetcard-content-font-size:var(--spectrum-body-size-s);
 
   --spectrum-tooltip-animation-distance:var(--spectrum-spacing-75);
+
+  --spectrum-ui-icon-medium-display:block;
+  --spectrum-ui-icon-large-display:none;
   --spectrum-checkbox-control-size-small:12px;
   --spectrum-checkbox-control-size-medium:14px;
   --spectrum-checkbox-control-size-large:16px;


### PR DESCRIPTION
## Description

Tokens additions for #2347 .

- Add icon XXL token, that is currently being used in a Card variant and at the top of each docs page. XXL does not currently exist as part of the formal design specs. Custom-vars are necessary to facilitate the migration to core tokens. The XXL size is planned to be deprecated in Spectrum 2.

- Add XXS token to support existing SWC size. The XXS size is also planned to be deprecated in Spectrum 2.

- Add large tokens used for combined UI Icon display.

CSS-511

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] ✨ This pull request is ready to merge. ✨
