### PR TITLE
chore(calendar): correct fallback date for testing

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -16,7 +16,7 @@ import { setConsoleOptions } from "@storybook/addon-console";
 
 const panelExclude = setConsoleOptions({}).panelExclude || [];
 setConsoleOptions({
-	panelExclude: [...panelExclude, /deprecated/, /TypeError/],
+	panelExclude: [...panelExclude, /deprecated/, /TypeError/, /postcss-dropunusedvars/],
 });
 
 import "@spectrum-css/vars/dist/spectrum-large.css";

--- a/components/calendar/stories/calendar.stories.js
+++ b/components/calendar/stories/calendar.stories.js
@@ -122,10 +122,7 @@ RangeSelection.args = {
 };
 
 export const TodayHighlighted = Template.bind({});
-TodayHighlighted.args = {
-	month: months[new Date().getMonth()],
-	year: new Date().getFullYear(),
-};
+TodayHighlighted.args = {};
 
 export const Disabled = Template.bind({});
 Disabled.args = {


### PR DESCRIPTION
## Description

A flaw in the logic for determining a static "today" value for testing purposes was introduced in #2499. This fixes it!

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Regression testing

Validate:

VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] ✨ This pull request is ready to merge. ✨
