### PR TITLE
docs: readme - clarify browser support and remove ie11 broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,17 @@ Adobe maintains separate JavaScript libraries written with [web components](http
 
 ## Using Spectrum CSS
 
-The preferred method of using Spectrum CSS relies on custom properties to swap out variables for different themes and colorstops. This has the lowest bundle size and the simplest usage, but is incompatible with < IE 11.
+The preferred method of using Spectrum CSS relies on custom properties to swap out variables for different themes and colorstops. This has the lowest bundle size and the simplest usage, but is incompatible with IE 11 and below.
 
-To use Spectrum CSS with IE 11, see the [legacy usage documentation](README-legacy.md).
+### Browser support
+
+We maintain a relatively modern codebase that supports the latest two versions of evergreen web browsers. The current list of browsers officially supported by Spectrum CSS can be found in the `browserslist` section of the project's [package.json file](https://github.com/adobe/spectrum-css/blob/main/package.json). This setting is used by the build tools when the source files are built. If you require additional browser support for your project, the CSS can processed further with your chosen tools.
+
+- last 2 Edge versions
+- last 2 Chrome versions
+- last 2 Firefox versions
+- last 2 Safari versions
+- last 2 iOS versions
 
 ### Installing components
 


### PR DESCRIPTION
## Description

Adds a section to the main project README that explains what browsers are currently supported by Spectrum CSS. IE11 is no longer supported and there was a 404 link to legacy IE11 support that needed to be removed.

## How and where has this been tested?

- [x] Proofread README updates and check for accuracy

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] ✨ This pull request is ready to merge. ✨
