### PR TITLE
chore(docs): increase dark mode compatibility

### DIFF
--- a/.storybook/deprecated/quickaction/quickaction.yml
+++ b/.storybook/deprecated/quickaction/quickaction.yml
@@ -1,7 +1,7 @@
 id: quickactions
 name: Quick actions
 status: Deprecated
-deprecationNotice: Use an <a href="actionbar.html">action bar</a> to allow users to perform actions on either a single or multiple items at the same time, instead.
+deprecationNotice: Use an <a class="spectrum-Link" href="actionbar.html">action bar</a> to allow users to perform actions on either a single or multiple items at the same time, instead.
 description: Note that the `.spectrum-QuickActions-overlay` class should be placed on the container where the Quick Actions are displayed, and the `.spectrum-QuickActions--textOnly` class should be applied when the buttons have text only.
 SpectrumSiteSlug: https://spectrum.adobe.com/page/quick-actions/
 examples:

--- a/components/accordion/metadata/accordion.yml
+++ b/components/accordion/metadata/accordion.yml
@@ -4,7 +4,7 @@ description: "While remaining backward compatible, the recommended markup has be
 sections:
   - name: Custom Properties API
     description: |
-      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/accordion/metadata/mods.md">here</a>.
+      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/accordion/metadata/mods.md">here</a>.
   - name: Migration Guide
     description: |
       ### T-shirt sizing

--- a/components/actionbar/metadata/actionbar.yml
+++ b/components/actionbar/metadata/actionbar.yml
@@ -4,7 +4,7 @@ SpectrumSiteSlug: https://spectrum.adobe.com/page/action-bar/
 sections:
   - name: Custom Properties API
     description: |
-      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/actionbar/metadata/mods.md">here</a>.
+      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/actionbar/metadata/mods.md">here</a>.
   - name: Migration Guide
     description: |
       ### Popover Dependency

--- a/components/actionbutton/metadata/actionbutton.yml
+++ b/components/actionbutton/metadata/actionbutton.yml
@@ -9,7 +9,7 @@ description: |
 sections:
   - name: Custom Properties API
     description: |
-      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/actionbutton/metadata/mods.md">here</a>.
+      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/actionbutton/metadata/mods.md">here</a>.
   - name: Migration Guide
     description: |
       ### Action Button now requires a class on its icon

--- a/components/actiongroup/metadata/actiongroup.yml
+++ b/components/actiongroup/metadata/actiongroup.yml
@@ -3,7 +3,7 @@ SpectrumSiteSlug: https://spectrum.adobe.com/page/action-group/
 sections:
   - name: Custom Properties API
     description: |
-      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/actiongroup/metadata/mods.md">here</a>.
+      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/actiongroup/metadata/mods.md">here</a>.
   - name: Migration Guide
     description: |
       ### New Action Button markup

--- a/components/avatar/metadata/avatar.yml
+++ b/components/avatar/metadata/avatar.yml
@@ -10,7 +10,7 @@ SpectrumSiteSlug: https://spectrum.adobe.com/page/avatar/
 sections:
   - name: Custom Properties API
     description: |
-      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/avatar/metadata/mods.md">here</a>.
+      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/avatar/metadata/mods.md">here</a>.
   - name: Migration Guide
     description: |
       ### A div wrapper is required for avatar

--- a/components/badge/metadata/badge.yml
+++ b/components/badge/metadata/badge.yml
@@ -8,7 +8,7 @@ description: |
 sections:
   - name: Custom Properties API
     description: |
-      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/badge/metadata/mods.md">here</a>.
+      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/badge/metadata/mods.md">here</a>.
   - name: Migration Guide
     description: |
       ### Badge now includes icon and label elements

--- a/components/breadcrumb/metadata/breadcrumb.yml
+++ b/components/breadcrumb/metadata/breadcrumb.yml
@@ -3,7 +3,7 @@ SpectrumSiteSlug: https://spectrum.adobe.com/page/breadcrumbs/
 sections:
   - name: Custom Properties API
     description: |
