### PR TITLE
docs(combobox,contextualhelp,datepicker): site docs to storybook

### DIFF
--- a/components/combobox/CHANGELOG.md
+++ b/components/combobox/CHANGELOG.md
@@ -643,3 +643,12 @@ there, but it was missing a control for testing.
 🗓 2023-03-28
 
 **Note:** Version bump only for package @spectrum-css/combobox
+
+### Component separated from InputGroup
+
+Combobox was previously a variant style for InputGroup. **InputGroup is deprecated**. The classes listed below containing `InputGroup` have been renamed or removed:
+
+- `.spectrum-InputGroup-textfield` -> `.spectrum-Combobox-textfield`
+- `.spectrum-InputGroup-input` -> `.spectrum-Combobox-input`
+- `.spectrum-InputGroup-button` -> `.spectrum-Combobox-button`
+- `.InputGroup` -> removed

--- a/components/combobox/stories/combobox.mdx
+++ b/components/combobox/stories/combobox.mdx
@@ -15,13 +15,6 @@ import * as ComboboxStories from './combobox.stories';
   - `.spectrum-Combobox-input` is required on the `<input>` element inside of Textfields (`.spectrum-Textfield-input`)
   - `.spectrum-Combobox-button` is required on the FieldButton (`.spectrum-ActionButton spectrum-ActionButton--sizeM`)
 
-### Component separated from InputGroup
-This component was previously a variant style for InputGroup. **InputGroup is deprecated**. The classes listed below containing `InputGroup` have been renamed or removed:
-- `.spectrum-InputGroup-textfield` -> `.spectrum-Combobox-textfield`
-- `.spectrum-InputGroup-input` -> `.spectrum-Combobox-input`
-- `.spectrum-InputGroup-button` -> `.spectrum-Combobox-button`
-- `.InputGroup` -> removed
-
 ### Indicating validity and focus
 Validity and focus must be bubbled up to the parent so descendants siblings can be styled. Implementations should add the following classes to the `.spectrum-Combobox` parent class in the following situations:
 

--- a/components/combobox/stories/combobox.mdx
+++ b/components/combobox/stories/combobox.mdx
@@ -1,0 +1,89 @@
+import { Canvas, ArgTypes, Meta, Description, Title } from '@storybook/blocks';
+
+import * as ComboboxStories from './combobox.stories';
+
+<Meta of={ComboboxStories} title="Docs" />
+
+<Title of={ComboboxStories} />
+<Description of={ComboboxStories} />
+
+## Usage notes
+### General notes
+- Combobox uses `.spectrum-PickerButton` instead of a `.spectrum-Picker`
+- The following classes must be added:
+  - `.spectrum-Combobox-textfield` is required on the Textfield outer element (`.spectrum-Textfield`)
+  - `.spectrum-Combobox-input` is required on the `<input>` element inside of Textfields (`.spectrum-Textfield-input`)
+  - `.spectrum-Combobox-button` is required on the FieldButton (`.spectrum-ActionButton spectrum-ActionButton--sizeM`)
+
+### Component separated from InputGroup
+This component was previously a variant style for InputGroup. **InputGroup is deprecated**. The classes listed below containing `InputGroup` have been renamed or removed:
+- `.spectrum-InputGroup-textfield` -> `.spectrum-Combobox-textfield`
+- `.spectrum-InputGroup-input` -> `.spectrum-Combobox-input`
+- `.spectrum-InputGroup-button` -> `.spectrum-Combobox-button`
+- `.InputGroup` -> removed
+
+### Indicating validity and focus
+Validity and focus must be bubbled up to the parent so descendants siblings can be styled. Implementations should add the following classes to the `.spectrum-Combobox` parent class in the following situations:
+
+- `.is-focused` - when the input or button is focused with the mouse
+- `.is-keyboardFocused` - when the input or button is focused with the keyboard
+- `.is-valid` - when the input has an explicit valid state
+- `.is-invalid` - when the input has an explicit invalid state
+- `.is-disabled` - when the control is disabled; should also add to the `.spectrum-Combobox-textfield` and include a `[disabled]` attribute to the `.spectrum-Combobox-button`
+- `.is-loading` - when the progress circle is being shown
+
+## Standard variants
+
+### Standard - open
+
+<Canvas of={ComboboxStories.Default} />
+
+### Standard - with label
+
+<Canvas of={ComboboxStories.WithLabel} />
+
+### Standard - closed
+
+<Canvas of={ComboboxStories.Closed} />
+
+### Standard - invalid
+
+<Canvas of={ComboboxStories.Invalid} />
+
+### Standard - loading
+
+<Canvas of={ComboboxStories.Loading} />
+
+### Standard - disabled
+
+<Canvas of={ComboboxStories.Disabled} />
+
+## Quiet variants
+
+### Quiet - open
+
+<Canvas of={ComboboxStories.Quiet} />
+
+### Quiet - with label
+
+<Canvas of={ComboboxStories.QuietWithLabel} />
+
+### Quiet - closed
+
+<Canvas of={ComboboxStories.QuietClosed} />
+
+### Quiet - invalid
+
+<Canvas of={ComboboxStories.QuietInvalid} />
+
+### Quiet - loading
+
+<Canvas of={ComboboxStories.QuietLoading} />
+
+### Quiet - disabled
+
+<Canvas of={ComboboxStories.QuietDisabled} />
+
+## Properties
+
+<ArgTypes />

