### PR TITLE
fix(popover): correct left/right tips for RTL, increase VRT coverage

### DIFF
--- a/.changeset/three-geese-relax.md
+++ b/.changeset/three-geese-relax.md
@@ -1,0 +1,7 @@
+---
+"@spectrum-css/popover": patch
+---
+
+fix(popover): correct left/right tips for RTL
+
+Includes exposing Start and End tip placement variants in Storybook, and increased VRT coverage for Chromatic.

--- a/components/popover/index.css
+++ b/components/popover/index.css
@@ -150,7 +150,8 @@ governing permissions and limitations under the License.
 	/* spacing to include tip in calculation of offset from source */
 	&.spectrum-Popover--withTip {
 		/* tip size minus where it overlaps with popover border */
-		margin-inline-start: calc(var(--mod-popover-pointer-width, var(--spectrum-popover-pointer-width)) - var(--mod-popover-border-width, var(--spectrum-popover-border-width)));
+		/* stylelint-disable-next-line csstools/use-logical -- intentional, right stays on the same side even for RTL */
+		margin-left: calc(var(--mod-popover-pointer-width, var(--spectrum-popover-pointer-width)) - var(--mod-popover-border-width, var(--spectrum-popover-border-width)));
 	}
 
 	/* popover animates towards right ⮕ */
@@ -166,7 +167,8 @@ governing permissions and limitations under the License.
 	/* spacing to include tip in calculation of offset from source */
 	&.spectrum-Popover--withTip {
 		/* tip size minus where it overlaps with popover border */
-		margin-inline-end: calc(var(--mod-popover-pointer-width, var(--spectrum-popover-pointer-width)) - var(--mod-popover-border-width, var(--spectrum-popover-border-width)));
+		/* stylelint-disable-next-line csstools/use-logical -- intentional, left stays on the same side even for RTL */
+		margin-right: calc(var(--mod-popover-pointer-width, var(--spectrum-popover-pointer-width)) - var(--mod-popover-border-width, var(--spectrum-popover-border-width)));
 	}
 
 	/* popover animates towards left ⬅ */
@@ -342,7 +344,9 @@ governing permissions and limitations under the License.
 	&.spectrum-Popover--left-bottom,
 	&.spectrum-Popover--left-top {
 		.spectrum-Popover-tip {
-			inset-inline: 100% auto;
+			/* stylelint-disable-next-line csstools/use-logical -- intentional, left stays on the same side even for RTL */
+			left: 100%;
+			right: auto;
 		}
 	}
 
@@ -351,7 +355,9 @@ governing permissions and limitations under the License.
 	&.spectrum-Popover--right-bottom,
 	&.spectrum-Popover--right-top {
 		.spectrum-Popover-tip {
-			inset-inline: auto 100%;
+			/* stylelint-disable-next-line csstools/use-logical -- intentional, right stays on the same side even for RTL */
+			right: 100%;
+			left: auto;
 
 			/* flip tip to point left ◁ */
 			transform: scaleX(-1);

--- a/components/popover/stories/popover.stories.js
+++ b/components/popover/stories/popover.stories.js
@@ -6,6 +6,31 @@ import { Template } from "./template";
 import { Template as ActionButton } from "@spectrum-css/actionbutton/stories/template.js";
 import { Template as Menu } from "@spectrum-css/menu/stories/template.js";
 
+const placementOptions = [
+	"top",
+	"top-left",
+	"top-right",
+	"top-start",
+	"top-end",
+	"bottom",
+	"bottom-left",
+	"bottom-right",
+	"bottom-start",
+	"bottom-end",
+	"right",
+	"right-bottom",
+	"right-top",
+	"left",
+	"left-bottom",
+	"left-top",
+	"start",
+	"start-top",
+	"start-bottom",
+	"end",
+	"end-top",
+	"end-bottom",
+];
+
 /**
  * A popover is used to display transient content (menus, options, additional actions etc.) and appears when clicking/tapping on a source (tools, buttons, etc.). It stands out via its visual style (stroke and drop shadow) and floats on top of the rest of the interface.
  */
@@ -44,20 +69,7 @@ export default {
 				category: "Component",
 			},
 			control: "select",
-			options: [
-				"top",
-				"top-start",
-				"top-end",
-				"bottom",
-				"bottom-start",
-				"bottom-end",
-				"left",
-				"left-top",
-				"left-bottom",
-				"right",
-				"right-top",
-				"right-bottom",
-			],
+			options: placementOptions,
 			if: { arg: "nested", truthy: false },
 		},
 	},

