### PR TITLE
fix(commons): remove renamed mods marked for deprecation

### DIFF
--- a/components/actionbutton/metadata/actionbutton.yml
+++ b/components/actionbutton/metadata/actionbutton.yml
@@ -17,6 +17,7 @@ sections:
       Action button now uses Spectrum 2 tokens and specifications. A few notable changes:
       - The mod custom property `--mod-line-height-100` has been renamed to `--mod-button-line-height`.
       - The mod custom property `--mod-sans-font-family-stack` has been renamed to `--mod-button-font-family`.
+      - The mod custom property `--mod-animation-duration-100` has been renamed to `--mod-button-animation-duration`.
 
       ### Versions prior to 6.0.0
       #### Action Button now requires a class on its icon

--- a/components/actionbutton/metadata/actionbutton.yml
+++ b/components/actionbutton/metadata/actionbutton.yml
@@ -12,16 +12,23 @@ sections:
       This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/actionbutton/metadata/mods.md">here</a>.
   - name: Migration Guide
     description: |
-      ### Action Button now requires a class on its icon
+      ### x/x/2024 - Version 6.0.0
+      #### Spectrum 2 release
+      Action button now uses Spectrum 2 tokens and specifications. A few notable changes:
+      - The mod custom property `--mod-line-height-100` has been renamed to `--mod-button-line-height`.
+      - The mod custom property `--mod-sans-font-family-stack` has been renamed to `--mod-button-font-family`.
+
+      ### Versions prior to 6.0.0
+      #### Action Button now requires a class on its icon
       The `.spectrum-ActionButton-icon` class is now required on the icon.
 
-      ### T-shirt sizing
+      #### T-shirt sizing
       Action Button now supports t-shirt sizing and requires that you specify the size by adding a `.spectrum-ActionButton--size*` class.
 
-      ### Action Button is now a separate component
+      #### Action Button is now a separate component
       Action Button has been moved to the [Action Button](actionbutton.html) component.
 
-      ### Change workflow icon size
+      #### Change workflow icon size
 
       Previously, all Action Buttons used `.spectrum-Icon--sizeS`. This has changed:
 
@@ -33,7 +40,7 @@ sections:
       | `.spectrum-ActionButton--sizeL`  | `.spectrum-Icon--sizeL`           |
       | `.spectrum-ActionButton--sizeXL` | `.spectrum-Icon--sizeXL`          |
 
-      ### Change hold icon classnames
+      #### Change hold icon classnames
 
       Hold icon classnames must be set as follows:
 
@@ -45,10 +52,10 @@ sections:
       | `.spectrum-ActionButton--sizeL`  | `.spectrum-UIIcon-CornerTriangle200` |
       | `.spectrum-ActionButton--sizeXL` | `.spectrum-UIIcon-CornerTriangle300` |
 
-      ### Include markup for hold icon before workflow icon
+      #### Include markup for hold icon before workflow icon
       Because of the way padding is calculated, the hold icon must be placed before the workflow icon.
 
-      ### Remove focus-ring class
+      #### Remove focus-ring class
       We've migrated away from the focus-ring class in favor of the native `:focus-visible` pseudo-class due to changes in browser support.
 examples:
   - id: actionbutton-sizing

--- a/components/actionbutton/metadata/mods.md
+++ b/components/actionbutton/metadata/mods.md
@@ -53,5 +53,3 @@
 | `--mod-button-animation-duration`                                 |
 | `--mod-button-font-family`                                        |
 | `--mod-button-line-height`                                        |
-| `--mod-line-height-100`                                           |
-| `--mod-sans-font-family-stack`                                    |

--- a/components/actionbutton/metadata/mods.md
+++ b/components/actionbutton/metadata/mods.md
@@ -49,7 +49,6 @@
 | `--mod-actionbutton-min-width`                                    |
 | `--mod-actionbutton-static-content-color`                         |
 | `--mod-actionbutton-text-to-visual`                               |
-| `--mod-animation-duration-100`                                    |
 | `--mod-button-animation-duration`                                 |
 | `--mod-button-font-family`                                        |
 | `--mod-button-line-height`                                        |

--- a/components/button/metadata/button-accent.yml
+++ b/components/button/metadata/button-accent.yml
@@ -8,20 +8,27 @@ sections:
       This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/button/metadata/mods.md">here</a>.
   - name: Migration Guide
     description: |
-      ### Fill or Outline class required
+      ### x/x/2024 - Version 13.0.0
+      #### Spectrum 2 release
+      Button now uses Spectrum 2 tokens and specifications. A few notable changes:
+      - The mod custom property `--mod-line-height-100` has been renamed to `--mod-button-line-height`.
+      - The mod custom property `--mod-sans-font-family-stack` has been renamed to `--mod-button-font-family`.
+
+      ### Versions prior to 13.0.0
+      #### Fill or Outline class required
       All buttons now require either the `.spectrum-Button--fill` or `.spectrum-Button--outline` class.
 
-      ### CTA replaced by Accent with Fill
+      #### CTA replaced by Accent with Fill
       Replace all `.spectrum-Button--cta` with `.spectrum-Button--accent .spectrum-Button--fill`.
 