-      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/breadcrumb/metadata/mods.md">here</a>.
+      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/breadcrumb/metadata/mods.md">here</a>.
   - name: Migration Guide
     description: |
       ### New Action Button markup

--- a/components/button/metadata/button-accent.yml
+++ b/components/button/metadata/button-accent.yml
@@ -5,7 +5,7 @@ SpectrumSiteSlug: https://spectrum.adobe.com/page/button/#Call-to-action-variant
 sections:
   - name: Custom Properties API
     description: |
-      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/button/metadata/mods.md">here</a>.
+      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/button/metadata/mods.md">here</a>.
   - name: Migration Guide
     description: |
       ### Fill or Outline class required

--- a/components/button/metadata/button-negative.yml
+++ b/components/button/metadata/button-negative.yml
@@ -5,7 +5,7 @@ SpectrumSiteSlug: https://spectrum.adobe.com/page/button/#Negative
 sections:
   - name: Custom Properties API
     description: |
-      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/button/metadata/mods.md">here</a>.
+      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/button/metadata/mods.md">here</a>.
   - name: Migration Guide
     description: |
       ### Fill or Outline class required

--- a/components/button/metadata/button-primary.yml
+++ b/components/button/metadata/button-primary.yml
@@ -5,7 +5,7 @@ SpectrumSiteSlug: https://spectrum.adobe.com/page/button/#Primary
 sections:
   - name: Custom Properties API
     description: |
-      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/button/metadata/mods.md">here</a>.
+      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/button/metadata/mods.md">here</a>.
   - name: Migration Guide
     description: |
       ### Fill or Outline class required
@@ -204,7 +204,7 @@ examples:
             </svg>
             <span class="spectrum-Button-label">Edit</span>
           </button>
-          
+
           <button class="spectrum-Button spectrum-Button--outline spectrum-Button--primary spectrum-Button--sizeL spectrum-Button--iconOnly" aria-label="Edit">
             <svg class="spectrum-Icon spectrum-Icon--sizeL" focusable="false" aria-hidden="true">
               <use xlink:href="#spectrum-icon-18-Edit" />

--- a/components/button/metadata/button-secondary.yml
+++ b/components/button/metadata/button-secondary.yml
@@ -5,7 +5,7 @@ SpectrumSiteSlug: https://spectrum.adobe.com/page/button/#Secondary
 sections:
   - name: Custom Properties API
     description: |
-      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/button/metadata/mods.md">here</a>.
+      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/button/metadata/mods.md">here</a>.
   - name: Migration Guide
     description: |
       ### Fill or Outline class required

--- a/components/button/metadata/button-staticcolor.yml
+++ b/components/button/metadata/button-staticcolor.yml
@@ -5,7 +5,7 @@ SpectrumSiteSlug: https://spectrum.adobe.com/page/button/#Over-background
 sections:
   - name: Custom Properties API
     description: |
-      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/button/metadata/mods.md">here</a>.
+      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/button/metadata/mods.md">here</a>.
   - name: Migration Guide
     description: |
       ### Fill or Outline class required

--- a/components/buttongroup/metadata/buttongroup.yml
+++ b/components/buttongroup/metadata/buttongroup.yml
@@ -3,7 +3,7 @@ SpectrumSiteSlug: https://spectrum.adobe.com/page/button/
 sections:
   - name: Custom Properties API
     description: |
-      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/buttongroup/metadata/mods.md">here</a>.
+      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/buttongroup/metadata/mods.md">here</a>.
 examples:
   - id: buttongroup-horizontal
     name: Horizontal

--- a/components/checkbox/metadata/checkbox.yml
+++ b/components/checkbox/metadata/checkbox.yml
@@ -9,7 +9,7 @@ description: |
 sections:
   - name: Custom Properties API
     description: |
-      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/checkbox/metadata/mods.md">here</a>.
+      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/checkbox/metadata/mods.md">here</a>.
   - name: Migration Guide
     description: |
       ### Quiet and emphasized

