### PR TITLE
docs(cyclebutton): setup for deprecation

### DIFF
--- a/.storybook/guides/deprecation.mdx
+++ b/.storybook/guides/deprecation.mdx
@@ -47,7 +47,7 @@ Before removing the component from the codebase, we need to flag the component a
     ```yaml
     name: Quick actions
     status: Deprecated
-    deprecationNotice: Use an <a href="actionbar.html">action bar</a> to allow users to perform actions on either a single or multiple items at the same time, instead.
+    deprecationNotice: Use an [action bar](actionbar.html) to allow users to perform actions on either a single or multiple items at the same time, instead.
     ```
 4. Commit these changes and open a pull request to the main branch. i.e., `git commit -m "chore(quickaction): prepare for deprecation"`.
 5. Once the pull request is approved, merge the changes into the main branch and publish the update to the package registry.

--- a/components/cyclebutton/metadata/cyclebutton.yml
+++ b/components/cyclebutton/metadata/cyclebutton.yml
@@ -1,9 +1,6 @@
 name: Cycle button
-sections:
-  - name: Migration Guide
-    description: |
-      ### Change workflow icon size to medium
-      Replace `.spectrum-Icon--sizeS` with `.spectrum-Icon--sizeM`.
+status: Deprecated
+deprecationNotice: Use the [quiet variant of action button](actionbutton.html#quiet) with the appropriate icon(s) instead. Any icon swapping that happens on-click/on-key should be handled by the implementation.
 examples:
   - id: cyclebutton
     name: Standard

--- a/components/cyclebutton/stories/cyclebutton.stories.js
+++ b/components/cyclebutton/stories/cyclebutton.stories.js
@@ -1,11 +1,11 @@
 // Import the component markup template
-import { Template } from "./template";
+import { Template } from "@spectrum-css/cyclebutton/stories/template";
 
-import { default as IconStories } from "@spectrum-css/icon/stories/icon.stories.js";
 import { default as ActionButtonStories } from "@spectrum-css/actionbutton/stories/actionbutton.stories.js";
+import { default as IconStories } from "@spectrum-css/icon/stories/icon.stories.js";
 
 export default {
-	title: "Components/Cycle button",
+	title: "Deprecated/Cycle button",
 	description:
 		"The Cycle button component is an action button that cycles through two different icons, a play that then changes to a pause, for example.",
 	component: "CycleButton",
@@ -35,10 +35,9 @@ export default {
 		actions: {
 			handles: [...(ActionButtonStories?.parameters?.actions?.handles ?? [])],
 		},
+		chromatic: { disable: true },
 		status: {
-			type: process.env.MIGRATED_PACKAGES.includes("cyclebutton")
-				? "migrated"
-				: undefined,
+			type: "deprecated"
 		},
 	},
 };


### PR DESCRIPTION
## Description

Preparation for deprecating the cyclebutton component. Includes a small change to docs to recommend markdown syntax for links instead of html (since markdown automatically handles links, vs needing to add classes when using html)

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
Check that the steps for [flagging a component as deprecated](https://github.com/adobe/spectrum-css/blob/main/.storybook/guides/deprecation.mdx#L29-L55) have been completed in this PR:

- [x] There's a [deprecation announcement](https://github.com/adobe/spectrum-css/discussions/2535) for cyclebutton
- [x] In storybook, cyclebutton is in the deprecated section
- [x] In storybook, cyclebutton has a deprecated status (seen in the toolbar)
- [x] VRTs on this PR do not include cyclebutton anymore (result of the parameter that disables chromatic)
- [x] In the docs site, cyclebutton has a deprecation notice at the top (with a link that is dark mode compatible)

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
