### PR TITLE
docs: allow loading assets from node_modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@commitlint/config-conventional": "^18.6.0",
     "@nx/devkit": "^18.0.4",
     "@spectrum-css/expressvars": "^3.0.9",
+    "@spectrum-css/quickaction": "^3.1.1",
     "@spectrum-css/vars": "^9.0.8",
     "colors": "^1.4.0",
     "conventional-changelog-spectrum": "^1.0.2",

--- a/tools/bundle-builder/dev/index.js
+++ b/tools/bundle-builder/dev/index.js
@@ -157,8 +157,8 @@ function watchCommons() {
 	gulp.watch(
 		[`${dirs.components}/commons/*.css`],
 		gulp.series(
-			bundleBuilder.buildDepenenciesOfCommons,
-			bundleBuilder.copyPackages,
+			bundleBuilder.buildDependenciesOfCommons,
+			docs.buildDocs_individualPackages,
 			reload
 		)
 	);

--- a/tools/bundle-builder/index.js
+++ b/tools/bundle-builder/index.js
@@ -12,7 +12,6 @@ governing permissions and limitations under the License.
 
 const gulp = require("gulp");
 const concat = require("gulp-concat");
-const rename = require("gulp-rename");
 
 const depUtils = require("./lib/depUtils");
 const dirs = require("./lib/dirs");
@@ -152,35 +151,21 @@ let buildStandalone = gulp.series(
 // run buildLite on a selected set of packages that depend on commons
 // yay: faster than 'rebuild everything' approach
 // boo: must add new packages here as commons grows
-function buildDepenenciesOfCommons() {
-	const dependentComponents = [
+function buildDependenciesOfCommons() {
+	return subrunner.runTaskOnPackages("buildLite", [
 		`${dirs.components}/actionbutton`,
 		`${dirs.components}/button`,
-		`${dirs.components}/clearbutton`,
 		`${dirs.components}/closebutton`,
-		`${dirs.components}/infieldbutton`,
 		`${dirs.components}/logicbutton`,
+		`${dirs.components}/modal`,
 		`${dirs.components}/picker`,
-		`${dirs.components}/pickerbutton`,
-	];
-	return subrunner.runTaskOnPackages("buildLite", dependentComponents);
+		`${dirs.components}/popover`,
+		`${dirs.components}/tooltip`,
+		`${dirs.components}/underlay`,
+	]);
 }
 
-function copyPackages() {
-	return gulp
-		.src([
-			`${dirs.components}/*/package.json`,
-			`${dirs.components}/*/dist/**`,
-		])
-		.pipe(
-			rename(function (file) {
-				file.dirname = file.dirname.replace("/dist", "");
-			})
-		)
-		.pipe(gulp.dest("dist/components/"));
-}
-
-const buildDocs = gulp.parallel(docs.build, vars.copyVars, copyPackages);
+const buildDocs = gulp.parallel(docs.build, vars.copyVars);
 
 function buildIfTopLevel() {
 	let builtTasks = gulp.parallel(buildCombined, buildStandalone, buildDocs);
@@ -196,15 +181,15 @@ function buildIfTopLevel() {
 
 let build = gulp.series(buildIfTopLevel(), vars.copyVars);
 
-let buildLite = gulp.series(function buildComponentsLite() {
+let buildLite = gulp.series(function buildComponents() {
 	return subrunner.runTaskOnAllComponents("buildLite");
 }, buildDocs);
 
-let buildMedium = gulp.series(function buildComponentsLite() {
+let buildMedium = gulp.series(function buildComponents() {
 	return subrunner.runTaskOnAllComponents("buildMedium");
 }, buildDocs);
 
-let buildHeavy = gulp.series(function buildComponentsLite() {
+let buildHeavy = gulp.series(function buildComponents() {
 	return subrunner.runTaskOnAllComponents("buildHeavy");
 }, buildDocs);
 
@@ -226,8 +211,7 @@ exports.buildCombined = buildCombined;
 exports.buildStandalone = buildStandalone;
 exports.buildLite = buildLite;
 exports.buildDocs = buildDocs;
-exports.buildDepenenciesOfCommons = buildDepenenciesOfCommons;
-exports.copyPackages = copyPackages;
+exports.buildDependenciesOfCommons = buildDependenciesOfCommons;
 exports.dev = devTask;
 exports.build = build;
 exports.watch = dev.watch;

--- a/tools/bundle-builder/package.json
+++ b/tools/bundle-builder/package.json
@@ -34,6 +34,7 @@
     "browser-sync": "^2.26.14",
     "colors": "^1.4.0",
     "dependency-solver": "^1.0.6",
+    "fast-glob": "^3.3.2",
     "gulp": "^4.0.0",
     "gulp-concat": "^2.6.1",
     "gulp-conventional-changelog": "^2.0.19",


### PR DESCRIPTION
## Description

This update allows us to load CSS assets for packages that no longer live in the monorepo structure to maintain their rendering on the docs site even after deprecation.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [ ] Open the [docs](https://pr-2521--spectrum-css.netlify.app/card#standardfocused) for the card component (see the `Standard (focused)` section) and confirm the quick actions rendering looks right.
- [ ] After building the site locally (`yarn build:all`), check the compiled assets folder under `dist/components/quickaction` and expect to see:
    - `index-vars.css`
    - `index`
    - `mods.json`
    - `package.json`
    - `vars.css`

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