--- a/components/closebutton/metadata/closebutton.yml
+++ b/components/closebutton/metadata/closebutton.yml
@@ -5,7 +5,7 @@ description: |
 sections:
   - name: Custom Properties API
     description: |
-      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/closebutton/metadata/mods.md">here</a>.
+      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/closebutton/metadata/mods.md">here</a>.
   - name: Migration Guide
     description: |
       ### Sizing

--- a/components/colorarea/metadata/colorarea.yml
+++ b/components/colorarea/metadata/colorarea.yml
@@ -11,7 +11,7 @@ description: |
 sections:
   - name: Custom Properties API
     description: |
-      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/colorarea/metadata/mods.md">here</a>.
+      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/colorarea/metadata/mods.md">here</a>.
   - name: Migration Guide
     description: |
       - canvas variant has been removed

--- a/components/colorslider/metadata/colorslider.yml
+++ b/components/colorslider/metadata/colorslider.yml
@@ -11,7 +11,7 @@ description: |
 sections:
   - name: Custom Properties API
     description: |
-      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/colorslider/metadata/mods.md">here</a>.
+      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/colorslider/metadata/mods.md">here</a>.
   - name: Migration Guide
     description: |
       - The component now supports a RTL (right-to-left) base direction with logical properties, and reverses the gradient.

--- a/components/colorwheel/metadata/colorwheel.yml
+++ b/components/colorwheel/metadata/colorwheel.yml
@@ -11,7 +11,7 @@ description: |
 sections:
   - name: Custom Properties API
     description: |
-      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/colorwheel/metadata/mods.md">here</a>.
+      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/colorwheel/metadata/mods.md">here</a>.
   - name: Migration Guide
     description: |
       - Colorwheel no longer displays a canvas variant

--- a/components/contextualhelp/metadata/contextualhelp.yml
+++ b/components/contextualhelp/metadata/contextualhelp.yml
@@ -4,7 +4,7 @@ SpectrumSiteSlug: https://spectrum.adobe.com/page/contextual-help/
 sections:
   - name: Custom Properties API
     description: |
-      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/popover/metadata/mods.md">here</a>.
+      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/popover/metadata/mods.md">here</a>.
 examples:
   - id: contextualhelp-variants
     name: Info Icon

--- a/components/divider/metadata/divider.yml
+++ b/components/divider/metadata/divider.yml
@@ -4,7 +4,7 @@ SpectrumSiteSlug: https://spectrum.adobe.com/page/divider/
 sections:
   - name: Custom Properties API
     description: |
-      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/divider/metadata/mods.md">here</a>.
+      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/divider/metadata/mods.md">here</a>.
   - name: Migration Guide
     description: |
       ### Change workflow icon size to medium

--- a/components/fieldlabel/metadata/fieldlabel.yml
+++ b/components/fieldlabel/metadata/fieldlabel.yml
@@ -3,7 +3,7 @@ SpectrumSiteSlug: https://spectrum.adobe.com/page/text-field/#Include-a-label
 sections:
   - name: Custom Properties API
     description: |
-      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/fieldlabel/metadata/mods.md">here</a>.
+      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/fieldlabel/metadata/mods.md">here</a>.
   - name: Migration Guide
     description: |
       ### T-shirt sizing
@@ -83,7 +83,7 @@ examples:
     description: A Field label for a required field can display either the text "(required)", or an asterisk. If using the asterisk icon, do not leave any space between the label text and the start of the `<svg>` element in the markup, so extra space is not added in addition to the inline margin.
     markup: |
       <label for="lifestory5" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">
-        Life story<svg 
+        Life story<svg
           class="spectrum-Icon spectrum-UIIcon-Asterisk100 spectrum-FieldLabel-requiredIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-css-icon-Asterisk100" />
         </svg>
@@ -111,7 +111,7 @@ examples:
       </div>
 
       <label for="lifestory8" class="spectrum-FieldLabel spectrum-FieldLabel--sizeM is-disabled">
