### PR TITLE
feat(button)!: s2 gradients prototyping

### DIFF
--- a/components/button/index.css
+++ b/components/button/index.css
@@ -13,553 +13,570 @@ governing permissions and limitations under the License.
 @import "@spectrum-css/commons/basebutton.css";
 
 .spectrum-Button {
-  --spectrum-button-animation-duration: var(--spectrum-animation-duration-100);
+	--spectrum-button-animation-duration: var(--spectrum-animation-duration-100);
 
-  --spectrum-button-focus-ring-gap: var(--spectrum-focus-indicator-gap);
-  --spectrum-button-focus-ring-thickness: var(--spectrum-focus-indicator-thickness);
-  --spectrum-button-focus-indicator-color: var(--spectrum-focus-indicator-color);
+	--spectrum-button-focus-ring-gap: var(--spectrum-focus-indicator-gap);
+	--spectrum-button-focus-ring-thickness: var(--spectrum-focus-indicator-thickness);
+	--spectrum-button-focus-indicator-color: var(--spectrum-focus-indicator-color);
 
-  --spectrum-button-min-width: calc(var(--spectrum-component-height-100) * var(--spectrum-button-minimum-width-multiplier));
-  --spectrum-button-height: var(--spectrum-component-height-100);
+	--spectrum-button-min-width: calc(var(--spectrum-component-height-100) * var(--spectrum-button-minimum-width-multiplier));
+	--spectrum-button-height: var(--spectrum-component-height-100);
 
-  --spectrum-button-border-radius: calc(var(--spectrum-button-height) / 2);
-  --spectrum-button-border-width: var(--spectrum-border-width-200);
+	--spectrum-button-border-radius: calc(var(--spectrum-button-height) / 2);
+	--spectrum-button-border-width: var(--spectrum-border-width-200);
 
-  /* @todo set line-height using font size specific line-height tokens when they are finalized along with the new variable font. */
-  --spectrum-button-line-height: 1.2;
-  --spectrum-button-font-weight: var(--spectrum-bold-font-weight);
-  --spectrum-button-font-size: var(--spectrum-font-size-100);
+	/* @todo set line-height using font size specific line-height tokens when they are finalized along with the new variable font. */
+	--spectrum-button-line-height: 1.2;
+	--spectrum-button-font-weight: var(--spectrum-bold-font-weight);
+	--spectrum-button-font-size: var(--spectrum-font-size-100);
 
-  --spectrum-button-edge-to-visual: calc(var(--spectrum-component-pill-edge-to-visual-100) - var(--mod-button-border-width, var(--spectrum-button-border-width)));
-  --spectrum-button-edge-to-visual-only: calc(var(--spectrum-component-pill-edge-to-visual-only-100) - var(--mod-button-border-width, var(--spectrum-button-border-width)));
-  --spectrum-button-edge-to-text: calc(var(--spectrum-component-pill-edge-to-text-100) - var(--mod-button-border-width, var(--spectrum-button-border-width)));
-  --spectrum-button-padding-label-to-icon: var(--spectrum-text-to-visual-100);
-  --spectrum-button-top-to-text: var(--spectrum-button-top-to-text-medium);
-  --spectrum-button-bottom-to-text: var(--spectrum-button-bottom-to-text-medium);
-  --spectrum-button-top-to-icon: var(--spectrum-component-top-to-workflow-icon-100);
-  --spectrum-button-intended-icon-size: var(--spectrum-workflow-icon-size-100);
+	--spectrum-button-edge-to-visual: calc(var(--spectrum-component-pill-edge-to-visual-100) - var(--mod-button-border-width, var(--spectrum-button-border-width)));
+	--spectrum-button-edge-to-visual-only: calc(var(--spectrum-component-pill-edge-to-visual-only-100) - var(--mod-button-border-width, var(--spectrum-button-border-width)));
+	--spectrum-button-edge-to-text: calc(var(--spectrum-component-pill-edge-to-text-100) - var(--mod-button-border-width, var(--spectrum-button-border-width)));
+	--spectrum-button-padding-label-to-icon: var(--spectrum-text-to-visual-100);
+	--spectrum-button-top-to-text: var(--spectrum-button-top-to-text-medium);
+	--spectrum-button-bottom-to-text: var(--spectrum-button-bottom-to-text-medium);
+	--spectrum-button-top-to-icon: var(--spectrum-component-top-to-workflow-icon-100);
+	--spectrum-button-intended-icon-size: var(--spectrum-workflow-icon-size-100);
 
-  --mod-progress-circle-position: absolute;
-  /* stylelint-disable-next-line spectrum-tools/no-unknown-custom-properties -- height and width are set by implementations */
-  --spectrum-downstate-perspective: max(var(--spectrum-downstate-height), var(--spectrum-downstate-width) * var(--spectrum-component-size-width-ratio-down));
+	--mod-progress-circle-position: absolute;
+	/* stylelint-disable-next-line spectrum-tools/no-unknown-custom-properties -- height and width are set by implementations */
+	--spectrum-downstate-perspective: max(var(--spectrum-downstate-height), var(--spectrum-downstate-width) * var(--spectrum-component-size-width-ratio-down));
 
-  &.spectrum-Button--iconOnly {
-    --spectrum-button-border-radius: var(--spectrum-corner-radius-full);
-  }
+	&.spectrum-Button--iconOnly {
+		--spectrum-button-border-radius: var(--spectrum-corner-radius-full);
+	}
 }
 
 .spectrum-Button--sizeS {
-  --spectrum-button-min-width: calc(var(--spectrum-component-height-75) * var(--spectrum-button-minimum-width-multiplier));
-  --spectrum-button-height: var(--spectrum-component-height-75);
+	--spectrum-button-min-width: calc(var(--spectrum-component-height-75) * var(--spectrum-button-minimum-width-multiplier));
+	--spectrum-button-height: var(--spectrum-component-height-75);
 
-  --spectrum-button-font-size: var(--spectrum-font-size-75);
+	--spectrum-button-font-size: var(--spectrum-font-size-75);
 
-  --spectrum-button-edge-to-visual: calc(var(--spectrum-component-pill-edge-to-visual-75) - var(--mod-button-border-width, var(--spectrum-button-border-width)));
-  --spectrum-button-edge-to-visual-only: calc(var(--spectrum-component-pill-edge-to-visual-only-75) - var(--mod-button-border-width, var(--spectrum-button-border-width)));
-  --spectrum-button-edge-to-text: calc(var(--spectrum-component-pill-edge-to-text-75) - var(--mod-button-border-width, var(--spectrum-button-border-width)));
-  --spectrum-button-padding-label-to-icon: var(--spectrum-text-to-visual-75);
-  --spectrum-button-top-to-text: var(--spectrum-button-top-to-text-small);
-  --spectrum-button-bottom-to-text: var(--spectrum-button-bottom-to-text-small);
-  --spectrum-button-top-to-icon: var(--spectrum-component-top-to-workflow-icon-75);
-  --spectrum-button-intended-icon-size: var(--spectrum-workflow-icon-size-75);
+	--spectrum-button-edge-to-visual: calc(var(--spectrum-component-pill-edge-to-visual-75) - var(--mod-button-border-width, var(--spectrum-button-border-width)));
+	--spectrum-button-edge-to-visual-only: calc(var(--spectrum-component-pill-edge-to-visual-only-75) - var(--mod-button-border-width, var(--spectrum-button-border-width)));
+	--spectrum-button-edge-to-text: calc(var(--spectrum-component-pill-edge-to-text-75) - var(--mod-button-border-width, var(--spectrum-button-border-width)));
+	--spectrum-button-padding-label-to-icon: var(--spectrum-text-to-visual-75);
+	--spectrum-button-top-to-text: var(--spectrum-button-top-to-text-small);
+	--spectrum-button-bottom-to-text: var(--spectrum-button-bottom-to-text-small);
+	--spectrum-button-top-to-icon: var(--spectrum-component-top-to-workflow-icon-75);
+	--spectrum-button-intended-icon-size: var(--spectrum-workflow-icon-size-75);
 
-  &.spectrum-Button--iconOnly {
-    --spectrum-downstate-perspective: var(--spectrum-component-size-minimum-perspective-down);
-  }
+	&.spectrum-Button--iconOnly {
+		--spectrum-downstate-perspective: var(--spectrum-component-size-minimum-perspective-down);
+	}
 }
 
 .spectrum-Button--sizeL {
-  --spectrum-button-min-width: calc(var(--spectrum-component-height-200) * var(--spectrum-button-minimum-width-multiplier));
-  --spectrum-button-height: var(--spectrum-component-height-200);
+	--spectrum-button-min-width: calc(var(--spectrum-component-height-200) * var(--spectrum-button-minimum-width-multiplier));
+	--spectrum-button-height: var(--spectrum-component-height-200);
 
-  --spectrum-button-font-size: var(--spectrum-font-size-200);
+	--spectrum-button-font-size: var(--spectrum-font-size-200);
 
-  --spectrum-button-edge-to-visual: calc(var(--spectrum-component-pill-edge-to-visual-200) - var(--mod-button-border-width, var(--spectrum-button-border-width)));
-  --spectrum-button-edge-to-visual-only: calc(var(--spectrum-component-pill-edge-to-visual-only-200) - var(--mod-button-border-width, var(--spectrum-button-border-width)));
-  --spectrum-button-edge-to-text: calc(var(--spectrum-component-pill-edge-to-text-200) - var(--mod-button-border-width, var(--spectrum-button-border-width)));
-  --spectrum-button-padding-label-to-icon: var(--spectrum-text-to-visual-200);
-  --spectrum-button-top-to-text: var(--spectrum-button-top-to-text-large);
-  --spectrum-button-bottom-to-text: var(--spectrum-button-bottom-to-text-large);
-  --spectrum-button-top-to-icon: var(--spectrum-component-top-to-workflow-icon-200);
-  --spectrum-button-intended-icon-size: var(--spectrum-workflow-icon-size-200);
+	--spectrum-button-edge-to-visual: calc(var(--spectrum-component-pill-edge-to-visual-200) - var(--mod-button-border-width, var(--spectrum-button-border-width)));
+	--spectrum-button-edge-to-visual-only: calc(var(--spectrum-component-pill-edge-to-visual-only-200) - var(--mod-button-border-width, var(--spectrum-button-border-width)));
+	--spectrum-button-edge-to-text: calc(var(--spectrum-component-pill-edge-to-text-200) - var(--mod-button-border-width, var(--spectrum-button-border-width)));
+	--spectrum-button-padding-label-to-icon: var(--spectrum-text-to-visual-200);
+	--spectrum-button-top-to-text: var(--spectrum-button-top-to-text-large);
+	--spectrum-button-bottom-to-text: var(--spectrum-button-bottom-to-text-large);
+	--spectrum-button-top-to-icon: var(--spectrum-component-top-to-workflow-icon-200);
+	--spectrum-button-intended-icon-size: var(--spectrum-workflow-icon-size-200);
 }
 
 .spectrum-Button--sizeXL {
-  --spectrum-button-min-width: calc(var(--spectrum-component-height-300) * var(--spectrum-button-minimum-width-multiplier));
-  --spectrum-button-height: var(--spectrum-component-height-300);
+	--spectrum-button-min-width: calc(var(--spectrum-component-height-300) * var(--spectrum-button-minimum-width-multiplier));
+	--spectrum-button-height: var(--spectrum-component-height-300);
 
-  --spectrum-button-font-size: var(--spectrum-font-size-300);
+	--spectrum-button-font-size: var(--spectrum-font-size-300);
 
-  --spectrum-button-edge-to-visual: calc(var(--spectrum-component-pill-edge-to-visual-300) - var(--mod-button-border-width, var(--spectrum-button-border-width)));
-  --spectrum-button-edge-to-visual-only: calc(var(--spectrum-component-pill-edge-to-visual-only-300) - var(--mod-button-border-width, var(--spectrum-button-border-width)));
-  --spectrum-button-edge-to-text: calc(var(--spectrum-component-pill-edge-to-text-300) - var(--mod-button-border-width, var(--spectrum-button-border-width)));
-  --spectrum-button-padding-label-to-icon: var(--spectrum-text-to-visual-300);
-  --spectrum-button-top-to-text: var(--spectrum-button-top-to-text-extra-large);
-  --spectrum-button-bottom-to-text: var(--spectrum-button-bottom-to-text-extra-large);
-  --spectrum-button-top-to-icon: var(--spectrum-component-top-to-workflow-icon-300);
-  --spectrum-button-intended-icon-size: var(--spectrum-workflow-icon-size-300);
+	--spectrum-button-edge-to-visual: calc(var(--spectrum-component-pill-edge-to-visual-300) - var(--mod-button-border-width, var(--spectrum-button-border-width)));
+	--spectrum-button-edge-to-visual-only: calc(var(--spectrum-component-pill-edge-to-visual-only-300) - var(--mod-button-border-width, var(--spectrum-button-border-width)));
+	--spectrum-button-edge-to-text: calc(var(--spectrum-component-pill-edge-to-text-300) - var(--mod-button-border-width, var(--spectrum-button-border-width)));
+	--spectrum-button-padding-label-to-icon: var(--spectrum-text-to-visual-300);
+	--spectrum-button-top-to-text: var(--spectrum-button-top-to-text-extra-large);
+	--spectrum-button-bottom-to-text: var(--spectrum-button-bottom-to-text-extra-large);
+	--spectrum-button-top-to-icon: var(--spectrum-component-top-to-workflow-icon-300);
+	--spectrum-button-intended-icon-size: var(--spectrum-workflow-icon-size-300);
 }
 
 /* Variants and colors */
 .spectrum-Button {
-  --spectrum-button-content-color-default: var(--spectrum-white);
-  --spectrum-button-content-color-hover: var(--spectrum-white);
-  --spectrum-button-content-color-down: var(--spectrum-white);
-  --spectrum-button-content-color-focus: var(--spectrum-white);
+	--spectrum-button-content-color-default: var(--spectrum-white);
+	--spectrum-button-content-color-hover: var(--spectrum-white);
+	--spectrum-button-content-color-down: var(--spectrum-white);
+	--spectrum-button-content-color-focus: var(--spectrum-white);
 
-  --spectrum-button-border-color-default: transparent;
-  --spectrum-button-border-color-hover: transparent;
-  --spectrum-button-border-color-down: transparent;
-  --spectrum-button-border-color-focus: transparent;
+	--spectrum-button-border-color-default: transparent;
+	--spectrum-button-border-color-hover: transparent;
+	--spectrum-button-border-color-down: transparent;
+	--spectrum-button-border-color-focus: transparent;
 
-  --spectrum-button-background-color-disabled: var(--spectrum-disabled-background-color);
-  --spectrum-button-border-color-disabled: transparent;
-  --spectrum-button-content-color-disabled: var(--spectrum-disabled-content-color);
+	--spectrum-button-background-color-disabled: var(--spectrum-disabled-background-color);
+	--spectrum-button-border-color-disabled: transparent;
+	--spectrum-button-content-color-disabled: var(--spectrum-disabled-content-color);
 
-  &.spectrum-Button--outline {
-    --spectrum-button-background-color-disabled: transparent;
-    --spectrum-button-border-color-disabled: var(--spectrum-disabled-border-color);
-    --spectrum-button-content-color-disabled: var(--spectrum-disabled-content-color);
-  }
+	&.spectrum-Button--outline {
+		--spectrum-button-background-color-disabled: transparent;
+		--spectrum-button-border-color-disabled: var(--spectrum-disabled-border-color);
+		--spectrum-button-content-color-disabled: var(--spectrum-disabled-content-color);
+	}
 
-  /* ---- Accent ---- */
-  /* Also shows as the default when a variant class is not used. */
-  &.spectrum-Button--accent,
-  & {
-    --spectrum-button-background-color-default: var(--spectrum-accent-background-color-default);
-    --spectrum-button-background-color-hover: var(--spectrum-accent-background-color-hover);
-    --spectrum-button-background-color-down: var(--spectrum-accent-background-color-down);
-    --spectrum-button-background-color-focus: var(--spectrum-accent-background-color-key-focus);
-  }
+	/* ---- Accent ---- */
+	/* Also shows as the default when a variant class is not used. */
+	&.spectrum-Button--accent,
+	& {
+		--spectrum-button-background-color-default: var(--spectrum-accent-background-color-default);
+		--spectrum-button-background-color-hover: var(--spectrum-accent-background-color-hover);
+		--spectrum-button-background-color-down: var(--spectrum-accent-background-color-down);
+		--spectrum-button-background-color-focus: var(--spectrum-accent-background-color-key-focus);
+	}
 
-  /* ---- Negative ---- */
-  &.spectrum-Button--negative {
-    --spectrum-button-background-color-default: var(--spectrum-negative-background-color-default);
-    --spectrum-button-background-color-hover: var(--spectrum-negative-background-color-hover);
-    --spectrum-button-background-color-down: var(--spectrum-negative-background-color-down);
-    --spectrum-button-background-color-focus: var(--spectrum-negative-background-color-key-focus);
-  }
+	/* ---- Negative ---- */
+	&.spectrum-Button--negative {
+		--spectrum-button-background-color-default: var(--spectrum-negative-background-color-default);
+		--spectrum-button-background-color-hover: var(--spectrum-negative-background-color-hover);
+		--spectrum-button-background-color-down: var(--spectrum-negative-background-color-down);
+		--spectrum-button-background-color-focus: var(--spectrum-negative-background-color-key-focus);
+	}
 
-  /* ---- Primary ---- */
-  &.spectrum-Button--primary {
-    --spectrum-button-background-color-default: var(--spectrum-neutral-background-color-default);
-    --spectrum-button-background-color-hover: var(--spectrum-neutral-background-color-hover);
-    --spectrum-button-background-color-down: var(--spectrum-neutral-background-color-down);
-    --spectrum-button-background-color-focus: var(--spectrum-neutral-background-color-key-focus);
+	/* ---- Primary ---- */
+	&.spectrum-Button--primary {
+		--spectrum-button-background-color-default: var(--spectrum-neutral-background-color-default);
+		--spectrum-button-background-color-hover: var(--spectrum-neutral-background-color-hover);
+		--spectrum-button-background-color-down: var(--spectrum-neutral-background-color-down);
+		--spectrum-button-background-color-focus: var(--spectrum-neutral-background-color-key-focus);
 
-    --spectrum-button-content-color-default: var(--spectrum-gray-25);
-    --spectrum-button-content-color-hover: var(--spectrum-gray-25);
-    --spectrum-button-content-color-down: var(--spectrum-gray-25);
-    --spectrum-button-content-color-focus: var(--spectrum-gray-25);
+		--spectrum-button-content-color-default: var(--spectrum-gray-25);
+		--spectrum-button-content-color-hover: var(--spectrum-gray-25);
+		--spectrum-button-content-color-down: var(--spectrum-gray-25);
+		--spectrum-button-content-color-focus: var(--spectrum-gray-25);
 
-    &.spectrum-Button--outline {
-      --spectrum-button-background-color-default: transparent;
-      --spectrum-button-background-color-hover: var(--spectrum-gray-100);
-      --spectrum-button-background-color-down: var(--spectrum-gray-100);
-      --spectrum-button-background-color-focus: var(--spectrum-gray-100);
+		&.spectrum-Button--outline {
+			--spectrum-button-background-color-default: transparent;
+			--spectrum-button-background-color-hover: var(--spectrum-gray-100);
+			--spectrum-button-background-color-down: var(--spectrum-gray-100);
+			--spectrum-button-background-color-focus: var(--spectrum-gray-100);
 
-      --spectrum-button-border-color-default: var(--spectrum-gray-800);
-      --spectrum-button-border-color-hover: var(--spectrum-gray-900);
-      --spectrum-button-border-color-down: var(--spectrum-gray-900);
-      --spectrum-button-border-color-focus: var(--spectrum-gray-900);
+			--spectrum-button-border-color-default: var(--spectrum-gray-800);
+			--spectrum-button-border-color-hover: var(--spectrum-gray-900);
+			--spectrum-button-border-color-down: var(--spectrum-gray-900);
+			--spectrum-button-border-color-focus: var(--spectrum-gray-900);
 
-      --spectrum-button-content-color-default: var(--spectrum-neutral-content-color-default);
-      --spectrum-button-content-color-hover: var(--spectrum-neutral-content-color-hover);
-      --spectrum-button-content-color-down: var(--spectrum-neutral-content-color-down);
-      --spectrum-button-content-color-focus: var(--spectrum-neutral-content-color-key-focus);
-    }
-  }
+			--spectrum-button-content-color-default: var(--spectrum-neutral-content-color-default);
+			--spectrum-button-content-color-hover: var(--spectrum-neutral-content-color-hover);
+			--spectrum-button-content-color-down: var(--spectrum-neutral-content-color-down);
+			--spectrum-button-content-color-focus: var(--spectrum-neutral-content-color-key-focus);
+		}
+	}
 
-  /* ---- Secondary ---- */
-  &.spectrum-Button--secondary {
-    --spectrum-button-background-color-default: var(--spectrum-gray-100);
-    --spectrum-button-background-color-hover: var(--spectrum-gray-200);
-    --spectrum-button-background-color-down: var(--spectrum-gray-200);
-    --spectrum-button-background-color-focus: var(--spectrum-gray-200);
+	/* ---- Secondary ---- */
+	&.spectrum-Button--secondary {
+		--spectrum-button-background-color-default: var(--spectrum-gray-100);
+		--spectrum-button-background-color-hover: var(--spectrum-gray-200);
+		--spectrum-button-background-color-down: var(--spectrum-gray-200);
+		--spectrum-button-background-color-focus: var(--spectrum-gray-200);
 
-    --spectrum-button-content-color-default: var(--spectrum-neutral-content-color-default);
-    --spectrum-button-content-color-hover: var(--spectrum-neutral-content-color-hover);
-    --spectrum-button-content-color-down: var(--spectrum-neutral-content-color-down);
-    --spectrum-button-content-color-focus: var(--spectrum-neutral-content-color-key-focus);
+		--spectrum-button-content-color-default: var(--spectrum-neutral-content-color-default);
+		--spectrum-button-content-color-hover: var(--spectrum-neutral-content-color-hover);
+		--spectrum-button-content-color-down: var(--spectrum-neutral-content-color-down);
+		--spectrum-button-content-color-focus: var(--spectrum-neutral-content-color-key-focus);
 
-    &.spectrum-Button--outline {
-      --spectrum-button-background-color-default: transparent;
-      --spectrum-button-background-color-hover: var(--spectrum-gray-100);
-      --spectrum-button-background-color-down: var(--spectrum-gray-100);
-      --spectrum-button-background-color-focus: var(--spectrum-gray-100);
+		&.spectrum-Button--outline {
+			--spectrum-button-background-color-default: transparent;
+			--spectrum-button-background-color-hover: var(--spectrum-gray-100);
+			--spectrum-button-background-color-down: var(--spectrum-gray-100);
+			--spectrum-button-background-color-focus: var(--spectrum-gray-100);
 
-      --spectrum-button-border-color-default: var(--spectrum-gray-300);
-      --spectrum-button-border-color-hover: var(--spectrum-gray-400);
-      --spectrum-button-border-color-down: var(--spectrum-gray-400);
-      --spectrum-button-border-color-focus: var(--spectrum-gray-400);
+			--spectrum-button-border-color-default: var(--spectrum-gray-300);
+			--spectrum-button-border-color-hover: var(--spectrum-gray-400);
+			--spectrum-button-border-color-down: var(--spectrum-gray-400);
+			--spectrum-button-border-color-focus: var(--spectrum-gray-400);
 
-      --spectrum-button-content-color-default: var(--spectrum-neutral-content-color-default);
-      --spectrum-button-content-color-hover: var(--spectrum-neutral-content-color-hover);
-      --spectrum-button-content-color-down: var(--spectrum-neutral-content-color-down);
-      --spectrum-button-content-color-focus: var(--spectrum-neutral-content-color-key-focus);
-    }
-  }
+			--spectrum-button-content-color-default: var(--spectrum-neutral-content-color-default);
+			--spectrum-button-content-color-hover: var(--spectrum-neutral-content-color-hover);
+			--spectrum-button-content-color-down: var(--spectrum-neutral-content-color-down);
+			--spectrum-button-content-color-focus: var(--spectrum-neutral-content-color-key-focus);
+		}
+	}
 
-  /* ---- Static White ---- */
-  &.spectrum-Button--staticWhite {
-    --spectrum-button-background-color-default: var(--spectrum-transparent-white-800);
-    --spectrum-button-background-color-hover: var(--spectrum-transparent-white-900);
-    --spectrum-button-background-color-down: var(--spectrum-transparent-white-900);
-    --spectrum-button-background-color-focus: var(--spectrum-transparent-white-900);
+	/* ---- Static White ---- */
+	&.spectrum-Button--staticWhite {
+		--spectrum-button-background-color-default: var(--spectrum-transparent-white-800);
+		--spectrum-button-background-color-hover: var(--spectrum-transparent-white-900);
+		--spectrum-button-background-color-down: var(--spectrum-transparent-white-900);
+		--spectrum-button-background-color-focus: var(--spectrum-transparent-white-900);
 
-    --spectrum-button-content-color-default: var(--spectrum-black);
-    --spectrum-button-content-color-hover: var(--spectrum-black);
-    --spectrum-button-content-color-down: var(--spectrum-black);
-    --spectrum-button-content-color-focus: var(--spectrum-black);
+		--spectrum-button-content-color-default: var(--spectrum-black);
+		--spectrum-button-content-color-hover: var(--spectrum-black);
+		--spectrum-button-content-color-down: var(--spectrum-black);
+		--spectrum-button-content-color-focus: var(--spectrum-black);
 
-    --spectrum-button-focus-indicator-color: var(--spectrum-static-white-focus-indicator-color);
+		--spectrum-button-focus-indicator-color: var(--spectrum-static-white-focus-indicator-color);
 
-    --spectrum-button-background-color-disabled: var(--spectrum-disabled-static-white-background-color);
-    --spectrum-button-border-color-disabled: transparent;
-    --spectrum-button-content-color-disabled: var(--spectrum-disabled-static-white-content-color);
+		--spectrum-button-background-color-disabled: var(--spectrum-disabled-static-white-background-color);
+		--spectrum-button-border-color-disabled: transparent;
+		--spectrum-button-content-color-disabled: var(--spectrum-disabled-static-white-content-color);
 
-    &.spectrum-Button--outline {
-      --spectrum-button-background-color-default: var(--spectrum-transparent-white-25);
-      --spectrum-button-background-color-hover: var(--spectrum-transparent-white-100);
-      --spectrum-button-background-color-down: var(--spectrum-transparent-white-100);
-      --spectrum-button-background-color-focus: var(--spectrum-transparent-white-100);
+		&.spectrum-Button--outline {
+			--spectrum-button-background-color-default: var(--spectrum-transparent-white-25);
+			--spectrum-button-background-color-hover: var(--spectrum-transparent-white-100);
+			--spectrum-button-background-color-down: var(--spectrum-transparent-white-100);
+			--spectrum-button-background-color-focus: var(--spectrum-transparent-white-100);
 
-      --spectrum-button-border-color-default: var(--spectrum-transparent-white-800);
-      --spectrum-button-border-color-hover: var(--spectrum-transparent-white-900);
-      --spectrum-button-border-color-down: var(--spectrum-transparent-white-900);
-      --spectrum-button-border-color-focus: var(--spectrum-transparent-white-900);
+			--spectrum-button-border-color-default: var(--spectrum-transparent-white-800);
+			--spectrum-button-border-color-hover: var(--spectrum-transparent-white-900);
+			--spectrum-button-border-color-down: var(--spectrum-transparent-white-900);
+			--spectrum-button-border-color-focus: var(--spectrum-transparent-white-900);
 
-      --spectrum-button-content-color-default: var(--spectrum-transparent-white-800);
-      --spectrum-button-content-color-hover: var(--spectrum-transparent-white-900);
-      --spectrum-button-content-color-down: var(--spectrum-transparent-white-900);
-      --spectrum-button-content-color-focus: var(--spectrum-transparent-white-900);
+			--spectrum-button-content-color-default: var(--spectrum-transparent-white-800);
+			--spectrum-button-content-color-hover: var(--spectrum-transparent-white-900);
+			--spectrum-button-content-color-down: var(--spectrum-transparent-white-900);
+			--spectrum-button-content-color-focus: var(--spectrum-transparent-white-900);
 
-      --spectrum-button-background-color-disabled: var(--spectrum-transparent-white-25);
-      --spectrum-button-border-color-disabled: var(--spectrum-disabled-static-white-border-color);
-      --spectrum-button-content-color-disabled: var(--spectrum-disabled-static-white-content-color);
-    }
+			--spectrum-button-background-color-disabled: var(--spectrum-transparent-white-25);
+			--spectrum-button-border-color-disabled: var(--spectrum-disabled-static-white-border-color);
+			--spectrum-button-content-color-disabled: var(--spectrum-disabled-static-white-content-color);
+		}
 
-    &.spectrum-Button--secondary {
-      --spectrum-button-background-color-default: var(--spectrum-transparent-white-100);
-      --spectrum-button-background-color-hover: var(--spectrum-transparent-white-200);
-      --spectrum-button-background-color-down: var(--spectrum-transparent-white-200);
-      --spectrum-button-background-color-focus: var(--spectrum-transparent-white-200);
-  
-      --spectrum-button-content-color-default: var(--spectrum-transparent-white-800);
-      --spectrum-button-content-color-hover: var(--spectrum-transparent-white-900);
-      --spectrum-button-content-color-down: var(--spectrum-transparent-white-900);
-      --spectrum-button-content-color-focus: var(--spectrum-transparent-white-900);
-  
-      &.spectrum-Button--outline {
-        --spectrum-button-background-color-default: var(--spectrum-transparent-white-25);
-        --spectrum-button-background-color-hover: var(--spectrum-transparent-white-100);
-        --spectrum-button-background-color-down: var(--spectrum-transparent-white-100);
-        --spectrum-button-background-color-focus: var(--spectrum-transparent-white-100);
+		&.spectrum-Button--secondary {
+			--spectrum-button-background-color-default: var(--spectrum-transparent-white-100);
+			--spectrum-button-background-color-hover: var(--spectrum-transparent-white-200);
+			--spectrum-button-background-color-down: var(--spectrum-transparent-white-200);
+			--spectrum-button-background-color-focus: var(--spectrum-transparent-white-200);
 
-        --spectrum-button-border-color-default: var(--spectrum-transparent-white-300);
-        --spectrum-button-border-color-hover: var(--spectrum-transparent-white-400);
-        --spectrum-button-border-color-down: var(--spectrum-transparent-white-400);
-        --spectrum-button-border-color-focus: var(--spectrum-transparent-white-400);
-      }
-    }
-  }
+			--spectrum-button-content-color-default: var(--spectrum-transparent-white-800);
+			--spectrum-button-content-color-hover: var(--spectrum-transparent-white-900);
+			--spectrum-button-content-color-down: var(--spectrum-transparent-white-900);
+			--spectrum-button-content-color-focus: var(--spectrum-transparent-white-900);
 
-  /* ---- Static Black ---- */
-  &.spectrum-Button--staticBlack {
-    --spectrum-button-background-color-default: var(--spectrum-transparent-black-800);
-    --spectrum-button-background-color-hover: var(--spectrum-transparent-black-900);
-    --spectrum-button-background-color-down: var(--spectrum-transparent-black-900);
-    --spectrum-button-background-color-focus: var(--spectrum-transparent-black-900);
+			&.spectrum-Button--outline {
+				--spectrum-button-background-color-default: var(--spectrum-transparent-white-25);
+				--spectrum-button-background-color-hover: var(--spectrum-transparent-white-100);
+				--spectrum-button-background-color-down: var(--spectrum-transparent-white-100);
+				--spectrum-button-background-color-focus: var(--spectrum-transparent-white-100);
 
-    --spectrum-button-content-color-default: var(--spectrum-white);
-    --spectrum-button-content-color-hover: var(--spectrum-white);
-    --spectrum-button-content-color-down: var(--spectrum-white);
-    --spectrum-button-content-color-focus: var(--spectrum-white);
+				--spectrum-button-border-color-default: var(--spectrum-transparent-white-300);
+				--spectrum-button-border-color-hover: var(--spectrum-transparent-white-400);
+				--spectrum-button-border-color-down: var(--spectrum-transparent-white-400);
+				--spectrum-button-border-color-focus: var(--spectrum-transparent-white-400);
+			}
+		}
+	}
 
-    --spectrum-button-focus-indicator-color: var(--spectrum-static-black-focus-indicator-color);
+	/* ---- Static Black ---- */
+	&.spectrum-Button--staticBlack {
+		--spectrum-button-background-color-default: var(--spectrum-transparent-black-800);
+		--spectrum-button-background-color-hover: var(--spectrum-transparent-black-900);
+		--spectrum-button-background-color-down: var(--spectrum-transparent-black-900);
+		--spectrum-button-background-color-focus: var(--spectrum-transparent-black-900);
 
-    --spectrum-button-background-color-disabled: var(--spectrum-disabled-static-black-background-color);
-    --spectrum-button-border-color-disabled: transparent;
-    --spectrum-button-content-color-disabled: var(--spectrum-disabled-static-black-content-color);
+		--spectrum-button-content-color-default: var(--spectrum-white);
+		--spectrum-button-content-color-hover: var(--spectrum-white);
+		--spectrum-button-content-color-down: var(--spectrum-white);
+		--spectrum-button-content-color-focus: var(--spectrum-white);
 
-    &.spectrum-Button--outline {
-      --spectrum-button-background-color-default: var(--spectrum-transparent-black-25);
-      --spectrum-button-background-color-hover: var(--spectrum-transparent-black-100);
-      --spectrum-button-background-color-down: var(--spectrum-transparent-black-100);
-      --spectrum-button-background-color-focus: var(--spectrum-transparent-black-100);
+		--spectrum-button-focus-indicator-color: var(--spectrum-static-black-focus-indicator-color);
 
-      --spectrum-button-border-color-default: var(--spectrum-transparent-black-800);
-      --spectrum-button-border-color-hover: var(--spectrum-transparent-black-900);
-      --spectrum-button-border-color-down: var(--spectrum-transparent-black-900);
-      --spectrum-button-border-color-focus: var(--spectrum-transparent-black-900);
+		--spectrum-button-background-color-disabled: var(--spectrum-disabled-static-black-background-color);
+		--spectrum-button-border-color-disabled: transparent;
+		--spectrum-button-content-color-disabled: var(--spectrum-disabled-static-black-content-color);
 
-      --spectrum-button-content-color-default: var(--spectrum-transparent-black-800);
-      --spectrum-button-content-color-hover: var(--spectrum-transparent-black-900);
-      --spectrum-button-content-color-down: var(--spectrum-transparent-black-900);
-      --spectrum-button-content-color-focus: var(--spectrum-transparent-black-900);
+		&.spectrum-Button--outline {
+			--spectrum-button-background-color-default: var(--spectrum-transparent-black-25);
+			--spectrum-button-background-color-hover: var(--spectrum-transparent-black-100);
+			--spectrum-button-background-color-down: var(--spectrum-transparent-black-100);
+			--spectrum-button-background-color-focus: var(--spectrum-transparent-black-100);
 
-      --spectrum-button-background-color-disabled: transparent;
-      --spectrum-button-border-color-disabled: var(--spectrum-disabled-static-black-border-color);
-      --spectrum-button-content-color-disabled: var(--spectrum-disabled-static-black-content-color);
-    }
+			--spectrum-button-border-color-default: var(--spectrum-transparent-black-800);
+			--spectrum-button-border-color-hover: var(--spectrum-transparent-black-900);
+			--spectrum-button-border-color-down: var(--spectrum-transparent-black-900);
+			--spectrum-button-border-color-focus: var(--spectrum-transparent-black-900);
 
-    &.spectrum-Button--secondary {
-      --spectrum-button-background-color-default: var(--spectrum-transparent-black-100);
-      --spectrum-button-background-color-hover: var(--spectrum-transparent-black-200);
-      --spectrum-button-background-color-down: var(--spectrum-transparent-black-200);
-      --spectrum-button-background-color-focus: var(--spectrum-transparent-black-200);
+			--spectrum-button-content-color-default: var(--spectrum-transparent-black-800);
+			--spectrum-button-content-color-hover: var(--spectrum-transparent-black-900);
+			--spectrum-button-content-color-down: var(--spectrum-transparent-black-900);
+			--spectrum-button-content-color-focus: var(--spectrum-transparent-black-900);
 
-      --spectrum-button-content-color-default: var(--spectrum-transparent-black-800);
-      --spectrum-button-content-color-hover: var(--spectrum-transparent-black-900);
-      --spectrum-button-content-color-down: var(--spectrum-transparent-black-900);
-      --spectrum-button-content-color-focus: var(--spectrum-transparent-black-900);
-  
-      &.spectrum-Button--outline {
-        --spectrum-button-background-color-default: var(--spectrum-transparent-black-25);
-        --spectrum-button-background-color-hover: var(--spectrum-transparent-black-100);
-        --spectrum-button-background-color-down: var(--spectrum-transparent-black-100);
-        --spectrum-button-background-color-focus: var(--spectrum-transparent-black-100);
-  
-        --spectrum-button-border-color-default: var(--spectrum-transparent-black-300);
-        --spectrum-button-border-color-hover: var(--spectrum-transparent-black-400);
-        --spectrum-button-border-color-down: var(--spectrum-transparent-black-400);
-        --spectrum-button-border-color-focus: var(--spectrum-transparent-black-400);
-      }
-    }
-  }
+			--spectrum-button-background-color-disabled: transparent;
+			--spectrum-button-border-color-disabled: var(--spectrum-disabled-static-black-border-color);
+			--spectrum-button-content-color-disabled: var(--spectrum-disabled-static-black-content-color);
+		}
+
+		&.spectrum-Button--secondary {
+			--spectrum-button-background-color-default: var(--spectrum-transparent-black-100);
+			--spectrum-button-background-color-hover: var(--spectrum-transparent-black-200);
+			--spectrum-button-background-color-down: var(--spectrum-transparent-black-200);
+			--spectrum-button-background-color-focus: var(--spectrum-transparent-black-200);
+
+			--spectrum-button-content-color-default: var(--spectrum-transparent-black-800);
+			--spectrum-button-content-color-hover: var(--spectrum-transparent-black-900);
+			--spectrum-button-content-color-down: var(--spectrum-transparent-black-900);
+			--spectrum-button-content-color-focus: var(--spectrum-transparent-black-900);
+
+			&.spectrum-Button--outline {
+				--spectrum-button-background-color-default: var(--spectrum-transparent-black-25);
+				--spectrum-button-background-color-hover: var(--spectrum-transparent-black-100);
+				--spectrum-button-background-color-down: var(--spectrum-transparent-black-100);
+				--spectrum-button-background-color-focus: var(--spectrum-transparent-black-100);
+
+				--spectrum-button-border-color-default: var(--spectrum-transparent-black-300);
+				--spectrum-button-border-color-hover: var(--spectrum-transparent-black-400);
+				--spectrum-button-border-color-down: var(--spectrum-transparent-black-400);
+				--spectrum-button-border-color-focus: var(--spectrum-transparent-black-400);
+			}
+		}
+	}
+}
+
+/* Check for Houdini support & register property */
+@supports (background: paint(something)) {
+	@property --spectrumColorStop1 {
+		syntax: "<color>";
+		inherits: false;
+		initial-value: #d92361;
+	}
+
+	@property --spectrumColorStop2 {
+		syntax: "<color>";
+		inherits: false;
+		initial-value: #7155fa;
+	}
+
+	@property --spectrumColorStop3 {
+		syntax: "<color>";
+		inherits: false;
+		initial-value: #3b63fb;
+	}
 }
 
 .spectrum-Button {
-  @extend %spectrum-BaseButton;
-  @extend %spectrum-ButtonWithFocusRing;
+	/* Gradients: allow gradients to transition their color stops */
+	transition:
+		--spectrumColorStop1 var(--mod-button-animation-duration, var(--spectrum-button-animation-duration, 130ms)) linear,
+		--spectrumColorStop2 var(--mod-button-animation-duration, var(--spectrum-button-animation-duration, 130ms)) linear,
+		--spectrumColorStop3 var(--mod-button-animation-duration, var(--spectrum-button-animation-duration, 130ms)) linear,
+		border var(--mod-button-animation-duration, var(--spectrum-button-animation-duration, 130ms)) linear,
+		color var(--mod-button-animation-duration, var(--spectrum-button-animation-duration, 130ms)) linear !important;
 
-  border-radius: var(--mod-button-border-radius, var(--spectrum-button-border-radius));
-  border-width: var(--mod-button-border-width, var(--spectrum-button-border-width));
-  border-style: solid;
-  font-size: var(--mod-button-font-size, var(--spectrum-button-font-size));
-  font-weight: var(--mod-button-font-weight, var(--spectrum-button-font-weight));
-  gap: var(--mod-button-padding-label-to-icon, var(--spectrum-button-padding-label-to-icon));
-  min-inline-size: var(--mod-button-min-width, var(--spectrum-button-min-width));
-  min-block-size: var(--mod-button-height, var(--spectrum-button-height));
+	/* Gradients: fallback for @property initial-value. */
+	--spectrumColorStop1: #d92361;
+	--spectrumColorStop2: #7155fa;
+	--spectrumColorStop3: #3b63fb;
 
-  padding-block: 0;
-  padding-inline: var(--mod-button-edge-to-text, var(--spectrum-button-edge-to-text));
-  position: relative;
+	/* Gradients: test */
+	&:hover,
+	&:focus-visible,
+	&:active {
+		--spectrumColorStop1: #ba1650;
+		--spectrumColorStop2: #6338ee;
+		--spectrumColorStop3: #274dea;
+	}
+}
 
