### PR TITLE
docs(breadcrumb, checkbox, clearbutton, coachindicator): Site Docs to Storybook

### DIFF
--- a/.storybook/decorators/utilities.js
+++ b/.storybook/decorators/utilities.js
@@ -49,7 +49,7 @@ const Heading = ({
  * @param {Object} props.containerStyles - Additional styles to apply to the container.
  * @param {Object} props.wrapperStyles - Additional styles to apply to the content wrapper.
  */
-const Container = ({
+export const Container = ({
 	heading,
 	content,
 	type = "heading",

--- a/.storybook/guides/develop.mdx
+++ b/.storybook/guides/develop.mdx
@@ -470,7 +470,7 @@ Default.args = {};
 
 Ideally you should have a single story file for each component with multiple variations and states represented in the testing grid that only renders in Chromatic. To preview the groups locally, there is a global toolbar setting with a beaker icon called "Show testing preview" that will activate the Chromatic view.
 
-In the event that you don't want a story to be tested in Chromatic, you can use the `disableSnapshot` paramter:
+In the event that you don't want a story to be tested in Chromatic, you can use the `disableSnapshot` parameter:
 
 ```js
 Default.parameters = {

--- a/components/breadcrumb/stories/breadcrumb.stories.js
+++ b/components/breadcrumb/stories/breadcrumb.stories.js
@@ -22,12 +22,14 @@ export default {
 		variant: {
 			name: "Variants",
 			type: { name: "string" },
+			defaultValue: "Default",
 			table: {
 				type: { summary: "string" },
 				category: "Component",
+				defaultValue: { summary: "Default" },
 			},
 			options: ["default", "compact", "multiline"],
-			control: "inline-radio",
+			control: "select",
 		},
 		isDragged: {
 			name: "Dragged",

--- a/components/breadcrumb/stories/breadcrumb.stories.js
+++ b/components/breadcrumb/stories/breadcrumb.stories.js
@@ -5,6 +5,14 @@ import { Template } from "./template";
 
 /**
  * Breadcrumbs show hierarchy and navigational context for a user's location within an app.
+ * 
+ * ## Nesting
+ * Breadcrumbs truncate when there is not enough room to display all levels of the breadcrumb list, or as a way of managing relevance of the visible breadcrumb items in a deeply nested hierarchy. The truncation of breadcrumb items begins when either there is not enough room to display all items, or if there are 5 or more breadcrumbs to display.
+ * 
+ * The nested variants below are non-functional. Implementations can add their own overflow menus to display all options within a breadcrumb.
+ * 
+ * ## Root Context
+ * Some applications find that displaying the root directory is useful for user orientation. This variation keeps the root visible when other folders are truncated into a menu. For example, when users can navigate file directories on their device as well as in the cloud, exposing a root directory called “On this device” is very helpful.
  */
 export default {
 	title: "Breadcrumbs",
@@ -41,6 +49,9 @@ export default {
 	},
 };
 
+/**
+ * By default, breadcrumbs are displayed inline with the hierarchy shown in reading order.
+ */
 export const Default = BreadcrumbGroup.bind({});
 Default.args = {
 	items: [
@@ -76,12 +87,15 @@ MultilineNested.args = {
 	],
 	variant: "multiline",
 };
-MultilineNested.storyName = "Multiline nested";
+MultilineNested.storyName = "Multiline, nested";
 MultilineNested.tags= ["!dev"];
 MultilineNested.parameters = {
 	chromatic: { disableSnapshot: true },
 };
 
+/**
+ * Breadcrumbs can have optional behavior to allow for drag and drop functionality.
+ */
 export const Dragged = Template.bind({});
 Dragged.args = {
 	items: [
@@ -103,8 +117,8 @@ Dragged.parameters = {
 	chromatic: { disableSnapshot: true },
 };
 
-export const Nested = Template.bind({});
-Nested.args = {
+export const DefaultNested = Template.bind({});
+DefaultNested.args = {
 	items: [
 		{
 			iconName: "FolderOpen",
@@ -120,13 +134,14 @@ Nested.args = {
 		},
 	],
 };
-Nested.tags = ["!dev"];
-Nested.parameters = {
+DefaultNested.tags = ["!dev"];
+DefaultNested.parameters = {
 	chromatic: { disableSnapshot: true },
 };
+DefaultNested.storyName = "Default, nested";
 
-export const NestedRootVisible = Template.bind({});
-NestedRootVisible.args = {
+export const DefaultNestedRootVisible = Template.bind({});
+DefaultNestedRootVisible.args = {
 	items: [
 		{
 			label: "Nav root",
@@ -142,12 +157,15 @@ NestedRootVisible.args = {
 		},
 	],
 };
-NestedRootVisible.tags = ["!dev"];
-NestedRootVisible.parameters = {
+DefaultNestedRootVisible.tags = ["!dev"];
+DefaultNestedRootVisible.parameters = {
 	chromatic: { disableSnapshot: true },
 };
-NestedRootVisible.storyName = "Nested (root visible)";
+DefaultNestedRootVisible.storyName = "Default, nested (root visible)";
 
+/**
+ * The multiline variation places emphasis on the selected breadcrumb item as a page title, helping a user to more clearly identify their current location.
+ */
 export const Multiline = Template.bind({});
 Multiline.args = {
 	items: [
@@ -167,29 +185,6 @@ Multiline.tags = ["!dev"];
 Multiline.parameters = {
 	chromatic: { disableSnapshot: true },
 };
-
-export const MultilineDragged = Template.bind({});
-MultilineDragged.args = {
-	items: [
-		{
-			label: "Nav root",
-		},
-		{
-			label: "Trendy",
-			isDragged: true,
-		},
-		{
-			label: "January 2019 Assets",
-		},
-	],
-	variant: "multiline",
-	isDragged: true,
-};
-MultilineDragged.tags = ["!dev"];
-MultilineDragged.parameters = {
-	chromatic: { disableSnapshot: true },
-};
-MultilineDragged.storyName = "Multiline (dragged)";
 
 export const MultilineNestedRootVisible = Template.bind({});
 MultilineNestedRootVisible.args = {
@@ -213,8 +208,11 @@ MultilineNestedRootVisible.tags = ["!dev"];
 MultilineNestedRootVisible.parameters = {
 	chromatic: { disableSnapshot: true },
 };
-MultilineNestedRootVisible.storyName = "Multiline nested (root visible)";
+MultilineNestedRootVisible.storyName = "Multiline, nested (root visible)";
 
+/**
+ * When needing to optimize for functional space, the compact option is useful for reducing the height of the breadcrumbs while still maintaining the proper user context.
+ */
 export const Compact = Template.bind({});
 Compact.args = {
 	items: [
@@ -257,7 +255,7 @@ CompactNested.tags = ["!dev"];
 CompactNested.parameters = {
 	chromatic: { disableSnapshot: true },
 };
-CompactNested.storyName = "Compact nested";
+CompactNested.storyName = "Compact, nested";
 
 export const CompactNestedRootVisible = Template.bind({});
 CompactNestedRootVisible.args = {
@@ -281,7 +279,7 @@ CompactNestedRootVisible.tags = ["!dev"];
 CompactNestedRootVisible.parameters = {
 	chromatic: { disableSnapshot: true },
 };
-CompactNestedRootVisible.storyName = "Compact nested (root visible)";
+CompactNestedRootVisible.storyName = "Compact, nested (root visible)";
 
 /**
  * The example below has two disabled breadcrumb items. When disabling the text link, the `is-disabled` class gets added to `.spectrum-Breadcrumbs-itemLink`. When disabling the Action button, the `[disabled]` attribute is applied.

--- a/components/breadcrumb/stories/breadcrumb.stories.js
+++ b/components/breadcrumb/stories/breadcrumb.stories.js
@@ -1,6 +1,7 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { version } from "../package.json";
 import { BreadcrumbGroup } from "./breadcrumb.test.js";
+import { Template } from "./template";
 
 /**
  * Breadcrumbs show hierarchy and navigational context for a user's location within an app.
@@ -17,7 +18,7 @@ export default {
 				type: { summary: "string" },
 				category: "Component",
 			},
-			options: ["compact", "multiline"],
+			options: ["default", "compact", "multiline"],
 			control: "inline-radio",
 		},
 		isDragged: {
@@ -33,6 +34,7 @@ export default {
 	args: {
 		rootClass: "spectrum-Breadcrumbs",
 		isDragged: false,
+		variant: "default",
 	},
 	parameters: {
 		componentVersion: version,
@@ -48,12 +50,264 @@ Default.args = {
 		},
 		{
 			label: "Trend",
+		},
+		{
+			label: "January 2019 Assets",
+		},
+	],
+};
+
+export const MultilineNested = Template.bind({});
+MultilineNested.args = {
+	items: [
+		{
+			iconName: "FolderOpen",
+		},
+		{
+			label: "Sub Item",
+		},
+		{
+			label: "Trend",
+			isDragged: true,
+		},
+		{
+			label: "January 2019 Assets",
+		},
+	],
+	variant: "multiline",
+};
+MultilineNested.storyName = "Multiline nested";
+MultilineNested.tags= ["!dev"];
+MultilineNested.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+export const Dragged = Template.bind({});
+Dragged.args = {
+	items: [
+		{
+			label: "Nav root",
+		},
+		{
+			label: "Trend",
+			isDragged: true,
+		},
+		{
+			label: "January 2019 Assets",
+		},
+	],
+	isDragged: true,
+};
+Dragged.tags = ["!dev"];
+Dragged.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+export const Nested = Template.bind({});
+Nested.args = {
+	items: [
+		{
+			iconName: "FolderOpen",
+		},
+		{
+			label: "Sub Item",
+		},
+		{
+			label: "Trend",
+		},
+		{
+			label: "January 2019 Assets",
+		},
+	],
+};
+Nested.tags = ["!dev"];
+Nested.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+export const NestedRootVisible = Template.bind({});
+NestedRootVisible.args = {
+	items: [
+		{
+			label: "Nav root",
+		},
+		{
+			iconName: "FolderOpen",
+		},
+		{
+			label: "Trend",
+		},
+		{
+			label: "January 2019 Assets",
+		},
+	],
+};
+NestedRootVisible.tags = ["!dev"];
+NestedRootVisible.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+NestedRootVisible.storyName = "Nested (root visible)";
+
+export const Multiline = Template.bind({});
+Multiline.args = {
+	items: [
+		{
+			label: "Nav root",
+		},
+		{
+			label: "Trend",
+		},
+		{
+			label: "January 2019 Assets",
+		},
+	],
+	variant: "multiline",
+};
+Multiline.tags = ["!dev"];
+Multiline.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+export const MultilineDragged = Template.bind({});
+MultilineDragged.args = {
+	items: [
+		{
+			label: "Nav root",
+		},
+		{
+			label: "Trendy",
+			isDragged: true,
+		},
+		{
+			label: "January 2019 Assets",
+		},
+	],
+	variant: "multiline",
+	isDragged: true,
+};
+MultilineDragged.tags = ["!dev"];
+MultilineDragged.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+MultilineDragged.storyName = "Multiline (dragged)";
+
+export const MultilineNestedRootVisible = Template.bind({});
+MultilineNestedRootVisible.args = {
+	items: [
+		{
+			label: "Nav root",
+		},
+		{
+			iconName: "FolderOpen",
+		},
+		{
+			label: "Trendy",
+		},
+		{
+			label: "January 2019 Assets",
+		},
+	],
+	variant: "multiline",
+};
+MultilineNestedRootVisible.tags = ["!dev"];
+MultilineNestedRootVisible.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+MultilineNestedRootVisible.storyName = "Multiline nested (root visible)";
+
+export const Compact = Template.bind({});
+Compact.args = {
+	items: [
+		{
+			label: "Nav root",
+		},
+		{
+			label: "Trendy",
+		},
+		{
+			label: "January 2019 Assets",
+		},
+	],
+	variant: "compact",
+};
+Compact.tags = ["!dev"];
+Compact.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+export const CompactNested = Template.bind({});
+CompactNested.args = {
+	items: [
+		{
+			iconName: "FolderOpen",
+		},
+		{
+			label: "Sub Item",
+		},
+		{
+			label: "Trendy",
+		},
+		{
+			label: "January 2019 Assets",
+		},
+	],
+	variant: "compact",
+};
+CompactNested.tags = ["!dev"];
+CompactNested.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+CompactNested.storyName = "Compact nested";
+
+export const CompactNestedRootVisible = Template.bind({});
+CompactNestedRootVisible.args = {
+	items: [
+		{
+			label: "Nav root",
+		},
+		{
+			iconName: "FolderOpen",
+		},
+		{
+			label: "Trendy",
+		},
+		{
+			label: "January 2019 Assets",
+		},
+	],
+	variant: "compact",
+};
+CompactNestedRootVisible.tags = ["!dev"];
+CompactNestedRootVisible.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+CompactNestedRootVisible.storyName = "Compact nested (root visible)";
+
+/**
+ * The example below has two disabled breadcrumb items. When disabling the text link, the `is-disabled` class gets added to `.spectrum-Breadcrumbs-itemLink`. When disabling the Action button, the `[disabled]` attribute is applied.
+ */
+export const Disabled = Template.bind({});
+Disabled.args = {
+	items: [
+		{
+			label: "Nav root",
+		},
+		{
+			iconName: "FolderOpen",
+			isDisabled: true,
+		},
+		{
+			label: "Trendy",
 			isDisabled: true,
 		},
 		{
 			label: "January 2019 Assets",
 		},
 	],
+};
+Disabled.tags = ["!dev"];
+Disabled.parameters = {
+	chromatic: { disableSnapshot: true },
 };
 
 // ********* VRT ONLY ********* //

--- a/components/breadcrumb/stories/breadcrumb.stories.js
+++ b/components/breadcrumb/stories/breadcrumb.stories.js
@@ -7,7 +7,7 @@ import { Template } from "./template";
  * Breadcrumbs show hierarchy and navigational context for a user's location within an app.
  * 
  * ## Nesting
- * Breadcrumbs truncate when there is not enough room to display all levels of the breadcrumb list, or as a way of managing relevance of the visible breadcrumb items in a deeply nested hierarchy. The truncation of breadcrumb items begins when either there is not enough room to display all items, or if there are 5 or more breadcrumbs to display.
+ * Breadcrumbs truncate when there is not enough room to display all levels of the breadcrumb list, or as a way of managing relevance of the visible breadcrumb items in a deeply nested hierarchy. The truncation of breadcrumb items begins when either there is not enough room to display all items, or if there are 5 or more breadcrumbs to display. They are typically indicated by the truncated menu folder icon.
  * 
  * The nested variants below are non-functional. Implementations can add their own overflow menus to display all options within a breadcrumb.
  * 
@@ -57,64 +57,15 @@ Default.args = {
 	items: [
 		{
 			label: "Nav root",
-			isDragged: true,
-		},
-		{
-			label: "Trend",
-		},
-		{
-			label: "January 2019 Assets",
-		},
-	],
-};
-
-export const MultilineNested = Template.bind({});
-MultilineNested.args = {
-	items: [
-		{
-			iconName: "FolderOpen",
-		},
-		{
-			label: "Sub Item",
 		},
 		{
 			label: "Trend",
 			isDragged: true,
 		},
 		{
-			label: "January 2019 Assets",
+			label: "January 2019 assets",
 		},
 	],
-	variant: "multiline",
-};
-MultilineNested.storyName = "Multiline, nested";
-MultilineNested.tags= ["!dev"];
-MultilineNested.parameters = {
-	chromatic: { disableSnapshot: true },
-};
-
-/**
- * Breadcrumbs can have optional behavior to allow for drag and drop functionality.
- */
-export const Dragged = Template.bind({});
-Dragged.args = {
-	items: [
-		{
-			label: "Nav root",
-		},
-		{
-			label: "Trend",
-			isDragged: true,
-		},
-		{
-			label: "January 2019 Assets",
-		},
-	],
-	isDragged: true,
-};
-Dragged.tags = ["!dev"];
-Dragged.parameters = {
-	chromatic: { disableSnapshot: true },
 };
 
 export const DefaultNested = Template.bind({});
@@ -124,13 +75,13 @@ DefaultNested.args = {
 			iconName: "FolderOpen",
 		},
 		{
-			label: "Sub Item",
+			label: "Sub item",
 		},
 		{
 			label: "Trend",
 		},
 		{
-			label: "January 2019 Assets",
+			label: "January 2019 assets",
 		},
 	],
 };
@@ -153,7 +104,7 @@ DefaultNestedRootVisible.args = {
 			label: "Trend",
 		},
 		{
-			label: "January 2019 Assets",
+			label: "January 2019 assets",
 		},
 	],
 };
@@ -168,17 +119,7 @@ DefaultNestedRootVisible.storyName = "Default, nested (root visible)";
  */
 export const Multiline = Template.bind({});
 Multiline.args = {
-	items: [
-		{
-			label: "Nav root",
-		},
-		{
-			label: "Trend",
-		},
-		{
-			label: "January 2019 Assets",
-		},
-	],
+	...Default.args,
 	variant: "multiline",
 };
 Multiline.tags = ["!dev"];
@@ -186,22 +127,20 @@ Multiline.parameters = {
 	chromatic: { disableSnapshot: true },
 };
 
+export const MultilineNested = Template.bind({});
+MultilineNested.args = {
+	...DefaultNested.args,
+	variant: "multiline",
+};
+MultilineNested.storyName = "Multiline, nested";
+MultilineNested.tags= ["!dev"];
+MultilineNested.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
 export const MultilineNestedRootVisible = Template.bind({});
 MultilineNestedRootVisible.args = {
-	items: [
-		{
-			label: "Nav root",
-		},
-		{
-			iconName: "FolderOpen",
-		},
-		{
-			label: "Trendy",
-		},
-		{
-			label: "January 2019 Assets",
-		},
-	],
+	...DefaultNestedRootVisible.args,
 	variant: "multiline",
 };
 MultilineNestedRootVisible.tags = ["!dev"];
@@ -215,17 +154,7 @@ MultilineNestedRootVisible.storyName = "Multiline, nested (root visible)";
  */
 export const Compact = Template.bind({});
 Compact.args = {
-	items: [
-		{
-			label: "Nav root",
-		},
-		{
-			label: "Trendy",
-		},
-		{
-			label: "January 2019 Assets",
-		},
-	],
+	...Default.args,
 	variant: "compact",
 };
 Compact.tags = ["!dev"];
@@ -235,20 +164,7 @@ Compact.parameters = {
 
 export const CompactNested = Template.bind({});
 CompactNested.args = {
-	items: [
-		{
-			iconName: "FolderOpen",
-		},
-		{
-			label: "Sub Item",
-		},
-		{
-			label: "Trendy",
-		},
-		{
-			label: "January 2019 Assets",
-		},
-	],
+	...DefaultNested.args,
 	variant: "compact",
 };
 CompactNested.tags = ["!dev"];
@@ -259,20 +175,7 @@ CompactNested.storyName = "Compact, nested";
 
 export const CompactNestedRootVisible = Template.bind({});
 CompactNestedRootVisible.args = {
-	items: [
-		{
-			label: "Nav root",
-		},
-		{
-			iconName: "FolderOpen",
-		},
-		{
-			label: "Trendy",
-		},
-		{
-			label: "January 2019 Assets",
-		},
-	],
+	...DefaultNestedRootVisible.args,
 	variant: "compact",
 };
 CompactNestedRootVisible.tags = ["!dev"];
@@ -280,6 +183,19 @@ CompactNestedRootVisible.parameters = {
 	chromatic: { disableSnapshot: true },
 };
 CompactNestedRootVisible.storyName = "Compact, nested (root visible)";
+
+/**
+ * Breadcrumbs can have optional behavior to allow for drag and drop functionality.
+ */
+export const Dragged = Template.bind({});
+Dragged.args = {
+	...Default.args,
+	isDragged: true,
+};
+Dragged.tags = ["!dev"];
+Dragged.parameters = {
+	chromatic: { disableSnapshot: true },
+};
 
 /**
  * The example below has two disabled breadcrumb items. When disabling the text link, the `is-disabled` class gets added to `.spectrum-Breadcrumbs-itemLink`. When disabling the Action button, the `[disabled]` attribute is applied.
@@ -299,7 +215,7 @@ Disabled.args = {
 			isDisabled: true,
 		},
 		{
-			label: "January 2019 Assets",
+			label: "January 2019 assets",
 		},
 	],
 };

--- a/components/breadcrumb/stories/breadcrumb.test.js
+++ b/components/breadcrumb/stories/breadcrumb.test.js
@@ -8,11 +8,49 @@ export const BreadcrumbGroup = Variants({
 			testHeading: "Default",
 		},
 		{
+			testHeading: "Default (nested)",
+			withStates: false,
+			items: [
+				{
+					iconName: "FolderOpen",
+				},
+				{
+					label: "Sub item",
+					isDragged: true,
+				},
+				{
+					label: "Trend",
+				},
+				{
+					label: "January 2019 Assets",
+				},
+			],
+		},
+		{
+			testHeading: "Default (nested, root visible)",
+			withStates: false,
+			items: [
+				{
+					label: "Nav root",
+				},
+				{
+					iconName: "FolderOpen",
+				},
+				{
+					label: "Sub item",
+				},
+				{
+					label: "January 2019 Assets",
+				},
+			],
+		},
+		{
 			testHeading: "Compact",
 			variant: "compact",
 		},
 		{
-			testHeading: "Compact, nested",
+			testHeading: "Compact (nested)",
+			withStates: false,
 			variant: "compact",
 			items: [
 				{
@@ -20,7 +58,48 @@ export const BreadcrumbGroup = Variants({
 				},
 				{
 					label: "Sub Item",
-					isDragged: true,
+				},
+				{
+					label: "Trend",
+				},
+				{
+					label: "January 2019 Assets",
+				},
+			],
+		},
+		{
+			testHeading: "Compact (nested, root visible)",
+			withStates: false,
+			variant: "compact",
+			items: [
+				{
+					label: "Nav root",
+				},
+				{
+					iconName: "FolderOpen",
+				},
+				{
+					label: "Sub item",
+				},
+				{
+					label: "January 2019 Assets",
+				},
+			],
+		},
+		{
+			testHeading: "Multiline",
+			variant: "multiline",
+		},
+		{
+			testHeading: "Multiline (nested)",
+			withStates: false,
+			variant: "multiline",
+			items: [
+				{
+					iconName: "FolderOpen",
+				},
+				{
+					label: "Sub Item",
 				},
 				{
 					label: "Trend",
@@ -32,6 +111,7 @@ export const BreadcrumbGroup = Variants({
 		},
 		{
 			testHeading: "Multiline (nested, root visible)",
+			withStates: false,
 			variant: "multiline",
 			items: [
 				{
@@ -41,26 +121,7 @@ export const BreadcrumbGroup = Variants({
 					iconName: "FolderOpen",
 				},
 				{
-					label: "Trend",
-					isDragged: true,
-				},
-				{
-					label: "January 2019 Assets",
-				},
-			],
-		},
-		{
-			testHeading: "Nested",
-			items: [
-				{
-					iconName: "FolderOpen",
-				},
-				{
-					label: "Sub Item",
-					isDragged: true,
-				},
-				{
-					label: "Trend",
+					label: "Sub item",
 				},
 				{
 					label: "January 2019 Assets",
@@ -70,21 +131,19 @@ export const BreadcrumbGroup = Variants({
 	],
 	stateData: [
 		{
-			testHeading: "Dragged",
+			testHeading: "Dragged, disabled",
 			isDragged: true,
-		},
-		{
-			testHeading: "Disabled",
+			isDisabled: true,
 			items: [
 				{
 					label: "Nav root",
 				},
 				{
-					iconName: "FolderOpen",
-					isDisabled: true,
+					label: "Dragged",
+					isDragged: true,
 				},
 				{
-					label: "Trend",
+					label: "Disabled",
 					isDisabled: true,
 				},
 				{

--- a/components/breadcrumb/stories/breadcrumb.test.js
+++ b/components/breadcrumb/stories/breadcrumb.test.js
@@ -1,155 +1,107 @@
 import { Variants } from "@spectrum-css/preview/decorators";
 import { Template } from "./template.js";
 
+const DefaultItems = [
+	{
+		label: "Nav root",
+	},
+	{
+		label: "Dragged",
+		isDragged: true,
+	},
+	{
+		label: "Disabled sub item",
+		isDisabled: true,
+	},
+	{
+		label: "January 2019 assets",
+	},
+];
+
+const NestedItems = [
+	{
+		iconName: "FolderOpen",
+	},
+	{
+		label: "Dragged",
+		isDragged: true,
+	},
+	{
+		label: "Disabled",
+		isDisabled: true,
+	},
+	{
+		label: "January 2019 assets",
+	},
+];
+
+const NestedRootVisibleItems = [
+	{
+		label: "Nav root",
+	},
+	{
+		iconName: "FolderOpen",
+		isDisabled: true,
+	},
+	{
+		label: "Dragged sub item",
+		isDragged: true,
+	},
+	{
+		label: "January 2019 assets",
+	},
+];
+
 export const BreadcrumbGroup = Variants({
 	Template,
 	testData: [
 		{
 			testHeading: "Default",
+			items: DefaultItems,
 		},
 		{
 			testHeading: "Default (nested)",
-			withStates: false,
-			items: [
-				{
-					iconName: "FolderOpen",
-				},
-				{
-					label: "Sub item",
-					isDragged: true,
-				},
-				{
-					label: "Trend",
-				},
-				{
-					label: "January 2019 Assets",
-				},
-			],
+			items: NestedItems,
 		},
 		{
 			testHeading: "Default (nested, root visible)",
-			withStates: false,
-			items: [
-				{
-					label: "Nav root",
-				},
-				{
-					iconName: "FolderOpen",
-				},
-				{
-					label: "Sub item",
-				},
-				{
-					label: "January 2019 Assets",
-				},
-			],
+			items: NestedRootVisibleItems,
 		},
 		{
 			testHeading: "Compact",
 			variant: "compact",
+			items: DefaultItems,
 		},
 		{
 			testHeading: "Compact (nested)",
-			withStates: false,
 			variant: "compact",
-			items: [
-				{
-					iconName: "FolderOpen",
-				},
-				{
-					label: "Sub Item",
-				},
-				{
-					label: "Trend",
-				},
-				{
-					label: "January 2019 Assets",
-				},
-			],
+			items: NestedItems,
 		},
 		{
 			testHeading: "Compact (nested, root visible)",
-			withStates: false,
 			variant: "compact",
-			items: [
-				{
-					label: "Nav root",
-				},
-				{
-					iconName: "FolderOpen",
-				},
-				{
-					label: "Sub item",
-				},
-				{
-					label: "January 2019 Assets",
-				},
-			],
+			items: NestedRootVisibleItems,
 		},
 		{
 			testHeading: "Multiline",
 			variant: "multiline",
+			items: DefaultItems,
 		},
 		{
 			testHeading: "Multiline (nested)",
-			withStates: false,
 			variant: "multiline",
-			items: [
-				{
-					iconName: "FolderOpen",
-				},
-				{
-					label: "Sub Item",
-				},
-				{
-					label: "Trend",
-				},
-				{
-					label: "January 2019 Assets",
-				},
-			],
+			items: NestedItems,
 		},
 		{
 			testHeading: "Multiline (nested, root visible)",
-			withStates: false,
 			variant: "multiline",
-			items: [
-				{
-					label: "Nav root",
-				},
-				{
-					iconName: "FolderOpen",
-				},
-				{
-					label: "Sub item",
-				},
-				{
-					label: "January 2019 Assets",
-				},
-			],
+			items: NestedRootVisibleItems,
 		},
 	],
 	stateData: [
 		{
 			testHeading: "Dragged, disabled",
 			isDragged: true,
-			isDisabled: true,
-			items: [
-				{
-					label: "Nav root",
-				},
-				{
-					label: "Dragged",
-					isDragged: true,
-				},
-				{
-					label: "Disabled",
-					isDisabled: true,
-				},
-				{
-					label: "January 2019 Assets",
-				},
-			],
 		}
 	]
 });

--- a/components/breadcrumb/stories/breadcrumb.test.js
+++ b/components/breadcrumb/stories/breadcrumb.test.js
@@ -3,36 +3,94 @@ import { Template } from "./template.js";
 
 export const BreadcrumbGroup = Variants({
 	Template,
-	testData: [{
-		testHeading: "Default"
-	}, {
-		testHeading: "Compact",
-		variant: "compact",
-	},
-	{
-		testHeading: "Multiline",
-		variant: "multiline",
-		items: [
-			{
-				label: "Nav root",
-			},
-			{
-				iconName: "FolderOpen",
-				isDisabled: true,
-			},
-			{
-				label: "Trend",
-				isDragged: true,
-			},
-			{
-				label: "January 2019 Assets",
-			},
-		],
-	}],
+	testData: [
+		{
+			testHeading: "Default",
+		},
+		{
+			testHeading: "Compact",
+			variant: "compact",
+		},
+		{
+			testHeading: "Compact, nested",
+			variant: "compact",
+			items: [
+				{
+					iconName: "FolderOpen",
+				},
+				{
+					label: "Sub Item",
+					isDragged: true,
+				},
+				{
+					label: "Trend",
+				},
+				{
+					label: "January 2019 Assets",
+				},
+			],
+		},
+		{
+			testHeading: "Multiline (nested, root visible)",
+			variant: "multiline",
+			items: [
+				{
+					label: "Nav root",
+				},
+				{
+					iconName: "FolderOpen",
+				},
+				{
+					label: "Trend",
+					isDragged: true,
+				},
+				{
+					label: "January 2019 Assets",
+				},
+			],
+		},
+		{
+			testHeading: "Nested",
+			items: [
+				{
+					iconName: "FolderOpen",
+				},
+				{
+					label: "Sub Item",
+					isDragged: true,
+				},
+				{
+					label: "Trend",
+				},
+				{
+					label: "January 2019 Assets",
+				},
+			],
+		},
+	],
 	stateData: [
 		{
 			testHeading: "Dragged",
 			isDragged: true,
+		},
+		{
+			testHeading: "Disabled",
+			items: [
+				{
+					label: "Nav root",
+				},
+				{
+					iconName: "FolderOpen",
+					isDisabled: true,
+				},
+				{
+					label: "Trend",
+					isDisabled: true,
+				},
+				{
+					label: "January 2019 Assets",
+				},
+			],
 		}
 	]
 });

--- a/components/breadcrumb/stories/template.js
+++ b/components/breadcrumb/stories/template.js
@@ -21,7 +21,7 @@ export const Template = (
 		<ul
 			class=${classMap({
 				[rootClass]: true,
-				[`${rootClass}--${variant}`]: typeof variant !== "undefined",
+				[`${rootClass}--${variant}`]: typeof variant !== "undefined" || variant !== "default",
 				...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
 			})}
 		>

--- a/components/checkbox/stories/checkbox.stories.js
+++ b/components/checkbox/stories/checkbox.stories.js
@@ -1,7 +1,8 @@
+import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isInvalid } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
-import { SizingGroup, AllVariantsCheckboxGroup, } from "./template";
+import { DocsCheckboxGroup, AllVariantsCheckboxGroup, } from "./template";
 import { CheckboxGroup } from "./checkbox.test.js";
 
 /**
@@ -126,7 +127,12 @@ EmphasizedVariants.parameters = {
 };
 EmphasizedVariants.storyName = "Emphasized";
 
-export const Sizing = SizingGroup.bind({});
+export const Sizing = (args, context) => Sizes({
+	Template: DocsCheckboxGroup,
+	withHeading: false,
+	withBorder: false,
+	...args,
+}, context);
 Sizing.args = {};
 Sizing.tags = ["!dev"];
 Sizing.parameters = {

--- a/components/checkbox/stories/checkbox.stories.js
+++ b/components/checkbox/stories/checkbox.stories.js
@@ -1,10 +1,17 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isInvalid } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
+import { SizingGroup, AllVariantsCheckboxGroup, } from "./template";
 import { CheckboxGroup } from "./checkbox.test.js";
 
 /**
  * Checkboxes allow users to select multiple items from a list of individual items, or mark one individual item as selected.
+ * 
+ * ## Usage notes  
+ * 
+ * Checkboxes should not be used on their own. They should always be used within a [field group](/docs/components-field-group--docs). Invalid checkboxes are indicated with an alert [help text](/docs/components-help-text--docs) when included in a Field group.  
+ * 
+ * When the label is too long for the horizontal space available, it wraps to form another line.  
  */
 export default {
 	title: "Checkbox",
@@ -98,6 +105,32 @@ export default {
 export const Default = CheckboxGroup.bind({});
 Default.args = {
 	id: "default-checkbox",
+};
+Default.tags = ["!autodocs"];
+
+export const DefaultVariants = AllVariantsCheckboxGroup.bind({});
+DefaultVariants.tags = ["!dev"];
+DefaultVariants.parameters = {
+	chromatic: { disableSnapshot: true }
+};
+DefaultVariants.storyName = "Default";
+
+export const EmphasizedVariants = AllVariantsCheckboxGroup.bind({});
+EmphasizedVariants.args = {
+	id: "checkbox-emphasized",
+	isEmphasized: true,
+};
+EmphasizedVariants.tags = ["!dev"];
+EmphasizedVariants.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+EmphasizedVariants.storyName = "Emphasized";
+
+export const Sizing = SizingGroup.bind({});
+Sizing.args = {};
+Sizing.tags = ["!dev"];
+Sizing.parameters = {
+	chromatic: { disableSnapshot: true },
 };
 
 // ********* VRT ONLY ********* //

--- a/components/checkbox/stories/checkbox.test.js
+++ b/components/checkbox/stories/checkbox.test.js
@@ -41,12 +41,22 @@ export const CheckboxGroup = Variants({
 			isDisabled: true,
 		},
 		{
+			testHeading: "Disabled, checked",
+			isDisabled: true,
+			isChecked: true,
+		},
+		{
 			testHeading: "Indeterminate",
 			isIndeterminate: true,
 		},
 		{
-			testHeading: "Read only",
+			testHeading: "Read-only",
 			isReadOnly: true,
+		},
+		{
+			testHeading: "Read-only, checked",
+			isReadOnly: true,
+			isChecked: true,
 		},
 	]
 });

--- a/components/checkbox/stories/checkbox.test.js
+++ b/components/checkbox/stories/checkbox.test.js
@@ -16,8 +16,10 @@ export const CheckboxGroup = Variants({
 		{
 			testHeading: "Truncation",
 			withStates: false,
-			label: "Checkbox with wrapping label text",
-			customStyles: { "max-inline-size": "100px" },
+			label: "Checkbox with an extraordinarily long label. Please don't do this but if you did, it should wrap text when it gets longer than the container that houses the checkbox with the unacceptably long label",
+			customStyles: {
+				"max-width": "200px",
+			}
 		}
 	],
 	stateData: [
@@ -28,6 +30,11 @@ export const CheckboxGroup = Variants({
 		{
 			testHeading: "Invalid",
 			isInvalid: true,
+		},
+		{
+			testHeading: "Invalid, checked",
+			isInvalid: true,
+			isChecked: true,
 		},
 		{
 			testHeading: "Disabled",

--- a/components/checkbox/stories/template.js
+++ b/components/checkbox/stories/template.js
@@ -1,5 +1,5 @@
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
-import { getRandomId } from "@spectrum-css/preview/decorators";
+import { getRandomId, Container } from "@spectrum-css/preview/decorators";
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
@@ -93,8 +93,10 @@ export const Template = ({
 };
 
 /* Shows multiple checkboxes in various states of selected, unselected, indeterminate, etc. */
-export const DocsCheckboxGroup = (args, context) => html`
-	<div style="display: flex; flex-direction: column; padding: 16px">
+export const DocsCheckboxGroup = (args, context) => Container({
+	direction: "column",
+	withBorder: false,
+	content: html`
 		${Template({
 			...args,
 			context,
@@ -119,42 +121,57 @@ export const DocsCheckboxGroup = (args, context) => html`
 			...args,
 			context,
 			label: "Checkbox with a long label that should wrap.",
-      customStyles: { "max-inline-size": "200px" },
+			customStyles: { "max-inline-size": "200px" },
 		})}
-	</div>
-`;
+	`
+});
 
-/* This template group showcases mulitple CheckboxGroups in various states of disabled, read-only, invalid, etc. */
-export const AllVariantsCheckboxGroup = (args, context) => {
-	return html`
-		<div style="display: flex;">
-			<div style="display: flex; flex-direction: column;">
-				<h4 style="margin: 0; padding-left: 16px;">Default</h4>
+/* This template group showcases multiple CheckboxGroups in various states of disabled, read-only, invalid, etc. */
+export const AllVariantsCheckboxGroup = (args, context) => Container({
+	withBorder: false,
+	content: html`
+		${Container({
+			withBorder: false,
+			direction: "column",
+			heading: "Default",
+			content: html`
 				${DocsCheckboxGroup({
 					...args,
 				}, context)}
-			</div>
-			<div style="display: flex; flex-direction: column;">
-				<h4 style="margin: 0; padding-left: 16px;">Invalid</h4>
+			`
+		})}
+		${Container({
+			withBorder: false,
+			direction: "column",
+			heading: "Invalid",
+			content: html`
 				${DocsCheckboxGroup({
 					...args,
 					isInvalid: true,
 				}, context)}
-			</div>
-			<div style="display: flex; flex-direction: column;">
-				<h4 style="margin: 0; padding-left: 16px;">Disabled</h4>
+			`
+		})}
+		${Container({
+			withBorder: false,
+			direction: "column",
+			heading: "Disabled",
+			content: html`
 				${DocsCheckboxGroup({
 					...args,
 					isDisabled: true,
 				}, context)}
-			</div>
-			<div style="display: flex; flex-direction: column;">
-				<h4 style="margin: 0; padding-left: 16px;">Read-Only</h4>
+			`
+		})}
+		${Container({
+			withBorder: false,
+			direction: "column",
+			heading: "Read-only",
+			content: html`
 				${DocsCheckboxGroup({
 					...args,
 					isReadOnly: true,
 				}, context)}
-			</div>
-		</div>
-	`;
-};
+			`
+		})}
+	`
+});

--- a/components/checkbox/stories/template.js
+++ b/components/checkbox/stories/template.js
@@ -1,5 +1,4 @@
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
-import { Template as Typography } from "@spectrum-css/typography/stories/template.js";
 import { getRandomId } from "@spectrum-css/preview/decorators";
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
@@ -94,7 +93,7 @@ export const Template = ({
 };
 
 /* Shows multiple checkboxes in various states of selected, unselected, indeterminate, etc. */
-const CheckboxGroup = (args, context) => html`
+export const DocsCheckboxGroup = (args, context) => html`
 	<div style="display: flex; flex-direction: column; padding: 16px">
 		${Template({
 			...args,
@@ -131,68 +130,31 @@ export const AllVariantsCheckboxGroup = (args, context) => {
 		<div style="display: flex;">
 			<div style="display: flex; flex-direction: column;">
 				<h4 style="margin: 0; padding-left: 16px;">Default</h4>
-				${CheckboxGroup({
+				${DocsCheckboxGroup({
 					...args,
 				}, context)}
 			</div>
 			<div style="display: flex; flex-direction: column;">
 				<h4 style="margin: 0; padding-left: 16px;">Invalid</h4>
-				${CheckboxGroup({
+				${DocsCheckboxGroup({
 					...args,
 					isInvalid: true,
 				}, context)}
 			</div>
 			<div style="display: flex; flex-direction: column;">
 				<h4 style="margin: 0; padding-left: 16px;">Disabled</h4>
-				${CheckboxGroup({
+				${DocsCheckboxGroup({
 					...args,
 					isDisabled: true,
 				}, context)}
 			</div>
 			<div style="display: flex; flex-direction: column;">
 				<h4 style="margin: 0; padding-left: 16px;">Read-Only</h4>
-				${CheckboxGroup({
+				${DocsCheckboxGroup({
 					...args,
 					isReadOnly: true,
 				}, context)}
 			</div>
 		</div>
-	`;
-};
-
-// TODO: refactor this SizingGroup to use the sizing decorator instead for standardized sizing story styles
-export const SizingGroup = (args, context) => {
-	// Color for heading that shows the name of the size.
-	let headingColor = "var(--spectrum-seafoam-900)";
-
-	return html`
-		${["s", "m", "l", "xl"].map((size) => html`
-			<div style=${styleMap({
-				display: "flex",
-				gap: "16px",
-				flexDirection: "column",
-				alignItems: "flex-start",
-				})}
-			>
-			${Typography({
-				semantics: "heading",
-				size: "xs",
-				content: [{
-					s: "Small",
-					m: "Medium (default)",
-					l: "Large",
-					xl: "Extra-large",
-				}[size]],
-				customClasses: ["chromatic-ignore"],
-				customStyles: {
-					"white-space": "nowrap",
-					"--mod-heading-font-color": headingColor,
-				},
-			})}
-			${CheckboxGroup({
-					...args,
-					size,
-			}, context)}
-		`)}
 	`;
 };

--- a/components/checkbox/stories/template.js
+++ b/components/checkbox/stories/template.js
@@ -1,4 +1,5 @@
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
+import { Template as Typography } from "@spectrum-css/typography/stories/template.js";
 import { getRandomId } from "@spectrum-css/preview/decorators";
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
@@ -89,5 +90,109 @@ export const Template = ({
 				() => html`<span class="${rootClass}-label">${label}</span>`
 			)}
 		</label>
+	`;
+};
+
+/* Shows multiple checkboxes in various states of selected, unselected, indeterminate, etc. */
+const CheckboxGroup = (args, context) => html`
+	<div style="display: flex; flex-direction: column; padding: 16px">
+		${Template({
+			...args,
+			context,
+			iconName: undefined,
+		})}
+		${Template({
+			...args,
+			context,
+			isChecked: true,
+		})}
+		${Template({
+			...args,
+			context,
+			isIndeterminate: true,
+		})}
+		${Template({
+			...args,
+			context,
+			isDisabled: true,
+		})}
+		${Template({
+			...args,
+			context,
+			label: "Checkbox with a long label that should wrap.",
+      customStyles: { "max-inline-size": "200px" },
+		})}
+	</div>
+`;
+
+/* This template group showcases mulitple CheckboxGroups in various states of disabled, read-only, invalid, etc. */
+export const AllVariantsCheckboxGroup = (args, context) => {
+	return html`
+		<div style="display: flex;">
+			<div style="display: flex; flex-direction: column;">
+				<h4 style="margin: 0; padding-left: 16px;">Default</h4>
+				${CheckboxGroup({
+					...args,
+				}, context)}
+			</div>
+			<div style="display: flex; flex-direction: column;">
+				<h4 style="margin: 0; padding-left: 16px;">Invalid</h4>
+				${CheckboxGroup({
+					...args,
+					isInvalid: true,
+				}, context)}
+			</div>
+			<div style="display: flex; flex-direction: column;">
+				<h4 style="margin: 0; padding-left: 16px;">Disabled</h4>
+				${CheckboxGroup({
+					...args,
+					isDisabled: true,
+				}, context)}
+			</div>
+			<div style="display: flex; flex-direction: column;">
+				<h4 style="margin: 0; padding-left: 16px;">Read-Only</h4>
+				${CheckboxGroup({
+					...args,
+					isReadOnly: true,
+				}, context)}
+			</div>
+		</div>
+	`;
+};
+
+// TODO: refactor this SizingGroup to use the sizing decorator instead for standardized sizing story styles
+export const SizingGroup = (args, context) => {
+	// Color for heading that shows the name of the size.
+	let headingColor = "var(--spectrum-seafoam-900)";
+
+	return html`
+		${["s", "m", "l", "xl"].map((size) => html`
+			<div style=${styleMap({
+				display: "flex",
+				gap: "16px",
+				flexDirection: "column",
+				alignItems: "flex-start",
+				})}
+			>
+			${Typography({
+				semantics: "heading",
+				size: "xs",
+				content: [{
+					s: "Small",
+					m: "Medium (default)",
+					l: "Large",
+					xl: "Extra-large",
+				}[size]],
+				customClasses: ["chromatic-ignore"],
+				customStyles: {
+					"white-space": "nowrap",
+					"--mod-heading-font-color": headingColor,
+				},
+			})}
+			${CheckboxGroup({
+					...args,
+					size,
+			}, context)}
+		`)}
 	`;
 };

--- a/components/checkbox/stories/template.js
+++ b/components/checkbox/stories/template.js
@@ -134,44 +134,26 @@ export const AllVariantsCheckboxGroup = (args, context) => Container({
 			withBorder: false,
 			direction: "column",
 			heading: "Default",
-			content: html`
-				${DocsCheckboxGroup({
-					...args,
-				}, context)}
-			`
+			content: DocsCheckboxGroup(args, context)
 		})}
 		${Container({
 			withBorder: false,
 			direction: "column",
 			heading: "Invalid",
-			content: html`
-				${DocsCheckboxGroup({
-					...args,
-					isInvalid: true,
-				}, context)}
-			`
+			content: DocsCheckboxGroup({...args, isInvalid: true }, context)
 		})}
 		${Container({
 			withBorder: false,
 			direction: "column",
 			heading: "Disabled",
-			content: html`
-				${DocsCheckboxGroup({
-					...args,
-					isDisabled: true,
-				}, context)}
-			`
+			content: DocsCheckboxGroup({...args, isDisabled: true }, context)
 		})}
 		${Container({
 			withBorder: false,
 			direction: "column",
 			heading: "Read-only",
-			content: html`
-				${DocsCheckboxGroup({
-					...args,
-					isReadOnly: true,
-				}, context)}
-			`
+			content: DocsCheckboxGroup({...args, isReadOnly: true }, context)
+
 		})}
 	`
 });

--- a/components/clearbutton/stories/clearbutton.stories.js
+++ b/components/clearbutton/stories/clearbutton.stories.js
@@ -1,9 +1,41 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { version } from "../package.json";
 import { ClearButtonGroup } from "./clearbutton.test.js";
+import { SizingGroup, Template } from "./template";
 
 /**
- * The clear button component is an in-field button used in search and tag.
+ * The clear button component is an in-field button used in search and tags.
+ * 
+ * ## Usage Notes
+
+	Use the correct cross icon size that corresponds to the t-shirt size you require for the clear button.
+
+	<table>
+		<thead>
+			<tr>
+				<th>**T-Shirt Size**</th>
+				<th>**Icon Size**</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<td>spectrum-ClearButton--sizeS</td>
+				<td>spectrum-css-icon-Cross75</td>
+			</tr>
+			<tr>
+				<td>spectrum-ClearButton--sizeM</td>
+				<td>spectrum-css-icon-Cross100</td>
+			</tr>
+			<tr>
+				<td>spectrum-ClearButton--sizeL</td>
+				<td>spectrum-css-icon-Cross200</td>
+			</tr>
+			<tr>
+				<td>spectrum-ClearButton--sizeXL</td>
+				<td>spectrum-css-icon-Cross300</td>
+			</tr>
+		</tbody>
+	</table>
  */
 export default {
 	title: "Clear button",
@@ -28,6 +60,15 @@ export default {
 			},
 			control: "boolean",
 		},
+		isQuiet: {
+			name: "Quiet Styling",
+			type: { name: "boolean" },
+			table: {
+				type: { summary: "boolean" },
+				category: "Component",
+			},
+			control: "boolean",
+		},
 		staticColor: {
 			name: "Static color",
 			type: { name: "string" },
@@ -44,22 +85,60 @@ export default {
 		rootClass: "spectrum-ClearButton",
 		size: "m",
 		isDisabled: false,
+		isQuiet: false,
 	},
 	parameters: {
 		componentVersion: version,
 	},
 };
 
+/**
+ * The default size for clear button is medium.
+ */
+
 export const Default = ClearButtonGroup.bind({});
 Default.args = {};
 
-// ********* VRT ONLY ********* //
+export const Disabled = Template.bind({});
+Disabled.args = {
+	isDisabled: true,
+};
+Disabled.tags = ["!dev"];
+Disabled.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+/**
+ * The `.spectrum-ClearButton--quiet` class will use a transparent background (including when the Express theme is active).
+ */
+export const Quiet = Template.bind({});
+Quiet.args = {
+	isQuiet: true,
+};
+Quiet.tags = ["!dev"];
+Quiet.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+export const Sizing = SizingGroup.bind({});
+Sizing.args = {};
+Sizing.tags = ["!dev"];
+Sizing.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
 export const OverBackground = ClearButtonGroup.bind({});
-OverBackground.tags = ["!autodocs", "!dev"];
+OverBackground.tags = ["!dev"];
 OverBackground.args = {
 	staticColor: "white",
 };
+OverBackground.parameters = {
+	chromatic: {
+		modes: disableDefaultModes
+	},
+};
 
+// ********* VRT ONLY ********* //
 export const WithForcedColors = ClearButtonGroup.bind({});
 WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {

--- a/components/clearbutton/stories/clearbutton.stories.js
+++ b/components/clearbutton/stories/clearbutton.stories.js
@@ -1,7 +1,8 @@
+import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { version } from "../package.json";
 import { ClearButtonGroup } from "./clearbutton.test.js";
-import { SizingGroup, Template } from "./template";
+import { Template } from "./template";
 
 /**
  * The clear button component is an in-field button used in search and tags.
@@ -120,7 +121,12 @@ Quiet.parameters = {
 	chromatic: { disableSnapshot: true },
 };
 
-export const Sizing = SizingGroup.bind({});
+export const Sizing = (args, context) => Sizes({
+	Template,
+	withHeading: false,
+	withBorder: false,
+	...args
+}, context);
 Sizing.args = {};
 Sizing.tags = ["!dev"];
 Sizing.parameters = {

--- a/components/clearbutton/stories/clearbutton.stories.js
+++ b/components/clearbutton/stories/clearbutton.stories.js
@@ -62,7 +62,7 @@ export default {
 			control: "boolean",
 		},
 		isQuiet: {
-			name: "Quiet Styling",
+			name: "Quiet styling",
 			type: { name: "boolean" },
 			table: {
 				type: { summary: "boolean" },

--- a/components/clearbutton/stories/clearbutton.test.js
+++ b/components/clearbutton/stories/clearbutton.test.js
@@ -9,6 +9,10 @@ export const ClearButtonGroup = Variants({
 		{
 			testHeading: "Default",
 		},
+		{
+			testHeading: "Quiet",
+			isQuiet: true,
+		},
 	],
 	stateData: [
 		{

--- a/components/clearbutton/stories/template.js
+++ b/components/clearbutton/stories/template.js
@@ -1,5 +1,6 @@
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 import { getRandomId } from "@spectrum-css/preview/decorators";
+import { Template as Typography } from "@spectrum-css/typography/stories/template.js";
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
@@ -11,6 +12,7 @@ export const Template = ({
 	rootClass = "spectrum-ClearButton",
 	isDisabled = false,
 	size = "m",
+	isQuiet = false,
 	staticColor,
 	id = getRandomId("clearbutton"),
 	customClasses = [],
@@ -22,6 +24,7 @@ export const Template = ({
 			[rootClass]: true,
 			[`${rootClass}--size${size?.toUpperCase()}`]:
 				typeof size !== "undefined",
+			[`${rootClass}--quiet`]: isQuiet,
 			[`${rootClass}--overBackground`]: staticColor === "white",
 			"is-disabled": isDisabled,
 			...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
@@ -39,3 +42,42 @@ export const Template = ({
 		</div>
 	</button>
 `;
+
+// TODO: refactor this SizingGroup to use the sizing decorator instead for standardized sizing story styles
+export const SizingGroup = (args, context) => {
+	// Color for heading that shows the name of the size. Adjustments for static white/over-background story,
+	// which doesn't change with the color context.
+	let headingColor = "var(--spectrum-seafoam-900)";
+	if (context?.args?.staticColor == "white") { headingColor = "rgb(255, 255, 255)"; }
+
+	return html`
+		${["s", "m", "l", "xl"].map((size) => html`
+			<div style=${styleMap({
+				display: "flex",
+				gap: "16px",
+				flexDirection: "column",
+				alignItems: "flex-start",
+				})}
+			>
+			${Typography({
+				semantics: "heading",
+				size: "xs",
+				content: [{
+					s: "Small",
+					m: "Medium (default)",
+					l: "Large",
+					xl: "Extra-large",
+				}[size]],
+				customClasses: ["chromatic-ignore"],
+				customStyles: {
+					"white-space": "nowrap",
+					"--mod-heading-font-color": headingColor,
+				},
+			})}
+			${Template({
+					...args,
+					size,
+			}, context)}
+		`)}
+	`;
+};

--- a/components/clearbutton/stories/template.js
+++ b/components/clearbutton/stories/template.js
@@ -1,6 +1,5 @@
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 import { getRandomId } from "@spectrum-css/preview/decorators";
-import { Template as Typography } from "@spectrum-css/typography/stories/template.js";
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
@@ -42,42 +41,3 @@ export const Template = ({
 		</div>
 	</button>
 `;
-
-// TODO: refactor this SizingGroup to use the sizing decorator instead for standardized sizing story styles
-export const SizingGroup = (args, context) => {
-	// Color for heading that shows the name of the size. Adjustments for static white/over-background story,
-	// which doesn't change with the color context.
-	let headingColor = "var(--spectrum-seafoam-900)";
-	if (context?.args?.staticColor == "white") { headingColor = "rgb(255, 255, 255)"; }
-
-	return html`
-		${["s", "m", "l", "xl"].map((size) => html`
-			<div style=${styleMap({
-				display: "flex",
-				gap: "16px",
-				flexDirection: "column",
-				alignItems: "flex-start",
-				})}
-			>
-			${Typography({
-				semantics: "heading",
-				size: "xs",
-				content: [{
-					s: "Small",
-					m: "Medium (default)",
-					l: "Large",
-					xl: "Extra-large",
-				}[size]],
-				customClasses: ["chromatic-ignore"],
-				customStyles: {
-					"white-space": "nowrap",
-					"--mod-heading-font-color": headingColor,
-				},
-			})}
-			${Template({
-					...args,
-					size,
-			}, context)}
-		`)}
-	`;
-};

--- a/components/coachindicator/stories/coachindicator.stories.js
+++ b/components/coachindicator/stories/coachindicator.stories.js
@@ -1,9 +1,12 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { version } from "../package.json";
 import { CoachIndicatorGroup } from "./coachindicator.test.js";
+import { AllVariantsCoachIndicatorGroup } from "./template";
 
 /**
  * The coach indicator component can be used to bring added attention to specific parts of a page.
+ * 
+ * Coach indicator is primarily used along with the [coach mark](/docs/components-coach-mark--docs) component.
  */
 export default {
 	title: "Coach indicator",
@@ -25,7 +28,7 @@ export default {
 				type: { summary: "string" },
 				category: "Component",
 			},
-			options: ["dark", "light"],
+			options: ["default", "dark", "light"],
 			control: "select"
 		},
 	},
@@ -46,6 +49,24 @@ Default.parameters = {
 		pauseAnimationAtEnd: true,
 	},
 };
+Default.tags = ["!autodocs"];
+
+export const DefaultVariants = AllVariantsCoachIndicatorGroup.bind({});
+DefaultVariants.tags = ["!dev"];
+DefaultVariants.storyName = "Default";
+DefaultVariants.parameters = {
+	chromatic: { disableSnapshot: true }
+};
+
+export const QuietVariants = AllVariantsCoachIndicatorGroup.bind({});
+QuietVariants.tags = ["!dev"];
+QuietVariants.storyName = "Quiet";
+QuietVariants.args = {
+	isQuiet: true,
+};
+QuietVariants.parameters = {
+	chromatic: { disableSnapshot: true }
+};
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = CoachIndicatorGroup.bind({});
@@ -57,7 +78,6 @@ WithForcedColors.parameters = {
 		forcedColors: "active",
 		prefersReducedMotion: "reduce",
 		pauseAnimationAtEnd: true,
-		modes: disableDefaultModes
-
+		modes: disableDefaultModes,
 	},
 };

--- a/components/coachindicator/stories/coachindicator.stories.js
+++ b/components/coachindicator/stories/coachindicator.stories.js
@@ -35,6 +35,7 @@ export default {
 	args: {
 		rootClass: "spectrum-CoachIndicator",
 		isQuiet: false,
+		variant: "default",
 	},
 	parameters: {
 		componentVersion: version,

--- a/components/coachindicator/stories/template.js
+++ b/components/coachindicator/stories/template.js
@@ -1,3 +1,4 @@
+import { Container } from "@spectrum-css/preview/decorators";
 import { html } from "lit-html";
 import { classMap } from "lit-html/directives/class-map.js";
 import { styleMap } from "lit-html/directives/style-map.js";
@@ -26,19 +27,43 @@ export const Template = ({
 	</div>
 `;
 
-export const AllVariantsCoachIndicatorGroup = (args, context) => html`
-	<div style="display: flex; flex-direction: column; padding: 16px">
-		${Template({
-				...args,
-				variant: "default"
-			}, context)}
-		${Template({
-				...args,
-				variant: "dark"
-			}, context)}
-		${Template({
-				...args,
-				variant: "light"
-			}, context)}
-	</div>
-`;
+/* This template group showcases multiple coach indicator variants at once. */
+export const AllVariantsCoachIndicatorGroup = (args, context) => Container({
+	withBorder: false,
+	content: html`
+		${Container({
+			direction: "column",
+			withBorder: false,
+			heading: "Default",
+			content: html`
+				${Template({
+					...args,
+					variant: "default"
+				}, context)}
+			`
+		})}
+		${Container({
+			direction: "column",
+			withBorder: false,
+			heading: "Dark",
+			content: html`
+				${Template({
+					...args,
+					variant: "dark"
+				}, context)}
+			`
+		})}
+		${Container({
+			direction: "column",
+			withBorder: false,
+			heading: "Light",
+			content: html`
+				${Template({
+					...args,
+					variant: "light"
+				}, context)}
+			`
+		})}
+	`
+});
+

--- a/components/coachindicator/stories/template.js
+++ b/components/coachindicator/stories/template.js
@@ -35,34 +35,20 @@ export const AllVariantsCoachIndicatorGroup = (args, context) => Container({
 			direction: "column",
 			withBorder: false,
 			heading: "Default",
-			content: html`
-				${Template({
-					...args,
-					variant: "default"
-				}, context)}
-			`
+			content: Template({ ...args, variant: "default" }, context)
 		})}
 		${Container({
 			direction: "column",
 			withBorder: false,
 			heading: "Dark",
-			content: html`
-				${Template({
-					...args,
-					variant: "dark"
-				}, context)}
-			`
+			content: Template({ ...args, variant: "dark" }, context)
 		})}
 		${Container({
 			direction: "column",
 			withBorder: false,
 			heading: "Light",
-			content: html`
-				${Template({
-					...args,
-					variant: "light"
-				}, context)}
-			`
+			content: Template({ ...args, variant: "light" }, context)
+
 		})}
 	`
 });

--- a/components/coachindicator/stories/template.js
+++ b/components/coachindicator/stories/template.js
@@ -15,7 +15,7 @@ export const Template = ({
 		class=${classMap({
 			[`${rootClass}`]: true,
 			[`${rootClass}--quiet`]: isQuiet,
-			[`${rootClass}--${variant}`]: typeof variant !== "undefined",
+			[`${rootClass}--${variant}`]: typeof variant !== "undefined" || variant !== "default",
 			...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
 		})}
 		style=${styleMap(customStyles)}
@@ -23,5 +23,22 @@ export const Template = ({
 		${Array.from({ length: 3 }).map(() => html`
 			<div class=${classMap({ [`${rootClass}-ring`]: true })}></div>
 		`)}
+	</div>
+`;
+
+export const AllVariantsCoachIndicatorGroup = (args, context) => html`
+	<div style="display: flex; flex-direction: column; padding: 16px">
+		${Template({
+				...args,
+				variant: "default"
+			}, context)}
+		${Template({
+				...args,
+				variant: "dark"
+			}, context)}
+		${Template({
+				...args,
+				variant: "light"
+			}, context)}
 	</div>
 `;


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->
This PR continues migrating documentation from the docs site into Storybook. The focus is on `breadcrumb`, `checkbox`, `clearbutton` and `coachindicator`. All variants of the component should now be displayed on the Storybook `Docs` page.

- `breadcrumb`: ~~new MDX docs page and~~ 3 `docs-only` stories
- `checkbox`: ~~new MDX docs page~~, usage notes and a `docs-only` story
- `clearbutton`: ~~new MDX docs page and~~ additional docs (Usage Notes) regarding proper icon size
- `coachindicator`: ~~new MDX docs page~~

**This PR doesn't need a changeset since it's docs-only.**

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
@jawinn 
- [x] The [breadcrumb storybook docs](https://pr-2793--spectrum-css.netlify.app/preview/?path=/docs/components-breadcrumbs--docs) include all necessary info when compared to the [corresponding docs site page](https://opensource.adobe.com/spectrum-css/breadcrumb.html)
- [x] The [checkbox storybook docs](https://pr-2793--spectrum-css.netlify.app/preview/?path=/docs/components-checkbox--docs) include all necessary info when compared to the [corresponding docs site page](https://opensource.adobe.com/spectrum-css/checkbox.html)
- [x] The [clear button storybook docs](https://pr-2793--spectrum-css.netlify.app/preview/?path=/docs/components-clear-button--docs) include all necessary info when compared to the [corresponding docs site page](https://opensource.adobe.com/spectrum-css/clearbutton.html)
- [x] The [coach indicator storybook docs](https://pr-2793--spectrum-css.netlify.app/preview/?path=/docs/components-coach-indicator--docs) include all necessary info when compared to the [corresponding docs site page](https://opensource.adobe.com/spectrum-css/coachindicator.html)
- [ ] Ensure the Chromatic testing view captures all new variants.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
