### PR TITLE
docs: update migration guide headings to remove dates

### DIFF
--- a/components/actionbutton/metadata/actionbutton.yml
+++ b/components/actionbutton/metadata/actionbutton.yml
@@ -12,7 +12,7 @@ sections:
       This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/actionbutton/metadata/mods.md">here</a>.
   - name: Migration Guide
     description: |
-      ### x/x/2024 - Version 6.0.0
+      ### Version 6.0.0
       #### Spectrum 2 release
       Action button now uses Spectrum 2 tokens and specifications. A few notable changes:
       - The mod custom property `--mod-line-height-100` has been renamed to `--mod-button-line-height`.

--- a/components/buttongroup/metadata/buttongroup.yml
+++ b/components/buttongroup/metadata/buttongroup.yml
@@ -3,7 +3,7 @@ SpectrumSiteSlug: https://spectrum.adobe.com/page/button/
 sections:
   - name: Migration Guide
     description: |
-      ### 1/24/2024 - Version 7.0.0
+      ### Version 7.0.0
       #### Spectrum 2 migration also removed `.spectrum-ButtonGroup--sizeM`, `.spectrum-ButtonGroup--sizeL`, and `.spectrum-ButtonGroup--sizeXL`
         Since each of these classes were using the same tokens for spacing, these classes were removed.
   - name: Custom Properties API

--- a/components/closebutton/metadata/closebutton.yml
+++ b/components/closebutton/metadata/closebutton.yml
@@ -8,7 +8,7 @@ sections:
       This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/closebutton/metadata/mods.md">here</a>.
   - name: Migration Guide
     description: |
-      ### x/x/2024 - Version 5.0.0
+      ### Version 5.0.0
       #### Spectrum 2 release
       Close button now uses Spectrum 2 tokens and specifications. A few notable changes and additions:
         * Removes all static-specific `--mod` custom properties since they are no longer needed. The existing background-color mods can be used instead:
@@ -32,11 +32,11 @@ sections:
         * The mod custom property `--mod-animation-duration-100` has been renamed to `--mod-button-animation-duration`.
         * The regular and large "Icon size" variants have been removed.
 
-      ### 8/16/2023 - Version 4.0.0
+      ### Version 4.0.0
       #### Remove focus-ring class
       We've migrated away from the focus-ring class in favor of the native `:focus-visible` pseudo-class due to changes in browser support.
 
-      ### 8/3/2022 - Version 2.0.0
+      ### Version 2.0.0
       #### Sizing and Spectrum tokens migration
       Close button was migrated to use Spectrum tokens. Close button now supports different sizes. By default, the following icons should be used for each size:
 

--- a/components/fieldlabel/metadata/fieldlabel.yml
+++ b/components/fieldlabel/metadata/fieldlabel.yml
@@ -6,14 +6,14 @@ sections:
       This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/fieldlabel/metadata/mods.md">here</a>.
   - name: Migration Guide
     description: |
-      ### x/x/2024 - Version 8.0.0
+      ### Version 8.0.0
       #### Spectrum 2 release
       Field label now uses Spectrum 2 tokens and specifications. A few notable changes and additions:
       - The medium size styles are used by default, so the `spectrum-FieldLabel--sizeM` class is no longer necessary and has been removed.
       - Two variant classes have been added for black and white static colors.
       - The mod custom property `--mod-disabled-content-color` has been renamed to `--mod-field-label-disabled-content-color`.
 
-      ### 11/13/2020 - Version 3.0.0
+      ### Version 3.0.0
       #### T-shirt sizing
       Field label now supports t-shirt sizing and requires that you specify the size by adding a `.spectrum-FieldLabel--size*` class.
 examples:

--- a/components/fieldlabel/metadata/form.yml
+++ b/components/fieldlabel/metadata/form.yml
@@ -6,7 +6,7 @@ sections:
       This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/fieldlabel/metadata/mods.md">here</a>.
   - name: Migration Guide
     description: |
-      ### x/x/2024 - Version 8.0.0
+      ### Version 8.0.0
       #### Spectrum 2 release
       The renamed mod properties previously marked as deprecated have been removed:
       - `--mod-tableform-item-block-spacing` has been renamed to `--mod-form-item-block-spacing`

--- a/components/logicbutton/metadata/logicbutton.yml
+++ b/components/logicbutton/metadata/logicbutton.yml
@@ -4,7 +4,7 @@ description: A LogicButton displays an operator within a boolean logic sequence.
 sections:
   - name: Migration Guide
     description: |
-      ### x/x/2024 - Version 4.0.0
+      ### Version 4.0.0
       #### Spectrum 2 release
       Logic button now uses Spectrum 2 tokens and specifications. A few notable changes:
       - The mod custom property `--mod-line-height-100` has been renamed to `--mod-button-line-height`.
@@ -12,7 +12,7 @@ sections:
       - The mod custom property `--mod-focus-indicator-gap` has been renamed to `--mod-button-focus-indicator-gap`.
       - The mod custom property `--mod-animation-duration-100` has been renamed to `--mod-button-animation-duration`.
 
-      ### 8/16/2023 - Version 2.0.0
+      ### Version 2.0.0
       #### Remove focus-ring class
       We've migrated away from the focus-ring class in favor of the native `:focus-visible` pseudo-class due to changes in browser support.
 examples:

--- a/components/picker/metadata/picker.yml
+++ b/components/picker/metadata/picker.yml
@@ -7,7 +7,7 @@ sections:
       This component can be modified via its `--mod-*` prefixed custom properties. A list of those prefixed custom properties can be found <a class="spectrum-Link" href="https://github.com/adobe/spectrum-css/tree/main/components/picker/metadata/mods.md">here</a>.
   - name: Migration Guide
     description: |
-      ### x/x/2024 - Version 8.0.0
+      ### Version 8.0.0
       #### Spectrum 2 release
       Picker now uses Spectrum 2 tokens and specifications. A few notable changes:
       - The mod custom property `--mod-line-height-100` has been renamed to `--mod-button-line-height`.


### PR DESCRIPTION
## Description

Remove dates from in front of version numbers on migration guides (recently added), as we're adjusting to this format with just the version number going forward. Includes removal of the placeholder "x/x/2024" dates that were added. The button component was excluded from this update as they're already removed in the button S2 migration PR.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [x] Proofread docs updates. Only dates are removed.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