-  background-color: var(--highcontrast-button-background-color-default, var(--mod-button-background-color-default, var(--spectrum-button-background-color-default)));
-  border-color: var(--highcontrast-button-border-color-default, var(--mod-button-border-color-default, var(--spectrum-button-border-color-default)));
-  color: var(--highcontrast-button-content-color-default, var(--mod-button-content-color-default, var(--spectrum-button-content-color-default)));
-  transition: border var(--mod-button-animation-duration, var(--spectrum-button-animation-duration, 130ms)) linear,
-    color var(--mod-button-animation-duration, var(--spectrum-button-animation-duration, 130ms)) linear,
-    background-color var(--mod-button-animation-duration, var(--spectrum-button-animation-duration, 130ms)) linear;
+.spectrum-Button {
+	@extend %spectrum-BaseButton;
+	@extend %spectrum-ButtonWithFocusRing;
 
-  margin-block: var(--mod-button-margin-block);
-  margin-inline-end: var(--mod-button-margin-right);
-  margin-inline-start: var(--mod-button-margin-left);
+	border-radius: var(--mod-button-border-radius, var(--spectrum-button-border-radius));
+	border-width: var(--mod-button-border-width, var(--spectrum-button-border-width));
+	border-style: solid;
+	font-size: var(--mod-button-font-size, var(--spectrum-button-font-size));
+	font-weight: var(--mod-button-font-weight, var(--spectrum-button-font-weight));
+	gap: var(--mod-button-padding-label-to-icon, var(--spectrum-button-padding-label-to-icon));
+	min-inline-size: var(--mod-button-min-width, var(--spectrum-button-min-width));
+	min-block-size: var(--mod-button-height, var(--spectrum-button-height));
 
-  .spectrum-Icon {
-    /* Any block-size difference between the intended workflow icon size and actual icon used.
+	padding-block: 0;
+	padding-inline: var(--mod-button-edge-to-text, var(--spectrum-button-edge-to-text));
+	position: relative;
+
+	background: var(--highcontrast-button-background-color-default, var(--mod-button-background-color-default, var(--spectrum-button-background-color-default)));
+	border-color: var(--highcontrast-button-border-color-default, var(--mod-button-border-color-default, var(--spectrum-button-border-color-default)));
+	color: var(--highcontrast-button-content-color-default, var(--mod-button-content-color-default, var(--spectrum-button-content-color-default)));
+	transition:
+		border var(--mod-button-animation-duration, var(--spectrum-button-animation-duration, 130ms)) linear,
+		color var(--mod-button-animation-duration, var(--spectrum-button-animation-duration, 130ms)) linear,
+		background-color var(--mod-button-animation-duration, var(--spectrum-button-animation-duration, 130ms)) linear;
+
+	margin-block: var(--mod-button-margin-block);
+	margin-inline-end: var(--mod-button-margin-right);
+	margin-inline-start: var(--mod-button-margin-left);
+
+	.spectrum-Icon {
+		/* Any block-size difference between the intended workflow icon size and actual icon used.
        Helps support any existing use of smaller UI icons instead of intended Workflow icons. */
-    --spectrum-button-icon-size-difference: max(0px,
-      var(--spectrum-button-intended-icon-size) -
-      var(--spectrum-icon-block-size, var(--spectrum-button-intended-icon-size))
-    );
+		--spectrum-button-icon-size-difference: max(0px, var(--spectrum-button-intended-icon-size) - var(--spectrum-icon-block-size, var(--spectrum-button-intended-icon-size)));
 
-    margin-block-start: var(--mod-button-icon-margin-block-start,
-      max(0px,
-        var(--mod-button-top-to-icon, var(--spectrum-button-top-to-icon)) -
-        var(--mod-button-border-width, var(--spectrum-button-border-width)) +
-        (var(--spectrum-button-icon-size-difference, 0px) / 2)
-      )
-    );
+		margin-block-start: var(--mod-button-icon-margin-block-start, max(0px, var(--mod-button-top-to-icon, var(--spectrum-button-top-to-icon)) - var(--mod-button-border-width, var(--spectrum-button-border-width)) + (var(--spectrum-button-icon-size-difference, 0px) / 2)));
 
-    margin-inline-start: calc(
-      var(--mod-button-edge-to-visual, var(--spectrum-button-edge-to-visual)) -
-      var(--mod-button-edge-to-text, var(--spectrum-button-edge-to-text))
-    );
-    color: inherit;
-    flex-shrink: 0;
-    align-self: flex-start;
-  }
+		margin-inline-start: calc(var(--mod-button-edge-to-visual, var(--spectrum-button-edge-to-visual)) - var(--mod-button-edge-to-text, var(--spectrum-button-edge-to-text)));
+		color: inherit;
+		flex-shrink: 0;
+		align-self: flex-start;
+	}
 
