### PR TITLE
fix(tray): full width at portrait orientation

### DIFF
--- a/components/tray/index.css
+++ b/components/tray/index.css
@@ -30,7 +30,7 @@ governing permissions and limitations under the License.
 
 @media (forced-colors: active) {
   .spectrum-Tray {
-    --highcontrast-tray-background-color: Background;
+    --highcontrast-tray-background-color: Canvas;
   }
 }
 
@@ -45,10 +45,11 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Tray {
-  /* Default to full width when the viewport is in portrait orientation
-   * (height is greater than width)
-   */
+  /* Default to full width when the viewport is in portrait orientation */
   inline-size: 100%;
+  --mod-modal-max-width: 100%;
+  max-inline-size: 100%;
+
   max-block-size: calc(100vh - var(--mod-tray-spacing-edge-to-tray-safe-zone, var(--spectrum-tray-spacing-edge-to-tray-safe-zone)));
   margin-block-start: var(--mod-tray-spacing-edge-to-tray-safe-zone, var(--spectrum-tray-spacing-edge-to-tray-safe-zone));
   padding-block-start: var(--mod-tray-top-to-content-area, var(--spectrum-tray-top-to-content-area));
@@ -56,9 +57,7 @@ governing permissions and limitations under the License.
   box-sizing: border-box;
   overflow: auto;
   outline: none;
-
-  /* Unset spectrum-Modal border-radius */
-  border-radius: unset;
+  border-radius: var(--mod-tray-corner-radius-portrait, 0) var(--mod-tray-corner-radius-portrait, 0) 0 0;
 
   /* Start offset by the animation distance */
   transform: translateY(100%);
@@ -91,10 +90,6 @@ governing permissions and limitations under the License.
   }
 }
 
-/* https://developer.mozilla.org/en-US/docs/Web/CSS/@media/orientation
- * Limit Tray width to 375px and round corners when the viewport is in landscape orientation
- * (width is greater than height)
- */
 @media screen and (orientation: landscape) {
   .spectrum-Tray {
     border-start-start-radius: var(--mod-tray-corner-radius, var(--spectrum-tray-corner-radius));

--- a/components/tray/index.css
+++ b/components/tray/index.css
@@ -28,12 +28,6 @@ governing permissions and limitations under the License.
   --spectrum-tray-background-color: var(--spectrum-background-layer-2-color);
 }
 
-@media (forced-colors: active) {
-  .spectrum-Tray {
-    --highcontrast-tray-background-color: Canvas;
-  }
-}
-
 .spectrum-Tray-wrapper {
   inset-inline-start: 0;
   /* Positioned at the bottom of the window */
@@ -95,5 +89,16 @@ governing permissions and limitations under the License.
     border-start-start-radius: var(--mod-tray-corner-radius, var(--spectrum-tray-corner-radius));
     border-start-end-radius: var(--mod-tray-corner-radius, var(--spectrum-tray-corner-radius));
     max-inline-size: var(--mod-tray-max-inline-size, var(--spectrum-tray-max-inline-size));
+  }
+}
+
+@media (forced-colors: active) {
+  .spectrum-Tray {
+    --highcontrast-tray-background-color: Canvas;
+
+    border: solid;
+    & .spectrum-Dialog {
+      border: none;
+    }
   }
 }

--- a/components/tray/metadata/mods.md
+++ b/components/tray/metadata/mods.md
@@ -3,6 +3,7 @@
 | `--mod-tray-background-color`               |
 | `--mod-tray-bottom-to-content-area`         |
 | `--mod-tray-corner-radius`                  |
+| `--mod-tray-corner-radius-portrait`         |
 | `--mod-tray-entry-animation-delay`          |
 | `--mod-tray-entry-animation-duration`       |
 | `--mod-tray-exit-animation-delay`           |

--- a/components/tray/metadata/tray.yml
+++ b/components/tray/metadata/tray.yml
@@ -1,15 +1,16 @@
 name: Tray
 description: |
-  Tray Dialogs are typically used to portray information on mobile device or
-  smaller screens.
+  The Tray component is typically used to portray information on mobile devices or smaller screens.
+
 sections:
   - name: Custom Properties API
     description: |
       This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/tray/metadata/mods.md">here</a>.
-SpectrumSiteSlug: https://spectrum.adobe.com/page/trays/
+SpectrumSiteSlug: https://spectrum.adobe.com/page/tray/
 examples:
   - id: tray
-    name: Tray
+    name: Standard
+    description: The following example displays differently depending on the orientation of the viewport, using the `orientation` CSS media feature. In portrait orientation, a Tray is displayed at the bottom of the screen and takes up the full width of the view. In landscape orientation, it keeps its portrait width, is centered horizontally, and has rounded upper corners.
     markup: |
       <div class="spectrum-Tray-wrapper spectrum-CSSExample-dialog" style="background: rgba(0,0,0,0.4);">
         <div class="spectrum-Modal spectrum-Tray is-open">

--- a/components/tray/stories/template.js
+++ b/components/tray/stories/template.js
@@ -3,8 +3,7 @@ import { classMap } from "lit/directives/class-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { styleMap } from "lit/directives/style-map.js";
 
-import { Template as Modal } from "@spectrum-css/modal/stories/template.js";
-
+import "@spectrum-css/modal/index.css";
 import "../index.css";
 
 export const Template = ({

--- a/components/tray/stories/tray.stories.js
+++ b/components/tray/stories/tray.stories.js
@@ -29,6 +29,7 @@ export default {
 		rootClass: "spectrum-Tray",
 		customClasses: ["spectrum-Modal"],
 		isOpen: true,
+		heading: "New Messages",
 	},
 	parameters: {
 		actions: {
@@ -43,15 +44,16 @@ export default {
 };
 
 export const Default = ({
+	heading,
 	...args
 }) => {
 	return html`
 		<div>
 			${Template({
-				heading: "Tray Dialog",
+				...args,
 				content: [
 					() => Dialog({
-							heading: "New Messages",
+							heading,
 							content: ["You have 5 new messages!"],
 							isDismissable: false,
 						})
@@ -62,7 +64,6 @@ export const Default = ({
 				window.isChromatic() ?
 				Template({
 					...args,
-					heading: "Tray Dialog",
 					content: [
 						() => Dialog({
 								heading: "You have new messages waiting in your inbox",
@@ -79,4 +80,3 @@ export const Default = ({
 		</div>
 	`;
 };
-Default.args = {};


### PR DESCRIPTION
## Description

The Tray was not appearing at the intended 100% width in portrait orientation because of a `max-inline-size` declaration coming from the `.spectrum-Modal` class used alongside `.spectrum-Tray`. This makes sure that the `max-inline-size` is 100%. 

This also:
- Adds a requested mod for rounding in portrait orientation:  `--mod-tray-corner-radius-portrait`. The landscape rounding can already be changed by `--mod-tray-corner-radius`.
- Cleans up some of the docs, including the guidelines link that was previously 404.
- forced-colors: Replaces an unknown system color with the one that is defined in the current spec.
- forced-colors: applies border to the correct element, so that rounded corners appear. Previously the border was on a nested element with padding around it, so the borders weren't really to the edge of the Tray.
- Fixes the heading control in Storybook to be usable.

CSS-698

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
- [x] Tray appears 100% width at portrait, with square corners. And continues to display the same at landscape (limited width and rounded top corners).
- [x] Test in the inspector that both `--mod-tray-corner-radius-portrait` and `--mod-tray-corner-radius` work. Including forced-colors mode.
- [x] Proofread docs changes
- [x] Heading control in Storybook changes the heading text

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
