### PR TITLE
fix(picker): correct disabled state colors

### DIFF
--- a/.changeset/sixty-pandas-impress.md
+++ b/.changeset/sixty-pandas-impress.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/picker": patch
+---
+
+Fixes an issue where colors could change when hovering over the Picker in the disabled state and disabled + invalid state.

--- a/components/picker/index.css
+++ b/components/picker/index.css
@@ -277,6 +277,26 @@ governing permissions and limitations under the License.
 		}
 	}
 
+	&.is-open:not(.spectrum-Picker--quiet, :disabled, .is-disabled) {
+		color: var(--highcontrast-picker-content-color-default, var(--mod-picker-font-color-default-open, var(--spectrum-picker-font-color-default-open)));
+		background-color: var(--highcontrast-picker-background-color, var(--mod-picker-background-color-default-open, var(--spectrum-picker-background-color-default-open)));
+		border-color: var(--highcontrast-picker-border-color-default, var(--mod-picker-border-default-open, var(--spectrum-picker-border-color-default-open)));
+
+		&:hover {
+			color: var(--highcontrast-picker-content-color-default, var(--mod-picker-font-color-hover-open, var(--spectrum-picker-font-color-hover-open)));
+			background-color: var(--highcontrast-picker-background-color, var(--mod-picker-background-color-hover-open, var(--spectrum-picker-background-color-hover-open)));
+			border-color: var(--highcontrast-picker-border-color-hover, var(--mod-picker-border-color-hover-open, var(--spectrum-picker-border-color-hover-open)));
+
+			.spectrum-Picker-menuIcon {
+				color: var(--highcontrast-picker-content-color-default, var(--mod-picker-icon-color-hover-open, var(--spectrum-picker-icon-color-hover-open)));
+			}
+		}
+
+		.spectrum-Picker-menuIcon {
+			color: var(--highcontrast-picker-content-color-default, var(--mod-picker-icon-color-default-open, var(--spectrum-picker-icon-color-default-open)));
+		}
+	}
+
 	&.is-invalid:not(:disabled, .is-disabled) {
 		border-color: var(--highcontrast-picker-border-color-default, var(--mod-picker-border-color-error-default, var(--spectrum-picker-border-color-error-default)));
 
@@ -321,47 +341,28 @@ governing permissions and limitations under the License.
 		}
 	}
 
-	&:disabled,
-	&.is-disabled {
-		cursor: default;
-		background-color: var(--highcontrast-picker-background-color, var(--mod-picker-background-color-disabled, var(--spectrum-picker-background-color-disabled)));
-		border-color: var(--highcontrast-picker-border-color-disabled, transparent);
-		color: var(--highcontrast-picker-content-color-disabled, var(--mod-picker-font-color-disabled, var(--spectrum-picker-font-color-disabled)));
-
-		.spectrum-Picker-icon,
-		.spectrum-Picker-menuIcon,
-		.spectrum-Picker-validationIcon {
-			color: var(--highcontrast-picker-content-color-disabled, var(--mod-picker-icon-color-disabled, var(--spectrum-picker-icon-color-disabled)));
-		}
-
-		.spectrum-Picker-label.is-placeholder {
-			color: var(--highcontrast-picker-content-color-disabled, var(--mod-picker-font-color-disabled, var(--spectrum-picker-font-color-disabled)));
-		}
-	}
-
 	.spectrum-Picker-icon {
 		flex-shrink: 0;
 		margin-inline-end: var(--mod-picker-spacing-text-to-icon, var(--spectrum-picker-spacing-text-to-icon));
 	}
 }
 
