### PR TITLE
fix(textarea): drag and grow behaviors

### DIFF
--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -1267,6 +1267,7 @@ governing permissions and limitations under the License.
 
 	.spectrum-Textfield-input {
 		resize: both;
+		block-size: unset;
 		min-inline-size: var(
 			--mod-text-area-min-inline-size,
 			var(--spectrum-text-area-min-inline-size)
@@ -1277,6 +1278,7 @@ governing permissions and limitations under the License.
 		);
 	}
 
+	/* CSS to support text area grow behavior */
 	&.spectrum-Textfield--grows {
 		.spectrum-Textfield-input {
 			grid-row: 2 / auto;

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -553,26 +553,15 @@ governing permissions and limitations under the License.
 
 	/****** Validation Icon - Invalid ⚠️ ******/
 	.spectrum-Textfield.is-invalid & {
+		justify-self: end;
+
 		block-size: var(
 			--mod-textfield-icon-size-invalid,
 			var(--spectrum-textfield-icon-size-invalid)
 		);
-		inline-size: var(
-			--mod-textfield-icon-size-invalid,
-			var(--spectrum-textfield-icon-size-invalid)
-		);
-		inset-block-start: var(
-			--mod-textfield-icon-spacing-block-invalid,
-			var(--spectrum-textfield-icon-spacing-block-invalid)
-		);
-		inset-block-end: var(
-			--mod-textfield-icon-spacing-block-invalid,
-			var(--spectrum-textfield-icon-spacing-block-invalid)
-		);
-		inset-inline-end: var(
-			--mod-textfield-icon-spacing-inline-end-invalid,
-			var(--spectrum-textfield-icon-spacing-inline-end-invalid)
-		);
+		padding-block-start: var(--spectrum-textfield-icon-spacing-block-invalid);
+		padding-inline-end: var(--spectrum-textfield-icon-spacing-inline-end-invalid);
+
 		color: var(
 			--highcontrast-textfield-icon-color-invalid,
 			var(
@@ -1264,6 +1253,11 @@ governing permissions and limitations under the License.
 /*** Text Area ***/
 .spectrum-Textfield--multiline {
   --spectrum-textfield-input-line-height: normal;
+
+	&.spectrum-Textfield {
+		inline-size: unset;
+		min-inline-size: var(--mod-textfield-width, var(--spectrum-textfield-width));
+	}
 
 	.spectrum-Textfield-input {
 		resize: both;

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -1265,7 +1265,8 @@ governing permissions and limitations under the License.
 .spectrum-Textfield--multiline {
   --spectrum-textfield-input-line-height: normal;
 
-  .spectrum-Textfield-input {
+	.spectrum-Textfield-input {
+		resize: both;
 		min-inline-size: var(
 			--mod-text-area-min-inline-size,
 			var(--spectrum-text-area-min-inline-size)
@@ -1274,11 +1275,6 @@ governing permissions and limitations under the License.
 			--mod-text-area-min-block-size,
 			var(--spectrum-text-area-min-block-size)
 		);
-		resize: inherit;
-	}
-
-	&.spectrum-Textfield--drag {
-		resize: both;
 	}
 
 	&.spectrum-Textfield--grows {
@@ -1287,13 +1283,13 @@ governing permissions and limitations under the License.
 		}
 
 		&.spectrum-Textfield--sideLabel .spectrum-Textfield-input {
-				grid-row: 1 / auto
+			resize: none;
+			grid-row: 1 / auto;
 		}
 	}
 
 	&.spectrum-Textfield--quiet {
 		.spectrum-Textfield-input {
-
 			min-block-size: var(
 				--mod-text-area-min-block-size-quiet,
 				var(--spectrum-text-area-min-block-size-quiet)

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -1277,6 +1277,10 @@ governing permissions and limitations under the License.
 		resize: inherit;
 	}
 
+	&.spectrum-Textfield--drag {
+		resize: both;
+	}
+
 	&.spectrum-Textfield--grows {
 		.spectrum-Textfield-input {
 			grid-row: 2 / auto;

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -1261,7 +1261,6 @@ governing permissions and limitations under the License.
 
 	.spectrum-Textfield-input {
 		resize: both;
-		block-size: unset;
 		min-inline-size: var(
 			--mod-text-area-min-inline-size,
 			var(--spectrum-text-area-min-inline-size)

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -1278,7 +1278,7 @@ governing permissions and limitations under the License.
 		);
 	}
 
-	/* CSS to support text area grow behavior */
+	/* CSS to support text area grow behavior, requires JavaScript to implement */
 	&.spectrum-Textfield--grows {
 		.spectrum-Textfield-input {
 			grid-row: 2 / auto;

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -1268,14 +1268,17 @@ governing permissions and limitations under the License.
 
 	&.spectrum-Textfield {
 		inline-size: unset;
-		min-inline-size: var(--mod-textfield-width, var(--spectrum-textfield-width));
+		min-inline-size: max(
+			var(--mod-textfield-width, var(--spectrum-textfield-width)),
+			var(--mod-text-area-min-inline-size, var(--spectrum-text-area-min-inline-size))
+		);
 	}
 
 	.spectrum-Textfield-input {
-		resize: both;
-		min-inline-size: var(
-			--mod-text-area-min-inline-size,
-			var(--spectrum-text-area-min-inline-size)
+		resize: var(--mod-text-area-resize, both);
+		min-inline-size: max(
+			var(--mod-textfield-width, var(--spectrum-textfield-width)),
+			var(--mod-text-area-min-inline-size, var(--spectrum-text-area-min-inline-size))
 		);
 		min-block-size: var(
 			--mod-text-area-min-block-size,

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -452,7 +452,7 @@ governing permissions and limitations under the License.
 
 	/* Grid layout for child components */
 	display: inline-grid;
-	grid-template-columns: auto auto;
+	grid-template-columns: minmax(0, auto) minmax(0, auto);
 	grid-template-rows: auto auto auto;
 }
 
@@ -1264,22 +1264,28 @@ governing permissions and limitations under the License.
 
 /*** Text Area ***/
 .spectrum-Textfield--multiline {
-  --spectrum-textfield-input-line-height: normal;
+	--spectrum-textfield-input-line-height: normal;
 
 	&.spectrum-Textfield {
+		/* Remove fixed inline-size to allow resize behavior. */
 		inline-size: unset;
-		min-inline-size: max(
-			var(--mod-textfield-width, var(--spectrum-textfield-width)),
-			var(--mod-text-area-min-inline-size, var(--spectrum-text-area-min-inline-size))
+		min-inline-size: var(
+			--mod-text-area-min-inline-size, 
+			var(--spectrum-text-area-min-inline-size)
 		);
 	}
 
 	.spectrum-Textfield-input {
 		resize: var(--mod-text-area-resize, both);
-		min-inline-size: max(
+		inline-size: max(
 			var(--mod-textfield-width, var(--spectrum-textfield-width)),
 			var(--mod-text-area-min-inline-size, var(--spectrum-text-area-min-inline-size))
 		);
+		min-inline-size: var(
+			--mod-text-area-min-inline-size, 
+			var(--spectrum-text-area-min-inline-size)
+		);
+		max-inline-size: var(--mod-text-area-max-inline-size, 100%);
 		min-block-size: var(
 			--mod-text-area-min-block-size,
 			var(--spectrum-text-area-min-block-size)

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -1280,6 +1280,12 @@ governing permissions and limitations under the License.
 
 	/* CSS to support text area grow behavior, requires JavaScript to implement */
 	&.spectrum-Textfield--grows {
+
+		.spectrum-Textfield-validationIcon {
+			grid-row: auto;
+			grid-column: auto;
+		}
+
 		.spectrum-Textfield-input {
 			grid-row: 2 / auto;
 		}

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -553,14 +553,26 @@ governing permissions and limitations under the License.
 
 	/****** Validation Icon - Invalid ⚠️ ******/
 	.spectrum-Textfield.is-invalid & {
-		justify-self: end;
-
 		block-size: var(
 			--mod-textfield-icon-size-invalid,
 			var(--spectrum-textfield-icon-size-invalid)
 		);
-		padding-block-start: var(--spectrum-textfield-icon-spacing-block-invalid);
-		padding-inline-end: var(--spectrum-textfield-icon-spacing-inline-end-invalid);
+		inline-size: var(
+			--mod-textfield-icon-size-invalid,
+			var(--spectrum-textfield-icon-size-invalid)
+		);
+		inset-block-start: var(
+			--mod-textfield-icon-spacing-block-invalid,
+			var(--spectrum-textfield-icon-spacing-block-invalid)
+		);
+		inset-block-end: var(
+			--mod-textfield-icon-spacing-block-invalid,
+			var(--spectrum-textfield-icon-spacing-block-invalid)
+		);
+		inset-inline-end: var(
+			--mod-textfield-icon-spacing-inline-end-invalid,
+			var(--spectrum-textfield-icon-spacing-inline-end-invalid)
+		);
 
 		color: var(
 			--highcontrast-textfield-icon-color-invalid,
@@ -1271,9 +1283,8 @@ governing permissions and limitations under the License.
 		);
 	}
 
-	/* CSS to support text area grow behavior, requires JavaScript to implement */
+	/* CSS to support text area grow behavior. This requires JavaScript to implement. */
 	&.spectrum-Textfield--grows {
-
 		.spectrum-Textfield-validationIcon {
 			grid-row: auto;
 			grid-column: auto;

--- a/components/textfield/metadata/mods.md
+++ b/components/textfield/metadata/mods.md
@@ -4,6 +4,7 @@
 | `--mod-text-area-min-block-size`                        |
 | `--mod-text-area-min-block-size-quiet`                  |
 | `--mod-text-area-min-inline-size`                       |
+| `--mod-text-area-resize`                                |
 | `--mod-textfield-background-color`                      |
 | `--mod-textfield-background-color-disabled`             |
 | `--mod-textfield-border-color`                          |

--- a/components/textfield/metadata/textarea.yml
+++ b/components/textfield/metadata/textarea.yml
@@ -1,7 +1,7 @@
 name: Text area
 status: Verified
 description: A multi-line text field using the `<textarea>` element.
-SpectrumSiteSlug: https://spectrum.adobe.com/page/text-field/
+SpectrumSiteSlug: https://spectrum.adobe.com/page/text-area/
 sections:
   - name: Migration Guide
     description: |
@@ -59,7 +59,7 @@ examples:
 
   - id: textfield-grow
     name: Textfield with Grow Behavior
-    description: By default the TextArea is draggable. Add `spectrum-Textfield--grows` to the text-field with `spectrum-Textfield--multiline` along with appropriate JavaScript to enable a text area that grows with input isntead of dragging.
+    description: By default the TextArea is draggable. Use `spectrum-Textfield--grows` to disable the drag behavior along with appropriate JavaScript to enable a text area that grows with input.
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--grows">
         <label for="textfield-helptext" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Password</label>

--- a/components/textfield/metadata/textarea.yml
+++ b/components/textfield/metadata/textarea.yml
@@ -47,7 +47,7 @@ examples:
       </div>
 
   - id: textfield-helptext
-    name: Textfield with Help Text
+    name: With Help Text
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline">
         <label for="textfield-helptext" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Tags</label>
@@ -55,15 +55,6 @@ examples:
         <div class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--neutral">
           <div id="helptext-5" class="spectrum-HelpText-text">Tags must be comma separated.</div>
         </div>
-      </div>
-
-  - id: textfield-grow
-    name: Textfield with Grow Behavior
-    description: By default the TextArea is draggable. Use `spectrum-Textfield--grows` to disable the drag behavior along with appropriate JavaScript to enable a text area that grows with input.
-    markup: |
-      <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--grows">
-        <label for="textfield-helptext" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Password</label>
-        <textarea id="textfield-helptext" name="field" class="spectrum-Textfield-input">something related to the max size of the text area</textarea>
       </div>
 
   - id: textfield-character-count
@@ -76,7 +67,7 @@ examples:
       </div>
 
   - id: textfield-sidelabel
-    name: Textfield with Side Label
+    name: With Side Label
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--sideLabel">
         <label for="textfield-m-sidelabel" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Comments</label>
@@ -183,8 +174,18 @@ examples:
         <textarea id="textarea-keyboard-focused-invalid" name="field"  class="spectrum-Textfield-input" pattern="[\w\s]+" required>Invalid input</textarea>
       </div>
 
+  - id: textfield-grow
+    name: TextArea with Grow Behavior
+    description: Use `spectrum-Textfield--grows` to disable the drag behavior along with appropriate JavaScript to enable a text area that grows with input.
+    markup: |
+      <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--grows">
+        <label for="textfield-helptext" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Password</label>
+        <textarea id="textfield-helptext" name="field" class="spectrum-Textfield-input"></textarea>
+      </div>
+
   - id: textfield-quiet
     name: Quiet
+    description: Text areas should rarely be presented in the quiet style. The height of the field should use grow logic so the height will adjust with the height of the entered value.
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--quiet">
         <label for="textarea-quiet" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Comments</label>

--- a/components/textfield/metadata/textarea.yml
+++ b/components/textfield/metadata/textarea.yml
@@ -176,7 +176,7 @@ examples:
 
   - id: textfield-grow
     name: TextArea with Grow Behavior
-    description: Use `spectrum-Textfield--grows` to disable the drag behavior along with appropriate JavaScript to enable a text area that grows with input.
+    description: Use `spectrum-Textfield--grows` to disable the drag behavior along with appropriate JavaScript to enable the height of the text area to <a href="https://spectrum.adobe.com/page/text-area/#Height">grow with input</a>.
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--grows">
         <label for="textfield-helptext" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Password</label>
@@ -185,7 +185,7 @@ examples:
 
   - id: textfield-quiet
     name: Quiet
-    description: Text areas should rarely be presented in the quiet style. When used, quiet text areas should use Javascript to enable a text area that grows with input.
+    description: Text areas should rarely be presented in the quiet style. When used, quiet text areas should use JavaScript to enable the height of the text area to <a href="https://spectrum.adobe.com/page/text-area/#Quiet">grow with input</a>.
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--quiet">
         <label for="textarea-quiet" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Comments</label>

--- a/components/textfield/metadata/textarea.yml
+++ b/components/textfield/metadata/textarea.yml
@@ -185,7 +185,7 @@ examples:
 
   - id: textfield-quiet
     name: Quiet
-    description: Text areas should rarely be presented in the quiet style. The height of the field should use grow logic so the height will adjust with the height of the entered value.
+    description: Text areas should rarely be presented in the quiet style. When used, quiet text areas should use Javascript to enable a text area that grows with input.
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--quiet">
         <label for="textarea-quiet" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Comments</label>

--- a/components/textfield/metadata/textarea.yml
+++ b/components/textfield/metadata/textarea.yml
@@ -59,22 +59,12 @@ examples:
 
   - id: textfield-grow
     name: Textfield with Grow Behavior
-    description: Add `spectrum-Textfield--grows` to the text-field with `spectrum-Textfield--multiline` along with appropriate JavaScript to enable a text area that grows with input.
+    description: By default the TextArea is draggable. Add `spectrum-Textfield--grows` to the text-field with `spectrum-Textfield--multiline` along with appropriate JavaScript to enable a text area that grows with input isntead of dragging.
     markup: |
       <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--grows">
         <label for="textfield-helptext" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Password</label>
         <textarea id="textfield-helptext" name="field" class="spectrum-Textfield-input">something related to the max size of the text area</textarea>
       </div>
-
-  - id: textfield-drag
-    name: Textfield with Drag Behavior
-    description: Add `spectrum-Textfield--drag` to the text-field with `spectrum-Textfield--multiline` to enable the resizable behavior.
-    markup: |
-      <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--drag">
-        <label for="textfield-helptext" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Password</label>
-        <textarea id="textfield-helptext" name="field" class="spectrum-Textfield-input"></textarea>
-      </div>
-
 
   - id: textfield-character-count
     name: With Character Count

--- a/components/textfield/metadata/textarea.yml
+++ b/components/textfield/metadata/textarea.yml
@@ -57,6 +57,25 @@ examples:
         </div>
       </div>
 
+  - id: textfield-grow
+    name: Textfield with Grow Behavior
+    description: Add `spectrum-Textfield--grows` to the text-field with `spectrum-Textfield--multiline` along with appropriate JavaScript to enable a text area that grows with input.
+    markup: |
+      <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--grows">
+        <label for="textfield-helptext" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Password</label>
+        <textarea id="textfield-helptext" name="field" class="spectrum-Textfield-input">something related to the max size of the text area</textarea>
+      </div>
+
+  - id: textfield-drag
+    name: Textfield with Drag Behavior
+    description: Add `spectrum-Textfield--drag` to the text-field with `spectrum-Textfield--multiline` to enable the resizable behavior.
+    markup: |
+      <div class="spectrum-Textfield spectrum-Textfield--multiline spectrum-Textfield--drag">
+        <label for="textfield-helptext" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">Password</label>
+        <textarea id="textfield-helptext" name="field" class="spectrum-Textfield-input"></textarea>
+      </div>
+
+
   - id: textfield-character-count
     name: With Character Count
     markup: |

--- a/components/textfield/stories/textfield.stories.js
+++ b/components/textfield/stories/textfield.stories.js
@@ -1,6 +1,6 @@
 // Import the component markup template
-import { Template } from "./template";
 import { html } from "lit";
+import { Template } from "./template";
 
 export default {
 	title: "Components/Text field",
@@ -201,7 +201,7 @@ const TextFieldGroup = ({
 	...args
 }) => {
 	return html`
-		<div style="display: flex; flex-direction: column; gap: 2rem;">
+		<div style="display: flex; flex-direction: column; align-items: flex-start; gap: 2rem;">
 			${Template({
 				...args
 			})}
@@ -235,7 +235,7 @@ const TextAreaGroup = ({
 	...args
 }) => {
 	return html`
-		<div style="display: flex; flex-direction: column; gap: 2rem;">
+		<div style="display: flex; flex-direction: column; align-items: flex-start; gap: 2rem;">
 			${Template({
 				...args,
 				multiline: true,

--- a/components/textfield/stories/textfield.stories.js
+++ b/components/textfield/stories/textfield.stories.js
@@ -281,6 +281,6 @@ Default.args = {
 export const TextArea = TextAreaGroup.bind({});
 TextArea.args = {
 	multiline: true,
-	grows: true,
-	value: "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.",
+	value:
+		"Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.",
 };

--- a/components/textfield/stories/textfield.stories.js
+++ b/components/textfield/stories/textfield.stories.js
@@ -1,5 +1,6 @@
 // Import the component markup template
 import { html } from "lit";
+import { when } from "lit/directives/when.js";
 import { Template } from "./template";
 
 export default {
@@ -205,28 +206,24 @@ const TextFieldGroup = ({
 			${Template({
 				...args
 			})}
-			${window.isChromatic() ?
-				Template({
+			${when(window.isChromatic(), () => html`
+				${Template({
 					displayLabel: true,
 					labelText: "Username",
-				})
-				: null }
-			${window.isChromatic() ?
-				Template({
+				})}
+				${Template({
 					displayLabel: true,
 					labelText: "Username that is really long and wraps onto a second line",
 					isInvalid: true,
-				})
-				: null }
-			${window.isChromatic() ?
-				Template({
+				})}
+				${Template({
 					displayLabel: true,
 					labelText: "Username",
 					labelPosition: 'side',
 					isValid: true,
 					value: "username@reallylongemail.com"
-				})
-				: null }
+				})}
+			`)}
 		</div>
 	`;
 };
@@ -241,33 +238,52 @@ const TextAreaGroup = ({
 				multiline: true,
 				value: "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt."
 			})}
-			${window.isChromatic() ?
-				Template({
+			${when(window.isChromatic(), () => html`
+				${Template({
 					displayLabel: true,
 					labelText: "Username",
 					multiline: true,
 					value: "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.",
-				})
-				: null }
-			${window.isChromatic() ?
-				Template({
+				})}
+				${Template({
 					displayLabel: true,
-					labelText: "Username that is really long and wraps onto a second line",
+					labelText: "Username",
+					multiline: true,
+					grows: true,
+					value: "Grows, with no resize. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.",
+				})}
+				${Template({
+					displayLabel: true,
+					labelText: "Username",
+					multiline: true,
+					value: "Example of behavior where Text area gets stretched by default within a flex container with flex-direction: column. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia volupta.",
+					customStyles: {
+						'align-self': 'stretch'
+					}
+				})}
+				${Template({
+					displayLabel: true,
+					labelText: "Username",
 					isInvalid: true,
 					multiline: true,
 					value: "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.",
-				})
-				: null }
-			${window.isChromatic() ?
-				Template({
+				})}
+				${Template({
+					displayLabel: true,
+					labelText: "Username that has a really long label and wraps onto a second line. Lorem ipsum dolor sit amet.",
+					isInvalid: true,
+					multiline: true,
+					value: "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.",
+				})}
+				${Template({
 					displayLabel: true,
 					labelText: "Username",
 					labelPosition: 'side',
 					isValid: true,
 					multiline: true,
 					value: "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.",
-				})
-				: null }
+				})}
+			`)}
 		</div>
 	`;
 };


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

Updates text area to display grow and drag behaviors. 

[Design Guidance](https://spectrum.adobe.com/page/text-area/#Drag-icon):
- TextArea should display drag by default 
- When grow is enabled this drag behavior and icon should go away 

Changes: 

- Update CSS for all text areas to be draggable by default 
- update docs site to include grow description

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

On the docs page for TextArea 
- [x] All variants, expect for grows, should be draggable
- [ ] Validation icons stay aligned on top of the textarea after resize.

In storybook:

- [x] TextArea is draggable by default
- [x] drag behavior goes away with Grows control toggled to true
- [ ] Validation icons stay aligned on top of the textarea after resize. Include testing in Chromatic-only view of Storybook. 

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

### Before
![Screenshot 2024-02-09 at 2 36 32 PM](https://github.com/adobe/spectrum-css/assets/63808889/e2e9a780-c339-4be4-b8c1-5888fe6a0522)

### After 
![Screenshot 2024-02-09 at 2 39 23 PM](https://github.com/adobe/spectrum-css/assets/63808889/7fc195a2-cb2a-48a0-9e1d-471bbf95d661)


<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
