### PR TITLE
fix(button): pending state width, transition

### DIFF
--- a/components/button/index.css
+++ b/components/button/index.css
@@ -24,6 +24,8 @@ governing permissions and limitations under the License.
   --spectrum-button-focus-ring-thickness: var(--spectrum-focus-indicator-thickness);
   --spectrum-button-focus-indicator-color: var(--spectrum-focus-indicator-color);
   --spectrum-button-intended-icon-size: var(--spectrum-workflow-icon-size-50);
+
+  --mod-progress-circle-position: absolute;
 }
 
 .spectrum-Button--sizeS {
@@ -60,11 +62,6 @@ governing permissions and limitations under the License.
   --spectrum-button-bottom-to-text: var(--spectrum-button-bottom-to-text-medium);
   --spectrum-button-top-to-icon: var(--spectrum-component-top-to-workflow-icon-100);
   --spectrum-button-intended-icon-size: var(--spectrum-workflow-icon-size-100);
-
-  &[pending],
-  &.is-pending {
-    --mod-button-edge-to-visual-only: calc(1px + var(--spectrum-button-edge-to-visual-only));
-  }
 }
 
 .spectrum-Button--sizeL {
@@ -83,11 +80,6 @@ governing permissions and limitations under the License.
   --spectrum-button-bottom-to-text: var(--spectrum-button-bottom-to-text-large);
   --spectrum-button-top-to-icon: var(--spectrum-component-top-to-workflow-icon-200);
   --spectrum-button-intended-icon-size: var(--spectrum-workflow-icon-size-200);
-
-  &[pending],
-  &.is-pending {
-    --mod-button-edge-to-visual-only: calc(2px + var(--spectrum-button-edge-to-visual-only));
-  }
 }
 
 .spectrum-Button--sizeXL {
@@ -106,16 +98,6 @@ governing permissions and limitations under the License.
   --spectrum-button-bottom-to-text: var(--spectrum-button-bottom-to-text-extra-large);
   --spectrum-button-top-to-icon: var(--spectrum-component-top-to-workflow-icon-300);
   --spectrum-button-intended-icon-size: var(--spectrum-workflow-icon-size-300);
-
-  .spectrum--medium &[pending],
-  .spectrum--medium &.is-pending {
-    --mod-button-edge-to-visual-only: calc(3px + var(--spectrum-button-edge-to-visual-only));
-  }
-
-  .spectrum--large &[pending],
-  .spectrum--large &.is-pending {
-    --mod-button-edge-to-visual-only: calc(4px + var(--spectrum-button-edge-to-visual-only));
-  }
 }
 
 .spectrum-Button {
@@ -151,13 +133,13 @@ governing permissions and limitations under the License.
     /* Any block-size difference between the intended workflow icon size and actual icon used.
        Helps support any existing use of smaller UI icons instead of intended Workflow icons. */
     --_icon-size-difference: max(0px,
-      var(--spectrum-button-intended-icon-size) - 
+      var(--spectrum-button-intended-icon-size) -
       var(--spectrum-icon-block-size, var(--spectrum-button-intended-icon-size))
     );
 
     margin-block-start: var(--mod-button-icon-margin-block-start,
       max(0px,
-        var(--mod-button-top-to-icon, var(--spectrum-button-top-to-icon)) - 
+        var(--mod-button-top-to-icon, var(--spectrum-button-top-to-icon)) -
         var(--mod-button-border-width, var(--spectrum-button-border-width)) +
         (var(--_icon-size-difference, 0px) / 2)
       )
@@ -254,6 +236,9 @@ a.spectrum-Button {
   background-color: var(--highcontrast-button-background-color-default, var(--mod-button-background-color-default, var(--spectrum-button-background-color-default)));
   border-color: var(--highcontrast-button-border-color-default, var(--mod-button-border-color-default, var(--spectrum-button-border-color-default)));
   color: var(--highcontrast-button-content-color-default, var(--mod-button-content-color-default, var(--spectrum-button-content-color-default)));
+  transition: border var(--mod-button-animation-duration, var(--spectrum-button-animation-duration, 130ms)) linear,
+              color var(--mod-button-animation-duration, var(--spectrum-button-animation-duration, 130ms)) linear,
+              background-color var(--mod-button-animation-duration, var(--spectrum-button-animation-duration, 130ms)) linear;
 
   &:hover {
     background-color: var(--highcontrast-button-background-color-hover, var(--mod-button-background-color-hover, var(--spectrum-button-background-color-hover)));
@@ -282,13 +267,36 @@ a.spectrum-Button {
     color: var(--highcontrast-button-content-color-disabled, var(--mod-button-content-color-disabled, var(--spectrum-button-content-color-disabled)));
   }
 
+  .spectrum-Icon,
+  .spectrum-Button-label {
+    visibility: visible;
+    opacity: 100%;
+    transition: opacity var(--mod-button-animation-duration, var(--spectrum-button-animation-duration, 130ms)) ease-in-out;
+  }
+
+  .spectrum-ProgressCircle {
+    visibility: hidden;
+    opacity: 0%;
+    transition: opacity var(--mod-button-animation-duration, var(--spectrum-button-animation-duration, 130ms)) ease-in-out,
+                visibility 0ms linear var(--mod-button-animation-duration, var(--spectrum-button-animation-duration, 130ms));
+  }
+
   &[pending],
   &.is-pending {
     cursor: default;
 
     .spectrum-Icon,
     .spectrum-Button-label {
-      display: none;
+      visibility: hidden;
+      opacity: 0%;
+      transition: opacity var(--mod-button-animation-duration, var(--spectrum-button-animation-duration, 130ms)) ease-in-out,
+                  visibility 0ms linear var(--mod-button-animation-duration, var(--spectrum-button-animation-duration, 130ms));
+    }
+
+    .spectrum-ProgressCircle {
+      visibility: visible;
+      opacity: 100%;
+      transition: opacity var(--mod-button-animation-duration, var(--spectrum-button-animation-duration, 130ms)) ease-in-out;
     }
   }
 }

--- a/components/button/metadata/button-pending.yml
+++ b/components/button/metadata/button-pending.yml
@@ -10,6 +10,29 @@ examples:
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">S</h4>
           <button class="spectrum-Button spectrum-Button--fill spectrum-Button--accent spectrum-Button--sizeS is-pending" disabled>
+            <span class="spectrum-Button-label">Edit</span>
+            <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small">
+              <div class="spectrum-ProgressCircle-track"></div>
+              <div class="spectrum-ProgressCircle-fills">
+                <div class="spectrum-ProgressCircle-fillMask1">
+                  <div class="spectrum-ProgressCircle-fillSubMask1">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+                <div class="spectrum-ProgressCircle-fillMask2">
+                  <div class="spectrum-ProgressCircle-fillSubMask2">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </button>
+
+          <button class="spectrum-Button spectrum-Button--fill spectrum-Button--accent spectrum-Button--sizeS is-pending" disabled>
+            <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-icon-18-Edit" />
+            </svg>
+            <span class="spectrum-Button-label">Edit</span>
             <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small">
               <div class="spectrum-ProgressCircle-track"></div>
               <div class="spectrum-ProgressCircle-fills">
@@ -28,6 +51,9 @@ examples:
           </button>
 
           <button class="spectrum-Button spectrum-Button--fill spectrum-Button--accent spectrum-Button--iconOnly spectrum-Button--sizeS is-pending" disabled>
+            <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-icon-18-Edit" />
+            </svg>
             <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small">
               <div class="spectrum-ProgressCircle-track"></div>
               <div class="spectrum-ProgressCircle-fills">
@@ -49,6 +75,29 @@ examples:
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">M (default)</h4>
           <button class="spectrum-Button spectrum-Button--fill spectrum-Button--negative spectrum-Button--sizeM is-pending" disabled>
+            <span class="spectrum-Button-label">Edit</span>
+            <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small">
+              <div class="spectrum-ProgressCircle-track"></div>
+              <div class="spectrum-ProgressCircle-fills">
+                <div class="spectrum-ProgressCircle-fillMask1">
+                  <div class="spectrum-ProgressCircle-fillSubMask1">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+                <div class="spectrum-ProgressCircle-fillMask2">
+                  <div class="spectrum-ProgressCircle-fillSubMask2">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </button>
+
+          <button class="spectrum-Button spectrum-Button--fill spectrum-Button--negative spectrum-Button--sizeM is-pending" disabled>
+            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-icon-18-Edit" />
+            </svg>
+            <span class="spectrum-Button-label">Edit</span>
             <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small">
               <div class="spectrum-ProgressCircle-track"></div>
               <div class="spectrum-ProgressCircle-fills">
@@ -67,6 +116,9 @@ examples:
           </button>
 
           <button class="spectrum-Button spectrum-Button--fill spectrum-Button--negative spectrum-Button--iconOnly spectrum-Button--sizeM is-pending" disabled>
+            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-icon-18-Edit" />
+            </svg>
             <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small">
               <div class="spectrum-ProgressCircle-track"></div>
               <div class="spectrum-ProgressCircle-fills">
@@ -88,6 +140,29 @@ examples:
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">L</h4>
           <button class="spectrum-Button spectrum-Button--fill spectrum-Button--primary spectrum-Button--sizeL is-pending" disabled>
+            <span class="spectrum-Button-label">Edit</span>
+            <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small">
+              <div class="spectrum-ProgressCircle-track"></div>
+              <div class="spectrum-ProgressCircle-fills">
+                <div class="spectrum-ProgressCircle-fillMask1">
+                  <div class="spectrum-ProgressCircle-fillSubMask1">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+                <div class="spectrum-ProgressCircle-fillMask2">
+                  <div class="spectrum-ProgressCircle-fillSubMask2">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </button>
+
+          <button class="spectrum-Button spectrum-Button--fill spectrum-Button--primary spectrum-Button--sizeL is-pending" disabled>
+            <svg class="spectrum-Icon spectrum-Icon--sizeL" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-icon-18-Edit" />
+            </svg>
+            <span class="spectrum-Button-label">Edit</span>
             <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small">
               <div class="spectrum-ProgressCircle-track"></div>
               <div class="spectrum-ProgressCircle-fills">
@@ -106,6 +181,9 @@ examples:
           </button>
 
           <button class="spectrum-Button spectrum-Button--fill spectrum-Button--primary spectrum-Button--iconOnly spectrum-Button--sizeL is-pending" disabled>
+            <svg class="spectrum-Icon spectrum-Icon--sizeL" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-icon-18-Edit" />
+            </svg>
             <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small">
               <div class="spectrum-ProgressCircle-track"></div>
               <div class="spectrum-ProgressCircle-fills">
@@ -127,6 +205,29 @@ examples:
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">XL</h4>
           <button class="spectrum-Button spectrum-Button--fill spectrum-Button--secondary spectrum-Button--sizeXL is-pending" disabled>
+            <span class="spectrum-Button-label">Edit</span>
+            <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small">
+              <div class="spectrum-ProgressCircle-track"></div>
+              <div class="spectrum-ProgressCircle-fills">
+                <div class="spectrum-ProgressCircle-fillMask1">
+                  <div class="spectrum-ProgressCircle-fillSubMask1">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+                <div class="spectrum-ProgressCircle-fillMask2">
+                  <div class="spectrum-ProgressCircle-fillSubMask2">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </button>
+
+          <button class="spectrum-Button spectrum-Button--fill spectrum-Button--secondary spectrum-Button--sizeXL is-pending" disabled>
+            <svg class="spectrum-Icon spectrum-Icon--sizeXL" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-icon-18-Edit" />
+            </svg>
+            <span class="spectrum-Button-label">Edit</span>
             <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small">
               <div class="spectrum-ProgressCircle-track"></div>
               <div class="spectrum-ProgressCircle-fills">
@@ -145,6 +246,9 @@ examples:
           </button>
 
           <button class="spectrum-Button spectrum-Button--fill spectrum-Button--secondary spectrum-Button--iconOnly spectrum-Button--sizeXL is-pending" disabled>
+            <svg class="spectrum-Icon spectrum-Icon--sizeXL" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-icon-18-Edit" />
+            </svg>
             <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small">
               <div class="spectrum-ProgressCircle-track"></div>
               <div class="spectrum-ProgressCircle-fills">
@@ -170,6 +274,29 @@ examples:
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">S</h4>
           <button class="spectrum-Button spectrum-Button--accent spectrum-Button--outline spectrum-Button--sizeS is-pending" disabled>
+            <span class="spectrum-Button-label">Edit</span>
+            <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small">
+              <div class="spectrum-ProgressCircle-track"></div>
+              <div class="spectrum-ProgressCircle-fills">
+                <div class="spectrum-ProgressCircle-fillMask1">
+                  <div class="spectrum-ProgressCircle-fillSubMask1">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+                <div class="spectrum-ProgressCircle-fillMask2">
+                  <div class="spectrum-ProgressCircle-fillSubMask2">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </button>
+
+          <button class="spectrum-Button spectrum-Button--accent spectrum-Button--outline spectrum-Button--sizeS is-pending" disabled>
+            <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-icon-18-Edit" />
+            </svg>
+            <span class="spectrum-Button-label">Edit</span>
             <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small">
               <div class="spectrum-ProgressCircle-track"></div>
               <div class="spectrum-ProgressCircle-fills">
@@ -188,6 +315,9 @@ examples:
           </button>
 
           <button class="spectrum-Button spectrum-Button--accent spectrum-Button--outline spectrum-Button--iconOnly spectrum-Button--sizeS is-pending" disabled>
+            <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-icon-18-Edit" />
+            </svg>
             <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small">
               <div class="spectrum-ProgressCircle-track"></div>
               <div class="spectrum-ProgressCircle-fills">
@@ -209,6 +339,29 @@ examples:
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">M (default)</h4>
           <button class="spectrum-Button spectrum-Button--negative spectrum-Button--outline spectrum-Button--sizeM is-pending" disabled>
+            <span class="spectrum-Button-label">Edit</span>
+            <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small">
+              <div class="spectrum-ProgressCircle-track"></div>
+              <div class="spectrum-ProgressCircle-fills">
+                <div class="spectrum-ProgressCircle-fillMask1">
+                  <div class="spectrum-ProgressCircle-fillSubMask1">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+                <div class="spectrum-ProgressCircle-fillMask2">
+                  <div class="spectrum-ProgressCircle-fillSubMask2">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </button>
+
+          <button class="spectrum-Button spectrum-Button--negative spectrum-Button--outline spectrum-Button--sizeM is-pending" disabled>
+            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-icon-18-Edit" />
+            </svg>
+            <span class="spectrum-Button-label">Edit</span>
             <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small">
               <div class="spectrum-ProgressCircle-track"></div>
               <div class="spectrum-ProgressCircle-fills">
@@ -227,6 +380,9 @@ examples:
           </button>
 
           <button class="spectrum-Button spectrum-Button--negative spectrum-Button--outline spectrum-Button--iconOnly spectrum-Button--sizeM is-pending" disabled>
+            <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-icon-18-Edit" />
+            </svg>
             <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small">
               <div class="spectrum-ProgressCircle-track"></div>
               <div class="spectrum-ProgressCircle-fills">
@@ -248,6 +404,29 @@ examples:
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">L</h4>
           <button class="spectrum-Button spectrum-Button--primary spectrum-Button--outline spectrum-Button--sizeL is-pending" disabled>
+            <span class="spectrum-Button-label">Edit</span>
+            <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small">
+              <div class="spectrum-ProgressCircle-track"></div>
+              <div class="spectrum-ProgressCircle-fills">
+                <div class="spectrum-ProgressCircle-fillMask1">
+                  <div class="spectrum-ProgressCircle-fillSubMask1">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+                <div class="spectrum-ProgressCircle-fillMask2">
+                  <div class="spectrum-ProgressCircle-fillSubMask2">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </button>
+
+          <button class="spectrum-Button spectrum-Button--primary spectrum-Button--outline spectrum-Button--sizeL is-pending" disabled>
+            <svg class="spectrum-Icon spectrum-Icon--sizeL" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-icon-18-Edit" />
+            </svg>
+            <span class="spectrum-Button-label">Edit</span>
             <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small">
               <div class="spectrum-ProgressCircle-track"></div>
               <div class="spectrum-ProgressCircle-fills">
@@ -266,6 +445,9 @@ examples:
           </button>
 
           <button class="spectrum-Button spectrum-Button--primary spectrum-Button--outline spectrum-Button--iconOnly spectrum-Button--sizeL is-pending" disabled>
+            <svg class="spectrum-Icon spectrum-Icon--sizeL" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-icon-18-Edit" />
+            </svg>
             <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small">
               <div class="spectrum-ProgressCircle-track"></div>
               <div class="spectrum-ProgressCircle-fills">
@@ -287,6 +469,29 @@ examples:
         <div class="spectrum-Examples-item">
           <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">XL</h4>
           <button class="spectrum-Button spectrum-Button--secondary spectrum-Button--outline spectrum-Button--sizeXL is-pending" disabled>
+            <span class="spectrum-Button-label">Edit</span>
+            <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small">
+              <div class="spectrum-ProgressCircle-track"></div>
+              <div class="spectrum-ProgressCircle-fills">
+                <div class="spectrum-ProgressCircle-fillMask1">
+                  <div class="spectrum-ProgressCircle-fillSubMask1">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+                <div class="spectrum-ProgressCircle-fillMask2">
+                  <div class="spectrum-ProgressCircle-fillSubMask2">
+                    <div class="spectrum-ProgressCircle-fill"></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </button>
+
+          <button class="spectrum-Button spectrum-Button--secondary spectrum-Button--outline spectrum-Button--sizeXL is-pending" disabled>
+            <svg class="spectrum-Icon spectrum-Icon--sizeXL" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-icon-18-Edit" />
+            </svg>
+            <span class="spectrum-Button-label">Edit</span>
             <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small">
               <div class="spectrum-ProgressCircle-track"></div>
               <div class="spectrum-ProgressCircle-fills">
@@ -305,6 +510,9 @@ examples:
           </button>
 
           <button class="spectrum-Button spectrum-Button--secondary spectrum-Button--outline spectrum-Button--iconOnly spectrum-Button--sizeXL is-pending" disabled>
+            <svg class="spectrum-Icon spectrum-Icon--sizeXL" focusable="false" aria-hidden="true">
+              <use xlink:href="#spectrum-icon-18-Edit" />
+            </svg>
             <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small">
               <div class="spectrum-ProgressCircle-track"></div>
               <div class="spectrum-ProgressCircle-fills">
@@ -332,6 +540,29 @@ examples:
           <div class="spectrum-Examples-item">
             <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">S</h4>
             <button class="spectrum-Button spectrum-Button--fill spectrum-Button--staticWhite spectrum-Button--sizeS is-pending" disabled>
+              <span class="spectrum-Button-label">Edit</span>
+              <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small spectrum-ProgressCircle--staticWhite">
+                <div class="spectrum-ProgressCircle-track"></div>
+                <div class="spectrum-ProgressCircle-fills">
+                  <div class="spectrum-ProgressCircle-fillMask1">
+                    <div class="spectrum-ProgressCircle-fillSubMask1">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                  <div class="spectrum-ProgressCircle-fillMask2">
+                    <div class="spectrum-ProgressCircle-fillSubMask2">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </button>
+
+            <button class="spectrum-Button spectrum-Button--fill spectrum-Button--staticWhite spectrum-Button--sizeS is-pending" disabled>
+              <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+              <span class="spectrum-Button-label">Edit</span>
               <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small spectrum-ProgressCircle--staticWhite">
                 <div class="spectrum-ProgressCircle-track"></div>
                 <div class="spectrum-ProgressCircle-fills">
@@ -350,6 +581,9 @@ examples:
             </button>
 
             <button class="spectrum-Button spectrum-Button--fill spectrum-Button--staticWhite spectrum-Button--iconOnly spectrum-Button--sizeS is-pending" disabled>
+              <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
               <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small spectrum-ProgressCircle--staticWhite">
                 <div class="spectrum-ProgressCircle-track"></div>
                 <div class="spectrum-ProgressCircle-fills">
@@ -371,6 +605,29 @@ examples:
           <div class="spectrum-Examples-item">
             <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">M (default)</h4>
             <button class="spectrum-Button spectrum-Button--fill spectrum-Button--staticWhite spectrum-Button--sizeM is-pending" disabled>
+              <span class="spectrum-Button-label">Edit</span>
+              <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small spectrum-ProgressCircle--staticWhite">
+                <div class="spectrum-ProgressCircle-track"></div>
+                <div class="spectrum-ProgressCircle-fills">
+                  <div class="spectrum-ProgressCircle-fillMask1">
+                    <div class="spectrum-ProgressCircle-fillSubMask1">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                  <div class="spectrum-ProgressCircle-fillMask2">
+                    <div class="spectrum-ProgressCircle-fillSubMask2">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </button>
+
+            <button class="spectrum-Button spectrum-Button--fill spectrum-Button--staticWhite spectrum-Button--sizeM is-pending" disabled>
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+              <span class="spectrum-Button-label">Edit</span>
               <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small spectrum-ProgressCircle--staticWhite">
                 <div class="spectrum-ProgressCircle-track"></div>
                 <div class="spectrum-ProgressCircle-fills">
@@ -389,6 +646,9 @@ examples:
             </button>
 
             <button class="spectrum-Button spectrum-Button--fill spectrum-Button--staticWhite spectrum-Button--iconOnly spectrum-Button--sizeM is-pending" disabled>
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
               <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small spectrum-ProgressCircle--staticWhite">
                 <div class="spectrum-ProgressCircle-track"></div>
                 <div class="spectrum-ProgressCircle-fills">
@@ -410,6 +670,29 @@ examples:
           <div class="spectrum-Examples-item">
             <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">L</h4>
             <button class="spectrum-Button spectrum-Button--fill spectrum-Button--staticWhite spectrum-Button--sizeL is-pending" disabled>
+              <span class="spectrum-Button-label">Edit</span>
+              <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small spectrum-ProgressCircle--staticWhite">
+                <div class="spectrum-ProgressCircle-track"></div>
+                <div class="spectrum-ProgressCircle-fills">
+                  <div class="spectrum-ProgressCircle-fillMask1">
+                    <div class="spectrum-ProgressCircle-fillSubMask1">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                  <div class="spectrum-ProgressCircle-fillMask2">
+                    <div class="spectrum-ProgressCircle-fillSubMask2">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </button>
+
+            <button class="spectrum-Button spectrum-Button--fill spectrum-Button--staticWhite spectrum-Button--sizeL is-pending" disabled>
+              <svg class="spectrum-Icon spectrum-Icon--sizeL" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+              <span class="spectrum-Button-label">Edit</span>
               <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small spectrum-ProgressCircle--staticWhite">
                 <div class="spectrum-ProgressCircle-track"></div>
                 <div class="spectrum-ProgressCircle-fills">
@@ -428,6 +711,9 @@ examples:
             </button>
 
             <button class="spectrum-Button spectrum-Button--fill spectrum-Button--staticWhite spectrum-Button--iconOnly spectrum-Button--sizeL is-pending" disabled>
+              <svg class="spectrum-Icon spectrum-Icon--sizeL" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
               <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small spectrum-ProgressCircle--staticWhite">
                 <div class="spectrum-ProgressCircle-track"></div>
                 <div class="spectrum-ProgressCircle-fills">
@@ -449,6 +735,29 @@ examples:
           <div class="spectrum-Examples-item">
             <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">XL</h4>
             <button class="spectrum-Button spectrum-Button--fill spectrum-Button--staticWhite spectrum-Button--sizeXL is-pending" disabled>
+              <span class="spectrum-Button-label">Edit</span>
+              <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small spectrum-ProgressCircle--staticWhite">
+                <div class="spectrum-ProgressCircle-track"></div>
+                <div class="spectrum-ProgressCircle-fills">
+                  <div class="spectrum-ProgressCircle-fillMask1">
+                    <div class="spectrum-ProgressCircle-fillSubMask1">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                  <div class="spectrum-ProgressCircle-fillMask2">
+                    <div class="spectrum-ProgressCircle-fillSubMask2">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </button>
+
+            <button class="spectrum-Button spectrum-Button--fill spectrum-Button--staticWhite spectrum-Button--sizeXL is-pending" disabled>
+              <svg class="spectrum-Icon spectrum-Icon--sizeL" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+              <span class="spectrum-Button-label">Edit</span>
               <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small spectrum-ProgressCircle--staticWhite">
                 <div class="spectrum-ProgressCircle-track"></div>
                 <div class="spectrum-ProgressCircle-fills">
@@ -467,6 +776,9 @@ examples:
             </button>
 
             <button class="spectrum-Button spectrum-Button--fill spectrum-Button--staticWhite spectrum-Button--iconOnly spectrum-Button--sizeXL is-pending" disabled>
+              <svg class="spectrum-Icon spectrum-Icon--sizeXL" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
               <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small spectrum-ProgressCircle--staticWhite">
                 <div class="spectrum-ProgressCircle-track"></div>
                 <div class="spectrum-ProgressCircle-fills">
@@ -495,6 +807,29 @@ examples:
           <div class="spectrum-Examples-item">
             <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">S</h4>
             <button class="spectrum-Button spectrum-Button--staticWhite spectrum-Button--outline spectrum-Button--sizeS is-pending" disabled>
+              <span class="spectrum-Button-label">Edit</span>
+              <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small spectrum-ProgressCircle--staticWhite">
+                <div class="spectrum-ProgressCircle-track"></div>
+                <div class="spectrum-ProgressCircle-fills">
+                  <div class="spectrum-ProgressCircle-fillMask1">
+                    <div class="spectrum-ProgressCircle-fillSubMask1">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                  <div class="spectrum-ProgressCircle-fillMask2">
+                    <div class="spectrum-ProgressCircle-fillSubMask2">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </button>
+
+            <button class="spectrum-Button spectrum-Button--staticWhite spectrum-Button--outline spectrum-Button--sizeS is-pending" disabled>
+              <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+              <span class="spectrum-Button-label">Edit</span>
               <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small spectrum-ProgressCircle--staticWhite">
                 <div class="spectrum-ProgressCircle-track"></div>
                 <div class="spectrum-ProgressCircle-fills">
@@ -513,6 +848,9 @@ examples:
             </button>
 
             <button class="spectrum-Button spectrum-Button--staticWhite spectrum-Button--outline spectrum-Button--iconOnly spectrum-Button--sizeS is-pending" disabled>
+              <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
               <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small spectrum-ProgressCircle--staticWhite">
                 <div class="spectrum-ProgressCircle-track"></div>
                 <div class="spectrum-ProgressCircle-fills">
@@ -534,6 +872,29 @@ examples:
           <div class="spectrum-Examples-item">
             <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">M (default)</h4>
             <button class="spectrum-Button spectrum-Button--staticWhite spectrum-Button--outline spectrum-Button--sizeM is-pending" disabled>
+              <span class="spectrum-Button-label">Edit</span>
+              <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small spectrum-ProgressCircle--staticWhite">
+                <div class="spectrum-ProgressCircle-track"></div>
+                <div class="spectrum-ProgressCircle-fills">
+                  <div class="spectrum-ProgressCircle-fillMask1">
+                    <div class="spectrum-ProgressCircle-fillSubMask1">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                  <div class="spectrum-ProgressCircle-fillMask2">
+                    <div class="spectrum-ProgressCircle-fillSubMask2">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </button>
+
+            <button class="spectrum-Button spectrum-Button--staticWhite spectrum-Button--outline spectrum-Button--sizeM is-pending" disabled>
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+              <span class="spectrum-Button-label">Edit</span>
               <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small spectrum-ProgressCircle--staticWhite">
                 <div class="spectrum-ProgressCircle-track"></div>
                 <div class="spectrum-ProgressCircle-fills">
@@ -552,6 +913,9 @@ examples:
             </button>
 
             <button class="spectrum-Button spectrum-Button--staticWhite spectrum-Button--outline spectrum-Button--iconOnly spectrum-Button--sizeM is-pending" disabled>
+              <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
               <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small spectrum-ProgressCircle--staticWhite">
                 <div class="spectrum-ProgressCircle-track"></div>
                 <div class="spectrum-ProgressCircle-fills">
@@ -573,6 +937,29 @@ examples:
           <div class="spectrum-Examples-item">
             <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">L</h4>
             <button class="spectrum-Button spectrum-Button--staticWhite spectrum-Button--outline spectrum-Button--sizeL is-pending" disabled>
+              <span class="spectrum-Button-label">Edit</span>
+              <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small spectrum-ProgressCircle--staticWhite">
+                <div class="spectrum-ProgressCircle-track"></div>
+                <div class="spectrum-ProgressCircle-fills">
+                  <div class="spectrum-ProgressCircle-fillMask1">
+                    <div class="spectrum-ProgressCircle-fillSubMask1">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                  <div class="spectrum-ProgressCircle-fillMask2">
+                    <div class="spectrum-ProgressCircle-fillSubMask2">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </button>
+
+            <button class="spectrum-Button spectrum-Button--staticWhite spectrum-Button--outline spectrum-Button--sizeL is-pending" disabled>
+              <svg class="spectrum-Icon spectrum-Icon--sizeL" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+              <span class="spectrum-Button-label">Edit</span>
               <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small spectrum-ProgressCircle--staticWhite">
                 <div class="spectrum-ProgressCircle-track"></div>
                 <div class="spectrum-ProgressCircle-fills">
@@ -591,6 +978,9 @@ examples:
             </button>
 
             <button class="spectrum-Button spectrum-Button--staticWhite spectrum-Button--outline spectrum-Button--iconOnly spectrum-Button--sizeL is-pending" disabled>
+              <svg class="spectrum-Icon spectrum-Icon--sizeL" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
               <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small spectrum-ProgressCircle--staticWhite">
                 <div class="spectrum-ProgressCircle-track"></div>
                 <div class="spectrum-ProgressCircle-fills">
@@ -612,6 +1002,29 @@ examples:
           <div class="spectrum-Examples-item">
             <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">XL</h4>
             <button class="spectrum-Button spectrum-Button--staticWhite spectrum-Button--outline spectrum-Button--sizeXL is-pending" disabled>
+              <span class="spectrum-Button-label">Edit</span>
+              <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small spectrum-ProgressCircle--staticWhite">
+                <div class="spectrum-ProgressCircle-track"></div>
+                <div class="spectrum-ProgressCircle-fills">
+                  <div class="spectrum-ProgressCircle-fillMask1">
+                    <div class="spectrum-ProgressCircle-fillSubMask1">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                  <div class="spectrum-ProgressCircle-fillMask2">
+                    <div class="spectrum-ProgressCircle-fillSubMask2">
+                      <div class="spectrum-ProgressCircle-fill"></div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </button>
+
+            <button class="spectrum-Button spectrum-Button--staticWhite spectrum-Button--outline spectrum-Button--sizeXL is-pending" disabled>
+              <svg class="spectrum-Icon spectrum-Icon--sizeXL" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
+              <span class="spectrum-Button-label">Edit</span>
               <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small spectrum-ProgressCircle--staticWhite">
                 <div class="spectrum-ProgressCircle-track"></div>
                 <div class="spectrum-ProgressCircle-fills">
@@ -630,6 +1043,9 @@ examples:
             </button>
 
             <button class="spectrum-Button spectrum-Button--staticWhite spectrum-Button--outline spectrum-Button--iconOnly spectrum-Button--sizeXL is-pending" disabled>
+              <svg class="spectrum-Icon spectrum-Icon--sizeXL" focusable="false" aria-hidden="true">
+                <use xlink:href="#spectrum-icon-18-Edit" />
+              </svg>
               <div class="spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate spectrum-ProgressCircle--small spectrum-ProgressCircle--staticWhite">
                 <div class="spectrum-ProgressCircle-track"></div>
                 <div class="spectrum-ProgressCircle-fills">

--- a/components/button/stories/button.stories.js
+++ b/components/button/stories/button.stories.js
@@ -74,11 +74,15 @@ export default {
 			name: "Pending",
 			type: { name: "boolean" },
 			table: {
-				type: { summary: "boolean" },
-				category: "State",
+				disable: true
 			},
-			control: "boolean",
-			if: { arg: "staticColor", neq: "black" }
+		},
+		isPendingStory: {
+			name: "Pending story",
+			type: { name: "boolean" },
+			table: {
+				disable: true,
+			},
 		},
 		staticColor: {
 			name: "Static color",
@@ -87,9 +91,11 @@ export default {
 			table: {
 				type: { summary: "string" },
 				category: "Advanced",
+
 			},
 			options: ["white", "black"],
 			control: "select",
+			if: { arg: "isPendingStory", truthy: false },
 		},
 		showIconOnlyButton: {
 			table: {
@@ -100,7 +106,7 @@ export default {
 		    name: "Layout",
 		    description: "How the buttons align in the preview (Storybook only).",
 		    type: { name: "string" },
-			table: { 
+			table: {
 			    type: { summary: "string" },
 			    category: "Advanced"
 			},
@@ -194,12 +200,21 @@ const CustomButton = ({
 const PendingButton = ({
 	staticColor,
 	customStyles = {},
+	layout,
 	...args
 }) => html`
+	${when(!window.isChromatic(), () =>
+		Typography({
+			semantics: "heading",
+			size: "xs",
+			content: ["Press any button to show the pending state on all buttons. Press again to remove the pending states."],
+		})
+	)}
 	<div style=${styleMap({
 		display: "flex",
 		flexDirection: "column",
 		gap: ".3rem",
+		marginTop: "1rem"
 	})}>
 		<div>
 			${Typography({
@@ -209,6 +224,25 @@ const PendingButton = ({
 			})}
 			${CustomButton({
 				...args,
+			})}
+			${ButtonWrap(layout = "stacked", Template({
+				...args,
+				staticColor,
+				label: "An example of text overflow behavior within the button component. When the button text is too long for the horizontal space available, it wraps to form another line.",
+			}))}
+			${when(window.isChromatic(), () => {
+				return html`
+					${CustomButton({
+						...args,
+						isPending: true,
+					})}
+
+					${ButtonWrap(layout = "stacked", Template({
+						...args,
+						label: "An example of text overflow behavior within the button component. When the button text is too long for the horizontal space available, it wraps to form another line.",
+						isPending: true,
+					}))}
+				`;
 			})}
 		</div>
 		<div>
@@ -220,6 +254,42 @@ const PendingButton = ({
 			${CustomButton({
 				...args,
 				staticColor: "white",
+			})}
+			<div
+				style=${ifDefined(styleMap({
+					padding: "1rem",
+					backgroundColor: "rgb(15, 121, 125)",
+					...customStyles
+				}))}
+			>
+				${ButtonWrap(layout = "stacked", Template({
+					...args,
+					staticColor: "white",
+					label: "An example of text overflow behavior within the button component. When the button text is too long for the horizontal space available, it wraps to form another line.",
+				}))}
+			</div>
+			${when(window.isChromatic(), () => {
+				return html`
+					${CustomButton({
+						...args,
+						staticColor: "white",
+						isPending: true,
+					})}
+					<div
+						style=${ifDefined(styleMap({
+							padding: "1rem",
+							backgroundColor: "rgb(15, 121, 125)",
+							...customStyles
+						}))}
+					>
+						${ButtonWrap(layout = "stacked", Template({
+							...args,
+							staticColor: "white",
+							label: "An example of text overflow behavior within the button component. When the button text is too long for the horizontal space available, it wraps to form another line.",
+							isPending: true,
+						}))}
+					</div>
+				`;
 			})}
 		</div>
 	</div>
@@ -330,8 +400,7 @@ Disabled.args = {
 
 export const Pending = PendingButton.bind({});
 Pending.args = {
-	isDisabled: true,
-	isPending: true,
+	isPendingStory: true,
 };
 
 export const WithForcedColors = ButtonsWithForcedColors.bind({});

--- a/components/button/stories/template.js
+++ b/components/button/stories/template.js
@@ -1,3 +1,4 @@
+import { useArgs } from "@storybook/client-api";
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
@@ -27,6 +28,7 @@ export const Template = ({
   onclick,
   isDisabled = false,
   isPending = false,
+  isPendingStory = false,
   ariaExpanded,
   ariaControls,
   ...globals
@@ -38,6 +40,8 @@ export const Template = ({
 	} catch (e) {
 		console.warn(e);
 	}
+
+  const [, updateArgs] = useArgs();
 
   return html`
     <button
@@ -54,7 +58,11 @@ export const Template = ({
       id=${ifDefined(id)}
       style=${ifDefined(styleMap(customStyles))}
       ?disabled=${isDisabled}
-      @click=${onclick}
+      @click=${!isPendingStory ? onclick : () => {
+        isPending
+          ? updateArgs({ isPending: false })
+          : updateArgs({ isPending: true });
+      }}
       aria-label=${ifDefined(hideLabel ? iconName : undefined)}
       aria-expanded=${ifDefined(ariaExpanded?.toString())}
       aria-controls=${ifDefined(ariaControls)}
@@ -64,11 +72,16 @@ export const Template = ({
         () => html`<span class=${`${rootClass}-label`}>${label}</span>`
       )}
       ${when(iconName && iconAfterLabel, () => Icon({ ...globals, iconName, size }))}
-      ${when(isPending, () => {
-          const isOverBackground = staticColor === 'white';
-          return ProgressCircle({ ...globals, size: 's', overBackground: isOverBackground, isIndeterminate: true, addStaticBackground: false })
-        }
-      )}
+      ${when(isPendingStory, () => {
+        const isOverBackground = staticColor === 'white';
+        return ProgressCircle({
+          ...globals,
+          size: 's',
+          overBackground: isOverBackground,
+          isIndeterminate: true,
+          addStaticBackground: false
+        })
+      })}
     </button>
   `;
 };

--- a/components/progresscircle/index.css
+++ b/components/progresscircle/index.css
@@ -70,7 +70,7 @@ governing permissions and limitations under the License.
                   var(--spectrum-progress-circle-size));
   block-size: var(--mod-progress-circle-size,
                   var(--spectrum-progress-circle-size));
-  position: relative;
+  position: var(--mod-progress-circle-position, relative);
   direction: ltr;
 
   /* Fix for Safari rendering bug */

--- a/components/progresscircle/metadata/mods.md
+++ b/components/progresscircle/metadata/mods.md
@@ -2,6 +2,7 @@
 | ---------------------------------------------------------- |
 | `--mod-progress-circle-fill-border-color`                  |
 | `--mod-progress-circle-fill-border-color-over-background`  |
+| `--mod-progress-circle-position`                           |
 | `--mod-progress-circle-size`                               |
 | `--mod-progress-circle-thickness`                          |
 | `--mod-progress-circle-track-border-color`                 |


### PR DESCRIPTION
## Description

This PR addresses [two issues SWC reported](https://adobedesign.slack.com/archives/G019JTYMT6H/p1708595849739049?thread_ts=1705006780.231489&cid=G019JTYMT6H) with Button's pending state:

- Button width was not being preserved when pending state was activated
- No animation/transition provided when going to pending state

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
- [x] Design validation for animation/transition ([done in slack](https://adobedesign.slack.com/archives/GQ09RCBA5/p1709239247585639?thread_ts=1708963456.726899&cid=GQ09RCBA5)) @mdt2 
- [x] Validate with SWC @mdt2 
- [x] In the [Pending button story](https://64762974a45b8bc5ca1705a2-nlnkpwsabm.chromatic.com/?path=/story/components-button--pending), when you click on a button: @jawinn 
  - [x] All buttons show pending state
  - [x] Smooth transition occurs between states when you click the button (you may need to use Storybook's "[open Canvas in new tab](https://64762974a45b8bc5ca1705a2-nlnkpwsabm.chromatic.com/iframe.html?id=components-button--pending&viewMode=story)" to see a less choppy version of the transition)
  - [x] Width is preserved when you click the button
  - [x] T-shirt sizes are correct, specifically the height of the icon-only version is the same as the other variants at the various t-shirt sizes
- [x] [Docs site pending page](https://pr-2570--spectrum-css.netlify.app/button-pending) still looks good (had to update the markup to better reflect ✨ reality ✨)

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [ ] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
