### PR TITLE
feat(progressbar): s2 migration

### DIFF
--- a/.changeset/proud-jokes-rule.md
+++ b/.changeset/proud-jokes-rule.md
@@ -1,0 +1,7 @@
+---
+"@spectrum-css/progressbar": major
+---
+
+feat(progressbar): S2 migration
+
+Progress bar now uses Spectrum 2 tokens and specifications. This migration includes updated colors, font sizes, and spacing. No mods were harmed in the migration of this component (all `--mod` properties remain the same).

--- a/.storybook/decorators/contextsWrapper.js
+++ b/.storybook/decorators/contextsWrapper.js
@@ -58,14 +58,14 @@ export const withContextWrapper = makeDecorator({
 				if (args.staticColor === "black") {
 					container.style.background = "var(--spectrum-examples-gradient-static-black)";
 				}
-				else if (args.staticColor === "white") {
+				else if (args.staticColor === "white" || args.isStaticWhite === true) {
 					container.style.background = "var(--spectrum-examples-gradient-static-white)";
 				}
 				else {
 					container.style.removeProperty("background");
 				}
 			}
-		}, [color, scale, isExpress, args.staticColor]);
+		}, [color, scale, isExpress, args.staticColor, args.isStaticWhite]);
 
 		return StoryFn(context);
 	},

--- a/components/progressbar/index.css
+++ b/components/progressbar/index.css
@@ -14,7 +14,7 @@ governing permissions and limitations under the License.
   /* Static tokens */
   --spectrum-progressbar-animation-ease-in-out-indeterminate: var(--spectrum-animation-ease-in-out);
   --spectrum-progressbar-animation-duration-indeterminate: var(--spectrum-animation-duration-2000);
-  --spectrum-progressbar-corner-radius: var(--spectrum-corner-radius-100);
+  --spectrum-progressbar-corner-radius: var(--spectrum-corner-radius-full);
 
   --spectrum-progressbar-fill-size-indeterminate: 70%;
 
@@ -28,14 +28,16 @@ governing permissions and limitations under the License.
   --spectrum-progressbar-size-2800: 224px;
 
   /* Size */
-  --spectrum-progressbar-font-size: var(--spectrum-font-size-75);
+  --spectrum-progressbar-size-default: var(--spectrum-progressbar-size-2400);
+
+  --spectrum-progressbar-font-size: var(--spectrum-font-size-100);
+  --spectrum-progressbar-line-height: var(--spectrum-line-height-100);
   --spectrum-progressbar-line-height-cjk: var(--spectrum-cjk-line-height-100);
 
   --spectrum-progressbar-min-size: var(--spectrum-progress-bar-minimum-width);
   --spectrum-progressbar-max-size: var(--spectrum-progress-bar-maximum-width);
 
   --spectrum-progressbar-thickness: var(--spectrum-progress-bar-thickness-medium);
-  --spectrum-progressbar-line-height: var(--spectrum-line-height-100);
 
   /* Spacing */
   --spectrum-progressbar-spacing-label-to-progressbar: var(--spectrum-spacing-75);
@@ -43,15 +45,15 @@ governing permissions and limitations under the License.
   --spectrum-progressbar-spacing-label-to-text: var(--spectrum-spacing-200);
 
   /* Color */
-  --spectrum-progressbar-text-color: var(--spectrum-neutral-content-color-default);
-  --spectrum-progressbar-track-color: var(--spectrum-gray-200);
-  --spectrum-progressbar-fill-color: var(--spectrum-accent-color-900);
+  --spectrum-progressbar-text-color: var(--spectrum-neutral-subdued-content-color-default);
+  --spectrum-progressbar-track-color: var(--spectrum-gray-300);
+  --spectrum-progressbar-fill-color: var(--spectrum-accent-content-color-default);
   --spectrum-progressbar-fill-color-positive: var(--spectrum-positive-visual-color);
   --spectrum-progressbar-fill-color-notice: var(--spectrum-notice-visual-color);
   --spectrum-progressbar-fill-color-negative: var(--spectrum-negative-visual-color);
-  --spectrum-progressbar-label-and-value-white: var(--spectrum-white);
+  --spectrum-progressbar-label-and-value-white: var(--spectrum-transparent-white-700);
   --spectrum-progressbar-track-color-white: var(--spectrum-transparent-white-300);
-  --spectrum-progressbar-fill-color-white: var(--spectrum-white);
+  --spectrum-progressbar-fill-color-white: var(--spectrum-transparent-white-900);
 
   /* Meter */
   --spectrum-meter-min-width: var(--spectrum-meter-minimum-width);
