### PR TITLE
build: keep selector list in dist output of not pseudo-class

### DIFF
--- a/.changeset/eight-spiders-help.md
+++ b/.changeset/eight-spiders-help.md
@@ -1,0 +1,11 @@
+---
+"@spectrum-css/calendar": patch
+"@spectrum-css/combobox": patch
+"@spectrum-css/datepicker": patch
+"@spectrum-css/menu": patch
+"@spectrum-css/picker": patch
+"@spectrum-css/slider": patch
+"@spectrum-css/stepper": patch
+---
+
+Build change to remove the `postcss-preset-env` polyfill for the dist output of `:not` selectors containing multiple selectors, to avoid an unintended increase in specificity, which caused some visual regressions.

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -118,7 +118,6 @@ module.exports = ({
 					// https://github.com/jsxtools/focus-within
 					"focus-within-pseudo-class": true,
 					"font-format-keywords": true,
-					"not-pseudo-class": true,
 					"opacity-percentage": true,
 					// https://github.com/csstools/postcss-plugins/tree/main/plugins/css-prefers-color-scheme
 					"prefers-color-scheme-query": true,


### PR DESCRIPTION
## Description

A change in the build configuration had resulted in some regressions due to increased specificity created in the dist output of `:not` selectors. One issue was with a disabled Menu item showing a change in icon color on hover.

The postcss-preset-env config override being removed here sets it to the default stage 2 configuration that allows multiple comma separated selectors within `:not()`. The configuration had been using a polyfill that converted each item in the `:not` selector list into its own `:not` selector, increasing specificity for the rule for each additional item.

Example:
Selector in dist CSS before this change: 
`.spectrum-Menu-item:hover > .spectrum-Menu-itemIcon:not(.spectrum-Menu-chevron):not(.spectrum-Menu-checkmark)`

Selector in dist CSS after this change (and that was generated in previous Menu 6.1.5). This is how the not selector is written in the source index.css: 
`.spectrum-Menu-item:hover>.spectrum-Menu-itemIcon:not(.spectrum-Menu-chevron,.spectrum-Menu-checkmark)`

CSS-755

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [x] Menu docs for "With disabled item(s)" no longer shows the hover color changes (as seen in screenshot)
- [x] The built dist/index.css is no longer creating a chain of `:not(.class1):not(.class2)` when defined as `:not(.class, .class2)`. Tip: run `yarn compare` locally to see the dist changes in the 7 affected components.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

Bug noticed on the current state of Menu docs in main. When hovering over the disabled "Share link", the color of the icon changed:
![Screenshot 2024-05-08 at 12 50 16 PM](https://github.com/adobe/spectrum-css/assets/965114/84a6774b-9f14-4abb-902a-8c4c9150665a)

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] ✨ This pull request is ready to merge. ✨
