### PR TITLE
chore: add schema validation to yaml for documentation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -99,6 +99,7 @@
 	"stylelint.reportNeedlessDisables": true,
 	"stylelint.validate": ["css", "postcss"],
 	"yaml.schemas": {
-		"~/.vscode/extensions/atlassian.atlascode-3.0.4/resources/schemas/pipelines-schema.json": "bitbucket-pipelines.yml"
+		"~/.vscode/extensions/atlassian.atlascode-3.0.4/resources/schemas/pipelines-schema.json": "bitbucket-pipelines.yml",
+		"./schemas/documentation.schema.json": ["/metadata/*.yml", "/metadata/*.yaml"]
 	}
 }

--- a/components/accordion/project.json
+++ b/components/accordion/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/actionbar/project.json
+++ b/components/actionbar/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/actionbutton/project.json
+++ b/components/actionbutton/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/actiongroup/project.json
+++ b/components/actiongroup/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/alertbanner/project.json
+++ b/components/alertbanner/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/alertdialog/project.json
+++ b/components/alertdialog/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/asset/project.json
+++ b/components/asset/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/assetcard/project.json
+++ b/components/assetcard/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/assetlist/project.json
+++ b/components/assetlist/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/avatar/project.json
+++ b/components/avatar/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/badge/project.json
+++ b/components/badge/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/breadcrumb/project.json
+++ b/components/breadcrumb/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/button/project.json
+++ b/components/button/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/buttongroup/project.json
+++ b/components/buttongroup/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/calendar/project.json
+++ b/components/calendar/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/card/project.json
+++ b/components/card/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/checkbox/project.json
+++ b/components/checkbox/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/clearbutton/project.json
+++ b/components/clearbutton/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/closebutton/project.json
+++ b/components/closebutton/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/coachindicator/project.json
+++ b/components/coachindicator/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/coachmark/project.json
+++ b/components/coachmark/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/colorarea/project.json
+++ b/components/colorarea/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/colorhandle/project.json
+++ b/components/colorhandle/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/colorloupe/project.json
+++ b/components/colorloupe/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/colorslider/project.json
+++ b/components/colorslider/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/colorwheel/project.json
+++ b/components/colorwheel/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/combobox/project.json
+++ b/components/combobox/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/commons/project.json
+++ b/components/commons/project.json
@@ -13,6 +13,7 @@
 			"executor": "nx:noop"
 		},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"executor": "nx:noop"

--- a/components/contextualhelp/project.json
+++ b/components/contextualhelp/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/cyclebutton/project.json
+++ b/components/cyclebutton/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/datepicker/project.json
+++ b/components/datepicker/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/dial/project.json
+++ b/components/dial/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/dialog/metadata/dialog.yml
+++ b/components/dialog/metadata/dialog.yml
@@ -143,8 +143,7 @@ examples:
       </div>
   - id: dialog-scrolling
     name: Dialog - Scrolling
-    dnaStatus: Contribution
-    status: Unverified
+    status: Contribution
     description: A dialog without `.spectrum-Dialog--alert` can expand to a larger size to house larger contents.
     demoClassName: spectrum-CSSExample-example--overlay
     markup: |
@@ -201,7 +200,7 @@ examples:
       </div>
   - id: dialog-fullscreen
     name: Dialog - Fullscreen
-    status: Unverified
+    status: Contribution
     description: A fullscreen dialog will automatically fill almost all of the available screen space.
     demoClassName: spectrum-CSSExample-example--overlay
     markup: |
@@ -258,7 +257,7 @@ examples:
       </div>
   - id: dialog-fullscreen
     name: Dialog - Fullscreen Takeover
-    status: Unverified
+    status: Contribution
     description: A fullscreen takeover dialog will fill all of the available screen space.
     demoClassName: spectrum-CSSExample-example--overlay
     markup: |

--- a/components/dialog/project.json
+++ b/components/dialog/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/divider/project.json
+++ b/components/divider/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/dropindicator/project.json
+++ b/components/dropindicator/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/dropzone/project.json
+++ b/components/dropzone/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/fieldgroup/project.json
+++ b/components/fieldgroup/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/fieldlabel/project.json
+++ b/components/fieldlabel/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/floatingactionbutton/project.json
+++ b/components/floatingactionbutton/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/helptext/project.json
+++ b/components/helptext/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/icon/project.json
+++ b/components/icon/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/illustratedmessage/project.json
+++ b/components/illustratedmessage/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/infieldbutton/project.json
+++ b/components/infieldbutton/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/inlinealert/project.json
+++ b/components/inlinealert/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/link/project.json
+++ b/components/link/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/logicbutton/project.json
+++ b/components/logicbutton/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/menu/project.json
+++ b/components/menu/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/miller/project.json
+++ b/components/miller/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/modal/project.json
+++ b/components/modal/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/opacitycheckerboard/project.json
+++ b/components/opacitycheckerboard/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/page/metadata/page.yml
+++ b/components/page/metadata/page.yml
@@ -1,5 +1,4 @@
 name: Page
-status: n/a
 description: |
   The outer page container. A parent tag should only have the `.spectrum` class if using a standalone CSS file.
   If using multistops, a parent tag should have both the `.spectrum` class and the corresponding colorstop variant class, i.e. `.spectrum--light`.

--- a/components/page/project.json
+++ b/components/page/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/pagination/metadata/pagination-listing.yml
+++ b/components/pagination/metadata/pagination-listing.yml
@@ -1,5 +1,5 @@
 name: Pagination - page
-dnaStatus: Contribution
+status: Contribution
 examples:
   - id: pagination-listing
     name: Standard

--- a/components/pagination/project.json
+++ b/components/pagination/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/picker/project.json
+++ b/components/picker/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/pickerbutton/project.json
+++ b/components/pickerbutton/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/popover/project.json
+++ b/components/popover/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/progressbar/project.json
+++ b/components/progressbar/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/progresscircle/project.json
+++ b/components/progresscircle/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/radio/project.json
+++ b/components/radio/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/rating/project.json
+++ b/components/rating/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/search/project.json
+++ b/components/search/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/searchwithin/project.json
+++ b/components/searchwithin/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/sidenav/project.json
+++ b/components/sidenav/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/site/project.json
+++ b/components/site/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/slider/project.json
+++ b/components/slider/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/splitbutton/project.json
+++ b/components/splitbutton/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/splitview/project.json
+++ b/components/splitview/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/statuslight/project.json
+++ b/components/statuslight/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/steplist/project.json
+++ b/components/steplist/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/stepper/project.json
+++ b/components/stepper/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/swatch/project.json
+++ b/components/swatch/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/swatchgroup/project.json
+++ b/components/swatchgroup/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/switch/project.json
+++ b/components/switch/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/table/project.json
+++ b/components/table/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/tabs/project.json
+++ b/components/tabs/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/tag/project.json
+++ b/components/tag/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/taggroup/project.json
+++ b/components/taggroup/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/textfield/project.json
+++ b/components/textfield/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/thumbnail/project.json
+++ b/components/thumbnail/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/toast/project.json
+++ b/components/toast/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/tooltip/metadata/tooltip.yml
+++ b/components/tooltip/metadata/tooltip.yml
@@ -299,7 +299,7 @@ examples:
       </span>
   - id: tooltip-showOnHover
     name: Show on hover