--- a/components/combobox/stories/combobox.stories.js
+++ b/components/combobox/stories/combobox.stories.js
@@ -165,7 +165,7 @@ export default {
 		},
 		docs: {
 			story: {
-				height: "200px"
+				height: "220px"
 			}
 		},
 	},
@@ -245,4 +245,108 @@ export const Quiet = (args) => window.isChromatic()
 	});
 Quiet.args = {
 	isQuiet: true,
+};
+
+/**
+ * Stories for the MDX "Docs" only.
+ */
+
+// Standard
+export const WithLabel = Template.bind({});
+WithLabel.tags = ["docs-only"];
+WithLabel.args = {
+	showFieldLabel: true,
+	fieldLabelText: "Country",
+	isOpen: true,
+};
+WithLabel.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+export const Closed = Template.bind({});
+Closed.tags = ["docs-only"];
+Closed.args = {
+	isOpen: false,
+};
+Closed.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+export const Invalid = Template.bind({});
+Invalid.tags = ["docs-only"];
+Invalid.args = {
+	isInvalid: true,
+};
+Invalid.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+export const Loading = Template.bind({});
+Loading.tags = ["docs-only"];
+Loading.args = {
+	isLoading: true,
+};
+Loading.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+export const Disabled = Template.bind({});
+Disabled.tags = ["docs-only"];
+Disabled.args = {
+	isDisabled: true,
+};
+Disabled.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+// Quiet
+export const QuietWithLabel = Template.bind({});
+QuietWithLabel.tags = ["docs-only"];
+QuietWithLabel.args = {
+	showFieldLabel: true,
+	fieldLabelText: "Country",
+	isQuiet: true,
+};
+QuietWithLabel.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+export const QuietClosed = Template.bind({});
+QuietClosed.tags = ["docs-only"];
+QuietClosed.args = {
+	isQuiet: true,
+	isOpen: false,
+};
+QuietClosed.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+export const QuietInvalid = Template.bind({});
+QuietInvalid.tags = ["docs-only"];
+QuietInvalid.args = {
+	isQuiet: true,
+	isInvalid: true,
+};
+QuietInvalid.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+export const QuietLoading = Template.bind({});
+QuietLoading.tags = ["docs-only"];
+QuietLoading.args = {
+	isQuiet: true,
+	isLoading: true,
+};
+QuietLoading.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+export const QuietDisabled = Template.bind({});
+QuietDisabled.tags = ["docs-only"];
+QuietDisabled.args = {
+	isQuiet: true,
+	isDisabled: true,
+};
+QuietDisabled.parameters = {
+	chromatic: { disableSnapshot: true },
 };