-        Life story<svg 
+        Life story<svg
           class="spectrum-Icon spectrum-UIIcon-Asterisk100 spectrum-FieldLabel-requiredIcon" focusable="false" aria-hidden="true">
           <use xlink:href="#spectrum-css-icon-Asterisk100" />
         </svg>

--- a/components/floatingactionbutton/metadata/floatingactionbutton.yml
+++ b/components/floatingactionbutton/metadata/floatingactionbutton.yml
@@ -7,7 +7,7 @@ description: |
 sections:
   - name: Custom Properties API
     description: |
-      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/floatingactionbutton/metadata/mods.md">here</a>.
+      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/floatingactionbutton/metadata/mods.md">here</a>.
 examples:
   - id: floatingactionbutton-primary
     name: Primary

--- a/components/helptext/metadata/helptext.yml
+++ b/components/helptext/metadata/helptext.yml
@@ -4,7 +4,7 @@ SpectrumSiteSlug: https://spectrum.adobe.com/page/help-text/
 sections:
   - name: Custom Properties API
     description: |
-      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/helptext/metadata/mods.md">here</a>.
+      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/helptext/metadata/mods.md">here</a>.
 examples:
   - id: helptext-sizing
     name: Sizing

--- a/components/inlinealert/metadata/inlinealert.yml
+++ b/components/inlinealert/metadata/inlinealert.yml
@@ -3,7 +3,7 @@ SpectrumSiteSlug: https://spectrum.adobe.com/page/in-line-alert/
 sections:
   - name: Custom Properties API
     description: |
-      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/inlinealert/metadata/mods.md">here</a>.
+      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/inlinealert/metadata/mods.md">here</a>.
 examples:
   - id: inlinealert-neutral
     name: Neutral

--- a/components/link/metadata/link.yml
+++ b/components/link/metadata/link.yml
@@ -5,7 +5,7 @@ status: Verified
 sections:
   - name: Custom Properties API
     description: |
-      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/link/metadata/mods.md">here</a>.
+      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/link/metadata/mods.md">here</a>.
   - name: Migration Guide
     description: |
       ### Subtle variant

--- a/components/menu/metadata/menu.yml
+++ b/components/menu/metadata/menu.yml
@@ -3,7 +3,7 @@ SpectrumSiteSlug: https://spectrum.adobe.com/page/menu/
 sections:
   - name: Custom Properties API
     description: |
-      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/menu/metadata/mods.md">here</a>.
+      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/menu/metadata/mods.md">here</a>.
   - name: Migration Guide
     description: |
       ### T-shirt sizing

--- a/components/modal/metadata/modal.yml
+++ b/components/modal/metadata/modal.yml
@@ -3,7 +3,7 @@ description: A modal component that is used primarily by Dialog.
 sections:
   - name: Custom Properties API
     description: |
-      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/modal/metadata/mods.md">here</a>.
+      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/modal/metadata/mods.md">here</a>.
 examples:
   - id: modal
     name: Modal

--- a/components/picker/metadata/picker.yml
+++ b/components/picker/metadata/picker.yml
@@ -4,7 +4,7 @@ SpectrumSiteSlug: https://spectrum.adobe.com/page/picker/
 sections:
   - name: Custom Properties API
     description: |
-      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/picker/metadata/mods.md">here</a>.
+      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/picker/metadata/mods.md">here</a>.
   - name: Migration Guide
     description: |
       ### Component renamed

--- a/components/popover/metadata/popover.yml
+++ b/components/popover/metadata/popover.yml
@@ -3,7 +3,7 @@ SpectrumSiteSlug: https://spectrum.adobe.com/page/popover/
 sections:
   - name: Custom Properties API
     description: |
-      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/popover/metadata/mods.md">here</a>.
+      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/popover/metadata/mods.md">here</a>.
   - name: Migration Guide
     description: |
       ### New Popover Positions

--- a/components/progressbar/metadata/meter.yml
+++ b/components/progressbar/metadata/meter.yml
@@ -11,7 +11,7 @@ SpectrumSiteSlug: https://spectrum.adobe.com/page/meter/
 sections:
   - name: Custom Properties API
     description: |
