### PR TITLE
fix(tabs): mod typo for font-size

### DIFF
--- a/components/tabs/index.css
+++ b/components/tabs/index.css
@@ -433,7 +433,7 @@ governing permissions and limitations under the License.
 
 	font-family: var(--mod-tabs-font-family, var(--spectrum-tabs-font-family));
 	font-style: var(--mod-tabs-font-style, var(--spectrum-tabs-font-style));
-	font-size: var(--mod-tabs-font-weight, var(--spectrum-tabs-font-size));
+	font-size: var(--mod-tabs-font-size, var(--spectrum-tabs-font-size));
 	font-weight: var(--mod-tabs-font-weight, var(--spectrum-tabs-font-weight));
 	line-height: var(--mod-tabs-line-height, var(--spectrum-tabs-line-height));
 	margin-block-start: var(

--- a/components/tabs/metadata/mods.md
+++ b/components/tabs/metadata/mods.md
@@ -20,6 +20,7 @@
 | `--mod-tabs-focus-indicator-gap`                      |
 | `--mod-tabs-focus-indicator-width`                    |
 | `--mod-tabs-font-family`                              |
+| `--mod-tabs-font-size`                                |
 | `--mod-tabs-font-style`                               |
 | `--mod-tabs-font-weight`                              |
 | `--mod-tabs-icon-size`                                |


### PR DESCRIPTION
## Description

This PR fixes an issue a user reported in [Adobe Slack](https://adobedesign.slack.com/archives/C5N154FEY/p1710842359652389) that the `.spectrum-Tabs-itemLabel` had a typo in the mod for font-size. It was `--mod-tabs-font-weight`, but should be `--mod-tabs-font-size`.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

In storybook with dev tools: @jawinn 

- [x] you can update the value of `--mod-tabs-font-size` and the font size is changed
- [x] you can update the value of `--mod-tabs-font-weight` and the font weight is changed. Font size is not affected by this


## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] ✨ This pull request is ready to merge. ✨
