### PR TITLE
chore: minor accordion story updates

### DIFF
--- a/.storybook/DocumentationTemplate.mdx
+++ b/.storybook/DocumentationTemplate.mdx
@@ -2,15 +2,12 @@
 
 import { Meta, Title, Subtitle, Description, Primary, Controls, Stories } from '@storybook/blocks';
 
-{/* 
-  * 👇 The isTemplate property is required to tell Storybook that this is a template
-  * See https://storybook.js.org/docs/react/api/doc-block-meta
-  * to learn how to use
-*/}
-
+{/* 👇 The isTemplate property is required to tell Storybook that this is a template */}
 <Meta isTemplate />
 
 <Title />
+<Subtitle />
+<Description />
 
 <Primary />
 
@@ -19,3 +16,5 @@ import { Meta, Title, Subtitle, Description, Primary, Controls, Stories } from '
 The component accepts the following inputs (properties):
 
 <Controls />
+
+<Stories includePrimary={ false } />

--- a/components/accordion/stories/accordion.stories.js
+++ b/components/accordion/stories/accordion.stories.js
@@ -1,9 +1,13 @@
 import { html } from "lit";
-import { when } from "lit/directives/when.js";
+import { styleMap } from "lit/directives/style-map.js";
 
-import { Template } from "./template";
+import { Template } from "@spectrum-css/accordion/stories/template.js";
+import { Template as Link } from "@spectrum-css/link/stories/template.js";
+import { Template as Typography } from "@spectrum-css/typography/stories/template.js";
 
-/** The accordion element contains a list of items that can be expanded or collapsed to reveal additional content or information associated with each item. There can be zero expanded items, exactly one expanded item, or more than one item expanded at a time, depending on the configuration. This list of items is defined by child accordion item elements. */
+/**
+ * The accordion element contains a list of items that can be expanded or collapsed to reveal additional content or information associated with each item. There can be zero expanded items, exactly one expanded item, or more than one item expanded at a time, depending on the configuration. This list of items is defined by child accordion item elements.
+ */
 export default {
 	title: "Components/Accordion",
 	component: "Accordion",
@@ -132,11 +136,6 @@ export default {
 				},
 			]
 		]),
