### PR TITLE
feat: storybook - disable whats new notification popup

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -45,6 +45,7 @@ module.exports = {
 	],
 	core: {
 		disableTelemetry: true,
+		disableWhatsNewNotifications: true,
 	},
 	webpackFinal: function (config) {
 		// Removing the global alias as it conflicts with the global npm pkg


### PR DESCRIPTION
## Description

This changes a [Storybook core configuration option](https://storybook.js.org/docs/api/main-config-core#disablewhatsnewnotifications) to prevent the intrusive "What's new in..." Storybook popup from appearing whenever Storybook is run. Previously this would appear every time when running `yarn start` locally:
![Screenshot 2024-03-29 at 4 22 08 PM](https://github.com/adobe/spectrum-css/assets/965114/ab1ff8d8-5be3-4fe9-a87a-9891478bc3ea)

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [x] Popup no longer appears when running Storybook with `yarn start` [@castastrophe]

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] ✨ This pull request is ready to merge. ✨