--- a/components/popover/stories/popover.stories.js
+++ b/components/popover/stories/popover.stories.js
@@ -1,7 +1,9 @@
+import { Template as Typography } from "@spectrum-css/typography/stories/template.js";
 import { userEvent, within } from "@storybook/testing-library";
 import { html } from "lit";
+import { when } from "lit/directives/when.js";
 
-import { Template } from "./template";
+import { SourcelessTemplate, Template } from "./template";
 
 import { Template as ActionButton } from "@spectrum-css/actionbutton/stories/template.js";
 import { Template as Menu } from "@spectrum-css/menu/stories/template.js";
@@ -125,9 +127,56 @@ export default {
 		},
 	},
 	decorators: [
-		(Story, context) => html`<div style="padding: 16px">${Story(context)}</div>`
+		(Story, context) => html`
+			<style>
+				.spectrum-Detail { display: inline-block; }
+				.spectrum-Typography > div {
+					/* Why seafoam? Because it separates it from the component styles. */
+					--mod-detail-font-color: var(--spectrum-seafoam-900);
+				}
+			</style>
+			<div style="padding: 16px">${Story(context)}</div>
+		`,
 	],
 };
+
+
+const ChromaticTipPlacementVariants = (args) => html`
+	${placementOptions.map(option => {
+		const optionDescription = () => {
+			if (option.startsWith("start") || option.startsWith("end"))
+				return "Changes side with text direction (like a logical property)";
+			if (option.startsWith("left") || option.startsWith("right"))
+				return "Text direction does not effect the position";
+			return null;
+		};
+
+		return html`
+			<div class="spectrum-Typography" style="padding-bottom: 12rem;">
+				${Typography({
+					semantics: "detail",
+					size: "l",
+					content: [`${option}`],
+				})}
+				<div>
+					${when(optionDescription() !== null, () => html`
+						${Typography({
+							semantics: "detail",
+							size: "s",
+							content: [`${optionDescription()}`],
+						})}
+					`)}
+					</div>
+				<div style="padding-top: 2rem">
+					${SourcelessTemplate({
+						...args,
+						position: option,
+					})}
+				</div>
+			</div>
+		`;
+	})}
+`;
 
 export const Default = Template.bind({});
 Default.play = async ({ canvasElement }) => {
@@ -136,7 +185,9 @@ Default.play = async ({ canvasElement }) => {
 };
 Default.args = {};
 
-export const WithTip = Template.bind({});
+export const WithTip = (args) => html`
+	${window.isChromatic() ? ChromaticTipPlacementVariants(args) : Template(args)}
+`;
 WithTip.play = async ({ canvasElement }) => {
 	const canvas = within(canvasElement);
 	await userEvent.click(canvas.getByRole("button"));

--- a/components/popover/stories/popover.stories.js
+++ b/components/popover/stories/popover.stories.js
@@ -147,7 +147,7 @@ const ChromaticTipPlacementVariants = (args) => html`
 			if (option.startsWith("start") || option.startsWith("end"))
 				return "Changes side with text direction (like a logical property)";
 			if (option.startsWith("left") || option.startsWith("right"))
-				return "Text direction does not effect the position";
+				return "Text direction does not affect the position";
 			return null;
 		};
 
@@ -166,11 +166,12 @@ const ChromaticTipPlacementVariants = (args) => html`
 							content: [`${optionDescription()}`],
 						})}
 					`)}
-					</div>
+				</div>
 				<div style="padding-top: 2rem">
 					${SourcelessTemplate({
 						...args,
 						position: option,
+						isOpen: true,
 					})}
 				</div>
 			</div>
@@ -190,7 +191,7 @@ export const WithTip = (args) => html`
 `;
 WithTip.play = async ({ canvasElement }) => {
 	const canvas = within(canvasElement);
-	await userEvent.click(canvas.getByRole("button"));
+	window.isChromatic() ? null : await userEvent.click(canvas.getByRole("button"));
 };
 WithTip.args = {
 	withTip: true,

--- a/components/popover/stories/popover.stories.js
+++ b/components/popover/stories/popover.stories.js
@@ -3,7 +3,7 @@ import { userEvent, within } from "@storybook/testing-library";
 import { html } from "lit";
 import { when } from "lit/directives/when.js";
 
-import { SourcelessTemplate, Template } from "./template";
+import { Template } from "./template";
 
 import { Template as ActionButton } from "@spectrum-css/actionbutton/stories/template.js";
 import { Template as Menu } from "@spectrum-css/menu/stories/template.js";
@@ -168,10 +168,11 @@ const ChromaticTipPlacementVariants = (args) => html`
 					`)}
 				</div>
 				<div style="padding-top: 2rem">
-					${SourcelessTemplate({
+					${Template({
 						...args,
 						position: option,
 						isOpen: true,
+						trigger: () => null,
 					})}
 				</div>
 			</div>

--- a/components/popover/stories/template.js
+++ b/components/popover/stories/template.js
@@ -60,48 +60,60 @@ export const Template = ({
 					const popWidth = popover.offsetWidth ?? 0;
 					const popHeight = popover.offsetHeight ?? 0;
 					const textDir = getComputedStyle(document.querySelector("html")).direction;
+
 					let x, y;
 					let xOffset = "+ 0px";
 					let yOffset = "+ 0px";
-					if (position.includes("top") || position.includes("bottom") && !(position.includes("-top") || position.includes("-bottom"))) {
+
+					if (position.startsWith("top") || position.startsWith("bottom")) {
 						x = triggerXCenter - (popWidth > 0 ? popWidth / 2 : popWidth);
 					}
-					if (position.includes("left") || position.includes("right")) {
+					if (position.includes("left") || position.includes("right") || position.startsWith("start") || position.startsWith("end")) {
 						y = triggerYCenter - (popHeight > 0 ? popHeight / 2 : popHeight);
 					}
-					if (position.includes("top") && !position.includes("-top")) {
+					if (position.startsWith("top")) {
 						y = rect.top - popHeight;
 						yOffset = withTip
 							? "- (var(--spectrum-popover-pointer-height) + var(--spectrum-popover-animation-distance) - 1px)"
 							: "- var(--spectrum-popover-animation-distance)";
 					}
- else if (position.includes("bottom") && !position.includes("-bottom")) {
+					else if (position.startsWith("bottom")) {
 						y = rect.bottom;
 						yOffset = "+ (var(--spectrum-popover-animation-distance))";
 					}
- else if (position.includes("left")) {
+					else if (position.includes("left")) {
 						if (textDir == "rtl") {
 							x = rect.right;
 							xOffset = withTip ? "+ 0px" : "+ var(--spectrum-popover-animation-distance)";
 						}
- else {
+						else {
 							x = rect.left - popWidth;
 							xOffset = withTip
 								? "- ((var(--spectrum-popover-pointer-width) / 2) + var(--spectrum-popover-animation-distance) - 2px)"
 								: "- var(--spectrum-popover-animation-distance)";
 						}
 					}
- else if (position.includes("right")) {
+					else if (position.includes("right")) {
 						if (textDir == "rtl") {
 							x = rect.left - popWidth;
 							xOffset = withTip
 								? "- ((var(--spectrum-popover-pointer-width) / 2) + var(--spectrum-popover-animation-distance) - 2px)"
 								: "- var(--spectrum-popover-animation-distance)";
 						}
- else {
+						else {
 							x = rect.right;
 							xOffset = withTip ? "+ 0px" : "+ var(--spectrum-popover-animation-distance)";
 						}
+					}
+					else if (position.includes("start")) {
+						x = rect.left - popWidth;
+						xOffset = withTip
+							? "- ((var(--spectrum-popover-pointer-width) / 2) + var(--spectrum-popover-animation-distance) - 2px)"
+							: "- var(--spectrum-popover-animation-distance)";
+					}
+					else if (position.includes("end")) {
+						x = rect.right;
+						xOffset = withTip ? "+ 0px" : "+ var(--spectrum-popover-animation-distance)";
 					}
 
 					if (x) transforms.push(`translateX(calc(var(--flow-direction) * calc(${parseInt(x, 10)}px ${xOffset})))`);
@@ -111,13 +123,13 @@ export const Template = ({
 					if (position === "top-start" || position === "bottom-start") {
 						additionalStyles["inset-inline-start"] = "calc(" + (popWidth / 2) + "px - var(--spectrum-popover-pointer-edge-offset))";
 					}
- else if (position === "top-end" || position === "bottom-end") {
+					else if (position === "top-end" || position === "bottom-end") {
 						additionalStyles["inset-inline-start"] = "calc(-1 *" + (popWidth / 2) + "px + var(--spectrum-popover-pointer-edge-offset))";
 					}
- else if (position === "left-top" || position === "right-top") {
+					else if (position === "left-top" || position === "right-top" || position === "start-top" || position === "end-top") {
 						additionalStyles["inset-block-start"] = "calc(" + (popHeight / 2) + "px - var(--spectrum-popover-pointer-edge-offset))";
 					}
- else if (position === "left-bottom" || position === "right-bottom") {
+					else if (position === "left-bottom" || position === "right-bottom" || position === "start-bottom" || position === "end-bottom") {
 						additionalStyles["inset-block-start"] = "calc(-1 *" + (popHeight / 2) + "px + var(--spectrum-popover-pointer-edge-offset))";
 					}
 

--- a/components/popover/stories/template.js
+++ b/components/popover/stories/template.js
@@ -171,39 +171,3 @@ export const Template = ({
 		</div>
 	`;
 };
