### PR TITLE
docs: storybook updates for icon sets, arrow and chevron

### DIFF
--- a/components/actionbutton/stories/template.js
+++ b/components/actionbutton/stories/template.js
@@ -17,6 +17,7 @@ export const Template = ({
 	rootClass = "spectrum-ActionButton",
 	size = "m",
 	iconName,
+	iconSet,
 	label,
 	isQuiet = false,
 	isSelected = false,
@@ -78,6 +79,7 @@ export const Template = ({
 					...globals,
 					size,
 					iconName,
+					setName: iconSet,
 					customClasses: [`${rootClass}-icon`, ...customIconClasses],
 				})
 			)}

--- a/components/combobox/stories/template.js
+++ b/components/combobox/stories/template.js
@@ -104,7 +104,7 @@ export const Template = ({
 						... isValid ? ['is-valid'] : [],
 					],
 					size,
-					iconType: "workflow",
+					iconType: "ui",
 					iconName: "ChevronDown",
 					isQuiet,
 					isOpen,

--- a/components/pagination/stories/template.js
+++ b/components/pagination/stories/template.js
@@ -30,6 +30,7 @@ export const Template = ({
 				${ActionButton({
 					size,
 					isQuiet: true,
+					iconSet: "ui",
 					iconName: "ChevronLeft",
 					customClasses: [`${rootClass}-prevButton`],
 				})}
@@ -42,6 +43,7 @@ export const Template = ({
 				${ActionButton({
 					size,
 					isQuiet: true,
+					iconSet: "ui",
 					iconName: "ChevronRight",
 					customClasses: [`${rootClass}-nextButton`],
 				})}

--- a/components/picker/stories/template.js
+++ b/components/picker/stories/template.js
@@ -81,6 +81,7 @@ export const Picker = ({
 			${Icon({
 				...globals,
 				size,
+				setName: "ui",
 				iconName: "ChevronDown",
 				customClasses: [`${rootClass}-menuIcon`],
 			})}

--- a/components/pickerbutton/stories/template.js
+++ b/components/pickerbutton/stories/template.js
@@ -1,7 +1,7 @@
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
-import { styleMap } from "lit/directives/style-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
+import { styleMap } from "lit/directives/style-map.js";
 
 import { useArgs } from "@storybook/client-api";
 
@@ -72,6 +72,7 @@ export const Template = ({
 					: ""}
 				${Icon({
 					...globals,
+					setName: iconType,
 					iconName: iconName ?? "ChevronDown",
 					size,
 					customClasses: [`${rootClass}-icon`],

--- a/components/treeview/stories/template.js
+++ b/components/treeview/stories/template.js
@@ -20,6 +20,7 @@ export const TreeViewItem = ({
 	isOpen,
 	isDropTarget,
 	icon,
+	iconSet,
 	thumbnail,
 	items,
 	customClasses = [],
@@ -80,6 +81,7 @@ export const TreeViewItem = ({
 					? Icon({
 							...globals,
 							size,
+							setName: "ui",
 							iconName: "ChevronRight",
 							customClasses: [`${rootClass}-itemIndicator`],
 					  })
@@ -89,6 +91,7 @@ export const TreeViewItem = ({
 							...globals,
 							size,
 							iconName: icon,
+							setName: iconSet,
 							customClasses: [`${rootClass}-itemIcon`],
 					  })
 					: ""}


### PR DESCRIPTION
## Description

Related component story fixes for a [fix](https://github.com/adobe/spectrum-css/pull/2347/commits/50ff030c9a2e2af7807a0c82e63eccb845806c52) in the Icon migration #2347 , that helps fix the wrong workflow icons appearing for arrow and chevron.

These are both icons with names that exist in both icon sets. Some component stories need the icon set specified. These changes were cherry-picked from that PR to avoid breaking changes.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [ ] Storybook pages for the affected components have not changed
- [ ] No VRT changes

### Regression testing

Validate:

If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x I have updated relevant storybook stories and templates.
- [ ] ✨ This pull request is ready to merge. ✨