-    status: Unverified
+    status: Contribution
     description: A tooltip that shows on hover using CSS only. Note that this approach does not support text wrapping. Also, note that these Tooltips will likely not work on touch-enabled devices without additional client-side scripting.
     markup: |
       <div class="spectrum-Examples">

--- a/components/tooltip/project.json
+++ b/components/tooltip/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/tray/project.json
+++ b/components/tray/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/treeview/project.json
+++ b/components/treeview/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/typography/metadata/typography-detail.yml
+++ b/components/typography/metadata/typography-detail.yml
@@ -1,5 +1,5 @@
 name: Typography detail
-dnaStatus: Verified
+status: Verified
 description: Detail is a typography component used for disclosing extra information or smaller items in hierarchical relationships of text.
 SpectrumSiteSlug: https://spectrum.adobe.com/page/detail/
 examples:

--- a/components/typography/metadata/typography-international.yml
+++ b/components/typography/metadata/typography-international.yml
@@ -1,5 +1,4 @@
 name: Typography (internationalized)
-fastLoad: false
 description: Internationalized typography examples. Note that, for these examples to work correctly, your Typekit needs to include the appropriate Han fonts.
 SpectrumSiteSlug: https://spectrum.adobe.com/page/typography/
 status: Verified

--- a/components/typography/metadata/typography.yml
+++ b/components/typography/metadata/typography.yml
@@ -1,5 +1,5 @@
 name: Typography
-dnaStatus: Verified
+status: Verified
 description: |
   Spectrum Typography is broken out into several separate components.
 

--- a/components/typography/project.json
+++ b/components/typography/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/underlay/project.json
+++ b/components/underlay/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/well/project.json
+++ b/components/well/project.json
@@ -7,6 +7,7 @@
 		"clean": {},
 		"compare": {},
 		"lint": {},
+		"validate": {},
 
 		"test": {
 			"defaultConfiguration": "scope"

--- a/nx.json
+++ b/nx.json
@@ -15,6 +15,7 @@
 	"namedInputs": {
 		"core": ["{projectRoot}/*.css", "{projectRoot}/themes/*.css"],
 		"scripts": ["{projectRoot}/stories/*.js"],
+		"docs": ["{projectRoot}/metadata/*.yml"],
 		"tools": [
 			"{projectRoot}/*.json",
 			"{workspaceRoot}/postcss.config.js",
@@ -95,6 +96,19 @@
 			"executor": "nx:run-commands",
 			"options": {
 				"commands": ["stylelint {projectRoot}/*.css {projectRoot}/themes/*.css"]
+			}
+		},
+		"validate": {
+			"inputs": [
+				"{workspaceRoot}/schemas/documentation.schema.json",
+				"docs",
+				{ "externalDependencies": ["pajv"] }
+			],
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					"test -e {projectRoot}/metadata && pajv validate -s ./schemas/documentation.schema.json -d \"{projectRoot}/metadata/*.yml\" || exit 0"
+				]
 			}
 		},
 		"test": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "predev": "nx run-many --projects ui-icons,tokens --target build",
     "dev": "NODE_ENV=development BROWSERSYNC_OPEN=true gulp devHeavy",
     "preinstall": "command -v nvm >/dev/null 2>&1 && nvm use || exit 0",
-    "lint": "yarn linter tag:component --verbose",
+    "lint": "yarn linter tag:component",
     "linter": "nx run-many --target lint --verbose --projects",
     "new": "nx run @spectrum-css/generator:new",
     "precommit": "lint-staged",
@@ -47,7 +47,9 @@
     "start": "NODE_ENV=development nx start storybook",
     "test": "nx test storybook",
     "test:plugins": "nx run-many --target test --projects tag:stylelint",
-    "tester": "nx run storybook:test:scope"
+    "tester": "nx run storybook:test:scope",
+    "validate": "yarn validator tag:component",
+    "validator": "nx run-many --target validate --verbose --projects"
   },
   "workspaces": [
     "components/*",
@@ -86,6 +88,7 @@
     "npm-run-all": "^4.1.5",
     "nunjucks": "^3.2.4",
     "nx": "^18.0.4",
+    "pajv": "^1.2.0",
     "prettier": "^2.8.8",
     "prettier-package-json": "^2.8.0",
     "prismjs": "^1.23.0",
@@ -118,6 +121,9 @@
     ],
     "dist/*.css": [
       "prettier --no-config --no-error-on-unmatched-pattern --ignore-unknown --loglevel silent --write"
+    ],
+    "components/*/metadata/*.{yml,yaml}": [
+      "pajv test --valid -s ./schemas/documentation.schema.json -d "
     ]
   }
 }

--- a/schemas/documentation.schema.json
+++ b/schemas/documentation.schema.json
@@ -1,0 +1,152 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"title": "JSON schema for Spectrum CSS documentation",
+	"type": "object",
+	"version": "1",
+	"description": "A validation schema for the Spectrum CSS documentation data.",
+	"properties": {
+		"id": {
+			"type": "string",
+			"description": "The unique identifier to use for this example set."
+		},
+		"name": {
+			"type": "string",
+			"description": "The human-readable title for the element."
+		},
+		"description": {
+			"type": "string",
+			"description": "A short description of the element's purpose and goals. For migration or additional context, add that information to the sections property."
+		},
+		"status": {
+			"$ref": "#/definitions/status"
+		},
+		"SpectrumSiteSlug": {
+			"type": "string",
+			"format": "uri",
+			"description": "The URL for the Spectrum design specifications for this element."
+		},
+		"sections": {
+			"description": "These are the sections of the documentation for the element that describe how to use the component and best practices.",
+			"type": "array",
+			"items": {
+				"type": "object",
+				"properties": {
+					"id": {
+						"type": "string",
+						"description": "The id for the section."
+					},
+					"name": {
+						"type": "string",
+						"description": "The title for the section."
+					},
+					"description": {
+						"type": "string",
+						"description": "The content of the section."
+					}
+				},
+				"required": ["description"]
+			}
+		},
+		"examplesHeading": {
+			"type": "string",
+			"description": "The human-readable title for the element."
+		},
+		"examples": {
+			"description": "These are the examples of the element in use.",
+			"type": "array",
+			"items": {
+				"oneOf": [
+					{
+						"type": "object",
+						"properties": {
+							"id": {
+								"type": "string",
+								"description": "The unique identifier to use for this example set."
+							},
+							"name": {
+								"type": "string",
+								"description": "The specific human-readable title for the example set."
+							},
+							"demoClassName": {
+								"type": "string",
+								"description": "The specific human-readable title for the example set."
+							},
+							"description": {
+								"type": "string",
+								"description": "The description for the example set."
+							},
+							"status": {
+								"$ref": "#/definitions/status"
+							},
+							"markup": {
+								"description": "The HTML markup for the example.",
+								"oneOf": [
+									{
+										"type": "string"
+									},
+									{
+										"type": "array",
+										"items": {
+											"oneOf": [
+												{
+													"type": "object",
+													"properties": {
+														"id": {
+															"type": "string",
+															"description": "The unique identifier to use for this example set."
+														},
+														"title": {
+															"type": "string",
+															"description": "The title for the section."
+														},
+														"description": {
+															"type": "string",
+															"description": "The description for the example set."
+														},
+														"group": {
+															"oneOf": [
+																{
+																	"type": "string"
+																},
+																{
+																	"type": "array",
+																	"description": "The content of the section.",
+																	"items": [
+																		{
+																			"type": "string"
+																		}
+																	]
+																}
+															]
+														}
+													}
+												},
+												{
+													"type": "string"
+												}
+											]
+										}
+									}
+								]
+							}
+						},
+						"required": ["id", "markup"],
+						"oneOf": [{ "required": ["name"] }, { "required": ["title"] }]
+					},
+					{
+						"type": "string"
+					}
+				]
+			}
+		}
+	},
+	"definitions": {
+		"status": {
+			"type": "string",
+			"description": "The design status of the element.",
+			"enum": ["Verified", "Experimental", "Deprecated", "Contribution", "Beta"]
+		}
+	},
+	"oneOf": [{ "required": ["name"] }, { "required": ["title"] }],
+	"additionalProperties": false
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5003,6 +5003,14 @@ address@^1.0.1:
   resolved "https://registry.yarnpkg.com/address/-/address-1.2.2.tgz#2b5248dac5485a6390532c6a517fda2e3faac89e"
   integrity sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==
 