-      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/progressbar/metadata/mods.md">here</a>.
+      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/progressbar/metadata/mods.md">here</a>.
   - name: Migration Guide
     description: |
       ### spectrum-Meter class

--- a/components/progresscircle/metadata/progresscircle.yml
+++ b/components/progresscircle/metadata/progresscircle.yml
@@ -4,7 +4,7 @@ SpectrumSiteSlug: https://spectrum.adobe.com/page/progress-circle/
 sections:
   - name: Custom Properties API
     description: |
-      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/progresscircle/metadata/mods.md">here</a>.
+      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/progresscircle/metadata/mods.md">here</a>.
   - name: Migration Guide
     description: |
       ### Component renamed

--- a/components/radio/metadata/radio.yml
+++ b/components/radio/metadata/radio.yml
@@ -9,7 +9,7 @@ description: |
 sections:
   - name: Custom Properties API
     description: |
-      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/radio/metadata/mods.md">here</a>.
+      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/radio/metadata/mods.md">here</a>.
   - name: Migration Guide
     description: |
       ### T-shirt sizing
@@ -21,7 +21,7 @@ sections:
       - Read-only radio buttons do not have a focus ring, but the button should be focusable.]
 
       ### Invalid/Error State
-      - Invalid radio buttons are signified by including [Help text](helptext.html) in a [Field group](fieldgroup.html). The `.is-invalid` class has been removed. See Field group for an example with an invalid radio group. 
+      - Invalid radio buttons are signified by including [Help text](helptext.html) in a [Field group](fieldgroup.html). The `.is-invalid` class has been removed. See Field group for an example with an invalid radio group.
 
       ### Remove focus-ring class
       We've migrated away from the focus-ring class in favor of the native `:focus-visible` pseudo-class due to changes in browser support.

--- a/components/statuslight/metadata/statuslight.yml
+++ b/components/statuslight/metadata/statuslight.yml
@@ -3,7 +3,7 @@ SpectrumSiteSlug: https://spectrum.adobe.com/page/status-light/
 sections:
   - name: Custom Properties API
     description: |
-      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/statuslight/metadata/mods.md">here</a>.
+      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/statuslight/metadata/mods.md">here</a>.
   - name: Migration Guide
     description: |
       ### T-shirt sizing

--- a/components/swatch/metadata/swatch.yml
+++ b/components/swatch/metadata/swatch.yml
@@ -6,7 +6,7 @@ description: |
 sections:
   - name: Custom Properties API
     description: |
-      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/swatch/metadata/mods.md">here</a>.
+      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/swatch/metadata/mods.md">here</a>.
 examples:
   - id: swatch-sizing
     name: Sizing

--- a/components/swatchgroup/metadata/swatchgroup.yml
+++ b/components/swatchgroup/metadata/swatchgroup.yml
@@ -7,7 +7,7 @@ description: |
 sections:
   - name: Custom Properties API
     description: |
-      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/swatchgroup/metadata/mods.md">here</a>.
+      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/swatchgroup/metadata/mods.md">here</a>.
 examples:
   - id: swatchgroup-compact
     name: Density - Compact

--- a/components/switch/metadata/switch.yml
+++ b/components/switch/metadata/switch.yml
@@ -3,13 +3,13 @@ SpectrumSiteSlug: https://spectrum.adobe.com/page/switch/
 sections:
   - name: Custom Properties API
     description: |
-      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/switch/metadata/mods.md">here</a>.
+      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/switch/metadata/mods.md">here</a>.
   - name: Migration Guide
     description: |
       ### Component renamed
       Toggle is now known as Switch. Replace all `.spectrum-ToggleSwitch*` classnames with `.spectrum-Switch*`.
       ### T-shirt sizing
-      Switch now supports t-shirt sizing and requires that you specify the size by adding a .spectrum-Switch--size* class. The default size is "medium". 
+      Switch now supports t-shirt sizing and requires that you specify the size by adding a .spectrum-Switch--size* class. The default size is "medium".
       ### Quiet and emphasized
       Spectrum has chosen the variant previously known as `quiet` to be the default and has added an `emphasized` variant with the same styles as the previous default.
       If you were using the `quiet` variant, the `.spectrum-Switch--quiet` class is no longer required and can be removed.

