### PR TITLE
refactor(tokens): remove some unused custom variables

### DIFF
--- a/tokens/custom-spectrum/custom-large-vars.css
+++ b/tokens/custom-spectrum/custom-large-vars.css
@@ -70,7 +70,6 @@ governing permissions and limitations under the License.
   --spectrum-well-min-width: 300px;
   --spectrum-well-border-radius: 5px;
 
-  --spectrum-icon-chevron-size-50: 8px;
   /* XXL and XXS icon sizes are not within the design spec and are planned to be deprecated in Spectrum 2. */
   --spectrum-workflow-icon-size-xxl: 40px;
   --spectrum-workflow-icon-size-xxs: 15px;

--- a/tokens/custom-spectrum/custom-large-vars.css
+++ b/tokens/custom-spectrum/custom-large-vars.css
@@ -13,12 +13,6 @@ governing permissions and limitations under the License.
 /* This file contains overrides and additions to core tokens */
 
 .spectrum--large {
-  /* edge-to-visual-only is used for icon-only buttons */
-  --spectrum-edge-to-visual-only-75: 5px;
-  --spectrum-edge-to-visual-only-100: 9px;
-  --spectrum-edge-to-visual-only-200: 13px;
-  --spectrum-edge-to-visual-only-300: 16px;
-
   --spectrum-slider-tick-mark-height: 13px;
   --spectrum-slider-ramp-track-height: 20px;
 

--- a/tokens/custom-spectrum/custom-medium-vars.css
+++ b/tokens/custom-spectrum/custom-medium-vars.css
@@ -13,12 +13,6 @@ governing permissions and limitations under the License.
 /* This file contains overrides and additions to core tokens */
 
 .spectrum--medium {
-  /* edge-to-visual-only is used for icon-only buttons */
-  --spectrum-edge-to-visual-only-75: 4px;
-  --spectrum-edge-to-visual-only-100: 7px;
-  --spectrum-edge-to-visual-only-200: 10px;
-  --spectrum-edge-to-visual-only-300: 13px;
-
   --spectrum-slider-tick-mark-height: 10px;
   --spectrum-slider-ramp-track-height: 16px;
 

--- a/tokens/custom-spectrum/custom-medium-vars.css
+++ b/tokens/custom-spectrum/custom-medium-vars.css
@@ -69,7 +69,6 @@ governing permissions and limitations under the License.
   --spectrum-well-min-width: 240px;
   --spectrum-well-border-radius: var(--spectrum-spacing-75);
 
-  --spectrum-icon-chevron-size-50: 6px;
   /* XXL and XXS icon sizes are not within the design spec and are planned to be deprecated in Spectrum 2. */
   --spectrum-workflow-icon-size-xxl: 32px;
   --spectrum-workflow-icon-size-xxs: 12px;

--- a/tokens/dist/css/spectrum/custom-large-vars.css
+++ b/tokens/dist/css/spectrum/custom-large-vars.css
@@ -1,10 +1,4 @@
 .spectrum--large{
-  /* edge-to-visual-only is used for icon-only buttons */
-  --spectrum-edge-to-visual-only-75:5px;
-  --spectrum-edge-to-visual-only-100:9px;
-  --spectrum-edge-to-visual-only-200:13px;
-  --spectrum-edge-to-visual-only-300:16px;
-
   --spectrum-slider-tick-mark-height:13px;
   --spectrum-slider-ramp-track-height:20px;
 

--- a/tokens/dist/css/spectrum/custom-large-vars.css
+++ b/tokens/dist/css/spectrum/custom-large-vars.css
@@ -56,7 +56,6 @@
   --spectrum-well-min-width:300px;
   --spectrum-well-border-radius:5px;
 
-  --spectrum-icon-chevron-size-50:8px;
   /* XXL and XXS icon sizes are not within the design spec and are planned to be deprecated in Spectrum 2. */
   --spectrum-workflow-icon-size-xxl:40px;
   --spectrum-workflow-icon-size-xxs:15px;

--- a/tokens/dist/css/spectrum/custom-medium-vars.css
+++ b/tokens/dist/css/spectrum/custom-medium-vars.css
@@ -1,10 +1,4 @@
 .spectrum--medium{
-  /* edge-to-visual-only is used for icon-only buttons */
-  --spectrum-edge-to-visual-only-75:4px;
-  --spectrum-edge-to-visual-only-100:7px;
-  --spectrum-edge-to-visual-only-200:10px;
-  --spectrum-edge-to-visual-only-300:13px;
-
   --spectrum-slider-tick-mark-height:10px;
   --spectrum-slider-ramp-track-height:16px;
 

--- a/tokens/dist/css/spectrum/custom-medium-vars.css
+++ b/tokens/dist/css/spectrum/custom-medium-vars.css
@@ -55,7 +55,6 @@
   --spectrum-well-min-width:240px;
   --spectrum-well-border-radius:var(--spectrum-spacing-75);
 
-  --spectrum-icon-chevron-size-50:6px;
   /* XXL and XXS icon sizes are not within the design spec and are planned to be deprecated in Spectrum 2. */
   --spectrum-workflow-icon-size-xxl:32px;
   --spectrum-workflow-icon-size-xxs:12px;

--- a/tokens/dist/index.css
+++ b/tokens/dist/index.css
@@ -2220,7 +2220,6 @@
   --spectrum-well-min-width:300px;
   --spectrum-well-border-radius:5px;
 
-  --spectrum-icon-chevron-size-50:8px;
   /* XXL and XXS icon sizes are not within the design spec and are planned to be deprecated in Spectrum 2. */
   --spectrum-workflow-icon-size-xxl:40px;
   --spectrum-workflow-icon-size-xxs:15px;
@@ -3377,7 +3376,6 @@
   --spectrum-well-min-width:240px;
   --spectrum-well-border-radius:var(--spectrum-spacing-75);
 
-  --spectrum-icon-chevron-size-50:6px;
   /* XXL and XXS icon sizes are not within the design spec and are planned to be deprecated in Spectrum 2. */
   --spectrum-workflow-icon-size-xxl:32px;
   --spectrum-workflow-icon-size-xxs:12px;

--- a/tokens/dist/index.css
+++ b/tokens/dist/index.css
@@ -2163,12 +2163,6 @@
   --spectrum-font-size-1100:55px;
   --spectrum-font-size-1200:62px;
   --spectrum-font-size-1300:70px;
-  /* edge-to-visual-only is used for icon-only buttons */
-  --spectrum-edge-to-visual-only-75:5px;
-  --spectrum-edge-to-visual-only-100:9px;
-  --spectrum-edge-to-visual-only-200:13px;
-  --spectrum-edge-to-visual-only-300:16px;
-
   --spectrum-slider-tick-mark-height:13px;
   --spectrum-slider-ramp-track-height:20px;
 
@@ -3327,12 +3321,6 @@
   --spectrum-font-size-1100:45px;
   --spectrum-font-size-1200:50px;
   --spectrum-font-size-1300:60px;
-  /* edge-to-visual-only is used for icon-only buttons */
-  --spectrum-edge-to-visual-only-75:4px;
-  --spectrum-edge-to-visual-only-100:7px;
-  --spectrum-edge-to-visual-only-200:10px;
-  --spectrum-edge-to-visual-only-300:13px;
-
   --spectrum-slider-tick-mark-height:10px;
   --spectrum-slider-ramp-track-height:16px;
 


### PR DESCRIPTION
## Description

**Removes unused custom variables for edge-to-visual-only and chevron size**
These custom vars are no longer referenced anywhere in the repo:
- `--spectrum-edge-to-visual-only-75`
- `--spectrum-edge-to-visual-only-100`
- `--spectrum-edge-to-visual-only-200`
- `--spectrum-edge-to-visual-only-300`
- `--spectrum-icon-chevron-size-50`

In the removed comment above these edge-to-visual-only tokens, it mentioned that this was for the icon only button. The icon only button currently uses other existing tokens (e.g. `component-pill-edge-to-visual-only-*`).

The chevron custom variable has already been replaced by an existing token, that has the same values:
`--spectrum-chevron-icon-size-50`

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [ ] The removed tokens do not exist in the repo, and there are no VRT changes

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] ✨ This pull request is ready to merge. ✨
