### PR TITLE
docs(colorhandle,colorloupe,colorslider,colorwheel): site docs to storybook

### DIFF
--- a/components/colorhandle/stories/colorhandle.mdx
+++ b/components/colorhandle/stories/colorhandle.mdx
@@ -1,0 +1,28 @@
+import { ArgTypes, Canvas, Meta, Description, Title } from '@storybook/blocks';
+
+import * as ColorHandleStories from './colorhandle.stories';
+
+<Meta of={ColorHandleStories} title="Docs" />
+
+<Title of={ColorHandleStories} />
+<Description of={ColorHandleStories} />
+
+## Standard
+
+Set the `--spectrum-picked-color` custom property to the color value you want to show.
+
+<Canvas of={ColorHandleStories.Default} />
+
+## Disabled
+
+<Canvas of={ColorHandleStories.Disabled} />
+
+## With color loupe
+
+Nest the color loupe component within the color handle markup and apply `.is-open` to the `.spectrum-ColorLoupe` to display the loupe.
+
+<Canvas of={ColorHandleStories.WithColorLoupe} />
+
+## Properties
+
+<ArgTypes />

--- a/components/colorhandle/stories/colorhandle.stories.js
+++ b/components/colorhandle/stories/colorhandle.stories.js
@@ -26,11 +26,21 @@ export default {
 			control: "boolean",
 			if: { arg: "isDisabled", truthy: false },
 		},
