### PR TITLE
chore: fix loglevel error message when running prettier commands

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,6 +1,6 @@
 module.exports = {
 	"components/*/*.css": [
-		"prettier --no-error-on-unmatched-pattern --ignore-unknown --loglevel silent --write",
+		"prettier --no-error-on-unmatched-pattern --ignore-unknown --log-level silent --write",
 		"stylelint --fix --cache --allow-empty-input --quiet"
 	],
 	"*.json": [
@@ -13,15 +13,15 @@ module.exports = {
 		"eslint --fix --cache --no-error-on-unmatched-pattern --quiet"
 	],
 	"dist/*.css": [
-		"prettier --no-config --no-error-on-unmatched-pattern --ignore-unknown --loglevel silent --write"
+		"prettier --no-config --no-error-on-unmatched-pattern --ignore-unknown --log-level silent --write"
 	],
 	"components/*/metadata/*.{yml,yaml}": (files) => {
 		return [
 			...(files.map(file => `pajv test --valid -s ./schemas/documentation.schema.json -d "${file}"`) ?? []),
-            `prettier --no-config --no-error-on-unmatched-pattern --ignore-unknown --loglevel silent --write ${files.join(" ")}`
+            `prettier --no-config --no-error-on-unmatched-pattern --ignore-unknown --log-level silent --write ${files.join(" ")}`
 		];
 	},
 	"*.md": [
-		"prettier --no-config --no-error-on-unmatched-pattern --ignore-unknown --loglevel silent --write"
+		"prettier --no-config --no-error-on-unmatched-pattern --ignore-unknown --log-level silent --write"
 	]
 };

--- a/nx.json
+++ b/nx.json
@@ -140,7 +140,7 @@
 				"commands": [
 					"stylelint --fix --cache --allow-empty-input {projectRoot}/*.css {projectRoot}/**/*.css",
 					"eslint --fix --cache --no-error-on-unmatched-pattern {projectRoot}/*.json {projectRoot}/stories/*.js",
-					"prettier --write --cache --loglevel error --ignore-unknown --no-error-on-unmatched-pattern {projectRoot}/*.{yml,md} {projectRoot}/**/*.{yml,md}"
+					"prettier --write --cache --log-level error --ignore-unknown --no-error-on-unmatched-pattern {projectRoot}/*.{yml,md} {projectRoot}/**/*.{yml,md}"
 				]
 			}
 		},


### PR DESCRIPTION
## Description

When running the format command, a notice would show up in the console log noting that the flag should be `log-level` and not `loglevel`. This PR corrects that typo.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [x] `yarn formatter actionbutton`: expect to see no warnings in the log about the log-level flag

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] ✨ This pull request is ready to merge. ✨
