### PR TITLE
ci: ensure the shas used by compare match the current PR

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -68,13 +68,44 @@ jobs:
         secrets: inherit
 
     # -------------------------------------------------------------
+    # Get the NX-blessed base and head shas.
+    # --------------------------------------------------------------
+    get-shas:
+        runs-on: ubuntu-latest
+        name: Get SHA values
+        outputs:
+            base-sha: ${{ steps.set-SHAs.outputs.base }}
+            head-sha: ${{ steps.set-SHAs.outputs.head }}
+        permissions:
+            pull-requests: read
+        steps:
+            - name: Check out code
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
+            - name: Use Node LTS version
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 18
+                  cache: yarn
+
+            - name: Derive appropriate SHAs for base and head for `nx affected` commands
+              id: set-SHAs
+              uses: nrwl/nx-set-shas@v3
+
+    # -------------------------------------------------------------
     # Compare the compiled assets
     # -------------------------------------------------------------
     compare:
         name: Compare
+        needs: [get-shas]
         # Check that the PR is not in draft mode (or if it is, that it has the run_ci label to force a build)
         if: ${{ github.event.pull_request.draft != 'true' || contains(github.event.pull_request.labels.*.name, 'run_ci') }}
         uses: ./.github/workflows/compare-results.yml
+        with:
+            base-sha: ${{ needs.get-shas.outputs.base-sha }}
+            head-sha: ${{ needs.get-shas.outputs.head-sha }}
         secrets: inherit
 
     # -------------------------------------------------------------


### PR DESCRIPTION
## Description

In this [PR](https://github.com/adobe/spectrum-css/pull/2617), I noticed that the base branch being used by the compare tool was main and not spectrum-two as expected. When I investigated further, I found in [the logs](https://github.com/adobe/spectrum-css/actions/runs/8483292394/job/23244124885) that it was using the default base branch rather than the base branch for the PR. To fix this, I've added a get-SHAs workflow that will fetch and pass the appropriate SHA values to the compare script.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [x] When CI runs, expect the derived base and head SHAS ([here](https://github.com/adobe/spectrum-css/actions/runs/8508700862/job/23302750563)) to be used in the compare script ([here](https://github.com/adobe/spectrum-css/actions/runs/8508700862/job/23302760341))

<img width="1084" alt="Screenshot 2024-04-01 at 9 36 03 AM" src="https://github.com/adobe/spectrum-css/assets/1840295/19276c6a-34b7-4f6a-8bd9-dacaee23868a">

<img width="1217" alt="Screenshot 2024-04-01 at 9 36 26 AM" src="https://github.com/adobe/spectrum-css/assets/1840295/dae098fb-c6c8-4af1-b4c2-a0227c6824d3">


## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] ✨ This pull request is ready to merge. ✨