-  /* Focus indicator */
-  &::after {
-    position: absolute;
-    inset: 0;
-    margin: calc((
-        var(--mod-button-focus-ring-gap, var(--spectrum-button-focus-ring-gap)) +
-        var(--mod-button-border-width, var(--spectrum-button-border-width))
-      ) * -1
-    );
-    border-radius: var(--mod-button-focus-ring-border-radius, calc(
-      var(--mod-button-border-radius, var(--spectrum-button-border-radius)) +
-      var(--mod-button-focus-ring-gap, var(--spectrum-button-focus-ring-gap))
-    ));
-    transition: box-shadow var(--mod-button-animation-duration, var(--spectrum-button-animation-duration)) ease-in-out;
-    pointer-events: none;
-    content: '';
-  }
+	/* Focus indicator */
+	&::after {
+		position: absolute;
+		inset: 0;
+		margin: calc((var(--mod-button-focus-ring-gap, var(--spectrum-button-focus-ring-gap)) + var(--mod-button-border-width, var(--spectrum-button-border-width))) * -1);
+		border-radius: var(--mod-button-focus-ring-border-radius, calc(var(--mod-button-border-radius, var(--spectrum-button-border-radius)) + var(--mod-button-focus-ring-gap, var(--spectrum-button-focus-ring-gap))));
+		transition: box-shadow var(--mod-button-animation-duration, var(--spectrum-button-animation-duration)) ease-in-out;
+		pointer-events: none;
+		content: "";
+	}
 
