### PR TITLE
ci: base and head ref fix

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -68,44 +68,16 @@ jobs:
         secrets: inherit
 
     # -------------------------------------------------------------
-    # Get the NX-blessed base and head shas.
-    # --------------------------------------------------------------
-    get-shas:
-        runs-on: ubuntu-latest
-        name: Get SHA values
-        outputs:
-            base-sha: ${{ steps.set-SHAs.outputs.base }}
-            head-sha: ${{ steps.set-SHAs.outputs.head }}
-        permissions:
-            pull-requests: read
-        steps:
-            - name: Check out code
-              uses: actions/checkout@v4
-              with:
-                  fetch-depth: 0
-
-            - name: Use Node LTS version
-              uses: actions/setup-node@v4
-              with:
-                  node-version: 18
-                  cache: yarn
-
-            - name: Derive appropriate SHAs for base and head for `nx affected` commands
-              id: set-SHAs
-              uses: nrwl/nx-set-shas@v3
-
-    # -------------------------------------------------------------
     # Compare the compiled assets
     # -------------------------------------------------------------
     compare:
         name: Compare
-        needs: [get-shas]
         # Check that the PR is not in draft mode (or if it is, that it has the run_ci label to force a build)
         if: ${{ github.event.pull_request.draft != 'true' || contains(github.event.pull_request.labels.*.name, 'run_ci') }}
         uses: ./.github/workflows/compare-results.yml
         with:
-            base-sha: ${{ needs.get-shas.outputs.base-sha }}
-            head-sha: ${{ needs.get-shas.outputs.head-sha }}
+            base-sha: ${{ github.event.pull_request.base.ref }}
+            head-sha: ${{ github.event.pull_request.head.ref }}
         secrets: inherit
 
     # -------------------------------------------------------------
@@ -185,5 +157,5 @@ jobs:
             deploy-message: ${{ github.event.pull_request.title }}
             alias: pr-${{ github.event.number }}
             # Only pass the storybook url if the vrt was successful
-            storybook-url: ${{ needs.vrt.result == 'success' && needs.vrt.outputs.storybook-url || '' }}
+            storybook-url: ${{ needs.vrt.outputs.storybook-url || '' }}
         secrets: inherit

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -62,7 +62,6 @@ jobs:
 
     vrt:
         name: Testing
-        needs: [build]
         uses: ./.github/workflows/vrt.yml
         with:
             skip: ${{ github.base_ref != 'main' }}
@@ -75,10 +74,10 @@ jobs:
     publish_site:
         name: Publish
         # The build step ensures we are leveraging the cache for the build
-        needs: [build, vrt]
+        needs: [vrt]
         uses: ./.github/workflows/publish-site.yml
         with:
-            storybook-url: ${{ needs.vrt.outputs.storybook-url }}
+            storybook-url: ${{ needs.vrt.outputs.storybook-url || '' }}
         secrets: inherit
 
     todo_to_issue:

--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -15,6 +15,7 @@ on:
             storybook-url:
                 required: false
                 type: string
+                default: ''
     workflow_call:
         inputs:
             deploy-message:
@@ -26,6 +27,7 @@ on:
             storybook-url:
                 required: false
                 type: string
+                default: ''
 
 permissions:
     contents: read
@@ -82,10 +84,10 @@ jobs:
               shell: bash
               run: yarn build:site
               env:
-                  CHROMATIC_URL: ${{ inputs.storybook-url }}
+                CHROMATIC_URL: ${{ inputs.storybook-url }}
 
             - name: Build storybook site
-              if: ${{ inputs.storybook-url == '' }}
+              if: ${{ ! inputs.storybook-url }}
               shell: bash
               run: yarn nx run storybook:build:docs
 

--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -24,7 +24,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 20
         outputs:
-            storybook-url: ${{ steps.chromatic.outputs.storybookUrl }}
+            storybook-url: ${{ steps.chromatic.outputs.storybookUrl != 'undefined' && steps.chromatic.outputs.storybookUrl || '' }}
 
         steps:
             - name: Check out code


### PR DESCRIPTION
## Description

When VRT is skipped, Chromatic is returning "undefined" as the value of storybook-url. This needs to be an empty string in order to trigger the local CI build.

This also corrects the SHAs being used - NX was not providing the correct base and head SHAs so this moves those to using the ones provided in the pull_request event.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [x] Add the run_vrt flag with a fresh commit. Expect the storybook url to be passed from chromatic to the publish command the the CI storybook build skipped. [link to CI run](https://github.com/adobe/spectrum-css/actions/runs/8513366300)
- [x] Remove the run_vrt label and add the skip_vrt label. Expect VRT to be skipped and empty string to be passed to the publish workflow. Publish workflow should build storybook in CI and publish preview link. [link to CI run](https://github.com/adobe/spectrum-css/actions/runs/8513475640)
- [x] Remove skip_vrt and add back the run_vrt label but this time without a fresh commit. Expect VRT to run but return undefined as the storybook-url value as the build gets skipped (identical cache). Storybook should be built during the publish workflow. [link to CI run](https://github.com/adobe/spectrum-css/actions/runs/8513523059)
 

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] ✨ This pull request is ready to merge. ✨