+adler-32@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/adler-32/-/adler-32-1.2.0.tgz#6a3e6bf0a63900ba15652808cb15c6813d1a5f25"
+  integrity sha512-/vUqU/UY4MVeFsg+SsK6c+/05RZXIHZMGJA+PX5JyWI0ZRcBpupnRuPLU/NXXoFwMYCPCoxIfElM2eS+DUXCqQ==
+  dependencies:
+    exit-on-epipe "~1.0.1"
+    printj "~1.1.0"
+
 agent-base@5:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-5.1.1.tgz#e8fb3f242959db44d63be665db7a8e739537a32c"
@@ -5055,6 +5063,16 @@ ajv-keywords@^5.1.0:
   integrity sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==
   dependencies:
     fast-deep-equal "^3.1.3"
+
+ajv@^5.0.0:
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
+  integrity sha512-Ajr4IcMXq/2QmMkEmSvxqfLN5zGmJ92gHXAeOXq1OekoH2rfDNsgdDoL2f7QaRCy7G/E6TpxBVdRuNraMztGHw==
+  dependencies:
+    co "^4.6.0"
+    fast-deep-equal "^1.0.0"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.3.0"
 
 ajv@^6.12.5:
   version "6.12.6"
@@ -5193,6 +5211,28 @@ ansi-wrap@0.1.0, ansi-wrap@^0.1.0:
   resolved "https://registry.yarnpkg.com/ansi-wrap/-/ansi-wrap-0.1.0.tgz#a82250ddb0015e9a27ca82e82ea603bbfa45efaf"
   integrity sha512-ZyznvL8k/FZeQHr2T6LzcJ/+vBApDnMNZvfVFy3At0knswWd6rJ3/0Hhmpu8oqa6C92npmozs890sX9Dl6q+Qw==
 
+any-json@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/any-json/-/any-json-3.1.0.tgz#4ace1722bacec1f4c81f921bc551546efb19d9f8"
+  integrity sha512-p4sFflxj6pQzn7T1omWd63GI7bNRmoDgpqxQWJIWNEOWp2+Z8PYtUY/DTGu7QA3MnSBpf7E+cDT3ZNQmeg+WNg==
+  dependencies:
+    cson "^4.1.0"
+    dashdash "^1.14.1"
+    fast-csv "^2.4.0"
+    format-unicorn "^1.1.0"
+    hjson "^2.4.1"
+    ini "^1.3.4"
+    js-yaml "^3.7.0"
+    json5 "^0.5.1"
+    strip-json-comments "^2.0.1"
+    toml-j0.4 "^1.0.10"
+    tomlify-j0.4 "^2.1.1"
+    typescript "^2.4.2"
+    util.promisify "^1.0.0"
+    xlsjs "^0.7.5"
+    xlsx "^0.11.3"
+    xml2js "0.4.17"
+
 anymatch@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-2.0.0.tgz#bcb24b4f37934d9aa7ac17b4adaf89e7c76ef2eb"
@@ -5317,6 +5357,14 @@ argparse@^2.0.1:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
+arguments-extended@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/arguments-extended/-/arguments-extended-0.0.3.tgz#6107e4917d0eb6f0a4dd66320fc15afc72ef4946"
+  integrity sha512-MNYdPKgCiywbgHAmNsYr1tSNLtfbSdwE1akZV+33hU9A8RG0lO5HAK9oMnw7y7bjYUhc04dJpcIBMUaPPYYtXg==
+  dependencies:
+    extended "~0.0.3"
+    is-extended "~0.0.8"
+
 aria-hidden@^1.1.1:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/aria-hidden/-/aria-hidden-1.2.3.tgz#14aeb7fb692bbb72d69bebfa47279c1fd725e954"
@@ -5403,6 +5451,15 @@ array-each@^1.0.0, array-each@^1.0.1:
   resolved "https://registry.yarnpkg.com/array-each/-/array-each-1.0.1.tgz#a794af0c05ab1752846ee753a1f211a05ba0c44f"
   integrity sha512-zHjL5SZa68hkKHBFBK6DJCTtr9sfTCPCaph/L7tMSLcTFgy+zX7E+6q5UArbtOtMBCtxdICpfTCspRse+ywyXA==
 
+array-extended@~0.0.3, array-extended@~0.0.4, array-extended@~0.0.5:
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/array-extended/-/array-extended-0.0.11.tgz#d7144ae748de93ca726f121009dbff1626d164bd"
+  integrity sha512-Fe4Ti2YgM1onQgrcCD8dUhFuZgHQxzqylSl1C5IDJVVVqY5D07h8RghIXL9sZ6COZ0e+oTL5IusTv5eXABJ9Kw==
+  dependencies:
+    arguments-extended "~0.0.3"
+    extended "~0.0.3"
+    is-extended "~0.0.3"
+
 array-find-index@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
@@ -5474,6 +5531,17 @@ array-unique@^0.3.2:
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
   integrity sha512-SleRWjh9JUud2wH1hPs9rZBZ33H6T9HOiL0uwGnGx9FpE6wKGyfWugmbkEOIs6qWrZhg0LWeLziLrEwQJhs5mQ==
 
+array.prototype.reduce@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/array.prototype.reduce/-/array.prototype.reduce-1.0.6.tgz#63149931808c5fc1e1354814923d92d45f7d96d5"
+  integrity sha512-UW+Mz8LG/sPSU8jRDCjVr6J/ZKAGpHfwrZ6kWTG5qCxIEiXdVshqGnu5vEZA8S1y6X4aCSbQZ0/EEsfvEvBiSg==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.2.0"
+    es-abstract "^1.22.1"
+    es-array-method-boxes-properly "^1.0.0"
+    is-string "^1.0.7"
+
 arraybuffer.prototype.slice@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.2.tgz#98bd561953e3e74bb34938e77647179dfe6e9f12"
@@ -5516,6 +5584,11 @@ assert-never@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/assert-never/-/assert-never-1.2.1.tgz#11f0e363bf146205fb08193b5c7b90f4d1cf44fe"
   integrity sha512-TaTivMB6pYI1kXwrFlEhLeGfOqoDNdTxjCdwRfFFkEA30Eu+k48W34nlok2EYWJfFFzqaEmichdNM7th6M5HNw==
+
+assert-plus@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
+  integrity sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==
 
 assert@^2.0.0, assert@^2.1.0:
   version "2.1.0"