-  &:focus-visible,
-  &.is-focused {
-    box-shadow: none;
-    outline: none;
+	&:focus-visible,
+	&.is-focused {
+		box-shadow: none;
+		outline: none;
 
-    &::after {
-      box-shadow: 0 0 0
-        var(--mod-button-focus-ring-thickness, var(--spectrum-button-focus-ring-thickness))
-        var(--highcontrast-button-focus-ring-color, var(--mod-button-focus-ring-color, var(--spectrum-button-focus-indicator-color)));
+		&::after {
+			box-shadow: 0 0 0 var(--mod-button-focus-ring-thickness, var(--spectrum-button-focus-ring-thickness)) var(--highcontrast-button-focus-ring-color, var(--mod-button-focus-ring-color, var(--spectrum-button-focus-indicator-color)));
 
-      /* Margin is repeated to override declaration coming from the imported BaseButton. */
-      margin: calc((
-          var(--mod-button-focus-ring-gap, var(--spectrum-button-focus-ring-gap)) +
-          var(--mod-button-border-width, var(--spectrum-button-border-width))
-        ) * -1
-      );
-    }
-  }
+			/* Margin is repeated to override declaration coming from the imported BaseButton. */
+			margin: calc((var(--mod-button-focus-ring-gap, var(--spectrum-button-focus-ring-gap)) + var(--mod-button-border-width, var(--spectrum-button-border-width))) * -1);
+		}
+	}
 
