### PR TITLE
chore: fix eslint formatting command

### DIFF
--- a/components/checkbox/stories/template.js
+++ b/components/checkbox/stories/template.js
@@ -42,17 +42,17 @@ export const Template = ({
 
 	let iconSize = "75";
 	switch (size) {
-	case "s":
-		iconSize = "50";
-		break;
-	case "l":
-		iconSize = "100";
-		break;
-	case "xl":
-		iconSize = "200";
-		break;
-	default:
-		iconSize = "75";
+		case "s":
+			iconSize = "50";
+			break;
+		case "l":
+			iconSize = "100";
+			break;
+		case "xl":
+			iconSize = "200";
+			break;
+		default:
+			iconSize = "75";
 	}
 
 	return html`

--- a/components/fieldlabel/stories/template.js
+++ b/components/fieldlabel/stories/template.js
@@ -27,17 +27,17 @@ export const Template = ({
 
 	let iconName = "Asterisk100";
 	switch (size) {
-	case "s":
-		iconName = "Asterisk100";
-		break;
-	case "l":
-		iconName = "Asterisk200";
-		break;
-	case "xl":
-		iconName = "Asterisk300";
-		break;
-	default:
-		iconName = "Asterisk100";
+		case "s":
+			iconName = "Asterisk100";
+			break;
+		case "l":
+			iconName = "Asterisk200";
+			break;
+		case "xl":
+			iconName = "Asterisk300";
+			break;
+		default:
+			iconName = "Asterisk100";
 	}
 
 	return html`

--- a/components/icon/stories/template.js
+++ b/components/icon/stories/template.js
@@ -96,20 +96,20 @@ export const Template = ({
 	) {
 		let sizeVal;
 		switch (size) {
-		case "xs":
-		case "s":
-			sizeVal = "75";
-			break;
-		case "l":
-			sizeVal = "200";
-			break;
-		case "xl":
-		case "xxl":
-			sizeVal = "300";
-			break;
-		default:
-			sizeVal = "100";
-			break;
+			case "xs":
+			case "s":
+				sizeVal = "75";
+				break;
+			case "l":
+				sizeVal = "200";
+				break;
+			case "xl":
+			case "xxl":
+				sizeVal = "300";
+				break;
+			default:
+				sizeVal = "100";
+				break;
 		}
 
 		idKey += sizeVal;

--- a/components/inlinealert/stories/template.js
+++ b/components/inlinealert/stories/template.js
@@ -20,19 +20,19 @@ export const Template = ({
 }) => {
 	let iconName;
 	switch (variant) {
-	case "info":
-		iconName = "Info";
-		break;
-	case "positive":
-		iconName = "CheckmarkCircle";
-		break;
-	case "notice":
-	case "negative":
-	case "closable":
-		iconName = "Alert";
-		break;
-	default:
-		iconName = undefined;
+		case "info":
+			iconName = "Info";
+			break;
+		case "positive":
+			iconName = "CheckmarkCircle";
+			break;
+		case "notice":
+		case "negative":
+		case "closable":
+			iconName = "Alert";
+			break;
+		default:
+			iconName = undefined;
 	}
 
 	const iconMarkup =

--- a/components/menu/stories/template.js
+++ b/components/menu/stories/template.js
@@ -155,14 +155,14 @@ export const MenuItem = ({
  */
 const backArrowWithScale = (size = "m", iconName = "ArrowLeft") => {
 	switch (size) {
-	case "s":
-		return `${iconName}200`;
-	case "l":
-		return `${iconName}400`;
-	case "xl":
-		return `${iconName}500`;
-	default:
-		return `${iconName}300`;
+		case "s":
+			return `${iconName}200`;
+		case "l":
+			return `${iconName}400`;
+		case "xl":
+			return `${iconName}500`;
+		default:
+			return `${iconName}300`;
 	}
 };
 

--- a/components/picker/stories/template.js
+++ b/components/picker/stories/template.js
@@ -122,17 +122,17 @@ export const Template = ({
 
 	let iconName = "ChevronDown200";
 	switch (size) {
-	case "s":
-		iconName = "ChevronDown75";
-		break;
-	case "m":
-		iconName = "ChevronDown100";
-		break;
-	case "xl":
-		iconName = "ChevronDown300";
-		break;
-	default:
-		iconName = "ChevronDown200";
+		case "s":
+			iconName = "ChevronDown75";
+			break;
+		case "m":
+			iconName = "ChevronDown100";
+			break;
+		case "xl":
+			iconName = "ChevronDown300";
+			break;
+		default:
+			iconName = "ChevronDown200";
 	}
 
 	return html`

--- a/components/progresscircle/stories/template.js
+++ b/components/progresscircle/stories/template.js
@@ -18,14 +18,14 @@ export const Template = ({
 }) => {
 	let sizeClassName = "medium";
 	switch (size) {
-	case "s":
-		sizeClassName = "small";
-		break;
-	case "l":
-		sizeClassName = "large";
-		break;
-	default:
-		sizeClassName = "medium";
+		case "s":
+			sizeClassName = "small";
+			break;
+		case "l":
+			sizeClassName = "large";
+			break;
+		default:
+			sizeClassName = "medium";
 	}
 
 	const componentMarkup = html`

--- a/components/stepper/stories/template.js
+++ b/components/stepper/stories/template.js
@@ -36,17 +36,17 @@ export const Template = ({
 
 	let iconSize = "75";
 	switch (size) {
-	case "s":
-		iconSize = "50";
-		break;
-	case "l":
-		iconSize = "100";
-		break;
-	case "xl":
-		iconSize = "200";
-		break;
-	default:
-		iconSize = "75";
+		case "s":
+			iconSize = "50";
+			break;
+		case "l":
+			iconSize = "100";
+			break;
+		case "xl":
+			iconSize = "200";
+			break;
+		default:
+			iconSize = "75";
 	}
 
 	return html`

--- a/nx.json
+++ b/nx.json
@@ -138,8 +138,8 @@
 			"executor": "nx:run-commands",
 			"options": {
 				"commands": [
-					"stylelint --fix --cache --allow-empty-input --quiet {projectRoot}/*.css {projectRoot}/**/*.css",
-					"eslint --fix --cache --no-error-on-unmatched-pattern --quiet {projectRoot}/*.json {projectRoot}/stories/*.js || exit 0",
+					"stylelint --fix --cache --allow-empty-input {projectRoot}/*.css {projectRoot}/**/*.css",
+					"eslint --fix --cache --no-error-on-unmatched-pattern {projectRoot}/*.json {projectRoot}/stories/*.js",
 					"prettier --write --cache --loglevel error --ignore-unknown --no-error-on-unmatched-pattern {projectRoot}/*.{yml,md} {projectRoot}/**/*.{yml,md}"
 				]
 			}


### PR DESCRIPTION
## Description

In a previous PR, the switch case indent rules were not being applied when running the `yarn format` command. Upon investigation, we found that the `|| exit 0` at the end of the command for eslint was causing the command not to run. I removed this line and successfully ran the formatter on files with the old switch syntax.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [x] Alter spacing on one of the corrected switch commands; run `yarn formatter <component name>` and expect to see those changes automatically reverted

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] ✨ This pull request is ready to merge. ✨
