### PR TITLE
style: adjust eslint config to have indented case statements

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,7 +12,7 @@
 	"rules": {
 		"brace-style": ["warn", "stroustrup", { "allowSingleLine": true }],
 		"func-call-spacing": ["warn", "never"],
-		"indent": ["warn", "tab", { "ignoredNodes": ["TemplateLiteral *"] }],
+		"indent": ["warn", "tab", { "ignoredNodes": ["TemplateLiteral *"], "SwitchCase": 1 }],
 		"linebreak-style": ["warn", "unix"],
 		"no-console": ["warn", { "allow": ["warn", "error"] }],
 		"quotes": ["warn", "double"],


### PR DESCRIPTION
## Description

Adjusts eslint config to have the case statements indented from "switch". The default was zero, which has the "switch" at the same indentation level as "case".

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

- [x] `yarn linter icon`: should report line indent errors in `stories/template.js` around line 99 [@castastrophe]
- [ ] `yarn formatter icon`: should fix line indent errors on switch statement in `stories/template.js` around line 99 [@castastrophe]

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] ✨ This pull request is ready to merge. ✨
