### PR TITLE
fix(storybook): body classes for story and docs pages

### DIFF
--- a/.storybook/decorators/contextsWrapper.js
+++ b/.storybook/decorators/contextsWrapper.js
@@ -8,7 +8,7 @@ export const withContextWrapper = makeDecorator({
 	name: "withContextWrapper",
 	parameterName: "context",
 	wrapper: (StoryFn, context) => {
-		const { args, argTypes, viewMode } = context;
+		const { args, argTypes, id, viewMode } = context;
 
 		const getDefaultValue = (type) => {
 			if (!type) return null;
@@ -31,7 +31,13 @@ export const withContextWrapper = makeDecorator({
 		const scales = ["medium", "large"];
 
 		useEffect(() => {
-			const container = viewMode === "docs" && !window.isChromatic() ? document.querySelector('#root-inner') ?? document.body : document.body;
+			const container =
+				viewMode === "docs" &&
+				!window.isChromatic() &&
+				!id.includes('foundation')
+					? document.querySelector('#root-inner') ?? document.body
+					: document.body;
+
 			container.classList.toggle("spectrum", true);
 
 			container.classList.toggle("spectrum--express", isExpress);


### PR DESCRIPTION
## Description

With this fix, Foundation documentation pages will receive the global classes required for styles to show correctly. The fix was to exclude foundation pages from the contextsWrapper. This allows the existing code in `manager.js` to add the `spectrum spectrum--light spectrum--medium` class stack to the `<body>` tag inside the foundations page iframe instead of adding it to only the first `<div id="root-inner>` (it works to add it here for our Story pages because we only have one Story instance on those pages, but in the docs pages we have 1+ story instances so we need the classes to be higher up on the iframe body).

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [ ] VRTs are passing
- [ ] When you navigate to storybook, navigate to a Foundations page first. All styles should look correct
- [ ] Click around to a component or two and then back to a Foundations page, the styles should look correct on all pages

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] ✨ This pull request is ready to merge. ✨