-
-export const SourcelessTemplate = ({
-	rootClass = "spectrum-Popover",
-	size = "m",
-	isOpen = false,
-	withTip = false,
-	position = "top",
-	customClasses = [],
-	id = "popover-1",
-	testId,
-	customStyles = {},
-	content = [],
-}) => html`
-	<div
-		class=${classMap({
-			[rootClass]: true,
-			"is-open": isOpen,
-			[`${rootClass}--size${size?.toUpperCase()}`]:
-				typeof size !== "undefined",
-			[`${rootClass}--withTip`]: withTip,
-			[`${rootClass}--${position}`]: typeof position !== "undefined",
-			...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
-		})}
-		style=${ifDefined(styleMap(customStyles))}
-		role="presentation"
-		id=${ifDefined(id)}
-		data-testid=${ifDefined(testId)}
-	>
-		${content.map((c) => (typeof c === "function" ? c({}) : c))}
-		${withTip
-			? position && ["top", "bottom"].some((e) => position.startsWith(e))
-				? html`<svg class="${rootClass}-tip" viewBox="0 -0.5 16 9" width="10"><path class="${rootClass}-tip-triangle" d="M-1,-1 8,8 17,-1"></svg>`
-				: html`<svg class="${rootClass}-tip" viewBox="0 -0.5 9 16" width="10"><path class="${rootClass}-tip-triangle" d="M-1,-1 8,8 -1,17"></svg>`
-			: ""}
-	</div>
-`;

