### PR TITLE
feat: cleanup legacy vendor prefixes and normalization

### DIFF
--- a/.changeset/tidy-balloons-cover.md
+++ b/.changeset/tidy-balloons-cover.md
@@ -1,0 +1,8 @@
+---
+"@spectrum-css/statuslight": minor
+"@spectrum-css/accordion": minor
+"@spectrum-css/textfield": minor
+"@spectrum-css/commons": minor
+---
+
+Removes some legacy vendor prefixes that are no longer necessary, including some that were for older browsers that are no longer in browser support list for Spectrum CSS. Such as Microsoft Edge before version 79. Includes some cleanup around some of the related normalization styles in the Text field component and the Commons `%spectrum-BaseButton` (used for multiple button components).

--- a/components/accordion/index.css
+++ b/components/accordion/index.css
@@ -242,10 +242,6 @@ governing permissions and limitations under the License.
 	font-family: var(--mod-accordion-item-header-font, var(--spectrum-accordion-item-header-font));
 
 	/* reset styling if button element is used */
-	/* stylelint-disable-next-line property-no-vendor-prefix -- todo may no longer be needed */
-	-webkit-appearance: none;
-	/* stylelint-disable-next-line property-no-vendor-prefix -- todo may no longer be needed */
-	-moz-appearance: none;
 	appearance: none;
 	border: 0;
 	text-align: start;

--- a/components/commons/basebutton.css
+++ b/components/commons/basebutton.css
@@ -12,9 +12,6 @@ governing permissions and limitations under the License.
 
 %spectrum-BaseButton {
 	cursor: pointer;
-
-	/* stylelint-disable-next-line property-no-vendor-prefix -- need to validate if this can be removed */
-	-webkit-user-select: none;
 	user-select: none;
 
 	/* Contain halo */
@@ -44,8 +41,9 @@ governing permissions and limitations under the License.
 	/* Adjacent buttons should be aligned correctly */
 	vertical-align: top;
 
-	/* stylelint-disable-next-line property-no-vendor-prefix -- Correct the inability to style clickable types in iOS and Safari. */
+	/* stylelint-disable-next-line property-no-vendor-prefix -- Correct the inability to style clickable types in iOS and Safari (normalize). */
 	-webkit-appearance: button;
+
 	border-style: solid;
 
 	transition:
@@ -55,21 +53,12 @@ governing permissions and limitations under the License.
 		box-shadow var(--mod-button-animation-duration, var(--mod-animation-duration-100, var(--spectrum-animation-duration-100))) ease-out;
 
 	-webkit-font-smoothing: antialiased;
-
-	/* Font smoothing for Firefox */
 	-moz-osx-font-smoothing: grayscale;
 
-	/* Fix Firefox */
+	/* Remove the inner border and padding in Firefox (normalize). */
 	&::-moz-focus-inner {
-		/* Use uppercase PX so values don't get converted to rem */
-		margin-block-start: -2px;
-		margin-block-end: -2px;
-		padding: 0;
-
-		border: 0;
-
-		/* Remove the inner border and padding for button in Firefox. */
 		border-style: none;
+		padding: 0;
 	}
 
 	&:focus {

--- a/components/statuslight/index.css
+++ b/components/statuslight/index.css
@@ -103,18 +103,6 @@ governing permissions and limitations under the License.
 	--spectrum-statuslight-spacing-bottom-to-label: var(--spectrum-component-bottom-to-text-300);
 }
 
-@media (forced-colors: active) {
-	.spectrum-StatusLight {
-		forced-color-adjust: none;
-		--highcontrast-statuslight-content-color-default: CanvasText;
-		--highcontrast-statuslight-subdued-content-color-default: CanvasText;
-
-		&::before {
-			border: var(--mod-statuslight-border-width, var(--spectrum-statuslight-border-width)) solid ButtonText;
-		}
-	}
-}
-
 .spectrum-StatusLight {
 	display: flex;
 	flex-direction: row;
@@ -153,10 +141,6 @@ governing permissions and limitations under the License.
 		--spectrum-statuslight-spacing-computed-top-to-dot: calc(var(--mod-statuslight-spacing-top-to-dot, var(--spectrum-statuslight-spacing-top-to-dot)) - var(--mod-statuslight-spacing-top-to-label, var(--spectrum-statuslight-spacing-top-to-label)));
 		margin-block-start: var(--spectrum-statuslight-spacing-computed-top-to-dot);
 		margin-inline-end: var(--mod-statuslight-spacing-dot-to-label, var(--spectrum-statuslight-spacing-dot-to-label));
-
-		/* support high contrast/forced-color-adjust mode for dot */
-		-ms-high-contrast-adjust: none;
-		forced-color-adjust: none;
 	}
 }
 
