### PR TITLE
fix(menu): disabled color for value text and add disabled stories

### DIFF
--- a/components/menu/index.css
+++ b/components/menu/index.css
@@ -779,7 +779,8 @@ governing permissions and limitations under the License.
   background-color: transparent;
 
   .spectrum-Menu-itemLabel,
-  .spectrum-Menu-sectionHeading {
+  .spectrum-Menu-sectionHeading,
+  .spectrum-Menu-itemValue {
     color: var(--highcontrast-menu-item-color-disabled, var(--mod-menu-item-label-content-color-disabled, var(--spectrum-menu-item-label-content-color-disabled)));
   }
 
@@ -797,7 +798,8 @@ governing permissions and limitations under the License.
     background-color: transparent;
 
     .spectrum-Menu-itemLabel,
-    .spectrum-Menu-sectionHeading {
+    .spectrum-Menu-sectionHeading,
+    .spectrum-Menu-itemValue {
       color: var(--highcontrast-menu-item-color-disabled, var(--mod-menu-item-label-content-color-disabled, var(--spectrum-menu-item-label-content-color-disabled)));
     }
     

--- a/components/menu/stories/menu.stories.js
+++ b/components/menu/stories/menu.stories.js
@@ -328,6 +328,10 @@ WithActions.args = {
     {
       label: "Subtract",
     },
+    {
+      label: "Example of a disabled menu item",
+      isDisabled: true,
+    },
   ],
 };
 
@@ -347,6 +351,11 @@ WithValueAndActions.args = {
     {
       label: "Subtract",
       value: "Value"
+    },
+    {
+      label: "Example of a disabled menu item",
+      value: "Value",
+      isDisabled: true,
     },
   ],
 };

--- a/components/menu/stories/template.js
+++ b/components/menu/stories/template.js
@@ -1,7 +1,7 @@
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
-import { styleMap } from "lit/directives/style-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
+import { styleMap } from "lit/directives/style-map.js";
 import { when } from "lit/directives/when.js";
 
 import { Template as Checkbox } from "@spectrum-css/checkbox/stories/template.js";
@@ -109,6 +109,7 @@ export const MenuItem = ({
           size,
           isEmphasized: true,
           isChecked: isSelected,
+          isDisabled,
           id: `menu-checkbox-${idx}`,
           customClasses: [
             `${rootClass}Checkbox`,
@@ -136,6 +137,7 @@ export const MenuItem = ({
               ...globals,
               size,
               isChecked: isSelected,
+              isDisabled,
               label: null,
               id: `menu-switch-${idx}`,
               customClasses: [


### PR DESCRIPTION
## Description

Increased Storybook coverage for **Menu** and a fix for a color issue noticed when additional coverage was added.

- Updates two existing stories to include a disabled menu item with the Switch input.
- Updates disabled styles so that the value area text also appears with the disabled content color when the menu item is disabled. Confirmed on newer design spec.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [x] Disabled menu items with disabled Switches appear for two Storybook stories, _With Actions_ and _With Values and Actions_. [@castastrophe]
- [x] Value text next to switch also appears in disabled content color in  _With Values and Actions_ story. [@castastrophe]

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
