### PR TITLE
chore(asset): prepare for deprecation

### DIFF
--- a/components/asset/metadata/asset.yml
+++ b/components/asset/metadata/asset.yml
@@ -1,4 +1,5 @@
 name: Asset
+status: Deprecated
 examples:
   - id: asset
     name: Image

--- a/components/asset/stories/asset.stories.js
+++ b/components/asset/stories/asset.stories.js
@@ -1,8 +1,7 @@
-// Import the component markup template
-import { Template } from "./template";
+import { Template } from "@spectrum-css/asset/stories/template.js";
 
 export default {
-	title: "Components/Asset",
+	title: "Deprecated/Asset",
 	description:
 		"Use an asset element to visually represent a file, folder or image. File and folder representations will center themselves horizontally and vertically in the space provided to the element. Images will be contained to the element, growing to the element's full height while centering itself within the width provided.",
 	component: "Asset",
@@ -33,9 +32,8 @@ export default {
 	},
 	parameters: {
 		status: {
-			type: process.env.MIGRATED_PACKAGES.includes("asset")
-				? "migrated"
-				: undefined,
+			chromatic: { disable: true },
+			type: "deprecated"
 		},
 	},
 };


### PR DESCRIPTION
## Description

Preparation for deprecating the asset component

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
Check that the steps for [flagging a component as deprecated](https://github.com/adobe/spectrum-css/blob/main/.storybook/guides/deprecation.mdx#L29-L55) have been completed in this PR:

- [ ] Announcement is posted: https://github.com/adobe/spectrum-css/discussions/2539
- [ ] In storybook, asset is in the deprecated section
- [ ] In storybook, asset has a deprecated status (seen in the toolbar)
- [ ] VRTs on this PR do not include asset anymore (result of the parameter that disables chromatic)
- [ ] In the docs site, the component has a deprecation notice at the top
- [ ] Test for regressions in Card

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
