### PR TITLE
chore: remove duplicate express import from templates

### DIFF
--- a/.storybook/guides/develop.mdx
+++ b/.storybook/guides/develop.mdx
@@ -76,17 +76,6 @@ CSS assets will be run through their respective postcss configurations. This mea
   import "../index.css";
   ```
 
-If you need to load an asset in your template based on storybook configurations, you can do so using dynamic imports and a webpackPrefetch flag (to prevent FOUC). These will follow the same compilation rules as noted above. i.e.,
-
-  ```js
-  try {
-   if (!express) import(/* webpackPrefetch: true */ "../themes/spectrum.css");
-   else import(/* webpackPrefetch: true */ "../themes/express.css");
-  } catch (e) {
-   console.warn(e);
-  }
-  ```
-
 We are leaning on Storybook's `@storybook/web-components-webpack5` framework configuration as our stories rely on lit for dynamic attribute assignment.
 
 ### Add-ons
@@ -272,7 +261,6 @@ All return values for Template functions should be outputting TemplateResults. S
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
-
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 import { Template as Avatar } from "@spectrum-css/avatar/stories/template.js";
 import { Template as ClearButton } from "@spectrum-css/clearbutton/stories/template.js";
@@ -294,29 +282,21 @@ export const Template = ({
  customClasses = [],
  ...globals
 }) => {
- const { express } = globals;
-
- try {
-  if (!express) import(/* webpackPrefetch: true */ "../themes/spectrum.css");
-  else import(/* webpackPrefetch: true */ "../themes/express.css");
- } catch (e) {
-  console.warn(e);
- }
-
  return html`
   <div
