### PR TITLE
feat(card): overflow hidden on cover photo for swc implementation

### DIFF
--- a/components/card/index.css
+++ b/components/card/index.css
@@ -365,6 +365,7 @@ governing permissions and limitations under the License.
 		var(--spectrum-card-preview-minimum-height)
 	);
 	box-sizing: border-box;
+	overflow: hidden;
 
 	display: flex;
 	align-items: center;


### PR DESCRIPTION
## Description

Adds overflow hidden to the .spectrum-Card-coverPhoto class, to help resolve an issue in the SWC implementation that uses sp-asset.

In SWC the photo could appear from behind the corners of the card. For example, when increasing the corner rounding when setting the mod --mod-card-corner-radius. This issue is not visible in Spectrum CSS. This overflow property used to exist in SWC as a CSS override, but is preferred to exist here in CSS.

**Example of the issue in SWC:** 
Set `--mod-card-corner-radius: 24px` on the sp-card in the [first example on the SWC docs site](https://opensource.adobe.com/spectrum-web-components/components/card/):
![Screenshot 2024-04-12 at 4 57 43 PM](https://github.com/adobe/spectrum-css/assets/965114/028c68c3-efc1-46a5-9e79-e4c6ffbac59e)
Setting `overflow: hidden` on the `#cover-photo` selector via the inspector fixes the issue. The spectrum-config in SWC converts our class to that ID (`converter.classToId('spectrum-Card-coverPhoto', 'cover-photo')`).

CSS-734

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [ ] Changes do not affect the component in Spectrum CSS.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] ✨ This pull request is ready to merge. ✨