--- a/components/contextualhelp/stories/contextualhelp.mdx
+++ b/components/contextualhelp/stories/contextualhelp.mdx
@@ -1,0 +1,40 @@
+import { Canvas, ArgTypes, Meta, Description, Title } from '@storybook/blocks';
+
+import * as ContextualHelpStories from './contextualhelp.stories';
+
+<Meta of={ContextualHelpStories} title="Docs" />
+
+<Title of={ContextualHelpStories} />
+<Description of={ContextualHelpStories} />
+
+## Info icon variants
+
+### Info icon - standard
+
+<Canvas of={ContextualHelpStories.Default} />
+
+### Info icon - with link
+
+<Canvas of={ContextualHelpStories.WithLink} />
+
+### Info icon - top popover
+
+<Canvas of={ContextualHelpStories.TopPopover} />
+
+## Help icon variants
+
+### Help icon - standard
+
+<Canvas of={ContextualHelpStories.HelpDefault} />
+
+### Help icon - with link
+
+<Canvas of={ContextualHelpStories.HelpWithLink} />
+
+### Help icon - top popover
+
+<Canvas of={ContextualHelpStories.HelpTopPopover} />
+
+## Properties
+
+<ArgTypes />

--- a/components/contextualhelp/stories/contextualhelp.stories.js
+++ b/components/contextualhelp/stories/contextualhelp.stories.js
@@ -88,6 +88,11 @@ export default {
 		status: {
 			type: "migrated",
 		},
+		docs: {
+			story: {
+				height: "200px",
+			},
+		},
 	},
 };
 
@@ -113,4 +118,46 @@ TopPopover.args = {
 	customStyles: { "max-inline-size": "275px" },
 	title: "Top popover example of text wrapping in the title",
 	body: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+};
+
+/**
+ * Stories for the MDX "Docs" only.
+ */
+export const HelpDefault = Template.bind({});
+HelpDefault.args = {
+	title: "Permission required",
+	body: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+	iconName: "Help",
+};
+HelpDefault.tags = ["docs-only"];
+HelpDefault.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+export const HelpWithLink = Template.bind({});
+HelpWithLink.args = {
+	title: "Permission required",
+	body: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+	link: {
+		text: "Learn about permissions",
+		url: "#",
+	},
+	iconName: "Help",
+};
+HelpWithLink.tags = ["docs-only"];
+HelpWithLink.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+export const HelpTopPopover = Template.bind({});
+HelpTopPopover.args = {
+	popoverPlacement: "top",
+	customStyles: { "max-inline-size": "275px" },
+	title: "Top popover example of text wrapping in the title",
+	body: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+	iconName: "Help",
+};
+HelpTopPopover.tags = ["docs-only"];
+HelpTopPopover.parameters = {
+	chromatic: { disableSnapshot: true },
 };

--- a/components/datepicker/CHANGELOG.md
+++ b/components/datepicker/CHANGELOG.md
@@ -627,3 +627,20 @@ Additionally:
 🗓 2023-03-28
 
 **Note:** Version bump only for package @spectrum-css/datepicker
+
+### Component separated from InputGroup
+
+Date picker was previously a variant within InputGroup. **InputGroup is deprecated**.
+
+These classes containing `InputGroup` have been renamed:
+
+- `.spectrum-Datepicker` -> `.spectrum-DatePicker`
+- `.spectrum-InputGroup-textfield` -> `.spectrum-DatePicker-textfield`
+- `.spectrum-InputGroup-input` -> `.spectrum-DatePicker-input`
+- `.spectrum-InputGroup-button` -> `.spectrum-DatePicker-button`
+- `.spectrum-Datepicker--rangeDash` -> `.spectrum-DatePicker-rangeDash`
+
+And these have been removed:
+
+- `.InputGroup` should be removed from the parent element
+- `.spectrum-Datepicker-focusRing` should be removed

--- a/components/datepicker/stories/datepicker.mdx
+++ b/components/datepicker/stories/datepicker.mdx
@@ -12,21 +12,6 @@ import * as DatePickerStories from './datepicker.stories';
 - Date picker uses `.spectrum-PickerButton` instead of a `.spectrum-Picker`.
 - Workflow icon size is medium. If your markup is still using the small icon, replace `.spectrum-Icon--sizeS` with `.spectrum-Icon--sizeM`.
 
