### PR TITLE
chore(storybook): allow local preview of chromatic snapshots

### DIFF
--- a/.storybook/README.md
+++ b/.storybook/README.md
@@ -67,6 +67,8 @@ We are leveraging the following add-ons:
 - [@storybook/addon-a11y](https://github.com/storybookjs/storybook/tree/next/code/addons/a11y)
 - [@whitespace/storybook-addon-html](https://www.npmjs.com/package/@whitespace/storybook-addon-html)
 - [@etchteam/storybook-addon-status](https://storybook.js.org/addons/@etchteam/storybook-addon-status)
+- [@storybook/addon-interactions](https://github.com/storybookjs/storybook/tree/next/code/addons/interactions)
+- [@chromaui/addon-visual-tests](https://www.chromatic.com/docs/visual-testing-addon/)
 
 ## Writing stories
 
@@ -322,6 +324,37 @@ export const Template = ({
 ## Testing stories
 
 Now that your stories are written, we need to add them to our visual regression suite. We are using [chromatic](https://www.chromatic.com), a tool that is designed to work with Storybook.
+
+To optimize snapshot usage, we organize our stories into groups when rendered inside the Chromatic environment. This is done by adding an `window.isChromatic()` check and creating groups of stories (note: do not import the `isChromatic` function directly, there is added functionality we've included when sourcing it from`window`). See example below:
+
+```js
+
+const AccordionGroup = ({
+ customStyles = {},
+ ...args
+}) => {
+ return html`
+   ${Template(args)}
+   ${when(window.isChromatic(), () =>
+    Template({
+     ...args,
+     customStyles: { "max-inline-size": "300px"},
+    })
+   )}
+   ${when(window.isChromatic(), () =>
+    Template({
+     ...args,
+     disableAll: true,
+    })
+   )}
+ `;
+};
+
+export const Default = AccordionGroup.bind({});
+Default.args = {};
+```
+
+Ideally you should have a single story file for each component with multiple variations and states represented in the "Kitchen sink" grouping that only renders in Chromatic. To preview the groups locally, there is a global toolbar setting with a beaker icon called "Show testing preview" that will activate the Chromatic view.
 
 ### Getting started
 

--- a/.storybook/decorators/contextsWrapper.js
+++ b/.storybook/decorators/contextsWrapper.js
@@ -1,5 +1,4 @@
 import { makeDecorator, useEffect } from "@storybook/preview-api";
-import isChromatic from "chromatic/isChromatic";
 
 /**
  * @type import('@storybook/csf').DecoratorFunction<import('@storybook/web-components').WebComponentsFramework>
@@ -32,7 +31,7 @@ export const withContextWrapper = makeDecorator({
 		const scales = ["medium", "large"];
 
 		useEffect(() => {
-			const container = viewMode === "docs" && !isChromatic() ? document.querySelector('#root-inner') ?? document.body : document.body;
+			const container = viewMode === "docs" && !window.isChromatic() ? document.querySelector('#root-inner') ?? document.body : document.body;
 			container.classList.toggle("spectrum", true);
 
 			container.classList.toggle("spectrum--express", isExpress);

--- a/.storybook/decorators/index.js
+++ b/.storybook/decorators/index.js
@@ -1,7 +1,8 @@
-import { useEffect, makeDecorator } from "@storybook/preview-api";
+import { makeDecorator, useEffect } from "@storybook/preview-api";
 import { html } from "lit";
 
 export { withContextWrapper } from "./contextsWrapper.js";
+export { withTestingPreviewWrapper } from "./withTestingPreviewWrapper.js";
 
 /**
  * @type import('@storybook/csf').DecoratorFunction<import('@storybook/web-components').WebComponentsFramework>

--- a/.storybook/decorators/withTestingPreviewWrapper.js
+++ b/.storybook/decorators/withTestingPreviewWrapper.js
@@ -1,0 +1,26 @@
+import { makeDecorator } from "@storybook/preview-api";
+
+import isChromatic from "chromatic/isChromatic";
+
+/**
+ * @type import('@storybook/csf').DecoratorFunction<import('@storybook/web-components').WebComponentsFramework>
+ * @description Lets you preview the Chromatic testing view locally
+ **/
+export const withTestingPreviewWrapper = makeDecorator({
+	name: "withTestingPreviewWrapper",
+	parameterName: "testingPreview",
+	wrapper: (StoryFn, context) => {
+        const { globals } = context;
+        const showTestingPreview = globals.testingPreview ?? false;
+
+        // If we're not in Chromatic and we want to show the testing preview, we need to override the isChromatic function
+        if (!isChromatic() && showTestingPreview) {
+            window.isChromatic = () => true;
+        } else {
+            // Otherwise, we need to reset it to the original function (in case it was overridden previously)
+            window.isChromatic = isChromatic;
+        }
+
+        return StoryFn(context);
+	},
+});

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -6,6 +6,7 @@ import {
 	withContextWrapper,
 	withLanguageWrapper,
 	withReducedMotionWrapper,
+	withTestingPreviewWrapper,
 	withTextDirectionWrapper,
 } from "./decorators/index.js";
 
@@ -74,6 +75,18 @@ export const globalTypes = {
 			dynamicTitle: true,
 		},
 	},
+	testingPreview: {
+		title: "Testing preview",
+		description: "See how the story will look to Chromatic",
+		defaultValue: false,
+		toolbar: {
+			icon: "beaker",
+			items: [
+				{ value: true, title: "Show testing preview" },
+				{ value: false, title: "Default mode" },
+			],
+		},
+	}
 };
 
 // Global properties added to each component;
@@ -243,8 +256,8 @@ export const decorators = [
 	withLanguageWrapper,
 	withReducedMotionWrapper,
 	withContextWrapper,
+	withTestingPreviewWrapper,
 	withActions,
-	// ...[isChromatic() ? withSizingWrapper : false].filter(Boolean),
 ];
 
 export default {

--- a/components/accordion/stories/accordion.stories.js
+++ b/components/accordion/stories/accordion.stories.js
@@ -1,7 +1,7 @@
-// Import the component markup template
-import { Template } from "./template";
 import { html } from "lit";
-import isChromatic from "chromatic/isChromatic";
+import { when } from "lit/directives/when.js";
+
+import { Template } from "./template";
 
 export default {
 	title: "Components/Accordion",
@@ -58,7 +58,7 @@ export default {
 	},
 };
 
-const AccordianGroup = ({
+const AccordionGroup = ({
 	customStyles = {},
 	...args
 }) => {
@@ -101,7 +101,7 @@ const AccordianGroup = ({
 				],
 			]),
 			})}
-			${isChromatic() ?
+			${when(window.isChromatic(), () =>
 				Template({
 					...args,
 					customStyles: { "max-inline-size": "300px"},
@@ -140,8 +140,8 @@ const AccordianGroup = ({
 					],
 				]),
 				})
-				: null }
-			${isChromatic() ?
+			)}
+			${when(window.isChromatic(), () =>
 				Template({
 					...args,
 					disableAll: true,
@@ -176,10 +176,10 @@ const AccordianGroup = ({
 					],
 				]),
 				})
-				: null }
+			)}
 		</div>
 	`;
 };
 
-export const Default = AccordianGroup.bind({});
+export const Default = AccordionGroup.bind({});
 Default.args = {};

--- a/components/alertbanner/stories/alertbanner.stories.js
+++ b/components/alertbanner/stories/alertbanner.stories.js
@@ -1,6 +1,5 @@
-import { Template } from "./template";
 import { html } from "lit";
-import isChromatic from "chromatic/isChromatic";
+import { Template } from "./template";
 
 export default {
 	title: "Components/Alert banner",
@@ -74,14 +73,14 @@ const AlertBannerGroup = ({
 			${Template({
 				...args,
 			})}
-			${isChromatic() ?
+			${window.isChromatic() ?
 			Template({
 				...args,
 				hasActionButton: true,
 				variant: "info",
 				text: "Your trial will expire in 3 days. Once it expires your files will be saved and ready for you to open again once you have purcahsed the software."
 			}): null }
-			${isChromatic() ?
+			${window.isChromatic() ?
 					Template({
 						...args,
 				hasActionButton: true,

--- a/components/calendar/stories/calendar.stories.js
+++ b/components/calendar/stories/calendar.stories.js
@@ -1,8 +1,6 @@
-// Import the component markup template
 import { Template } from "./template";
 
 import ActionButtonStories from "@spectrum-css/actionbutton/stories/actionbutton.stories.js";
-import isChromatic from "chromatic/isChromatic";
 
 const months = [...Array(12).keys()].map((key) =>
 	new Date(0, key).toLocaleString("en", { month: "long" })
@@ -125,8 +123,8 @@ RangeSelection.args = {
 
 export const TodayHighlighted = Template.bind({});
 TodayHighlighted.args = {
-	month: isChromatic() ? months[0] : months[new Date().getMonth()],
-	year: isChromatic() ? 2021 : new Date().getFullYear(),
+	month: months[new Date().getMonth()],
+	year: new Date().getFullYear(),
 };
 
 export const Disabled = Template.bind({});

--- a/components/calendar/stories/template.js
+++ b/components/calendar/stories/template.js
@@ -6,7 +6,6 @@ import { styleMap } from "lit/directives/style-map.js";
 
 import { action } from "@storybook/addon-actions";
 import { useArgs, useGlobals } from "@storybook/client-api";
-import isChromatic from "chromatic/isChromatic";
 
 import { Template as ActionButton } from "@spectrum-css/actionbutton/stories/template.js";
 
@@ -32,13 +31,6 @@ export const Template = ({
 	id,
 	...globals
 }) => {
-	const [_, updateArgs] = useArgs();
-	const [{ lang }] = useGlobals();
-
-	const displayedDate = new Date(`${month} 1, ${year}`);
-	const displayedMonth = displayedDate.getMonth();
-	const displayedYear = displayedDate.getFullYear();
-
 	const DOW = [
 		"Sunday",
 		"Monday",
@@ -62,6 +54,23 @@ export const Template = ({
 		return date.toLocaleString(lang, { month: format });
 	};
 
+	const [_, updateArgs] = useArgs();
+	const [{ lang, testingPreview }] = useGlobals();
+
+	if (testingPreview && window.isChromatic()) {
+		month = getMonthName(0);
+		year = 2021;
+	}
+
+	const displayedDate = new Date(`${month} 1, ${year}`);
+	const displayedMonth = displayedDate.getMonth();
+	const displayedYear = displayedDate.getFullYear();
+
+	let today = new Date();
+	if (testingPreview && window.isChromatic()) {
+		today = displayedDate;
+	}
+
 	/**
 	 * @typedef {{ date: Date, dateClassList: import('lit').ClassInfo, isSelected: boolean, isToday: boolean, isOutsideMonth: boolean }} DateMetadata
 	 **/
@@ -75,7 +84,6 @@ export const Template = ({
 	 */
 	const generateMonthArray = ({ selectedDate, lastSelectedDate }) => {
 		/* Fetch a clean (time-free) version of today's date */
-		const today = !isChromatic() ? new Date() : displayedDate;
 		today.setHours(0, 0, 0, 0);
 		const todayDatetime = today.getTime();
 

--- a/components/coachindicator/stories/coachindicator.stories.js
+++ b/components/coachindicator/stories/coachindicator.stories.js
@@ -1,5 +1,4 @@
 import { html } from "lit";
-import isChromatic from "chromatic/isChromatic";
 
 import { Template } from "./template";
 
@@ -84,7 +83,7 @@ const chromaticGroup = (args) => {
 };
 
 
-export const Default = (args) => isChromatic() ? chromaticGroup(args) : Template(args);
+export const Default = (args) => html`${window.isChromatic() ? chromaticGroup(args) : Template(args)}`;
 Default.args = {
 	variant: "default"
 };

--- a/components/dropzone/stories/dropzone.stories.js
+++ b/components/dropzone/stories/dropzone.stories.js
@@ -1,5 +1,4 @@
 import { Template as Link } from "@spectrum-css/link/stories/template.js";
-import isChromatic from "chromatic/isChromatic";
 import { html } from "lit";
 import { Template } from "./template";
 
@@ -57,7 +56,7 @@ export const Default = ({
 				...args
 			})}
 
-			${isChromatic() ?
+			${window.isChromatic() ?
 				Template({
 					...args,
 					customHeading: 'Drag and drop your file to upload',

--- a/components/icon/stories/icon.stories.js
+++ b/components/icon/stories/icon.stories.js
@@ -1,5 +1,4 @@
 // Import the component markup template
-import isChromatic from "chromatic/isChromatic";
 import { html } from "lit";
 import { styleMap } from "lit/directives/style-map.js";
 import { when } from "lit/directives/when.js";
@@ -9,7 +8,7 @@ import { uiIconSizes, uiIconsWithDirections, workflowIcons } from "./utilities.j
 
 /**
  * Create a list of all UI Icons with their sizing numbers.
- * 
+ *
  * The list is a little long until Storybook adds a way to use conditional options
  * in controls, e.g. a "uiSize" control with options pulled from uiIconSizes:
  * @see https://github.com/storybookjs/storybook/discussions/24235
@@ -19,7 +18,7 @@ const uiIconNameOptions = uiIconsWithDirections.map((iconName) => {
 	// Icons like Gripper that don't have sizes yet, represented by any empty array.
 	if (uiIconSizes[baseIconName]?.length == 0){
 		return [baseIconName];
-	} 
+	}
 	return uiIconSizes[baseIconName]?.map(sizeNum => iconName + sizeNum) ?? [];
 }).flat();
 
@@ -104,7 +103,7 @@ export default {
 };
 
 export const Default = (args) => {
-	if (isChromatic()){
+	if (window.isChromatic()){
 		return TestTemplate({ ...args });
 	} else {
 		return Template({
@@ -113,7 +112,7 @@ export const Default = (args) => {
 			setName: args.setName ?? (args.uiIconName ? "ui" : "workflow"),
 		});
 	}
-} 
+}
 
 Default.args = {};
 

--- a/components/illustratedmessage/stories/illustratedmessage.stories.js
+++ b/components/illustratedmessage/stories/illustratedmessage.stories.js
@@ -1,4 +1,3 @@
-import isChromatic from "chromatic/isChromatic";
 import { html } from "lit";
 
 // Import the component markup template
@@ -67,7 +66,7 @@ export const Default = ({
 				],
 				useAccentColor: false,
 			})}
-			${isChromatic() ?
+			${window.isChromatic() ?
 				Template({
 					...args,
 					heading: "Error 404: This is not the page you're looking for",

--- a/components/inlinealert/stories/inlinealert.stories.js
+++ b/components/inlinealert/stories/inlinealert.stories.js
@@ -1,4 +1,3 @@
-import isChromatic from "chromatic/isChromatic";
 import { html } from "lit";
 import { Template } from "./template";
 
@@ -77,7 +76,7 @@ export const Default = ({
 			})}
 
 			${
-				isChromatic() ?
+				window.isChromatic() ?
 					Template({
 						...args,
 						headerText: 'in-line alert header announcing something very long and in-line',

--- a/components/statuslight/stories/statuslight.stories.js
+++ b/components/statuslight/stories/statuslight.stories.js
@@ -1,4 +1,3 @@
-import isChromatic from "chromatic/isChromatic";
 import { html } from "lit";
 import { Template } from "./template";
 
@@ -86,7 +85,7 @@ export const Default = ({
 			})}
 
 			${
-				isChromatic() ?
+				window.isChromatic() ?
 				Template({
 					...args,
 					label: "Status light label that is long and wraps to the next line",

--- a/components/stepper/stories/stepper.stories.js
+++ b/components/stepper/stories/stepper.stories.js
@@ -1,4 +1,3 @@
-import isChromatic from "chromatic/isChromatic";
 import { html } from "lit";
 import { Template } from "./template";
 
@@ -104,7 +103,7 @@ export const Default = ({
 				...args
 			})}
 
-			${isChromatic() ? chromaticKitchenSink(args) : null}
+			${window.isChromatic() ? chromaticKitchenSink(args) : null}
 		</div>
 	`;
 };

--- a/components/tray/stories/tray.stories.js
+++ b/components/tray/stories/tray.stories.js
@@ -1,4 +1,3 @@
-import isChromatic from "chromatic/isChromatic";
 import { html } from "lit";
 import { Template } from "./template";
 
@@ -60,7 +59,7 @@ export const Default = ({
 			})}
 
 			${
-				isChromatic() ?
+				window.isChromatic() ?
 				Template({
 					...args,
 					heading: "Tray Dialog",


### PR DESCRIPTION
## Description

As we expand our Chromatic test coverage leveraging the `isChromatic` flag, there's a larger need to be able to preview the "kitchen sink" set-up without having to take a snapshot. Enter, the global "Testing preview" setting!

https://github.com/adobe/spectrum-css/assets/1840295/b9ec5c75-38f8-48bf-8335-935e61033118

With the global setting, you can activate "Testing preview" mode and see all storybook stories the way Chromatic will see them. It persists as you navigate through components until you deactivate it in the global toolbar.

Going forward, all use of the `isChromatic` function should be sourced from `window.isChromatic` rather than imported manually into each story.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

1. Open the [storybook](url) for the accordion component:
    - [ ] Activate the "Testing preview" from the top toolbar as demonstrated in the video above
    - [ ] Click over to the alert banner, calendar, and status light stories to validate the setting persists; confirm each component is showing the snapshot view
    - [ ] Toggle the "Testing preview" off (Default mode)
    - [ ] Confirm that accordion, alert banner, calendar, and status light are now showing their developer mode

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