--- a/components/table/metadata/table.yml
+++ b/components/table/metadata/table.yml
@@ -4,7 +4,7 @@ SpectrumSiteSlug: https://spectrum.adobe.com/page/table/
 sections:
   - name: Custom properties API
     description: |
-      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/table/metadata/mods.md">here</a>.
+      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/table/metadata/mods.md">here</a>.
   - name: Migration guide
     description: |
       ### Sorted icon moved to left side of text
@@ -1040,8 +1040,8 @@ examples:
           <tr class="spectrum-Table-row spectrum-Table-row--collapsible" data-tier="0" id="table-cr-alpha">
             <td class="spectrum-Table-cell spectrum-Table-cell--collapsible">
               <div class="spectrum-Table-collapseInner">
-                <button 
-                  class="spectrum-Button spectrum-Button--sizeM spectrum-Button--iconOnly spectrum-Table-disclosureIcon" 
+                <button
+                  class="spectrum-Button spectrum-Button--sizeM spectrum-Button--iconOnly spectrum-Table-disclosureIcon"
                   aria-label="Collapse"
                   aria-expanded="true"
                   aria-controls="table-cr-bravo table-cr-delta"
@@ -1059,8 +1059,8 @@ examples:
           <tr class="spectrum-Table-row spectrum-Table-row--collapsible" data-tier="1" id="table-cr-bravo">
             <td class="spectrum-Table-cell spectrum-Table-cell--collapsible">
               <div class="spectrum-Table-collapseInner">
-                <button 
-                  class="spectrum-Button spectrum-Button--sizeM spectrum-Button--iconOnly spectrum-Table-disclosureIcon" 
+                <button
+                  class="spectrum-Button spectrum-Button--sizeM spectrum-Button--iconOnly spectrum-Table-disclosureIcon"
                   aria-label="Expand"
                   aria-expanded="false"
                   aria-controls="table-cr-charlie"

--- a/components/tag/metadata/tag.yml
+++ b/components/tag/metadata/tag.yml
@@ -5,7 +5,7 @@ SpectrumSiteSlug: https://spectrum.adobe.com/page/tag/
 sections:
   - name: Custom Properties API
     description: |
-      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/tag/metadata/mods.md">here</a>.
+      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/tag/metadata/mods.md">here</a>.
   - name: Migration Guide
     description: |
       ### Pluralized classes changed to singular

--- a/components/taggroup/metadata/taggroup.yml
+++ b/components/taggroup/metadata/taggroup.yml
@@ -5,7 +5,7 @@ SpectrumSiteSlug: https://spectrum.adobe.com/page/tag/
 sections:
   - name: Custom Properties API
     description: |
-      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/taggroup/metadata/mods.md">here</a>.
+      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/taggroup/metadata/mods.md">here</a>.
   - name: Migration Guide
     description: |
       ### Updated tag classes

--- a/components/toast/metadata/toast.yml
+++ b/components/toast/metadata/toast.yml
@@ -3,7 +3,7 @@ SpectrumSiteSlug: https://spectrum.adobe.com/page/toast/
 sections:
   - name: Custom Properties API
     description: |
-      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/toast/metadata/mods.md">here</a>.
+      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/toast/metadata/mods.md">here</a>.
   - name: Migration Guide
     description: |
       ### Clear button replaced by Close button

--- a/components/tooltip/metadata/tooltip.yml
+++ b/components/tooltip/metadata/tooltip.yml
@@ -3,7 +3,7 @@ SpectrumSiteSlug: https://spectrum.adobe.com/page/tooltip/
 sections:
   - name: Custom Properties API
     description: |
-      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/tooltip/metadata/mods.md">here</a>.
+      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/tooltip/metadata/mods.md">here</a>.
   - name: Migration Guide
     description: |
       ### Tooltip now has 22 directions

