### PR TITLE
ci: remove spectrum-two from automated VRT runs

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -138,10 +138,10 @@ jobs:
     # -------------------------------------------------------------
     vrt:
         name: Testing
-        if: ${{ contains(github.event.pull_request.labels.*.name, 'run_vrt') || ((github.event.pull_request.draft != true || contains(github.event.pull_request.labels.*.name, 'run_ci')) && github.event.pull_request.mergeable == true) }}
+        if: contains(github.event.pull_request.labels.*.name, 'run_vrt') || ((github.event.pull_request.draft != true || contains(github.event.pull_request.labels.*.name, 'run_ci')) && github.event.pull_request.mergeable == true)
         uses: ./.github/workflows/vrt.yml
         with:
-            skip: ${{ contains(github.event.pull_request.labels.*.name, 'skip_vrt') }}
+            skip: ${{ github.base_ref == 'spectrum-two' || contains(github.event.pull_request.labels.*.name, 'skip_vrt') }}
         secrets: inherit
 
     # -------------------------------------------------------------

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -64,6 +64,8 @@ jobs:
         name: Testing
         needs: [build]
         uses: ./.github/workflows/vrt.yml
+        with:
+            skip: ${{ github.base_ref != 'main' }}
         secrets: inherit
 
     # -------------------------------------------------------------


### PR DESCRIPTION
## Description

The optimal way to run VRT on a feature branch is to manually create a review. To support that, we need to prevent automated VRT from running on spectrum-two based PRs.

## Testing

To validate this work, I'm going to create a fork branch off `spectrum-two` and copy this code into it. I'll open a PR against `spectrum-two` and see if it fires VRT. 

- https://github.com/adobe/spectrum-css/pull/2568

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] ✨ This pull request is ready to merge. ✨
