### PR TITLE
fix(textfield): no pointer events for focus pseudo element

### DIFF
--- a/.changeset/lazy-rivers-leave.md
+++ b/.changeset/lazy-rivers-leave.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/textfield": patch
+---
+
+Fixes an issue in the Quiet variant where hovering over the focus pseudo element was firing pointer events that weren't meant to be seen unless the user hovered over the input element itself.

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -249,6 +249,7 @@ governing permissions and limitations under the License.
 .spectrum-Textfield.spectrum-Textfield--quiet {
 	&::after {
 		content: "";
+		pointer-events: none;
 		position: absolute;
 		inset-block-end: calc(-1 * (var(--mod-textfield-focus-indicator-gap, var(--spectrum-textfield-focus-indicator-gap)) + var(--mod-textfield-focus-indicator-width, var(--spectrum-textfield-focus-indicator-width))));
 		inset-inline-start: 0;


### PR DESCRIPTION
## Description

Fixes an issue specifically for the Quiet variant where hovering over the focus pseudo element triggers the hover event, which causes the hover event to flicker if the user hovers over the focus, then the space between the focus (which doesn't have pointer events and turns off the hover effect), then onto the textfield (which does have pointer events and the hover effect).

See Josh's helpful screen capture for an example of the issue this fixes: 

https://github.com/adobe/spectrum-css/assets/23404383/148fee9f-1077-49c5-93c2-7acaeac23d8d



## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [x] Pointer events arent triggered by the focus pseudo element: @jawinn 
  - Open the Quiet, keyboard-focused textfield in [Storybook](https://pr-2761--spectrum-css.netlify.app/preview/?path=/story/components-text-field--default&args=isKeyboardFocused:!true;isQuiet:!true)
  - To be able to see what you're doing better, zoom in on the component and in dev tools, set `.spectrum-Textfield:hover { background-color: red }`
  - Hover the mouse over the focus line. The background shouldn't turn red.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] ✨ This pull request is ready to merge. ✨