+		isWithColorLoupe: {
+			name: "With color loupe",
+			type: { name: "boolean" },
+			table: {
+				type: { summary: "boolean" },
+				category: "State",
+			},
+			control: "boolean",
+		},
 	},
 	args: {
 		rootClass: "spectrum-ColorHandle",
 		isDisabled: false,
 		isFocused: false,
+		isWithColorLoupe: false,
 	},
 	parameters: {
 		actions: {
@@ -44,3 +54,30 @@ export default {
 
 export const Default = Template.bind({});
 Default.args = {};
+
+/**
+ * Stories for the MDX "Docs" only.
+ */
+export const Disabled = Template.bind({});
+Disabled.args = {
+	isDisabled: true,
+};
+Disabled.tags = ["docs-only"];
+Disabled.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+export const WithColorLoupe = Template.bind({});
+WithColorLoupe.args = {
+	isWithColorLoupe: true,
+};
+WithColorLoupe.tags = ["docs-only"];
+WithColorLoupe.parameters = {
+	chromatic: { disableSnapshot: true },
+	docs: {
+		story: {
+			inline: false,
+			iframeHeight: 150,
+		},
+	},
+};

--- a/components/colorhandle/stories/template.js
+++ b/components/colorhandle/stories/template.js
@@ -1,5 +1,8 @@
-import { Template as OpacityCheckerboard } from "@spectrum-css/opacitycheckerboard/stories/template.js";
 import { html } from "lit";
+import { when } from "lit/directives/when.js";
+
+import { Template as ColorLoupe } from "@spectrum-css/colorloupe/stories/template.js";
+import { Template as OpacityCheckerboard } from "@spectrum-css/opacitycheckerboard/stories/template.js";
 
 import "../index.css";
 
@@ -8,18 +11,44 @@ export const Template = ({
 	customClasses = [],
 	isDisabled = false,
 	isFocused = false,
+	isWithColorLoupe = false,
 	customStyles = {
 		"--spectrum-picked-color": "rgba(255, 0, 0, 0.5)",
 	},
 	...globals
-}) => OpacityCheckerboard({
-	...globals,
-	customClasses: [
-		`${rootClass}`,
-		...!isDisabled && isFocused ? ["is-focused"] : [],
-		...isDisabled ? ["is-disabled"] : [],
-		...customClasses,
-	],
-	content: [html `<div class="${rootClass}-inner"></div>`],
-	customStyles,
-});
+}) => {
+	const withColorLoupeStyles = () => isWithColorLoupe ? {
+		"position": "absolute",
+		"inset-block": "75%",
+		"inset-inline": "50%"
+	} : null;
+
+	return (
+		OpacityCheckerboard({
+			...globals,
+			customClasses: [
+				`${rootClass}`,
+				...!isDisabled && isFocused ? ["is-focused"] : [],
+				...isDisabled ? ["is-disabled"] : [],
+				...customClasses,
+			],
+			content: [html `
+				<div class="${rootClass}-inner"></div>
+				${when(isWithColorLoupe, () => html`
+					${ColorLoupe({
+						...globals,
+						isOpen: true,
+						customStyles: {
+							"inset-inline-start": "unset",
+							"inset-block-start": "unset",
+						}
+					})}
+				`)}
+			`],
+			customStyles: {
+				...customStyles,
+				...withColorLoupeStyles()
+			},
+		})
+	);
+};

--- a/components/colorloupe/stories/colorloupe.mdx
+++ b/components/colorloupe/stories/colorloupe.mdx
@@ -1,0 +1,20 @@
+import { ArgTypes, Canvas, Meta, Description, Title } from '@storybook/blocks';
+
+import * as ColorLoupeStories from './colorloupe.stories';
+
+<Meta of={ColorLoupeStories} title="Docs" />
+
+<Title of={ColorLoupeStories} />
+<Description of={ColorLoupeStories} />
+
+## Usage notes
+- Set the `--spectrum-picked-color` custom property to the CSS color value you want to show
+- You must apply `.is-open` to display the loupe
+- Color Loupe does not have a disabled style; do not show it when the handle it's attached to is disabled.
+
+## Standard
+<Canvas of={ColorLoupeStories.Default} />
+
+## Properties
+
+<ArgTypes />

--- a/components/colorslider/stories/colorslider.mdx
+++ b/components/colorslider/stories/colorslider.mdx
@@ -1,0 +1,40 @@
+import { ArgTypes, Canvas, Meta, Description, Title } from '@storybook/blocks';
+
+import * as ColorSliderStories from './colorslider.stories';
+
+<Meta of={ColorSliderStories} title="Docs" />
+
+<Title of={ColorSliderStories} />
+<Description of={ColorSliderStories} />
+
+## Usage notes
+- Set the color of the nested Color handle component to match Color slider’s currently selected color using its custom property: `--spectrum-picked-color`
+- The `.spectrum-ColorHandle` should be moved with `inset-inline-*` (horizontal) or `inset-block-*` (vertical) style properties as the slider is dragged
+- Ensure that you set the min and max attributes of the `.spectrum-ColorSlider-slider` input to the corresponding scale (i.e. 0 to 1 for a, 0 to 255 for r, etc)
+- Ensure that you set the step attribute of the `.spectrum-ColorSlider-slider` input appropriately (i.e. 0.1 for a, s, v or 1 and h, r, etc)
+- Set the background style property of `.spectrum-ColorSlider-gradient` to the gradient of the colors to be selected. The CSS will automatically reverse the gradient element horizontally when using a RTL (right-to-left) base direction
+  - Alternatively, provide an `<img>` element with the gradient you want to use and apply the `.spectrum-ColorSlider-gradient` class
+
+## Standard
+
+<Canvas of={ColorSliderStories.Default} />
+
+## Alpha
+
+<Canvas of={ColorSliderStories.Alpha} />
+
+## Disabled
+
+<Canvas of={ColorSliderStories.Disabled} />
+
+## Vertical
+
+<Canvas of={ColorSliderStories.Vertical} />
+
+## With image
+
+<Canvas of={ColorSliderStories.WithImage} />
+
+## Properties
+
+<ArgTypes />

--- a/components/colorwheel/stories/colorwheel.mdx
+++ b/components/colorwheel/stories/colorwheel.mdx
@@ -1,0 +1,35 @@
+import { ArgTypes, Canvas, Meta, Description, Title } from '@storybook/blocks';
+
+import * as ColorWheelStories from './colorwheel.stories';
+
+<Meta of={ColorWheelStories} title="Docs" />
+
+<Title of={ColorWheelStories} />
+<Description of={ColorWheelStories} />
+
+## Usage notes:
+- For a given rotation on the wheel, X, the `.spectrum-ColorHandle` should be moved by applying the style property `transform: translate(${Y * Math.cos(X)}px, ${Y * Math.sin(X)}px)`, where Y is `((radius - .spectrum-colorwheel-track-width) / 2))`
+- Set the value attribute of `.spectrum-ColorWheel-value` to the currently selected color (i.e. `hsl(326, 100%, 50%)`)
+- Add `.is-dragged` when the handle is being dragged
+
+## Standard
+
+<Canvas of={ColorWheelStories.Default} />
+
+## Disabled
+
+<Canvas of={ColorWheelStories.Disabled} />
+
+## With color area
+
+Usage notes:
+
+- To display with ColorArea inside of ColorWheel, add ColorArea to `.spectrum-ColorWheel-colorarea-container` with `style="--mod-colorarea-width: 70.1%; --mod-colorarea-height: 70.1%"`
+- `.spectrum-colorwheel-colorarea-container-size` is hard coded to position the ColorArea within the ColorWheel using `.spectrum-color-wheel-color-area-margin`. Using JS container size can be calcaulted with `Math.sqrt(2 * R * R)`, where R is the `innerRadius` as calcaulted for the clip paths
+- `.spectrum-colorwheel-path`, `.spectrum-colorwheel-path-borders`, and `.spectrum-colorwheel-colorarea-container` are hard coded in CSS and include token values in custom CSS variables so they can be accessed with JS to and used to calculate these values, `const wheel = document.querySelector(".spectrum-ColorWheel-wheel") getComputedStyle(wheel).getPropertyValue('--track-width'))`
+
+<Canvas of={ColorWheelStories.WithColorArea} />
+
+## Properties
+
+<ArgTypes />

--- a/components/colorwheel/stories/colorwheel.stories.js
+++ b/components/colorwheel/stories/colorwheel.stories.js
@@ -26,11 +26,21 @@ export default {
 			control: "boolean",
 			if: { arg: "isDisabled", truthy: false },
 		},
+		isWithColorArea: {
+			name: "With Color Area",
+			type: { name: "boolean" },
+			table: {
+				type: { summary: "boolean" },
+				category: "State",
+			},
+			control: "boolean",
+		},
 	},
 	args: {
 		rootClass: "spectrum-ColorWheel",
 		isDisabled: false,
 		isFocused: false,
+		isWithColorArea: false,
 	},
 	parameters: {
 		actions: {
@@ -44,3 +54,24 @@ export default {
 
 export const Default = Template.bind({});
 Default.args = {};
+
+/**
+ * Stories for the MDX "Docs" only.
+ */
+export const Disabled = Template.bind({});
+Disabled.args = {
+	isDisabled: true,
+};
+Disabled.tags = ["docs-only"];
+Disabled.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+export const WithColorArea = Template.bind({});
+WithColorArea.args = {
+	isWithColorArea: true,
+};
+WithColorArea.tags = ["docs-only"];
+WithColorArea.parameters = {
+	chromatic: { disableSnapshot: true },
+};

--- a/components/colorwheel/stories/template.js
+++ b/components/colorwheel/stories/template.js
@@ -1,6 +1,9 @@
-import { Template as ColorHandle } from "@spectrum-css/colorhandle/stories/template.js";
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
+import { when } from "lit/directives/when.js";
+
+import { Template as ColorArea } from "@spectrum-css/colorarea/stories/template.js";
+import { Template as ColorHandle } from "@spectrum-css/colorhandle/stories/template.js";
 
 import "../index.css";
 
@@ -9,6 +12,7 @@ export const Template = ({
 	customClasses = [],
 	isDisabled = false,
 	isFocused = false,
+	isWithColorArea = false,
 	colorHandleStyle = {
 		"--spectrum-picked-color": "rgb(255, 0, 0)",
 	},
@@ -21,7 +25,18 @@ export const Template = ({
 		...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
 	})}>
 		<div class="${rootClass}-inner">
-			<div class="${rootClass}-colorarea-container"></div>
+			<div class="${rootClass}-colorarea-container">
+			${when(isWithColorArea, () => html`
+				${ColorArea({
+					...globals,
+					isDisabled,
+					customStyles: {
+						"--mod-colorarea-width": "80px",
+						"--mod-colorarea-height": "80px",
+					},
+				})}
+			`)}
+			</div>
 		</div>
 		<div class=${classMap({
 			[`${rootClass}-border`]: true,


### PR DESCRIPTION
## Description

This migrates the documentation from the deprecated docs site over to Storybook, including showing the variants on the Storybook Docs page.

Note that some of the docs site examples show implementation of combinations of the color components (colorhandle using colorloupe for example). I didn't include these examples in Storybook, but did include documentation about what's required when using components together at the implementation level.

- Colorhandle - got a new MDX page and one MDX-only story
- Colorloupe - MDX page wasn't required but got some usage notes added to the storybook description
- Colorslider - got a new MDX page and usage notes added to the storybook description
- Colorwheel - got a new MDX page, usage notes in the storybook description, and one MDX-only story

This PR doesn't need a changeset since it's docs-only.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [ ] The [Colorhandle storybook](https://pr-2787--spectrum-css.netlify.app/preview/?path=/docs/components-color-handle--docs) docs include all necessary info when compared to the [docs site](https://opensource.adobe.com/spectrum-css/colorhandle.html)
- [x] The [Colorloupe storybook](https://pr-2787--spectrum-css.netlify.app/preview/?path=/docs/components-color-loupe--docs) docs include all necessary info when compared to the [docs site](https://opensource.adobe.com/spectrum-css/colorloupe.html) @jawinn 
- [ ] The [Colorslider storybook](https://pr-2787--spectrum-css.netlify.app/preview/?path=/docs/components-color-slider--docs) docs include all necessary info when compared to the [docs site](https://opensource.adobe.com/spectrum-css/colorslider.html)
- [ ] The [Colorwheel storybook](https://pr-2787--spectrum-css.netlify.app/preview/?path=/docs/components-color-wheel--docs) docs include all necessary info when compared to the [docs site](https://opensource.adobe.com/spectrum-css/colorwheel.html)

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.


## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