-  /* States and interaction */
-  &:hover,
-  &:active {
-    box-shadow: none;
-  }
+	/* States and interaction */
+	&:hover,
+	&:active {
+		box-shadow: none;
+	}
 
-  &:hover {
-    background-color: var(--highcontrast-button-background-color-hover, var(--mod-button-background-color-hover, var(--spectrum-button-background-color-hover)));
-    border-color: var(--highcontrast-button-border-color-hover, var(--mod-button-border-color-hover, var(--spectrum-button-border-color-hover)));
-    color: var(--highcontrast-button-content-color-hover, var(--mod-button-content-color-hover, var(--spectrum-button-content-color-hover)));
-  }
+	&:hover {
+		background: var(--highcontrast-button-background-color-hover, var(--mod-button-background-color-hover, var(--spectrum-button-background-color-hover)));
+		border-color: var(--highcontrast-button-border-color-hover, var(--mod-button-border-color-hover, var(--spectrum-button-border-color-hover)));
+		color: var(--highcontrast-button-content-color-hover, var(--mod-button-content-color-hover, var(--spectrum-button-content-color-hover)));
+	}
 
-  &:focus-visible {
-    background-color: var(--highcontrast-button-background-color-focus, var(--mod-button-background-color-focus, var(--spectrum-button-background-color-focus)));
-    border-color: var(--highcontrast-button-border-color-focus, var(--mod-button-border-color-focus, var(--spectrum-button-border-color-focus)));
-    color: var(--highcontrast-button-content-color-focus, var(--mod-button-content-color-focus, var(--spectrum-button-content-color-focus)));
-  }
+	&:focus-visible {
+		background: var(--highcontrast-button-background-color-focus, var(--mod-button-background-color-focus, var(--spectrum-button-background-color-focus)));
+		border-color: var(--highcontrast-button-border-color-focus, var(--mod-button-border-color-focus, var(--spectrum-button-border-color-focus)));
+		color: var(--highcontrast-button-content-color-focus, var(--mod-button-content-color-focus, var(--spectrum-button-content-color-focus)));
+	}
 
