### PR TITLE
ci(actions): bump to v4, resolve outdated node messages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
             - name: Check for cached dependencies
               continue-on-error: true
               id: cache-dependencies
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               with:
                   path: |
                       .cache/yarn

--- a/.github/workflows/compare-results.yml
+++ b/.github/workflows/compare-results.yml
@@ -64,7 +64,7 @@ jobs:
             - name: Check for cached dependencies
               continue-on-error: true
               id: cache-dependencies
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               with:
                   path: |
                       .cache/yarn
@@ -148,7 +148,7 @@ jobs:
             - name: Check for cached dependencies
               continue-on-error: true
               id: cache-dependencies
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               with:
                   path: |
                       .cache/yarn

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -60,7 +60,7 @@ jobs:
             - name: Check for cached dependencies
               continue-on-error: true
               id: cache-dependencies
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               with:
                   path: |
                       .cache/yarn

--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -60,7 +60,7 @@ jobs:
             - name: Check for cached dependencies
               continue-on-error: true
               id: cache-dependencies
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               with:
                   path: |
                       .cache/yarn

--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -46,7 +46,7 @@ jobs:
             - name: Check for cached dependencies
               continue-on-error: true
               id: cache-dependencies
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               with:
                   path: |
                       .cache/yarn


### PR DESCRIPTION
## Description

CI console is outputting warnings for each use of the actions/cache@v3 which is using a node 16 environment image. This PR updates our use to actions/cache@v4 which has been updated to node 20.

<img width="912" alt="Screenshot 2024-02-07 at 10 56 53 AM" src="https://github.com/adobe/spectrum-css/assets/1840295/d91f8556-53b5-440a-b4d3-5791ce3cc7b3">

## How and where has this been tested?

Expect to see no more warnings in the console and all CI tests to pass.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] ✨ This pull request is ready to merge. ✨
