### PR TITLE
fix(textfield): remove extra padding on nested label and help

### DIFF
--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -616,12 +616,6 @@ governing permissions and limitations under the License.
 		);
 		grid-row: 1;
 		grid-column: 1 / span 1;
-		padding-inline-start: calc(
-			var(
-					--mod-textfield-corner-radius,
-					var(--spectrum-textfield-corner-radius)
-				) / 2
-		);
 	}
 
 	.spectrum-Textfield--quiet & {
@@ -645,12 +639,6 @@ governing permissions and limitations under the License.
 		);
 		grid-row: 3;
 		grid-column: 1 / span 2;
-		padding-inline-start: calc(
-			var(
-					--mod-textfield-corner-radius,
-					var(--spectrum-textfield-corner-radius)
-				) / 2
-		);
 	}
 }
 

--- a/components/textfield/stories/template.js
+++ b/components/textfield/stories/template.js
@@ -33,6 +33,7 @@ export const Template = ({
 	labelPosition = "top",
 	labelText,
 	iconName,
+	iconSet,
 	pattern,
 	placeholder,
 	name,
@@ -54,8 +55,13 @@ export const Template = ({
 		console.warn(e);
 	}
 
-	if (isInvalid) iconName = "Alert";
-	else if (isValid) iconName = "Checkmark";
+	if (isInvalid) {
+		iconName = "Alert";
+		iconSet = "workflow";
+	} else if (isValid) {
+		iconName = "Checkmark";
+		iconSet = "ui";
+	}
 
 	return html`
 		<div
@@ -101,6 +107,7 @@ export const Template = ({
 				...globals,
 				size,
 				iconName,
+				setName: iconSet,
 				customClasses: [
 					!!(isInvalid || isValid)
 						? `${rootClass}-validationIcon`


### PR DESCRIPTION
## Description

Previously some styles were adding a small amount of extra inline-start padding to the label and help text, when they are nested within Text field (as shown on the docs page for Text field). This was particularly noticeable on the quiet variation—see screenshot.
    
It looks like this previously was adding padding that matched the amount of corner rounding, so the label text would start where the corner started its curve.
    
On the design, there is no additional left padding. This update removes that padding to adhere to the design.

This also includes a small Storybook fix for the alignment of the valid checkmark. Due to recent Icon fixes, it was necessary to specify the icon set as "ui" in some of the args.

CSS-674

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps @jenndiaz 

- [x] There is no additional inline-start padding on the label and help text within the docs for Textfield **non-quiet variants**
- [x] There is no additional inline-start padding on the label and help text within the docs for Textfield **quiet variants**

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

Note: Variations of Text field, including with a Field label, are not currently well represented in Chromatic/VRT, but there are already improvements to this coming in PR #2380 .

## Screenshots

Design:
![design-reference](https://github.com/adobe/spectrum-css/assets/965114/a772ab23-e398-4cc1-a299-cededce71966)

Previous behavior:
![previous-behavior](https://github.com/adobe/spectrum-css/assets/965114/7dee1be0-e887-4279-a9e9-12d3a2c1e898)

![Screenshot 2024-02-13 at 3 08 36 PM](https://github.com/adobe/spectrum-css/assets/965114/a26d530d-0906-4194-87e2-be80b7fc2cca)

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] ✨ This pull request is ready to merge. ✨