-  &:active {
-    background-color: var(--highcontrast-button-background-color-down, var(--mod-button-background-color-down, var(--spectrum-button-background-color-down)));
-    border-color: var(--highcontrast-button-border-color-down, var(--mod-button-border-color-down, var(--spectrum-button-border-color-down)));
-    color: var(--highcontrast-button-content-color-down, var(--mod-button-content-color-down, var(--spectrum-button-content-color-down)));
-    transform: perspective(var(--spectrum-downstate-perspective)) translateZ(var(--spectrum-component-size-difference-down));
-  }
+	&:active {
+		background: var(--highcontrast-button-background-color-down, var(--mod-button-background-color-down, var(--spectrum-button-background-color-down)));
+		border-color: var(--highcontrast-button-border-color-down, var(--mod-button-border-color-down, var(--spectrum-button-border-color-down)));
+		color: var(--highcontrast-button-content-color-down, var(--mod-button-content-color-down, var(--spectrum-button-content-color-down)));
+		transform: perspective(var(--spectrum-downstate-perspective)) translateZ(var(--spectrum-component-size-difference-down));
+	}
 
-  &:disabled,
-  &.is-disabled,
-  &[pending],
-  &.is-pending {
-    background-color: var(--highcontrast-button-background-color-disabled, var(--mod-button-background-color-disabled, var(--spectrum-button-background-color-disabled)));
-    border-color: var(--highcontrast-button-border-color-disabled, var(--mod-button-border-color-disabled, var(--spectrum-button-border-color-disabled)));
-    color: var(--highcontrast-button-content-color-disabled, var(--mod-button-content-color-disabled, var(--spectrum-button-content-color-disabled)));
-  }
+	&:disabled,
+	&.is-disabled,
+	&[pending],
+	&.is-pending {
+		background: var(--highcontrast-button-background-color-disabled, var(--mod-button-background-color-disabled, var(--spectrum-button-background-color-disabled)));
+		border-color: var(--highcontrast-button-border-color-disabled, var(--mod-button-border-color-disabled, var(--spectrum-button-border-color-disabled)));
+		color: var(--highcontrast-button-content-color-disabled, var(--mod-button-content-color-disabled, var(--spectrum-button-content-color-disabled)));
+	}
 