@@ -59,7 +61,6 @@ governing permissions and limitations under the License.
   --spectrum-meter-inline-size: var(--spectrum-meter-default-width);
   --spectrum-meter-thickness-s: var(--spectrum-meter-thickness-small);
   --spectrum-meter-thickness-l: var(--spectrum-meter-thickness-large);
-  --spectrum-meter-top-to-text: var(--spectrum-component-top-to-text);
 }
 
 .spectrum-ProgressBar--sizeS, .spectrum-Meter--sizeS {
@@ -71,19 +72,10 @@ governing permissions and limitations under the License.
   --spectrum-progressbar-spacing-top-to-text: var(--spectrum-component-top-to-text-75);
 }
 
-.spectrum-ProgressBar--sizeM {
-  --spectrum-progressbar-size-default: var(--spectrum-progressbar-size-2400);
-
-  --spectrum-progressbar-font-size: var(--spectrum-font-size-75);
-  --spectrum-progressbar-thickness: var(--spectrum-progress-bar-thickness-large);
-
-  --spectrum-progressbar-spacing-top-to-text: var(--spectrum-component-top-to-text-75);
-}
-
 .spectrum-ProgressBar--sizeL, .spectrum-Meter--sizeL {
   --spectrum-progressbar-size-default: var(--spectrum-progressbar-size-2500);
 
-  --spectrum-progressbar-font-size: var(--spectrum-font-size-100);
+  --spectrum-progressbar-font-size: var(--spectrum-font-size-200);
   --spectrum-progressbar-thickness: var(--spectrum-progress-bar-thickness-large);
 
   --spectrum-progressbar-spacing-top-to-text: var(--spectrum-component-top-to-text-200);
@@ -92,7 +84,7 @@ governing permissions and limitations under the License.
 .spectrum-ProgressBar--sizeXL {
   --spectrum-progressbar-size-default: var(--spectrum-progressbar-size-2800);
 
-  --spectrum-progressbar-font-size: var(--spectrum-font-size-200);
+  --spectrum-progressbar-font-size: var(--spectrum-font-size-300);
   --spectrum-progressbar-thickness: var(--spectrum-progress-bar-thickness-extra-large);
 
   --spectrum-progressbar-spacing-top-to-text: var(--spectrum-component-top-to-text-300);
@@ -126,7 +118,6 @@ governing permissions and limitations under the License.
   }
 }
 
-
 .spectrum-ProgressBar {
   position: relative;
   display: inline-flex;
@@ -135,6 +126,7 @@ governing permissions and limitations under the License.
   align-items: center;
   font-size: var(--mod-progressbar-font-size, var(--spectrum-progressbar-font-size));
   vertical-align: top;
+  word-break: break-word;
 
   inline-size: var(--mod-progressbar-size-default, var(--spectrum-progressbar-size-default));
   max-inline-size: var(--mod-progressbar-max-size, var(--spectrum-progressbar-max-size));
@@ -167,6 +159,7 @@ governing permissions and limitations under the License.
   .spectrum-ProgressBar-percentage {
     align-self: flex-start;
     margin-inline-start: var(--mod-progressbar-spacing-label-to-text, var(--spectrum-progressbar-spacing-label-to-text));
+    word-break: normal;
   }
 
   /* Track */
@@ -201,6 +194,7 @@ governing permissions and limitations under the License.
   display: inline-flex;
   flex-flow: row;
   justify-content: space-between;
+  word-break: normal;
 
   .spectrum-ProgressBar-track {
     flex: 1 1 var(--mod-progressbar-size-default, var(--spectrum-progressbar-size-default));
@@ -210,6 +204,7 @@ governing permissions and limitations under the License.
     flex-grow: 0;
     margin-inline-end: var(--mod-progressbar-spacing-label-to-text, var(--spectrum-progressbar-spacing-label-to-text));
     margin-block-end: 0;
+    margin-block-start: 0;
   }
 
   .spectrum-ProgressBar-percentage {
@@ -217,6 +212,7 @@ governing permissions and limitations under the License.
     text-align: end;
     margin-inline-start: var(--mod-spacing-progressbar-label-to-text, var(--spectrum-progressbar-spacing-label-to-text));
     margin-block-end: 0;
+    margin-block-start: 0;
   }
 }
 