-      ### Icon Only
+      #### Icon Only
       Add the `.spectrum-Button--iconOnly` class to apply the correct styling when an icon is used without a label.
       Provide an `aria-label` on the button itself when using this variant for accessibility.
 
-      ### T-shirt sizing
+      #### T-shirt sizing
       Button now supports t-shirt sizing and requires that you specify the size of button by adding a `.spectrum-Button--size*` class.
 
-      ### Change workflow icon size
+      #### Change workflow icon size
 
       Previously, all Buttons used `.spectrum-Icon--sizeS`. This has changed:
 
@@ -32,7 +39,7 @@ sections:
       | `.spectrum-Button--sizeL`  | `.spectrum-Icon--sizeL`           |
       | `.spectrum-Button--sizeXL` | `.spectrum-Icon--sizeXL`          |
 
-      ### Remove focus-ring class
+      #### Remove focus-ring class
       We've migrated away from the focus-ring class in favor of the native `:focus-visible` pseudo-class due to changes in browser support.
 examples:
   - id: button-accent

--- a/components/button/metadata/button-accent.yml
+++ b/components/button/metadata/button-accent.yml
@@ -13,6 +13,7 @@ sections:
       Button now uses Spectrum 2 tokens and specifications. A few notable changes:
       - The mod custom property `--mod-line-height-100` has been renamed to `--mod-button-line-height`.
       - The mod custom property `--mod-sans-font-family-stack` has been renamed to `--mod-button-font-family`.
+      - The mod custom property `--mod-animation-duration-100` has been renamed to `--mod-button-animation-duration`.
 
       ### Versions prior to 13.0.0
       #### Fill or Outline class required

--- a/components/button/metadata/button-negative.yml
+++ b/components/button/metadata/button-negative.yml
@@ -8,23 +8,30 @@ sections:
       This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/button/metadata/mods.md">here</a>.
   - name: Migration Guide
     description: |
-      ### Fill or Outline class required
+      ### x/x/2024 - Version 13.0.0
+      #### Spectrum 2 release
+      Button now uses Spectrum 2 tokens and specifications. A few notable changes:
+      - The mod custom property `--mod-line-height-100` has been renamed to `--mod-button-line-height`.
+      - The mod custom property `--mod-sans-font-family-stack` has been renamed to `--mod-button-font-family`.
+
+      ### Versions prior to 13.0.0
+      #### Fill or Outline class required
       All buttons now require either the `.spectrum-Button--fill` or `.spectrum-Button--outline` class.
 
-      ### Negative replaced by Negative with Outline
+      #### Negative replaced by Negative with Outline
       Replace all `.spectrum-Button--negative` with `.spectrum-Button--negative .spectrum-Button--outline`.
 
-      ### Negative Quiet replaced by Negative with Outline
+      #### Negative Quiet replaced by Negative with Outline
       Replace all `.spectrum-Button--negative .spectrum-Button--quiet` with `.spectrum-Button--negative .spectrum-Button--outline`.
 
-      ### Icon Only
+      #### Icon Only
       Add the `.spectrum-Button--iconOnly` class to apply the correct styling when an icon is used without a label.
       Provide an `aria-label` on the button itself when using this variant for accessibility.
 
-      ### T-shirt sizing
+      #### T-shirt sizing
       Button now supports t-shirt sizing and requires that you specify the size of button by adding a `.spectrum-Button--size*` class.
 
-      ### Change workflow icon size
+      #### Change workflow icon size
 
       Previously, all Buttons used `.spectrum-Icon--sizeS`. This has changed:
 
@@ -35,7 +42,7 @@ sections:
       | `.spectrum-Button--sizeL`  | `.spectrum-Icon--sizeL`           |
       | `.spectrum-Button--sizeXL` | `.spectrum-Icon--sizeXL`          |
 
-      ### Remove focus-ring class
+      #### Remove focus-ring class
       We've migrated away from the focus-ring class in favor of the native `:focus-visible` pseudo-class due to changes in browser support.
 examples:
   - id: button-negative

--- a/components/button/metadata/button-negative.yml
+++ b/components/button/metadata/button-negative.yml
@@ -13,6 +13,7 @@ sections:
       Button now uses Spectrum 2 tokens and specifications. A few notable changes:
       - The mod custom property `--mod-line-height-100` has been renamed to `--mod-button-line-height`.
       - The mod custom property `--mod-sans-font-family-stack` has been renamed to `--mod-button-font-family`.
+      - The mod custom property `--mod-animation-duration-100` has been renamed to `--mod-button-animation-duration`.
 
       ### Versions prior to 13.0.0
       #### Fill or Outline class required

--- a/components/button/metadata/button-primary.yml
+++ b/components/button/metadata/button-primary.yml
@@ -13,6 +13,7 @@ sections:
       Button now uses Spectrum 2 tokens and specifications. A few notable changes:
       - The mod custom property `--mod-line-height-100` has been renamed to `--mod-button-line-height`.
       - The mod custom property `--mod-sans-font-family-stack` has been renamed to `--mod-button-font-family`.
