### PR TITLE
docs(combobox): update to use local chromatic preview

### DIFF
--- a/components/combobox/stories/combobox.stories.js
+++ b/components/combobox/stories/combobox.stories.js
@@ -1,5 +1,3 @@
-import isChromatic from "chromatic/isChromatic";
-
 import { html } from "lit";
 
 import { Template } from "./template";
@@ -233,10 +231,10 @@ const chromaticKitchenSink = (args) => html`
 	</div>
 `;
 
-export const Default = (args) => isChromatic() ? chromaticKitchenSink(args) : Template(args);
+export const Default = (args) => window.isChromatic() ? chromaticKitchenSink(args) : Template(args);
 Default.args = {};
 
-export const Quiet = (args) => isChromatic()
+export const Quiet = (args) => window.isChromatic()
 	? chromaticKitchenSink(args)
 	: Template({
 		...args


### PR DESCRIPTION
## Description

Changes to combobox, including using `isChromatic()`, snuck in before the [local Chromatic preview PR](https://github.com/adobe/spectrum-css/pull/2499) was merged. This adjusts the combobox story to use the new setup.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps @jenndiaz 

- [x] In storybook, Combobox shows the Chromatic preview when you turn on the preview (beaker in the global toolbar) 

Note that I've noticed sometimes Storybook shows a hooks error. That is a separate issue from this PR that Cassondra is taking a look at. If you run into it, refresh the page and you should be able to review.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [ ] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