@@ -224,7 +220,7 @@ governing permissions and limitations under the License.
 .spectrum-ProgressBar--staticWhite {
   .spectrum-ProgressBar-fill {
     color: var(--mod-progressbar-label-and-value-white, var(--spectrum-progressbar-label-and-value-white));
-    background-color: var(--mod-progressbar-fill-color-white, var(--spectrum-progressbar-fill-color-white));
+    background-color: var(--highcontrast-progressbar-fill-color-white, var(--mod-progressbar-fill-color-white, var(--spectrum-progressbar-fill-color-white)));
   }
 
   .spectrum-ProgressBar-label,
@@ -275,6 +271,7 @@ governing permissions and limitations under the License.
     forced-color-adjust: none;
     --highcontrast-progressbar-fill-color: ButtonText;
     --highcontrast-progressbar-track-color: ButtonFace;
+    --highcontrast-progressbar-fill-color-white: ButtonText;
     border: 1px solid ButtonText;
   }
 }

--- a/components/progressbar/metadata/progressbar.yml
+++ b/components/progressbar/metadata/progressbar.yml
@@ -5,13 +5,19 @@ id: progressbar-m
 sections:
   - name: Migration Guide
     description: |
-      ### Component renamed
+      ### Version 4.0.0
+      #### Spectrum 2 release
+      Progress bar now uses Spectrum 2 tokens and specifications. This migration includes updated colors, font sizes, and spacing. No mods were harmed in the migration of this component (all `--mod` properties remain the same).
+
+      ### Version 1.0.0-beta.3
+      #### Component renamed
       Bar loader is now known as Progress bar. Replace all `.spectrum-BarLoader*` classnames with `.spectrum-ProgressBar*`.
 
-      ### T-shirt sizing
+      #### T-shirt sizing
       Progress bar now supports t-shirt sizing and requires that you specify the size of button by adding a `.spectrum-ProgressBar--size*` class.
 
-      ### Size classnames changed
+
+      #### Size classnames changed
       Previous size classnames map as follows:
 
       | Previous size classname         | New size classname                |
@@ -19,7 +25,7 @@ sections:
       | `.spectrum-ProgressBar--small`  | `.spectrum-ProgressBar--sizeS`    |
       | `.spectrum-ProgressBar--large`  | `.spectrum-ProgressBar--sizeM`    |
 
-      ### Label and percentage now use Field Label
+      #### Label and percentage now use Field Label
       Progress bar now uses [Field label](fieldlabel.html) for its label and percentage. Add the appropriately sized Field label to match the t-shirt size of the Progress bar.
 examples:
   - id: progressbar-m

