### PR TITLE
docs(button): fix appearance of pending in forced colors story

### DIFF
--- a/components/button/stories/template.js
+++ b/components/button/stories/template.js
@@ -13,37 +13,38 @@ import { Template as ProgressCircle } from "@spectrum-css/progresscircle/stories
 import "../index.css";
 
 export const Template = ({
-  rootClass = "spectrum-Button",
-  id,
-  customClasses = [],
-  customStyles = {},
-  size = "m",
-  label,
-  hideLabel = false,
-  iconName,
-  iconAfterLabel = false,
-  variant,
-  staticColor,
-  treatment,
-  onclick,
-  isDisabled = false,
-  isPending = false,
-  isPendingStory = false,
-  ariaExpanded,
-  ariaControls,
-  ...globals
+	rootClass = "spectrum-Button",
+	id,
+	customClasses = [],
+	customStyles = {},
+	size = "m",
+	label,
+	hideLabel = false,
+	iconName,
+	iconAfterLabel = false,
+	variant,
+	staticColor,
+	treatment,
+	onclick,
+	isDisabled = false,
+	isPending = false,
+	isPendingStory = false,
+	ariaExpanded,
+	ariaControls,
+	...globals
 }) => {
 	const { express } = globals;
 	try {
 		if (express) import(/* webpackPrefetch: true */ "../themes/express.css");
 		else import(/* webpackPrefetch: true */ "../themes/spectrum.css");
-	} catch (e) {
+	}
+	catch (e) {
 		console.warn(e);
 	}
 
-  const [, updateArgs] = useArgs();
+	const [, updateArgs] = useArgs();
 
-  return html`
+	return html`
     <button
       class=${classMap({
         [rootClass]: true,
@@ -73,14 +74,14 @@ export const Template = ({
       )}
       ${when(iconName && iconAfterLabel, () => Icon({ ...globals, iconName, size }))}
       ${when(isPendingStory || isPending, () => {
-        const isOverBackground = staticColor === 'white';
+        const isOverBackground = staticColor === "white";
         return ProgressCircle({
           ...globals,
-          size: 's',
+          size: "s",
           overBackground: isOverBackground,
           isIndeterminate: true,
           addStaticBackground: false
-        })
+        });
       })}
     </button>
   `;

--- a/components/button/stories/template.js
+++ b/components/button/stories/template.js
@@ -72,7 +72,7 @@ export const Template = ({
         () => html`<span class=${`${rootClass}-label`}>${label}</span>`
       )}
       ${when(iconName && iconAfterLabel, () => Icon({ ...globals, iconName, size }))}
-      ${when(isPendingStory, () => {
+      ${when(isPendingStory || isPending, () => {
         const isOverBackground = staticColor === 'white';
         return ProgressCircle({
           ...globals,


### PR DESCRIPTION
## Description

The pending icon was not appearing in the Button story titled "With Forced Colors". Updates a conditional in the template so the progress circle renders.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [x] Progress circles appear in the "Pending State" section of [Storybook->Button->With Forced Colors](https://64762974a45b8bc5ca1705a2-auophesfqw.chromatic.com/?path=/story/components-button--with-forced-colors) @mdt2 

### Regression testing

Validate:

1. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [ ] ✨ This pull request is ready to merge. ✨