+      - The mod custom property `--mod-animation-duration-100` has been renamed to `--mod-button-animation-duration`.
 
       ### Versions prior to 13.0.0
       #### Fill or Outline class required

--- a/components/button/metadata/button-primary.yml
+++ b/components/button/metadata/button-primary.yml
@@ -8,23 +8,30 @@ sections:
       This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/button/metadata/mods.md">here</a>.
   - name: Migration Guide
     description: |
-      ### Fill or Outline class required
+      ### x/x/2024 - Version 13.0.0
+      #### Spectrum 2 release
+      Button now uses Spectrum 2 tokens and specifications. A few notable changes:
+      - The mod custom property `--mod-line-height-100` has been renamed to `--mod-button-line-height`.
+      - The mod custom property `--mod-sans-font-family-stack` has been renamed to `--mod-button-font-family`.
+
+      ### Versions prior to 13.0.0
+      #### Fill or Outline class required
       All buttons now require either the `.spectrum-Button--fill` or `.spectrum-Button--outline` class.
 
-      ### Primary replaced by Primary with Outline
+      #### Primary replaced by Primary with Outline
       Replace all `.spectrum-Button--primary` with `.spectrum-Button--primary .spectrum-Button--outline`.
 
-      ### Primary Quiet replaced by Secondary with Outline
+      #### Primary Quiet replaced by Secondary with Outline
       Replace all `.spectrum-Button--primary .spectrum-Button--quiet` with `.spectrum-Button--secondary .spectrum-Button--outline`.
 
-      ### Icon Only
+      #### Icon Only
       Add the `.spectrum-Button--iconOnly` class to apply the correct styling when an icon is used without a label.
       Provide an `aria-label` on the button itself when using this variant for accessibility.
 
-      ### T-shirt sizing
+      #### T-shirt sizing
       Button now supports t-shirt sizing and requires that you specify the size of button by adding a `.spectrum-Button--size*` class.
 
-      ### Change workflow icon size
+      #### Change workflow icon size
 
       Previously, all Buttons used `.spectrum-Icon--sizeS`. This has changed:
 
@@ -35,7 +42,7 @@ sections:
       | `.spectrum-Button--sizeL`  | `.spectrum-Icon--sizeL`           |
       | `.spectrum-Button--sizeXL` | `.spectrum-Icon--sizeXL`          |
 
-      ### Remove focus-ring class
+      #### Remove focus-ring class
       We've migrated away from the focus-ring class in favor of the native `:focus-visible` pseudo-class due to changes in browser support.
 examples:
   - id: button-primary

--- a/components/button/metadata/button-secondary.yml
+++ b/components/button/metadata/button-secondary.yml
@@ -8,23 +8,30 @@ sections:
       This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/button/metadata/mods.md">here</a>.
   - name: Migration Guide
     description: |
-      ### Fill or Outline class required
+      ### x/x/2024 - Version 13.0.0
+      #### Spectrum 2 release
+      Button now uses Spectrum 2 tokens and specifications. A few notable changes:
+      - The mod custom property `--mod-line-height-100` has been renamed to `--mod-button-line-height`.
+      - The mod custom property `--mod-sans-font-family-stack` has been renamed to `--mod-button-font-family`.
+
+      ### Versions prior to 13.0.0
+      #### Fill or Outline class required
       All buttons now require either the `.spectrum-Button--fill` or `.spectrum-Button--outline` class.
 
-      ### Secondary replaced by Secondary with Outline
+      #### Secondary replaced by Secondary with Outline
       Replace all `.spectrum-Button--secondary` with `.spectrum-Button--secondary .spectrum-Button--outline`.
 
-      ### Secondary Quiet replaced by Secondary with Outline
+      #### Secondary Quiet replaced by Secondary with Outline
       Replace all `.spectrum-Button--secondary .spectrum-Button--quiet` with `.spectrum-Button--secondary .spectrum-Button--outline`.
 
-      ### Icon Only
+      #### Icon Only
       Add the `.spectrum-Button--iconOnly` class to apply the correct styling when an icon is used without a label.
       Provide an `aria-label` on the button itself when using this variant for accessibility.
 
-      ### T-shirt sizing
+      #### T-shirt sizing
       Button now supports t-shirt sizing and requires that you specify the size of button by adding a `.spectrum-Button--size*` class.
 
-      ### Change workflow icon size
+      #### Change workflow icon size
 
       Previously, all Buttons used `.spectrum-Icon--sizeS`. This has changed:
 
@@ -35,7 +42,7 @@ sections:
       | `.spectrum-Button--sizeL`  | `.spectrum-Icon--sizeL`           |
       | `.spectrum-Button--sizeXL` | `.spectrum-Icon--sizeXL`          |
 
-      ### Remove focus-ring class
+      #### Remove focus-ring class
       We've migrated away from the focus-ring class in favor of the native `:focus-visible` pseudo-class due to changes in browser support.
 examples:
   - id: button-secondary