@@ -6380,6 +6453,21 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
+cfb@~0.11.0:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/cfb/-/cfb-0.11.1.tgz#a96db8f272a6c3fb99dbbb23ef41223f48be1ea7"
+  integrity sha512-1GEqpcO365hTRpP+GzHXNiUF5SB7qmY5aVYwrJm8ISx27HzHpaFlTQhnOCMNhqP0WPkHR0OGE9WDSqtksV4anw==
+  dependencies:
+    commander ""
+
+cfb@~1.0.2:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/cfb/-/cfb-1.0.8.tgz#77f213493d697d754fd9c0f5511eab5ad72d02cf"
+  integrity sha512-oA7VomcgZRWTo8V20UYLlXu4ZOCFEAfwwrcxE8PcVzXW12WOhsi38PVnymb6Xoj8y7ghoZQOOOVRBMdLJ4jCjg==
+  dependencies:
+    commander "^2.14.1"
+    printj "~1.1.2"
+
 chainsaw@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/chainsaw/-/chainsaw-0.1.0.tgz#5eab50b28afe58074d0d58291388828b5e5fbc98"
@@ -6793,6 +6881,11 @@ cmd-shim@^6.0.0:
   resolved "https://registry.yarnpkg.com/cmd-shim/-/cmd-shim-6.0.2.tgz#435fd9e5c95340e61715e19f90209ed6fcd9e0a4"
   integrity sha512-+FFYbB0YLaAkhkcrjkyNLYDiOsFSfRjwjY19LXk/psmMx1z00xlCv7hhQoTGXXIKi+YXHL/iiFo8NqMVQX9nOw==
 
+co@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
+  integrity sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==
+
 code-excerpt@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/code-excerpt/-/code-excerpt-4.0.0.tgz#2de7d46e98514385cb01f7b3b741320115f4c95e"
@@ -6804,6 +6897,24 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==
+
+codepage@:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/codepage/-/codepage-1.15.0.tgz#2e00519024b39424ec66eeb3ec07227e692618ab"
+  integrity sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==
+
+codepage@~1.12.0:
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/codepage/-/codepage-1.12.2.tgz#fd4424448c8bf1db5d7e01f9ecf9e8346582a195"
+  integrity sha512-FAN+oPs/ocaPLFvIt4vEOHgWA6UJ6t+fVbbVBoXDpTpC+4JYasomYZEEjR/Miph3qQrVnIShRwwmwu4P35JW1w==
+  dependencies:
+    commander "~2.14.1"
+    exit-on-epipe "~1.0.1"
+
+coffee-script@^1.10.0, coffee-script@^1.12.4:
+  version "1.12.7"
+  resolved "https://registry.yarnpkg.com/coffee-script/-/coffee-script-1.12.7.tgz#c05dae0cb79591d05b3070a8433a98c9a89ccc53"
+  integrity sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==
 
 collection-map@^1.0.0:
   version "1.0.0"
@@ -6861,6 +6972,11 @@ colorette@^2.0.10, colorette@^2.0.20:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz#9eb793e6833067f7235902fcd3b09917a000a95a"
   integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
 
+colors@0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-0.6.2.tgz#2423fe6678ac0c5dae8852e5d0e5be08c997abcc"
+  integrity sha512-OsSVtHK8Ir8r3+Fxw/b4jS1ZLPXkV6ZxDRJQzeD7qo0SqMXWrHDM71DgYzPMHY8SFJ0Ao+nNU2p1MmwdzKqPrw==
+
 colors@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
@@ -6886,6 +7002,11 @@ comma-separated-tokens@^1.0.0:
   resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz#632b80b6117867a158f1080ad498b2fbe7e3f5ea"
   integrity sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==
 
+commander@:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-12.0.0.tgz#b929db6df8546080adfd004ab215ed48cf6f2592"
+  integrity sha512-MwVNWlYjDTtOjX5PiD7o5pK0UrFU/OYgcJfjjK4RaHZETNtjJqrZa9Y9ds88+A+f+d5lv+561eZ+yCKoS3gbAA==
+
 commander@11.0.0:
   version "11.0.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-11.0.0.tgz#43e19c25dbedc8256203538e8d7e9346877a6f67"
@@ -6896,7 +7017,7 @@ commander@^11.0.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-11.1.0.tgz#62fdce76006a68e5c1ab3314dc92e800eb83d906"
   integrity sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==
 
-commander@^2.2.0, commander@^2.20.0:
+commander@^2.14.1, commander@^2.2.0, commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -6925,6 +7046,16 @@ commander@^8.3.0:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
   integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
+
+commander@~2.13.0:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
+  integrity sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==
+
+commander@~2.14.1:
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.14.1.tgz#2235123e37af8ca3c65df45b026dbd357b01b9aa"
+  integrity sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==
 
 common-ancestor-path@^1.0.1:
   version "1.0.1"
@@ -7423,7 +7554,7 @@ cosmiconfig@^9.0.0:
     js-yaml "^4.1.0"
     parse-json "^5.2.0"
 
-crc-32@^1.2.0:
+crc-32@^1.2.0, crc-32@~1.2.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/crc-32/-/crc-32-1.2.2.tgz#3cad35a934b8bf71f25ca524b6da51fb7eace2ff"
   integrity sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==
@@ -7470,6 +7601,24 @@ crypto@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/crypto/-/crypto-1.0.1.tgz#2af1b7cad8175d24c8a1b0778255794a21803037"
   integrity sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==
+
+cson-parser@^1.3.4:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/cson-parser/-/cson-parser-1.3.5.tgz#7ec675e039145533bf2a6a856073f1599d9c2d24"
+  integrity sha512-Pchz4dDkyafUL4V3xBuP9Os8Hu9VU96R+MxuTKh7NR+D866UiWrhBiSLbfuvwApEaJzpXhXTr3iPe4lFtXLzcQ==
+  dependencies:
+    coffee-script "^1.10.0"
+
+cson@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/cson/-/cson-4.1.0.tgz#b1075344fa9d9fe5cf88d80f21d9366296b865c7"
+  integrity sha512-WJE4sajPn19i2NVs7PUjODPoEcwE7NEmVDsXYxyYca7UOcWcGIZM7xPtI0VQeOWxNbCLI+uvuP0BetJJfsspxQ==
+  dependencies:
+    coffee-script "^1.12.4"
+    cson-parser "^1.3.4"
+    extract-opts "^3.3.1"
+    requirefresh "^2.1.0"
+    safefs "^4.1.0"
 
 css-functions-list@^3.2.1:
   version "3.2.1"
@@ -7580,6 +7729,22 @@ dargs@^7.0.0:
   resolved "https://registry.yarnpkg.com/dargs/-/dargs-7.0.0.tgz#04015c41de0bcb69ec84050f3d9be0caf8d6d5cc"
   integrity sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==
 
+dashdash@^1.14.1:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
+  integrity sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==
+  dependencies:
+    assert-plus "^1.0.0"
+
+date-extended@~0.0.3:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/date-extended/-/date-extended-0.0.6.tgz#23802d57dd1bf7818813fe0c32e851a86da267c9"
+  integrity sha512-v9a2QLTVn1GQGXf02TQaSvNfeXA/V1FL2Tr0OQYqjI5+L9T5jEtCpLYG01sxFk+m1OtwMxydkKa8NKcflANAoQ==
+  dependencies:
+    array-extended "~0.0.3"
+    extended "~0.0.3"
+    is-extended "~0.0.3"
+
 date-fns@^2.30.0:
   version "2.30.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.30.0.tgz#f367e644839ff57894ec6ac480de40cae4b0f4d0"