--- a/components/popover/stories/template.js
+++ b/components/popover/stories/template.js
@@ -171,3 +171,39 @@ export const Template = ({
 		</div>
 	`;
 };
+
+export const SourcelessTemplate = ({
+	rootClass = "spectrum-Popover",
+	size = "m",
+	isOpen = false,
+	withTip = false,
+	position = "top",
+	customClasses = [],
+	id = "popover-1",
+	testId,
+	customStyles = {},
+	content = [],
+}) => html`
+	<div
+		class=${classMap({
+			[rootClass]: true,
+			"is-open": isOpen,
+			[`${rootClass}--size${size?.toUpperCase()}`]:
+				typeof size !== "undefined",
+			[`${rootClass}--withTip`]: withTip,
+			[`${rootClass}--${position}`]: typeof position !== "undefined",
+			...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
+		})}
+		style=${ifDefined(styleMap(customStyles))}
+		role="presentation"
+		id=${ifDefined(id)}
+		data-testid=${ifDefined(testId)}
+	>
+		${content.map((c) => (typeof c === "function" ? c({}) : c))}
+		${withTip
+			? position && ["top", "bottom"].some((e) => position.startsWith(e))
+				? html`<svg class="${rootClass}-tip" viewBox="0 -0.5 16 9" width="10"><path class="${rootClass}-tip-triangle" d="M-1,-1 8,8 17,-1"></svg>`
+				: html`<svg class="${rootClass}-tip" viewBox="0 -0.5 9 16" width="10"><path class="${rootClass}-tip-triangle" d="M-1,-1 8,8 -1,17"></svg>`
+			: ""}
+	</div>
+`;


### PR DESCRIPTION
## Description

Fixes an issue in Popover where Left and Right tips were mirrored incorrectly for RTL. This is simliar to some [work done on Tooltip](https://github.com/adobe/spectrum-css/pull/2736). Note that the Left and Right placement for the tips are always on the LTR left and right, even if RTL is turned on. Start and End, however, are adjusted based on the text direction.

Also included Storybook enhancements including:
- Show all placement options (previously Start and End placements weren't included in the Storybook controls)
- Increase Chromatic VRT coverage for the tip variant

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps 

- [x] VRTs passing @mdt2 
- [x] Check Popover With Tip's new [testing preview](https://pr-2753--spectrum-css.netlify.app/preview/?path=/story/components-popover--with-tip&args=isOpen:!true&globals=testingPreview:!true) in Storybook. All the tips should look correctly positioned in LTR @jawinn
- [x] Now check RTL, tips should be correctly positioned
- [x] All placement options are shown in the Storybook controls

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

Before
![before-popover](https://github.com/adobe/spectrum-css/assets/23404383/08f7f1b8-a613-456f-bd0a-1df9c69d9c6a)

After
![after-popover](https://github.com/adobe/spectrum-css/assets/23404383/96dcb144-6d96-4495-bb51-974593662e95)


## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