--- a/components/button/metadata/button-secondary.yml
+++ b/components/button/metadata/button-secondary.yml
@@ -13,6 +13,7 @@ sections:
       Button now uses Spectrum 2 tokens and specifications. A few notable changes:
       - The mod custom property `--mod-line-height-100` has been renamed to `--mod-button-line-height`.
       - The mod custom property `--mod-sans-font-family-stack` has been renamed to `--mod-button-font-family`.
+      - The mod custom property `--mod-animation-duration-100` has been renamed to `--mod-button-animation-duration`.
 
       ### Versions prior to 13.0.0
       #### Fill or Outline class required

--- a/components/button/metadata/button-staticcolor.yml
+++ b/components/button/metadata/button-staticcolor.yml
@@ -8,23 +8,30 @@ sections:
       This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/button/metadata/mods.md">here</a>.
   - name: Migration Guide
     description: |
-      ### Fill or Outline class required
+      ### x/x/2024 - Version 13.0.0
+      #### Spectrum 2 release
+      Button now uses Spectrum 2 tokens and specifications. A few notable changes:
+      - The mod custom property `--mod-line-height-100` has been renamed to `--mod-button-line-height`.
+      - The mod custom property `--mod-sans-font-family-stack` has been renamed to `--mod-button-font-family`.
+
+      ### Versions prior to 13.0.0
+      #### Fill or Outline class required
       All buttons now require either the `.spectrum-Button--fill` or `.spectrum-Button--outline` class.
 
-      ### Over background replaced by StaticWhite with Outline
+      #### Over background replaced by StaticWhite with Outline
       Replace all `.spectrum-Button--overBackground` with `.spectrum-Button--staticWhite .spectrum-Button--outline`.
 
-      ### Over background Quiet replaced by StaticWhite with Outline
+      #### Over background Quiet replaced by StaticWhite with Outline
       Replace all `.spectrum-Button--overBackground .spectrum-Button--quiet` with `.spectrum-Button--staticWhite .spectrum-Button--outline`.
 
-      ### Icon Only
+      #### Icon Only
       Add the `.spectrum-Button--iconOnly` class to apply the correct styling when an icon is used without a label.
       Provide an `aria-label` on the button itself when using this variant for accessibility.
 
-      ### T-shirt sizing
+      #### T-shirt sizing
       Button now supports t-shirt sizing and requires that you specify the size of button by adding a `.spectrum-Button--size*` class.
 
-      ### Change workflow icon size
+      #### Change workflow icon size
 
       Previously, all Buttons used `.spectrum-Icon--sizeS`. This has changed:
 
@@ -35,7 +42,7 @@ sections:
       | `.spectrum-Button--sizeL`  | `.spectrum-Icon--sizeL`           |
       | `.spectrum-Button--sizeXL` | `.spectrum-Icon--sizeXL`          |
 
-      ### Remove focus-ring class
+      #### Remove focus-ring class
       We've migrated away from the focus-ring class in favor of the native `:focus-visible` pseudo-class due to changes in browser support.
 examples:
   - id: button-staticcolor

--- a/components/button/metadata/button-staticcolor.yml
+++ b/components/button/metadata/button-staticcolor.yml
@@ -13,6 +13,7 @@ sections:
       Button now uses Spectrum 2 tokens and specifications. A few notable changes:
       - The mod custom property `--mod-line-height-100` has been renamed to `--mod-button-line-height`.
       - The mod custom property `--mod-sans-font-family-stack` has been renamed to `--mod-button-font-family`.
+      - The mod custom property `--mod-animation-duration-100` has been renamed to `--mod-button-animation-duration`.
 
       ### Versions prior to 13.0.0
       #### Fill or Outline class required

--- a/components/button/metadata/mods.md
+++ b/components/button/metadata/mods.md
@@ -1,6 +1,5 @@
 | Modifiable custom properties               |
 | ------------------------------------------ |
-| `--mod-animation-duration-100`             |
 | `--mod-bold-font-weight`                   |
 | `--mod-button-animation-duration`          |
 | `--mod-button-background-color-default`    |

--- a/components/button/metadata/mods.md
+++ b/components/button/metadata/mods.md
@@ -45,6 +45,4 @@
 | `--mod-button-top-to-icon`                 |
 | `--mod-button-top-to-text`                 |
 | `--mod-focus-indicator-gap`                |
-| `--mod-line-height-100`                    |
-| `--mod-sans-font-family-stack`             |
 | `--mod-static-black-focus-indicator-color` |

--- a/components/closebutton/metadata/closebutton.yml
+++ b/components/closebutton/metadata/closebutton.yml
@@ -27,10 +27,12 @@ sections:
             | `--mod-closebutton-background-color-focus`   |
             | `--mod-closebutton-background-color-hover`   |
           
-        * Also removes --mod-closebutton-size since we'll be setting rounded border-radius with a single rounding token, to be formally implemented as part of [S2 Corner Rounding](https://github.com/adobe/spectrum-css/pull/2559/files#diff-d6e9caa794bd8e1c659425d223e23ab53a93a254f00fb11a626e1b7563bd0c61R39-R41).
-      
+        * Also removes `--mod-closebutton-size` since it was only used for a rounded border-radius, that is now set with a single rounding token.
+        * The mod custom property `--mod-line-height-100` has been renamed to `--mod-button-line-height`.
+        * The mod custom property `--mod-sans-font-family-stack` has been renamed to `--mod-button-font-family`.
 
