### PR TITLE
chore: add format, formatter to apply lint fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,20 +238,16 @@ This project is leveraging caching from [Nx](https://nx.dev/) to speed up the bu
 
 The following tasks are available:
 
-* `yarn clean` - Cleans all output files for the project and all components
-* `yarn build` - Performs a build of all components
-* `yarn build:all` - Performs a build of all components, documentation site, and storybook
-* `yarn dev` - Performs a component build, runs storybook, and serves the documentation on the default port (3000), then starts watching components and website files
-* `yarn compare`: This compares the current version of components with the previous versions published to NPM and output a list of all the changes that have been made. This is useful for reviewing changes before a release. The information is provided in the command-line output as well as in a simple web page that is opened in your default browser upon completion. The web page includes links to the visual diffs for each component when the file sizes have changed.
-  * Components with no changes are not included in the output.
-  * To run comparisons on one or multiple components, `yarn compare` accepts a list of components as arguments. For example, `yarn compare button` will compare the current version of the button component with the previous version published to NPM. `yarn compare button checkbox` will compare the current version of the button and checkbox components with the previous versions published to NPM.
-  * Named components should be space-separated.
-  * Running `yarn compare` with no inputs will automatically run against all packages.
-  * **Note** that you must run `yarn build` before running `yarn compare` to ensure that the latest build is being compared.
-* `yarn lint`: Provides helpful updates and warnings for a component's package.json file. This helps keep all components in alignment.
-  * Use `yarn lint --fix` to automatically fix any issues that are found.
-  * To run on a single component, use `yarn linter accordion` (where `accordion` is the name of the component or components you want to lint).
-* `yarn refresh:env`: This copies values for the project's `.env` file (an asset never committed to the repo as it contains login secrets) by using the `.env.example` file as a template. This script is useful when you need to update the `.env` file with new values from the `.env.example` file or when you checkout or clean the repo and need to restore the `.env` file.
+| Command | Description | Examples |
+| --- | --- | --- |
+| `clean` | Cleans all output files for the project and all components | `yarn clean` |
+| `build` | Performs a build of all components | `yarn build` |
+| `build:all` | Performs a build of all components, documentation site, and storybook | `yarn build:all` |
+| `dev` | Performs a component build and serves the documentation on the default port (3000) | `yarn dev` |
+| `compare` | This compares the current version of components with the previous versions published to NPM and output a list of all the changes that have been made. This is useful for reviewing changes before a release. The information is provided in the command-line output as well as in a simple web page that is opened in your default browser upon completion. The web page includes links to the visual diffs for each component when the file sizes have changed. <ul><li>Components with no changes are not included in the output.</li><li>To run comparisons on one or multiple components, `compare` accepts a list of components as arguments. For example, `yarn compare button` will compare the current version of the button component with the previous version published to NPM. `yarn compare button checkbox` will compare the current version of the button and checkbox components with the previous versions published to NPM.</li><li>Named components should be space-separated.</li><li>Running `compare` with no inputs will automatically run against all packages.</li></ul> | `yarn compare`<br/>`yarn compare accordion`<br/>`yarn compare accordion actionbutton` |
+| `lint` | Provides helpful updates and warnings for a component's package.json file. This helps keep all components in alignment. Use `format` to automatically fix any issues that are found. To run on a single component, use `yarn linter accordion` (where `accordion` is the name of the component or components you want to lint). | `yarn lint`<br/>`yarn linter accordion`<br/>`yarn linter accordion actionbutton` |
+| `format` | Provides helpful updates and warnings for a component's package.json file. This helps keep all components in alignment. To run on a single component, use `yarn formatter accordion` (where `accordion` is the name of the component or components you want to lint). | `yarn format`<br/>`yarn formatter accordion`<br/>`yarn formatter accordion actionbutton` |
+| `refresh:env` | This copies values for the project's `.env` file (an asset never committed to the repo as it contains login secrets) by using the `.env.example` file as a template. This script is useful when you need to update the `.env` file with new values from the `.env.example` file or when you checkout or clean the repo and need to restore the `.env` file. | `yarn refresh:env` |
 
 ### Documentation
 

--- a/components/accordion/project.json
+++ b/components/accordion/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/actionbar/project.json
+++ b/components/actionbar/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/actionbutton/project.json
+++ b/components/actionbutton/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/actiongroup/project.json
+++ b/components/actiongroup/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/alertbanner/project.json
+++ b/components/alertbanner/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/alertdialog/project.json
+++ b/components/alertdialog/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/asset/project.json
+++ b/components/asset/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/assetcard/project.json
+++ b/components/assetcard/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/assetlist/project.json
+++ b/components/assetlist/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/avatar/project.json
+++ b/components/avatar/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/badge/project.json
+++ b/components/badge/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/breadcrumb/project.json
+++ b/components/breadcrumb/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/button/project.json
+++ b/components/button/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/buttongroup/project.json
+++ b/components/buttongroup/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/calendar/project.json
+++ b/components/calendar/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/card/project.json
+++ b/components/card/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/checkbox/project.json
+++ b/components/checkbox/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/clearbutton/project.json
+++ b/components/clearbutton/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/closebutton/project.json
+++ b/components/closebutton/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/coachindicator/project.json
+++ b/components/coachindicator/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/coachmark/project.json
+++ b/components/coachmark/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/colorarea/project.json
+++ b/components/colorarea/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/colorhandle/project.json
+++ b/components/colorhandle/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/colorloupe/project.json
+++ b/components/colorloupe/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/colorslider/project.json
+++ b/components/colorslider/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/colorwheel/project.json
+++ b/components/colorwheel/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/combobox/project.json
+++ b/components/combobox/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/commons/project.json
+++ b/components/commons/project.json
@@ -12,6 +12,7 @@
 		"compare": {
 			"executor": "nx:noop"
 		},
+		"format": {},
 		"lint": {},
 		"test": {
 			"executor": "nx:noop"

--- a/components/contextualhelp/project.json
+++ b/components/contextualhelp/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/datepicker/project.json
+++ b/components/datepicker/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/dial/project.json
+++ b/components/dial/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/dialog/project.json
+++ b/components/dialog/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/divider/project.json
+++ b/components/divider/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/dropindicator/project.json
+++ b/components/dropindicator/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/dropzone/project.json
+++ b/components/dropzone/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/fieldgroup/project.json
+++ b/components/fieldgroup/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/fieldlabel/project.json
+++ b/components/fieldlabel/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/floatingactionbutton/project.json
+++ b/components/floatingactionbutton/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/helptext/project.json
+++ b/components/helptext/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/icon/project.json
+++ b/components/icon/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/illustratedmessage/project.json
+++ b/components/illustratedmessage/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/infieldbutton/project.json
+++ b/components/infieldbutton/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/inlinealert/project.json
+++ b/components/inlinealert/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/link/project.json
+++ b/components/link/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/logicbutton/project.json
+++ b/components/logicbutton/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/menu/project.json
+++ b/components/menu/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/miller/project.json
+++ b/components/miller/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/modal/project.json
+++ b/components/modal/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/opacitycheckerboard/project.json
+++ b/components/opacitycheckerboard/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/page/project.json
+++ b/components/page/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/pagination/project.json
+++ b/components/pagination/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/picker/project.json
+++ b/components/picker/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/pickerbutton/project.json
+++ b/components/pickerbutton/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/popover/project.json
+++ b/components/popover/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/progressbar/project.json
+++ b/components/progressbar/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/progresscircle/project.json
+++ b/components/progresscircle/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/radio/project.json
+++ b/components/radio/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/rating/project.json
+++ b/components/rating/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/search/project.json
+++ b/components/search/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/sidenav/project.json
+++ b/components/sidenav/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/site/project.json
+++ b/components/site/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/slider/project.json
+++ b/components/slider/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/splitview/project.json
+++ b/components/splitview/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/statuslight/project.json
+++ b/components/statuslight/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/steplist/project.json
+++ b/components/steplist/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/stepper/project.json
+++ b/components/stepper/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/swatch/project.json
+++ b/components/swatch/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/swatchgroup/project.json
+++ b/components/swatchgroup/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/switch/project.json
+++ b/components/switch/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/table/project.json
+++ b/components/table/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/tabs/project.json
+++ b/components/tabs/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/tag/project.json
+++ b/components/tag/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/taggroup/project.json
+++ b/components/taggroup/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/textfield/project.json
+++ b/components/textfield/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/thumbnail/project.json
+++ b/components/thumbnail/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/toast/project.json
+++ b/components/toast/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/tooltip/project.json
+++ b/components/tooltip/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/tray/project.json
+++ b/components/tray/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/treeview/project.json
+++ b/components/treeview/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/typography/project.json
+++ b/components/typography/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/underlay/project.json
+++ b/components/underlay/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/components/well/project.json
+++ b/components/well/project.json
@@ -6,6 +6,7 @@
 		"build": {},
 		"clean": {},
 		"compare": {},
+		"format": {},
 		"lint": {},
 		"test": {
 			"defaultConfiguration": "scope"

--- a/nx.json
+++ b/nx.json
@@ -106,7 +106,7 @@
 			"options": {
 				"commands": [
 					"stylelint --fix {projectRoot}/*.css {projectRoot}/themes/*.css",
-					"eslint --fix {projectRoot}/stories/*.js"
+					"eslint --fix --no-error-on-unmatched-pattern {projectRoot}/stories/*.js"
 				]
 			}
 		},

--- a/nx.json
+++ b/nx.json
@@ -96,7 +96,17 @@
 			"options": {
 				"commands": [
 					"stylelint {projectRoot}/*.css {projectRoot}/themes/*.css",
-					"eslint {projectRoot}/package.json {projectRoot}/project.json {projectRoot}/stories/*.js"
+					"eslint {projectRoot}/stories/*.js"
+				]
+			}
+		},
+		"format": {
+			"inputs": ["core", { "externalDependencies": ["stylelint", "eslint"] }],
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					"stylelint --fix {projectRoot}/*.css {projectRoot}/themes/*.css",
+					"eslint --fix {projectRoot}/stories/*.js"
 				]
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "cleaner": "nx run-many --target clean --projects",
     "compare": "cross-env NODE_ENV=production node ./tasks/compare-compiled-output.js",
     "dev": "cross-env NODE_ENV=production nx start docs",
+    "format": "yarn formatter tag:component",
+    "formatter": "nx run-many --target format --verbose --projects",
     "preinstall": "command -v nvm >/dev/null 2>&1 && nvm use || exit 0",
     "lint": "yarn linter tag:component",
     "linter": "nx run-many --target lint --verbose --projects",


### PR DESCRIPTION
## Description

This PR adds the `yarn format` and `yarn formatter [component]` commands to automatically apply lint fixes to *.css and storybook *.js assets for a component.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

@jawinn 
- [x] Expect `yarn format` to apply lint fixes to all components (do not commit these changes)
- [x] Expect `yarn formatter accordion` to apply style fixes to `accordion/index.css` (do not commit these changes)

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
