### PR TITLE
docs(icon): storybook documentation page

### DIFF
--- a/components/icon/stories/icon.mdx
+++ b/components/icon/stories/icon.mdx
@@ -1,0 +1,66 @@
+import { Canvas, ArgTypes, Meta, Description, Title } from '@storybook/blocks';
+
+import * as IconStories from './icon.stories';
+
+<Meta of={IconStories} title="Docs" />
+
+<Title of={IconStories} />
+<Description of={IconStories} />
+
+## Icon sets
+
+The SVG icons used in Spectrum CSS are a part of two different icon sets, "workflow" and "ui". The two sets have different uses and methods of sizing.
+
+### Workflow icons
+
+The workflow icon set contains several hundred icons to choose from.
+These icons can be seen in use within Button, Action button, Menu, and many other components. 
+Here is an example with just a few of these icons:
+
+<Canvas of={IconStories.WorkflowDefault} />
+
+These icons use "t-shirt" sizes (e.g. small, medium), that are the same width and height for each icon in the set:
+
+<Canvas of={IconStories.WorkflowSizing} />
+
+### UI icons
+
+UI icons are atomic pieces (e.g., arrows, crosses, etc.) that are used as part of some components. The chevron within
+the [Combobox component](?path=/docs/components-combobox--docs) is one example.
+
+Unlike workflow icons, each UI icon comes in specific numbered sizes. They do not use "t-shirt" sizing.
+They have unique classes applied that set their size in CSS. For example:
+
+  - `.spectrum-UIIcon-Asterisk300`
+  - `.spectrum-UIIcon-ChevronDown75`
+
+Different UI icons have different number sizes available. The smallest size for some may be "50", while others may start at "100". Some have up to a "600" size.
+Some may only have two different sizes, while others have six. Because of this, they can't be mapped one to one to t-shirt sizes. The correct UI icon sizes to use for each of a component's
+size options is typically defined on the design spec.
+
+An example of some UI icons in their available sizes:
+
+<Canvas of={IconStories.UIDefault} />
+
+Directional UI icons such as Chevron and Arrow have classes for each direction. They rotate the same base icon with a CSS `transform: rotate`. For example, the `Arrow100.svg` icon is used
+with:
+
+- `.spectrum-UIIcon-ArrowRight100`
+- `.spectrum-UIIcon-ArrowLeft100`
+- `.spectrum-UIIcon-ArrowDown100`
+- `.spectrum-UIIcon-ArrowUp100`
+
+<Canvas of={IconStories.UIArrows} />
+
+## Repositories for the icon SVG files
+
+The UI icon SVGs are within the Spectrum CSS repository, which has its own package published to NPM:
+  - GitHub: [adobe/spectrum-css — ui-icons folder](https://github.com/adobe/spectrum-css/tree/main/ui-icons)
+  - NPM: [@spectrum-css/ui-icons](https://www.npmjs.com/package/@spectrum-css/ui-icons).
+
+The workflow icon SVGs are within a separate respository, which is also published to NPM:
+  - GitHub: [adobe/spectrum-css-workflow-icons](https://github.com/adobe/spectrum-css-workflow-icons)
+  - NPM: [@adobe/spectrum-css-workflow-icons](https://www.npmjs.com/package/@adobe/spectrum-css-workflow-icons).
+
+## Properties
+<ArgTypes />

--- a/components/icon/stories/icon.stories.js
+++ b/components/icon/stories/icon.stories.js
@@ -2,6 +2,7 @@ import { html } from "lit";
 import { styleMap } from "lit/directives/style-map.js";
 import { when } from "lit/directives/when.js";
 
+import { Template as Typography } from "@spectrum-css/typography/stories/template.js";
 import { Template } from "./template";
 import { uiIconSizes, uiIconsWithDirections, workflowIcons } from "./utilities.js";
 
@@ -22,7 +23,7 @@ const uiIconNameOptions = uiIconsWithDirections.map((iconName) => {
 }).flat();
 
 /**
- * The icons component contains all UI icons used for components as well as the CSS for UI and workflow icons.
+ * The Icon component contains all of the CSS used for displaying both workflow and UI icons.
  */
 export default {
 	title: "Icon",
@@ -162,3 +163,194 @@ const TestTemplate = (args) => html`
 		)}
 	</div>
 `;
+
+/**
+ * Display all icon sizes for the Docs page.
+ */
+const WorkflowSizingTemplate = (args) => html`
+	<div
+		style=${styleMap({
+			"display": "flex",
+			"gap": "24px",
+			"flexWrap": "wrap",
+		})}
+	>
+		${["xs","s","m","l","xl"].map(
+			(size) => html`
+				<div
+					style=${styleMap({
+						"display": "flex",
+						"gap": "16px",
+						"flexDirection": "column",
+						"alignItems": "center",
+						"flexBasis": "80px",
+					})}
+				>
+					${Typography({
+						semantics: "detail",
+						size: "s",
+						content: [
+							{
+								xs: "Extra-small",
+								s: "Small",
+								m: "Medium",
+								l: "Large",
+								xl: "Extra-large",
+							}[size],
+						],
+						customStyles: {
+							"white-space": "nowrap",
+							"--mod-detail-font-color": "var(--spectrum-seafoam-900)",
+						}
+					})}
+					${Template({ ...args, size })}
+				</div>
+			`
+		)}
+	</div>
+`;
+
+
+/**
+ * Helper template function to display multiple icons using an array of icon names.
+ */
+const IconListTemplate = (args, iconsList = []) => html`
+	<div
+		style=${styleMap({
+			"display": "flex",
+			"gap": "32px",
+			"flexWrap": "wrap",
+		})}
+	>
+		${iconsList.map(
+			(iconName) => Template({
+				...args,
+				iconName,
+			})
+		)}
+	</div>
+`;
+
+/**
+ * Display examples of multiple workflow icons.
+ */
+const WorkflowDefaultTemplate = (args) => html`
+	${IconListTemplate(
+		{
+			...args,
+			setName: "workflow",
+			size: "xl",
+		}, 
+		[
+			"Alert",
+			"Asset",
+			"Actions",
+			"ArrowDown",
+			"Camera",
+			"Copy",
+			"DeviceDesktop",
+			"Download",
+			"FilterAdd",
+			"Form",
+			"Light",
+			"Polygon",
+		]
+	)}
+`;
+
+/**
+ * Display examples of all directions of a single UI arrow.
+ */
+const UIArrowsTemplate = (args) => html`
+	${IconListTemplate(
+		{
+			...args,
+			setName: "ui",
+		},
+		[
+			"ArrowRight100",
+			"ArrowLeft100",
+			"ArrowDown100",
+			"ArrowUp100",
+		]
+	)}
+`;
+
+/**
+ * Display examples of multiple UI icons.
+ */
+const UIDefaultTemplate = (args) => html`
+	<div style="margin-bottom: 32px;">
+		${IconListTemplate(
+			{
+				...args,
+				setName: "ui",
+			},  
+			[
+				"Asterisk100",
+				"Asterisk200",
+				"Asterisk300",
+			]
+		)}
+	</div>
+	<div>
+		${IconListTemplate(
+			{
+				...args,
+				setName: "ui",
+			}, 
+			[
+				"ChevronDown50",
+				"ChevronDown75",
+				"ChevronDown100",
+				"ChevronDown200",
+				"ChevronDown300",
+				"ChevronDown400",
+			]
+		)}
+	</div>
+`;
+
+/* Stories for the MDX "Docs" only. */
+
+/**
+ * A sampling of multiple Workflow icons.
+ */
+export const WorkflowDefault = WorkflowDefaultTemplate.bind({});
+WorkflowDefault.tags = ["docs-only"];
+WorkflowDefault.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+/**
+ * An example of a Workflow icon displayed at all sizes, from small to extra-large.
+ */
+export const WorkflowSizing = WorkflowSizingTemplate.bind({});
+WorkflowSizing.tags = ["docs-only"];
+WorkflowSizing.args = {
+	setName: "workflow",
+	iconName: "Asset",
+};
+WorkflowSizing.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+/**
+ * A sampling of a few UI icons.
+ */
+export const UIDefault = UIDefaultTemplate.bind({});
+UIDefault.storyName = "UI Default";
+UIDefault.tags = ["docs-only"];
+UIDefault.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+/**
+ * A UI arrow displayed for all directions (left, right, up, down).
+ */
+export const UIArrows = UIArrowsTemplate.bind({});
+UIArrows.storyName = "UI Arrows";
+UIArrows.tags = ["docs-only"];
+UIArrows.parameters = {
+	chromatic: { disableSnapshot: true },
+};


### PR DESCRIPTION
## Description

Creates an MDX documentation page for the Icon component. Icon previously did not have a page on the docs site. This documentation covers some of the important info uncovered during some of the more recent icons work. It helps to explain the different icon sets, how they are used, and how they are sized differently.

CSS-671
CSS-759

_Note: a changeset should not be required, as this is a docs only update._

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

- [ ] Review the [Icons "Docs" page in Storybook](https://64762974a45b8bc5ca1705a2-hdngkhwrhf.chromatic.com/?path=/docs/components-icon--docs)

### Regression testing

N/A for this PR.

## Screenshots

![Screenshot 2024-05-30 at 2 40 19 PM](https://github.com/adobe/spectrum-css/assets/965114/7c39e7e0-e7d9-4ead-ac4e-ebfef19dd6c2)

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
