### PR TITLE
chore(searchwithin): setup for deprecation

### DIFF
--- a/components/searchwithin/metadata/searchwithin.yml
+++ b/components/searchwithin/metadata/searchwithin.yml
@@ -1,22 +1,7 @@
 name: Search within
+status: Deprecated
+deprecationNotice: Use a [search field](search.html) with a separate control to filter the search instead.
 description: Override the width of the component where necessary.
-sections:
-  - name: Migration Guide
-    description: |
-      ### Component renamed
-      Since Dropdown is now known as Picker, Replace all `.spectrum-Dropdown*` classnames with `.spectrum-Picker*` and replace all `.spectrum-SearchWithin-dropdown` with `.spectrum-SearchWithin-picker`.
-
-      ### New Picker markup
-      Combobox now uses `.spectrum-Picker`. See [Picker migration guide](picker.html#migrationguide) for details.
-
-      Since Picker's markup has changed, `.spectrum-SearchWithin-pickerTrigger` is no longer required.
-
-      ### New ClearButton classes
-      The `.spectrum-SearchWithin-clearButton` class is now required on the `.spectrum-ClearButton` element.
-
-      ### New ClearButton markup
-      See the [ClearButton migration guide](clearbutton.html#migrationguide) for more information.
-
 examples:
   - id: searchwithin
     name: Standard

--- a/components/searchwithin/stories/searchwithin.stories.js
+++ b/components/searchwithin/stories/searchwithin.stories.js
@@ -1,12 +1,11 @@
 // Import the component markup template
-import { Template } from "./template";
+import { Template } from "@spectrum-css/searchwithin/stories/template.js";
 
 import { default as PickerStories } from "@spectrum-css/picker/stories/picker.stories.js";
 const ignoreProps = ["rootClass", "position", "isRounded"];
 
 export default {
-	title: "Components/Search within",
-	description: "The Search within component is...",
+	title: "Deprecated/Search within",
 	component: "SearchWithin",
 	argTypes: {
 		...Object.entries(PickerStories.argTypes).reduce((acc, [key, value]) => {
@@ -36,10 +35,9 @@ export default {
 		actions: {
 			handles: [],
 		},
+		chromatic: { disable: true },
 		status: {
-			type: process.env.MIGRATED_PACKAGES.includes("searchwithin")
-				? "migrated"
-				: undefined,
+			type: "deprecated"
 		},
 	},
 };


### PR DESCRIPTION
## Description

Preparation for deprecating the searchwithin component

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
Check that the steps for [flagging a component as deprecated](https://github.com/adobe/spectrum-css/blob/main/.storybook/guides/deprecation.mdx#L29-L55) have been completed in this PR:

- [x] In storybook, searchwithin is in the deprecated section
- [x] In storybook, searchwithin has a deprecated status (seen in the toolbar)
- [x] VRTs on this PR do not include searchwithin anymore (result of the parameter that disables chromatic)
- [x] In the docs site, the component has a deprecation notice at the top

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