-  .spectrum-Icon,
-  .spectrum-Button-label {
-    visibility: visible;
-    opacity: 1;
-    transition: opacity var(--mod-button-animation-duration, var(--spectrum-button-animation-duration, 130ms)) ease-in-out;
-  }
+	.spectrum-Icon,
+	.spectrum-Button-label {
+		visibility: visible;
+		opacity: 1;
+		transition: opacity var(--mod-button-animation-duration, var(--spectrum-button-animation-duration, 130ms)) ease-in-out;
+	}
 
-  .spectrum-ProgressCircle {
-    visibility: hidden;
-    opacity: 0;
-    transition: opacity var(--mod-button-animation-duration, var(--spectrum-button-animation-duration, 130ms)) ease-in-out,
-                visibility 0ms linear var(--mod-button-animation-duration, var(--spectrum-button-animation-duration, 130ms));
-  }
+	.spectrum-ProgressCircle {
+		visibility: hidden;
+		opacity: 0;
+		transition:
+			opacity var(--mod-button-animation-duration, var(--spectrum-button-animation-duration, 130ms)) ease-in-out,
+			visibility 0ms linear var(--mod-button-animation-duration, var(--spectrum-button-animation-duration, 130ms));
+	}
 
-  &[pending],
-  &.is-pending {
-    cursor: default;
+	&[pending],
+	&.is-pending {
+		cursor: default;
 
-    .spectrum-Icon,
-    .spectrum-Button-label {
-      visibility: hidden;
-      opacity: 0;
-      transition: opacity var(--mod-button-animation-duration, var(--spectrum-button-animation-duration, 130ms)) ease-in-out,
-                  visibility 0ms linear var(--mod-button-animation-duration, var(--spectrum-button-animation-duration, 130ms));
-    }
+		.spectrum-Icon,
+		.spectrum-Button-label {
+			visibility: hidden;
+			opacity: 0;
+			transition:
+				opacity var(--mod-button-animation-duration, var(--spectrum-button-animation-duration, 130ms)) ease-in-out,
+				visibility 0ms linear var(--mod-button-animation-duration, var(--spectrum-button-animation-duration, 130ms));
+		}
 
-    .spectrum-ProgressCircle {
-      visibility: visible;
-      opacity: 1;
-      transition: opacity var(--mod-button-animation-duration, var(--spectrum-button-animation-duration, 130ms)) ease-in-out;
-    }
-  }
+		.spectrum-ProgressCircle {
+			visibility: visible;
+			opacity: 1;
+			transition: opacity var(--mod-button-animation-duration, var(--spectrum-button-animation-duration, 130ms)) ease-in-out;
+		}
+	}
 }
 
 a.spectrum-Button {
-  @extend %spectrum-AnchorButton;
+	@extend %spectrum-AnchorButton;
 }
 
 .spectrum-Button-label {
-  @extend %spectrum-ButtonLabel;
-  padding-block-start: calc(var(--mod-button-top-to-text, var(--spectrum-button-top-to-text)) - var(--mod-button-border-width, var(--spectrum-button-border-width)));
-  padding-block-end: calc(var(--mod-button-bottom-to-text, var(--spectrum-button-bottom-to-text)) - var(--mod-button-border-width, var(--spectrum-button-border-width)));
-  line-height: var(--mod-button-line-height, var(--spectrum-button-line-height));
-  align-self: start;
-  text-align: var(--mod-button-text-align, center);
+	@extend %spectrum-ButtonLabel;
+	padding-block-start: calc(var(--mod-button-top-to-text, var(--spectrum-button-top-to-text)) - var(--mod-button-border-width, var(--spectrum-button-border-width)));
+	padding-block-end: calc(var(--mod-button-bottom-to-text, var(--spectrum-button-bottom-to-text)) - var(--mod-button-border-width, var(--spectrum-button-border-width)));
+	line-height: var(--mod-button-line-height, var(--spectrum-button-line-height));
+	align-self: start;
+	text-align: var(--mod-button-text-align, center);
 }
 
 .spectrum-Button .spectrum-Icon + .spectrum-Button-label {
-  text-align: var(--mod-button-text-align-with-icon, start);
+	text-align: var(--mod-button-text-align-with-icon, start);
 }
 
 /* Icon only variant */
 .spectrum-Button.spectrum-Button--iconOnly {
-  min-inline-size: unset;
-  padding: var(--mod-button-edge-to-visual-only, var(--spectrum-button-edge-to-visual-only));
+	min-inline-size: unset;
+	padding: var(--mod-button-edge-to-visual-only, var(--spectrum-button-edge-to-visual-only));
 
-  .spectrum-Icon {
-    align-self: center;
-    margin-inline-start: 0;
-    margin-block-start: 0;
-  }
+	.spectrum-Icon {
+		align-self: center;
+		margin-inline-start: 0;
+		margin-block-start: 0;
+	}
 }
 
 /* Forced colors / high contrast mode */
 @media (forced-colors: active) {
-  .spectrum-Button {
-    --highcontrast-button-content-color-disabled: GrayText;
-    --highcontrast-button-border-color-disabled: GrayText;
-    --highcontrast-button-background-color-disabled: ButtonFace;
+	.spectrum-Button {
+		--highcontrast-button-content-color-disabled: GrayText;
+		--highcontrast-button-border-color-disabled: GrayText;
+		--highcontrast-button-background-color-disabled: ButtonFace;
 
-    --mod-progress-circle-track-border-color: ButtonText;
-    --mod-progress-circle-track-border-color-over-background: ButtonText;
-    --mod-progress-circle-thickness: var(--spectrum-progress-circle-thickness-medium);
+		--mod-progress-circle-track-border-color: ButtonText;
+		--mod-progress-circle-track-border-color-over-background: ButtonText;
+		--mod-progress-circle-thickness: var(--spectrum-progress-circle-thickness-medium);
 
-    --highcontrast-button-focus-ring-color: ButtonText;
+		--highcontrast-button-focus-ring-color: ButtonText;
 
-    &:focus-visible {
-      &::after {
-        /* Make sure the box-shadow used for the focus indicator is displayed. */
-        forced-color-adjust: none;
-      }
-    }
+		&:focus-visible {
+			&::after {
+				/* Make sure the box-shadow used for the focus indicator is displayed. */
+				forced-color-adjust: none;
+			}
+		}
 
-    &.spectrum-Button--accent,
-    &:not(
-      .spectrum-Button--primary,
-      .spectrum-Button--negative,
-      .spectrum-Button--secondary,
-      .spectrum-Button--staticBlack,
-      .spectrum-Button--staticWhite
-    ){
-      /* The accent fill variant looks different than the other buttons.
+		&.spectrum-Button--accent,
+		&:not(.spectrum-Button--primary, .spectrum-Button--negative, .spectrum-Button--secondary, .spectrum-Button--staticBlack, .spectrum-Button--staticWhite) {
+			/* The accent fill variant looks different than the other buttons.
          It inverts the background and content colors. */
-      --highcontrast-button-background-color-default: ButtonText;
-      --highcontrast-button-content-color-default: ButtonFace;
+			--highcontrast-button-background-color-default: ButtonText;
+			--highcontrast-button-content-color-default: ButtonFace;
 
-      --highcontrast-button-background-color-hover: Highlight;
-      --highcontrast-button-background-color-down: Highlight;
-      --highcontrast-button-background-color-focus: Highlight;
+			--highcontrast-button-background-color-hover: Highlight;
+			--highcontrast-button-background-color-down: Highlight;
+			--highcontrast-button-background-color-focus: Highlight;
 
-      --highcontrast-button-content-color-hover: HighlightText;
-      --highcontrast-button-content-color-down: HighlightText;
-      --highcontrast-button-content-color-focus: HighlightText;
+			--highcontrast-button-content-color-hover: HighlightText;
+			--highcontrast-button-content-color-down: HighlightText;
+			--highcontrast-button-content-color-focus: HighlightText;
 
-      .spectrum-Button-label {
-        forced-color-adjust: none;
-      }
-    }
-  }
+			.spectrum-Button-label {
+				forced-color-adjust: none;
+			}
+		}
+	}
 }