--- a/components/progressbar/package.json
+++ b/components/progressbar/package.json
@@ -21,7 +21,7 @@
   ],
   "peerDependencies": {
     "@spectrum-css/fieldlabel": ">=7",
-    "@spectrum-css/tokens": ">=14.0.0-next.3"
+    "@spectrum-css/tokens": ">=14.0.0-next.6"
   },
   "peerDependenciesMeta": {
     "@spectrum-css/fieldlabel": {

--- a/components/progressbar/stories/progressbar.stories.js
+++ b/components/progressbar/stories/progressbar.stories.js
@@ -1,3 +1,7 @@
+import { html } from "lit";
+
+import { Template as Typography } from "@spectrum-css/typography/stories/template.js";
+import { styleMap } from "lit/directives/style-map.js";
 import { Template } from "./template";
 
 /**
@@ -7,8 +11,25 @@ export default {
 	title: "Components/Progress bar",
 	component: "ProgressBar",
 	argTypes: {
-		customWidth: { table: { disable: true } },
-		indeterminate: { table: { disable: true } },
+		customWidth: {
+			name: "Custom width",
+			description: "A number to adjust the width of the component. Spectrum 2 specifications limit the component width to be between 48px and 768px.",
+			type: { name: "number" },
+			table: {
+				type: { summary: "number" },
+				category: "Component",
+			},
+			control: { type: "range", min: 48, max: 768,},
+		},
+		isIndeterminate: {
+			name: "Indeterminate",
+			type: { name: "boolean" },
+			table: {
+				type: { summary: "boolean" },
+				category: "State",
+			},
+			control: "boolean",
+		},
 		size: {
 			name: "Size",
 			type: { name: "string", required: true },
@@ -48,15 +69,14 @@ export default {
 			control: { type: "range", min: 0, max: 100,},
 			if: { arg: "indeterminate", truthy: false },
 		},
-		staticColor: {
-			name: "Static color",
-			type: { name: "string" },
+		isStaticWhite: {
+			name: "Static White",
+			type: { name: "boolean" },
 			table: {
-				type: { summary: "string" },
+				type: { summary: "boolean" },
 				category: "Advanced",
 			},
-			options: ["white"],
-			control: "select",
+			control: "boolean",
 		},
 	},
 	args: {
@@ -65,6 +85,9 @@ export default {
 		labelPosition: "top",
 		label: "Loading",
 		value: 50,
+		isStaticWhite: false,
+		isIndeterminate: false,
+		customWidth: 200,
 	},
 	parameters: {
 		actions: {
@@ -74,25 +97,174 @@ export default {
 			type: "migrated",
 		},
 	},
+	decorators: [
+		(Story, context) => html`
+			<style>
+				.spectrum-Detail { display: inline-block; }
+				.spectrum-Typography > div {
+					border: 1px solid var(--spectrum-gray-200);
+					border-radius: 4px;
+					padding: 0 1em 1em;
+					/* Why seafoam? Because it separates it from the component styles. */
+					--mod-detail-font-color: var(--spectrum-seafoam-900);
+				}
+			</style>
+			<div
+				style=${styleMap({
+					display: "flex",
+					flexDirection: "column",
+					alignItems: "flex-start",
+					gap: "1rem",
+					"--mod-detail-margin-end": ".3rem",
+				})}
+			>
+				${Story(context)}
+			</div>
+		`,
+	],
 };
 
-export const Default = Template.bind({});
+const States = (args) =>
+	html`
+		<div>
+			${Typography({
+				semantics: "detail",
+				size: "s",
+				content: ["Default"],
+			})}
+			${Template(args)}
+		</div>
+		<div>
+			${Typography({
+				semantics: "detail",
+				size: "s",
+				content: ["Side label"],
+			})}
+			${Template({
+				...args,
+				labelPosition: "side",
+			})}
+		</div>
+		<div>
+			${Typography({
+				semantics: "detail",
+				size: "s",
+				content: ["Indeterminate"],
+			})}
+			${Template({
+				...args,
+				isIndeterminate: true,
+			})}
+		</div>
+		<div>
+			${Typography({
+				semantics: "detail",
+				size: "s",
+				content: ["Custom width"],
+			})}
+			${Template({
+				...args,
+				customWidth: "500px",
+			})}
+		</div>
+		<div>
+			${Typography({
+				semantics: "detail",
+				size: "s",
+				content: ["Static white"],
+			})}
+			<div style=${styleMap({
+					background: "var(--spectrum-examples-gradient-static-white)",
+					padding: "1rem",
+				})}
+			>
+				${Template({
+					...args,
+					isStaticWhite: true,
+					/* Force dark mode to make typography readable */
+					color: "dark",
+					label: "Loading your fonts, images, and icons, longwordverylongworddoesntcauseoverflow",
+				})}
+			</div>
+		</div>
+	`;
+
+const Sizes = (args) =>
+	html` ${["s", "m", "l", "xl"].map((size) => {
+		return html` <div>
+			${Typography({
+				semantics: "detail",
+				size: "s",
+				content: [
+					{
+						s: "Small",
+						m: "Medium",
+						l: "Large",
+						xl: "Extra-large",
+					}[size],
+				],
+			})}
+			${Template({
+				...args,
+				size,
+			})}
+		</div>`;
+	})}`;
+
+const Variants = (args) =>
+	html` ${window.isChromatic()
+		? html` <div class="spectrum-Typography">
+					${Typography({
+						semantics: "detail",
+						size: "l",
+						content: ["Standard"],
+					})}
+					<div
+						style=${styleMap({
+							display: "flex",
+							flexDirection: "column",
+							gap: ".3rem",
+						})}
+					>
+						${States(args)}
+					</div>
+				</div>
+				<div class="spectrum-Typography">
+					${Typography({
+						semantics: "detail",
+						size: "l",
+						content: ["Sizing"],
+					})}
+					<div
+						style=${styleMap({
+							display: "flex",
+							flexDirection: "column",
+							gap: ".3rem",
+						})}
+					>
+						${Sizes(args)}
+					</div>
+				</div>
+				<div class="spectrum-Typography">
+					${Typography({
+						semantics: "detail",
+						size: "l",
+						content: ["Sizing - Side label"],
+					})}
+					<div
+						style=${styleMap({
+							display: "flex",
+							flexDirection: "column",
+							gap: ".3rem",
+						})}
+					>
+						${Sizes({
+							...args,
+							labelPosition: "side",
+						})}
+					</div>
+				</div>`
+		: Template(args)}`;
+
+export const Default = Variants.bind({});
 Default.args = {};
-
-export const CustomWidth = Template.bind({});
-CustomWidth.args = {
-	customWidth: "500px",
-};
-
-export const Indeterminate = Template.bind({});
-Indeterminate.args = {
-	indeterminate: "indeterminate",
-};
-
-export const StaticWhite = Template.bind({});
-StaticWhite.args = {
-	/* Force dark mode to make typography readable */
-	color: "dark",
-	staticColor: "white",
-	label: "Loading your fonts, images, and icons"
-};

--- a/components/progressbar/stories/template.js
+++ b/components/progressbar/stories/template.js
@@ -1,8 +1,7 @@
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 import { styleMap } from "lit/directives/style-map.js";
-
-import { capitalize, lowerCase } from "lodash-es";
 
 import { Template as FieldLabel } from "@spectrum-css/fieldlabel/stories/template.js";
 
@@ -12,28 +11,28 @@ export const Template = ({
 	rootClass = "spectrum-ProgressBar",
 	customClasses = [],
 	labelPosition,
-	staticColor,
+	isStaticWhite,
 	customWidth,
-	indeterminate,
+	isIndeterminate = false,
 	label,
 	value,
-	customStyles = {},
+	customStyles = {
+		width: customWidth ? `${customWidth}px` : "",
+	},
 	size = "m",
 	...globals
 }) => html`
+	<div>
 		<div
 			class=${classMap({
 				[rootClass]: true,
 				[`${rootClass}--size${size?.toUpperCase()}`]: typeof size !== "undefined",
 				[`${rootClass}--${labelPosition}Label`]: typeof labelPosition !== "undefined",
-				[`${rootClass}--static${capitalize(lowerCase(staticColor))}`]: typeof staticColor !== "undefined",
-				[`${rootClass}--${indeterminate}`]: typeof indeterminate !== "undefined",
+				[`${rootClass}--staticWhite`]: isStaticWhite,
+				[`${rootClass}--indeterminate`]: isIndeterminate,
 				...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
 			})}
-			style=${styleMap({
-				"width": customWidth,
-				...customStyles,
-			})}
+			style=${ifDefined(styleMap(customStyles))}
 			value="${value}%"
 			role="progressbar"
 			aria-valuenow="${value}%"
@@ -50,7 +49,7 @@ export const Template = ({
 			${FieldLabel({
 				...globals,
 				size,
-				label: indeterminate ? "" : `${value}%`,
+				label: isIndeterminate ? "" : `${value}%`,
 				alignment: "",
 				customClasses: [`${rootClass}-percentage`],
 			})}
@@ -58,4 +57,5 @@ export const Template = ({
 				<div class="${rootClass}-fill" style="width: ${value}%;"></div>
 			</div>
 		</div>
-	`;
+	</div>
+`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5286,7 +5286,7 @@ __metadata:
   resolution: "@spectrum-css/progressbar@workspace:components/progressbar"
   peerDependencies:
     "@spectrum-css/fieldlabel": ">=7"
-    "@spectrum-css/tokens": ">=14.0.0-next.3"
+    "@spectrum-css/tokens": ">=14.0.0-next.6"
   peerDependenciesMeta:
     "@spectrum-css/fieldlabel":
       optional: true


### PR DESCRIPTION
## Description

Migrates Progress Bar to Spectrum 2 ([design spec](https://www.figma.com/file/eoZHKJH9a3LJkHYCGt60Vb/S2-token-specs?type=design&node-id=9602-4210&mode=design&t=dE1k2G9oVanenmOD-0)). Includes:

- Updated font sizes
- Updated colors
- WHCM improvement for Static White variant
- Increased Chromatic coverage
- Consolidation of Storybook stories (only Default now and users can use controls to see other variants/states)
- No mods were changed

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

@jawinn 
- [x] Variants are accessible by controls in [Storybook](https://pr-2659--spectrum-css.netlify.app/preview/?path=/story/components-progress-bar--default) (especially check Static White)
- [x] Check Chromatic testing preview in Storybook
- [x] design review @mdt2  ([Slack approval](https://adobedesign.slack.com/archives/GQ09RCBA5/p1715093042181289?thread_ts=1714399943.756669&cid=GQ09RCBA5))

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.


## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