-      ### Sizing
+      ### Versions prior to 5.0
+      #### Sizing
       Close button supports different sized icons. By default, you should use the following icons:
 
       | Close button classname          | UI icon classname           |
@@ -40,7 +42,7 @@ sections:
       | `.spectrum-CloseButton--sizeL`  | `.spectrum-UIIcon-Cross200` |
       | `.spectrum-CloseButton--sizeXL` | `.spectrum-UIIcon-Cross300` |
 
-      ### Remove focus-ring class
+      #### Remove focus-ring class
       We've migrated away from the focus-ring class in favor of the native `:focus-visible` pseudo-class due to changes in browser support.
 examples:
   - id: close

--- a/components/closebutton/metadata/closebutton.yml
+++ b/components/closebutton/metadata/closebutton.yml
@@ -29,7 +29,8 @@ sections:
         * The mod custom property `--mod-closebutton-size` has been removed. It was only used for rounded corners, that are now set with a single rounding token.
         * The mod custom property `--mod-line-height-100` has been renamed to `--mod-button-line-height`.
         * The mod custom property `--mod-sans-font-family-stack` has been renamed to `--mod-button-font-family`.
-        * Separate regular and large "Icon size" variants have been removed.
+        * The mod custom property `--mod-animation-duration-100` has been renamed to `--mod-button-animation-duration`.
+        * The regular and large "Icon size" variants have been removed.
 
       ### 8/16/2023 - Version 4.0.0
       #### Remove focus-ring class

--- a/components/closebutton/metadata/closebutton.yml
+++ b/components/closebutton/metadata/closebutton.yml
@@ -11,15 +11,14 @@ sections:
       ### x/x/2024 - Version 5.0.0
       #### Spectrum 2 release
       Close button now uses Spectrum 2 tokens and specifications. A few notable changes and additions:
-        * Removes all static-specific `--mod` custom properties since they are no longer needed:
+        * Removes all static-specific `--mod` custom properties since they are no longer needed. The existing background-color mods can be used instead:
             | Removed |
             |-----------------------------------------------------|
             | `--mod-closebutton-static-background-color-default` |
             | `--mod-closebutton-static-background-color-down`    |
             | `--mod-closebutton-static-background-color-focus`   |
             | `--mod-closebutton-static-background-color-hover`   |
-          
-          Consumers can use these existing background-color mods instead:
+
             | Use these existing mods instead              |
             |----------------------------------------------|
             | `--mod-closebutton-background-color-default` |
@@ -27,13 +26,18 @@ sections:
             | `--mod-closebutton-background-color-focus`   |
             | `--mod-closebutton-background-color-hover`   |
           
-        * Also removes `--mod-closebutton-size` since it was only used for a rounded border-radius, that is now set with a single rounding token.
+        * The mod custom property `--mod-closebutton-size` has been removed. It was only used for rounded corners, that are now set with a single rounding token.
         * The mod custom property `--mod-line-height-100` has been renamed to `--mod-button-line-height`.
         * The mod custom property `--mod-sans-font-family-stack` has been renamed to `--mod-button-font-family`.
+        * Separate regular and large "Icon size" variants have been removed.
 
-      ### Versions prior to 5.0
-      #### Sizing
-      Close button supports different sized icons. By default, you should use the following icons:
+      ### 8/16/2023 - Version 4.0.0
+      #### Remove focus-ring class
+      We've migrated away from the focus-ring class in favor of the native `:focus-visible` pseudo-class due to changes in browser support.
+
+      ### 8/3/2022 - Version 2.0.0
+      #### Sizing and Spectrum tokens migration
+      Close button was migrated to use Spectrum tokens. Close button now supports different sizes. By default, the following icons should be used for each size:
 
       | Close button classname          | UI icon classname           |
       | ------------------------------- | --------------------------- |
@@ -41,72 +45,18 @@ sections:
       | `.spectrum-CloseButton--sizeM`  | `.spectrum-UIIcon-Cross100` |
       | `.spectrum-CloseButton--sizeL`  | `.spectrum-UIIcon-Cross200` |
       | `.spectrum-CloseButton--sizeXL` | `.spectrum-UIIcon-Cross300` |
-
-      #### Remove focus-ring class
-      We've migrated away from the focus-ring class in favor of the native `:focus-visible` pseudo-class due to changes in browser support.
 examples:
