### PR TITLE
feat(downstate): utility class/placeholder mixed implementation

### DIFF
--- a/components/checkbox/index.css
+++ b/components/checkbox/index.css
@@ -16,6 +16,8 @@ governing permissions and limitations under the License.
  * .spectrum-Checkbox-box::after is the focus indicator
  */
 
+@import "@spectrum-css/downstate/index.css";
+
 /* Component tokens by t-shirt size */
 .spectrum-Checkbox {
   /* Color */
@@ -372,6 +374,11 @@ governing permissions and limitations under the License.
     }
   }
 }
+
+.spectrum-Checkbox:active:not(.is-readOnly, :disabled, .is-disabled) .spectrum-Checkbox-box {
+  @extend %spectrum-DownState--min-perspective;
+}
+
 /* stylelint-enable max-nesting-depth */
 
 .spectrum-Checkbox-label {
@@ -571,7 +578,7 @@ governing permissions and limitations under the License.
       outline-style: auto;
       outline-offset: var(--highcontrast-checkbox-focus-indicator-gap, var(--mod-checkbox-focus-indicator-gap, var(--spectrum-checkbox-focus-indicator-gap)));
       /* stylelint-disable-next-line declaration-block-no-redundant-longhand-properties */
-      outline-width: var(--mod-focus-indicator-thickness, var(--spectrum-focus-indicator-thickness)); 
+      outline-width: var(--mod-focus-indicator-thickness, var(--spectrum-focus-indicator-thickness));
 
       &::after {
         box-shadow:

--- a/components/checkbox/package.json
+++ b/components/checkbox/package.json
@@ -18,6 +18,9 @@
     "@spectrum-css/icon": ">=4",
     "@spectrum-css/tokens": ">=13"
   },
+  "devDependencies": {
+    "@spectrum-css/downstate": "^1.0.0"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/components/checkbox/stories/template.js
+++ b/components/checkbox/stories/template.js
@@ -1,7 +1,7 @@
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
-import { styleMap } from "lit/directives/style-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
+import { styleMap } from "lit/directives/style-map.js";
 import { when } from "lit/directives/when.js";
 
 import { useArgs } from "@storybook/client-api";
@@ -26,6 +26,7 @@ export const Template = ({
 	ariaLabelledby,
 	customStyles = {},
 	customClasses = [],
+	customDownstateClasses = [],
 	...globals
 }) => {
 	const [_, updateArgs] = useArgs();
@@ -72,7 +73,10 @@ export const Template = ({
 		>
 			<input
 				type="checkbox"
-				class="${rootClass}-input"
+				class=${classMap({
+					[`${rootClass}-input`]: true,
+					...customDownstateClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
+				})}
 				aria-labelledby=${ifDefined(ariaLabelledby)}
 				?checked=${isChecked}
 				?disabled=${isDisabled || isReadOnly}
@@ -84,7 +88,12 @@ export const Template = ({
 				}}
 				id=${ifDefined(id ? `${id}-input` : undefined)}
 			/>
-			<span class="${rootClass}-box">
+			<span
+				class=${classMap({
+					[`${rootClass}-box`]: true,
+					// ...customDownstateClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
+				})}
+			>
 				${Icon({
 					...globals,
 					size,

--- a/components/downstate/README.md
+++ b/components/downstate/README.md
@@ -1,0 +1,13 @@
+# @spectrum-css/downstate
+
+> > The Spectrum CSS, down state is a utility class used to apply active states to Spectrum 2 components. Consult design documentation for further usage and infomation.
+
+`.spectrum-DownState`
+
+To use this classes:
+- add @spectrum-css/downstate as a dependency
+- Use the class on the component's parent element (for example, it would be on the same element as the `.spectrum-Checkbox` class, or the `.spectrum-Button` class)
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/downstate).

--- a/components/downstate/gulpfile.js
+++ b/components/downstate/gulpfile.js
@@ -1,0 +1,1 @@
+module.exports = require("@spectrum-css/component-builder-simple");

--- a/components/downstate/index.css
+++ b/components/downstate/index.css
@@ -1,0 +1,26 @@
+/*!
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+/* stylelint-disable custom-property-pattern */
+
+.spectrum-DownState {
+	/* stylelint-disable-next-line spectrum-tools/no-unknown-custom-properties */
+	--spectrum-downstate-perspective: max(var(--spectrum-downstate-height), var(--spectrum-downstate-width) * var(--spectrum-component-size-width-ratio-down));
+
+	&--min-perspective {
+		--spectrum-downstate-perspective: var(--spectrum-component-size-minimum-perspective-down);
+	}
+
+	&:active {
+		transform: perspective(var(--spectrum-downstate-perspective)) translateZ(var(--spectrum-component-size-difference-down)) !important;
+	}
+}

--- a/components/downstate/index.css
+++ b/components/downstate/index.css
@@ -21,6 +21,17 @@ governing permissions and limitations under the License.
 	}
 
 	&:active {
-		transform: perspective(var(--spectrum-downstate-perspective)) translateZ(var(--spectrum-component-size-difference-down)) !important;
+		transform: perspective(var(--spectrum-downstate-perspective)) translateZ(var(--spectrum-component-size-difference-down));
 	}
+}
+
+%spectrum-DownState {
+	/* stylelint-disable-next-line spectrum-tools/no-unknown-custom-properties */
+	--spectrum-downstate-perspective: max(var(--spectrum-downstate-height), var(--spectrum-downstate-width) * var(--spectrum-component-size-width-ratio-down));
+	transform: perspective(var(--spectrum-downstate-perspective)) translateZ(var(--spectrum-component-size-difference-down));
+}
+
+%spectrum-DownState--min-perspective {
+	--spectrum-downstate-perspective: var(--spectrum-component-size-minimum-perspective-down);
+	transform: perspective(var(--spectrum-downstate-perspective)) translateZ(var(--spectrum-component-size-difference-down));
 }

--- a/components/downstate/metadata/downstate.yml
+++ b/components/downstate/metadata/downstate.yml
@@ -1,35 +1,23 @@
 name: Down state
 SpectrumSiteSlug: https://spectrum.adobe.com/page/down-state/
 description: |
-  Down state is a Spectrum 2 feature that creates the illusion of components being pressed-in when active. To implement down state:
+  Down state is a Spectrum 2 (S2) feature that creates the illusion of components being pressed-in when active. There are two different ways to implement down state depending on the component.
+
+  If the component is interactable at it's root level:
     - Add the `.spectrum-DownState` class to the root of the element that receives interactions.
+      - Components with a width of 24px or less require the addition of the `.spectrum-DownState--min-perpsective` class next to the `.spectrum-DownState` class.
     - Develop an implementation to determine the width and height of the component. Assign this to the `--spectrum-downstate-width` and `--spectrum-downstate-height` custom properties in a `style` attribute on the HTML element.
+
+  If the component has an interactable element nested within it, this will require CSS changes:
+    - Use the `%spectrum-DownState` or `%spectrum-DownState--min-perspective` placeholder on the interactable element when the root of the component is in an `:active` state.
+      - Components with a width of 24px or less require the `%spectrum-DownState--min-perspective` placeholder instead.
+    - Note that this functionality is included in S2 components that require down state in this project. This can be seen in the [checkbox component](/checkbox.html).
 examples:
   - id: downstate
-    name: Down state - default
+    name: Down state - utility class
     markup: |
       <div class="spectrum-Examples">
         <button class="spectrum-DownState spectrum-Button spectrum-Button--fill spectrum-Button--accent spectrum-Button--sizeM" style="--spectrum-downstate-width: 72px; --spectrum-downstate-height: 32px;">
           <span class="spectrum-Button-label">Edit</span>
         </button>
-      </div>
-  - id: downstate-min
-    name: Down state - minimum perspective
-    description: |
-      Components with a width of 24px or less require the addition of the `.spectrum-DownState--min-perpsective` class next to the `.spectrum-DownState` class.
-      * Note that in this example, the element that will be interacted with is nested in a component. In this case, the "root" is the element that is interacted with, not the parent component.
-    markup: |
-      <div class="spectrum-Examples">
-        <label class="spectrum-Checkbox spectrum-Checkbox--sizeM">
-          <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-0">
-          <span class="spectrum-Checkbox-box spectrum-DownState spectrum-DownState--min-perspective" style="--spectrum-downstate-width: 14px; --spectrum-downstate-height: 14px;">
-            <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
-              <use xlink:href="#spectrum-css-icon-Checkmark100" />
-            </svg>
-            <svg class="spectrum-Icon spectrum-UIIcon-Dash100 spectrum-Checkbox-partialCheckmark" focusable="false" aria-hidden="true">
-              <use xlink:href="#spectrum-css-icon-Dash100" />
-            </svg>
-          </span>
-          <span class="spectrum-Checkbox-label">Checkbox</span>
-        </label>
       </div>

--- a/components/downstate/metadata/downstate.yml
+++ b/components/downstate/metadata/downstate.yml
@@ -1,0 +1,35 @@
+name: Down state
+SpectrumSiteSlug: https://spectrum.adobe.com/page/down-state/
+description: |
+  Down state is a Spectrum 2 feature that creates the illusion of components being pressed-in when active. To implement down state:
+    - Add the `.spectrum-DownState` class to the root of the element that receives interactions.
+    - Develop an implementation to determine the width and height of the component. Assign this to the `--spectrum-downstate-width` and `--spectrum-downstate-height` custom properties in a `style` attribute on the HTML element.
+examples:
+  - id: downstate
+    name: Down state - default
+    markup: |
+      <div class="spectrum-Examples">
+        <button class="spectrum-DownState spectrum-Button spectrum-Button--fill spectrum-Button--accent spectrum-Button--sizeM" style="--spectrum-downstate-width: 72px; --spectrum-downstate-height: 32px;">
+          <span class="spectrum-Button-label">Edit</span>
+        </button>
+      </div>
+  - id: downstate-min
+    name: Down state - minimum perspective
+    description: |
+      Components with a width of 24px or less require the addition of the `.spectrum-DownState--min-perpsective` class next to the `.spectrum-DownState` class.
+      * Note that in this example, the element that will be interacted with is nested in a component. In this case, the "root" is the element that is interacted with, not the parent component.
+    markup: |
+      <div class="spectrum-Examples">
+        <label class="spectrum-Checkbox spectrum-Checkbox--sizeM">
+          <input type="checkbox" class="spectrum-Checkbox-input" id="checkbox-0">
+          <span class="spectrum-Checkbox-box spectrum-DownState spectrum-DownState--min-perspective" style="--spectrum-downstate-width: 14px; --spectrum-downstate-height: 14px;">
+            <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Checkmark100" />
+            </svg>
+            <svg class="spectrum-Icon spectrum-UIIcon-Dash100 spectrum-Checkbox-partialCheckmark" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-css-icon-Dash100" />
+            </svg>
+          </span>
+          <span class="spectrum-Checkbox-label">Checkbox</span>
+        </label>
+      </div>

--- a/components/downstate/package.json
+++ b/components/downstate/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@spectrum-css/downstate",
+  "version": "1.0.0-alpha.0",
+  "description": "The Spectrum CSS downstate utility class",
+  "license": "Apache-2.0",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/downstate"
+  },
+  "bugs": {
+    "url": "https://github.com/adobe/spectrum-css/issues"
+  },
+  "main": "dist/index-vars.css",
+  "peerDependencies": {
+    "@spectrum-css/tokens": ">=13"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/components/downstate/project.json
+++ b/components/downstate/project.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "../../node_modules/nx/schemas/project-schema.json",
+	"name": "downstate",
+	"tags": ["component"],
+	"targets": {
+		"build": {},
+		"clean": {},
+		"compare": {},
+		"lint": {},
+
+		"test": {
+			"defaultConfiguration": "scope"
+		}
+	}
+}

--- a/components/downstate/stories/downstate.stories.js
+++ b/components/downstate/stories/downstate.stories.js
@@ -1,0 +1,22 @@
+import { Template } from './template';
+
+export default {
+  title: "UtilityClasses/Down state",
+  description: "Down state is utility class used to add an active state to S2 components.",
+  component: "DownState",
+  argTypes: {},
+  args: {
+    rootClass: "spectrum-DownState",
+  },
+  parameters: {
+    actions: {
+      handles: []
+    },
+    status: {
+      type: process.env.MIGRATED_PACKAGES.includes('downstate') ? 'migrated' : undefined
+    }
+  },
+};
+
+export const Default = Template.bind({});
+Default.args = {};

--- a/components/downstate/stories/template.js
+++ b/components/downstate/stories/template.js
@@ -1,0 +1,53 @@
+import { html } from "lit";
+
+import { Template as Button } from "@spectrum-css/button/stories/template.js";
+import { Template as Checkbox } from "@spectrum-css/checkbox/stories/template.js";
+
+import "../index.css";
+
+export const Template = ({
+  rootClass = "spectrum-DownState",
+  ...globals
+}) => {
+
+  document.addEventListener("DOMContentLoaded", () => {
+    for (let checkbox of document.querySelectorAll(".spectrum-Checkbox-box")) {
+      // Ideally these values would be found dynamically but this can get wonky with logical properties
+      const width = "14px";
+      const height = "14px";
+
+      checkbox.style.setProperty("--spectrum-downstate-width", width);
+      checkbox.style.setProperty("--spectrum-downstate-height", height);
+    };
+
+    for (let button of document.querySelectorAll(".spectrum-Button")) {
+      // Ideally these values would be found dynamically but this can get wonky with logical properties
+      const width = "72px";
+      const height = "32px";
+
+      button.style.setProperty("--spectrum-downstate-width", width);
+      button.style.setProperty("--spectrum-downstate-height", height);
+    };
+  });
+
+  console.log(globals);
+
+  return html`
+    ${Checkbox({
+      ...globals,
+      isEmphasized: true,
+      isChecked: true,
+      label: "Checkbox",
+      customDownstateClasses: [`${rootClass}`, `${rootClass}--min-perspective`],
+    })}
+    <div style="padding: 1rem 0;">
+      ${Button({
+        ...globals,
+        treatment: "accent",
+        label: "Edit",
+        customClasses: [`${rootClass}`]
+      })}
+    </div>
+
+  `;
+}

--- a/components/downstate/themes/express.css
+++ b/components/downstate/themes/express.css
@@ -1,0 +1,13 @@
+/*!
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+@container (--system: express) {}

--- a/components/downstate/themes/spectrum.css
+++ b/components/downstate/themes/spectrum.css
@@ -1,0 +1,13 @@
+/*!
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+@container (--system: spectrum) {}


### PR DESCRIPTION
## Description

I ran into some challenges with a purely class based implementation of down state. For components like Button where the whole component is interactable, class based works fine because you can apply the classes to the root/parent of the component. But with a more complex component like Checkbox, you have to apply the styles to the box itself, but the `active` state that we're targeting happens at the root/parent level.

So I experimented with this mix of utility class and placeholder approaches. Maybe we should drop the utility class and use the placeholder approach since we want these states to ship with our S2 components? Maybe users will need the utility classes? It feels a bit ick to keep both because it can lead to confusion for users. Looking for thoughts and opinions for now.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
- Take a look at the down state docs site, which shows the class based approach on button and should also link you to the checkbox page to see the placeholder approach working there
- Take a look at the down state page in Storybook. This contains both the button using the class approach and the checkbox using the placeholder approach

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [ ] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
