### PR TITLE
fix(popover): no more duplicate class selectors in dist

### DIFF
--- a/.changeset/tidy-olives-notice.md
+++ b/.changeset/tidy-olives-notice.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/popover": patch
+---
+
+fix(popover): Adjust selectors to remove duplicate class selectors in the dist output

--- a/components/popover/index.css
+++ b/components/popover/index.css
@@ -335,46 +335,46 @@ governing permissions and limitations under the License.
 			block-size: var(--mod-popover-pointer-width, var(--spectrum-popover-pointer-width));
 			inset-block: 0;
 		}
+	}
 
-		/* left popover with tip pointing right ▷ */
-		&.spectrum-Popover--left,
-		&.spectrum-Popover--left-bottom,
-		&.spectrum-Popover--left-top {
-			.spectrum-Popover-tip {
-				inset-inline: 100% auto;
-			}
+	/* left popover with tip pointing right ▷ */
+	&.spectrum-Popover--left,
+	&.spectrum-Popover--left-bottom,
+	&.spectrum-Popover--left-top {
+		.spectrum-Popover-tip {
+			inset-inline: 100% auto;
 		}
+	}
 
-		/* right popover with tip pointing left ◁ */
-		&.spectrum-Popover--right,
-		&.spectrum-Popover--right-bottom,
-		&.spectrum-Popover--right-top {
-			.spectrum-Popover-tip {
-				inset-inline: auto 100%;
+	/* right popover with tip pointing left ◁ */
+	&.spectrum-Popover--right,
+	&.spectrum-Popover--right-bottom,
+	&.spectrum-Popover--right-top {
+		.spectrum-Popover-tip {
+			inset-inline: auto 100%;
 
-				/* flip tip to point left ◁ */
-				transform: scaleX(-1);
-			}
+			/* flip tip to point left ◁ */
+			transform: scaleX(-1);
 		}
+	}
 
-		/* popover with tip at top */
-		&.spectrum-Popover--right-top,
-		&.spectrum-Popover--left-top,
-		&.spectrum-Popover--start-top,
-		&.spectrum-Popover--end-top {
-			.spectrum-Popover-tip {
-				inset-block: var(--mod-popover-pointer-edge-spacing, var(--spectrum-popover-pointer-edge-spacing)) auto;
-			}
+	/* popover with tip at top */
+	&.spectrum-Popover--right-top,
+	&.spectrum-Popover--left-top,
+	&.spectrum-Popover--start-top,
+	&.spectrum-Popover--end-top {
+		.spectrum-Popover-tip {
+			inset-block: var(--mod-popover-pointer-edge-spacing, var(--spectrum-popover-pointer-edge-spacing)) auto;
 		}
+	}
 
-		/* popover with tip at bottom */
-		&.spectrum-Popover--right-bottom,
-		&.spectrum-Popover--left-bottom,
-		&.spectrum-Popover--start-bottom,
-		&.spectrum-Popover--end-bottom {
-			.spectrum-Popover-tip {
-				inset-block: auto var(--mod-popover-pointer-edge-spacing, var(--spectrum-popover-pointer-edge-spacing));
-			}
+	/* popover with tip at bottom */
+	&.spectrum-Popover--right-bottom,
+	&.spectrum-Popover--left-bottom,
+	&.spectrum-Popover--start-bottom,
+	&.spectrum-Popover--end-bottom {
+		.spectrum-Popover-tip {
+			inset-block: auto var(--mod-popover-pointer-edge-spacing, var(--spectrum-popover-pointer-edge-spacing));
 		}
 	}
 


### PR DESCRIPTION
## Description

Fix for issue #2705. Previously, there were duplicate class selectors in dist. This update adjusts the selectors to remove the duplicates.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
- [x] Validate that there aren't any duplicate classes in the dist output locally
- [x] Check that popover tip placement still looks good in [Storybook](https://pr-2745--spectrum-css.netlify.app/preview/?path=/story/components-popover--with-tip&args=isOpen:!true)

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [ ] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