-  - id: close
-    name: Icon Size - Regular
-    markup: |
-      <div class="spectrum-Examples">
-        <div class="spectrum-Examples-item">
-          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">S</h4>
-
-          <div class="spectrum-Examples-itemGroup">
-            <button class="spectrum-CloseButton spectrum-CloseButton--sizeS">
-              <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross75" focusable="false" aria-hidden="true">
-                <use xlink:href="#spectrum-css-icon-Cross75" />
-              </svg>
-            </button>
-          </div>
-        </div>
-        <div class="spectrum-Examples-item">
-          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">M (default)</h4>
-
-          <div class="spectrum-Examples-itemGroup">
-            <button class="spectrum-CloseButton spectrum-CloseButton--sizeM">
-              <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross100" focusable="false" aria-hidden="true">
-                <use xlink:href="#spectrum-css-icon-Cross100" />
-              </svg>
-            </button>
-          </div>
-        </div>
-
-        <div class="spectrum-Examples-item">
-          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">L</h4>
-
-          <div class="spectrum-Examples-itemGroup">
-            <button class="spectrum-CloseButton spectrum-CloseButton--sizeL">
-              <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross200" focusable="false" aria-hidden="true">
-                <use xlink:href="#spectrum-css-icon-Cross200" />
-              </svg>
-            </button>
-          </div>
-        </div>
-
-        <div class="spectrum-Examples-item">
-          <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">XL</h4>
-
-          <div class="spectrum-Examples-itemGroup">
-            <button class="spectrum-CloseButton spectrum-CloseButton--sizeXL">
-              <svg class="spectrum-CloseButton-UIIcon spectrum-Icon spectrum-UIIcon-Cross300" focusable="false" aria-hidden="true">
-                <use xlink:href="#spectrum-css-icon-Cross300" />
-              </svg>
-            </button>
-          </div>
-        </div>
-      </div>
-  - id: closebutton-largeicon
-    name: Icon Size - Large
+  - id: closebutton
+    name: Sizing
     description: |
-      Close button supports different sized icons. For cases where you need large icons, you should use the following icons:
+      At each size, Close button uses a specific UI icon size:
 
-      | Close button classname          | UI icon classname           |
-      | ------------------------------- | --------------------------- |
-      | `.spectrum-CloseButton--sizeS`  | `.spectrum-UIIcon-Cross200` |
-      | `.spectrum-CloseButton--sizeM`  | `.spectrum-UIIcon-Cross300` |
-      | `.spectrum-CloseButton--sizeL`  | `.spectrum-UIIcon-Cross400` |
-      | `.spectrum-CloseButton--sizeXL` | `.spectrum-UIIcon-Cross500` |
+      | Close button size  | UI icon    |
+      | ------------------ | ---------- |
+      | Small              | `Cross200` |
+      | Medium             | `Cross300` |
+      | Large              | `Cross400` |
+      | Extra large        | `Cross500` |
     markup: |
       <div class="spectrum-Examples">
         <div class="spectrum-Examples-item">

--- a/components/closebutton/metadata/mods.md
+++ b/components/closebutton/metadata/mods.md
@@ -24,5 +24,3 @@
 | `--mod-closebutton-margin-inline`             |
 | `--mod-closebutton-margin-top`                |
 | `--mod-closebutton-width`                     |
-| `--mod-line-height-100`                       |
-| `--mod-sans-font-family-stack`                |

--- a/components/closebutton/metadata/mods.md
+++ b/components/closebutton/metadata/mods.md
@@ -1,6 +1,5 @@
 | Modifiable custom properties                  |
 | --------------------------------------------- |
-| `--mod-animation-duration-100`                |
 | `--mod-button-animation-duration`             |
 | `--mod-button-font-family`                    |
 | `--mod-button-line-height`                    |

--- a/components/commons/basebutton.css
+++ b/components/commons/basebutton.css
@@ -31,13 +31,9 @@ governing permissions and limitations under the License.
   /* Remove button the margin in Firefox and Safari. */
   margin: 0;
 
-  /* @deprecation --mod-sans-font-family-stack has been renamed and will be removed in a future version. */
-  font-family: var(--mod-button-font-family, var(--mod-sans-font-family-stack, var(--spectrum-sans-font-family-stack)));
-
-  /* @deprecation --mod-line-height-100 has been renamed and will be removed in a future version. */
-  line-height: var(--mod-button-line-height, var(--mod-line-height-100, var(--spectrum-line-height-100)));
+  font-family: var(--mod-button-font-family, var(--spectrum-sans-font-family-stack));
+  line-height: var(--mod-button-line-height, var(--spectrum-line-height-100));
   text-decoration: none;
-
 
   /* Remove the inheritance of text transform on button in Edge, Firefox, and IE. */
   text-transform: none;