@@ -7598,6 +7763,21 @@ dateformat@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
+
+deasync-promise@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/deasync-promise/-/deasync-promise-1.0.1.tgz#2b27de478167af4ef34ba99879c52ec0cedd61c2"
+  integrity sha512-VzJ6J6beJcSXM7SMVhug3JNZzLiPGUNJWDuevXcFeXQCa+zlnP7ZrByI+8DZQZ3AoZJj9W32ceqF6JBKmsTdgg==
+  dependencies:
+    deasync "^0.1.7"
+
+deasync@^0.1.10, deasync@^0.1.7:
+  version "0.1.29"
+  resolved "https://registry.yarnpkg.com/deasync/-/deasync-0.1.29.tgz#8bbbf9d0b235c561b36edd440b6272f1de6c572c"
+  integrity sha512-EBtfUhVX23CE9GR6m+F8WPeImEE4hR/FW9RkK0PMl9V1t283s0elqsTD8EZjaKX28SY1BW2rYfCgNsAYdpamUw==
+  dependencies:
+    bindings "^1.5.0"
+    node-addon-api "^1.7.1"
 
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   version "2.6.9"
@@ -7637,6 +7817,11 @@ decamelize@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-5.0.1.tgz#db11a92e58c741ef339fb0a2868d8a06a9a7b1e9"
   integrity sha512-VfxadyCECXgQlkoEAjeghAr5gY3Hf+IKjKb+X8tGVDtveCjN+USwprd2q3QXBR9T1+x2DG0XZF5/w+7HAtSaXA==
+
+declare.js@~0.0.4:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/declare.js/-/declare.js-0.0.8.tgz#0478adff9564c004f51df73d8bc134019d28dcde"
+  integrity sha512-O659hy1gcHef7JnwtqdQlrj2c5DAEgtxm8pgFXofW7eUE1L4FjsSLlziovWcrOJAOFlEPaOJshY+0hBWCG/AnA==
 
 decode-uri-component@^0.2.0:
   version "0.2.2"
@@ -8059,6 +8244,14 @@ each-props@^1.3.2:
     is-plain-object "^2.0.1"
     object.defaults "^1.1.0"
 
+eachr@^3.2.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/eachr/-/eachr-3.3.0.tgz#11f7287be7d31d6b99947fe0d8a79de99ac2a469"
+  integrity sha512-yKWuGwOE283CTgbEuvqXXusLH4VBXnY2nZbDkeWev+cpAXY6zCIADSPLdvfkAROc0t8S4l07U1fateCdEDuuvg==
+  dependencies:
+    editions "^2.2.0"
+    typechecker "^4.9.0"
+
 eastasianwidth@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
@@ -8077,6 +8270,14 @@ eazy-logger@^4.0.1:
   integrity sha512-2GSFtnnC6U4IEKhEI7+PvdxrmjJ04mdsj3wHZTFiw0tUtG4HCWzTr13ZYTk8XOGnA1xQMaDljoBOYlk3D/MMSw==
   dependencies:
     chalk "4.1.2"
+
+editions@^2.2.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/editions/-/editions-2.3.1.tgz#3bc9962f1978e801312fbd0aebfed63b49bfe698"
+  integrity sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==
+  dependencies:
+    errlop "^2.0.0"
+    semver "^6.3.0"
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -8226,6 +8427,11 @@ err-code@^2.0.2:
   resolved "https://registry.yarnpkg.com/err-code/-/err-code-2.0.3.tgz#23c2f3b756ffdfc608d30e27c9a941024807e7f9"
   integrity sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==
 
+errlop@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/errlop/-/errlop-2.2.0.tgz#1ff383f8f917ae328bebb802d6ca69666a42d21b"
+  integrity sha512-e64Qj9+4aZzjzzFpZC7p5kmm/ccCrbLhAJplhsDXQFs87XTsXwOpH4s1Io2s90Tau/8r2j9f4l/thhDevRjzxw==
+
 error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
@@ -8277,6 +8483,11 @@ es-abstract@^1.22.1:
     typed-array-length "^1.0.4"
     unbox-primitive "^1.0.2"
     which-typed-array "^1.1.13"
+
+es-array-method-boxes-properly@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz#873f3e84418de4ee19c5be752990b2e44718d09e"
+  integrity sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==
 
 es-get-iterator@^1.1.3:
   version "1.1.3"
@@ -8551,6 +8762,11 @@ exenv@^1.2.0:
   resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.2.tgz#2ae78e85d9894158670b03d47bec1f03bd91bb9d"
   integrity sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw==
 
+exit-on-epipe@, exit-on-epipe@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz#0bdd92e87d5285d267daa8171d0eb06159689692"
+  integrity sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==
+
 expand-brackets@^2.1.4:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-2.1.4.tgz#b77735e315ce30f6b6eff0f83b04151a22449622"
@@ -8647,6 +8863,20 @@ extend@^3.0.0, extend@^3.0.2:
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
+extended@0.0.6, extended@~0.0.3:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/extended/-/extended-0.0.6.tgz#7fb8bf7b9dae397586e48570acfd642c78e50669"
+  integrity sha512-rvAV3BDGsV1SYGzUOu7aO0k82quhfl0QAyZudYhAcTeIr1rPbBnyOhOlkCLwLpDfP7HyKAWAPNSjRb9p7lE3rg==
+  dependencies:
+    extender "~0.0.5"
+
+extender@~0.0.5:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/extender/-/extender-0.0.10.tgz#589c07482be61a1460b6d81f9c24aa67e8f324cd"
+  integrity sha512-iPLUHZJaNW6RuOShQX33ZpewEUIlijFBcsXnKWyiYERKWPsFxfKgx8J0xRz29hKQWPFFPACgBW6cHM7Ke1pfaA==
+  dependencies:
+    declare.js "~0.0.4"
+
 external-editor@^3.0.3, external-editor@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.1.0.tgz#cb03f740befae03ea4d283caed2741a83f335495"
@@ -8669,6 +8899,15 @@ extglob@^2.0.4:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
+
+extract-opts@^3.3.1:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/extract-opts/-/extract-opts-3.4.0.tgz#ab07a7873896a1a7e350f27e2d52645c2ceba9ac"
+  integrity sha512-M7Y+1cJDkzOWqvGH5F/V2qgkD6+uitW3NV9rQGl+pLSVuXZ4IDDQgxxMeLPKcWUyfypBWczIILiroSuhXG7Ytg==
+  dependencies:
+    eachr "^3.2.0"
+    editions "^2.2.0"
+    typechecker "^4.9.0"
 
 extract-zip@^1.6.6:
   version "1.7.0"
@@ -8696,6 +8935,22 @@ fancy-log@^2.0.0:
   integrity sha512-9CzxZbACXMUXW13tS0tI8XsGGmxWzO2DmYrGuBJOJ8k8q2K7hwfJA5qHjuPPe8wtsco33YR9wc+Rlr5wYFvhSA==
   dependencies:
     color-support "^1.1.3"
