### PR TITLE
chore: use local workspace package to prevent version mismatch

### DIFF
--- a/.changeset/slimy-donkeys-roll.md
+++ b/.changeset/slimy-donkeys-roll.md
@@ -1,0 +1,6 @@
+---
+"@spectrum-css/preview": patch
+"@spectrum-tools/documentation": patch
+---
+
+Align versions to the latest local package version instead of fetching it externally

--- a/.storybook/package.json
+++ b/.storybook/package.json
@@ -11,8 +11,8 @@
 	},
 	"dependencies": {
 		"@adobe/spectrum-css-workflow-icons": "^1.5.4",
-		"@spectrum-css/tokens": "^14.0.0",
-		"@spectrum-css/ui-icons": "^1.1.2"
+		"@spectrum-css/tokens": "workspace:^",
+		"@spectrum-css/ui-icons": "workspace:^"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.24.5",

--- a/site/package.json
+++ b/site/package.json
@@ -18,8 +18,8 @@
   "devDependencies": {
     "@adobe/focus-ring-polyfill": "^0.1.5",
     "@adobe/spectrum-css-workflow-icons": "^1.5.4",
-    "@spectrum-css/tokens": "^14.0.0",
-    "@spectrum-css/ui-icons": "^1.1.2",
+    "@spectrum-css/tokens": "workspace:^",
+    "@spectrum-css/ui-icons": "workspace:^",
     "browser-sync": "^3.0.2",
     "colors": "^1.4.0",
     "dependency-solver": "^1.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5390,8 +5390,8 @@ __metadata:
     "@babel/core": "npm:^7.24.5"
     "@chromaui/addon-visual-tests": "npm:^1.0.0"
     "@etchteam/storybook-addon-status": "npm:^4.2.4"
-    "@spectrum-css/tokens": "npm:^14.0.0"
-    "@spectrum-css/ui-icons": "npm:^1.1.2"
+    "@spectrum-css/tokens": "workspace:^"
+    "@spectrum-css/ui-icons": "workspace:^"
     "@storybook/addon-a11y": "npm:^8.1.1"
     "@storybook/addon-actions": "npm:^8.1.1"
     "@storybook/addon-console": "npm:^3.0.0"
@@ -5703,14 +5703,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@spectrum-css/tokens@npm:^14.0.0":
-  version: 14.0.0
-  resolution: "@spectrum-css/tokens@npm:14.0.0"
-  checksum: 10c0/59b9a49c01b939035af8e73fec914f18cbd18eae17815fb8ce93a0c2e3b1217d21a20f8b697a6ac7b4d135d5dca52f985d6556e5f9c2a9f52698ce0c5dd401b1
-  languageName: node
-  linkType: hard
-
-"@spectrum-css/tokens@workspace:tokens":
+"@spectrum-css/tokens@workspace:^, @spectrum-css/tokens@workspace:tokens":
   version: 0.0.0-use.local
   resolution: "@spectrum-css/tokens@workspace:tokens"
   dependencies:
@@ -5779,7 +5772,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@spectrum-css/ui-icons@npm:^1.1.2, @spectrum-css/ui-icons@workspace:ui-icons":
+"@spectrum-css/ui-icons@workspace:^, @spectrum-css/ui-icons@workspace:ui-icons":
   version: 0.0.0-use.local
   resolution: "@spectrum-css/ui-icons@workspace:ui-icons"
   dependencies:
@@ -5814,8 +5807,8 @@ __metadata:
   dependencies:
     "@adobe/focus-ring-polyfill": "npm:^0.1.5"
     "@adobe/spectrum-css-workflow-icons": "npm:^1.5.4"
-    "@spectrum-css/tokens": "npm:^14.0.0"
-    "@spectrum-css/ui-icons": "npm:^1.1.2"
+    "@spectrum-css/tokens": "workspace:^"
+    "@spectrum-css/ui-icons": "workspace:^"
     browser-sync: "npm:^3.0.2"
     colors: "npm:^1.4.0"
     dependency-solver: "npm:^1.0.6"


### PR DESCRIPTION
## Description

Current build is failing because the documentation and storybook packages are bringing in the external @spectrum-css/tokens 14.0.0 rather than using the local 14.1.0 version. These version bumps were missed in the chromatic release. In order to prevent that issue in future, this updates those packages to use the `workspace:^` version instead.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [x] Expect CI build to pass with no errors
- [x] Expect compare script to fail on build of main

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
