### PR TITLE
refactor(button): remove spectrum-ButtonWithFocusRing extend

### DIFF
--- a/.changeset/fresh-seahorses-join.md
+++ b/.changeset/fresh-seahorses-join.md
@@ -1,0 +1,8 @@
+---
+"@spectrum-css/button": patch
+---
+
+#### refactor: remove spectrum-ButtonWithFocusRing placeholder class extend
+
+Removes the need for the extend from this placeholder class, as the styles it provides have diverged slightly from what is in button and it was causing some unnecessary CSS to override.
+This should not result in any changed visuals or behavior, as the same CSS has been integrated.

--- a/components/button/index.css
+++ b/components/button/index.css
@@ -331,7 +331,6 @@ governing permissions and limitations under the License.
 
 .spectrum-Button {
   @extend %spectrum-BaseButton;
-  @extend %spectrum-ButtonWithFocusRing;
 
   border-radius: var(--mod-button-border-radius, var(--spectrum-button-border-radius));
   border-width: var(--mod-button-border-width, var(--spectrum-button-border-width));
@@ -384,6 +383,8 @@ governing permissions and limitations under the License.
 
   /* Focus indicator */
   &::after {
+    content: "";
+    display: block;
     position: absolute;
     inset: 0;
     margin: calc((
@@ -397,7 +398,6 @@ governing permissions and limitations under the License.
     ));
     transition: box-shadow var(--mod-button-animation-duration, var(--spectrum-button-animation-duration)) ease-in-out;
     pointer-events: none;
-    content: '';
   }
 
   &:focus-visible,
@@ -409,13 +409,6 @@ governing permissions and limitations under the License.
       box-shadow: 0 0 0
         var(--mod-button-focus-ring-thickness, var(--spectrum-button-focus-ring-thickness))
         var(--highcontrast-button-focus-ring-color, var(--mod-button-focus-ring-color, var(--spectrum-button-focus-indicator-color)));
-
-      /* Margin is repeated to override declaration coming from the imported BaseButton. */
-      margin: calc((
-          var(--mod-button-focus-ring-gap, var(--spectrum-button-focus-ring-gap)) +
-          var(--mod-button-border-width, var(--spectrum-button-border-width))
-        ) * -1
-      );
     }
   }
 

--- a/components/button/metadata/mods.md
+++ b/components/button/metadata/mods.md
@@ -22,7 +22,6 @@
 | `--mod-button-edge-to-text`              |
 | `--mod-button-edge-to-visual`            |
 | `--mod-button-edge-to-visual-only`       |
-| `--mod-button-focus-indicator-gap`       |
 | `--mod-button-focus-ring-border-radius`  |
 | `--mod-button-focus-ring-color`          |
 | `--mod-button-focus-ring-gap`            |


### PR DESCRIPTION
## Description

**refactor: remove spectrum-ButtonWithFocusRing placeholder class** `extend` from the button component

Removes the need for the `extend` from this placeholder class in the button component, as the styles it provides have diverged slightly from what is in button and it was causing some unnecessary CSS to override. This should not result in any changed visuals or behavior, as the same CSS has been integrated.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [ ] Button visuals are not affected. Focus indicator ring remains unchanged (test button sizes and wrapping button).

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] ✨ This pull request is ready to merge. ✨