--- a/components/tray/metadata/tray.yml
+++ b/components/tray/metadata/tray.yml
@@ -5,7 +5,7 @@ description: |
 sections:
   - name: Custom Properties API
     description: |
-      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/tray/metadata/mods.md">here</a>.
+      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/tray/metadata/mods.md">here</a>.
 SpectrumSiteSlug: https://spectrum.adobe.com/page/trays/
 examples:
   - id: tray

--- a/components/treeview/metadata/treeview.yml
+++ b/components/treeview/metadata/treeview.yml
@@ -6,7 +6,7 @@ SpectrumSiteSlug: https://spectrum.adobe.com/page/tree-view/
 sections:
   - name: Custom Properties API
     description: |
-      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/treeview/metadata/mods.md">here</a>.
+      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/treeview/metadata/mods.md">here</a>.
   - name: Migration Guide
     description: |
       ### T-shirt sizing
@@ -38,7 +38,7 @@ sections:
 
       ### Revised sections markup
       The markup for sections has changed so that the heading is now a child of an `li` instead of the `ul`, to ensure valid markup. An additional
-      class `spectrum-TreeView-section` has been added for the first level `li` elements that contain the section heading and its child Tree view. 
+      class `spectrum-TreeView-section` has been added for the first level `li` elements that contain the section heading and its child Tree view.
 
 examples:
   - id: treeview-standard

--- a/components/typography/metadata/typography.yml
+++ b/components/typography/metadata/typography.yml
@@ -46,7 +46,7 @@ examples:
 sections:
   - name: Custom Properties API
     description: |
-      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a href="https://github.com/adobe/spectrum-css/tree/main/components/typography/metadata/mods.md">here</a>.
+      This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/typography/metadata/mods.md">here</a>.
   - name: Applying margins
     description: |
       By default, Typography components do not include outer margins. If you would like to add margins, simply add the `.spectrum-Typography` class to your container, and every typography component inside of your container will have the correct margins.

--- a/site/templates/siteComponent.pug
+++ b/site/templates/siteComponent.pug
@@ -149,9 +149,10 @@ html(lang='en-US' dir="ltr").spectrum.spectrum--light.spectrum--medium
                   h3.spectrum-InLineAlert-header Deprecated component
                     svg(class="spectrum-Icon spectrum-Icon--sizeM spectrum-InLineAlert-icon" focusable="false" aria-hidden="true" role="img" xmlns="http://www.w3.org/2000/svg" height="36" viewBox="0 0 36 36" width="36")
                       path(d="M17.127 2.579.4 32.512A1 1 0 0 0 1.272 34h33.456a1 1 0 0 0 .872-1.488L18.873 2.579a1 1 0 0 0-1.746 0ZM20 29.5a.5.5 0 0 1-.5.5h-3a.5.5 0 0 1-.5-.5v-3a.5.5 0 0 1 .5-.5h3a.5.5 0 0 1 .5.5Zm0-6a.5.5 0 0 1-.5.5h-3a.5.5 0 0 1-.5-.5v-12a.5.5 0 0 1 .5-.5h3a.5.5 0 0 1 .5.5Z")
-                  p.spectrum-InLineAlert-content This component has been deprecated.
-                    if component.deprecationNotice
-                      span!= util.markdown.render(component.deprecationNotice)
+                  section.spectrum-InLineAlert-content
+                    p This component has been deprecated.
+                      if component.deprecationNotice
+                        span!= util.markdown.render(component.deprecationNotice)
 
               table.spectrum-CSSComponent-detailsTable
                 tr.spectrum-Body


### PR DESCRIPTION
## Description

Updating the pug templates to:

- make the deprecationNotice part of the deprecation alert dark mode compatible
- make links in the deprecationNotice and description fields dark mode compatible

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [x] In the docs site, go to Quick Actions and turn on dark mode. All text in the deprecation notice should be white other than the link (but the link should also be using dark mode colors)
- [x] Go to Accordion, scroll down to the Custom Properties API section. With dark mode on, the link should be dark mode compatible

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [ ] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