--- a/components/button/stories/button.stories.js
+++ b/components/button/stories/button.stories.js
@@ -121,6 +121,11 @@ export default {
 			options: ["white", "black"],
 			control: "select",
 		},
+		customStyles: {
+			name: "Custom styles",
+			control: "object",
+			table: { disable: false },
+		},
 	},
 	args: {
 		rootClass: "spectrum-Button",
@@ -505,6 +510,72 @@ const CustomButtonWrap = (args) =>
 /* Stories */
 export const Default = Variants.bind({});
 Default.args = {};
+
+export const GradientTest = Variants.bind({});
+GradientTest.args = {
+	label: "Premium",
+	iconName: "Star",
+	customStyles: {
+		"--mod-button-background-color-default": "linear-gradient(135deg, #D92361, #7155FA 75%, #3B63FB)",
+		"--mod-button-background-color-focus": "linear-gradient(135deg, #BA1650, #6338EE 75%, #274DEA)",
+		"--mod-button-background-color-hover": "linear-gradient(135deg, #BA1650, #6338EE 75%, #274DEA)",
+		"--mod-button-background-color-active": "linear-gradient(135deg, #BA1650, #6338EE 75%, #274DEA)",
+		"background-origin": "border-box",
+	}
+};
+
+export const GradientTest2 = Variants.bind({});
+GradientTest2.args = {
+	label: "Generate",
+	iconName: "Asset",
+	customStyles: {
+		"--mod-button-background-color-default": "linear-gradient(135deg, #D45B00, #D92361 33%, #7155FA)",
+		"--mod-button-background-color-focus": "linear-gradient(135deg, #C24E00, #BA1650 33%, #6338EE)",
+		"--mod-button-background-color-hover": "linear-gradient(135deg, #C24E00, #BA1650 33%, #6338EE)",
+		"--mod-button-background-color-active": "linear-gradient(135deg, #C24E00, #BA1650 33%, #6338EE)",
+		"background-origin": "border-box",
+	}
+};
+
+export const GradientTest3 = Variants.bind({});
+GradientTest3.args = {
+	label: "Generate",
+	iconName: "Asset",
+	customStyles: {
+		"--mod-button-background-color-default": "linear-gradient(135deg, #D45B00 -50%, #D92361 33%, #7155FA 150%)",
+		"--mod-button-background-color-focus": "linear-gradient(135deg, #C24E00 -50%, #BA1650 33%, #6338EE 150%)",
+		"--mod-button-background-color-hover": "linear-gradient(135deg, #C24E00 -50%, #BA1650 33%, #6338EE 150%)",
+		"--mod-button-background-color-active": "linear-gradient(135deg, #C24E00 -50%, #BA1650 33%, #6338EE 150%)",
+		"background-origin": "border-box",
+	}
+};
+
+export const GradientTest4 = Variants.bind({});
+GradientTest4.args = {
+	label: "Generate",
+	iconName: "Asset",
+	customStyles: {
+		"--mod-button-background-color-default": "linear-gradient(135deg, #D45B00 -50%, #D92361 33%, #7155FA calc(100% + 40px))",
+		"--mod-button-background-color-focus": "linear-gradient(135deg, #C24E00 -50%, #BA1650 33%, #6338EE calc(100% + 40px))",
+		"--mod-button-background-color-hover": "linear-gradient(135deg, #C24E00 -50%, #BA1650 33%, #6338EE calc(100% + 40px))",
+		"--mod-button-background-color-active": "linear-gradient(135deg, #C24E00 -50%, #BA1650 33%, #6338EE calc(100% + 40px))",
+		"background-origin": "border-box",
+	}
+};
+
+export const GradientTestTransition = Variants.bind({});
+GradientTestTransition.args = {
+	label: "Premium",
+	iconName: "Star",
+	customStyles: {
+		"--mod-button-background-color-default": "linear-gradient(135deg, var(--spectrumColorStop1), var(--spectrumColorStop2) 75%, var(--spectrumColorStop3))",
+		"--mod-button-background-color-focus": "linear-gradient(135deg, var(--spectrumColorStop1), var(--spectrumColorStop2) 75%, var(--spectrumColorStop3))",
+		"--mod-button-background-color-hover": "linear-gradient(135deg, var(--spectrumColorStop1), var(--spectrumColorStop2) 75%, var(--spectrumColorStop3))",
+		"--mod-button-background-color-active": "linear-gradient(135deg, var(--spectrumColorStop1), var(--spectrumColorStop2) 75%, var(--spectrumColorStop3))",
+		"background-origin": "border-box",
+	}
+};
+
 
 export const StaticColorWhite = Variants.bind({});
 StaticColorWhite.args = {


### PR DESCRIPTION
## Description

=== For testing purposes only. Do not merge. ===

Adds additional stories to the Button component for testing the design and implementation of gradient backgrounds in Spectrum 2. Colors and color stop percentages are based on the Figma.

  - **[Gradient Test](https://pr-2785--spectrum-css.netlify.app/preview/?path=/story/components-button--gradient-test)**, **[Gradient Test 2](http://localhost:49792/?path=/story/components-button--gradient-test-2)**: Two button color variations with hover change of the linear-gradient.
  - **[Gradient Test 3](https://pr-2785--spectrum-css.netlify.app/preview/?path=/story/components-button--gradient-test-3)**: Example showing that a color stop position in the linear-gradient can be less than 0% and greater than 100%, and that this affects how it displays. Compare to Gradient Test 2.
  - **[Gradient Test 4](http://localhost:49792/?path=/story/components-button--gradient-test-4)**: Similar to test 3, except showing that the final stop stop can be a pixel value past 100% using a calc: `calc(100% + 40px)`
  - **[Gradient Test Transition](https://pr-2785--spectrum-css.netlify.app/preview/?path=/story/components-button--gradient-test-transition)**: Example of progressive enhancement that uses the cutting edge `@property` syntax in CSS behind an `@supports`, in order to transition the color stops with CSS `transition`. The support for `@property` is in Chrome, and coming soon to Firefox (currently in the Nightly version). In browsers where it is not supported, it has a fallback to the regular behavior of not having the transition (tested in Firefox). 

The PR includes the "customStyles" JSON object as a control in Button's Storybook, to allow experimentation and to show the values of `linear-gradient`.

## Screenshots

![Screenshot 2024-05-23 at 5 00 47 PM](https://github.com/adobe/spectrum-css/assets/965114/73a419ee-cf39-47a6-ad15-5df2a60548f9)

## To-do list

N/A