@@ -61,11 +57,9 @@ governing permissions and limitations under the License.
 
   /* Fix Firefox */
   &::-moz-focus-inner {
-    /* Use uppercase PX so values don't get converted to rem */
     margin-block-start: -2px;
     margin-block-end: -2px;
     padding: 0;
-
     border: 0;
 
     /* Remove the inner border and padding for button in Firefox. */
@@ -98,17 +92,14 @@ governing permissions and limitations under the License.
     inset-inline-end: 0;
 
     display: block;
+    margin: calc(var(--mod-button-focus-indicator-gap, var(--spectrum-focus-indicator-gap)) * -1);
 
-    /* @deprecation --mod-focus-indicator-gap has been renamed and will be removed in a future version. */
-    margin: calc(var(--mod-button-focus-indicator-gap, var(--mod-focus-indicator-gap, var(--spectrum-focus-indicator-gap))) * -1);
-
-    /* @deprecation --mod-animation-duration-100 has been renamed and will be removed in a future version. */
-    transition: opacity var(--mod-button-animation-duration, var(--mod-button-animation-duration, var(--mod-animation-duration-100, var(--spectrum-animation-duration-100)))) ease-out,
-                margin var(--mod-button-animation-duration, var(--mod-button-animation-duration, var(--mod-animation-duration-100, var(--spectrum-animation-duration-100)))) ease-out;
+    transition: opacity var(--mod-button-animation-duration, var(--spectrum-animation-duration-100)) ease-out,
+                margin var(--mod-button-animation-duration, var(--spectrum-animation-duration-100)) ease-out;
   }
 
   &:focus-visible::after {
-    margin: calc(var(--mod-focus-indicator-gap, var(--spectrum-focus-indicator-gap)) * -2);
+    margin: calc(var(--mod-button-focus-indicator-gap, var(--spectrum-focus-indicator-gap)) * -2);
   }
 }
 

--- a/components/commons/basebutton.css
+++ b/components/commons/basebutton.css
@@ -45,10 +45,10 @@ governing permissions and limitations under the License.
   -webkit-appearance: button;
   border-style: solid;
 
-  transition: background var(--mod-button-animation-duration, var(--mod-animation-duration-100, var(--spectrum-animation-duration-100))) ease-out,
-    border-color var(--mod-button-animation-duration, var(--mod-animation-duration-100, var(--spectrum-animation-duration-100))) ease-out,
-    color var(--mod-button-animation-duration, var(--mod-animation-duration-100, var(--spectrum-animation-duration-100))) ease-out,
-    box-shadow var(--mod-button-animation-duration, var(--mod-animation-duration-100, var(--spectrum-animation-duration-100))) ease-out;
+  transition: background var(--mod-button-animation-duration, var(--spectrum-animation-duration-100)) ease-out,
+    border-color var(--mod-button-animation-duration, var(--spectrum-animation-duration-100)) ease-out,
+    color var(--mod-button-animation-duration, var(--spectrum-animation-duration-100)) ease-out,
+    box-shadow var(--mod-button-animation-duration, var(--spectrum-animation-duration-100)) ease-out;
 
   -webkit-font-smoothing: antialiased;
 

--- a/components/logicbutton/metadata/logicbutton.yml
+++ b/components/logicbutton/metadata/logicbutton.yml
@@ -10,6 +10,7 @@ sections:
       - The mod custom property `--mod-line-height-100` has been renamed to `--mod-button-line-height`.
       - The mod custom property `--mod-sans-font-family-stack` has been renamed to `--mod-button-font-family`.
       - The mod custom property `--mod-focus-indicator-gap` has been renamed to `--mod-button-focus-indicator-gap`.
+      - The mod custom property `--mod-animation-duration-100` has been renamed to `--mod-button-animation-duration`.
 
       ### 8/16/2023 - Version 2.0.0
       #### Remove focus-ring class

--- a/components/logicbutton/metadata/logicbutton.yml
+++ b/components/logicbutton/metadata/logicbutton.yml
@@ -4,7 +4,15 @@ description: A LogicButton displays an operator within a boolean logic sequence.
 sections:
   - name: Migration Guide
     description: |
-      ### Remove focus-ring class
+      ### x/x/2024 - Version 4.0.0
+      #### Spectrum 2 release
+      Logic button now uses Spectrum 2 tokens and specifications. A few notable changes:
+      - The mod custom property `--mod-line-height-100` has been renamed to `--mod-button-line-height`.
+      - The mod custom property `--mod-sans-font-family-stack` has been renamed to `--mod-button-font-family`.
+      - The mod custom property `--mod-focus-indicator-gap` has been renamed to `--mod-button-focus-indicator-gap`.
+
+      ### 8/16/2023 - Version 2.0.0
+      #### Remove focus-ring class
       We've migrated away from the focus-ring class in favor of the native `:focus-visible` pseudo-class due to changes in browser support.
 examples:
   - id: logicbutton-and

--- a/components/logicbutton/metadata/mods.md
+++ b/components/logicbutton/metadata/mods.md
@@ -1,6 +1,5 @@
 | Modifiable custom properties                             |
 | -------------------------------------------------------- |
-| `--mod-animation-duration-100`                           |
 | `--mod-button-animation-duration`                        |
 | `--mod-button-focus-indicator-gap`                       |
 | `--mod-button-font-family`                               |

--- a/components/logicbutton/metadata/mods.md
+++ b/components/logicbutton/metadata/mods.md
@@ -5,8 +5,6 @@
 | `--mod-button-focus-indicator-gap`                       |
 | `--mod-button-font-family`                               |
 | `--mod-button-line-height`                               |
-| `--mod-focus-indicator-gap`                              |
-| `--mod-line-height-100`                                  |
 | `--mod-logic-button-and-background-color`                |
 | `--mod-logic-button-and-background-color-disabled`       |
 | `--mod-logic-button-and-background-color-hover`          |
