### PR TITLE
chore: minor fixes in build workflow and package alignment

### DIFF
--- a/.storybook/project.json
+++ b/.storybook/project.json
@@ -4,7 +4,8 @@
 		"tools": [
 			"{projectRoot}/assets",
 			"{projectRoot}/decorators",
-			"{projectRoot}/*.{js,html}"
+			"{projectRoot}/guides",
+			"{projectRoot}/*.{js,html,mdx}"
 		]
 	},
 	"targets": {
@@ -15,29 +16,30 @@
 			],
 			"executor": "nx:run-commands",
 			"options": {
+				"cwd": "{projectRoot}",
 				"commands": [
-					"rimraf {projectRoot}/storybook-static",
-					"test -d {projectRoot}/storybook-static && echo \"Error: storybook-static directory could not be removed\" && exit 1 || exit 0"
+					"rimraf storybook-static",
+					"test -d storybook-static && echo \"Error: storybook-static directory could not be removed\" && exit 1 || exit 0"
 				],
 				"parallel": false
+			},
+			"configurations": {
+				"docs": {
+					"inputs": [
+						"{workspaceRoot}/dist/preview",
+						{ "externalDependencies": ["rimraf"] }
+					],
+					"cwd": "{workspaceRoot}",
+					"commands": [
+						"rimraf dist/preview",
+						"test -d dist/preview && echo \"Error: dist/preview directory could not be removed\" && exit 1 || exit 0"
+					]
+				}
 			}
 		},
 		"build": {
-			"dependsOn": [
-				"^build",
-				{
-					"target": "build",
-					"projects": "ui-icons"
-				}
-			],
-			"inputs": [
-				"{projectRoot}/assets",
-				"{projectRoot}/decorators",
-				"{projectRoot}/*.js",
-				"{projectRoot}/*.html",
-				"{workspaceRoot}/components/*/dist",
-				{ "externalDependencies": ["storybook"] }
-			],
+			"dependsOn": ["clean", "^build"],
+			"inputs": ["tools", { "externalDependencies": ["storybook"] }],
 			"outputs": ["{projectRoot}/storybook-static"],
 			"executor": "nx:run-commands",
 			"options": {
@@ -60,19 +62,9 @@
 		},
 		"start": {
 			"cache": true,
-			"dependsOn": [
-				"^build",
-				{
-					"target": "build",
-					"projects": "ui-icons"
-				}
-			],
+			"dependsOn": ["^build"],
 			"inputs": [
-				"{projectRoot}/assets",
-				"{projectRoot}/decorators",
-				"{projectRoot}/*.js",
-				"{projectRoot}/*.html",
-				"{workspaceRoot}/components/*/dist",
+				"tools",
 				{ "externalDependencies": ["storybook"] },
 				{ "env": "WATCH_MODE" }
 			],
@@ -85,11 +77,7 @@
 		"test": {
 			"cache": true,
 			"inputs": [
-				"{projectRoot}/assets",
-				"{projectRoot}/decorators",
-				"{projectRoot}/*.js",
-				"{projectRoot}/*.html",
-				"{workspaceRoot}/components/*/dist",
+				"tools",
 				{ "externalDependencies": ["chromatic", "storybook"] },
 				{ "env": "CHROMATIC_PROJECT_TOKEN" }
 			],

--- a/nx.json
+++ b/nx.json
@@ -53,8 +53,7 @@
 			"cache": true,
 			"dependsOn": [
 				"^build",
-				"clean",
-				{ "target": "build", "projects": "tokens" }
+				"clean"
 			],
 			"inputs": [
 				"core",

--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
 		"url": "https://github.com/adobe/spectrum-css/issues"
 	},
 	"scripts": {
-		"build": "yarn builder tag:component",
+		"build": "yarn builder tag:component,ui-icons",
 		"build:preview": "nx build storybook",
 		"build:site": "nx clean docs && nx build docs && nx run storybook:build:docs",
 		"builder": "nx run-many --target build --projects",
 		"changeset": "changeset",
-		"ci": "cross-env NODE_ENV=production yarn builder tag:component,ui-icons --skip-nx-cache",
+		"ci": "cross-env NODE_ENV=production yarn build --skip-nx-cache",
 		"ci:storybook": "cross-env NODE_ENV=production nx run storybook:build:ci --skip-nx-cache",
 		"clean": "yarn cleaner tag:component",
 		"clean:docs": "rimraf dist",

--- a/site/package.json
+++ b/site/package.json
@@ -19,7 +19,7 @@
     "@adobe/focus-ring-polyfill": "^0.1.5",
     "@adobe/spectrum-css-workflow-icons": "^1.5.4",
     "@spectrum-css/tokens": "^14.0.0",
-    "@spectrum-css/ui-icons": "^1.1.1",
+    "@spectrum-css/ui-icons": "^1.1.2",
     "browser-sync": "^3.0.2",
     "colors": "^1.4.0",
     "dependency-solver": "^1.0.6",

--- a/site/project.json
+++ b/site/project.json
@@ -33,10 +33,6 @@
 					"target": "build",
 					"projects": "tag:component"
 				},
-				{
-					"target": "build",
-					"projects": "ui-icons"
-				},
 				"clean"
 			],
 			"inputs": ["core", "tools"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -5620,7 +5620,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@spectrum-css/ui-icons@npm:^1.1.1, @spectrum-css/ui-icons@npm:^1.1.2, @spectrum-css/ui-icons@workspace:ui-icons":
+"@spectrum-css/ui-icons@npm:^1.1.2, @spectrum-css/ui-icons@workspace:ui-icons":
   version: 0.0.0-use.local
   resolution: "@spectrum-css/ui-icons@workspace:ui-icons"
   dependencies:
@@ -5656,7 +5656,7 @@ __metadata:
     "@adobe/focus-ring-polyfill": "npm:^0.1.5"
     "@adobe/spectrum-css-workflow-icons": "npm:^1.5.4"
     "@spectrum-css/tokens": "npm:^14.0.0"
-    "@spectrum-css/ui-icons": "npm:^1.1.1"
+    "@spectrum-css/ui-icons": "npm:^1.1.2"
     browser-sync: "npm:^3.0.2"
     colors: "npm:^1.4.0"
     dependency-solver: "npm:^1.0.6"


### PR DESCRIPTION
## Description

- Add the guides folder to the storybook dependencies and include mdx assets as well
- Use a shared list of storybook dependencies called "tools" instead of redefining them in every tasks inputs
- Remove the manual ui-icons build task from the storybook build and start tasks and the site build task
- Remove the manual token build from the shared build task
- Add ui-icons to the default yarn builder and leverage the shared build task in subsequent commands

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
