### PR TITLE
fix: remove custom storybook keyboard shortcuts for text direction

### DIFF
--- a/.storybook/decorators/index.js
+++ b/.storybook/decorators/index.js
@@ -6,27 +6,15 @@ export { withTestingPreviewWrapper } from "./withTestingPreviewWrapper.js";
 
 /**
  * @type import('@storybook/csf').DecoratorFunction<import('@storybook/web-components').WebComponentsFramework>
- * @description Rendered as controls; these properties are assigned to the document root element
+ * @description Sets the text direction of the document, using the global set with a toolbar control. These properties are assigned to the document root element.
  **/
 export const withTextDirectionWrapper = makeDecorator({
 	name: "withTextDirectionWrapper",
 	parameterName: "textDecoration",
 	wrapper: (StoryFn, context) => {
 		const { globals, parameters } = context;
-    const defaultDirection = "ltr"
+		const defaultDirection = "ltr"
 		const textDirection = parameters.textDirection || globals.textDirection || defaultDirection;
-
-		// Shortkeys for the global types
-		document.addEventListener("keydown", (e) => {
-			switch (e.key || e.keyCode) {
-				case "r":
-					document.documentElement.dir = "rtl";
-					break;
-				case "n":
-					document.documentElement.dir = defaultDirection;
-					break;
-			}
-		});
 
 		useEffect(() => {
 			if (textDirection) document.documentElement.dir = textDirection;


### PR DESCRIPTION
## Description

This PR removes the Storybook "r" and "n" key shortcuts for the text direction toolbar control.

When pressing the "r" or "n" key, the document direction would change due to this custom keydown code. This was causing problems such as typing into a text input and the document direction would flip if you typed anything with the letter "r". This also conflicted with other shortcuts, such as Cmd+Shift+R to reload the page.

CSS-647

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [ ] Storybook - pressing the "r" or "n" keys no longer changes text direction (after clicking into story content area)
- [ ] Storybook - text direction toolbar control continues to function

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