@@ -250,4 +234,18 @@ governing permissions and limitations under the License.
 
 .spectrum-StatusLight--magenta::before {
 	background-color: var(--mod-statuslight-nonsemantic-magenta-color, var(--spectrum-statuslight-nonsemantic-magenta-color));
+}
+
+@media (forced-colors: active) {
+	.spectrum-StatusLight {
+		forced-color-adjust: none;
+		--highcontrast-statuslight-content-color-default: CanvasText;
+		--highcontrast-statuslight-subdued-content-color-default: CanvasText;
+
+		/* Dot */
+		&::before {
+			forced-color-adjust: none;
+			border: var(--mod-statuslight-border-width, var(--spectrum-statuslight-border-width)) solid ButtonText;
+		}
+	}
 }

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -211,39 +211,22 @@ governing permissions and limitations under the License.
 /********* TEXT FIELD and TEXT AREA Outer Wrapper *********/
 .spectrum-Textfield {
 	position: relative;
-
-	/* prevent input from expanding to width of helptext */
-	inline-size: var(--mod-textfield-width, var(--spectrum-textfield-width));
-
-	/*** ↓ Browser Mitigations for Text Field ↓ ***/
-	/* Edge - Use padding instead of text-indent because text-indent does not left align the text  */
-	text-indent: 0;
-
-	/* Edge - Show the overflow for input. */
-	overflow: visible;
-
-	/* Firefox and Safari - Remove the margin for input. */
-	margin: 0;
-
-	/* TODO: Determine if the vendor prefix toggling of appearance is still needed  */
-	/* Firefox -
-    Removes the native spin buttons in Firefox; -moz-appearance: none results in spinners.
-    This has to come after -webkit-appearance or it gets overridden (#214)
-    Details: http://stackoverflow.com/questions/23372903/hide-spinner-in-input-number-firefox-29
-
-    Sets the opacity to 1 as normalize.css sets an opacity to placeholders
-    Details: https://github.com/csstools/normalize.css/blob/main/normalize.css#L297
-  */
-	/* stylelint-disable-next-line value-no-vendor-prefix */
-	appearance: textfield;
-
-	/* All browsers - Change the input font styles */
 	text-overflow: ellipsis;
+
+	/* Prevent input from expanding to width of Help text */
+	inline-size: var(--mod-textfield-width, var(--spectrum-textfield-width));
 
 	/* Grid layout for child components */
 	display: inline-grid;
 	grid-template-columns: auto auto;
 	grid-template-rows: auto auto auto;
+
+	/*** ↓ Browser Mitigations for Text Field ↓ ***/
+	/* Edge - Show the overflow for input. */
+	overflow: visible;
+
+	/* Firefox and Safari - Remove the margin for input. */
+	margin: 0;
 }
 
 .spectrum-Textfield.spectrum-Textfield--quiet {
@@ -393,8 +376,6 @@ governing permissions and limitations under the License.
 
 	padding-inline: calc(var(--mod-textfield-spacing-inline, var(--spectrum-textfield-spacing-inline)) - var(--mod-textfield-border-width, var(--spectrum-textfield-border-width)));
 
-	/* Use padding instead of text-indent because text-indent does not left align the text in Edge browser  */
-	text-indent: 0;
 	vertical-align: top; /* used to align them correctly in forms. */
 	outline: none;
 	background-color: var(--mod-textfield-background-color, var(--spectrum-textfield-background-color));
@@ -406,64 +387,37 @@ governing permissions and limitations under the License.
 	font-family: var(--mod-textfield-font-family, var(--spectrum-textfield-font-family));
 	font-weight: var(--mod-textfield-font-weight, var(--spectrum-textfield-font-weight));
 	color: var(--highcontrast-textfield-text-color-default, var(--mod-textfield-text-color-default, var(--spectrum-textfield-text-color-default)));
-
-	/*** ↓ Browser Mitigations for Input ↓ ***/
-	/* Remove the margin for input in Firefox and Safari. */
-	margin: 0;
-
 	text-overflow: ellipsis;
-
-	/* TODO: Determine if the vendor prefix toggling of appearance is still needed  */
-	/* stylelint-disable-next-line value-no-vendor-prefix */
-	appearance: none;
-
-	/*
-    Removes the native spin buttons in Firefox; -moz-appearance: none results in spinners.
-    This has to come after -webkit-appearance or it gets overridden (#214)
-    Details: http://stackoverflow.com/questions/23372903/hide-spinner-in-input-number-firefox-29
-
-    Sets the opacity to 1 as normalize.css sets an opacity to placeholders
-    Details: https://github.com/csstools/normalize.css/blob/main/normalize.css#L297
-  */
-	/* stylelint-disable-next-line value-no-vendor-prefix */
-	appearance: textfield;
 
 	/* place in same cell: input, focus indicator, and grows sizer */
 	grid-row: 2;
 	grid-column: 1 / span 2;
 
-	/* Remove the native clear button in IE */
-	/* http://stackoverflow.com/questions/14007655/remove-ie10s-clear-field-x-button-on-certain-inputs */
-	&::-ms-clear {
-		inline-size: 0;
-		block-size: 0;
+	/*** ↓ Browser Mitigations for Input ↓ ***/
+	/* Firefox and Safari - Remove the margin for input. */
+	margin: 0;
+	appearance: none;
+
+	&[type="number"] {
+		/* stylelint-disable-next-line property-no-vendor-prefix -- Removes the native spin buttons in Firefox. */
+		-moz-appearance: textfield;
+
+		&::-webkit-inner-spin-button,
+		&::-webkit-outer-spin-button {
+			/* stylelint-disable-next-line property-no-vendor-prefix -- Remove the native spin buttons in webkit-based browsers. */
+			-webkit-appearance: none;
+			margin: 0;
+		}
 	}
 
-	/* removes the native spin buttons */
-	/* http://stackoverflow.com/questions/23372903/hide-spinner-in-input-number-firefox-29 */
-	&::-webkit-inner-spin-button,
-	&::-webkit-outer-spin-button {
-		/* stylelint-disable-next-line value-no-vendor-prefix */
-		appearance: none;
-		margin: 0;
-	}
-
-	/* removes the red border that appears in Firefox */
+	/* Removes the red border that appears in Firefox (normalize). */
 	&:-moz-ui-invalid {
 		box-shadow: none;
 	}
 
-	/* added to work with Edge, note, it needs double ::
-   * not single : which is what autoprefixer will add
-   */
-	/* stylelint-disable selector-no-vendor-prefix */
-	&::-ms-input-placeholder {
-		opacity: 1;
-	}
-	/* stylelint-enable selector-no-vendor-prefix */
-
 	/*** Input Placeholder Text ***/
 	&::placeholder {
+		/* Normalize opacity between browsers. */
 		opacity: 1;
 		font-size: var(--mod-textfield-placeholder-font-size, var(--spectrum-textfield-placeholder-font-size));
 		font-family: var(--mod-textfield-font-family, var(--spectrum-textfield-font-family));
@@ -479,13 +433,6 @@ governing permissions and limitations under the License.
 		&::placeholder {
 			font-style: normal;
 		}
-
-		/* stylelint-disable selector-no-vendor-prefix */
-		&::-ms-input-placeholder {
-			/* added to work with Edge, same as above */
-			font-style: normal;
-		}
-		/* stylelint-enable selector-no-vendor-prefix */
 	}
 
 	/* hover */
@@ -579,9 +526,6 @@ governing permissions and limitations under the License.
 		background-color: var(--mod-textfield-background-color-disabled, var(--spectrum-textfield-background-color-disabled));
 		border-color: transparent;
 		color: var(--highcontrast-textfield-text-color-disabled, var(--mod-textfield-text-color-disabled, var(--spectrum-textfield-text-color-disabled)));
-
-		/* For safari mobile browser */
-		-webkit-text-fill-color: var(--highcontrast-textfield-text-color-disabled, var(--mod-textfield-text-color-disabled, var(--spectrum-textfield-text-color-disabled)));
 
 		/* Disable the resize functionality when disabled */
 		resize: none;


### PR DESCRIPTION
## Description

In this work I searched for all uses of `-webkit-*`, `-moz-*`, and `-ms-*` prefixed properties in the repo, to find any cases where we no longer need them. I discovered a few that could be removed, and some tied to normalization styles that needed some cleanup and clarification.

### ===== accordion =====
The `appearance` property no longer needs vendor prefixes. Any necessary vendor prefixes for supported browsers would be added in the build process (none are added for our current browser support list).

### ===== statuslight =====
Removed the legacy `-ms-high-contrast-adjust` property. This CSS property was removed from Microsoft Edge starting with version 79 (when Edge started using Chromium). Our current browser support list does not support Edge versions before that.

This also moves the high contrast mode properties to the bottom of the file, and moves one high contrast property for the dot to within the forced-colors media query.

### ===== commons: BaseButton =====
#### Vendor prefixes removed
`-webkit-user-select`: the `user-select` property is already set and no longer needs manual prefixing.

#### note on `appearance` normalization prefixes
The use of `-webkit-appearance: button` is for normalization; this is still included in modern-normalize and csstools/normalize.css (with the same code comment). I've left these as-is for now because of some lingering questions, and created a followup Jira issue.

#### Simplified ::-moz-focus-inner normalization
These normalization styles only needed two declarations. They now match with what's done in modern-normalize and normalize.css.

### ===== textfield =====
#### Legacy vendor prefixes removed
These both are no longer needed in our library given our current browser support list:
  * `::-ms-clear` -- removed in Microsoft Edge 79
  * `::-ms-input-placeholder` -- removed in Microsoft Edge 79
  * `-webkit-text-fill-color` -- only needed for setting the text color on disabled inputs in Safari versions before version 12 (2018).

#### Cleanup and selector update for hide spinner styles
There were styles and comments for removing the native spin buttons for number fields. These now are now only applied to `[type="number"]`. I confirmed that `appearance: none` does not hide them in Firefox and the `textfield` value is still needed.

#### Removed some properties that weren't doing anything
There was a duplicative `appearance: textfield` on `.spectrum-Textfield` which didn't make sense there, as that isn't the input element; `.spectrum-Textfield-input` already has it set.

Two instances of `text-indent: 0` were removed. There is nowhere where text-indent is being set, and this already defaults to zero in the browser, and is not present in any of the normalization libraries.

Note: I also confirmed that the existing `:-moz-ui-invalid` in Text field is part of modern normalization libraries, so it was kept.

CSS-663

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

_Note for code review: you'll likely want to hide whitespace changes in files changed for BaseButton, as that does not appear to have gotten the tab/space whitespace change yet._

- [ ] Confirm no visual regressions in accordion, statuslight, textfield, and components that inherit from BaseButton
- [ ] -- Textfield input with `type="number"` should continue to show no spinners in both Firefox and Chrome
- [ ] -- Focus indicator still looks the same in Firefox
- [ ] -- Status light dot looks the same in high contrast mode

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