-### Component separated from InputGroup
-This component was previously a variant within InputGroup. **InputGroup is deprecated**.
-
-These classes containing `InputGroup` have been renamed:
-
-- `.spectrum-Datepicker` -> `.spectrum-DatePicker`
-- `.spectrum-InputGroup-textfield` -> `.spectrum-DatePicker-textfield`
-- `.spectrum-InputGroup-input` -> `.spectrum-DatePicker-input`
-- `.spectrum-InputGroup-button` -> `.spectrum-DatePicker-button`
-- `.spectrum-Datepicker--rangeDash` -> `.spectrum-DatePicker-rangeDash`
-
-And these have been removed:
-- `.InputGroup` should be removed from the parent element
-- `.spectrum-Datepicker-focusRing` should be removed
-
 ## Standard
 
 <Canvas of={DatePickerStories.Default} />

--- a/components/datepicker/stories/datepicker.mdx
+++ b/components/datepicker/stories/datepicker.mdx
@@ -1,0 +1,76 @@
+import { Canvas, ArgTypes, Meta, Description, Title } from '@storybook/blocks';
+
+import * as DatePickerStories from './datepicker.stories';
+
+<Meta of={DatePickerStories} title="Docs" />
+
+<Title of={DatePickerStories} />
+<Description of={DatePickerStories} />
+
+## Usage notes
+### General notes
+- Date picker uses `.spectrum-PickerButton` instead of a `.spectrum-Picker`.
+- Workflow icon size is medium. If your markup is still using the small icon, replace `.spectrum-Icon--sizeS` with `.spectrum-Icon--sizeM`.
+
+### Component separated from InputGroup
+This component was previously a variant within InputGroup. **InputGroup is deprecated**.
+
+These classes containing `InputGroup` have been renamed:
+
+- `.spectrum-Datepicker` -> `.spectrum-DatePicker`
+- `.spectrum-InputGroup-textfield` -> `.spectrum-DatePicker-textfield`
+- `.spectrum-InputGroup-input` -> `.spectrum-DatePicker-input`
+- `.spectrum-InputGroup-button` -> `.spectrum-DatePicker-button`
+- `.spectrum-Datepicker--rangeDash` -> `.spectrum-DatePicker-rangeDash`
+
+And these have been removed:
+- `.InputGroup` should be removed from the parent element
+- `.spectrum-Datepicker-focusRing` should be removed
+
+## Standard
+
+<Canvas of={DatePickerStories.Default} />
+
+## Quiet
+
+<Canvas of={DatePickerStories.Quiet} />
+
+## Range
+
+### Standard
+
+<Canvas of={DatePickerStories.Range} />
+
+### Quiet
+
+<Canvas of={DatePickerStories.QuietRange} />
+
+## Invalid
+
+### Standard
+
+<Canvas of={DatePickerStories.Invalid} />
+
+### Quiet
+
+<Canvas of={DatePickerStories.QuietInvalid} />
+
+## Read-only
+
+Read-only displays the same for standard and quiet variants.
+
+<Canvas of={DatePickerStories.ReadOnly} />
+
+## Disabled
+
+### Standard
+
+<Canvas of={DatePickerStories.Disabled} />
+
+### Quiet
+
+<Canvas of={DatePickerStories.QuietDisabled} />
+
+## Properties
+
+<ArgTypes />