+
+fast-csv@^2.4.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/fast-csv/-/fast-csv-2.5.0.tgz#5332dfede3f59340cb8e9f46b2e6dff1e7612005"
+  integrity sha512-M/9ezLU9/uDwvDZTt9sNFJa0iLDUsbhYJwPtnE0D9MjeuB6DY9wRCyUPZta9iI6cSz5wBWGaUPL61QH8h92cNA==
+  dependencies:
+    extended "0.0.6"
+    is-extended "0.0.10"
+    object-extended "0.0.7"
+    safer-buffer "^2.1.2"
+    string-extended "0.0.8"
+
+fast-deep-equal@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
+  integrity sha512-fueX787WZKCV0Is4/T2cyAdM4+x1S3MXXOAhavE1ys/W42SHAPacLTQhucja22QBYrfGw50M2sRiXPtTGv9Ymw==
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
@@ -8728,6 +8983,11 @@ fast-glob@^3.2.9, fast-glob@^3.3.0, fast-glob@^3.3.1, fast-glob@^3.3.2:
     glob-parent "^5.1.2"
     merge2 "^1.3.0"
     micromatch "^4.0.4"
+
+fast-json-patch@^0.5.6:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/fast-json-patch/-/fast-json-patch-0.5.7.tgz#b5a8f49d259624596ef98b872f3fda895b4d8665"
+  integrity sha512-NhO4vmGg6SNtDenXBGMmtZ9el0BCNsEr009bI+qpMaqt7q690SDXiHnyGVUESsx7wLtSA4+lrHp8f+OekAlHtw==
 
 fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
@@ -9152,6 +9412,11 @@ form-data@^4.0.0:
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
+format-unicorn@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/format-unicorn/-/format-unicorn-1.1.1.tgz#533423f9c6bdb261bf508fff54f2d7a9b27a2251"
+  integrity sha512-MEjmrLmOsxswQC+TLVgGRZTRw+QSwMTQ0aqnkWPMAw1jKcO710mET0GMwoxrm0GxN0nSSBSUVaxC4MNYyrDXHQ==
+
 format@^0.2.0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
@@ -9161,6 +9426,16 @@ forwarded@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.2.0.tgz#2269936428aad4c15c7ebe9779a84bf0b2a81811"
   integrity sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==
+
+frac@0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/frac/-/frac-0.3.1.tgz#577677b7fdcbe6faf7c461f1801d34137cda4354"
+  integrity sha512-1Lzf2jOjhIkRaa013KlxNOn2D9FemmQNeYUDpEIyPeFXmpLvbZXJOlaayMBT6JKXx+afQFgQ1QJ4kaF7Z07QFQ==
+
+frac@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/frac/-/frac-1.1.2.tgz#3d74f7f6478c88a1b5020306d747dc6313c74d0b"
+  integrity sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==
 
 fraction.js@^4.3.7:
   version "4.3.7"
@@ -9739,7 +10014,7 @@ graceful-fs@4.2.10:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
-graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
+graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.3, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -10044,6 +10319,11 @@ highlight.js@^10.4.1, highlight.js@~10.7.0:
   version "10.7.3"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
   integrity sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==
+
+hjson@^2.4.1:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/hjson/-/hjson-2.4.3.tgz#878578a45d13486ec364e11e642f57ff1a2ccbbe"
+  integrity sha512-gpLABogUGlxNdW/PwdEYRBMsfU3Jvl96qkXx2D+GZIg0xllpNkuscV53Ibb1Wk4goyY6Hfm63yMRaNUExFe0hw==
 
 hogan.js@3.0.2:
   version "3.0.2"
@@ -10698,6 +10978,13 @@ is-extendable@^1.0.1:
   dependencies:
     is-plain-object "^2.0.4"
 
+is-extended@0.0.10, is-extended@~0.0.3, is-extended@~0.0.8:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/is-extended/-/is-extended-0.0.10.tgz#244e140df75bb1c9a3106f412ff182fb534a6d62"
+  integrity sha512-qp+HR+L9QXbgFurvqiVgD+JiGyUboRgICNzCXmbiLtZBFVSNFbxRsI4q7Be9mCWTO5PoO1IxoWp5sl+j5b83FA==
+  dependencies:
+    extended "~0.0.3"
+
 is-extglob@^2.1.0, is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
@@ -11252,7 +11539,7 @@ js-yaml@4.1.0, js-yaml@^4.1.0:
   dependencies:
     argparse "^2.0.1"
 
-js-yaml@^3.10.0, js-yaml@^3.13.1, js-yaml@^3.14.1:
+js-yaml@^3.10.0, js-yaml@^3.13.1, js-yaml@^3.14.1, js-yaml@^3.7.0:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
   integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
@@ -11316,6 +11603,11 @@ json-parse-even-better-errors@^3.0.0:
   resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.0.tgz#2cb2ee33069a78870a0c7e3da560026b89669cf7"
   integrity sha512-iZbGHafX/59r39gPwVPRBGw0QQKnA7tte5pSMrhWOW7swGsVvVTjmfyAV9pNqk8YGT7tRCdxRu8uzcgZwoDooA==
 
+json-schema-traverse@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
+  integrity sha512-4JD/Ivzg7PoW8NzdrBSr3UFwC9mHgvI7Z6z3QGBsSHgKaRTUDmyZAAKJo2UbG1kUVfS9WS8bi36N49U1xw43DA==
+
 json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
@@ -11340,6 +11632,11 @@ json-stringify-safe@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==
+
+json5@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
+  integrity sha512-4xrs1aW+6N5DalkqSVA8fxh458CXvR99WU8WLKmq4v8eWAL86Xo3BVqyd3SkA9wEVjCMqyvvRRkshAdOnBp5rw==
 
 json5@^2.1.2, json5@^2.2.2, json5@^2.2.3:
   version "2.2.3"
@@ -11945,7 +12242,7 @@ lodash.upperfirst@^4.3.1:
   resolved "https://registry.yarnpkg.com/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce"
   integrity sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==
 
-lodash@>=4.17.21, lodash@^4.17.10, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4:
+lodash@>=4.17.21, lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -12726,6 +13023,11 @@ node-abort-controller@^3.0.1:
   resolved "https://registry.yarnpkg.com/node-abort-controller/-/node-abort-controller-3.1.1.tgz#a94377e964a9a37ac3976d848cb5c765833b8548"
   integrity sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==
 
+node-addon-api@^1.7.1:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.7.2.tgz#3df30b95720b53c24e59948b49532b662444f54d"
+  integrity sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==
+
 node-addon-api@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
@@ -13270,6 +13572,15 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
+object-extended@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/object-extended/-/object-extended-0.0.7.tgz#84fd23f56b15582aeb3e88b05cb55d2432d68a33"
+  integrity sha512-2LJYIacEXoZ1glGkAZuvA/4pfJM4Y1ShReAo9jWpBSuz89TiUCdiPqhGJJ6m97F3WjhCSRwrbgaxYEAm9dRYBw==
+  dependencies:
+    array-extended "~0.0.4"
+    extended "~0.0.3"
+    is-extended "~0.0.3"
+
 object-inspect@^1.13.1, object-inspect@^1.9.0:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.1.tgz#b96c6109324ccfef6b12216a956ca4dc2ff94bc2"
@@ -13314,6 +13625,17 @@ object.defaults@^1.0.0, object.defaults@^1.1.0:
     array-slice "^1.0.0"
     for-own "^1.0.0"
     isobject "^3.0.0"
