### PR TITLE
docs(calendar,card,coachmark,colorarea): site docs to storybook

### DIFF
--- a/components/asset/stories/template.js
+++ b/components/asset/stories/template.js
@@ -12,6 +12,7 @@ export const Template = ({
 	id,
 	customClasses = [],
 	customStyles = {},
+	isCardAssetOverride = false,
 }) => {
 	let visual;
 	if (preset === "file") {
@@ -32,7 +33,7 @@ export const Template = ({
 		visual = html`<img
 			class="${rootClass}-image"
 			src=${ifDefined(image)}
-			style=${styleMap({
+			style=${isCardAssetOverride ? null : styleMap({
 				"max-width": "75%",
 				"max-height": "75%",
 				"object-fit": "contain",

--- a/components/calendar/stories/calendar.mdx
+++ b/components/calendar/stories/calendar.mdx
@@ -1,0 +1,37 @@
+import { ArgTypes, Canvas, Meta, Description, Title } from '@storybook/blocks';
+
+import * as CalendarStories from './calendar.stories';
+
+<Meta of={CalendarStories} title="Docs" />
+
+<Title of={CalendarStories} />
+<Description of={CalendarStories} />
+
+## Standard
+
+<Canvas of={CalendarStories.Default} />
+
+## Abbreviated weekdays
+
+<Canvas of={CalendarStories.AbbreviatedWeekdays} />
+
+## Range selection
+
+For calendars with a selected range:
+
+- `.is-selection-start` class goes on the first day in the selection, and `.is-range-start` goes on the first day of each week or month in the middle of a selection (but not the first day of the selection)
+- `.is-selection-end` goes on the last day of the selection, and `.is-range-end goes` on the last day of each week or month in the middle of the selection (but not on the last day of the selection)
+
+<Canvas of={CalendarStories.RangeSelection} />
+
+## Focused
+
+<Canvas of={CalendarStories.Focused} />
+
+## Disabled
+
+<Canvas of={CalendarStories.Disabled} />
+
+## Properties
+
+<ArgTypes />

--- a/components/calendar/stories/calendar.stories.js
+++ b/components/calendar/stories/calendar.stories.js
@@ -85,11 +85,13 @@ export default {
 		buttonSize: {
 			table: { disable: true },
 		},
+		isFocused: { table: { disable: true }, },
 	},
 	args: {
 		rootClass: "spectrum-Calendar",
 		padded: false,
 		isDisabled: false,
+		isFocused: false,
 		useDOWAbbrev: false,
 		buttonSize: ActionButtonStories.args.size,
 	},
@@ -131,4 +133,25 @@ Disabled.args = {
 	selectedDay: new Date(2023, 6, 3),
 	year: 2023,
 	isDisabled: true
+};
+
+/**
+ * Stories for the MDX "Docs" only.
+ */
+export const AbbreviatedWeekdays = Template.bind({});
+AbbreviatedWeekdays.args = {
+	useDOWAbbrev: true,
+};
+AbbreviatedWeekdays.tags = ["docs-only"];
+AbbreviatedWeekdays.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+export const Focused = Template.bind({});
+Focused.args = {
+	isFocused: true,
+};
+Focused.tags = ["docs-only"];
+Focused.parameters = {
+	chromatic: { disableSnapshot: true },
 };

--- a/components/calendar/stories/template.js
+++ b/components/calendar/stories/template.js
@@ -19,6 +19,7 @@ export const Template = ({
 	year,
 	padded,
 	isDisabled = false,
+	isFocused = false,
 	useDOWAbbrev = false,
 	buttonSize = "s",
 	customClasses = [],
@@ -193,6 +194,9 @@ export const Template = ({
 						(selectedDate && selectedDatetime === thisDatetime) ||
 						isInRange
 					);
+					const isFocused = thisDay === 5;
+
+					console.log(thisDay, isFocused);
 
 					return {
 						date: thisDate,
@@ -202,6 +206,7 @@ export const Template = ({
 						isInRange,
 						isRangeStart: !!(isInRange && thisDatetime === selectedDatetime),
 						isRangeEnd: !!(isInRange && thisDatetime === lastSelectedDatetime),
+						isFocused,
 					};
 				})
 			);
@@ -366,6 +371,7 @@ export const Template = ({
 												"is-selection-start": thisDay.isRangeStart,
 												"is-selection-end": thisDay.isRangeEnd,
 												"is-disabled": isDisabled,
+												"is-focused": isFocused && thisDay.isFocused,
 											})}
 											@click=${onDateClick.bind(null, thisDay)}
 											>${thisDay.date.getDate()}</span

--- a/components/calendar/stories/template.js
+++ b/components/calendar/stories/template.js
@@ -196,7 +196,6 @@ export const Template = ({
 					);
 					const isFocused = thisDay === 5;
 
-					console.log(thisDay, isFocused);
 
 					return {
 						date: thisDate,

--- a/components/card/stories/card.mdx
+++ b/components/card/stories/card.mdx
@@ -1,0 +1,62 @@
+import { ArgTypes, Canvas, Meta, Description, Title } from '@storybook/blocks';
+
+import * as CardStories from './card.stories';
+
+<Meta of={CardStories} title="Docs" />
+
+<Title of={CardStories} />
+<Description of={CardStories} />
+
+## Standard
+
+<Canvas of={CardStories.Default} />
+
+### No image
+
+<Canvas of={CardStories.NoImage} />
+
+### Focused
+
+<Canvas of={CardStories.Focused} />
+
+### Selected
+
+<Canvas of={CardStories.Selected} />
+
+## Quiet
+
+<Canvas of={CardStories.Quiet} />
+
+### Quiet File
+
+<Canvas of={CardStories.QuietFile} />
+
+### Quiet Folder
+
+<Canvas of={CardStories.QuietFolder} />
+
+### Quiet Focused
+
+<Canvas of={CardStories.QuietFocused} />
+
+### Quiet Selected
+
+<Canvas of={CardStories.QuietSelected} />
+
+## Horizontal
+
+<Canvas of={CardStories.Horizontal} />
+
+## Asset preview
+A standard card with a full-sized asset preview.
+
+<Canvas of={CardStories.AssetPreview} />
+
+## Gallery
+A gallery card for an image.
+
+<Canvas of={CardStories.Gallery} />
+
+## Properties
+
+<ArgTypes />

--- a/components/card/stories/card.stories.js
+++ b/components/card/stories/card.stories.js
@@ -89,6 +89,7 @@ export default {
 		},
 		footer: { table: { disable: true } },
 		isGallery: { table: { disable: true } },
+		isCardAssetOverride: { table: { disable: true } },
 		isGrid: { table: { disable: true } },
 		isHorizontal: { table: { disable: true } },
 		isDropTarget: { table: { disable: true } },
@@ -170,4 +171,91 @@ Horizontal.args = {
 	isHorizontal: true,
 	hasActions: false,
 	hasQuickAction: false,
+};
+
+/**
+ * Stories for the MDX "Docs" only.
+ */
+export const NoImage = Template.bind({});
+NoImage.args = {
+	title: "Card title",
+	description: "Optional description that should be one or two lines",
+};
+NoImage.tags = ["docs-only"];
+NoImage.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+export const QuietFolder = Quiet.bind({});
+QuietFolder.args = {
+	title: "Name",
+	showAsset: "folder",
+	description: "10/15/18",
+	isQuiet: true,
+};
+QuietFolder.tags = ["docs-only"];
+QuietFolder.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+export const QuietFocused = Quiet.bind({});
+QuietFocused.args = {
+	title: "Name",
+	showAsset: "image",
+	image: "example-ava@2x.png",
+	description: "10/15/18",
+	isQuiet: true,
+	isFocused: true,
+};
+QuietFocused.tags = ["docs-only"];
+QuietFocused.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+export const QuietSelected = Quiet.bind({});
+QuietSelected.args = {
+	title: "Name",
+	showAsset: "image",
+	image: "example-ava@2x.png",
+	description: "10/15/18",
+	isQuiet: true,
+	isSelected: true,
+};
+QuietSelected.tags = ["docs-only"];
+QuietSelected.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+export const AssetPreview = Template.bind({});
+AssetPreview.args = {
+	title: "Card title",
+	showAsset: "image",
+	image: "example-card-portrait.png",
+	description: "jpg",
+	hasActions: false,
+	isCardAssetOverride: true,
+	customStyles: {
+		"width": "200px",
+	}
+};
+AssetPreview.tags = ["docs-only"];
+AssetPreview.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+export const Gallery = Template.bind({});
+Gallery.args = {
+	title: "Card title",
+	showAsset: "image",
+	image: "example-card-landscape.png",
+	description: "jpg",
+	isGallery: true,
+	isCardAssetOverride: true,
+	customStyles: {
+		"width": "700px",
+	}
+};
+Gallery.tags = ["docs-only"];
+Gallery.parameters = {
+	chromatic: { disableSnapshot: true },
 };

--- a/components/card/stories/template.js
+++ b/components/card/stories/template.js
@@ -26,6 +26,7 @@ export const Template = ({
 	isHorizontal = false,
 	isQuiet = false,
 	isGallery = false,
+	isCardAssetOverride = false,
 	isGrid = false,
 	hasQuickAction = false,
 	hasActions = false,
@@ -66,6 +67,7 @@ export const Template = ({
                   ...globals,
                   image,
                   preset: !image ? showAsset : undefined,
+                  isCardAssetOverride,
                 }),
                 () => Icon({
                   ...globals,

--- a/components/coachmark/stories/coachmark.mdx
+++ b/components/coachmark/stories/coachmark.mdx
@@ -1,0 +1,20 @@
+import { ArgTypes, Canvas, Meta, Description, Title } from '@storybook/blocks';
+
+import * as CoachmarkStories from './coachmark.stories';
+
+<Meta of={CoachmarkStories} title="Docs" />
+
+<Title of={CoachmarkStories} />
+<Description of={CoachmarkStories} />
+
+## Standard
+
+<Canvas of={CoachmarkStories.Default} />
+
+## With media
+
+<Canvas of={CoachmarkStories.WithMedia} />
+
+## Properties
+
+<ArgTypes />

--- a/components/coachmark/stories/coachmark.stories.js
+++ b/components/coachmark/stories/coachmark.stories.js
@@ -4,7 +4,7 @@ import { default as ActionButton } from "@spectrum-css/actionbutton/stories/acti
 import { default as Menu } from "@spectrum-css/menu/stories/menu.stories.js";
 
 /**
- * The coach mark component can be used to bring added attention to specific parts of a page.
+ * The coach mark component can be used to bring added attention to specific parts of a page. It is a separate component from the coach indicator.
  */
 export default {
 	title: "Components/Coach mark",
@@ -68,4 +68,12 @@ Default.args = {};
 export const WithMedia = Template.bind({});
 WithMedia.args = {
 	hasImage: true,
+};
+WithMedia.parameters = {
+	docs: {
+		story: {
+			inline: false,
+			height: 475,
+		},
+	},
 };

--- a/components/coachmark/stories/template.js
+++ b/components/coachmark/stories/template.js
@@ -20,95 +20,97 @@ export const Template = ({
 	isOpen = true,
 	...globals
 }) => html`
-	<div
-		class=${classMap({
-			[rootClass]: true,
-			...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
-		})}
-		style=${ifDefined(styleMap(customStyles))}
-	>
-		${Popover({
-			...globals,
-			nested: true,
-			testId: "popover-nested",
-			id: "popover-nested",
-			triggerId: "trigger-nested",
-			customStyles: {
-				"margin-inline-start": "0px",
-			},
-			customClasses: [`${rootClass}-popover`],
-			isOpen: true,
-			content: [
-				html`
-				${hasImage ? html`
-					<div class="${rootClass}-image-wrapper">
-						<img class="${rootClass}-image" src="example-card-landscape.png" />
-					</div>` : ""}
-				<div class="spectrum-CoachMark-header">
-					<div class="spectrum-CoachMark-title">Try playing with a pixel brush</div>
-					<div class="spectrum-CoachMark-action-menu">
-					${hasActionMenu ? ActionMenu({
-						isOpen,
-						popoverPosition: "right",
-						popoverTestId: "popover-nested-2",
-						popoverId: "popover-nested-2",
-						popoverTriggerId: "trigger-nested-2",
-						customStyles: {
-							"margin-block-start": "30px",
-							"margin-inline-start": "-32px"
-						},
-						iconName: "More",
+	<div style=${styleMap({"margin-top": "8px"})}>
+		<div
+			class=${classMap({
+				[rootClass]: true,
+				...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
+			})}
+			style=${ifDefined(styleMap(customStyles))}
+		>
+			${Popover({
+				...globals,
+				nested: true,
+				testId: "popover-nested",
+				id: "popover-nested",
+				triggerId: "trigger-nested",
+				customStyles: {
+					"margin-inline-start": "0px",
+				},
+				customClasses: [`${rootClass}-popover`],
+				isOpen: true,
+				content: [
+					html`
+					${hasImage ? html`
+						<div class="${rootClass}-image-wrapper">
+							<img class="${rootClass}-image" src="example-card-landscape.png" />
+						</div>` : ""}
+					<div class="spectrum-CoachMark-header">
+						<div class="spectrum-CoachMark-title">Try playing with a pixel brush</div>
+						<div class="spectrum-CoachMark-action-menu">
+						${hasActionMenu ? ActionMenu({
+							isOpen,
+							popoverPosition: "right",
+							popoverTestId: "popover-nested-2",
+							popoverId: "popover-nested-2",
+							popoverTriggerId: "trigger-nested-2",
+							customStyles: {
+								"margin-block-start": "30px",
+								"margin-inline-start": "-32px"
+							},
+							iconName: "More",
+							size: globals.scale === "large" ? "s" : "m",
+							items: [
+								{
+									label: "Skip tour",
+								},
+								{
+									label: "Reset tour",
+								}
+							],
+						}) : ""}
+					</div>
+					</div>
+					<div class="spectrum-CoachMark-content">
+						Pixel brushes use pixels to create brush strokes, just like in other design and drawing tools. Start drawing, and zoom in to see the pixels in each stroke.
+					</div>
+					<div class="${rootClass}-footer">
+					${hasPagination ? html`<div class="spectrum-CoachMark-step"><bdo dir="ltr">2 of 8</bdo></div>` : ""}
+					${ButtonGroup({
+						customClasses: globals.scale === "large" ? [`${rootClass}-buttongroup--mobile`] : [`${rootClass}-buttongroup`],
 						size: globals.scale === "large" ? "s" : "m",
-						items: [
+						items: globals.scale === "large" ?
+						[
 							{
-								label: "Skip tour",
+								variant: "secondary",
+								treatment: "outline",
+								hideLabel: true,
+								iconName: "ChevronLeft75",
 							},
 							{
-								label: "Reset tour",
-							}
+								variant: "primary",
+								treatment: "outline",
+								label: "Next",
+							},
+						]
+						:
+						[
+							{
+								variant: "secondary",
+								treatment: "outline",
+								label: "Previous",
+							},
+							{
+								variant: "primary",
+								treatment: "outline",
+								label: "Next",
+							},
 						],
-					}) : ""}
-				</div>
-				</div>
-				<div class="spectrum-CoachMark-content">
-					Pixel brushes use pixels to create brush strokes, just like in other design and drawing tools. Start drawing, and zoom in to see the pixels in each stroke.
-				</div>
-				<div class="${rootClass}-footer">
-				${hasPagination ? html`<div class="spectrum-CoachMark-step"><bdo dir="ltr">2 of 8</bdo></div>` : ""}
-				${ButtonGroup({
-					customClasses: globals.scale === "large" ? [`${rootClass}-buttongroup--mobile`] : [`${rootClass}-buttongroup`],
-					size: globals.scale === "large" ? "s" : "m",
-					items: globals.scale === "large" ?
-					[
-						{
-							variant: "secondary",
-							treatment: "outline",
-							hideLabel: true,
-							iconName: "ChevronLeft75",
-						},
-						{
-							variant: "primary",
-							treatment: "outline",
-							label: "Next",
-						},
-					]
-					:
-					[
-						{
-							variant: "secondary",
-							treatment: "outline",
-							label: "Previous",
-						},
-						{
-							variant: "primary",
-							treatment: "outline",
-							label: "Next",
-						},
-					],
-				})}
-				</div>
-				`
-			],
-		})}
+					})}
+					</div>
+					`
+				],
+			})}
+		</div>
 	</div>
 `;

--- a/components/colorarea/stories/colorarea.mdx
+++ b/components/colorarea/stories/colorarea.mdx
@@ -1,0 +1,24 @@
+import { ArgTypes, Canvas, Meta, Description, Title } from '@storybook/blocks';
+
+import * as ColorAreaStories from './colorarea.stories';
+
+<Meta of={ColorAreaStories} title="Docs" />
+
+<Title of={ColorAreaStories} />
+<Description of={ColorAreaStories} />
+
+## Standard
+
+<Canvas of={ColorAreaStories.Default} />
+
+## Custom size
+
+<Canvas of={ColorAreaStories.CustomSize} />
+
+## Disabled
+
+<Canvas of={ColorAreaStories.Disabled} />
+
+## Properties
+
+<ArgTypes />

--- a/components/colorarea/stories/colorarea.stories.js
+++ b/components/colorarea/stories/colorarea.stories.js
@@ -1,7 +1,13 @@
 import { Template } from "./template";
 
 /**
- * The color area component allows users to visually select two properties of a color simultaneously. It's commonly used together with a color slider or color wheel.
+ * The color area component allows users to visually select two properties of a color simultaneously. It's commonly used together with a color slider or color wheel. Some usage notes:
+ * - The `.spectrum-ColorHandle` should be moved with the `transform: translate(x, y)` style property as the sliders are dragged
+ * - Set the background style property of `.spectrum-ColorArea-gradient` to the gradient of the colors to be selected
+ * - Set the value attribute of `.spectrum-ColorArea-slider[name=x]` to the currently selected x value (i.e. saturation)
+ * - Set the value attribute of `.spectrum-ColorArea-slider[name=y]` to the currently selected y value (i.e. value)
+ * - Set the value of the ColorHandle component to the selected color
+ * - Marshall focus between the saturation and value sliders according to which keys are pressed (up/down for value, left/right for saturation)
  */
 export default {
 	title: "Components/Color area",
@@ -52,4 +58,17 @@ export const CustomSize = Template.bind({});
 CustomSize.args = {
 	customWidth: "80px",
 	customHeight: "80px",
+};
+
+
+/**
+ * Stories for the MDX "Docs" only.
+ */
+export const Disabled = Template.bind({});
+Disabled.args = {
+	isDisabled: true,
+};
+Disabled.tags = ["docs-only"];
+Disabled.parameters = {
+	chromatic: { disableSnapshot: true },
 };


### PR DESCRIPTION
## Description

This migrates the documentation from the deprecated docs site over to Storybook, including showing the variants on the Storybook Docs page.

- Calendar - got a new MDX page and one MDX-only story
- Card - got a new MDX page and some MDX-only stories
- Coachmark - got a new MDX page and some extra parameters to make sure "with media" variant shows whole component on Docs page
- Colorarea - got a new MDX page and one MDX-only story

This PR doesn't need a changeset since it's docs-only.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [x] The [Calendar storybook](https://pr-2783--spectrum-css.netlify.app/preview/?path=/docs/components-calendar--docs) docs include all necessary info when compared to the [docs site](https://pr-2783--spectrum-css.netlify.app/calendar)
- [x] The [Card storybook](https://pr-2783--spectrum-css.netlify.app/preview/?path=/docs/components-card--docs) docs include all necessary info when compared to the [docs site](https://pr-2783--spectrum-css.netlify.app/card)
  - [x] Also check that the variants from the [docs site asset preview](https://pr-2783--spectrum-css.netlify.app/card-asset) and [gallery pages](https://pr-2783--spectrum-css.netlify.app/card-gallery) are covered.
- [ ] The [Coachmark storybook](https://pr-2783--spectrum-css.netlify.app/preview/?path=/docs/components-coach-mark--docs) docs include all necessary info when compared to the [docs site](https://pr-2783--spectrum-css.netlify.app/coachmark)
- [ ] The [Colorarea storybook](https://pr-2783--spectrum-css.netlify.app/preview/?path=/docs/components-color-area--docs) docs include all necessary info when compared to the [docs site](https://pr-2783--spectrum-css.netlify.app/colorarea)

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.


## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