-   class=${classMap({
-    [rootClass]: true,
-    [`${rootClass}--size${size?.toUpperCase()}`]:
-     typeof size !== "undefined",
-    "is-emphasized": isEmphasized,
-    "is-disabled": isDisabled,
-    "is-invalid": isInvalid,
-    "is-selected": isSelected,
-    ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
-   })}
-   id=${ifDefined(id)}
-   tabindex="0"
+    class=${classMap({
+      [rootClass]: true,
+      [`${rootClass}--size${size?.toUpperCase()}`]:
+      typeof size !== "undefined",
+      "is-emphasized": isEmphasized,
+      "is-disabled": isDisabled,
+      "is-invalid": isInvalid,
+      "is-selected": isSelected,
+      ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
+    })}
+    id=${ifDefined(id)}
+    tabindex=${isDisabled ? "-1" : "0"}
+    style=${ifDefined(styleMap(customStyles))}
   >
    ${avatarUrl && !iconName
     ? Avatar({

--- a/components/button/stories/button.stories.js
+++ b/components/button/stories/button.stories.js
@@ -476,7 +476,14 @@ StaticBlack.args = {
 	staticColor: "black",
 };
 
+export const Express = Variants.bind();
+Express.tags = ["vrt-only"];
+Express.args = {
+	express: true,
+};
+
 export const WithForcedColors = Variants.bind({});
+WithForcedColors.tags = ["vrt-only"];
 WithForcedColors.parameters = {
 	chromatic: { forcedColors: "active" },
 };

--- a/components/button/stories/template.js
+++ b/components/button/stories/template.js
@@ -37,15 +37,6 @@ export const Template = ({
 	ariaControls,
 	...globals
 }) => {
-	const { express } = globals;
-	try {
-		if (express) import(/* webpackPrefetch: true */ "../themes/express.css");
-		else import(/* webpackPrefetch: true */ "../themes/spectrum.css");
-	}
-	catch (e) {
-		console.warn(e);
-	}
-
 	const [, updateArgs] = useArgs();
 
 	return html`

--- a/components/icon/stories/icon.stories.js
+++ b/components/icon/stories/icon.stories.js
@@ -28,8 +28,6 @@ export default {
 	title: "Components/Icon",
 	component: "Icon",
 	argTypes: {
-		/* Turn off express theme for icon preview b/c they use a separate icon set */
-		express: { table: { disable: true } },
 		reducedMotion: { table: { disable: true } },
 		size: {
 			name: "Workflow Icon Size",

--- a/components/picker/stories/picker.stories.js
+++ b/components/picker/stories/picker.stories.js
@@ -1,7 +1,6 @@
-import { html } from "lit";
-
 import { Default as MenuStories } from "@spectrum-css/menu/stories/menu.stories.js";
-
+import { html } from "lit";
+import { styleMap } from "lit/directives/style-map.js";
 import { Template } from "./template";
 
 /**
@@ -127,6 +126,9 @@ export default {
 		isInvalid: false,
 		isOpen: false,
 		withSwitch: false,
+		content: [
+			() => MenuStories(MenuStories.args)
+		],
 	},
 	parameters: {
 		actions: {
@@ -145,7 +147,10 @@ export default {
 
 
 const ChromaticPickerGroup = (args) => html`
-	<div style="display: grid; gap: 20px;">
+	<div style=${styleMap({
+		"display": window.isChromatic() ? "grid" : "none",
+		"gap": "20px",
+	})}>
 		<div>
 			${Template({
 				labelPosition: "top",
@@ -234,30 +239,31 @@ const ChromaticPickerGroup = (args) => html`
 			})}
 		</div>
 	</div>
+	<div style=${styleMap({
+		"display": window.isChromatic() ? "none" : undefined,
+	})}>
+		${Template(args)}
+	</div>
 `;
 
-export const Default = (args) => window.isChromatic() ? ChromaticPickerGroup(args) : Template(args);
-Default.args = {
-	content: [
-		() => MenuStories(MenuStories.args)
-	],
-};
+export const Default = ChromaticPickerGroup.bind({});
+Default.args = {};
 
 export const Open = Template.bind({});
 Open.args = {
 	isOpen: true,
-	content: [
-		() => MenuStories(MenuStories.args)
-	],
 };
 
-export const WithForcedColors = (args) => window.isChromatic() ? ChromaticPickerGroup(args) : Template(args);
+export const Express = ChromaticPickerGroup.bind({});
+Express.tags = ["vrt-only"];
+Express.args = {
+	express: true,
+};
+
+export const WithForcedColors = ChromaticPickerGroup.bind({});
+WithForcedColors.tags = ["vrt-only"];
 WithForcedColors.parameters = {
 	// Sets the forced-colors media feature for a specific story.
 	chromatic: { forcedColors: "active" },
 };
-WithForcedColors.args = {
-	content: [
-		() => MenuStories(MenuStories.args)
-	]
-};
+WithForcedColors.args = {};

--- a/components/picker/stories/template.js
+++ b/components/picker/stories/template.js
@@ -31,15 +31,6 @@ export const Picker = ({
 }) => {
 	const [, updateArgs] = useArgs();
 
-	const { express } = globals;
-	try {
-		if (!express) import(/* webpackPrefetch: true */ "../themes/spectrum.css");
-		else import(/* webpackPrefetch: true */ "../themes/express.css");
-	}
-	catch (e) {
-		console.warn(e);
-	}
-
 	return html`
 	<button
 			class=${classMap({
@@ -111,15 +102,6 @@ export const Template = ({
 	id,
 	...globals
 }) => {
-	const { express } = globals;
-	try {
-		if (!express) import(/* webpackPrefetch: true */ "../themes/spectrum.css");
-		else import(/* webpackPrefetch: true */ "../themes/express.css");
-	}
-	catch (e) {
-		console.warn(e);
-	}
-
 	let iconName = "ChevronDown200";
 	switch (size) {
 		case "s":

--- a/components/rating/stories/rating.stories.js
+++ b/components/rating/stories/rating.stories.js
@@ -103,3 +103,9 @@ export const Disabled = Template.bind({});
 Disabled.args = {
 	isDisabled: true,
 };
+
+export const Express = Template.bind({});
+Express.tags = ["vrt-only"];
+Express.args = {
+	express: true,
+};

--- a/components/rating/stories/template.js
+++ b/components/rating/stories/template.js
@@ -21,15 +21,6 @@ export const Template = ({
 	id,
 	...globals
 }) => {
-	const { express } = globals;
-	try {
-		if (express) import(/* webpackPrefetch: true */ "../themes/express.css");
-		else import(/* webpackPrefetch: true */ "../themes/spectrum.css");
-	}
-	catch (e) {
-		console.warn(e);
-	}
-
 	const [, updateArgs] = useArgs();
 
 	return html`


### PR DESCRIPTION
## Description

Express styles are loaded into Storybook from the index.css export and toggled through the .spectrum--express class.  The themes/express.css assets do not need to be imported at the template level (this is a duplicate action).

## How and where has this been tested?

### Validation steps

- [x] Expect to see no regressions after removing the imports from `button`, `icon`, `picker`, `rating`

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] ✨ This pull request is ready to merge. ✨