@@ -36,4 +34,3 @@
 | `--mod-logic-button-or-text-color`                       |
 | `--mod-logic-button-or-text-color-disabled`              |
 | `--mod-logic-button-padding`                             |
-| `--mod-sans-font-family-stack`                           |

--- a/components/picker/metadata/mods.md
+++ b/components/picker/metadata/mods.md
@@ -4,7 +4,6 @@
 | `--mod-button-animation-duration`                      |
 | `--mod-button-font-family`                             |
 | `--mod-button-line-height`                             |
-| `--mod-line-height-100`                                |
 | `--mod-picker-animation-duration`                      |
 | `--mod-picker-background-color-active`                 |
 | `--mod-picker-background-color-default`                |
@@ -67,4 +66,3 @@
 | `--mod-picker-spacing-top-to-disclosure-icon`          |
 | `--mod-picker-spacing-top-to-progress-circle`          |
 | `--mod-picker-spacing-top-to-text`                     |
-| `--mod-sans-font-family-stack`                         |

--- a/components/picker/metadata/mods.md
+++ b/components/picker/metadata/mods.md
@@ -1,6 +1,5 @@
 | Modifiable custom properties                           |
 | ------------------------------------------------------ |
-| `--mod-animation-duration-100`                         |
 | `--mod-button-animation-duration`                      |
 | `--mod-button-font-family`                             |
 | `--mod-button-line-height`                             |

--- a/components/picker/metadata/picker.yml
+++ b/components/picker/metadata/picker.yml
@@ -7,17 +7,24 @@ sections:
       This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/picker/metadata/mods.md">here</a>.
   - name: Migration Guide
     description: |
-      ### Component renamed
+      ### x/x/2024 - Version 8.0.0
+      #### Spectrum 2 release
+      Picker now uses Spectrum 2 tokens and specifications. A few notable changes:
+      - The mod custom property `--mod-line-height-100` has been renamed to `--mod-button-line-height`.
+      - The mod custom property `--mod-sans-font-family-stack` has been renamed to `--mod-button-font-family`.
+
+      ### Versions prior to 8.0
+      #### Component renamed
       Dropdown is now known as Picker. Replace all `.spectrum-Dropdown*` classnames with `.spectrum-Picker*`.
 
-      ### Markup change
+      #### Markup change
       The outer `<div>` is now gone and `.spectrum-FieldButton` is no longer used. Instead, the outer tag is now `<button>` with the `.spectrum-Picker` classname.
 
       Additionally, `.spectrum-Picker` should not contain the `.spectrum-Popover` that it opens.
 
       In order to use a side label with a Picker, add the `spectrum-Picker--sideLabel` class to the Picker.
 
-      ### Icon classname changes
+      #### Icon classname changes
 
       Each of the 3 possible icons now has its own specific classname:
 
@@ -27,13 +34,13 @@ sections:
       | `.spectrum-Icon` (workflow)       | `.spectrum-Picker-icon`           |
       | `.spectrum-Icon` (validation)     | `.spectrum-Picker-validationIcon` |
 
-      ### `.is-selected` is now `.is-open`
+      #### `.is-selected` is now `.is-open`
       In order to more accurately reflect what's going on, you should add `.is-open` to `.spectrum-Picker` when the menu is shown.
 
-      ### Change workflow icon size to medium
+      #### Change workflow icon size to medium
       If you use a `.spectrum-Picker-icon` in your markup, please replace `.spectrum-Icon--sizeS` with `.spectrum-Icon--sizeM`.
 
-      ### T-shirt sizing
+      #### T-shirt sizing
       Picker now supports t-shirt sizing and requires that you specify the size by adding a `.spectrum-Picker--size*` class.
       Using the classes `.spectrum-Picker .spectrum-Picker--sizeM` will get result in the previous default picker size.
 
@@ -46,7 +53,7 @@ sections:
       | `spectrum-Picker--sizeL`  | `spectrum-css-icon-Chevron200` |
       | `spectrum-Picker--sizeXL` | `spectrum-css-icon-Chevron300` |
 
-      ### Remove focus-ring class
+      #### Remove focus-ring class
       We've migrated away from the focus-ring class in favor of the native `:focus-visible` pseudo-class due to changes in browser support.
 examples:
   - id: picker-standard

--- a/components/picker/metadata/picker.yml
+++ b/components/picker/metadata/picker.yml
@@ -12,6 +12,7 @@ sections:
       Picker now uses Spectrum 2 tokens and specifications. A few notable changes:
       - The mod custom property `--mod-line-height-100` has been renamed to `--mod-button-line-height`.
       - The mod custom property `--mod-sans-font-family-stack` has been renamed to `--mod-button-font-family`.
+      - The mod custom property `--mod-animation-duration-100` has been renamed to `--mod-button-animation-duration`.
 
       ### Versions prior to 8.0
       #### Component renamed


### PR DESCRIPTION
## Description

Remove mod properties that were renamed and previously marked for deprecation, and regenerate the mods lists. This will help in reviewing the accuracy of other components' mods lists as they are being migrated to s2. Also updates some Close Button documentation.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [ ] No VRT changes
- [ ] Mod properties removed looks correct

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
