### PR TITLE
chore(storybook): set up automatic categorization

### DIFF
--- a/.storybook/deprecated/cyclebutton/cyclebutton.stories.js
+++ b/.storybook/deprecated/cyclebutton/cyclebutton.stories.js
@@ -13,7 +13,7 @@ import "@spectrum-css/cyclebutton/dist/vars.css";
  * The cycle button component is an action button that cycles through two different icons, a play that then changes to a pause, for example.
  */
 export default {
-	title: "Deprecated/Cycle button",
+	title: "Cycle button",
 	component: "CycleButton",
 	argTypes: {
 		size: ActionButtonStories?.argTypes?.size ?? {},

--- a/.storybook/deprecated/quickaction/quickaction.stories.js
+++ b/.storybook/deprecated/quickaction/quickaction.stories.js
@@ -11,7 +11,7 @@ import "@spectrum-css/quickaction/dist/vars.css";
  * **This component is deprecated.** Please use an action bar to allow users to perform actions on either a single or multiple items at the same time, instead.
  */
 export default {
-	title: "Deprecated/Quick actions",
+	title: "Quick actions",
 	component: "QuickAction",
 	argTypes: {
 		content: { table: { disable: true } },

--- a/.storybook/deprecated/searchwithin/searchwithin.stories.js
+++ b/.storybook/deprecated/searchwithin/searchwithin.stories.js
@@ -17,7 +17,7 @@ import "@spectrum-css/searchwithin/dist/vars.css";
  * **This component is deprecated.** Please use a search field with a separate control to filter the search instead.
  */
 export default {
-	title: "Deprecated/Search within",
+	title: "Search within",
 	component: "SearchWithin",
 	argTypes: {
 		size: {

--- a/.storybook/deprecated/splitbutton/splitbutton.stories.js
+++ b/.storybook/deprecated/splitbutton/splitbutton.stories.js
@@ -12,7 +12,7 @@ import "@spectrum-css/splitbutton/dist/vars.css";
  * A split button surfaces an immediately invokable action via it's main button, as well as a list of alternative actions in its toggle-able menu overlay.
  */
 export default {
-	title: "Deprecated/Split button",
+	title: "Split button",
 	component: "SplitButton",
 	argTypes: {
 		size: {

--- a/.storybook/guides/code_of_conduct.mdx
+++ b/.storybook/guides/code_of_conduct.mdx
@@ -1,6 +1,6 @@
 import { Meta, Title } from '@storybook/blocks';
 
-<Meta title="Guides/Adobe Code of Conduct" />
+<Meta title="Adobe Code of Conduct" />
 
 <Title>Adobe Code of Conduct</Title>
 <br/>

--- a/.storybook/guides/deprecation.mdx
+++ b/.storybook/guides/deprecation.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks';
 
-<Meta title="Guides/Deprecation workflow"/>
+<Meta title="Deprecation workflow"/>
 
 # Deprecating a component
 
@@ -32,7 +32,7 @@ Before removing the component from the codebase, we need to flag the component a
 
 1. Create a new branch for the deprecation. i.e., `git checkout -b deprecate-quickaction`.
 2. Open up any `*.stories.js` files inside the component's folder:
-    a. Edit the title of any exported stories to be prefixed with the `Deprecated` category, i.e., `title: "Deprecated/Quick actions"`.
+    a. Edit the title of any exported stories to be prefixed with the `Deprecated` category, i.e., `title: "Quick actions"`.
     b. Update any local references to point to the package name instead, i.e.,<br/>_Original_:<br/>`import { Template } from "./template";`<br/><br/>_Updated to_:<br/>`import { Template } from "@spectrum-css/quickaction/stories/template.js";`.
     c. In the parameters section, there are 2 important updates to make:
         - Add `chromatic: { disable: true },` to ensure it no longer runs regression tests.

--- a/.storybook/guides/develop.mdx
+++ b/.storybook/guides/develop.mdx
@@ -2,7 +2,7 @@ import { Meta } from '@storybook/blocks';
 
 import Illustration from '../../assets/spectrum_illustration_2x.png';
 
-<Meta title="Guides/Contributing"/>
+<Meta title="Contributing"/>
 
 <img src={Illustration} style={{marginTop: "-20px", marginBottom: "20px"}}/>
 

--- a/.storybook/guides/releasing.mdx
+++ b/.storybook/guides/releasing.mdx
@@ -1,6 +1,6 @@
 import { Meta, Title } from '@storybook/blocks';
 
-<Meta title="Guides/Release workflow" />
+<Meta title="Release workflow" />
 
 <Title>Release workflow</Title>
 

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -9,13 +9,19 @@ const componentPkgs = readdirSync(componentsPath, {
 	.map((dirent) => dirent.name);
 
 module.exports = {
-	stories: [
-		"../components/*/stories/*.stories.js",
-		"../components/*/stories/*.mdx",
-		"./guides/*.mdx",
-		"./deprecated/*/*.stories.js",
-		"./deprecated/*/*.mdx",
-	],
+	stories: [{
+		directory: '../components',
+		files: '*/stories/*.@(stories.js|mdx)',
+		titlePrefix: 'Components',
+	}, {
+		directory: './guides',
+		files: '*.mdx',
+		titlePrefix: 'Guides',
+	}, {
+		directory: './deprecated',
+		files: '**/*.@(stories.js|mdx)',
+		titlePrefix: 'Deprecated',
+	}],
 	rootDir: "../",
 	staticDirs: ["../assets"],
 	addons: [
@@ -164,12 +170,6 @@ module.exports = {
 	},
 	framework: {
 		name: "@storybook/web-components-webpack5",
-	},
-	features: {
-		/* Code splitting flag; load stories on-demand */
-		storyStoreV7: true,
-		/* Builds stories.json to help with on-demand loading */
-		buildStoriesJson: true,
 	},
 	docs: {
 		autodocs: true, // see below for alternatives

--- a/components/accordion/stories/accordion.stories.js
+++ b/components/accordion/stories/accordion.stories.js
@@ -9,7 +9,7 @@ import { Template } from "./template.js";
  * The accordion element contains a list of items that can be expanded or collapsed to reveal additional content or information associated with each item. There can be zero expanded items, exactly one expanded item, or more than one item expanded at a time, depending on the configuration. This list of items is defined by child accordion item elements.
  */
 export default {
-	title: "Components/Accordion",
+	title: "Accordion",
 	component: "Accordion",
 	argTypes: {
 		items: { table: { disable: true } },

--- a/components/actionbar/stories/actionbar.stories.js
+++ b/components/actionbar/stories/actionbar.stories.js
@@ -8,7 +8,7 @@ import { default as Popover } from "@spectrum-css/popover/stories/popover.storie
  * The action bar component is a floating full width bar that appears upon selection.
  */
 export default {
-	title: "Components/Action bar",
+	title: "Action bar",
 	component: "ActionBar",
 	argTypes: {
 		isOpen: {

--- a/components/actionbutton/stories/actionbutton.stories.js
+++ b/components/actionbutton/stories/actionbutton.stories.js
@@ -11,7 +11,7 @@ import { Template as Typography } from "@spectrum-css/typography/stories/templat
  * The action button component represents an action a user can take.
  */
 export default {
-	title: "Components/Action button",
+	title: "Action button",
 	component: "ActionButton",
 	argTypes: {
 		size: {

--- a/components/actiongroup/stories/actiongroup.stories.js
+++ b/components/actiongroup/stories/actiongroup.stories.js
@@ -6,7 +6,7 @@ import { default as ActionButton } from "@spectrum-css/actionbutton/stories/acti
  * The action group component is a collection of action buttons.
  */
 export default {
-	title: "Components/Action group",
+	title: "Action group",
 	component: "ActionGroup",
 	argTypes: {
 		areQuiet: ActionButton.argTypes.isQuiet,

--- a/components/actionmenu/stories/actionmenu.stories.js
+++ b/components/actionmenu/stories/actionmenu.stories.js
@@ -12,7 +12,7 @@ import { default as Popover } from "@spectrum-css/popover/stories/popover.storie
  * The action menu component is an action button with a popover. The `is-selected` class should be applied to the button when the menu is open. Note that the accessibility roles are different for an action menu compared to a normal menu.
  */
 export default {
-	title: "Components/Action menu",
+	title: "Action menu",
 	component: "ActionMenu",
 	argTypes: {
 		items: { table: { disable: true } },

--- a/components/alertbanner/stories/alertbanner.stories.js
+++ b/components/alertbanner/stories/alertbanner.stories.js
@@ -7,7 +7,7 @@ import { Template } from "./template";
  * The alert banner show pressing and high-signal messages, such as system alerts. They're meant to be noticed and prompt users to take action.
  */
 export default {
-	title: "Components/Alert banner",
+	title: "r",
 	component: "AlertBanner",
 	argTypes: {
 		isOpen: {

--- a/components/alertdialog/stories/alertdialog.stories.js
+++ b/components/alertdialog/stories/alertdialog.stories.js
@@ -4,7 +4,7 @@ import { Template } from "./template";
  * Alert dialogs display important information that users need to acknowledge. They appear over the interface and block further interactions until an action is selected.
  */
 export default {
-	title: "Components/Alert dialog",
+	title: "Alert dialog",
 	component: "AlertDialog",
 	argTypes: {
 		heading: {

--- a/components/asset/stories/asset.stories.js
+++ b/components/asset/stories/asset.stories.js
@@ -7,7 +7,7 @@ import { Template } from "./template";
  * Use an asset element to visually represent a file, folder or image. File and folder representations will center themselves horizontally and vertically in the space provided to the element. Images will be contained to the element, growing to the element's full height while centering itself within the width provided.
 */
 export default {
-	title: "Components/Asset",
+	title: "Asset",
 	component: "Asset",
 	argTypes: {
 		reducedMotion: { table: { disable: true } },

--- a/components/assetcard/stories/assetcard.stories.js
+++ b/components/assetcard/stories/assetcard.stories.js
@@ -6,7 +6,7 @@ import { default as Checkbox } from "@spectrum-css/checkbox/stories/checkbox.sto
  * The asset card component allows users to select and manage assets and their metadata in a grid.
  */
 export default {
-	title: "Components/Asset card",
+	title: "Asset card",
 	component: "AssetCard",
 	argTypes: {
 		image: {

--- a/components/assetlist/stories/assetlist.stories.js
+++ b/components/assetlist/stories/assetlist.stories.js
@@ -6,7 +6,7 @@ import { default as Checkbox } from "@spectrum-css/checkbox/stories/checkbox.sto
  * A selectable list of assets, often used inside of miller columns.
  */
 export default {
-	title: "Components/Asset list",
+	title: "Asset list",
 	component: "AssetList",
 	argTypes: {
 		items: { table: { disable: true } },

--- a/components/avatar/stories/avatar.stories.js
+++ b/components/avatar/stories/avatar.stories.js
@@ -15,7 +15,7 @@ const sizeOptions = ["50", "75", "100", "200", "300", "400", "500", "600", "700"
  * ```
  */
 export default {
-	title: "Components/Avatar",
+	title: "Avatar",
 	component: "Avatar",
 	argTypes: {
 		reducedMotion: { table: { disable: true } },

--- a/components/badge/stories/badge.stories.js
+++ b/components/badge/stories/badge.stories.js
@@ -16,7 +16,7 @@ const fixedOptions = ["none", "fixed-inline-start", "fixed-inline-end", "fixed-b
  * - Fixed positioning impacts the border radius of the badge component
  */
 export default {
-	title: "Components/Badge",
+	title: "Badge",
 	component: "Badge",
 	argTypes: {
 		size: {

--- a/components/breadcrumb/stories/breadcrumb.stories.js
+++ b/components/breadcrumb/stories/breadcrumb.stories.js
@@ -4,7 +4,7 @@ import { Template } from "./template";
  * Breadcrumbs show hierarchy and navigational context for a user's location within an app.
  */
 export default {
-	title: "Components/Breadcrumbs",
+	title: "Breadcrumbs",
 	component: "Breadcrumbs",
 	argTypes: {
 		items: { table: { disable: true } },

--- a/components/button/stories/button.stories.js
+++ b/components/button/stories/button.stories.js
@@ -10,7 +10,7 @@ import { Template } from "./template";
  * Buttons allow users to perform an action or to navigate to another page. They have multiple styles for various needs, and are ideal for calling attention to where a user needs to do something in order to move forward in a flow.
  */
 export default {
-	title: "Components/Button",
+	title: "Button",
 	component: "Button",
 	argTypes: {
 		size: {

--- a/components/buttongroup/stories/buttongroup.stories.js
+++ b/components/buttongroup/stories/buttongroup.stories.js
@@ -4,7 +4,7 @@ import { Template } from "./template";
  * A grouping of buttons.
  */
 export default {
-	title: "Components/Button group",
+	title: "Button group",
 	component: "ButtonGroup",
 	argTypes: {
 		size: {

--- a/components/calendar/stories/calendar.stories.js
+++ b/components/calendar/stories/calendar.stories.js
@@ -10,7 +10,7 @@ const months = [...Array(12).keys()].map((key) =>
  * Calendars display a grid of days in one or more months and allow users to select a single date.
  */
 export default {
-	title: "Components/Calendar",
+	title: "Calendar",
 	component: "Calendar",
 	argTypes: {
 		reducedMotion: { table: { disable: true } },

--- a/components/card/stories/card.stories.js
+++ b/components/card/stories/card.stories.js
@@ -7,7 +7,7 @@ import { default as Checkbox } from "@spectrum-css/checkbox/stories/checkbox.sto
  * A card represents a rectangular space to contain text or images. Cards are typically used to encapsulate units of a data set, such as a gallery of image/caption pairs.
  */
 export default {
-	title: "Components/Card",
+	title: "Card",
 	component: "Card",
 	argTypes: {
 		image: {

--- a/components/checkbox/stories/checkbox.stories.js
+++ b/components/checkbox/stories/checkbox.stories.js
@@ -6,7 +6,7 @@ import { Template } from "./template";
  * Checkboxes allow users to select multiple items from a list of individual items, or mark one individual item as selected.
  */
 export default {
-	title: "Components/Checkbox",
+	title: "Checkbox",
 	component: "Checkbox",
 	argTypes: {
 		size: {

--- a/components/clearbutton/stories/clearbutton.stories.js
+++ b/components/clearbutton/stories/clearbutton.stories.js
@@ -5,7 +5,7 @@ import { Template } from "./template";
  * The clear button component is an in-field button used in search and tag.
  */
 export default {
-	title: "Components/Clear button",
+	title: "Clear button",
 	component: "ClearButton",
 	argTypes: {
 		size: {

--- a/components/closebutton/stories/closebutton.stories.js
+++ b/components/closebutton/stories/closebutton.stories.js
@@ -4,7 +4,7 @@ import { Template } from "./template";
  * A button used to close or dismiss components.
  */
 export default {
-	title: "Components/Close button",
+	title: "Close button",
 	component: "CloseButton",
 	argTypes: {
 		size: {

--- a/components/coachmark/stories/coachmark.stories.js
+++ b/components/coachmark/stories/coachmark.stories.js
@@ -7,7 +7,7 @@ import { default as Menu } from "@spectrum-css/menu/stories/menu.stories.js";
  * The coach mark component can be used to bring added attention to specific parts of a page. It is a separate component from the coach indicator.
  */
 export default {
-	title: "Components/Coach mark",
+	title: "Coach mark",
 	component: "CoachMark",
 	argTypes: {
 		hasActionMenu: {

--- a/components/colorarea/stories/colorarea.stories.js
+++ b/components/colorarea/stories/colorarea.stories.js
@@ -10,7 +10,7 @@ import { Template } from "./template";
  * - Marshall focus between the saturation and value sliders according to which keys are pressed (up/down for value, left/right for saturation)
  */
 export default {
-	title: "Components/Color area",
+	title: "Color area",
 	component: "ColorArea",
 	argTypes: {
 		customWidth: { table: { disable: true } },

--- a/components/colorhandle/stories/colorhandle.stories.js
+++ b/components/colorhandle/stories/colorhandle.stories.js
@@ -4,7 +4,7 @@ import { Template } from "./template";
  * The color handle component is used with color area, color slider and color wheel as the color selector.
  */
 export default {
-	title: "Components/Color handle",
+	title: "Color handle",
 	component: "ColorHandle",
 	argTypes: {
 		isDisabled: {

--- a/components/colorloupe/stories/colorloupe.stories.js
+++ b/components/colorloupe/stories/colorloupe.stories.js
@@ -4,7 +4,7 @@ import { Template } from "./template";
  * The color loupe component shows the output color that would otherwise be covered by a cursor, stylus, or finger during color selection.
  */
 export default {
-	title: "Components/Color loupe",
+	title: "Color loupe",
 	component: "ColorLoupe",
 	argTypes: {
 		isOpen: {

--- a/components/colorslider/stories/colorslider.stories.js
+++ b/components/colorslider/stories/colorslider.stories.js
@@ -4,7 +4,7 @@ import { Template } from "./template";
  * The color slider component lets users visually change an individual channel of a color.
  */
 export default {
-	title: "Components/Color slider",
+	title: "Color slider",
 	component: "ColorSlider",
 	argTypes: {
 		colorHandleStyle: { table: { disable: true } },

--- a/components/colorwheel/stories/colorwheel.stories.js
+++ b/components/colorwheel/stories/colorwheel.stories.js
@@ -4,7 +4,7 @@ import { Template } from "./template";
  * The color wheel component lets users visually change an individual channel of a color on a circular track.
  */
 export default {
-	title: "Components/Color wheel",
+	title: "Color wheel",
 	component: "ColorWheel",
 	argTypes: {
 		isDisabled: {

--- a/components/combobox/stories/combobox.stories.js
+++ b/components/combobox/stories/combobox.stories.js
@@ -8,7 +8,7 @@ import { Template as Menu } from "@spectrum-css/menu/stories/template.js";
  * Comboboxes combine a text entry with a picker menu, allowing users to filter longer lists to only the selections matching a query.
  */
 export default {
-	title: "Components/Combobox",
+	title: "Combobox",
 	component: "Combobox",
 	argTypes: {
 		size: {

--- a/components/contextualhelp/stories/contextualhelp.stories.js
+++ b/components/contextualhelp/stories/contextualhelp.stories.js
@@ -6,7 +6,7 @@ import { default as ActionButtonStories } from "@spectrum-css/actionbutton/stori
  * Contextual help shows a user extra information in relation to another component or view.
  */
 export default {
-	title: "Components/Contextual help",
+	title: "Contextual help",
 	component: "ContextualHelp",
 	argTypes: {
 		title: {

--- a/components/datepicker/stories/datepicker.stories.js
+++ b/components/datepicker/stories/datepicker.stories.js
@@ -8,7 +8,7 @@ const ignoreProps = ["rootClass", "isDisabled"];
  * A date picker displays a text field input with a button next to it, and can display two text fields next to each other for choosing a date range.
  */
 export default {
-	title: "Components/Date picker",
+	title: "Date picker",
 	component: "DatePicker",
 	argTypes: {
 		...Object.entries(CalendarStories.argTypes).reduce((acc, [key]) => {
@@ -253,4 +253,3 @@ QuietDisabled.parameters = {
 	}
 };
 QuietDisabled.tags = ["docs-only"];
-

--- a/components/dial/stories/dial.stories.js
+++ b/components/dial/stories/dial.stories.js
@@ -4,7 +4,7 @@ import { Template } from "./template";
  * A dial is an input control used for selecting a value within a range, similar to a slider. It's often used in audio and video mixing and editing applications, where horizontal space is limited.
  */
 export default {
-	title: "Components/Dial",
+	title: "Dial",
 	component: "Dial",
 	argTypes: {
 		size: {

--- a/components/dialog/stories/dialog.stories.js
+++ b/components/dialog/stories/dialog.stories.js
@@ -6,7 +6,7 @@ import { Template as Typography } from "@spectrum-css/typography/stories/templat
  * A dialog displays important information that users need to acknowledge. They appear over the interface and block further interactions.
  */
 export default {
-	title: "Components/Dialog",
+	title: "Dialog",
 	component: "Dialog",
 	argTypes: {
 		heading: {

--- a/components/divider/stories/divider.stories.js
+++ b/components/divider/stories/divider.stories.js
@@ -4,7 +4,7 @@ import { Template } from "./template";
  * Dividers bring clarity to a layout by grouping and dividing content that exists in close proximity. It can also be used to establish rhythm and hierarchy.
  */
 export default {
-	title: "Components/Divider",
+	title: "Divider",
 	component: "Divider",
 	argTypes: {
 		size: {

--- a/components/dropindicator/stories/dropindicator.stories.js
+++ b/components/dropindicator/stories/dropindicator.stories.js
@@ -4,7 +4,7 @@ import { Template } from "./template";
  * The drop indicator component is used to show the insertion position into a list or table.
  */
 export default {
-	title: "Components/Drop indicator",
+	title: "Drop indicator",
 	component: "DropIndicator",
 	argTypes: {
 		direction: {

--- a/components/dropzone/stories/dropzone.stories.js
+++ b/components/dropzone/stories/dropzone.stories.js
@@ -8,7 +8,7 @@ import { Template as Link } from "@spectrum-css/link/stories/template.js";
  * A drop zone is an area on the screen into a which an object can be dragged and dropped to accomplish a task. For example, a drop zone might be used in an upload workflow to enable the user to simply drop a file from their operating system into the drop zone, which is a more efficient and intuitive action, rather than utilize the standard "Choose file" dialog.
  */
 export default {
-	title: "Components/Drop zone",
+	title: "Drop zone",
 	component: "DropZone",
 	argTypes: {
 		isDragged: {

--- a/components/fieldgroup/stories/fieldgroup.stories.js
+++ b/components/fieldgroup/stories/fieldgroup.stories.js
@@ -3,7 +3,7 @@ import { Template } from "./template";
 import { default as Radio } from "@spectrum-css/radio/stories/radio.stories.js";
 
 export default {
-	title: "Components/Field group",
+	title: "Field group",
 	component: "FieldGroup",
 	argTypes: {
 		layout: {

--- a/components/fieldlabel/stories/fieldlabel.stories.js
+++ b/components/fieldlabel/stories/fieldlabel.stories.js
@@ -4,7 +4,7 @@ import { Template } from "./template";
  * The field label component is used along with inputs to display a label for that input.
  */
 export default {
-	title: "Components/Field label",
+	title: "Field label",
 	component: "FieldLabel",
 	argTypes: {
 		size: {

--- a/components/fieldlabel/stories/form.stories.js
+++ b/components/fieldlabel/stories/form.stories.js
@@ -6,7 +6,7 @@ import { Template } from "./form.template.js";
  * The form component is used for aligning multiple inputs and field groups within a form.
  */
 export default {
-	title: "Components/Form",
+	title: "Form",
 	component: "Form",
 	argTypes: {
 		labelsAbove: {

--- a/components/floatingactionbutton/stories/floatingactionbutton.stories.js
+++ b/components/floatingactionbutton/stories/floatingactionbutton.stories.js
@@ -6,7 +6,7 @@ import { default as IconStories } from "@spectrum-css/icon/stories/icon.stories.
  * The floating action button component is used to give users a more prominent button for high frequency actions.
  */
 export default {
-	title: "Components/Floating action button",
+	title: "Floating action button",
 	component: "FloatingActionButton",
 	argTypes: {
 		variant: {

--- a/components/helptext/stories/helptext.stories.js
+++ b/components/helptext/stories/helptext.stories.js
@@ -4,7 +4,7 @@ import { Template } from "./template";
  * Help text provides either an informative description or an error message that gives more context about what a user needs to input. It's commonly used in forms.
  */
 export default {
-	title: "Components/Help text",
+	title: "Help text",
 	component: "HelpText",
 	argTypes: {
 		reducedMotion: { table: { disable: true } },

--- a/components/icon/stories/icon.stories.js
+++ b/components/icon/stories/icon.stories.js
@@ -25,7 +25,7 @@ const uiIconNameOptions = uiIconsWithDirections.map((iconName) => {
  * The icons component contains all UI icons used for components as well as the CSS for UI and workflow icons.
  */
 export default {
-	title: "Components/Icon",
+	title: "Icon",
 	component: "Icon",
 	argTypes: {
 		reducedMotion: { table: { disable: true } },

--- a/components/illustratedmessage/stories/illustratedmessage.stories.js
+++ b/components/illustratedmessage/stories/illustratedmessage.stories.js
@@ -8,7 +8,7 @@ import { Template } from "./template";
  * The illustrated message component is used for status and errors. It is also used for calls-to-action, such as within the drop zone component.
  */
 export default {
-	title: "Components/Illustrated message",
+	title: "Illustrated message",
 	component: "IllustratedMessage",
 	argTypes: {
 		useAccentColor: {

--- a/components/infieldbutton/stories/infieldbutton.stories.js
+++ b/components/infieldbutton/stories/infieldbutton.stories.js
@@ -6,7 +6,7 @@ import { default as IconStories } from "@spectrum-css/icon/stories/icon.stories.
  * The in-field button component is a button used inside a text field.
  */
 export default {
-	title: "Components/In-field button",
+	title: "In-field button",
 	component: "InFieldButton",
 	argTypes: {
 		size: {

--- a/components/inlinealert/stories/inlinealert.stories.js
+++ b/components/inlinealert/stories/inlinealert.stories.js
@@ -6,7 +6,7 @@ import { Template } from "./template";
  * In-line alerts display a non-modal message associated with objects in a view. These are often used in form validation, providing a place to aggregate feedback related to multiple fields.
  */
 export default {
-	title: "Components/In-line alert",
+	title: "In-line alert",
 	component: "InLineAlert",
 	argTypes: {
 		headerText: {

--- a/components/link/stories/link.stories.js
+++ b/components/link/stories/link.stories.js
@@ -4,7 +4,7 @@ import { Template } from "./template";
  * A link allow users to navigate to a different location. They can be presented in-line inside a paragraph or as a standalone text.
  */
 export default {
-	title: "Components/Link",
+	title: "Link",
 	component: "Link",
 	argTypes: {
 		url: {

--- a/components/logicbutton/stories/logicbutton.stories.js
+++ b/components/logicbutton/stories/logicbutton.stories.js
@@ -4,7 +4,7 @@ import { Template } from "./template";
  * A logic button displays an operator within a boolean logic sequence.
  */
 export default {
-	title: "Components/Logic button",
+	title: "Logic button",
 	component: "LogicButton",
 	argTypes: {
 		variant: {

--- a/components/menu/stories/menu.stories.js
+++ b/components/menu/stories/menu.stories.js
@@ -8,7 +8,7 @@ import { Template } from "./template";
  * A menu is used for creating a menu list. The various elements inside a menu can be: a menu group, a menu item, or a menu divider. Often a menu will appear in a popover so that it displays as a togglig menu.
 */
 export default {
-	title: "Components/Menu",
+	title: "Menu",
 	component: "Menu",
 	argTypes: {
 		selectionMode: {

--- a/components/miller/stories/miller.stories.js
+++ b/components/miller/stories/miller.stories.js
@@ -4,7 +4,7 @@ import { Template } from "./template";
  * Miller columns are a browsing/visualization technique that can be applied to tree structures. The columns allow for multiple levels of the hierarchy to be open at once and provide a visual representation of the current location.
  */
 export default {
-	title: "Components/Miller columns",
+	title: "Miller columns",
 	component: "MillerColumns",
 	argTypes: {
 		columns: { table: { disable: true } },

--- a/components/modal/stories/modal.stories.js
+++ b/components/modal/stories/modal.stories.js
@@ -4,7 +4,7 @@ import { Template } from "./template";
  * A modal component is a dialog box/popup window that is displayed on top of the current page.
  */
 export default {
-	title: "Components/Modal",
+	title: "Modal",
 	component: "Modal",
 	argTypes: {
 		isOpen: {

--- a/components/opacitycheckerboard/stories/opacitycheckerboard.stories.js
+++ b/components/opacitycheckerboard/stories/opacitycheckerboard.stories.js
@@ -7,7 +7,7 @@ import { Template } from "./template";
  * Opacity checkerboard is used with other components to highlight opacity.
  */
 export default {
-	title: "Components/Opacity checkerboard",
+	title: "Opacity checkerboard",
 	component: "OpacityCheckerboard",
 	argTypes: {
 		backgroundPosition: {

--- a/components/pagination/stories/pagination.stories.js
+++ b/components/pagination/stories/pagination.stories.js
@@ -6,7 +6,7 @@ import { default as ActionButton } from "@spectrum-css/actionbutton/stories/acti
  * The pagination component displays numbered buttons or an input field to allow for navigation.
  */
 export default {
-	title: "Components/Pagination",
+	title: "Pagination",
 	component: "Pagination",
 	argTypes: {
 		size: {

--- a/components/picker/stories/picker.stories.js
+++ b/components/picker/stories/picker.stories.js
@@ -7,7 +7,7 @@ import { Template } from "./template";
  * A picker outlines a set of options for a user.
  */
 export default {
-	title: "Components/Picker",
+	title: "Picker",
 	component: "Picker",
 	argTypes: {
 		size: {

--- a/components/pickerbutton/stories/pickerbutton.stories.js
+++ b/components/pickerbutton/stories/pickerbutton.stories.js
@@ -6,7 +6,7 @@ import { default as Icon } from "@spectrum-css/icon/stories/icon.stories.js";
  * The picker button component is used as a dropdown trigger. See Combobox.
  */
 export default {
-	title: "Components/Picker button",
+	title: "Picker button",
 	component: "PickerButton",
 	argTypes: {
 		size: {

--- a/components/popover/stories/popover.stories.js
+++ b/components/popover/stories/popover.stories.js
@@ -37,7 +37,7 @@ const placementOptions = [
  * A popover is used to display transient content (menus, options, additional actions etc.) and appears when clicking/tapping on a source (tools, buttons, etc.). It stands out via its visual style (stroke and drop shadow) and floats on top of the rest of the interface.
  */
 export default {
-	title: "Components/Popover",
+	title: "Popover",
 	component: "Popover",
 	argTypes: {
 		trigger: { table: { disable: true } },

--- a/components/progressbar/stories/meter.stories.js
+++ b/components/progressbar/stories/meter.stories.js
@@ -4,7 +4,7 @@ import { Template } from "./meter.template";
  * The meter component is a visual representations of a quantity or an achievement. Their progress is determined by user actions, rather than system actions.
  */
 export default {
-	title: "Components/Meter",
+	title: "Meter",
 	component: "ProgressBar",
 	argTypes: {
 		items: { table: { disable: true } },

--- a/components/progressbar/stories/progressbar.stories.js
+++ b/components/progressbar/stories/progressbar.stories.js
@@ -4,7 +4,7 @@ import { Template } from "./template";
  * The progress bar component shows the progression of a system operation such as downloading, uploading, processing, etc. in a visual way.
  */
 export default {
-	title: "Components/Progress bar",
+	title: "Progress bar",
 	component: "ProgressBar",
 	argTypes: {
 		customWidth: { table: { disable: true } },

--- a/components/progresscircle/stories/progresscircle.stories.js
+++ b/components/progresscircle/stories/progresscircle.stories.js
@@ -6,7 +6,7 @@ import { Template } from "./template";
  * Progress circles show the progression of a system operation such as downloading, uploading, processing, etc. in a visual way. They can represent determinate or indeterminate progress.
  */
 export default {
-	title: "Components/Progress circle",
+	title: "Progress circle",
 	component: "ProgressCircle",
 	argTypes: {
 		size: {

--- a/components/radio/stories/radio.stories.js
+++ b/components/radio/stories/radio.stories.js
@@ -6,7 +6,7 @@ import { Template } from "./template";
  * A radio selector allow users to select a single option from a list of mutually exclusive options. All possible options are exposed up front for users to compare.
  */
 export default {
-	title: "Components/Radio",
+	title: "Radio",
 	component: "Radio",
 	argTypes: {
 		size: {

--- a/components/rating/stories/rating.stories.js
+++ b/components/rating/stories/rating.stories.js
@@ -4,7 +4,7 @@ import { Template } from "./template";
  * A rating element is used to display or collect a user's rating of an item as represented by a number of stars.
  */
 export default {
-	title: "Components/Rating",
+	title: "Rating",
 	component: "Rating",
 	argTypes: {
 		isEmphasized: {

--- a/components/search/stories/search.stories.js
+++ b/components/search/stories/search.stories.js
@@ -4,7 +4,7 @@ import { Template } from "./template.js";
  * This component contains a single input field with both a magnifying glass icon and a "reset" button displayed within it.
  */
 export default {
-	title: "Components/Search",
+	title: "Search",
 	component: "Search",
 	argTypes: {
 		size: {

--- a/components/sidenav/stories/sidenav.stories.js
+++ b/components/sidenav/stories/sidenav.stories.js
@@ -4,7 +4,7 @@ import { Template } from "./template";
  * Side nav lets users navigate the entire content of a product or a section. These can be used for a single level or a multi-level navigation.
  */
 export default {
-	title: "Components/Side nav",
+	title: "Side nav",
 	component: "SideNav",
 	argTypes: {
 		hasIcon: {

--- a/components/slider/stories/slider.stories.js
+++ b/components/slider/stories/slider.stories.js
@@ -4,7 +4,7 @@ import { Template } from "./template";
  * A slider allows users to quickly select a value within a range. They should be used when the upper and lower bounds to the range are invariable.
  */
 export default {
-	title: "Components/Slider",
+	title: "Slider",
 	component: "Slider",
 	argTypes: {
 		reducedMotion: { table: { disable: true } },

--- a/components/splitview/stories/splitview.stories.js
+++ b/components/splitview/stories/splitview.stories.js
@@ -3,7 +3,7 @@ import { within } from "@storybook/testing-library";
 import { Template } from "./template";
 
 export default {
-	title: "Components/Split view",
+	title: "Split view",
 	component: "SplitView",
 	argTypes: {
 		orientation: {

--- a/components/statuslight/stories/statuslight.stories.js
+++ b/components/statuslight/stories/statuslight.stories.js
@@ -3,7 +3,7 @@ import { html } from "lit";
 import { Template } from "./template";
 
 export default {
-	title: "Components/Status light",
+	title: "Status light",
 	component: "Statuslight",
 	argTypes: {
 		size: {

--- a/components/steplist/stories/steplist.stories.js
+++ b/components/steplist/stories/steplist.stories.js
@@ -4,7 +4,7 @@ import { Template } from "./template";
  * A steplist can communicate the progress of a task or workflow. It can help users understand where they are in a process and what they need to do next.
  */
 export default {
-	title: "Components/Steplist",
+	title: "Steplist",
 	component: "Steplist",
 	argTypes: {
 		isSmall: {

--- a/components/stepper/stories/stepper.stories.js
+++ b/components/stepper/stories/stepper.stories.js
@@ -6,7 +6,7 @@ import { Template } from "./template";
  * A stepper can be used to increment or decrement a value by a specified amount via an up/down button. An input field displays the current value.
  */
 export default {
-	title: "Components/Stepper",
+	title: "Stepper",
 	component: "Stepper",
 	argTypes: {
 		size: {

--- a/components/swatch/stories/swatch.stories.js
+++ b/components/swatch/stories/swatch.stories.js
@@ -4,7 +4,7 @@ import { Template } from "./template";
  * A swatch shows a small sample of a fill&emdash;such as a color, gradient, texture, or material&emdash;that is intended to be applied to an object.
  */
 export default {
-	title: "Components/Swatch",
+	title: "Swatch",
 	component: "Swatch",
 	argTypes: {
 		size: {

--- a/components/swatchgroup/stories/swatchgroup.stories.js
+++ b/components/swatchgroup/stories/swatchgroup.stories.js
@@ -6,7 +6,7 @@ import { default as Swatch } from "@spectrum-css/swatch/stories/swatch.stories.j
  * The swatch group component is a collection of swatches.
  */
 export default {
-	title: "Components/Swatch group",
+	title: "Swatch group",
 	component: "SwatchGroup",
 	argTypes: {
 		...Swatch.argTypes,

--- a/components/switch/stories/switch.stories.js
+++ b/components/switch/stories/switch.stories.js
@@ -4,7 +4,7 @@ import { Template } from "./template";
  * A switch is used to turn an option on or off. Switches allow users to select the state of a single option at a time.
  */
 export default {
-	title: "Components/Switch",
+	title: "Switch",
 	component: "Switch",
 	argTypes: {
 		size: {

--- a/components/table/stories/table.stories.js
+++ b/components/table/stories/table.stories.js
@@ -4,7 +4,7 @@ import { Template } from "./template";
  * A table is used to create a container for displaying information. It allows users to sort, compare, and take action on large amounts of data.
  */
 export default {
-	title: "Components/Table",
+	title: "Table",
 	component: "Table",
 	argTypes: {
 		size: {

--- a/components/tabs/stories/tabs.stories.js
+++ b/components/tabs/stories/tabs.stories.js
@@ -8,7 +8,7 @@ import { Template as Typography } from "@spectrum-css/typography/stories/templat
  * Tabs organize content into multiple sections and allow users to navigate between them. The content under the set of tabs should be related and form a coherent unit.
  */
 export default {
-	title: "Components/Tabs",
+	title: "Tabs",
 	component: "Tabs",
 	argTypes: {
 		content: { table: { disable: true } },

--- a/components/tag/stories/tag.stories.js
+++ b/components/tag/stories/tag.stories.js
@@ -6,7 +6,7 @@ import { default as IconStories } from "@spectrum-css/icon/stories/icon.stories.
  * A tag categorizes content. They can represent keywords or people, and are grouped to describe an item or a search request.
  */
 export default {
-	title: "Components/Tag",
+	title: "Tag",
 	component: "Tag",
 	argTypes: {
 		size: {

--- a/components/taggroup/stories/taggroup.stories.js
+++ b/components/taggroup/stories/taggroup.stories.js
@@ -7,7 +7,7 @@ const ignoreProps = ["rootClass", "hasClearButton", "label"];
  * A group of tags.
  */
 export default {
-	title: "Components/Tag group",
+	title: "Tag group",
 	component: "TagGroup",
 	argTypes: {
 		...Object.entries(TagStories.argTypes).reduce((acc, [key, value]) => {

--- a/components/textfield/stories/textfield.stories.js
+++ b/components/textfield/stories/textfield.stories.js
@@ -5,7 +5,7 @@ import { Template } from "./template";
  * Text fields are text boxes that allow users to input custom text entries with a keyboard. Various decorations can be displayed around the field to communicate the entry requirements.
  */
 export default {
-	title: "Components/Text field",
+	title: "Text field",
 	component: "TextField",
 	argTypes: {
 		isValid: {

--- a/components/thumbnail/stories/thumbnail.stories.js
+++ b/components/thumbnail/stories/thumbnail.stories.js
@@ -4,7 +4,7 @@ import { Template } from "./template";
  * A thumbnail is used to display a preview of an image, layer, or effect.
  */
 export default {
-	title: "Components/Thumbnail",
+	title: "Thumbnail",
 	component: "Thumbnail",
 	argTypes: {
 		reduceMotion: { table: { disable: true } },

--- a/components/toast/stories/toast.stories.js
+++ b/components/toast/stories/toast.stories.js
@@ -4,7 +4,7 @@ import { Template } from "./template";
  * Toasts display brief, temporary notifications. They are noticeable but do not disrupt the user experience and do not require an action to be taken.
  */
 export default {
-	title: "Components/Toast",
+	title: "Toast",
 	component: "Toast",
 	argTypes: {
 		variant: {

--- a/components/tooltip/stories/tooltip.stories.js
+++ b/components/tooltip/stories/tooltip.stories.js
@@ -33,7 +33,7 @@ const placementOptions = [
 ];
 
 export default {
-	title: "Components/Tooltip",
+	title: "Tooltip",
 	component: "Tooltip",
 	argTypes: {
 		label: {

--- a/components/tray/stories/tray.stories.js
+++ b/components/tray/stories/tray.stories.js
@@ -7,7 +7,7 @@ import { Template as Dialog } from "@spectrum-css/dialog/stories/template.js";
  * Tray dialogs are typically used to portray information on mobile device or smaller screens.
  */
 export default {
-	title: "Components/Tray",
+	title: "Tray",
 	component: "Tray",
 	argTypes: {
 		content: { table: { disable: true } },

--- a/components/treeview/stories/treeview.stories.js
+++ b/components/treeview/stories/treeview.stories.js
@@ -4,7 +4,7 @@ import { Template } from "./template";
  * The typical usage of a treeview involves nesting a .spectrum-Treeview element within the .spectrum-TreeView-item parent element.
  */
 export default {
-	title: "Components/Tree view",
+	title: "Tree view",
 	component: "TreeView",
 	argTypes: {
 		items: { table: { disable: true } },

--- a/components/typography/stories/typography.stories.js
+++ b/components/typography/stories/typography.stories.js
@@ -7,7 +7,7 @@ import { when } from "lit/directives/when.js";
  * Spectrum typography is broken out into several separate components.
  */
 export default {
-	title: "Components/Typography",
+	title: "Typography",
 	component: "Typography",
 	argTypes: {
 		reduceMotion: { table: { disable: true } },

--- a/components/underlay/stories/underlay.stories.js
+++ b/components/underlay/stories/underlay.stories.js
@@ -4,7 +4,7 @@ import { Template } from "./template";
  * An underlay component is used with modal and dialog. It lays over the rest of the page to deliver a blocking layer between the two contexts.
  */
 export default {
-	title: "Components/Underlay",
+	title: "Underlay",
 	component: "Underlay",
 	argTypes: {
 		isOpen: {

--- a/components/well/stories/well.stories.js
+++ b/components/well/stories/well.stories.js
@@ -5,7 +5,7 @@ import { Template } from "./template";
  * A well is a content container that displays non-editable content separate from other content on the screen. Often this is used to display preformatted text, such as code/markup examples on a documentation page.
  */
 export default {
-	title: "Components/Well",
+	title: "Well",
 	component: "Well",
 	argTypes: {
 		content: { table: { disable: true } },

--- a/generator/templates/stories/{{ folderName }}.stories.js.hbs
+++ b/generator/templates/stories/{{ folderName }}.stories.js.hbs
@@ -9,7 +9,7 @@ import { Template } from "./template.js";
   * {{ description }}
   */
 export default {
-  title: "Components/{{ name }}",
+  title: "{{ name }}",
   component: "{{ pascalCase name }}",
   argTypes: {
     size: {


### PR DESCRIPTION
## Description

Allow Storybook to manage categorization automatically based on where the story is loaded from; this lets us easily rename stories if we wish.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [x] Expect to see stories organized into the same categories in this update as they were previously

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