--- a/components/datepicker/stories/datepicker.stories.js
+++ b/components/datepicker/stories/datepicker.stories.js
@@ -5,7 +5,7 @@ import { default as CalendarStories } from "@spectrum-css/calendar/stories/calen
 const ignoreProps = ["rootClass", "isDisabled"];
 
 /**
- * A date picker displays a text field input with a button next to it, and can display two Text Fields next to each other for choosing a date range.
+ * A date picker displays a text field input with a button next to it, and can display two text fields next to each other for choosing a date range.
  */
 export default {
 	title: "Components/Date picker",
@@ -149,3 +149,108 @@ Range.args = {
 	isRange: true,
 	isOpen: false,
 };
+
+/**
+ * Stories for the MDX "Docs" only.
+ */
+export const QuietRange = Template.bind({});
+QuietRange.args = {
+	month: "March",
+	selectedDay: 1,
+	year: 2023,
+	lastDay: 3,
+	content: [{}],
+	isRange: true,
+	isQuiet: true,
+	isOpen: false,
+};
+QuietRange.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+QuietRange.tags = ["docs-only"];
+
+export const ReadOnly = Template.bind({});
+ReadOnly.args = {
+	readOnly: true,
+	month: "March",
+	selectedDay: 1,
+	year: 2023,
+	content: [{}],
+};
+ReadOnly.parameters = {
+	chromatic: { disableSnapshot: true },
+	docs: {
+		story: {
+			height: "60px",
+		}
+	}
+};
+ReadOnly.tags = ["docs-only"];
+
+export const Invalid = Template.bind({});
+Invalid.args = {
+	isInvalid: true,
+	month: "March",
+	selectedDay: 1,
+	year: 2023,
+	content: [{}],
+	isOpen: false,
+};
+Invalid.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+Invalid.tags = ["docs-only"];
+
+export const QuietInvalid = Template.bind({});
+QuietInvalid.args = {
+	isInvalid: true,
+	month: "March",
+	selectedDay: 1,
+	year: 2023,
+	content: [{}],
+	isQuiet: true,
+	isOpen: false,
+};
+QuietInvalid.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+QuietInvalid.tags = ["docs-only"];
+
+
+export const Disabled = Template.bind({});
+Disabled.args = {
+	isDisabled: true,
+	month: "March",
+	selectedDay: 1,
+	year: 2023,
+	content: [{}],
+};
+Disabled.parameters = {
+	chromatic: { disableSnapshot: true },
+	docs: {
+		story: {
+			height: "60px",
+		}
+	}
+};
+Disabled.tags = ["docs-only"];
+
+export const QuietDisabled = Template.bind({});
+QuietDisabled.args = {
+	isDisabled: true,
+	month: "March",
+	selectedDay: 1,
+	year: 2023,
+	content: [{}],
+	isQuiet: true,
+};
+QuietDisabled.parameters = {
+	chromatic: { disableSnapshot: true },
+	docs: {
+		story: {
+			height: "60px",
+		}
+	}
+};
+QuietDisabled.tags = ["docs-only"];
+

--- a/components/datepicker/stories/template.js
+++ b/components/datepicker/stories/template.js
@@ -103,23 +103,25 @@ export const Template = ({
 					updateArgs({ isOpen: !isOpen });
 				},
 			})}
-			${Popover({
-				...globals,
-				isOpen: isOpen && !isDisabled && !readOnly,
-				withTip: false,
-				position: "bottom",
-				isQuiet,
-				customStyles: isOpen
-					? {
-							position: "absolute",
-							top: "100%",
-							left: "0",
-							width: undefined,
-					}
-					: {},
-				content: [Calendar(globals)],
-				// @todo this implementation of calendar does not currently display range selections or selected date on first load
-			})}
+			${when(!readOnly && !isDisabled, () => html`
+				${Popover({
+					...globals,
+					isOpen: isOpen && !isDisabled && !readOnly,
+					withTip: false,
+					position: "bottom",
+					isQuiet,
+					customStyles: isOpen
+						? {
+								position: "absolute",
+								top: "100%",
+								left: "0",
+								width: undefined,
+						}
+						: {},
+					content: [Calendar(globals)],
+					// @todo this implementation of calendar does not currently display range selections or selected date on first load
+				})}`
+			)}
 		</div>
 	`;
 };


### PR DESCRIPTION
## Description

This migrates the documentation from the deprecated docs site over to Storybook, including showing the variants on the Storybook Docs page.

Combobox, Contextual help, and Date picker all got new MDX pages and some MDX-only stories.

This PR doesn't need a changeset since it's docs-only.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
- [x] The [Combobox storybook docs](https://pr-2794--spectrum-css.netlify.app/preview/?path=/docs/components-combobox--docs) include all necessary info when compared to the [docs site](https://opensource.adobe.com/spectrum-css/combobox.html) @marissahuysentruyt 
- [x] The [Contextualhelp storybook docs](https://pr-2794--spectrum-css.netlify.app/preview/?path=/docs/components-contextual-help--docs) include all necessary info when compared to the [docs site](https://opensource.adobe.com/spectrum-css/contextualhelp.html) @marissahuysentruyt 
- [x] The [Datepicker storybook docs](https://pr-2794--spectrum-css.netlify.app/preview/?path=/docs/components-date-picker--docs) include all necessary info when compared to the [docs site](https://opensource.adobe.com/spectrum-css/datepicker.html) @marissahuysentruyt 
  - Note that these MDX previews look a bit big, but it's to accommodate the edge case of someone expanding the datepicker so they can see the whole thing

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.


## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