-.spectrum-Picker.is-open:not(.spectrum-Picker--quiet) {
-	color: var(--highcontrast-picker-content-color-default, var(--mod-picker-font-color-default-open, var(--spectrum-picker-font-color-default-open)));
-	background-color: var(--highcontrast-picker-background-color, var(--mod-picker-background-color-default-open, var(--spectrum-picker-background-color-default-open)));
-	border-color: var(--highcontrast-picker-border-color-default, var(--mod-picker-border-default-open, var(--spectrum-picker-border-color-default-open)));
+/* Disabled state. */
+.spectrum-Picker.spectrum-Picker:disabled,
+.spectrum-Picker.spectrum-Picker.is-disabled {
+	cursor: default;
+	background-color: var(--highcontrast-picker-background-color, var(--mod-picker-background-color-disabled, var(--spectrum-picker-background-color-disabled)));
+	border-color: var(--highcontrast-picker-border-color-disabled, transparent);
+	color: var(--highcontrast-picker-content-color-disabled, var(--mod-picker-font-color-disabled, var(--spectrum-picker-font-color-disabled)));
 
-	&:hover {
-		color: var(--highcontrast-picker-content-color-default, var(--mod-picker-font-color-hover-open, var(--spectrum-picker-font-color-hover-open)));
-		background-color: var(--highcontrast-picker-background-color, var(--mod-picker-background-color-hover-open, var(--spectrum-picker-background-color-hover-open)));
-		border-color: var(--highcontrast-picker-border-color-hover, var(--mod-picker-border-color-hover-open, var(--spectrum-picker-border-color-hover-open)));
-
-		.spectrum-Picker-menuIcon {
-			color: var(--highcontrast-picker-content-color-default, var(--mod-picker-icon-color-hover-open, var(--spectrum-picker-icon-color-hover-open)));
-		}
+	.spectrum-Picker-icon,
+	.spectrum-Picker-menuIcon,
+	.spectrum-Picker-validationIcon {
+		color: var(--highcontrast-picker-content-color-disabled, var(--mod-picker-icon-color-disabled, var(--spectrum-picker-icon-color-disabled)));
 	}
 
-	.spectrum-Picker-menuIcon {
-		color: var(--highcontrast-picker-content-color-default, var(--mod-picker-icon-color-default-open, var(--spectrum-picker-icon-color-default-open)));
+	.spectrum-Picker-label.is-placeholder {
+		color: var(--highcontrast-picker-content-color-disabled, var(--mod-picker-font-color-disabled, var(--spectrum-picker-font-color-disabled)));
 	}
 }
 
@@ -481,8 +482,8 @@ governing permissions and limitations under the License.
 		background-color: var(--highcontrast-picker-background-color, transparent);
 	}
 
-	&:disabled,
-	&.is-disabled {
+	&.spectrum-Picker:disabled,
+	&.spectrum-Picker.is-disabled {
 		background-color: var(--highcontrast-picker-background-color, transparent);
 	}
 }

--- a/components/picker/index.css
+++ b/components/picker/index.css
@@ -32,7 +32,6 @@ governing permissions and limitations under the License.
 	--spectrum-picker-spacing-bottom-to-text: var(--spectrum-component-bottom-to-text-100);
 	--spectrum-picker-spacing-edge-to-text: var(--spectrum-component-edge-to-text-100);
 	--spectrum-picker-spacing-edge-to-text-quiet: var(--spectrum-field-edge-to-text-quiet);
-	--spectrum-picker-spacing-top-to-text-side-label-quiet: var(--spectrum-component-top-to-text-100);
 	--spectrum-picker-spacing-label-to-picker: var(--spectrum-field-label-to-component);
 
 	--spectrum-picker-spacing-text-to-icon: var(--spectrum-text-to-visual-100);
@@ -89,7 +88,6 @@ governing permissions and limitations under the License.
 .spectrum-Picker--sizeS {
 	--spectrum-picker-font-size: var(--spectrum-font-size-75);
 	--spectrum-picker-block-size: var(--spectrum-component-height-75);
-	--spectrum-picker-spacing-top-to-text-side-label-quiet: var(--spectrum-component-top-to-text-75);
 	--spectrum-picker-spacing-top-to-text: var(--spectrum-component-top-to-text-75);
 	--spectrum-picker-spacing-bottom-to-text: var(--spectrum-component-bottom-to-text-75);
 	--spectrum-picker-spacing-edge-to-text: var(--spectrum-component-edge-to-text-75);
@@ -110,7 +108,6 @@ governing permissions and limitations under the License.
 .spectrum-Picker--sizeL {
 	--spectrum-picker-font-size: var(--spectrum-font-size-200);
 	--spectrum-picker-block-size: var(--spectrum-component-height-200);
-	--spectrum-picker-spacing-top-to-text-side-label-quiet: var(--spectrum-component-top-to-text-200);
 	--spectrum-picker-spacing-top-to-text: var(--spectrum-component-top-to-text-200);
 	--spectrum-picker-spacing-bottom-to-text: var(--spectrum-component-bottom-to-text-200);
 	--spectrum-picker-spacing-edge-to-text: var(--spectrum-component-edge-to-text-200);
@@ -131,7 +128,6 @@ governing permissions and limitations under the License.
 .spectrum-Picker--sizeXL {
 	--spectrum-picker-font-size: var(--spectrum-font-size-300);
 	--spectrum-picker-block-size: var(--spectrum-component-height-300);
-	--spectrum-picker-spacing-top-to-text-side-label-quiet: var(--spectrum-component-top-to-text-300);
 	--spectrum-picker-spacing-top-to-text: var(--spectrum-component-top-to-text-300);
 	--spectrum-picker-spacing-bottom-to-text: var(--spectrum-component-bottom-to-text-300);
 	--spectrum-picker-spacing-edge-to-text: var(--spectrum-component-edge-to-text-300);

--- a/components/picker/index.css
+++ b/components/picker/index.css
@@ -343,25 +343,6 @@ governing permissions and limitations under the License.
 	}
 }
 
-/* Disabled state. */
-.spectrum-Picker.spectrum-Picker:disabled,
-.spectrum-Picker.spectrum-Picker.is-disabled {
-	cursor: default;
-	background-color: var(--highcontrast-picker-background-color, var(--mod-picker-background-color-disabled, var(--spectrum-picker-background-color-disabled)));
-	border-color: var(--highcontrast-picker-border-color-disabled, transparent);
-	color: var(--highcontrast-picker-content-color-disabled, var(--mod-picker-font-color-disabled, var(--spectrum-picker-font-color-disabled)));
-
-	.spectrum-Picker-icon,
-	.spectrum-Picker-menuIcon,
-	.spectrum-Picker-validationIcon {
-		color: var(--highcontrast-picker-content-color-disabled, var(--mod-picker-icon-color-disabled, var(--spectrum-picker-icon-color-disabled)));
-	}
-
-	.spectrum-Picker-label.is-placeholder {
-		color: var(--highcontrast-picker-content-color-disabled, var(--mod-picker-font-color-disabled, var(--spectrum-picker-font-color-disabled)));
-	}
-}
-
 .spectrum-Picker-label {
 	/* Be the biggest, but also shrink! */
 	flex: 1 1 auto;
@@ -487,4 +468,25 @@ governing permissions and limitations under the License.
 .spectrum-Picker--sideLabel {
 	display: inline-flex;
 	vertical-align: top;
+}
+
+/* Disabled state:
+   Make sure this appears after any use of :hover while postcss-hover-media-feature is being used. The plugin moves
+   all hover styles within a media query that changes the order of the CSS, affecting styles with the same specificity. */
+.spectrum-Picker:disabled,
+.spectrum-Picker.is-disabled {
+	cursor: default;
+	background-color: var(--highcontrast-picker-background-color, var(--mod-picker-background-color-disabled, var(--spectrum-picker-background-color-disabled)));
+	border-color: var(--highcontrast-picker-border-color-disabled, transparent);
+	color: var(--highcontrast-picker-content-color-disabled, var(--mod-picker-font-color-disabled, var(--spectrum-picker-font-color-disabled)));
+
+	.spectrum-Picker-icon,
+	.spectrum-Picker-menuIcon,
+	.spectrum-Picker-validationIcon {
+		color: var(--highcontrast-picker-content-color-disabled, var(--mod-picker-icon-color-disabled, var(--spectrum-picker-icon-color-disabled)));
+	}
+
+	.spectrum-Picker-label.is-placeholder {
+		color: var(--highcontrast-picker-content-color-disabled, var(--mod-picker-font-color-disabled, var(--spectrum-picker-font-color-disabled)));
+	}
 }


### PR DESCRIPTION
## Description

**Picker**: The following states were showing a change of colors when they shouldn't:
- Disabled + hover
- Disabled + invalid + hover
- Disabled + open
- Disabled + open + hover

This was caused by a few different issues. One is that that the `.spectrum-Picker:hover` styles are being moved farther down in the built dist file, as part of the hover media query from the postcss-hover-media-feature plugin. The hover styles with the same specificity as the disabled styles were then later in the order than intended and overriding the disabled styles. The other is that the `.is-open` styles had a higher specificity than some of the disabled styles.

This also removes an unused variable flagged by the linter, `--spectrum-picker-spacing-top-to-text-side-label-quiet`. This was used nowhere in the file or repo.

CSS-754

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [x] Disabled + hover does not show color changes in Storybook
- [x] Disabled + invalid + hover does not show color changes in Storybook
- [x] Disabled + open does not show color changes in Storybook
- [x] Disabled + open + hover does not show color changes in Storybook

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
