### PR TITLE
chore(tokens): inconsistent compilation results caused by caching

### DIFF
--- a/tokens/project.json
+++ b/tokens/project.json
@@ -11,6 +11,7 @@
 	},
 	"targets": {
 		"build": {
+			"cache": false,
 			"dependsOn": ["clean", "style-dictionary"],
 			"inputs": ["core", "tools", { "externalDependencies": ["postcss"] }],
 			"executor": "nx:run-commands",
@@ -31,7 +32,7 @@
 			]
 		},
 		"clean": {
-			"cache": true,
+			"cache": false,
 			"inputs": ["{projectRoot}/dist", { "externalDependencies": ["rimraf"] }],
 			"outputs": [],
 			"executor": "nx:run-commands",


### PR DESCRIPTION
## Description

During development, the committed token assets sometimes revert to a compiled result without the -rgb postfixed properties. This is due to an issue with how caching is being handled. By removing caching from the tokens package, we can prevent bad dist results being generated for tokens.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

To test this update, we run a collection of the commands and check each time that tokens output has not regressed. We expect after each command, there should be no tokens/dist results to be committed.

- `yarn build`, validate with `git status` (✅ @pfulton)
- `yarn start`, validate with `git status` (✅ @pfulton)
- `yarn build`, validate with `git status` (components should use the cache EXCEPT tokens which should rebuild every time) (✅ @pfulton - it was super fast! 1s actually!)
- `yarn dev`, validate with `git status` (✅  @pfulton)
- `yarn ci:storybook`, validate with `git status` (✅ @pfulton)

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] ✨ This pull request is ready to merge. ✨