-		customStorybookStyles: {
-			display: "flex",
-			flexWrap: "wrap",
-			gap: "2rem",
-		},
 	},
 	parameters: {
 		actions: {
@@ -151,21 +150,25 @@ export default {
 };
 
 const AccordionGroup = (args) => html`
-	${Template(args)}
-	${when(window.isChromatic(), () =>
-		Template({
-			...args,
-			customStyles: {
-				maxInlineSize: "300px",
-			},
-		})
-	)}
-	${when(window.isChromatic(), () =>
-		Template({
-			...args,
-			disableAll: true,
-		})
-	)}
+	${window.isChromatic() ? html`
+		<div style=${styleMap({
+			display: "flex",
+			flexWrap: "wrap",
+			gap: "2em"
+		})}>
+			${Template(args)}
+			${Template({
+				...args,
+				customStyles: {
+					maxInlineSize: "300px",
+				},
+			})}
+			${Template({
+				...args,
+				disableAll: true,
+			})}
+		</div>
+	` : Template(args)}
 `;
 
 export const Default = AccordionGroup.bind({});

--- a/components/accordion/stories/accordion.stories.js
+++ b/components/accordion/stories/accordion.stories.js
@@ -3,10 +3,9 @@ import { when } from "lit/directives/when.js";
 
 import { Template } from "./template";
 
+/** The accordion element contains a list of items that can be expanded or collapsed to reveal additional content or information associated with each item. There can be zero expanded items, exactly one expanded item, or more than one item expanded at a time, depending on the configuration. This list of items is defined by child accordion item elements. */
 export default {
 	title: "Components/Accordion",
-	description:
-		"The accordion element contains a list of items that can be expanded or collapsed to reveal additional content or information associated with each item. There can be zero expanded items, exactly one expanded item, or more than one item expanded at a time, depending on the configuration. This list of items is defined by child accordion item elements.",
 	component: "Accordion",
 	argTypes: {
 		items: { table: { disable: true } },
@@ -45,6 +44,99 @@ export default {
 		size: "m",
 		density: "regular",
 		disableAll: false,
+		/* Content sourced from: https://www.adobe.com/products/catalog.html#:~:text=Frequently%20asked%20questions. */
+		items: new Map([
+			[
+				"Are any Adobe products free?",
+				{
+					content:
+						"Yes, Adobe offers free products like Acrobat Reader, Aero, Fill & Sign, Photoshop Express, and Adobe Scan. You can also use Creative Cloud Express, Fresco, and Lightroom Mobile for free, with the option of making in-app purchases.",
+					isDisabled: true,
+				},
+			],
+			[
+				"Are Adobe products worth it?",
+				{
+					content: Typography({
+						semantics: "body",
+						content: [
+							"Adobe makes some of the most widely used software applications in the world, many of which are industry standard. Get started with free apps like Adobe Acrobat Reader, Aero, Fill & Sign, Photoshop Express, and Adobe Scan. Or consider Creative Cloud, with plans starting at just US$9.99/mo. Every Adobe Creative Cloud plan includes perks like free stock images and fonts, collaboration tools, and cloud storage as well as regular feature updates to deliver the latest technology.",
+							Link({
+								url: "https://www.adobe.com/creativecloud/plans.html",
+								text: "Learn more about Adobe Creative Cloud plans and pricing.",
+							}),
+						],
+					}),
+					isOpen: true,
+				},
+			],
+			[
+				"Which Adobe product is best for editing PDFs?",
+				{
+					content: Typography({
+						semantics: "body",
+						content: [
+							"You can edit PDFs with Adobe Acrobat, which is available in two editions: Standard and Pro. Acrobat Standard provides basic tools to create, edit, and sign PDFs on Windows devices. Acrobat Pro is the complete PDF solution with tools to edit, convert, and sign PDFs across web, mobile, and tablet, as well as on Windows and macOS computers. If you'd like to try before you buy, you can get a free 7-day trial of Acrobat Pro.",
+							Link({
+								url: "https://www.adobe.com/acrobat.html",
+								text: "Learn more about Acrobat.",
+							}),
+						],
+					}),
+				},
+			],
+			[
+				"How many products does Adobe have?",
+				{
+					content:
+						"Adobe offers nearly 100 products. Get creative with industry-standard apps like Adobe Photoshop, Illustrator InDesign, and Lightroom. Create, edit, and sign PDFs with Adobe Acrobat and Acrobat Sign. And deliver exceptional customer experiences with our marketing and commerce apps such as Adobe Experience Manager, Campaign, and Target.",
+					isOpen: true,
+				},
+			],
+			[
+				"How much do Adobe products cost?",
+				{
+					content: Typography({
+						semantics: "body",
+						content: [
+							"Creative Cloud plans start at US$9.99/mo. You can subscribe to specific Single App plans or get 20+ creative apps and services in the Creative Cloud All Apps plan.",
+							Link({
+								url: "https://www.adobe.com/creativecloud/plans.html",
+								text: "Explore Creative Cloud plans.",
+							}),
+						],
+					}),
+				},
+			],
+			[
+				"What are the most popular Adobe products?",
+				{
+					content:
+						"Adobe makes some of the most widely used software in the world, including popular apps like Acrobat Pro, Photoshop, Illustrator, InDesign, Lightroom, and Premiere Pro.",
+				},
+			],
+			[
+				"How can I get a student discount on Adobe products?",
+				{
+					content: Typography({
+						semantics: "body",
+						content: [
+							`Students who provide a valid school-issued email address at purchase are eligible to save over 60% on Creative Cloud All Apps, which includes 20+ apps such as Photoshop, Illustrator, InDesign, Acrobat Pro, and more. ${Link(
+								{
+									url: "https://www.adobe.com/creativecloud/buy/students.html",
+									text: "Learn more about Creative Cloud for students.",
+								}
+							)}`,
+						],
+					}),
+				},
+			]
+		]),
+		customStorybookStyles: {
+			display: "flex",
+			flexWrap: "wrap",
+			gap: "2rem",
+		},
 	},
 	parameters: {
 		actions: {
@@ -53,133 +145,28 @@ export default {
 		status: {
 			type: process.env.MIGRATED_PACKAGES.includes("accordion")
 				? "migrated"
-				: undefined,
+				: "legacy",
 		},
 	},
 };
 
-const AccordionGroup = ({
-	customStyles = {},
-	...args
-}) => {
-	return html`
-		<div style="display: flex; gap: 2rem;">
-			${Template({
-				...args,
-				items: new Map([
-				[
-					"Recent",
-					{
-						content: "Item 1",
-						isOpen: true,
-						isDisabled: false,
-					},
-				],
-				[
-					"Architecture",
-					{
-						content: "Item 2",
-						isOpen: false,
-						isDisabled: true,
-					},
-				],
-				[
-					"Nature",
-					{
-						content: "Item 3",
-						isOpen: false,
-						isDisabled: false,
-					},
-				],
-				[
-					"Really Long Accordion Item that should wrap",
-					{
-						content: "Really long content that should wrap when component has a max or fixed width",
-						isOpen: true,
-						isDisabled: false,
-					},
-				],
-			]),
-			})}
-			${when(window.isChromatic(), () =>
-				Template({
-					...args,
-					customStyles: { "max-inline-size": "300px"},
-					items: new Map([
-					[
-						"Recent",
-						{
-							content: "Item 1",
-							isOpen: true,
-							isDisabled: false,
-						},
-					],
-					[
-						"Architecture",
-						{
-							content: "Item 2",
-							isOpen: false,
-							isDisabled: true,
-						},
-					],
-					[
-						"Nature",
-						{
-							content: "Item 3",
-							isOpen: false,
-							isDisabled: false,
-						},
-					],
-					[
-						"Really Long Accordion Item that should wrap",
-						{
-							content: "Really long content that should wrap when component has a max or fixed width",
-							isOpen: true,
-							isDisabled: false,
-						},
-					],
-				]),
-				})
-			)}
-			${when(window.isChromatic(), () =>
-				Template({
-					...args,
-					disableAll: true,
-					items: new Map([
-					[
-						"Recent",
-						{
-							content: "Item 1",
-							isOpen: true,
-						},
-					],
-					[
-						"Architecture",
-						{
-							content: "Item 2",
-							isOpen: false,
-						},
-					],
-					[
-						"Nature",
-						{
-							content: "Item 3",
-							isOpen: false,
-						},
-					],
-					[
-						"Really Long Accordion Item that should wrap",
-						{
-							content: "Really long content that should wrap when component has a max or fixed width",
-							isOpen: true,
-						},
-					],
-				]),
-				})
-			)}
-		</div>
-	`;
-};
+const AccordionGroup = (args) => html`
+	${Template(args)}
+	${when(window.isChromatic(), () =>
+		Template({
+			...args,
+			customStyles: {
+				maxInlineSize: "300px",
+			},
+		})
+	)}
+	${when(window.isChromatic(), () =>
+		Template({
+			...args,
+			disableAll: true,
+		})
+	)}
+`;
 
 export const Default = AccordionGroup.bind({});
 Default.args = {};

--- a/components/accordion/stories/template.js
+++ b/components/accordion/stories/template.js
@@ -23,52 +23,55 @@ export const AccordionItem = ({
 	customClasses = [],
 	onclick,
 	...globals
-}) => html`
-	<div
-		class=${classMap({
-			[rootClass]: true,
-			"is-open": isOpen,
-			"is-disabled": isDisabled,
-			...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
-		})}
-		id=${ifDefined(id)}
-		style=${ifDefined(styleMap(customStyles))}
-		role="presentation"
-		@click=${onclick}
-	>
-		<!-- WAI-ARIA 1.1: Item header is a <button> wrapped within a <h3> element, rather than a <div> element with role="tab" -->
-		<h3 class="${rootClass}Heading">
-			<!-- WAI-ARIA 1.1: Item header <button> uses aria-expanded attribute to indicate expanded state. -->
-			<button
-				class="${rootClass}Header"
-				type="button"
-				?disabled=${isDisabled}
-				id="spectrum-accordion-item-${idx}-header"
-				aria-controls="spectrum-accordion-item-${idx}-content"
-				aria-expanded="${open ? "true" : "false"}"
-			>
-				${heading}
-			</button>
-			<span class="${rootClass}IconContainer">
-				${Icon({
-					uiIconName: !isOpen ? "ChevronRight" : "ChevronDown",
-					size: iconSize,
-					customClasses: [`${rootClass}Indicator`],
-					...globals,
-				})}
-			</span>
-		</h3>
-		<!-- WAI-ARIA 1.1: Item content role changed from "tabpanel" to "region" -->
+}) => {
+	return html`
 		<div
-			class="${rootClass}Content"
-			role="region"
-			id="spectrum-accordion-item-${idx}-content"
-			aria-labelledby="spectrum-accordion-item-${idx}-header"
+			class=${classMap({
+		[rootClass]: true,
+		"is-open": isOpen && !isDisabled,
+		"is-disabled": isDisabled,
+		...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
+	})}
+			id=${ifDefined(id)}
+			style=${ifDefined(styleMap(customStyles))}
+			role="presentation"
+			@click=${onclick}
 		>
-			${content}
+			<!-- WAI-ARIA 1.1: Item header is a <button> wrapped within a <h3> element, rather than a <div> element with role="tab" -->
+			<h3 class="${rootClass}Heading">
+				<!-- WAI-ARIA 1.1: Item header <button> uses aria-expanded attribute to indicate expanded state. -->
+				<button
+					class="${rootClass}Header"
+					type="button"
+					?disabled=${isDisabled}
+					id="spectrum-accordion-item-${idx}-header"
+					aria-controls="spectrum-accordion-item-${idx}-content"
+					aria-expanded="${open ? "true" : "false"}"
+				>
+					${heading}
+				</button>
+				<span class="${rootClass}IconContainer">
+					${Icon({
+						iconName: !isOpen ? "ChevronRight" : "ChevronDown",
+						setName: "ui",
+						size: iconSize,
+						customClasses: [`${rootClass}Indicator`],
+						...globals,
+					})}
+				</span>
+			</h3>
+			<!-- WAI-ARIA 1.1: Item content role changed from "tabpanel" to "region" -->
+			<div
+				class="${rootClass}Content"
+				role="region"
+				id="spectrum-accordion-item-${idx}-content"
+				aria-labelledby="spectrum-accordion-item-${idx}-header"
+			>
+				${content}
+			</div>
 		</div>
-	</div>
-`;
+	`;
+};
 
 export const Template = ({
 	rootClass = "spectrum-Accordion",
@@ -84,6 +87,7 @@ export const Template = ({
 	const [_, updateArgs] = useArgs();
 
 	if (!items || !items.size) return html``;
+
 	return html`
 		<div
 			class="${classMap({
@@ -109,6 +113,8 @@ export const Template = ({
 					isDisabled: item.isDisabled || disableAll,
 					...item,
 					onclick: () => {
+						if (item.isDisabled) return;
+
 						// Update the args
 						const newItems = new Map(items);
 						newItems.set(heading, {


### PR DESCRIPTION
## Description

A few changes to enhance the Accordion story:

- Moved the description to a [JSDoc comment](https://storybook.js.org/docs/api/doc-block-description#writing-descriptions) so it will show up in the autodocs
- Leverage practical real-world content (inspired by feedback Jess provided in a design meeting) by pulling an accordion example from the marketing site
- Move the items definition to the args to prevent duplication and simplify the template calls
- Update the import to use the package name instead of relative pathing, this will make our stories more portable
- Move disableAll usage out of the AccordionItem so that it is passed down and processed only by the parent
- Use an updateArgs from the parent via an onclick event to trigger the AccordionItem
 

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [x] Expect [new content](https://pr-2577--spectrum-css.netlify.app/preview/?path=/story/components-accordion--default) to show up in the baselines
- [x] Expect clicking on the accordion items (that are not disabled) should toggle them open and closed
- [x] Expect no other regressions in accordion styles or functionality
- [x] Expect to see the accordion description in the [Docs](https://pr-2577--spectrum-css.netlify.app/preview/?path=/docs/components-accordion--docs)

[Link to VRT preview](https://pr-2577--spectrum-css.netlify.app/preview/iframe.html?args=&globals=testingPreview:!true&id=components-accordion--default&viewMode=story)

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

5. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<img width="1185" alt="Screenshot 2024-03-04 at 11 29 13 AM" src="https://github.com/adobe/spectrum-css/assets/1840295/228d1664-ec0f-45ad-87f7-d361af43cdb0">

<img width="1083" alt="Screenshot 2024-03-04 at 11 30 26 AM" src="https://github.com/adobe/spectrum-css/assets/1840295/87108738-1136-4a66-bc16-a370c70e0291">

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] ✨ This pull request is ready to merge. ✨
