### PR TITLE
feat: add example gradients for static black and white

### DIFF
--- a/.storybook/assets/base.css
+++ b/.storybook/assets/base.css
@@ -22,6 +22,13 @@ body {
 }
 
 .spectrum {
+	/* ---- Storybook only custom properties ---- */
+	/* Gradient that changes with the color theme. */
+	--spectrum-examples-gradient: linear-gradient(45deg, var(--spectrum-magenta-1500), var(--spectrum-blue-1500));
+	/* Gradients that do not change with the color theme, for use in static color backgrounds. */
+	--spectrum-examples-gradient-static-black: linear-gradient(45deg, rgb(255, 241, 246), rgb(238, 245, 255));
+	--spectrum-examples-gradient-static-white: linear-gradient(45deg, rgb(64, 0, 22), rgb(14, 24, 67));
+
 	background-color: var(--spectrum-background-layer-1-color);
 
 	/* @todo: add back the text color and update VRTs */

--- a/.storybook/decorators/contextsWrapper.js
+++ b/.storybook/decorators/contextsWrapper.js
@@ -50,12 +50,13 @@ export const withContextWrapper = makeDecorator({
 				container.classList.toggle(`spectrum--${s}`, s === scale);
 			}
 
+			// Change background color when demonstrating static color options.
 			if (args.staticColor === "black") {
-				container.style.backgroundColor = "rgb(181, 209, 211)";
+				container.style.background = "var(--spectrum-examples-gradient-static-black)";
 			} else if (args.staticColor === "white") {
-				 container.style.backgroundColor = "rgb(15, 121, 125)";
+				 container.style.background = "var(--spectrum-examples-gradient-static-white)";
 			} else {
-				container.style.removeProperty("background-color");
+				container.style.removeProperty("background");
 			}
 		}, [color, scale, isExpress, args.staticColor]);
 

--- a/components/closebutton/stories/closebutton.stories.js
+++ b/components/closebutton/stories/closebutton.stories.js
@@ -55,29 +55,25 @@ export default {
 	},
 };
 
-const CloseButton = ({
-	staticColor,
-	...args
-}) => {
+const CloseButton = (args) => {
 	return html`
 		<div
 			style=${ifDefined(styleMap({
 				padding: "1rem",
-				backgroundColor: staticColor === "white" ? "rgb(15, 121, 125)" : staticColor === "black" ? "rgb(181, 209, 211)" : undefined,
 			}))}
 		>
-			${Template({...args, staticColor})}
+			${Template(args)}
 			${when(window.isChromatic(), () =>
 				html`
 					${Template({
-							...args,
-							isDisabled: true,
-						})}
+						...args,
+						isDisabled: true,
+					})}
 					${html`
 						<div
 							style=${ifDefined(styleMap({
 								padding: "1rem",
-								backgroundColor: "rgb(15, 121, 125)"
+								background: "var(--spectrum-examples-gradient-static-white)"
 							}))}
 						>
 							${Template({
@@ -95,7 +91,7 @@ const CloseButton = ({
 						<div
 							style=${ifDefined(styleMap({
 								padding: "1rem",
-								backgroundColor: "rgb(181, 209, 211)"
+								background: "var(--spectrum-examples-gradient-static-black)"
 							}))}
 						>
 							${Template({
@@ -113,7 +109,7 @@ const CloseButton = ({
 			)}
 		</div>
 	`;
-}
+};
 
 export const Default = CloseButton.bind({});
 Default.args = {};

--- a/components/fieldlabel/stories/fieldlabel.stories.js
+++ b/components/fieldlabel/stories/fieldlabel.stories.js
@@ -1,4 +1,3 @@
-import { html } from "lit";
 import { Template } from "./template";
 
 export default {
@@ -111,21 +110,14 @@ WrappingAndRequired.args = {
 	style: { width: "200px" },
 };
 
-export const StaticColors = (args) => html`
-	${Template({
-		...args,
-		label: "The black static color class used on a label marked as required",
-		staticColor: "black",
-	})}
-	${Template({
-		...args,
-		label: "The white static color class used on a label marked as required",
-		staticColor: "white",
-	})}
-`;
+export const StaticWhite = Template.bind({});
+StaticWhite.args = {
+	label: "The static white class used on a label marked as required",
+	staticColor: "white",
+};
 
-StaticColors.storyName = "Static colors";
-StaticColors.args = {
-	alignment: "left",
-	isRequired: true,
+export const StaticBlack = Template.bind({});
+StaticBlack.args = {
+	label: "The static black class used on a label marked as required",
+	staticColor: "black",
 };

--- a/components/fieldlabel/stories/template.js
+++ b/components/fieldlabel/stories/template.js
@@ -29,17 +29,17 @@ export const Template = ({
 
 	let iconName = "Asterisk100";
 	switch (size) {
-		case "s":
-			iconName = "Asterisk100";
-			break;
-		case "l":
-			iconName = "Asterisk200";
-			break;
-		case "xl":
-			iconName = "Asterisk300";
-			break;
-		default:
-			iconName = "Asterisk100";
+	case "s":
+		iconName = "Asterisk100";
+		break;
+	case "l":
+		iconName = "Asterisk200";
+		break;
+	case "xl":
+		iconName = "Asterisk300";
+		break;
+	default:
+		iconName = "Asterisk100";
 	}
 
 	return html`
@@ -63,7 +63,7 @@ export const Template = ({
 						size,
 						iconName,
 						customClasses: [`${rootClass}-UIIcon`, `${rootClass}-requiredIcon`],
-				  })
+					})
 				: ""}
 		</label>
 	`;

--- a/components/fieldlabel/stories/template.js
+++ b/components/fieldlabel/stories/template.js
@@ -42,7 +42,7 @@ export const Template = ({
 			iconName = "Asterisk100";
 	}
 
-	const labelMarkup = html`
+	return html`
 		<label
 			class=${classMap({
 				[rootClass]: true,
@@ -67,18 +67,4 @@ export const Template = ({
 				: ""}
 		</label>
 	`;
-
-	// When using the static color variants, wrap the label in an example element with a background color.
-	return !staticColor
-		? labelMarkup
-		: html`
-			<div
-				style=${styleMap({
-					padding: "1rem",
-					backgroundColor: staticColor === "white" ? "rgb(15, 121, 125)" : staticColor === "black" ? "rgb(181, 209, 211)" : undefined,
-				})}
-			</div>
-				${labelMarkup}
-			</div>
-		`;
 };


### PR DESCRIPTION
## Description

Adds new gradient backgrounds to Storybook, that are displayed for static black and static white variants. These are used for examples only. This adds CSS custom properties available globally within Storybook and sets them on the existing decorator.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [ ] Static black and static white gradients are appearing for components with a staticColor control: button, close button, field label, divider, link
- [ ] Gradients match the "Gradients for documentation" Figma design spec
- [ ] Updated Field label stories work correctly. There are now two separate stories for static black and static white, instead of one single story.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<img width="875" alt="Screenshot 2024-04-02 at 5 05 02 PM" src="https://github.com/adobe/spectrum-css/assets/965114/80099781-d7a5-4ca2-beea-e0cf0dc23651">

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
