### PR TITLE
fix(slider): use high contrast properties and fix ramp handle circle

### DIFF
--- a/.changeset/eight-crabs-smile.md
+++ b/.changeset/eight-crabs-smile.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/slider": patch
+---
+
+Fixes the visibility of the handle's outer circle on the ramp variant for high contrast mode. And refactors which custom properties are set in the forced-colors media query.

--- a/components/slider/index.css
+++ b/components/slider/index.css
@@ -683,57 +683,40 @@ governing permissions and limitations under the License.
 
 @media (forced-colors: active) {
 	.spectrum-Slider {
-		/*  over-writes */
 		--highcontrast-slider-track-color: ButtonText;
+		--highcontrast-slider-track-color-disabled: GrayText;
 		--highcontrast-slider-track-color-static: ButtonText;
 		--highcontrast-slider-track-fill-color: ButtonText;
+		--highcontrast-slider-track-fill-color-disabled: GrayText;
 		--highcontrast-slider-filled-track-fill-color: Highlight;
+
 		--highcontrast-slider-ramp-track-color: ButtonText;
 		--highcontrast-slider-ramp-track-color-disabled: GrayText;
 		--highcontrast-slider-tick-mark-color: ButtonText;
+		--highcontrast-slider-tick-mark-color-disabled: GrayText;
+
 		--highcontrast-slider-handle-border-color: ButtonText;
 		--highcontrast-slider-handle-border-color-hover: Highlight;
 		--highcontrast-slider-handle-border-color-down: Highlight;
 		--highcontrast-slider-handle-border-color-key-focus: Highlight;
+		--highcontrast-slider-handle-border-color-disabled: GrayText;
 		--highcontrast-slider-handle-focus-ring-color-key-focus: CanvasText;
 		--highcontrast-slider-handle-background-color: ButtonFace;
+		--highcontrast-slider-handle-background-color-disabled: GrayText;
+		--highcontrast-slider-handle-disabled-background-color: GrayText;
+
 		--highcontrast-slider-ramp-handle-border-color-active: ButtonFace;
 		--highcontrast-slider-ramp-handle-background-color: ButtonFace;
 
-		--spectrum-slider-track-color: ButtonText;
-		--spectrum-slider-track-fill-color: ButtonText;
-		--spectrum-slider-ramp-track-color: ButtonText;
-		--spectrum-slider-ramp-track-color-disabled: GrayText;
-
-		--spectrum-slider-handle-background-color: ButtonFace;
-		--spectrum-slider-handle-background-color-disabled: GrayText;
-		--spectrum-slider-handle-border-color: ButtonText;
-		--spectrum-slider-handle-disabled-background-color: GrayText;
-
-		--spectrum-slider-tick-mark-color: ButtonText;
-		--spectrum-slider-tick-mark-color-disabled: GrayText;
-
-		--spectrum-slider-handle-border-color-hover: Highlight;
-		--spectrum-slider-handle-border-color-down: Highlight;
-		--spectrum-slider-handle-border-color-key-focus: Highlight;
-		--spectrum-slider-handle-focus-ring-color-key-focus: Highlight;
-
-		--spectrum-slider-track-color-disabled: GrayText;
-		--spectrum-slider-track-fill-color-disabled: GrayText;
-
-		--spectrum-slider-handle-border-color-disabled: GrayText;
-
-		--spectrum-slider-label-text-color: CanvasText;
-		--spectrum-slider-label-text-color-disabled: GrayText;
-
-		--spectrum-slider-ramp-handle-border-color-active: ButtonText;
+		--highcontrast-slider-label-text-color: CanvasText;
+		--highcontrast-slider-label-text-color-disabled: GrayText;
 
 		.spectrum-Slider-handle.is-focused::before {
 			forced-color-adjust: none;
 		}
 
-		.spectrum-Slider--ramp .spectrum-Slider-handle {
-			/* forced-color-adjust required to ensure the "circle" around the handle is transparent */
+		&.spectrum-Slider--ramp .spectrum-Slider-handle {
+			/* forced-color-adjust is required to ensure the contrasting "circle" around the ramp handle (created by box-shadow) is visible. */
 			forced-color-adjust: none;
 		}
 


### PR DESCRIPTION
## Description

Updates the Slider high contrast styles to use all `--highcontrast` prefixed custom properties. It was noticed that some were being set with `--spectrum` prefixed custom properties. Some were duplicative, as they already had `--highcontrast` prefixed custom properties being set (which take precendence in the `var()` fallback chains). A few needed a rename.

In the process, it was also found that the ramp variant was missing the handle outer circle (gap between the ramp background and handle), that created contrast between the handle in the background. This was particularly noticeable on hover/active, as the handle was blending into the same ramp highlight color. The fix was already present but the nested `.spectrum-Slider--ramp` selector was missing an `&` to make it the same element as the `.spectrum-Slider`

CSS-760

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [x] Take a look at the Ramp story in forced-colors mode. The gap around the handle should be visible.
- [x] There are no other changes in forced-colors mode. Make sure to check filled, filled offset, hover, active, and keyboard focus.

_Review note: The only changes made here are within the `@media (forced-colors: active)`. The rest of the files modified are automatic prettier fixes, including changes to whitespace._

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

"Ramp" variant high contrast bug before and after fix:

<img width="269" alt="before" src="https://github.com/adobe/spectrum-css/assets/965114/05cb4799-dafa-4bcd-9d4f-203c2a654d25">
<img width="265" alt="after" src="https://github.com/adobe/spectrum-css/assets/965114/e6d83ca3-7d67-42c0-8644-4448f086657a">

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have tested these changes in Windows High Contrast mode.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