+
+object.getownpropertydescriptors@^2.1.6:
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.7.tgz#7a466a356cd7da4ba8b9e94ff6d35c3eeab5d56a"
+  integrity sha512-PrJz0C2xJ58FNn11XV2lr4Jt5Gzl94qpy9Lu0JlfEj14z88sqbSBJCBEzdlNUCzY2gburhbrwOZ5BHCmuNUy0g==
+  dependencies:
+    array.prototype.reduce "^1.0.6"
+    call-bind "^1.0.2"
+    define-properties "^1.2.0"
+    es-abstract "^1.22.1"
+    safe-array-concat "^1.0.0"
 
 object.map@^1.0.0, object.map@^1.0.1:
   version "1.0.1"
@@ -13644,6 +13966,20 @@ pacote@^15.0.0, pacote@^15.0.8:
     sigstore "^1.3.0"
     ssri "^10.0.0"
     tar "^6.1.11"
+
+pajv@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/pajv/-/pajv-1.2.0.tgz#bbf8388c6c57af33650a3b85a0a7401661ca5972"
+  integrity sha512-bNJ4USHijOH4ZX64HlzIdooa0KS+o+nOqVQZtHXzzH4OB+hYNXTyPQ07Rq8gWaTJvt1Hu89aeWlmKARgcdo2IQ==
+  dependencies:
+    ajv "^5.0.0"
+    any-json "^3.0.0"
+    deasync "^0.1.10"
+    deasync-promise "^1.0.1"
+    fast-json-patch "^0.5.6"
+    glob "^7.0.3"
+    minimist "^1.2.0"
+    util.promisify "^1.0.0"
 
 pako@~0.2.0:
   version "0.2.9"
@@ -14472,6 +14808,11 @@ pretty-ms@^9.0.0:
   integrity sha512-E9e9HJ9R9NasGOgPaPE8VMeiPKAyWR5jcFpNnwIejslIhWqdqOrb2wShBsncMPUb+BcCd2OPYfh7p2W6oemTng==
   dependencies:
     parse-ms "^4.0.0"
+
+printj@~1.1.0, printj@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/printj/-/printj-1.1.2.tgz#d90deb2975a8b9f600fb3a1c94e3f4c53c78a222"
+  integrity sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==
 
 prismjs@1.25.0:
   version "1.25.0"
@@ -15486,6 +15827,13 @@ require-main-filename@^1.0.1:
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
   integrity sha512-IqSUtOVP4ksd1C/ej5zeEh/BIP2ajqpn8c5x+q99gvcIG/Qf0cud5raVnE/Dwd0ua9TXYDoDc0RE5hBSdz22Ug==
 
+requirefresh@^2.1.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/requirefresh/-/requirefresh-2.3.0.tgz#fb09387b57f5ed335ff4a4beea3d8c0bf2367306"
+  integrity sha512-oskKAg0pSlPnJAkFMrcqrHeCGzYunl4Hkl+N/NW3nnFWDHRg97yb475HtF5ax8LP9i8QvVkenVIhjNb+h+P7nA==
+  dependencies:
+    editions "^2.2.0"
+
 requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
@@ -15659,6 +16007,16 @@ rxjs@^7.2.0, rxjs@^7.5.5, rxjs@^7.5.6, rxjs@^7.8.1:
   dependencies:
     tslib "^2.1.0"
 
+safe-array-concat@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/safe-array-concat/-/safe-array-concat-1.1.0.tgz#8d0cae9cb806d6d1c06e08ab13d847293ebe0692"
+  integrity sha512-ZdQ0Jeb9Ofti4hbt5lX3T2JcAamT9hfzYU1MNB+z/jaEbB6wfFfPIR/zEORmZqobkCCJhSjodobH6WHNmJ97dg==
+  dependencies:
+    call-bind "^1.0.5"
+    get-intrinsic "^1.2.2"
+    has-symbols "^1.0.3"
+    isarray "^2.0.5"
+
 safe-array-concat@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/safe-array-concat/-/safe-array-concat-1.0.1.tgz#91686a63ce3adbea14d61b14c99572a8ff84754c"
@@ -15695,7 +16053,15 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
-"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0":
+safefs@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/safefs/-/safefs-4.2.0.tgz#6d60d3aecc47c3d02b0ecf39ee0a3798cb363218"
+  integrity sha512-1amPBO92jw/hWS+gH/u7z7EL7YxaJ8WecBQl49tMQ6Y6EQfndxNNKwlPqDOcwpUetdmK6nKLoVdjybVScRwq5A==
+  dependencies:
+    editions "^2.2.0"
+    graceful-fs "^4.2.3"
+
+"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0", safer-buffer@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -16251,6 +16617,22 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
 
+ssf@~0.10.1:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/ssf/-/ssf-0.10.3.tgz#8eae1fc29c90a552e7921208f81892d6f77acb2b"
+  integrity sha512-pRuUdW0WwyB2doSqqjWyzwCD6PkfxpHAHdZp39K3dp/Hq7f+xfMwNAWIi16DyrRg4gg9c/RvLYkJTSawTPTm1w==
+  dependencies:
+    frac "~1.1.2"
+
+ssf@~0.8.1:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/ssf/-/ssf-0.8.2.tgz#b9d4dc6a1c1bcf76f8abfa96d7d7656fb2abecd6"
+  integrity sha512-+ZkFDAG+ImJ48DcZvabx6YTrZ67DKkM0kbyOOtH73mbUEvNhQWWgRZrHC8+k7GuGKWQnACYLi7bj0eCt1jmosQ==
+  dependencies:
+    colors "0.6.2"
+    frac "0.3.1"
+    voc ""
+
 ssri@9.0.1, ssri@^9.0.0:
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/ssri/-/ssri-9.0.1.tgz#544d4c357a8d7b71a19700074b6883fcb4eae057"
@@ -16360,6 +16742,16 @@ string-argv@0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
+
+string-extended@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/string-extended/-/string-extended-0.0.8.tgz#741957dff487b0272a79eec5a44f239ee6f17ccd"
+  integrity sha512-CK46p3AxBvBhJbBi6WrF9bCcaWH20E4NwlLSzpooG2nXWvcP2gy2YR8VN6fSwZyrbcvL4S4zoNKbR0QG52X4rw==
+  dependencies:
+    array-extended "~0.0.5"
+    date-extended "~0.0.3"
+    extended "~0.0.3"
+    is-extended "~0.0.3"
 
 string-similarity@^4.0.4:
   version "4.0.4"
@@ -16518,6 +16910,11 @@ strip-indent@^4.0.0:
   integrity sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==
   dependencies:
     min-indent "^1.0.1"
+
+strip-json-comments@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
+  integrity sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==
 
 strip-json-comments@^3.0.1:
   version "3.1.1"
@@ -17151,6 +17548,16 @@ token-stream@1.0.0:
   resolved "https://registry.yarnpkg.com/token-stream/-/token-stream-1.0.0.tgz#cc200eab2613f4166d27ff9afc7ca56d49df6eb4"
   integrity sha512-VSsyNPPW74RpHwR8Fc21uubwHY7wMDeJLys2IX5zJNih+OnAnaifKHo+1LHT7DAdloQ7apeaaWg8l7qnf/TnEg==
 
+toml-j0.4@^1.0.10:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/toml-j0.4/-/toml-j0.4-1.1.1.tgz#eb0c70348609a0263bb1d6e4a3dd191dcca60866"
+  integrity sha512-lYK5otg0+cto8YmsWcPEfeiTiC/VU6P6HA6ooaYI9K/KYT24Jg0BrYtRZK1K3cwakSMyh6nttfJL9RmQH0gyCg==
+
+tomlify-j0.4@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/tomlify-j0.4/-/tomlify-j0.4-2.2.1.tgz#60c4e7dd2066b2e917dd9a0de5fd676c0a6d7c7b"
+  integrity sha512-0kCocYX8ujnbK6jQ9e+g9GLiCIfVkFaCB3DCTQDP7J79gPVZVmZgQZ/KUNe1a6hUfrmHHaErVGUjedfpaX5EZw==
+
 tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
@@ -17335,6 +17742,13 @@ type@^2.7.2:
   resolved "https://registry.yarnpkg.com/type/-/type-2.7.2.tgz#2376a15a3a28b1efa0f5350dcf72d24df6ef98d0"
   integrity sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==
 
+typechecker@^4.9.0:
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/typechecker/-/typechecker-4.11.0.tgz#8219cd90d2f7b585a3f5af9c146c8a23891f1eac"
+  integrity sha512-lz39Mc/d1UBcF/uQFL5P8L+oWdIn/stvkUgHf0tPRW4aEwGGErewNXo2Nb6We2WslWifn00rhcHbbRWRcTGhuw==
+  dependencies:
+    editions "^2.2.0"
+
 typed-array-buffer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/typed-array-buffer/-/typed-array-buffer-1.0.0.tgz#18de3e7ed7974b0a729d3feecb94338d1472cd60"
@@ -17383,6 +17797,11 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
+
+typescript@^2.4.2:
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
+  integrity sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==
 
 "typescript@^3 || ^4":
   version "4.9.5"
@@ -17723,6 +18142,19 @@ util-extend@^1.0.1:
   resolved "https://registry.yarnpkg.com/util-extend/-/util-extend-1.0.3.tgz#a7c216d267545169637b3b6edc6ca9119e2ff93f"
   integrity sha512-mLs5zAK+ctllYBj+iAQvlDCwoxU/WDOUaJkcFudeiAX6OajC6BKXJUa9a+tbtkC11dz2Ufb7h0lyvIOVn4LADA==
 
+util.promisify@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/util.promisify/-/util.promisify-1.1.2.tgz#02b3dbadbb80071eee4c43aed58747afdfc516db"
+  integrity sha512-PBdZ03m1kBnQ5cjjO0ZvJMJS+QsbyIcFwi4hY4U76OQsCO9JrOYjbCFgIF76ccFg9xnJo7ZHPkqyj1GqmdS7MA==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.2.0"
+    for-each "^0.3.3"
+    has-proto "^1.0.1"
+    has-symbols "^1.0.3"
+    object.getownpropertydescriptors "^2.1.6"
+    safe-array-concat "^1.0.0"
+
 util@^0.12.4, util@^0.12.5:
   version "0.12.5"
   resolved "https://registry.yarnpkg.com/util/-/util-0.12.5.tgz#5f17a6059b73db61a875668781a1c2b136bd6fbc"
@@ -17883,6 +18315,11 @@ vinyl@^2.0.0:
     cloneable-readable "^1.0.0"
     remove-trailing-separator "^1.0.1"
     replace-ext "^1.0.0"
+
+voc@:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/voc/-/voc-1.2.0.tgz#c459024531d71067c09e2c0c2bda6c2b13af32d8"
+  integrity sha512-BOuDjFFYvJdZO6e/N65AlaDItXo2TgyLjeyRYcqgAPkXpp5yTJcvkL2n+syO1r9Qc5g96tfBD2tuiMhYDmaGcA==
 
 void-elements@^2.0.1:
   version "2.0.1"
@@ -18220,6 +18657,38 @@ ws@~8.11.0:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.11.0.tgz#6a0d36b8edfd9f96d8b25683db2f8d7de6e8e143"
   integrity sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==
 
+xlsjs@^0.7.5:
+  version "0.7.6"
+  resolved "https://registry.yarnpkg.com/xlsjs/-/xlsjs-0.7.6.tgz#d88754569aabcf8eea70cc23961b462634a49565"
+  integrity sha512-IQtL2z+BVYaIVzEhknZ1YBr8ItUbqiS7kaQZ3O35/k1q+kSgjVxmzwno6r3EbBgEWhrVCad2mKbnFeMmEE5zdw==
+  dependencies:
+    cfb "~0.11.0"
+    codepage ""
+    commander ""
+    exit-on-epipe ""
+    ssf "~0.8.1"
+
+xlsx@^0.11.3:
+  version "0.11.19"
+  resolved "https://registry.yarnpkg.com/xlsx/-/xlsx-0.11.19.tgz#2f019d9df756f6345aac5bc1af2442cf22a025e3"
+  integrity sha512-UTfD64o5Ka/E6QHL12fzcq5wnt9MCtuwgoUdYSTDxjjDkhNmZwSfPlJH/+Yh8vE6nU/0ax3MXNrc9AP4haAmIg==
+  dependencies:
+    adler-32 "~1.2.0"
+    cfb "~1.0.2"
+    codepage "~1.12.0"
+    commander "~2.13.0"
+    crc-32 "~1.2.0"
+    exit-on-epipe "~1.0.1"
+    ssf "~0.10.1"
+
+xml2js@0.4.17:
+  version "0.4.17"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.17.tgz#17be93eaae3f3b779359c795b419705a8817e868"
+  integrity sha512-1O7wk/NTQN0UEOItIYTxK4qP4sMUVU60MbF4Nj0a8jd6eebMXOicVI/KFOEsYKKH4uBpx6XG9ZGZctXK5rtO5Q==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "^4.1.0"
+
 xml2js@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.5.0.tgz#d9440631fbb2ed800203fad106f2724f62c493b7"
@@ -18227,6 +18696,13 @@ xml2js@^0.5.0:
   dependencies:
     sax ">=0.6.0"
     xmlbuilder "~11.0.0"
+
+xmlbuilder@^4.1.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-4.2.1.tgz#aa58a3041a066f90eaa16c2f5389ff19f3f461a5"
+  integrity sha512-oEePiEefhQhAeUnwRnIBLBWmk/fsWWbQ53EEWsRuzECbQ3m5o/Esmq6H47CYYwSLW+Ynt0rS9hd0pd2ogMAWjg==
+  dependencies:
+    lodash "^4.0.0"
 
 xmlbuilder@~11.0.0:
   version "11.0.1"


### PR DESCRIPTION
## Description

This adds a schema validation task to each component which will check all metadata files for valid formatting and that it aligns with the defined rules in `./schemas/documentation.schema.json`.

This validation can be run ad-hoc and runs as part of the lint-staged task to prevent new invalid schema from being committed (can still be overwritten with --no-verify).

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

Add an invalid entry to the `components/accordion/metadata/*.yml` (i.e., `foo: bar`):
  - [x] `yarn validator accordion`: should report the error to the console
  - [x] `yarn validate`: should report success for other components and report the failure for accordion's schema
  - [x] Try to commit the error to the branch. Expect the commit to fail with the following:

<img width="955" alt="Screenshot 2024-02-13 at 1 45 37 PM" src="https://github.com/adobe/spectrum-css/assets/1840295/d40f7ef8-5115-4b11-b77d-fe97d26a619a">

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
