### PR TITLE
docs: fix changelog headings missing spaces and make consistent

### DIFF
--- a/.storybook/CHANGELOG.md
+++ b/.storybook/CHANGELOG.md
@@ -35,7 +35,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="9.0.0"></a>
-# 9.0.0
+## 9.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@8.0.4...@spectrum-css/preview@9.0.0)
 
@@ -82,7 +82,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/preview
 
 <a name="8.0.0"></a>
-# 8.0.0
+## 8.0.0
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@7.5.0...@spectrum-css/preview@8.0.0)
 
@@ -99,7 +99,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 This component has been deprecated. Use an action bar to allow users to perform actions on either a single or multiple items at the same time, instead.
 
 <a name="7.5.0"></a>
-# 7.5.0
+## 7.5.0
 🗓
 2024-02-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@7.4.2...@spectrum-css/preview@7.5.0)
 
@@ -122,14 +122,14 @@ This component has been deprecated. Use an action bar to allow users to perform 
 **Note:** Version bump only for package @spectrum-css/preview
 
 <a name="7.4.0"></a>
-# 7.4.0
+## 7.4.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@7.3.0...@spectrum-css/preview@7.4.0)
 
 **Note:** Version bump only for package @spectrum-css/preview
 
 <a name="7.3.0"></a>
-# 7.3.0
+## 7.3.0
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@7.2.1...@spectrum-css/preview@7.3.0)
 
@@ -145,7 +145,7 @@ This component has been deprecated. Use an action bar to allow users to perform 
 **Note:** Version bump only for package @spectrum-css/preview
 
 <a name="7.2.0"></a>
-# 7.2.0
+## 7.2.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@7.1.0...@spectrum-css/preview@7.2.0)
 
@@ -158,7 +158,7 @@ This component has been deprecated. Use an action bar to allow users to perform 
 \*remove storybook-addon-pseudo-states ([#2401](https://github.com/adobe/spectrum-css/issues/2401))([4510975](https://github.com/adobe/spectrum-css/commit/4510975))
 
 <a name="7.1.0"></a>
-# 7.1.0
+## 7.1.0
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@7.0.0...@spectrum-css/preview@7.1.0)
 
@@ -167,7 +167,7 @@ This component has been deprecated. Use an action bar to allow users to perform 
 - **ui-icons:**graduate to 1.0 release ([#2366](https://github.com/adobe/spectrum-css/issues/2366))([afd369a](https://github.com/adobe/spectrum-css/commit/afd369a))
 
 <a name="7.0.0"></a>
-# 7.0.0
+## 7.0.0
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@6.0.1...@spectrum-css/preview@7.0.0)
 
@@ -195,7 +195,7 @@ This component has been deprecated. Use an action bar to allow users to perform 
 - **storybook:**postcss parsing error for node_modules paths ([#2321](https://github.com/adobe/spectrum-css/issues/2321))([a6bd124](https://github.com/adobe/spectrum-css/commit/a6bd124))
 
 <a name="6.0.0"></a>
-# 6.0.0
+## 6.0.0
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@5.1.0...@spectrum-css/preview@6.0.0)
 
@@ -218,7 +218,7 @@ structure for Spectrum CSS.
 **Note:** Version bump only for package @spectrum-css/preview
 
 <a name="5.1.0"></a>
-# 5.1.0
+## 5.1.0
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@5.0.5...@spectrum-css/preview@5.1.0)
 
@@ -262,7 +262,7 @@ structure for Spectrum CSS.
 **Note:** Version bump only for package @spectrum-css/preview
 
 <a name="5.0.0"></a>
-# 5.0.0
+## 5.0.0
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@4.1.14...@spectrum-css/preview@5.0.0)
 
@@ -394,7 +394,7 @@ fix max nesting depth
 **Note:** Version bump only for package @spectrum-css/preview
 
 <a name="4.1.0"></a>
-# 4.1.0
+## 4.1.0
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@4.0.0...@spectrum-css/preview@4.1.0)
 
@@ -407,7 +407,7 @@ fix max nesting depth
 - **actionbutton:**update action button color tokens ([#1982](https://github.com/adobe/spectrum-css/issues/1982))([95e4353](https://github.com/adobe/spectrum-css/commit/95e4353))
 
 <a name="4.0.0"></a>
-# 4.0.0
+## 4.0.0
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@3.2.0...@spectrum-css/preview@4.0.0)
 
@@ -420,7 +420,7 @@ fix max nesting depth
     		Migrates the Tabs component to use `@adobe/spectrum-tokens`.
 
 <a name="3.2.0"></a>
-# 3.2.0
+## 3.2.0
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@3.1.3...@spectrum-css/preview@3.2.0)
 
@@ -454,7 +454,7 @@ fix max nesting depth
 **Note:** Version bump only for package @spectrum-css/preview
 
 <a name="3.1.0"></a>
-# 3.1.0
+## 3.1.0
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@3.0.26...@spectrum-css/preview@3.1.0)
 
@@ -671,7 +671,7 @@ fix max nesting depth
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2023-04-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@2.1.3...@spectrum-css/preview@3.0.0)
 
@@ -709,7 +709,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="2.1.0"></a>
 
-# 2.1.0
+## 2.1.0
 
 🗓 2023-03-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@2.0.8...@spectrum-css/preview@2.1.0)
 
@@ -783,7 +783,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2023-02-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@1.0.9...@spectrum-css/preview@2.0.0)
 

--- a/.storybook/CHANGELOG.md
+++ b/.storybook/CHANGELOG.md
@@ -35,7 +35,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="9.0.0"></a>
-#9.0.0
+# 9.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@8.0.4...@spectrum-css/preview@9.0.0)
 
@@ -54,35 +54,35 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="8.0.4"></a>
-##8.0.4
+## 8.0.4
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@8.0.3...@spectrum-css/preview@8.0.4)
 
 **Note:** Version bump only for package @spectrum-css/preview
 
 <a name="8.0.3"></a>
-##8.0.3
+## 8.0.3
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@8.0.2...@spectrum-css/preview@8.0.3)
 
 **Note:** Version bump only for package @spectrum-css/preview
 
 <a name="8.0.2"></a>
-##8.0.2
+## 8.0.2
 🗓
 2024-02-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@8.0.1...@spectrum-css/preview@8.0.2)
 
 **Note:** Version bump only for package @spectrum-css/preview
 
 <a name="8.0.1"></a>
-##8.0.1
+## 8.0.1
 🗓
 2024-02-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@8.0.0...@spectrum-css/preview@8.0.1)
 
 **Note:** Version bump only for package @spectrum-css/preview
 
 <a name="8.0.0"></a>
-#8.0.0
+# 8.0.0
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@7.5.0...@spectrum-css/preview@8.0.0)
 
@@ -99,7 +99,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 This component has been deprecated. Use an action bar to allow users to perform actions on either a single or multiple items at the same time, instead.
 
 <a name="7.5.0"></a>
-#7.5.0
+# 7.5.0
 🗓
 2024-02-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@7.4.2...@spectrum-css/preview@7.5.0)
 
@@ -108,28 +108,28 @@ This component has been deprecated. Use an action bar to allow users to perform 
 - **preview:**add figma support to storybook [CSS-284] ([#1680](https://github.com/adobe/spectrum-css/issues/1680))([3c6194e](https://github.com/adobe/spectrum-css/commit/3c6194e))
 
 <a name="7.4.2"></a>
-##7.4.2
+## 7.4.2
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/preview
 
 <a name="7.4.1"></a>
-##7.4.1
+## 7.4.1
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@7.4.0...@spectrum-css/preview@7.4.1)
 
 **Note:** Version bump only for package @spectrum-css/preview
 
 <a name="7.4.0"></a>
-#7.4.0
+# 7.4.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@7.3.0...@spectrum-css/preview@7.4.0)
 
 **Note:** Version bump only for package @spectrum-css/preview
 
 <a name="7.3.0"></a>
-#7.3.0
+# 7.3.0
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@7.2.1...@spectrum-css/preview@7.3.0)
 
@@ -138,14 +138,14 @@ This component has been deprecated. Use an action bar to allow users to perform 
 \*migrate build packages to postcss v8 ([#2460](https://github.com/adobe/spectrum-css/issues/2460))([bd6c40e](https://github.com/adobe/spectrum-css/commit/bd6c40e))
 
 <a name="7.2.1"></a>
-##7.2.1
+## 7.2.1
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@7.2.0...@spectrum-css/preview@7.2.1)
 
 **Note:** Version bump only for package @spectrum-css/preview
 
 <a name="7.2.0"></a>
-#7.2.0
+# 7.2.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@7.1.0...@spectrum-css/preview@7.2.0)
 
@@ -158,7 +158,7 @@ This component has been deprecated. Use an action bar to allow users to perform 
 \*remove storybook-addon-pseudo-states ([#2401](https://github.com/adobe/spectrum-css/issues/2401))([4510975](https://github.com/adobe/spectrum-css/commit/4510975))
 
 <a name="7.1.0"></a>
-#7.1.0
+# 7.1.0
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@7.0.0...@spectrum-css/preview@7.1.0)
 
@@ -167,7 +167,7 @@ This component has been deprecated. Use an action bar to allow users to perform 
 - **ui-icons:**graduate to 1.0 release ([#2366](https://github.com/adobe/spectrum-css/issues/2366))([afd369a](https://github.com/adobe/spectrum-css/commit/afd369a))
 
 <a name="7.0.0"></a>
-#7.0.0
+# 7.0.0
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@6.0.1...@spectrum-css/preview@7.0.0)
 
@@ -186,7 +186,7 @@ This component has been deprecated. Use an action bar to allow users to perform 
 * NEW: @spectrum-css/ui-icons package for all SVG icons in the UI set.
 
 <a name="6.0.1"></a>
-##6.0.1
+## 6.0.1
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@6.0.0...@spectrum-css/preview@6.0.1)
 
@@ -195,7 +195,7 @@ This component has been deprecated. Use an action bar to allow users to perform 
 - **storybook:**postcss parsing error for node_modules paths ([#2321](https://github.com/adobe/spectrum-css/issues/2321))([a6bd124](https://github.com/adobe/spectrum-css/commit/a6bd124))
 
 <a name="6.0.0"></a>
-#6.0.0
+# 6.0.0
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@5.1.0...@spectrum-css/preview@6.0.0)
 
@@ -211,14 +211,14 @@ these legacy token packages, these assets no longer need to exist in the monorep
 structure for Spectrum CSS.
 
 <a name="5.1.1"></a>
-##5.1.1
+## 5.1.1
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@5.1.0...@spectrum-css/preview@5.1.1)
 
 **Note:** Version bump only for package @spectrum-css/preview
 
 <a name="5.1.0"></a>
-#5.1.0
+# 5.1.0
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@5.0.5...@spectrum-css/preview@5.1.0)
 
@@ -227,42 +227,42 @@ structure for Spectrum CSS.
 - **storybook:**move config folder to root ([#2267](https://github.com/adobe/spectrum-css/issues/2267))([5f7037d](https://github.com/adobe/spectrum-css/commit/5f7037d))
 
 <a name="5.0.5"></a>
-##5.0.5
+## 5.0.5
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@5.0.4...@spectrum-css/preview@5.0.5)
 
 **Note:** Version bump only for package @spectrum-css/preview
 
 <a name="5.0.4"></a>
-##5.0.4
+## 5.0.4
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@5.0.3...@spectrum-css/preview@5.0.4)
 
 **Note:** Version bump only for package @spectrum-css/preview
 
 <a name="5.0.3"></a>
-##5.0.3
+## 5.0.3
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@5.0.2...@spectrum-css/preview@5.0.3)
 
 **Note:** Version bump only for package @spectrum-css/preview
 
 <a name="5.0.2"></a>
-##5.0.2
+## 5.0.2
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@5.0.1...@spectrum-css/preview@5.0.2)
 
 **Note:** Version bump only for package @spectrum-css/preview
 
 <a name="5.0.1"></a>
-##5.0.1
+## 5.0.1
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@5.0.0...@spectrum-css/preview@5.0.1)
 
 **Note:** Version bump only for package @spectrum-css/preview
 
 <a name="5.0.0"></a>
-#5.0.0
+# 5.0.0
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@4.1.14...@spectrum-css/preview@5.0.0)
 
@@ -292,21 +292,21 @@ fix max nesting depth
 - fix(splitview): use vertical gripper width for vertical gripper
 
 <a name="4.1.14"></a>
-##4.1.14
+## 4.1.14
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@4.1.13...@spectrum-css/preview@4.1.14)
 
 **Note:** Version bump only for package @spectrum-css/preview
 
 <a name="4.1.13"></a>
-##4.1.13
+## 4.1.13
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@4.1.12...@spectrum-css/preview@4.1.13)
 
 **Note:** Version bump only for package @spectrum-css/preview
 
 <a name="4.1.12"></a>
-##4.1.12
+## 4.1.12
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@4.1.11...@spectrum-css/preview@4.1.12)
 
@@ -315,42 +315,42 @@ fix max nesting depth
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="4.1.11"></a>
-##4.1.11
+## 4.1.11
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@4.1.10...@spectrum-css/preview@4.1.11)
 
 **Note:** Version bump only for package @spectrum-css/preview
 
 <a name="4.1.10"></a>
-##4.1.10
+## 4.1.10
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@4.1.8...@spectrum-css/preview@4.1.10)
 
 **Note:** Version bump only for package @spectrum-css/preview
 
 <a name="4.1.9"></a>
-##4.1.9
+## 4.1.9
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@4.1.8...@spectrum-css/preview@4.1.9)
 
 **Note:** Version bump only for package @spectrum-css/preview
 
 <a name="4.1.8"></a>
-##4.1.8
+## 4.1.8
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@4.1.7...@spectrum-css/preview@4.1.8)
 
 **Note:** Version bump only for package @spectrum-css/preview
 
 <a name="4.1.7"></a>
-##4.1.7
+## 4.1.7
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@4.1.6...@spectrum-css/preview@4.1.7)
 
 **Note:** Version bump only for package @spectrum-css/preview
 
 <a name="4.1.6"></a>
-##4.1.6
+## 4.1.6
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@4.1.5...@spectrum-css/preview@4.1.6)
 
@@ -359,42 +359,42 @@ fix max nesting depth
 \*revert prettier ([#2074](https://github.com/adobe/spectrum-css/issues/2074))([ebb98df](https://github.com/adobe/spectrum-css/commit/ebb98df))
 
 <a name="4.1.5"></a>
-##4.1.5
+## 4.1.5
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@4.1.4...@spectrum-css/preview@4.1.5)
 
 **Note:** Version bump only for package @spectrum-css/preview
 
 <a name="4.1.4"></a>
-##4.1.4
+## 4.1.4
 🗓
 2023-07-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@4.1.3...@spectrum-css/preview@4.1.4)
 
 **Note:** Version bump only for package @spectrum-css/preview
 
 <a name="4.1.3"></a>
-##4.1.3
+## 4.1.3
 🗓
 2023-07-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@4.1.2...@spectrum-css/preview@4.1.3)
 
 **Note:** Version bump only for package @spectrum-css/preview
 
 <a name="4.1.2"></a>
-##4.1.2
+## 4.1.2
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@4.1.1...@spectrum-css/preview@4.1.2)
 
 **Note:** Version bump only for package @spectrum-css/preview
 
 <a name="4.1.1"></a>
-##4.1.1
+## 4.1.1
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@4.1.0...@spectrum-css/preview@4.1.1)
 
 **Note:** Version bump only for package @spectrum-css/preview
 
 <a name="4.1.0"></a>
-#4.1.0
+# 4.1.0
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@4.0.0...@spectrum-css/preview@4.1.0)
 
@@ -407,7 +407,7 @@ fix max nesting depth
 - **actionbutton:**update action button color tokens ([#1982](https://github.com/adobe/spectrum-css/issues/1982))([95e4353](https://github.com/adobe/spectrum-css/commit/95e4353))
 
 <a name="4.0.0"></a>
-#4.0.0
+# 4.0.0
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@3.2.0...@spectrum-css/preview@4.0.0)
 
@@ -420,7 +420,7 @@ fix max nesting depth
     		Migrates the Tabs component to use `@adobe/spectrum-tokens`.
 
 <a name="3.2.0"></a>
-#3.2.0
+# 3.2.0
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@3.1.3...@spectrum-css/preview@3.2.0)
 
@@ -433,28 +433,28 @@ fix max nesting depth
 \*revert prettier version bump ([#2004](https://github.com/adobe/spectrum-css/issues/2004))([29b179c](https://github.com/adobe/spectrum-css/commit/29b179c))
 
 <a name="3.1.3"></a>
-##3.1.3
+## 3.1.3
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@3.1.2...@spectrum-css/preview@3.1.3)
 
 **Note:** Version bump only for package @spectrum-css/preview
 
 <a name="3.1.2"></a>
-##3.1.2
+## 3.1.2
 🗓
 2023-06-28 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@3.1.1...@spectrum-css/preview@3.1.2)
 
 **Note:** Version bump only for package @spectrum-css/preview
 
 <a name="3.1.1"></a>
-##3.1.1
+## 3.1.1
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@3.1.0...@spectrum-css/preview@3.1.1)
 
 **Note:** Version bump only for package @spectrum-css/preview
 
 <a name="3.1.0"></a>
-#3.1.0
+# 3.1.0
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@3.0.26...@spectrum-css/preview@3.1.0)
 
@@ -463,21 +463,21 @@ fix max nesting depth
 \*update to Storybook v7 ([#1935](https://github.com/adobe/spectrum-css/issues/1935))([6dcf09b](https://github.com/adobe/spectrum-css/commit/6dcf09b))
 
 <a name="3.0.26"></a>
-##3.0.26
+## 3.0.26
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@3.0.25...@spectrum-css/preview@3.0.26)
 
 **Note:** Version bump only for package @spectrum-css/preview
 
 <a name="3.0.25"></a>
-##3.0.25
+## 3.0.25
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@3.0.24...@spectrum-css/preview@3.0.25)
 
 **Note:** Version bump only for package @spectrum-css/preview
 
 <a name="3.0.24"></a>
-##3.0.24
+## 3.0.24
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/preview@3.0.23...@spectrum-css/preview@3.0.24)
 

--- a/components/accordion/CHANGELOG.md
+++ b/components/accordion/CHANGELOG.md
@@ -35,7 +35,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-# 5.0.0
+## 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@4.2.6...@spectrum-css/accordion@5.0.0)
 
@@ -96,7 +96,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/accordion
 
 <a name="4.2.0"></a>
-# 4.2.0
+## 4.2.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@4.1.1...@spectrum-css/accordion@4.2.0)
 
@@ -112,7 +112,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*deprecate logical transform plugin ([#2437](https://github.com/adobe/spectrum-css/issues/2437))([ff5dda6](https://github.com/adobe/spectrum-css/commit/ff5dda6))
 
 <a name="4.1.0"></a>
-# 4.1.0
+## 4.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@4.0.27...@spectrum-css/accordion@4.1.0)
 
@@ -314,7 +314,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/accordion
 
 <a name="4.0.0"></a>
-# 4.0.0
+## 4.0.0
 🗓
 2023-06-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@3.0.50...@spectrum-css/accordion@4.0.0)
 
@@ -767,7 +767,7 @@ Additionally:
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@3.0.0-beta.5...@spectrum-css/accordion@3.0.0)
 
@@ -775,7 +775,7 @@ Additionally:
 
 <a name="3.0.0-beta.5"></a>
 
-# 3.0.0-beta.5
+## 3.0.0-beta.5
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@3.0.0-beta.4...@spectrum-css/accordion@3.0.0-beta.5)
 
@@ -786,7 +786,7 @@ Additionally:
 
 <a name="3.0.0-beta.4"></a>
 
-# 3.0.0-beta.4
+## 3.0.0-beta.4
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@3.0.0-beta.3...@spectrum-css/accordion@3.0.0-beta.4)
 
@@ -794,7 +794,7 @@ Additionally:
 
 <a name="3.0.0-beta.3"></a>
 
-# 3.0.0-beta.3
+## 3.0.0-beta.3
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@3.0.0-beta.2...@spectrum-css/accordion@3.0.0-beta.3)
 
@@ -804,7 +804,7 @@ Additionally:
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@3.0.0-beta.1...@spectrum-css/accordion@3.0.0-beta.2)
 
@@ -812,7 +812,7 @@ Additionally:
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@3.0.0-beta.0...@spectrum-css/accordion@3.0.0-beta.1)
 
@@ -820,7 +820,7 @@ Additionally:
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@2.0.5...@spectrum-css/accordion@3.0.0-beta.0)
 
@@ -870,7 +870,7 @@ Additionally:
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/accordion/CHANGELOG.md
+++ b/components/accordion/CHANGELOG.md
@@ -35,7 +35,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-#5.0.0
+# 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@4.2.6...@spectrum-css/accordion@5.0.0)
 
@@ -54,56 +54,56 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="4.2.6"></a>
-##4.2.6
+## 4.2.6
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@4.2.5...@spectrum-css/accordion@4.2.6)
 
 **Note:** Version bump only for package @spectrum-css/accordion
 
 <a name="4.2.5"></a>
-##4.2.5
+## 4.2.5
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@4.2.4...@spectrum-css/accordion@4.2.5)
 
 **Note:** Version bump only for package @spectrum-css/accordion
 
 <a name="4.2.4"></a>
-##4.2.4
+## 4.2.4
 🗓
 2024-02-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@4.2.3...@spectrum-css/accordion@4.2.4)
 
 **Note:** Version bump only for package @spectrum-css/accordion
 
 <a name="4.2.3"></a>
-##4.2.3
+## 4.2.3
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@4.2.2...@spectrum-css/accordion@4.2.3)
 
 **Note:** Version bump only for package @spectrum-css/accordion
 
 <a name="4.2.2"></a>
-##4.2.2
+## 4.2.2
 🗓
 2024-02-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@4.2.1...@spectrum-css/accordion@4.2.2)
 
 **Note:** Version bump only for package @spectrum-css/accordion
 
 <a name="4.2.1"></a>
-##4.2.1
+## 4.2.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/accordion
 
 <a name="4.2.0"></a>
-#4.2.0
+# 4.2.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@4.1.1...@spectrum-css/accordion@4.2.0)
 
 **Note:** Version bump only for package @spectrum-css/accordion
 
 <a name="4.1.1"></a>
-##4.1.1
+## 4.1.1
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@4.1.0...@spectrum-css/accordion@4.1.1)
 
@@ -112,7 +112,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*deprecate logical transform plugin ([#2437](https://github.com/adobe/spectrum-css/issues/2437))([ff5dda6](https://github.com/adobe/spectrum-css/commit/ff5dda6))
 
 <a name="4.1.0"></a>
-#4.1.0
+# 4.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@4.0.27...@spectrum-css/accordion@4.1.0)
 
@@ -121,98 +121,98 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="4.0.27"></a>
-##4.0.27
+## 4.0.27
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@4.0.26...@spectrum-css/accordion@4.0.27)
 
 **Note:** Version bump only for package @spectrum-css/accordion
 
 <a name="4.0.26"></a>
-##4.0.26
+## 4.0.26
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@4.0.25...@spectrum-css/accordion@4.0.26)
 
 **Note:** Version bump only for package @spectrum-css/accordion
 
 <a name="4.0.25"></a>
-##4.0.25
+## 4.0.25
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@4.0.23...@spectrum-css/accordion@4.0.25)
 
 **Note:** Version bump only for package @spectrum-css/accordion
 
 <a name="4.0.24"></a>
-##4.0.24
+## 4.0.24
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@4.0.23...@spectrum-css/accordion@4.0.24)
 
 **Note:** Version bump only for package @spectrum-css/accordion
 
 <a name="4.0.23"></a>
-##4.0.23
+## 4.0.23
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@4.0.22...@spectrum-css/accordion@4.0.23)
 
 **Note:** Version bump only for package @spectrum-css/accordion
 
 <a name="4.0.22"></a>
-##4.0.22
+## 4.0.22
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@4.0.21...@spectrum-css/accordion@4.0.22)
 
 **Note:** Version bump only for package @spectrum-css/accordion
 
 <a name="4.0.21"></a>
-##4.0.21
+## 4.0.21
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@4.0.20...@spectrum-css/accordion@4.0.21)
 
 **Note:** Version bump only for package @spectrum-css/accordion
 
 <a name="4.0.20"></a>
-##4.0.20
+## 4.0.20
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@4.0.19...@spectrum-css/accordion@4.0.20)
 
 **Note:** Version bump only for package @spectrum-css/accordion
 
 <a name="4.0.19"></a>
-##4.0.19
+## 4.0.19
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@4.0.18...@spectrum-css/accordion@4.0.19)
 
 **Note:** Version bump only for package @spectrum-css/accordion
 
 <a name="4.0.18"></a>
-##4.0.18
+## 4.0.18
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@4.0.17...@spectrum-css/accordion@4.0.18)
 
 **Note:** Version bump only for package @spectrum-css/accordion
 
 <a name="4.0.17"></a>
-##4.0.17
+## 4.0.17
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@4.0.16...@spectrum-css/accordion@4.0.17)
 
 **Note:** Version bump only for package @spectrum-css/accordion
 
 <a name="4.0.16"></a>
-##4.0.16
+## 4.0.16
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@4.0.15...@spectrum-css/accordion@4.0.16)
 
 **Note:** Version bump only for package @spectrum-css/accordion
 
 <a name="4.0.15"></a>
-##4.0.15
+## 4.0.15
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@4.0.14...@spectrum-css/accordion@4.0.15)
 
 **Note:** Version bump only for package @spectrum-css/accordion
 
 <a name="4.0.14"></a>
-##4.0.14
+## 4.0.14
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@4.0.13...@spectrum-css/accordion@4.0.14)
 
@@ -221,56 +221,56 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="4.0.13"></a>
-##4.0.13
+## 4.0.13
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@4.0.12...@spectrum-css/accordion@4.0.13)
 
 **Note:** Version bump only for package @spectrum-css/accordion
 
 <a name="4.0.12"></a>
-##4.0.12
+## 4.0.12
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@4.0.10...@spectrum-css/accordion@4.0.12)
 
 **Note:** Version bump only for package @spectrum-css/accordion
 
 <a name="4.0.11"></a>
-##4.0.11
+## 4.0.11
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@4.0.10...@spectrum-css/accordion@4.0.11)
 
 **Note:** Version bump only for package @spectrum-css/accordion
 
 <a name="4.0.10"></a>
-##4.0.10
+## 4.0.10
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@4.0.9...@spectrum-css/accordion@4.0.10)
 
 **Note:** Version bump only for package @spectrum-css/accordion
 
 <a name="4.0.9"></a>
-##4.0.9
+## 4.0.9
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@4.0.8...@spectrum-css/accordion@4.0.9)
 
 **Note:** Version bump only for package @spectrum-css/accordion
 
 <a name="4.0.8"></a>
-##4.0.8
+## 4.0.8
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@4.0.7...@spectrum-css/accordion@4.0.8)
 
 **Note:** Version bump only for package @spectrum-css/accordion
 
 <a name="4.0.7"></a>
-##4.0.7
+## 4.0.7
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@4.0.6...@spectrum-css/accordion@4.0.7)
 
 **Note:** Version bump only for package @spectrum-css/accordion
 
 <a name="4.0.6"></a>
-##4.0.6
+## 4.0.6
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@4.0.5...@spectrum-css/accordion@4.0.6)
 
@@ -279,42 +279,42 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*icon sizing in Storybook story templates ([#2037](https://github.com/adobe/spectrum-css/issues/2037))([c90c8a3](https://github.com/adobe/spectrum-css/commit/c90c8a3))
 
 <a name="4.0.5"></a>
-##4.0.5
+## 4.0.5
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@4.0.4...@spectrum-css/accordion@4.0.5)
 
 **Note:** Version bump only for package @spectrum-css/accordion
 
 <a name="4.0.4"></a>
-##4.0.4
+## 4.0.4
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@4.0.3...@spectrum-css/accordion@4.0.4)
 
 **Note:** Version bump only for package @spectrum-css/accordion
 
 <a name="4.0.3"></a>
-##4.0.3
+## 4.0.3
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@4.0.2...@spectrum-css/accordion@4.0.3)
 
 **Note:** Version bump only for package @spectrum-css/accordion
 
 <a name="4.0.2"></a>
-##4.0.2
+## 4.0.2
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@4.0.1...@spectrum-css/accordion@4.0.2)
 
 **Note:** Version bump only for package @spectrum-css/accordion
 
 <a name="4.0.1"></a>
-##4.0.1
+## 4.0.1
 🗓
 2023-06-28 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@4.0.0...@spectrum-css/accordion@4.0.1)
 
 **Note:** Version bump only for package @spectrum-css/accordion
 
 <a name="4.0.0"></a>
-#4.0.0
+# 4.0.0
 🗓
 2023-06-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@3.0.50...@spectrum-css/accordion@4.0.0)
 
@@ -331,21 +331,21 @@ Additionally:
 - feat: adds t-shirt sizes
 
 <a name="3.0.50"></a>
-##3.0.50
+## 3.0.50
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@3.0.49...@spectrum-css/accordion@3.0.50)
 
 **Note:** Version bump only for package @spectrum-css/accordion
 
 <a name="3.0.49"></a>
-##3.0.49
+## 3.0.49
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@3.0.48...@spectrum-css/accordion@3.0.49)
 
 **Note:** Version bump only for package @spectrum-css/accordion
 
 <a name="3.0.48"></a>
-##3.0.48
+## 3.0.48
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@3.0.47...@spectrum-css/accordion@3.0.48)
 
@@ -354,14 +354,14 @@ Additionally:
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="3.0.47"></a>
-##3.0.47
+## 3.0.47
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@3.0.46...@spectrum-css/accordion@3.0.47)
 
 **Note:** Version bump only for package @spectrum-css/accordion
 
 <a name="3.0.46"></a>
-##3.0.46
+## 3.0.46
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/accordion@3.0.45...@spectrum-css/accordion@3.0.46)
 

--- a/components/actionbar/CHANGELOG.md
+++ b/components/actionbar/CHANGELOG.md
@@ -34,7 +34,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="8.0.0"></a>
-#8.0.0
+# 8.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@7.2.4...@spectrum-css/actionbar@8.0.0)
 
@@ -49,35 +49,35 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="7.2.4"></a>
-##7.2.4
+## 7.2.4
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@7.2.3...@spectrum-css/actionbar@7.2.4)
 
 **Note:** Version bump only for package @spectrum-css/actionbar
 
 <a name="7.2.3"></a>
-##7.2.3
+## 7.2.3
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@7.2.2...@spectrum-css/actionbar@7.2.3)
 
 **Note:** Version bump only for package @spectrum-css/actionbar
 
 <a name="7.2.2"></a>
-##7.2.2
+## 7.2.2
 🗓
 2024-02-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@7.2.1...@spectrum-css/actionbar@7.2.2)
 
 **Note:** Version bump only for package @spectrum-css/actionbar
 
 <a name="7.2.1"></a>
-##7.2.1
+## 7.2.1
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@7.2.0...@spectrum-css/actionbar@7.2.1)
 
 **Note:** Version bump only for package @spectrum-css/actionbar
 
 <a name="7.2.0"></a>
-#7.2.0
+# 7.2.0
 🗓
 2024-02-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@7.1.1...@spectrum-css/actionbar@7.2.0)
 
@@ -86,14 +86,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **preview:**add figma support to storybook [CSS-284] ([#1680](https://github.com/adobe/spectrum-css/issues/1680))([3c6194e](https://github.com/adobe/spectrum-css/commit/3c6194e))
 
 <a name="7.1.1"></a>
-##7.1.1
+## 7.1.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/actionbar
 
 <a name="7.1.0"></a>
-#7.1.0
+# 7.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@7.0.11...@spectrum-css/actionbar@7.1.0)
 
@@ -102,84 +102,84 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="7.0.11"></a>
-##7.0.11
+## 7.0.11
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@7.0.10...@spectrum-css/actionbar@7.0.11)
 
 **Note:** Version bump only for package @spectrum-css/actionbar
 
 <a name="7.0.10"></a>
-##7.0.10
+## 7.0.10
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@7.0.9...@spectrum-css/actionbar@7.0.10)
 
 **Note:** Version bump only for package @spectrum-css/actionbar
 
 <a name="7.0.9"></a>
-##7.0.9
+## 7.0.9
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@7.0.7...@spectrum-css/actionbar@7.0.9)
 
 **Note:** Version bump only for package @spectrum-css/actionbar
 
 <a name="7.0.8"></a>
-##7.0.8
+## 7.0.8
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@7.0.7...@spectrum-css/actionbar@7.0.8)
 
 **Note:** Version bump only for package @spectrum-css/actionbar
 
 <a name="7.0.7"></a>
-##7.0.7
+## 7.0.7
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@7.0.6...@spectrum-css/actionbar@7.0.7)
 
 **Note:** Version bump only for package @spectrum-css/actionbar
 
 <a name="7.0.6"></a>
-##7.0.6
+## 7.0.6
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@7.0.5...@spectrum-css/actionbar@7.0.6)
 
 **Note:** Version bump only for package @spectrum-css/actionbar
 
 <a name="7.0.5"></a>
-##7.0.5
+## 7.0.5
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@7.0.4...@spectrum-css/actionbar@7.0.5)
 
 **Note:** Version bump only for package @spectrum-css/actionbar
 
 <a name="7.0.4"></a>
-##7.0.4
+## 7.0.4
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@7.0.3...@spectrum-css/actionbar@7.0.4)
 
 **Note:** Version bump only for package @spectrum-css/actionbar
 
 <a name="7.0.3"></a>
-##7.0.3
+## 7.0.3
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@7.0.2...@spectrum-css/actionbar@7.0.3)
 
 **Note:** Version bump only for package @spectrum-css/actionbar
 
 <a name="7.0.2"></a>
-##7.0.2
+## 7.0.2
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@7.0.1...@spectrum-css/actionbar@7.0.2)
 
 **Note:** Version bump only for package @spectrum-css/actionbar
 
 <a name="7.0.1"></a>
-##7.0.1
+## 7.0.1
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@7.0.0...@spectrum-css/actionbar@7.0.1)
 
 **Note:** Version bump only for package @spectrum-css/actionbar
 
 <a name="7.0.0"></a>
-#7.0.0
+# 7.0.0
 🗓
 2023-09-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@6.0.67...@spectrum-css/actionbar@7.0.0)
 
@@ -672,28 +672,28 @@ transparent. This is no longer needed as the background color is now
 set on the cell instead of the row (previous fix for Firefix bug).
 
 <a name="6.0.67"></a>
-##6.0.67
+## 6.0.67
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@6.0.66...@spectrum-css/actionbar@6.0.67)
 
 **Note:** Version bump only for package @spectrum-css/actionbar
 
 <a name="6.0.66"></a>
-##6.0.66
+## 6.0.66
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@6.0.65...@spectrum-css/actionbar@6.0.66)
 
 **Note:** Version bump only for package @spectrum-css/actionbar
 
 <a name="6.0.65"></a>
-##6.0.65
+## 6.0.65
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@6.0.64...@spectrum-css/actionbar@6.0.65)
 
 **Note:** Version bump only for package @spectrum-css/actionbar
 
 <a name="6.0.64"></a>
-##6.0.64
+## 6.0.64
 🗓
 2023-08-25 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@6.0.63...@spectrum-css/actionbar@6.0.64)
 
@@ -702,133 +702,133 @@ set on the cell instead of the row (previous fix for Firefix bug).
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="6.0.63"></a>
-##6.0.63
+## 6.0.63
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@6.0.62...@spectrum-css/actionbar@6.0.63)
 
 **Note:** Version bump only for package @spectrum-css/actionbar
 
 <a name="6.0.62"></a>
-##6.0.62
+## 6.0.62
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@6.0.60...@spectrum-css/actionbar@6.0.62)
 
 **Note:** Version bump only for package @spectrum-css/actionbar
 
 <a name="6.0.61"></a>
-##6.0.61
+## 6.0.61
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@6.0.60...@spectrum-css/actionbar@6.0.61)
 
 **Note:** Version bump only for package @spectrum-css/actionbar
 
 <a name="6.0.60"></a>
-##6.0.60
+## 6.0.60
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@6.0.59...@spectrum-css/actionbar@6.0.60)
 
 **Note:** Version bump only for package @spectrum-css/actionbar
 
 <a name="6.0.59"></a>
-##6.0.59
+## 6.0.59
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@6.0.58...@spectrum-css/actionbar@6.0.59)
 
 **Note:** Version bump only for package @spectrum-css/actionbar
 
 <a name="6.0.58"></a>
-##6.0.58
+## 6.0.58
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@6.0.57...@spectrum-css/actionbar@6.0.58)
 
 **Note:** Version bump only for package @spectrum-css/actionbar
 
 <a name="6.0.57"></a>
-##6.0.57
+## 6.0.57
 🗓
 2023-08-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@6.0.56...@spectrum-css/actionbar@6.0.57)
 
 **Note:** Version bump only for package @spectrum-css/actionbar
 
 <a name="6.0.56"></a>
-##6.0.56
+## 6.0.56
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@6.0.55...@spectrum-css/actionbar@6.0.56)
 
 **Note:** Version bump only for package @spectrum-css/actionbar
 
 <a name="6.0.55"></a>
-##6.0.55
+## 6.0.55
 🗓
 2023-07-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@6.0.54...@spectrum-css/actionbar@6.0.55)
 
 **Note:** Version bump only for package @spectrum-css/actionbar
 
 <a name="6.0.54"></a>
-##6.0.54
+## 6.0.54
 🗓
 2023-07-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@6.0.53...@spectrum-css/actionbar@6.0.54)
 
 **Note:** Version bump only for package @spectrum-css/actionbar
 
 <a name="6.0.53"></a>
-##6.0.53
+## 6.0.53
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@6.0.52...@spectrum-css/actionbar@6.0.53)
 
 **Note:** Version bump only for package @spectrum-css/actionbar
 
 <a name="6.0.52"></a>
-##6.0.52
+## 6.0.52
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@6.0.51...@spectrum-css/actionbar@6.0.52)
 
 **Note:** Version bump only for package @spectrum-css/actionbar
 
 <a name="6.0.51"></a>
-##6.0.51
+## 6.0.51
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@6.0.50...@spectrum-css/actionbar@6.0.51)
 
 **Note:** Version bump only for package @spectrum-css/actionbar
 
 <a name="6.0.50"></a>
-##6.0.50
+## 6.0.50
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@6.0.49...@spectrum-css/actionbar@6.0.50)
 
 **Note:** Version bump only for package @spectrum-css/actionbar
 
 <a name="6.0.49"></a>
-##6.0.49
+## 6.0.49
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@6.0.48...@spectrum-css/actionbar@6.0.49)
 
 **Note:** Version bump only for package @spectrum-css/actionbar
 
 <a name="6.0.48"></a>
-##6.0.48
+## 6.0.48
 🗓
 2023-06-28 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@6.0.47...@spectrum-css/actionbar@6.0.48)
 
 **Note:** Version bump only for package @spectrum-css/actionbar
 
 <a name="6.0.47"></a>
-##6.0.47
+## 6.0.47
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@6.0.46...@spectrum-css/actionbar@6.0.47)
 
 **Note:** Version bump only for package @spectrum-css/actionbar
 
 <a name="6.0.46"></a>
-##6.0.46
+## 6.0.46
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@6.0.45...@spectrum-css/actionbar@6.0.46)
 
 **Note:** Version bump only for package @spectrum-css/actionbar
 
 <a name="6.0.45"></a>
-##6.0.45
+## 6.0.45
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@6.0.44...@spectrum-css/actionbar@6.0.45)
 
@@ -837,14 +837,14 @@ set on the cell instead of the row (previous fix for Firefix bug).
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="6.0.44"></a>
-##6.0.44
+## 6.0.44
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@6.0.43...@spectrum-css/actionbar@6.0.44)
 
 **Note:** Version bump only for package @spectrum-css/actionbar
 
 <a name="6.0.43"></a>
-##6.0.43
+## 6.0.43
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@6.0.42...@spectrum-css/actionbar@6.0.43)
 

--- a/components/actionbar/CHANGELOG.md
+++ b/components/actionbar/CHANGELOG.md
@@ -34,7 +34,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="8.0.0"></a>
-# 8.0.0
+## 8.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@7.2.4...@spectrum-css/actionbar@8.0.0)
 
@@ -77,7 +77,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/actionbar
 
 <a name="7.2.0"></a>
-# 7.2.0
+## 7.2.0
 🗓
 2024-02-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@7.1.1...@spectrum-css/actionbar@7.2.0)
 
@@ -93,7 +93,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/actionbar
 
 <a name="7.1.0"></a>
-# 7.1.0
+## 7.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@7.0.11...@spectrum-css/actionbar@7.1.0)
 
@@ -179,7 +179,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/actionbar
 
 <a name="7.0.0"></a>
-# 7.0.0
+## 7.0.0
 🗓
 2023-09-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@6.0.67...@spectrum-css/actionbar@7.0.0)
 
@@ -1188,7 +1188,7 @@ set on the cell instead of the row (previous fix for Firefix bug).
 
 <a name="6.0.0"></a>
 
-# 6.0.0
+## 6.0.0
 
 🗓 2023-02-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@5.0.14...@spectrum-css/actionbar@6.0.0)
 
@@ -1314,7 +1314,7 @@ set on the cell instead of the row (previous fix for Firefix bug).
 
 <a name="5.0.0"></a>
 
-# 5.0.0
+## 5.0.0
 
 🗓 2022-11-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@4.0.1...@spectrum-css/actionbar@5.0.0)
 
@@ -1336,7 +1336,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="4.0.0"></a>
 
-# 4.0.0
+## 4.0.0
 
 🗓 2022-06-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@3.0.28...@spectrum-css/actionbar@4.0.0)
 
@@ -1633,7 +1633,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@3.0.0-beta.6...@spectrum-css/actionbar@3.0.0)
 
@@ -1647,7 +1647,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0-beta.6"></a>
 
-# 3.0.0-beta.6
+## 3.0.0-beta.6
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@3.0.0-beta.5...@spectrum-css/actionbar@3.0.0-beta.6)
 
@@ -1665,7 +1665,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0-beta.5"></a>
 
-# 3.0.0-beta.5
+## 3.0.0-beta.5
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@3.0.0-beta.4...@spectrum-css/actionbar@3.0.0-beta.5)
 
@@ -1675,7 +1675,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0-beta.4"></a>
 
-# 3.0.0-beta.4
+## 3.0.0-beta.4
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@3.0.0-beta.3...@spectrum-css/actionbar@3.0.0-beta.4)
 
@@ -1683,7 +1683,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0-beta.3"></a>
 
-# 3.0.0-beta.3
+## 3.0.0-beta.3
 
 🗓 2020-06-19 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@3.0.0-beta.2...@spectrum-css/actionbar@3.0.0-beta.3)
 
@@ -1691,7 +1691,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@3.0.0-beta.1...@spectrum-css/actionbar@3.0.0-beta.2)
 
@@ -1699,7 +1699,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@3.0.0-beta.0...@spectrum-css/actionbar@3.0.0-beta.1)
 
@@ -1707,7 +1707,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@2.1.5...@spectrum-css/actionbar@3.0.0-beta.0)
 
@@ -1757,7 +1757,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="2.1.0"></a>
 
-# 2.1.0
+## 2.1.0
 
 🗓 2019-11-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbar@2.0.0...@spectrum-css/actionbar@2.1.0)
 
@@ -1767,7 +1767,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/actionbutton/CHANGELOG.md
+++ b/components/actionbutton/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="6.0.0"></a>
-#6.0.0
+# 6.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@5.2.6...@spectrum-css/actionbutton@6.0.0)
 
@@ -44,56 +44,56 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="5.2.6"></a>
-##5.2.6
+## 5.2.6
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@5.2.5...@spectrum-css/actionbutton@5.2.6)
 
 **Note:** Version bump only for package @spectrum-css/actionbutton
 
 <a name="5.2.5"></a>
-##5.2.5
+## 5.2.5
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@5.2.4...@spectrum-css/actionbutton@5.2.5)
 
 **Note:** Version bump only for package @spectrum-css/actionbutton
 
 <a name="5.2.4"></a>
-##5.2.4
+## 5.2.4
 🗓
 2024-02-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@5.2.3...@spectrum-css/actionbutton@5.2.4)
 
 **Note:** Version bump only for package @spectrum-css/actionbutton
 
 <a name="5.2.3"></a>
-##5.2.3
+## 5.2.3
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@5.2.2...@spectrum-css/actionbutton@5.2.3)
 
 **Note:** Version bump only for package @spectrum-css/actionbutton
 
 <a name="5.2.2"></a>
-##5.2.2
+## 5.2.2
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/actionbutton
 
 <a name="5.2.1"></a>
-##5.2.1
+## 5.2.1
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@5.2.0...@spectrum-css/actionbutton@5.2.1)
 
 **Note:** Version bump only for package @spectrum-css/actionbutton
 
 <a name="5.2.0"></a>
-#5.2.0
+# 5.2.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@5.1.0...@spectrum-css/actionbutton@5.2.0)
 
 **Note:** Version bump only for package @spectrum-css/actionbutton
 
 <a name="5.1.0"></a>
-#5.1.0
+# 5.1.0
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@5.0.18...@spectrum-css/actionbutton@5.1.0)
 
@@ -106,77 +106,77 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **commons:**rename and deprecate mods referencing global tokens ([#2423](https://github.com/adobe/spectrum-css/issues/2423))([3a49432](https://github.com/adobe/spectrum-css/commit/3a49432))\*deprecate logical transform plugin ([#2437](https://github.com/adobe/spectrum-css/issues/2437))([ff5dda6](https://github.com/adobe/spectrum-css/commit/ff5dda6))
 
 <a name="5.0.18"></a>
-##5.0.18
+## 5.0.18
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@5.0.17...@spectrum-css/actionbutton@5.0.18)
 
 **Note:** Version bump only for package @spectrum-css/actionbutton
 
 <a name="5.0.17"></a>
-##5.0.17
+## 5.0.17
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@5.0.16...@spectrum-css/actionbutton@5.0.17)
 
 **Note:** Version bump only for package @spectrum-css/actionbutton
 
 <a name="5.0.16"></a>
-##5.0.16
+## 5.0.16
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@5.0.15...@spectrum-css/actionbutton@5.0.16)
 
 **Note:** Version bump only for package @spectrum-css/actionbutton
 
 <a name="5.0.15"></a>
-##5.0.15
+## 5.0.15
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@5.0.13...@spectrum-css/actionbutton@5.0.15)
 
 **Note:** Version bump only for package @spectrum-css/actionbutton
 
 <a name="5.0.14"></a>
-##5.0.14
+## 5.0.14
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@5.0.13...@spectrum-css/actionbutton@5.0.14)
 
 **Note:** Version bump only for package @spectrum-css/actionbutton
 
 <a name="5.0.13"></a>
-##5.0.13
+## 5.0.13
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@5.0.12...@spectrum-css/actionbutton@5.0.13)
 
 **Note:** Version bump only for package @spectrum-css/actionbutton
 
 <a name="5.0.12"></a>
-##5.0.12
+## 5.0.12
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@5.0.11...@spectrum-css/actionbutton@5.0.12)
 
 **Note:** Version bump only for package @spectrum-css/actionbutton
 
 <a name="5.0.11"></a>
-##5.0.11
+## 5.0.11
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@5.0.10...@spectrum-css/actionbutton@5.0.11)
 
 **Note:** Version bump only for package @spectrum-css/actionbutton
 
 <a name="5.0.10"></a>
-##5.0.10
+## 5.0.10
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@5.0.9...@spectrum-css/actionbutton@5.0.10)
 
 **Note:** Version bump only for package @spectrum-css/actionbutton
 
 <a name="5.0.9"></a>
-##5.0.9
+## 5.0.9
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@5.0.8...@spectrum-css/actionbutton@5.0.9)
 
 **Note:** Version bump only for package @spectrum-css/actionbutton
 
 <a name="5.0.8"></a>
-##5.0.8
+## 5.0.8
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@5.0.7...@spectrum-css/actionbutton@5.0.8)
 
@@ -185,28 +185,28 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **actionbutton:**fix min-width for xs size ([#2153](https://github.com/adobe/spectrum-css/issues/2153))([9205ac4](https://github.com/adobe/spectrum-css/commit/9205ac4))
 
 <a name="5.0.7"></a>
-##5.0.7
+## 5.0.7
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@5.0.6...@spectrum-css/actionbutton@5.0.7)
 
 **Note:** Version bump only for package @spectrum-css/actionbutton
 
 <a name="5.0.6"></a>
-##5.0.6
+## 5.0.6
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@5.0.5...@spectrum-css/actionbutton@5.0.6)
 
 **Note:** Version bump only for package @spectrum-css/actionbutton
 
 <a name="5.0.5"></a>
-##5.0.5
+## 5.0.5
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@5.0.4...@spectrum-css/actionbutton@5.0.5)
 
 **Note:** Version bump only for package @spectrum-css/actionbutton
 
 <a name="5.0.4"></a>
-##5.0.4
+## 5.0.4
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@5.0.3...@spectrum-css/actionbutton@5.0.4)
 
@@ -215,28 +215,28 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="5.0.3"></a>
-##5.0.3
+## 5.0.3
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@5.0.2...@spectrum-css/actionbutton@5.0.3)
 
 **Note:** Version bump only for package @spectrum-css/actionbutton
 
 <a name="5.0.2"></a>
-##5.0.2
+## 5.0.2
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@5.0.0...@spectrum-css/actionbutton@5.0.2)
 
 **Note:** Version bump only for package @spectrum-css/actionbutton
 
 <a name="5.0.1"></a>
-##5.0.1
+## 5.0.1
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@5.0.0...@spectrum-css/actionbutton@5.0.1)
 
 **Note:** Version bump only for package @spectrum-css/actionbutton
 
 <a name="5.0.0"></a>
-#5.0.0
+# 5.0.0
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@4.0.13...@spectrum-css/actionbutton@5.0.0)
 
@@ -249,28 +249,28 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
     		native focus-visible pseudo class used for styling
 
 <a name="4.0.13"></a>
-##4.0.13
+## 4.0.13
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@4.0.12...@spectrum-css/actionbutton@4.0.13)
 
 **Note:** Version bump only for package @spectrum-css/actionbutton
 
 <a name="4.0.12"></a>
-##4.0.12
+## 4.0.12
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@4.0.11...@spectrum-css/actionbutton@4.0.12)
 
 **Note:** Version bump only for package @spectrum-css/actionbutton
 
 <a name="4.0.11"></a>
-##4.0.11
+## 4.0.11
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@4.0.10...@spectrum-css/actionbutton@4.0.11)
 
 **Note:** Version bump only for package @spectrum-css/actionbutton
 
 <a name="4.0.10"></a>
-##4.0.10
+## 4.0.10
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@4.0.9...@spectrum-css/actionbutton@4.0.10)
 
@@ -279,14 +279,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*icon sizing in Storybook story templates ([#2037](https://github.com/adobe/spectrum-css/issues/2037))([c90c8a3](https://github.com/adobe/spectrum-css/commit/c90c8a3))
 
 <a name="4.0.9"></a>
-##4.0.9
+## 4.0.9
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@4.0.8...@spectrum-css/actionbutton@4.0.9)
 
 **Note:** Version bump only for package @spectrum-css/actionbutton
 
 <a name="4.0.8"></a>
-##4.0.8
+## 4.0.8
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@4.0.7...@spectrum-css/actionbutton@4.0.8)
 
@@ -295,35 +295,35 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **actionbutton:**update action button color tokens ([#1982](https://github.com/adobe/spectrum-css/issues/1982))([95e4353](https://github.com/adobe/spectrum-css/commit/95e4353))
 
 <a name="4.0.7"></a>
-##4.0.7
+## 4.0.7
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@4.0.6...@spectrum-css/actionbutton@4.0.7)
 
 **Note:** Version bump only for package @spectrum-css/actionbutton
 
 <a name="4.0.6"></a>
-##4.0.6
+## 4.0.6
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@4.0.5...@spectrum-css/actionbutton@4.0.6)
 
 **Note:** Version bump only for package @spectrum-css/actionbutton
 
 <a name="4.0.5"></a>
-##4.0.5
+## 4.0.5
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@4.0.4...@spectrum-css/actionbutton@4.0.5)
 
 **Note:** Version bump only for package @spectrum-css/actionbutton
 
 <a name="4.0.4"></a>
-##4.0.4
+## 4.0.4
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@4.0.3...@spectrum-css/actionbutton@4.0.4)
 
 **Note:** Version bump only for package @spectrum-css/actionbutton
 
 <a name="4.0.3"></a>
-##4.0.3
+## 4.0.3
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@4.0.2...@spectrum-css/actionbutton@4.0.3)
 
@@ -332,14 +332,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="4.0.2"></a>
-##4.0.2
+## 4.0.2
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@4.0.1...@spectrum-css/actionbutton@4.0.2)
 
 **Note:** Version bump only for package @spectrum-css/actionbutton
 
 <a name="4.0.1"></a>
-##4.0.1
+## 4.0.1
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@4.0.0...@spectrum-css/actionbutton@4.0.1)
 

--- a/components/actionbutton/CHANGELOG.md
+++ b/components/actionbutton/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="6.0.0"></a>
-# 6.0.0
+## 6.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@5.2.6...@spectrum-css/actionbutton@6.0.0)
 
@@ -86,14 +86,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/actionbutton
 
 <a name="5.2.0"></a>
-# 5.2.0
+## 5.2.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@5.1.0...@spectrum-css/actionbutton@5.2.0)
 
 **Note:** Version bump only for package @spectrum-css/actionbutton
 
 <a name="5.1.0"></a>
-# 5.1.0
+## 5.1.0
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@5.0.18...@spectrum-css/actionbutton@5.1.0)
 
@@ -236,7 +236,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/actionbutton
 
 <a name="5.0.0"></a>
-# 5.0.0
+## 5.0.0
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@4.0.13...@spectrum-css/actionbutton@5.0.0)
 
@@ -347,7 +347,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="4.0.0"></a>
 
-# 4.0.0
+## 4.0.0
 
 🗓 2023-05-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@3.0.45...@spectrum-css/actionbutton@4.0.0)
 
@@ -723,7 +723,7 @@ Also updates IllustratedMessage and ActionButton to share `--mod-` properties.
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2022-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@2.1.8...@spectrum-css/actionbutton@3.0.0)
 
@@ -805,7 +805,7 @@ Also updates IllustratedMessage and ActionButton to share `--mod-` properties.
 
 <a name="2.1.0"></a>
 
-# 2.1.0
+## 2.1.0
 
 🗓 2022-07-27 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@2.0.5...@spectrum-css/actionbutton@2.1.0)
 
@@ -863,7 +863,7 @@ Also updates IllustratedMessage and ActionButton to share `--mod-` properties.
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2022-06-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@1.1.14...@spectrum-css/actionbutton@2.0.0)
 
@@ -1014,7 +1014,7 @@ Also updates IllustratedMessage and ActionButton to share `--mod-` properties.
 
 <a name="1.1.0"></a>
 
-# 1.1.0
+## 1.1.0
 
 🗓 2021-12-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@1.0.10...@spectrum-css/actionbutton@1.1.0)
 
@@ -1138,7 +1138,7 @@ Also updates IllustratedMessage and ActionButton to share `--mod-` properties.
 
 <a name="1.0.0"></a>
 
-# 1.0.0
+## 1.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionbutton@1.0.0-beta.1...@spectrum-css/actionbutton@1.0.0)
 
@@ -1146,7 +1146,7 @@ Also updates IllustratedMessage and ActionButton to share `--mod-` properties.
 
 <a name="1.0.0-beta.1"></a>
 
-# 1.0.0-beta.1
+## 1.0.0-beta.1
 
 🗓 2020-12-04
 

--- a/components/actiongroup/CHANGELOG.md
+++ b/components/actiongroup/CHANGELOG.md
@@ -20,7 +20,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-#5.0.0
+# 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@4.2.5...@spectrum-css/actiongroup@5.0.0)
 
@@ -35,119 +35,119 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="4.2.5"></a>
-##4.2.5
+## 4.2.5
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@4.2.4...@spectrum-css/actiongroup@4.2.5)
 
 **Note:** Version bump only for package @spectrum-css/actiongroup
 
 <a name="4.2.4"></a>
-##4.2.4
+## 4.2.4
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@4.2.3...@spectrum-css/actiongroup@4.2.4)
 
 **Note:** Version bump only for package @spectrum-css/actiongroup
 
 <a name="4.2.3"></a>
-##4.2.3
+## 4.2.3
 🗓
 2024-02-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@4.2.2...@spectrum-css/actiongroup@4.2.3)
 
 **Note:** Version bump only for package @spectrum-css/actiongroup
 
 <a name="4.2.2"></a>
-##4.2.2
+## 4.2.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@4.2.1...@spectrum-css/actiongroup@4.2.2)
 
 **Note:** Version bump only for package @spectrum-css/actiongroup
 
 <a name="4.2.1"></a>
-##4.2.1
+## 4.2.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/actiongroup
 
 <a name="4.2.0"></a>
-#4.2.0
+# 4.2.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@4.1.10...@spectrum-css/actiongroup@4.2.0)
 
 **Note:** Version bump only for package @spectrum-css/actiongroup
 
 <a name="4.1.10"></a>
-##4.1.10
+## 4.1.10
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@4.1.9...@spectrum-css/actiongroup@4.1.10)
 
 **Note:** Version bump only for package @spectrum-css/actiongroup
 
 <a name="4.1.9"></a>
-##4.1.9
+## 4.1.9
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@4.1.8...@spectrum-css/actiongroup@4.1.9)
 
 **Note:** Version bump only for package @spectrum-css/actiongroup
 
 <a name="4.1.8"></a>
-##4.1.8
+## 4.1.8
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@4.1.7...@spectrum-css/actiongroup@4.1.8)
 
 **Note:** Version bump only for package @spectrum-css/actiongroup
 
 <a name="4.1.7"></a>
-##4.1.7
+## 4.1.7
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@4.1.5...@spectrum-css/actiongroup@4.1.7)
 
 **Note:** Version bump only for package @spectrum-css/actiongroup
 
 <a name="4.1.6"></a>
-##4.1.6
+## 4.1.6
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@4.1.5...@spectrum-css/actiongroup@4.1.6)
 
 **Note:** Version bump only for package @spectrum-css/actiongroup
 
 <a name="4.1.5"></a>
-##4.1.5
+## 4.1.5
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@4.1.4...@spectrum-css/actiongroup@4.1.5)
 
 **Note:** Version bump only for package @spectrum-css/actiongroup
 
 <a name="4.1.4"></a>
-##4.1.4
+## 4.1.4
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@4.1.3...@spectrum-css/actiongroup@4.1.4)
 
 **Note:** Version bump only for package @spectrum-css/actiongroup
 
 <a name="4.1.3"></a>
-##4.1.3
+## 4.1.3
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@4.1.2...@spectrum-css/actiongroup@4.1.3)
 
 **Note:** Version bump only for package @spectrum-css/actiongroup
 
 <a name="4.1.2"></a>
-##4.1.2
+## 4.1.2
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@4.1.1...@spectrum-css/actiongroup@4.1.2)
 
 **Note:** Version bump only for package @spectrum-css/actiongroup
 
 <a name="4.1.1"></a>
-##4.1.1
+## 4.1.1
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@4.1.0...@spectrum-css/actiongroup@4.1.1)
 
 **Note:** Version bump only for package @spectrum-css/actiongroup
 
 <a name="4.1.0"></a>
-#4.1.0
+# 4.1.0
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@4.0.7...@spectrum-css/actiongroup@4.1.0)
 
@@ -156,28 +156,28 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **actiongroup:**add support for extra small ([#2154](https://github.com/adobe/spectrum-css/issues/2154))([f115fa0](https://github.com/adobe/spectrum-css/commit/f115fa0))
 
 <a name="4.0.7"></a>
-##4.0.7
+## 4.0.7
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@4.0.6...@spectrum-css/actiongroup@4.0.7)
 
 **Note:** Version bump only for package @spectrum-css/actiongroup
 
 <a name="4.0.6"></a>
-##4.0.6
+## 4.0.6
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@4.0.5...@spectrum-css/actiongroup@4.0.6)
 
 **Note:** Version bump only for package @spectrum-css/actiongroup
 
 <a name="4.0.5"></a>
-##4.0.5
+## 4.0.5
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@4.0.4...@spectrum-css/actiongroup@4.0.5)
 
 **Note:** Version bump only for package @spectrum-css/actiongroup
 
 <a name="4.0.4"></a>
-##4.0.4
+## 4.0.4
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@4.0.3...@spectrum-css/actiongroup@4.0.4)
 
@@ -186,28 +186,28 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="4.0.3"></a>
-##4.0.3
+## 4.0.3
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@4.0.2...@spectrum-css/actiongroup@4.0.3)
 
 **Note:** Version bump only for package @spectrum-css/actiongroup
 
 <a name="4.0.2"></a>
-##4.0.2
+## 4.0.2
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@4.0.0...@spectrum-css/actiongroup@4.0.2)
 
 **Note:** Version bump only for package @spectrum-css/actiongroup
 
 <a name="4.0.1"></a>
-##4.0.1
+## 4.0.1
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@4.0.0...@spectrum-css/actiongroup@4.0.1)
 
 **Note:** Version bump only for package @spectrum-css/actiongroup
 
 <a name="4.0.0"></a>
-#4.0.0
+# 4.0.0
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@3.0.61...@spectrum-css/actiongroup@4.0.0)
 
@@ -220,63 +220,63 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
     		use native focus-visible pseudo class for focus styling
 
 <a name="3.0.61"></a>
-##3.0.61
+## 3.0.61
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@3.0.60...@spectrum-css/actiongroup@3.0.61)
 
 **Note:** Version bump only for package @spectrum-css/actiongroup
 
 <a name="3.0.60"></a>
-##3.0.60
+## 3.0.60
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@3.0.59...@spectrum-css/actiongroup@3.0.60)
 
 **Note:** Version bump only for package @spectrum-css/actiongroup
 
 <a name="3.0.59"></a>
-##3.0.59
+## 3.0.59
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@3.0.58...@spectrum-css/actiongroup@3.0.59)
 
 **Note:** Version bump only for package @spectrum-css/actiongroup
 
 <a name="3.0.58"></a>
-##3.0.58
+## 3.0.58
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@3.0.57...@spectrum-css/actiongroup@3.0.58)
 
 **Note:** Version bump only for package @spectrum-css/actiongroup
 
 <a name="3.0.57"></a>
-##3.0.57
+## 3.0.57
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@3.0.56...@spectrum-css/actiongroup@3.0.57)
 
 **Note:** Version bump only for package @spectrum-css/actiongroup
 
 <a name="3.0.56"></a>
-##3.0.56
+## 3.0.56
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@3.0.55...@spectrum-css/actiongroup@3.0.56)
 
 **Note:** Version bump only for package @spectrum-css/actiongroup
 
 <a name="3.0.55"></a>
-##3.0.55
+## 3.0.55
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@3.0.54...@spectrum-css/actiongroup@3.0.55)
 
 **Note:** Version bump only for package @spectrum-css/actiongroup
 
 <a name="3.0.54"></a>
-##3.0.54
+## 3.0.54
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@3.0.53...@spectrum-css/actiongroup@3.0.54)
 
 **Note:** Version bump only for package @spectrum-css/actiongroup
 
 <a name="3.0.53"></a>
-##3.0.53
+## 3.0.53
 🗓
 2023-06-28 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@3.0.52...@spectrum-css/actiongroup@3.0.53)
 
@@ -285,21 +285,21 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **actiongroup:**fix variable names for focus indicator border radius([ec8c8ec](https://github.com/adobe/spectrum-css/commit/ec8c8ec))
 
 <a name="3.0.52"></a>
-##3.0.52
+## 3.0.52
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@3.0.51...@spectrum-css/actiongroup@3.0.52)
 
 **Note:** Version bump only for package @spectrum-css/actiongroup
 
 <a name="3.0.51"></a>
-##3.0.51
+## 3.0.51
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@3.0.50...@spectrum-css/actiongroup@3.0.51)
 
 **Note:** Version bump only for package @spectrum-css/actiongroup
 
 <a name="3.0.50"></a>
-##3.0.50
+## 3.0.50
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@3.0.49...@spectrum-css/actiongroup@3.0.50)
 
@@ -308,14 +308,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="3.0.49"></a>
-##3.0.49
+## 3.0.49
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@3.0.48...@spectrum-css/actiongroup@3.0.49)
 
 **Note:** Version bump only for package @spectrum-css/actiongroup
 
 <a name="3.0.48"></a>
-##3.0.48
+## 3.0.48
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@3.0.47...@spectrum-css/actiongroup@3.0.48)
 

--- a/components/actiongroup/CHANGELOG.md
+++ b/components/actiongroup/CHANGELOG.md
@@ -20,7 +20,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-# 5.0.0
+## 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@4.2.5...@spectrum-css/actiongroup@5.0.0)
 
@@ -70,7 +70,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/actiongroup
 
 <a name="4.2.0"></a>
-# 4.2.0
+## 4.2.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@4.1.10...@spectrum-css/actiongroup@4.2.0)
 
@@ -147,7 +147,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/actiongroup
 
 <a name="4.1.0"></a>
-# 4.1.0
+## 4.1.0
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@4.0.7...@spectrum-css/actiongroup@4.1.0)
 
@@ -207,7 +207,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/actiongroup
 
 <a name="4.0.0"></a>
-# 4.0.0
+## 4.0.0
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@3.0.61...@spectrum-css/actiongroup@4.0.0)
 
@@ -699,7 +699,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2022-09-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@2.0.0...@spectrum-css/actiongroup@3.0.0)
 
@@ -714,7 +714,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2022-06-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@1.0.26...@spectrum-css/actiongroup@2.0.0)
 
@@ -975,7 +975,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="1.0.0"></a>
 
-# 1.0.0
+## 1.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@1.0.0-beta.5...@spectrum-css/actiongroup@1.0.0)
 
@@ -983,7 +983,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="1.0.0-beta.5"></a>
 
-# 1.0.0-beta.5
+## 1.0.0-beta.5
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@1.0.0-beta.4...@spectrum-css/actiongroup@1.0.0-beta.5)
 
@@ -1002,7 +1002,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="1.0.0-beta.4"></a>
 
-# 1.0.0-beta.4
+## 1.0.0-beta.4
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@1.0.0-beta.3...@spectrum-css/actiongroup@1.0.0-beta.4)
 
@@ -1010,7 +1010,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="1.0.0-beta.3"></a>
 
-# 1.0.0-beta.3
+## 1.0.0-beta.3
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@1.0.0-beta.2...@spectrum-css/actiongroup@1.0.0-beta.3)
 
@@ -1022,7 +1022,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="1.0.0-beta.2"></a>
 
-# 1.0.0-beta.2
+## 1.0.0-beta.2
 
 🗓 2020-06-19 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actiongroup@1.0.0-beta.1...@spectrum-css/actiongroup@1.0.0-beta.2)
 
@@ -1030,7 +1030,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="1.0.0-beta.1"></a>
 
-# 1.0.0-beta.1
+## 1.0.0-beta.1
 
 🗓 2020-05-14
 
@@ -1058,7 +1058,7 @@ fix: correct Quiet Emphasized Action Button
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@3.0.0-beta.0...@spectrum-css/buttongroup@3.0.0-beta.1)
 
@@ -1066,7 +1066,7 @@ fix: correct Quiet Emphasized Action Button
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@2.2.1...@spectrum-css/buttongroup@3.0.0-beta.0)
 
@@ -1084,7 +1084,7 @@ fix: correct Quiet Emphasized Action Button
 
 <a name="2.2.0"></a>
 
-# 2.2.0
+## 2.2.0
 
 🗓 2020-02-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@2.1.0...@spectrum-css/buttongroup@2.2.0)
 
@@ -1094,7 +1094,7 @@ fix: correct Quiet Emphasized Action Button
 
 <a name="2.1.0"></a>
 
-# 2.1.0
+## 2.1.0
 
 🗓 2020-01-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@2.0.3...@spectrum-css/buttongroup@2.1.0)
 
@@ -1128,7 +1128,7 @@ fix: correct Quiet Emphasized Action Button
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/actionmenu/CHANGELOG.md
+++ b/components/actionmenu/CHANGELOG.md
@@ -35,7 +35,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="6.0.0"></a>
-#6.0.0
+# 6.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@5.1.3...@spectrum-css/actionmenu@6.0.0)
 
@@ -50,28 +50,28 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="5.1.3"></a>
-##5.1.3
+## 5.1.3
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@5.1.2...@spectrum-css/actionmenu@5.1.3)
 
 **Note:** Version bump only for package @spectrum-css/actionmenu
 
 <a name="5.1.2"></a>
-##5.1.2
+## 5.1.2
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@5.1.1...@spectrum-css/actionmenu@5.1.2)
 
 **Note:** Version bump only for package @spectrum-css/actionmenu
 
 <a name="5.1.1"></a>
-##5.1.1
+## 5.1.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/actionmenu
 
 <a name="5.1.0"></a>
-#5.1.0
+# 5.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@5.0.10...@spectrum-css/actionmenu@5.1.0)
 
@@ -80,77 +80,77 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="5.0.10"></a>
-##5.0.10
+## 5.0.10
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@5.0.9...@spectrum-css/actionmenu@5.0.10)
 
 **Note:** Version bump only for package @spectrum-css/actionmenu
 
 <a name="5.0.9"></a>
-##5.0.9
+## 5.0.9
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@5.0.8...@spectrum-css/actionmenu@5.0.9)
 
 **Note:** Version bump only for package @spectrum-css/actionmenu
 
 <a name="5.0.8"></a>
-##5.0.8
+## 5.0.8
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@5.0.6...@spectrum-css/actionmenu@5.0.8)
 
 **Note:** Version bump only for package @spectrum-css/actionmenu
 
 <a name="5.0.7"></a>
-##5.0.7
+## 5.0.7
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@5.0.6...@spectrum-css/actionmenu@5.0.7)
 
 **Note:** Version bump only for package @spectrum-css/actionmenu
 
 <a name="5.0.6"></a>
-##5.0.6
+## 5.0.6
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@5.0.5...@spectrum-css/actionmenu@5.0.6)
 
 **Note:** Version bump only for package @spectrum-css/actionmenu
 
 <a name="5.0.5"></a>
-##5.0.5
+## 5.0.5
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@5.0.4...@spectrum-css/actionmenu@5.0.5)
 
 **Note:** Version bump only for package @spectrum-css/actionmenu
 
 <a name="5.0.4"></a>
-##5.0.4
+## 5.0.4
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@5.0.3...@spectrum-css/actionmenu@5.0.4)
 
 **Note:** Version bump only for package @spectrum-css/actionmenu
 
 <a name="5.0.3"></a>
-##5.0.3
+## 5.0.3
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@5.0.2...@spectrum-css/actionmenu@5.0.3)
 
 **Note:** Version bump only for package @spectrum-css/actionmenu
 
 <a name="5.0.2"></a>
-##5.0.2
+## 5.0.2
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@5.0.1...@spectrum-css/actionmenu@5.0.2)
 
 **Note:** Version bump only for package @spectrum-css/actionmenu
 
 <a name="5.0.1"></a>
-##5.0.1
+## 5.0.1
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@5.0.0...@spectrum-css/actionmenu@5.0.1)
 
 **Note:** Version bump only for package @spectrum-css/actionmenu
 
 <a name="5.0.0"></a>
-#5.0.0
+# 5.0.0
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@4.0.58...@spectrum-css/actionmenu@5.0.0)
 
@@ -167,161 +167,161 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - chore(actionmenu): update dependencies
 
 <a name="4.0.58"></a>
-##4.0.58
+## 4.0.58
 🗓
 2023-09-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@4.0.57...@spectrum-css/actionmenu@4.0.58)
 
 **Note:** Version bump only for package @spectrum-css/actionmenu
 
 <a name="4.0.57"></a>
-##4.0.57
+## 4.0.57
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@4.0.56...@spectrum-css/actionmenu@4.0.57)
 
 **Note:** Version bump only for package @spectrum-css/actionmenu
 
 <a name="4.0.56"></a>
-##4.0.56
+## 4.0.56
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@4.0.55...@spectrum-css/actionmenu@4.0.56)
 
 **Note:** Version bump only for package @spectrum-css/actionmenu
 
 <a name="4.0.55"></a>
-##4.0.55
+## 4.0.55
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@4.0.54...@spectrum-css/actionmenu@4.0.55)
 
 **Note:** Version bump only for package @spectrum-css/actionmenu
 
 <a name="4.0.54"></a>
-##4.0.54
+## 4.0.54
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@4.0.53...@spectrum-css/actionmenu@4.0.54)
 
 **Note:** Version bump only for package @spectrum-css/actionmenu
 
 <a name="4.0.53"></a>
-##4.0.53
+## 4.0.53
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@4.0.51...@spectrum-css/actionmenu@4.0.53)
 
 **Note:** Version bump only for package @spectrum-css/actionmenu
 
 <a name="4.0.52"></a>
-##4.0.52
+## 4.0.52
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@4.0.51...@spectrum-css/actionmenu@4.0.52)
 
 **Note:** Version bump only for package @spectrum-css/actionmenu
 
 <a name="4.0.51"></a>
-##4.0.51
+## 4.0.51
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@4.0.50...@spectrum-css/actionmenu@4.0.51)
 
 **Note:** Version bump only for package @spectrum-css/actionmenu
 
 <a name="4.0.50"></a>
-##4.0.50
+## 4.0.50
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@4.0.49...@spectrum-css/actionmenu@4.0.50)
 
 **Note:** Version bump only for package @spectrum-css/actionmenu
 
 <a name="4.0.49"></a>
-##4.0.49
+## 4.0.49
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@4.0.48...@spectrum-css/actionmenu@4.0.49)
 
 **Note:** Version bump only for package @spectrum-css/actionmenu
 
 <a name="4.0.48"></a>
-##4.0.48
+## 4.0.48
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@4.0.47...@spectrum-css/actionmenu@4.0.48)
 
 **Note:** Version bump only for package @spectrum-css/actionmenu
 
 <a name="4.0.47"></a>
-##4.0.47
+## 4.0.47
 🗓
 2023-07-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@4.0.46...@spectrum-css/actionmenu@4.0.47)
 
 **Note:** Version bump only for package @spectrum-css/actionmenu
 
 <a name="4.0.46"></a>
-##4.0.46
+## 4.0.46
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@4.0.45...@spectrum-css/actionmenu@4.0.46)
 
 **Note:** Version bump only for package @spectrum-css/actionmenu
 
 <a name="4.0.45"></a>
-##4.0.45
+## 4.0.45
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@4.0.44...@spectrum-css/actionmenu@4.0.45)
 
 **Note:** Version bump only for package @spectrum-css/actionmenu
 
 <a name="4.0.44"></a>
-##4.0.44
+## 4.0.44
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@4.0.43...@spectrum-css/actionmenu@4.0.44)
 
 **Note:** Version bump only for package @spectrum-css/actionmenu
 
 <a name="4.0.43"></a>
-##4.0.43
+## 4.0.43
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@4.0.42...@spectrum-css/actionmenu@4.0.43)
 
 **Note:** Version bump only for package @spectrum-css/actionmenu
 
 <a name="4.0.42"></a>
-##4.0.42
+## 4.0.42
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@4.0.41...@spectrum-css/actionmenu@4.0.42)
 
 **Note:** Version bump only for package @spectrum-css/actionmenu
 
 <a name="4.0.41"></a>
-##4.0.41
+## 4.0.41
 🗓
 2023-06-28 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@4.0.40...@spectrum-css/actionmenu@4.0.41)
 
 **Note:** Version bump only for package @spectrum-css/actionmenu
 
 <a name="4.0.40"></a>
-##4.0.40
+## 4.0.40
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@4.0.39...@spectrum-css/actionmenu@4.0.40)
 
 **Note:** Version bump only for package @spectrum-css/actionmenu
 
 <a name="4.0.39"></a>
-##4.0.39
+## 4.0.39
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@4.0.38...@spectrum-css/actionmenu@4.0.39)
 
 **Note:** Version bump only for package @spectrum-css/actionmenu
 
 <a name="4.0.38"></a>
-##4.0.38
+## 4.0.38
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@4.0.37...@spectrum-css/actionmenu@4.0.38)
 
 **Note:** Version bump only for package @spectrum-css/actionmenu
 
 <a name="4.0.37"></a>
-##4.0.37
+## 4.0.37
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@4.0.36...@spectrum-css/actionmenu@4.0.37)
 
 **Note:** Version bump only for package @spectrum-css/actionmenu
 
 <a name="4.0.36"></a>
-##4.0.36
+## 4.0.36
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@4.0.35...@spectrum-css/actionmenu@4.0.36)
 

--- a/components/actionmenu/CHANGELOG.md
+++ b/components/actionmenu/CHANGELOG.md
@@ -35,7 +35,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="6.0.0"></a>
-# 6.0.0
+## 6.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@5.1.3...@spectrum-css/actionmenu@6.0.0)
 
@@ -71,7 +71,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/actionmenu
 
 <a name="5.1.0"></a>
-# 5.1.0
+## 5.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@5.0.10...@spectrum-css/actionmenu@5.1.0)
 
@@ -150,7 +150,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/actionmenu
 
 <a name="5.0.0"></a>
-# 5.0.0
+## 5.0.0
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@4.0.58...@spectrum-css/actionmenu@5.0.0)
 
@@ -609,7 +609,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="4.0.0"></a>
 
-# 4.0.0
+## 4.0.0
 
 🗓 2022-06-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@3.0.28...@spectrum-css/actionmenu@4.0.0)
 
@@ -907,7 +907,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@3.0.0-beta.6...@spectrum-css/actionmenu@3.0.0)
 
@@ -915,7 +915,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.6"></a>
 
-# 3.0.0-beta.6
+## 3.0.0-beta.6
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@3.0.0-beta.5...@spectrum-css/actionmenu@3.0.0-beta.6)
 
@@ -933,7 +933,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.5"></a>
 
-# 3.0.0-beta.5
+## 3.0.0-beta.5
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@3.0.0-beta.4...@spectrum-css/actionmenu@3.0.0-beta.5)
 
@@ -941,7 +941,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.4"></a>
 
-# 3.0.0-beta.4
+## 3.0.0-beta.4
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@3.0.0-beta.3...@spectrum-css/actionmenu@3.0.0-beta.4)
 
@@ -951,7 +951,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.3"></a>
 
-# 3.0.0-beta.3
+## 3.0.0-beta.3
 
 🗓 2020-06-19 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@3.0.0-beta.2...@spectrum-css/actionmenu@3.0.0-beta.3)
 
@@ -959,7 +959,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@3.0.0-beta.1...@spectrum-css/actionmenu@3.0.0-beta.2)
 
@@ -967,7 +967,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@3.0.0-beta.0...@spectrum-css/actionmenu@3.0.0-beta.1)
 
@@ -975,7 +975,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/actionmenu@2.0.6...@spectrum-css/actionmenu@3.0.0-beta.0)
 
@@ -1031,7 +1031,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/alertbanner/CHANGELOG.md
+++ b/components/alertbanner/CHANGELOG.md
@@ -43,7 +43,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="2.0.0"></a>
-#2.0.0
+# 2.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertbanner@1.1.41...@spectrum-css/alertbanner@2.0.0)
 
@@ -58,140 +58,140 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="1.1.41"></a>
-##1.1.41
+## 1.1.41
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertbanner@1.1.40...@spectrum-css/alertbanner@1.1.41)
 
 **Note:** Version bump only for package @spectrum-css/alertbanner
 
 <a name="1.1.40"></a>
-##1.1.40
+## 1.1.40
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertbanner@1.1.39...@spectrum-css/alertbanner@1.1.40)
 
 **Note:** Version bump only for package @spectrum-css/alertbanner
 
 <a name="1.1.39"></a>
-##1.1.39
+## 1.1.39
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertbanner@1.1.38...@spectrum-css/alertbanner@1.1.39)
 
 **Note:** Version bump only for package @spectrum-css/alertbanner
 
 <a name="1.1.38"></a>
-##1.1.38
+## 1.1.38
 🗓
 2024-02-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertbanner@1.1.37...@spectrum-css/alertbanner@1.1.38)
 
 **Note:** Version bump only for package @spectrum-css/alertbanner
 
 <a name="1.1.37"></a>
-##1.1.37
+## 1.1.37
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/alertbanner
 
 <a name="1.1.36"></a>
-##1.1.36
+## 1.1.36
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertbanner@1.1.35...@spectrum-css/alertbanner@1.1.36)
 
 **Note:** Version bump only for package @spectrum-css/alertbanner
 
 <a name="1.1.35"></a>
-##1.1.35
+## 1.1.35
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertbanner@1.1.34...@spectrum-css/alertbanner@1.1.35)
 
 **Note:** Version bump only for package @spectrum-css/alertbanner
 
 <a name="1.1.34"></a>
-##1.1.34
+## 1.1.34
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertbanner@1.1.33...@spectrum-css/alertbanner@1.1.34)
 
 **Note:** Version bump only for package @spectrum-css/alertbanner
 
 <a name="1.1.33"></a>
-##1.1.33
+## 1.1.33
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertbanner@1.1.31...@spectrum-css/alertbanner@1.1.33)
 
 **Note:** Version bump only for package @spectrum-css/alertbanner
 
 <a name="1.1.32"></a>
-##1.1.32
+## 1.1.32
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertbanner@1.1.31...@spectrum-css/alertbanner@1.1.32)
 
 **Note:** Version bump only for package @spectrum-css/alertbanner
 
 <a name="1.1.31"></a>
-##1.1.31
+## 1.1.31
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertbanner@1.1.30...@spectrum-css/alertbanner@1.1.31)
 
 **Note:** Version bump only for package @spectrum-css/alertbanner
 
 <a name="1.1.30"></a>
-##1.1.30
+## 1.1.30
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertbanner@1.1.29...@spectrum-css/alertbanner@1.1.30)
 
 **Note:** Version bump only for package @spectrum-css/alertbanner
 
 <a name="1.1.29"></a>
-##1.1.29
+## 1.1.29
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertbanner@1.1.28...@spectrum-css/alertbanner@1.1.29)
 
 **Note:** Version bump only for package @spectrum-css/alertbanner
 
 <a name="1.1.28"></a>
-##1.1.28
+## 1.1.28
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertbanner@1.1.27...@spectrum-css/alertbanner@1.1.28)
 
 **Note:** Version bump only for package @spectrum-css/alertbanner
 
 <a name="1.1.27"></a>
-##1.1.27
+## 1.1.27
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertbanner@1.1.26...@spectrum-css/alertbanner@1.1.27)
 
 **Note:** Version bump only for package @spectrum-css/alertbanner
 
 <a name="1.1.26"></a>
-##1.1.26
+## 1.1.26
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertbanner@1.1.25...@spectrum-css/alertbanner@1.1.26)
 
 **Note:** Version bump only for package @spectrum-css/alertbanner
 
 <a name="1.1.25"></a>
-##1.1.25
+## 1.1.25
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertbanner@1.1.24...@spectrum-css/alertbanner@1.1.25)
 
 **Note:** Version bump only for package @spectrum-css/alertbanner
 
 <a name="1.1.24"></a>
-##1.1.24
+## 1.1.24
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertbanner@1.1.23...@spectrum-css/alertbanner@1.1.24)
 
 **Note:** Version bump only for package @spectrum-css/alertbanner
 
 <a name="1.1.23"></a>
-##1.1.23
+## 1.1.23
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertbanner@1.1.22...@spectrum-css/alertbanner@1.1.23)
 
 **Note:** Version bump only for package @spectrum-css/alertbanner
 
 <a name="1.1.22"></a>
-##1.1.22
+## 1.1.22
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertbanner@1.1.21...@spectrum-css/alertbanner@1.1.22)
 
@@ -200,112 +200,112 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="1.1.21"></a>
-##1.1.21
+## 1.1.21
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertbanner@1.1.20...@spectrum-css/alertbanner@1.1.21)
 
 **Note:** Version bump only for package @spectrum-css/alertbanner
 
 <a name="1.1.20"></a>
-##1.1.20
+## 1.1.20
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertbanner@1.1.18...@spectrum-css/alertbanner@1.1.20)
 
 **Note:** Version bump only for package @spectrum-css/alertbanner
 
 <a name="1.1.19"></a>
-##1.1.19
+## 1.1.19
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertbanner@1.1.18...@spectrum-css/alertbanner@1.1.19)
 
 **Note:** Version bump only for package @spectrum-css/alertbanner
 
 <a name="1.1.18"></a>
-##1.1.18
+## 1.1.18
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertbanner@1.1.17...@spectrum-css/alertbanner@1.1.18)
 
 **Note:** Version bump only for package @spectrum-css/alertbanner
 
 <a name="1.1.17"></a>
-##1.1.17
+## 1.1.17
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertbanner@1.1.16...@spectrum-css/alertbanner@1.1.17)
 
 **Note:** Version bump only for package @spectrum-css/alertbanner
 
 <a name="1.1.16"></a>
-##1.1.16
+## 1.1.16
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertbanner@1.1.15...@spectrum-css/alertbanner@1.1.16)
 
 **Note:** Version bump only for package @spectrum-css/alertbanner
 
 <a name="1.1.15"></a>
-##1.1.15
+## 1.1.15
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertbanner@1.1.14...@spectrum-css/alertbanner@1.1.15)
 
 **Note:** Version bump only for package @spectrum-css/alertbanner
 
 <a name="1.1.14"></a>
-##1.1.14
+## 1.1.14
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertbanner@1.1.13...@spectrum-css/alertbanner@1.1.14)
 
 **Note:** Version bump only for package @spectrum-css/alertbanner
 
 <a name="1.1.13"></a>
-##1.1.13
+## 1.1.13
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertbanner@1.1.12...@spectrum-css/alertbanner@1.1.13)
 
 **Note:** Version bump only for package @spectrum-css/alertbanner
 
 <a name="1.1.12"></a>
-##1.1.12
+## 1.1.12
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertbanner@1.1.11...@spectrum-css/alertbanner@1.1.12)
 
 **Note:** Version bump only for package @spectrum-css/alertbanner
 
 <a name="1.1.11"></a>
-##1.1.11
+## 1.1.11
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertbanner@1.1.10...@spectrum-css/alertbanner@1.1.11)
 
 **Note:** Version bump only for package @spectrum-css/alertbanner
 
 <a name="1.1.10"></a>
-##1.1.10
+## 1.1.10
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertbanner@1.1.9...@spectrum-css/alertbanner@1.1.10)
 
 **Note:** Version bump only for package @spectrum-css/alertbanner
 
 <a name="1.1.9"></a>
-##1.1.9
+## 1.1.9
 🗓
 2023-06-28 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertbanner@1.1.8...@spectrum-css/alertbanner@1.1.9)
 
 **Note:** Version bump only for package @spectrum-css/alertbanner
 
 <a name="1.1.8"></a>
-##1.1.8
+## 1.1.8
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertbanner@1.1.7...@spectrum-css/alertbanner@1.1.8)
 
 **Note:** Version bump only for package @spectrum-css/alertbanner
 
 <a name="1.1.7"></a>
-##1.1.7
+## 1.1.7
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertbanner@1.1.6...@spectrum-css/alertbanner@1.1.7)
 
 **Note:** Version bump only for package @spectrum-css/alertbanner
 
 <a name="1.1.6"></a>
-##1.1.6
+## 1.1.6
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertbanner@1.1.5...@spectrum-css/alertbanner@1.1.6)
 
@@ -314,14 +314,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="1.1.5"></a>
-##1.1.5
+## 1.1.5
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertbanner@1.1.4...@spectrum-css/alertbanner@1.1.5)
 
 **Note:** Version bump only for package @spectrum-css/alertbanner
 
 <a name="1.1.4"></a>
-##1.1.4
+## 1.1.4
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertbanner@1.1.3...@spectrum-css/alertbanner@1.1.4)
 

--- a/components/alertbanner/CHANGELOG.md
+++ b/components/alertbanner/CHANGELOG.md
@@ -43,7 +43,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="2.0.0"></a>
-# 2.0.0
+## 2.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertbanner@1.1.41...@spectrum-css/alertbanner@2.0.0)
 
@@ -353,7 +353,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="1.1.0"></a>
 
-# 1.1.0
+## 1.1.0
 
 🗓 2023-05-22
 

--- a/components/alertdialog/CHANGELOG.md
+++ b/components/alertdialog/CHANGELOG.md
@@ -37,7 +37,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="2.0.0"></a>
-#2.0.0
+# 2.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertdialog@1.2.4...@spectrum-css/alertdialog@2.0.0)
 
@@ -56,35 +56,35 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="1.2.4"></a>
-##1.2.4
+## 1.2.4
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertdialog@1.2.3...@spectrum-css/alertdialog@1.2.4)
 
 **Note:** Version bump only for package @spectrum-css/alertdialog
 
 <a name="1.2.3"></a>
-##1.2.3
+## 1.2.3
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertdialog@1.2.2...@spectrum-css/alertdialog@1.2.3)
 
 **Note:** Version bump only for package @spectrum-css/alertdialog
 
 <a name="1.2.2"></a>
-##1.2.2
+## 1.2.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertdialog@1.2.1...@spectrum-css/alertdialog@1.2.2)
 
 **Note:** Version bump only for package @spectrum-css/alertdialog
 
 <a name="1.2.1"></a>
-##1.2.1
+## 1.2.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/alertdialog
 
 <a name="1.2.0"></a>
-#1.2.0
+# 1.2.0
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertdialog@1.1.0...@spectrum-css/alertdialog@1.2.0)
 
@@ -93,7 +93,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **overlay,commons:**deprecate overlay; migrate references to commons ([#2429](https://github.com/adobe/spectrum-css/issues/2429))([7eecd96](https://github.com/adobe/spectrum-css/commit/7eecd96))
 
 <a name="1.1.0"></a>
-#1.1.0
+# 1.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertdialog@1.0.16...@spectrum-css/alertdialog@1.1.0)
 
@@ -102,119 +102,119 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="1.0.16"></a>
-##1.0.16
+## 1.0.16
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertdialog@1.0.15...@spectrum-css/alertdialog@1.0.16)
 
 **Note:** Version bump only for package @spectrum-css/alertdialog
 
 <a name="1.0.15"></a>
-##1.0.15
+## 1.0.15
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertdialog@1.0.14...@spectrum-css/alertdialog@1.0.15)
 
 **Note:** Version bump only for package @spectrum-css/alertdialog
 
 <a name="1.0.14"></a>
-##1.0.14
+## 1.0.14
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertdialog@1.0.12...@spectrum-css/alertdialog@1.0.14)
 
 **Note:** Version bump only for package @spectrum-css/alertdialog
 
 <a name="1.0.13"></a>
-##1.0.13
+## 1.0.13
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertdialog@1.0.12...@spectrum-css/alertdialog@1.0.13)
 
 **Note:** Version bump only for package @spectrum-css/alertdialog
 
 <a name="1.0.12"></a>
-##1.0.12
+## 1.0.12
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertdialog@1.0.11...@spectrum-css/alertdialog@1.0.12)
 
 **Note:** Version bump only for package @spectrum-css/alertdialog
 
 <a name="1.0.11"></a>
-##1.0.11
+## 1.0.11
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertdialog@1.0.10...@spectrum-css/alertdialog@1.0.11)
 
 **Note:** Version bump only for package @spectrum-css/alertdialog
 
 <a name="1.0.10"></a>
-##1.0.10
+## 1.0.10
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertdialog@1.0.9...@spectrum-css/alertdialog@1.0.10)
 
 **Note:** Version bump only for package @spectrum-css/alertdialog
 
 <a name="1.0.9"></a>
-##1.0.9
+## 1.0.9
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertdialog@1.0.8...@spectrum-css/alertdialog@1.0.9)
 
 **Note:** Version bump only for package @spectrum-css/alertdialog
 
 <a name="1.0.8"></a>
-##1.0.8
+## 1.0.8
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertdialog@1.0.7...@spectrum-css/alertdialog@1.0.8)
 
 **Note:** Version bump only for package @spectrum-css/alertdialog
 
 <a name="1.0.7"></a>
-##1.0.7
+## 1.0.7
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertdialog@1.0.6...@spectrum-css/alertdialog@1.0.7)
 
 **Note:** Version bump only for package @spectrum-css/alertdialog
 
 <a name="1.0.6"></a>
-##1.0.6
+## 1.0.6
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertdialog@1.0.5...@spectrum-css/alertdialog@1.0.6)
 
 **Note:** Version bump only for package @spectrum-css/alertdialog
 
 <a name="1.0.5"></a>
-##1.0.5
+## 1.0.5
 🗓
 2023-09-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertdialog@1.0.4...@spectrum-css/alertdialog@1.0.5)
 
 **Note:** Version bump only for package @spectrum-css/alertdialog
 
 <a name="1.0.4"></a>
-##1.0.4
+## 1.0.4
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertdialog@1.0.3...@spectrum-css/alertdialog@1.0.4)
 
 **Note:** Version bump only for package @spectrum-css/alertdialog
 
 <a name="1.0.3"></a>
-##1.0.3
+## 1.0.3
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertdialog@1.0.2...@spectrum-css/alertdialog@1.0.3)
 
 **Note:** Version bump only for package @spectrum-css/alertdialog
 
 <a name="1.0.2"></a>
-##1.0.2
+## 1.0.2
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertdialog@1.0.1...@spectrum-css/alertdialog@1.0.2)
 
 **Note:** Version bump only for package @spectrum-css/alertdialog
 
 <a name="1.0.1"></a>
-##1.0.1
+## 1.0.1
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertdialog@1.0.0...@spectrum-css/alertdialog@1.0.1)
 
 **Note:** Version bump only for package @spectrum-css/alertdialog
 
 <a name="1.0.0"></a>
-#1.0.0
+# 1.0.0
 🗓
 2023-08-22
 

--- a/components/alertdialog/CHANGELOG.md
+++ b/components/alertdialog/CHANGELOG.md
@@ -37,7 +37,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="2.0.0"></a>
-# 2.0.0
+## 2.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertdialog@1.2.4...@spectrum-css/alertdialog@2.0.0)
 
@@ -84,7 +84,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/alertdialog
 
 <a name="1.2.0"></a>
-# 1.2.0
+## 1.2.0
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertdialog@1.1.0...@spectrum-css/alertdialog@1.2.0)
 
@@ -93,7 +93,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **overlay,commons:**deprecate overlay; migrate references to commons ([#2429](https://github.com/adobe/spectrum-css/issues/2429))([7eecd96](https://github.com/adobe/spectrum-css/commit/7eecd96))
 
 <a name="1.1.0"></a>
-# 1.1.0
+## 1.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alertdialog@1.0.16...@spectrum-css/alertdialog@1.1.0)
 
@@ -214,7 +214,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/alertdialog
 
 <a name="1.0.0"></a>
-# 1.0.0
+## 1.0.0
 🗓
 2023-08-22
 

--- a/components/asset/CHANGELOG.md
+++ b/components/asset/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-# 5.0.0
+## 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/asset@4.0.0...@spectrum-css/asset@5.0.0)
 
@@ -40,7 +40,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="4.0.0"></a>
-# 4.0.0
+## 4.0.0
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/asset@3.1.2...@spectrum-css/asset@4.0.0)
 
@@ -70,7 +70,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/asset
 
 <a name="3.1.0"></a>
-# 3.1.0
+## 3.1.0
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/asset@3.0.52...@spectrum-css/asset@3.1.0)
 
@@ -541,7 +541,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/asset@3.0.0-beta.5...@spectrum-css/asset@3.0.0)
 
@@ -549,7 +549,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.5"></a>
 
-# 3.0.0-beta.5
+## 3.0.0-beta.5
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/asset@3.0.0-beta.4...@spectrum-css/asset@3.0.0-beta.5)
 
@@ -557,7 +557,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.4"></a>
 
-# 3.0.0-beta.4
+## 3.0.0-beta.4
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/asset@3.0.0-beta.3...@spectrum-css/asset@3.0.0-beta.4)
 
@@ -565,7 +565,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.3"></a>
 
-# 3.0.0-beta.3
+## 3.0.0-beta.3
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/asset@3.0.0-beta.2...@spectrum-css/asset@3.0.0-beta.3)
 
@@ -573,7 +573,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/asset@3.0.0-beta.1...@spectrum-css/asset@3.0.0-beta.2)
 
@@ -581,7 +581,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/asset@3.0.0-beta.0...@spectrum-css/asset@3.0.0-beta.1)
 
@@ -589,7 +589,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/asset@2.0.5...@spectrum-css/asset@3.0.0-beta.0)
 
@@ -639,7 +639,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/asset/CHANGELOG.md
+++ b/components/asset/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-#5.0.0
+# 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/asset@4.0.0...@spectrum-css/asset@5.0.0)
 
@@ -40,7 +40,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="4.0.0"></a>
-#4.0.0
+# 4.0.0
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/asset@3.1.2...@spectrum-css/asset@4.0.0)
 
@@ -56,21 +56,21 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - chore: add mods values for customization
 
 <a name="3.1.2"></a>
-##3.1.2
+## 3.1.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/asset@3.1.1...@spectrum-css/asset@3.1.2)
 
 **Note:** Version bump only for package @spectrum-css/asset
 
 <a name="3.1.1"></a>
-##3.1.1
+## 3.1.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/asset
 
 <a name="3.1.0"></a>
-#3.1.0
+# 3.1.0
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/asset@3.0.52...@spectrum-css/asset@3.1.0)
 
@@ -79,7 +79,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **asset,cyclebutton,quickaction,site:**deprecate skin.css assets ([#2438](https://github.com/adobe/spectrum-css/issues/2438))([d6de839](https://github.com/adobe/spectrum-css/commit/d6de839))
 
 <a name="3.0.52"></a>
-##3.0.52
+## 3.0.52
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/asset@3.0.51...@spectrum-css/asset@3.0.52)
 
@@ -88,14 +88,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **asset:**add whcm values for asset background color ([#2369](https://github.com/adobe/spectrum-css/issues/2369))([4c1c959](https://github.com/adobe/spectrum-css/commit/4c1c959))
 
 <a name="3.0.51"></a>
-##3.0.51
+## 3.0.51
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/asset@3.0.50...@spectrum-css/asset@3.0.51)
 
 **Note:** Version bump only for package @spectrum-css/asset
 
 <a name="3.0.50"></a>
-##3.0.50
+## 3.0.50
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/asset@3.0.48...@spectrum-css/asset@3.0.50)
 
@@ -104,7 +104,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="3.0.49"></a>
-##3.0.49
+## 3.0.49
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/asset@3.0.48...@spectrum-css/asset@3.0.49)
 
@@ -113,35 +113,35 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="3.0.48"></a>
-##3.0.48
+## 3.0.48
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/asset@3.0.47...@spectrum-css/asset@3.0.48)
 
 **Note:** Version bump only for package @spectrum-css/asset
 
 <a name="3.0.47"></a>
-##3.0.47
+## 3.0.47
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/asset@3.0.46...@spectrum-css/asset@3.0.47)
 
 **Note:** Version bump only for package @spectrum-css/asset
 
 <a name="3.0.46"></a>
-##3.0.46
+## 3.0.46
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/asset@3.0.45...@spectrum-css/asset@3.0.46)
 
 **Note:** Version bump only for package @spectrum-css/asset
 
 <a name="3.0.45"></a>
-##3.0.45
+## 3.0.45
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/asset@3.0.44...@spectrum-css/asset@3.0.45)
 
 **Note:** Version bump only for package @spectrum-css/asset
 
 <a name="3.0.44"></a>
-##3.0.44
+## 3.0.44
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/asset@3.0.43...@spectrum-css/asset@3.0.44)
 
@@ -150,14 +150,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="3.0.43"></a>
-##3.0.43
+## 3.0.43
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/asset@3.0.42...@spectrum-css/asset@3.0.43)
 
 **Note:** Version bump only for package @spectrum-css/asset
 
 <a name="3.0.42"></a>
-##3.0.42
+## 3.0.42
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/asset@3.0.41...@spectrum-css/asset@3.0.42)
 

--- a/components/assetcard/CHANGELOG.md
+++ b/components/assetcard/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="4.0.0"></a>
-#4.0.0
+# 4.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetcard@3.1.4...@spectrum-css/assetcard@4.0.0)
 
@@ -48,77 +48,77 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="3.1.4"></a>
-##3.1.4
+## 3.1.4
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetcard@3.1.3...@spectrum-css/assetcard@3.1.4)
 
 **Note:** Version bump only for package @spectrum-css/assetcard
 
 <a name="3.1.3"></a>
-##3.1.3
+## 3.1.3
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetcard@3.1.2...@spectrum-css/assetcard@3.1.3)
 
 **Note:** Version bump only for package @spectrum-css/assetcard
 
 <a name="3.1.2"></a>
-##3.1.2
+## 3.1.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetcard@3.1.1...@spectrum-css/assetcard@3.1.2)
 
 **Note:** Version bump only for package @spectrum-css/assetcard
 
 <a name="3.1.1"></a>
-##3.1.1
+## 3.1.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/assetcard
 
 <a name="3.1.0"></a>
-#3.1.0
+# 3.1.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetcard@3.0.5...@spectrum-css/assetcard@3.1.0)
 
 **Note:** Version bump only for package @spectrum-css/assetcard
 
 <a name="3.0.5"></a>
-##3.0.5
+## 3.0.5
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetcard@3.0.4...@spectrum-css/assetcard@3.0.5)
 
 **Note:** Version bump only for package @spectrum-css/assetcard
 
 <a name="3.0.4"></a>
-##3.0.4
+## 3.0.4
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetcard@3.0.3...@spectrum-css/assetcard@3.0.4)
 
 **Note:** Version bump only for package @spectrum-css/assetcard
 
 <a name="3.0.3"></a>
-##3.0.3
+## 3.0.3
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetcard@3.0.2...@spectrum-css/assetcard@3.0.3)
 
 **Note:** Version bump only for package @spectrum-css/assetcard
 
 <a name="3.0.2"></a>
-##3.0.2
+## 3.0.2
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetcard@3.0.0...@spectrum-css/assetcard@3.0.2)
 
 **Note:** Version bump only for package @spectrum-css/assetcard
 
 <a name="3.0.1"></a>
-##3.0.1
+## 3.0.1
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetcard@3.0.0...@spectrum-css/assetcard@3.0.1)
 
 **Note:** Version bump only for package @spectrum-css/assetcard
 
 <a name="3.0.0"></a>
-#3.0.0
+# 3.0.0
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetcard@2.0.13...@spectrum-css/assetcard@3.0.0)
 
@@ -131,70 +131,70 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
     		migrate asset card to updated token system
 
 <a name="2.0.13"></a>
-##2.0.13
+## 2.0.13
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetcard@2.0.12...@spectrum-css/assetcard@2.0.13)
 
 **Note:** Version bump only for package @spectrum-css/assetcard
 
 <a name="2.0.12"></a>
-##2.0.12
+## 2.0.12
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetcard@2.0.11...@spectrum-css/assetcard@2.0.12)
 
 **Note:** Version bump only for package @spectrum-css/assetcard
 
 <a name="2.0.11"></a>
-##2.0.11
+## 2.0.11
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetcard@2.0.10...@spectrum-css/assetcard@2.0.11)
 
 **Note:** Version bump only for package @spectrum-css/assetcard
 
 <a name="2.0.10"></a>
-##2.0.10
+## 2.0.10
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetcard@2.0.9...@spectrum-css/assetcard@2.0.10)
 
 **Note:** Version bump only for package @spectrum-css/assetcard
 
 <a name="2.0.9"></a>
-##2.0.9
+## 2.0.9
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetcard@2.0.8...@spectrum-css/assetcard@2.0.9)
 
 **Note:** Version bump only for package @spectrum-css/assetcard
 
 <a name="2.0.8"></a>
-##2.0.8
+## 2.0.8
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetcard@2.0.7...@spectrum-css/assetcard@2.0.8)
 
 **Note:** Version bump only for package @spectrum-css/assetcard
 
 <a name="2.0.7"></a>
-##2.0.7
+## 2.0.7
 🗓
 2023-09-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetcard@2.0.6...@spectrum-css/assetcard@2.0.7)
 
 **Note:** Version bump only for package @spectrum-css/assetcard
 
 <a name="2.0.6"></a>
-##2.0.6
+## 2.0.6
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetcard@2.0.5...@spectrum-css/assetcard@2.0.6)
 
 **Note:** Version bump only for package @spectrum-css/assetcard
 
 <a name="2.0.5"></a>
-##2.0.5
+## 2.0.5
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetcard@2.0.4...@spectrum-css/assetcard@2.0.5)
 
 **Note:** Version bump only for package @spectrum-css/assetcard
 
 <a name="2.0.4"></a>
-##2.0.4
+## 2.0.4
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetcard@2.0.3...@spectrum-css/assetcard@2.0.4)
 
@@ -203,28 +203,28 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="2.0.3"></a>
-##2.0.3
+## 2.0.3
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetcard@2.0.2...@spectrum-css/assetcard@2.0.3)
 
 **Note:** Version bump only for package @spectrum-css/assetcard
 
 <a name="2.0.2"></a>
-##2.0.2
+## 2.0.2
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetcard@2.0.0...@spectrum-css/assetcard@2.0.2)
 
 **Note:** Version bump only for package @spectrum-css/assetcard
 
 <a name="2.0.1"></a>
-##2.0.1
+## 2.0.1
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetcard@2.0.0...@spectrum-css/assetcard@2.0.1)
 
 **Note:** Version bump only for package @spectrum-css/assetcard
 
 <a name="2.0.0"></a>
-#2.0.0
+# 2.0.0
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetcard@1.1.52...@spectrum-css/assetcard@2.0.0)
 
@@ -237,84 +237,84 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
     		use native focus-visible pseudo class for focus styling
 
 <a name="1.1.52"></a>
-##1.1.52
+## 1.1.52
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetcard@1.1.51...@spectrum-css/assetcard@1.1.52)
 
 **Note:** Version bump only for package @spectrum-css/assetcard
 
 <a name="1.1.51"></a>
-##1.1.51
+## 1.1.51
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetcard@1.1.50...@spectrum-css/assetcard@1.1.51)
 
 **Note:** Version bump only for package @spectrum-css/assetcard
 
 <a name="1.1.50"></a>
-##1.1.50
+## 1.1.50
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetcard@1.1.49...@spectrum-css/assetcard@1.1.50)
 
 **Note:** Version bump only for package @spectrum-css/assetcard
 
 <a name="1.1.49"></a>
-##1.1.49
+## 1.1.49
 🗓
 2023-07-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetcard@1.1.48...@spectrum-css/assetcard@1.1.49)
 
 **Note:** Version bump only for package @spectrum-css/assetcard
 
 <a name="1.1.48"></a>
-##1.1.48
+## 1.1.48
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetcard@1.1.47...@spectrum-css/assetcard@1.1.48)
 
 **Note:** Version bump only for package @spectrum-css/assetcard
 
 <a name="1.1.47"></a>
-##1.1.47
+## 1.1.47
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetcard@1.1.46...@spectrum-css/assetcard@1.1.47)
 
 **Note:** Version bump only for package @spectrum-css/assetcard
 
 <a name="1.1.46"></a>
-##1.1.46
+## 1.1.46
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetcard@1.1.45...@spectrum-css/assetcard@1.1.46)
 
 **Note:** Version bump only for package @spectrum-css/assetcard
 
 <a name="1.1.45"></a>
-##1.1.45
+## 1.1.45
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetcard@1.1.44...@spectrum-css/assetcard@1.1.45)
 
 **Note:** Version bump only for package @spectrum-css/assetcard
 
 <a name="1.1.44"></a>
-##1.1.44
+## 1.1.44
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetcard@1.1.43...@spectrum-css/assetcard@1.1.44)
 
 **Note:** Version bump only for package @spectrum-css/assetcard
 
 <a name="1.1.43"></a>
-##1.1.43
+## 1.1.43
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetcard@1.1.42...@spectrum-css/assetcard@1.1.43)
 
 **Note:** Version bump only for package @spectrum-css/assetcard
 
 <a name="1.1.42"></a>
-##1.1.42
+## 1.1.42
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetcard@1.1.41...@spectrum-css/assetcard@1.1.42)
 
 **Note:** Version bump only for package @spectrum-css/assetcard
 
 <a name="1.1.41"></a>
-##1.1.41
+## 1.1.41
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetcard@1.1.40...@spectrum-css/assetcard@1.1.41)
 
@@ -323,14 +323,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="1.1.40"></a>
-##1.1.40
+## 1.1.40
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetcard@1.1.39...@spectrum-css/assetcard@1.1.40)
 
 **Note:** Version bump only for package @spectrum-css/assetcard
 
 <a name="1.1.39"></a>
-##1.1.39
+## 1.1.39
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetcard@1.1.38...@spectrum-css/assetcard@1.1.39)
 

--- a/components/assetcard/CHANGELOG.md
+++ b/components/assetcard/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="4.0.0"></a>
-# 4.0.0
+## 4.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetcard@3.1.4...@spectrum-css/assetcard@4.0.0)
 
@@ -76,7 +76,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/assetcard
 
 <a name="3.1.0"></a>
-# 3.1.0
+## 3.1.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetcard@3.0.5...@spectrum-css/assetcard@3.1.0)
 
@@ -118,7 +118,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/assetcard
 
 <a name="3.0.0"></a>
-# 3.0.0
+## 3.0.0
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetcard@2.0.13...@spectrum-css/assetcard@3.0.0)
 
@@ -224,7 +224,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/assetcard
 
 <a name="2.0.0"></a>
-# 2.0.0
+## 2.0.0
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetcard@1.1.52...@spectrum-css/assetcard@2.0.0)
 
@@ -642,7 +642,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="1.1.0"></a>
 
-# 1.1.0
+## 1.1.0
 
 🗓 2022-03-22
 

--- a/components/assetlist/CHANGELOG.md
+++ b/components/assetlist/CHANGELOG.md
@@ -31,7 +31,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="6.0.0"></a>
-#6.0.0
+# 6.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@5.2.4...@spectrum-css/assetlist@6.0.0)
 
@@ -50,42 +50,42 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="5.2.4"></a>
-##5.2.4
+## 5.2.4
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@5.2.3...@spectrum-css/assetlist@5.2.4)
 
 **Note:** Version bump only for package @spectrum-css/assetlist
 
 <a name="5.2.3"></a>
-##5.2.3
+## 5.2.3
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@5.2.2...@spectrum-css/assetlist@5.2.3)
 
 **Note:** Version bump only for package @spectrum-css/assetlist
 
 <a name="5.2.2"></a>
-##5.2.2
+## 5.2.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@5.2.1...@spectrum-css/assetlist@5.2.2)
 
 **Note:** Version bump only for package @spectrum-css/assetlist
 
 <a name="5.2.1"></a>
-##5.2.1
+## 5.2.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/assetlist
 
 <a name="5.2.0"></a>
-#5.2.0
+# 5.2.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@5.1.1...@spectrum-css/assetlist@5.2.0)
 
 **Note:** Version bump only for package @spectrum-css/assetlist
 
 <a name="5.1.1"></a>
-##5.1.1
+## 5.1.1
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@5.1.0...@spectrum-css/assetlist@5.1.1)
 
@@ -94,7 +94,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*deprecate logical transform plugin ([#2437](https://github.com/adobe/spectrum-css/issues/2437))([ff5dda6](https://github.com/adobe/spectrum-css/commit/ff5dda6))
 
 <a name="5.1.0"></a>
-#5.1.0
+# 5.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@5.0.4...@spectrum-css/assetlist@5.1.0)
 
@@ -103,35 +103,35 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="5.0.4"></a>
-##5.0.4
+## 5.0.4
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@5.0.3...@spectrum-css/assetlist@5.0.4)
 
 **Note:** Version bump only for package @spectrum-css/assetlist
 
 <a name="5.0.3"></a>
-##5.0.3
+## 5.0.3
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@5.0.2...@spectrum-css/assetlist@5.0.3)
 
 **Note:** Version bump only for package @spectrum-css/assetlist
 
 <a name="5.0.2"></a>
-##5.0.2
+## 5.0.2
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@5.0.0...@spectrum-css/assetlist@5.0.2)
 
 **Note:** Version bump only for package @spectrum-css/assetlist
 
 <a name="5.0.1"></a>
-##5.0.1
+## 5.0.1
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@5.0.0...@spectrum-css/assetlist@5.0.1)
 
 **Note:** Version bump only for package @spectrum-css/assetlist
 
 <a name="5.0.0"></a>
-#5.0.0
+# 5.0.0
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@4.0.0...@spectrum-css/assetlist@5.0.0)
 
@@ -178,7 +178,7 @@ Additionally:
 - chore(assetlist): id for storybook checkbox
 
 <a name="4.0.0"></a>
-#4.0.0
+# 4.0.0
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@3.0.85...@spectrum-css/assetlist@4.0.0)
 
@@ -200,63 +200,63 @@ Additionally:
 - docs(miller): generate mods
 
 <a name="3.0.85"></a>
-##3.0.85
+## 3.0.85
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@3.0.84...@spectrum-css/assetlist@3.0.85)
 
 **Note:** Version bump only for package @spectrum-css/assetlist
 
 <a name="3.0.84"></a>
-##3.0.84
+## 3.0.84
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@3.0.83...@spectrum-css/assetlist@3.0.84)
 
 **Note:** Version bump only for package @spectrum-css/assetlist
 
 <a name="3.0.83"></a>
-##3.0.83
+## 3.0.83
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@3.0.82...@spectrum-css/assetlist@3.0.83)
 
 **Note:** Version bump only for package @spectrum-css/assetlist
 
 <a name="3.0.82"></a>
-##3.0.82
+## 3.0.82
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@3.0.81...@spectrum-css/assetlist@3.0.82)
 
 **Note:** Version bump only for package @spectrum-css/assetlist
 
 <a name="3.0.81"></a>
-##3.0.81
+## 3.0.81
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@3.0.80...@spectrum-css/assetlist@3.0.81)
 
 **Note:** Version bump only for package @spectrum-css/assetlist
 
 <a name="3.0.80"></a>
-##3.0.80
+## 3.0.80
 🗓
 2023-09-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@3.0.79...@spectrum-css/assetlist@3.0.80)
 
 **Note:** Version bump only for package @spectrum-css/assetlist
 
 <a name="3.0.79"></a>
-##3.0.79
+## 3.0.79
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@3.0.78...@spectrum-css/assetlist@3.0.79)
 
 **Note:** Version bump only for package @spectrum-css/assetlist
 
 <a name="3.0.78"></a>
-##3.0.78
+## 3.0.78
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@3.0.77...@spectrum-css/assetlist@3.0.78)
 
 **Note:** Version bump only for package @spectrum-css/assetlist
 
 <a name="3.0.77"></a>
-##3.0.77
+## 3.0.77
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@3.0.76...@spectrum-css/assetlist@3.0.77)
 
@@ -265,112 +265,112 @@ Additionally:
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="3.0.76"></a>
-##3.0.76
+## 3.0.76
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@3.0.75...@spectrum-css/assetlist@3.0.76)
 
 **Note:** Version bump only for package @spectrum-css/assetlist
 
 <a name="3.0.75"></a>
-##3.0.75
+## 3.0.75
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@3.0.73...@spectrum-css/assetlist@3.0.75)
 
 **Note:** Version bump only for package @spectrum-css/assetlist
 
 <a name="3.0.74"></a>
-##3.0.74
+## 3.0.74
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@3.0.73...@spectrum-css/assetlist@3.0.74)
 
 **Note:** Version bump only for package @spectrum-css/assetlist
 
 <a name="3.0.73"></a>
-##3.0.73
+## 3.0.73
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@3.0.72...@spectrum-css/assetlist@3.0.73)
 
 **Note:** Version bump only for package @spectrum-css/assetlist
 
 <a name="3.0.72"></a>
-##3.0.72
+## 3.0.72
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@3.0.71...@spectrum-css/assetlist@3.0.72)
 
 **Note:** Version bump only for package @spectrum-css/assetlist
 
 <a name="3.0.71"></a>
-##3.0.71
+## 3.0.71
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@3.0.70...@spectrum-css/assetlist@3.0.71)
 
 **Note:** Version bump only for package @spectrum-css/assetlist
 
 <a name="3.0.70"></a>
-##3.0.70
+## 3.0.70
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@3.0.69...@spectrum-css/assetlist@3.0.70)
 
 **Note:** Version bump only for package @spectrum-css/assetlist
 
 <a name="3.0.69"></a>
-##3.0.69
+## 3.0.69
 🗓
 2023-07-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@3.0.68...@spectrum-css/assetlist@3.0.69)
 
 **Note:** Version bump only for package @spectrum-css/assetlist
 
 <a name="3.0.68"></a>
-##3.0.68
+## 3.0.68
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@3.0.67...@spectrum-css/assetlist@3.0.68)
 
 **Note:** Version bump only for package @spectrum-css/assetlist
 
 <a name="3.0.67"></a>
-##3.0.67
+## 3.0.67
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@3.0.66...@spectrum-css/assetlist@3.0.67)
 
 **Note:** Version bump only for package @spectrum-css/assetlist
 
 <a name="3.0.66"></a>
-##3.0.66
+## 3.0.66
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@3.0.65...@spectrum-css/assetlist@3.0.66)
 
 **Note:** Version bump only for package @spectrum-css/assetlist
 
 <a name="3.0.65"></a>
-##3.0.65
+## 3.0.65
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@3.0.64...@spectrum-css/assetlist@3.0.65)
 
 **Note:** Version bump only for package @spectrum-css/assetlist
 
 <a name="3.0.64"></a>
-##3.0.64
+## 3.0.64
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@3.0.63...@spectrum-css/assetlist@3.0.64)
 
 **Note:** Version bump only for package @spectrum-css/assetlist
 
 <a name="3.0.63"></a>
-##3.0.63
+## 3.0.63
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@3.0.62...@spectrum-css/assetlist@3.0.63)
 
 **Note:** Version bump only for package @spectrum-css/assetlist
 
 <a name="3.0.62"></a>
-##3.0.62
+## 3.0.62
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@3.0.61...@spectrum-css/assetlist@3.0.62)
 
 **Note:** Version bump only for package @spectrum-css/assetlist
 
 <a name="3.0.61"></a>
-##3.0.61
+## 3.0.61
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@3.0.60...@spectrum-css/assetlist@3.0.61)
 
@@ -379,14 +379,14 @@ Additionally:
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="3.0.60"></a>
-##3.0.60
+## 3.0.60
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@3.0.59...@spectrum-css/assetlist@3.0.60)
 
 **Note:** Version bump only for package @spectrum-css/assetlist
 
 <a name="3.0.59"></a>
-##3.0.59
+## 3.0.59
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@3.0.58...@spectrum-css/assetlist@3.0.59)
 

--- a/components/assetlist/CHANGELOG.md
+++ b/components/assetlist/CHANGELOG.md
@@ -31,7 +31,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="6.0.0"></a>
-# 6.0.0
+## 6.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@5.2.4...@spectrum-css/assetlist@6.0.0)
 
@@ -78,7 +78,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/assetlist
 
 <a name="5.2.0"></a>
-# 5.2.0
+## 5.2.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@5.1.1...@spectrum-css/assetlist@5.2.0)
 
@@ -94,7 +94,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*deprecate logical transform plugin ([#2437](https://github.com/adobe/spectrum-css/issues/2437))([ff5dda6](https://github.com/adobe/spectrum-css/commit/ff5dda6))
 
 <a name="5.1.0"></a>
-# 5.1.0
+## 5.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@5.0.4...@spectrum-css/assetlist@5.1.0)
 
@@ -131,7 +131,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/assetlist
 
 <a name="5.0.0"></a>
-# 5.0.0
+## 5.0.0
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@4.0.0...@spectrum-css/assetlist@5.0.0)
 
@@ -178,7 +178,7 @@ Additionally:
 - chore(assetlist): id for storybook checkbox
 
 <a name="4.0.0"></a>
-# 4.0.0
+## 4.0.0
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@3.0.85...@spectrum-css/assetlist@4.0.0)
 
@@ -896,7 +896,7 @@ Additionally:
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@3.0.0-beta.6...@spectrum-css/assetlist@3.0.0)
 
@@ -910,7 +910,7 @@ Additionally:
 
 <a name="3.0.0-beta.6"></a>
 
-# 3.0.0-beta.6
+## 3.0.0-beta.6
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@3.0.0-beta.5...@spectrum-css/assetlist@3.0.0-beta.6)
 
@@ -921,7 +921,7 @@ Additionally:
 
 <a name="3.0.0-beta.5"></a>
 
-# 3.0.0-beta.5
+## 3.0.0-beta.5
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@3.0.0-beta.4...@spectrum-css/assetlist@3.0.0-beta.5)
 
@@ -929,7 +929,7 @@ Additionally:
 
 <a name="3.0.0-beta.4"></a>
 
-# 3.0.0-beta.4
+## 3.0.0-beta.4
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@3.0.0-beta.3...@spectrum-css/assetlist@3.0.0-beta.4)
 
@@ -939,7 +939,7 @@ Additionally:
 
 <a name="3.0.0-beta.3"></a>
 
-# 3.0.0-beta.3
+## 3.0.0-beta.3
 
 🗓 2020-06-19 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@3.0.0-beta.2...@spectrum-css/assetlist@3.0.0-beta.3)
 
@@ -947,7 +947,7 @@ Additionally:
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@3.0.0-beta.1...@spectrum-css/assetlist@3.0.0-beta.2)
 
@@ -955,7 +955,7 @@ Additionally:
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@3.0.0-beta.0...@spectrum-css/assetlist@3.0.0-beta.1)
 
@@ -963,7 +963,7 @@ Additionally:
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/assetlist@2.0.6...@spectrum-css/assetlist@3.0.0-beta.0)
 
@@ -1025,7 +1025,7 @@ Additionally:
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/avatar/CHANGELOG.md
+++ b/components/avatar/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="7.0.0"></a>
-#7.0.0
+# 7.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@6.1.5...@spectrum-css/avatar@7.0.0)
 
@@ -40,42 +40,42 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="6.1.5"></a>
-##6.1.5
+## 6.1.5
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@6.1.4...@spectrum-css/avatar@6.1.5)
 
 **Note:** Version bump only for package @spectrum-css/avatar
 
 <a name="6.1.4"></a>
-##6.1.4
+## 6.1.4
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@6.1.3...@spectrum-css/avatar@6.1.4)
 
 **Note:** Version bump only for package @spectrum-css/avatar
 
 <a name="6.1.3"></a>
-##6.1.3
+## 6.1.3
 🗓
 2024-02-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@6.1.2...@spectrum-css/avatar@6.1.3)
 
 **Note:** Version bump only for package @spectrum-css/avatar
 
 <a name="6.1.2"></a>
-##6.1.2
+## 6.1.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@6.1.1...@spectrum-css/avatar@6.1.2)
 
 **Note:** Version bump only for package @spectrum-css/avatar
 
 <a name="6.1.1"></a>
-##6.1.1
+## 6.1.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/avatar
 
 <a name="6.1.0"></a>
-#6.1.0
+# 6.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@6.0.62...@spectrum-css/avatar@6.1.0)
 
@@ -84,35 +84,35 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="6.0.62"></a>
-##6.0.62
+## 6.0.62
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@6.0.61...@spectrum-css/avatar@6.0.62)
 
 **Note:** Version bump only for package @spectrum-css/avatar
 
 <a name="6.0.61"></a>
-##6.0.61
+## 6.0.61
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@6.0.60...@spectrum-css/avatar@6.0.61)
 
 **Note:** Version bump only for package @spectrum-css/avatar
 
 <a name="6.0.60"></a>
-##6.0.60
+## 6.0.60
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@6.0.58...@spectrum-css/avatar@6.0.60)
 
 **Note:** Version bump only for package @spectrum-css/avatar
 
 <a name="6.0.59"></a>
-##6.0.59
+## 6.0.59
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@6.0.58...@spectrum-css/avatar@6.0.59)
 
 **Note:** Version bump only for package @spectrum-css/avatar
 
 <a name="6.0.58"></a>
-##6.0.58
+## 6.0.58
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@6.0.57...@spectrum-css/avatar@6.0.58)
 
@@ -121,63 +121,63 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **avatar:**remove link markup from disabled state, whcm fix ([#2265](https://github.com/adobe/spectrum-css/issues/2265))([026b03d](https://github.com/adobe/spectrum-css/commit/026b03d))
 
 <a name="6.0.57"></a>
-##6.0.57
+## 6.0.57
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@6.0.56...@spectrum-css/avatar@6.0.57)
 
 **Note:** Version bump only for package @spectrum-css/avatar
 
 <a name="6.0.56"></a>
-##6.0.56
+## 6.0.56
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@6.0.55...@spectrum-css/avatar@6.0.56)
 
 **Note:** Version bump only for package @spectrum-css/avatar
 
 <a name="6.0.55"></a>
-##6.0.55
+## 6.0.55
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@6.0.54...@spectrum-css/avatar@6.0.55)
 
 **Note:** Version bump only for package @spectrum-css/avatar
 
 <a name="6.0.54"></a>
-##6.0.54
+## 6.0.54
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@6.0.53...@spectrum-css/avatar@6.0.54)
 
 **Note:** Version bump only for package @spectrum-css/avatar
 
 <a name="6.0.53"></a>
-##6.0.53
+## 6.0.53
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@6.0.52...@spectrum-css/avatar@6.0.53)
 
 **Note:** Version bump only for package @spectrum-css/avatar
 
 <a name="6.0.52"></a>
-##6.0.52
+## 6.0.52
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@6.0.51...@spectrum-css/avatar@6.0.52)
 
 **Note:** Version bump only for package @spectrum-css/avatar
 
 <a name="6.0.51"></a>
-##6.0.51
+## 6.0.51
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@6.0.50...@spectrum-css/avatar@6.0.51)
 
 **Note:** Version bump only for package @spectrum-css/avatar
 
 <a name="6.0.50"></a>
-##6.0.50
+## 6.0.50
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@6.0.49...@spectrum-css/avatar@6.0.50)
 
 **Note:** Version bump only for package @spectrum-css/avatar
 
 <a name="6.0.49"></a>
-##6.0.49
+## 6.0.49
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@6.0.48...@spectrum-css/avatar@6.0.49)
 
@@ -186,105 +186,105 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="6.0.48"></a>
-##6.0.48
+## 6.0.48
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@6.0.47...@spectrum-css/avatar@6.0.48)
 
 **Note:** Version bump only for package @spectrum-css/avatar
 
 <a name="6.0.47"></a>
-##6.0.47
+## 6.0.47
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@6.0.45...@spectrum-css/avatar@6.0.47)
 
 **Note:** Version bump only for package @spectrum-css/avatar
 
 <a name="6.0.46"></a>
-##6.0.46
+## 6.0.46
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@6.0.45...@spectrum-css/avatar@6.0.46)
 
 **Note:** Version bump only for package @spectrum-css/avatar
 
 <a name="6.0.45"></a>
-##6.0.45
+## 6.0.45
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@6.0.44...@spectrum-css/avatar@6.0.45)
 
 **Note:** Version bump only for package @spectrum-css/avatar
 
 <a name="6.0.44"></a>
-##6.0.44
+## 6.0.44
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@6.0.43...@spectrum-css/avatar@6.0.44)
 
 **Note:** Version bump only for package @spectrum-css/avatar
 
 <a name="6.0.43"></a>
-##6.0.43
+## 6.0.43
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@6.0.42...@spectrum-css/avatar@6.0.43)
 
 **Note:** Version bump only for package @spectrum-css/avatar
 
 <a name="6.0.42"></a>
-##6.0.42
+## 6.0.42
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@6.0.41...@spectrum-css/avatar@6.0.42)
 
 **Note:** Version bump only for package @spectrum-css/avatar
 
 <a name="6.0.41"></a>
-##6.0.41
+## 6.0.41
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@6.0.40...@spectrum-css/avatar@6.0.41)
 
 **Note:** Version bump only for package @spectrum-css/avatar
 
 <a name="6.0.40"></a>
-##6.0.40
+## 6.0.40
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@6.0.39...@spectrum-css/avatar@6.0.40)
 
 **Note:** Version bump only for package @spectrum-css/avatar
 
 <a name="6.0.39"></a>
-##6.0.39
+## 6.0.39
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@6.0.38...@spectrum-css/avatar@6.0.39)
 
 **Note:** Version bump only for package @spectrum-css/avatar
 
 <a name="6.0.38"></a>
-##6.0.38
+## 6.0.38
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@6.0.37...@spectrum-css/avatar@6.0.38)
 
 **Note:** Version bump only for package @spectrum-css/avatar
 
 <a name="6.0.37"></a>
-##6.0.37
+## 6.0.37
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@6.0.36...@spectrum-css/avatar@6.0.37)
 
 **Note:** Version bump only for package @spectrum-css/avatar
 
 <a name="6.0.36"></a>
-##6.0.36
+## 6.0.36
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@6.0.35...@spectrum-css/avatar@6.0.36)
 
 **Note:** Version bump only for package @spectrum-css/avatar
 
 <a name="6.0.35"></a>
-##6.0.35
+## 6.0.35
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@6.0.34...@spectrum-css/avatar@6.0.35)
 
 **Note:** Version bump only for package @spectrum-css/avatar
 
 <a name="6.0.34"></a>
-##6.0.34
+## 6.0.34
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@6.0.33...@spectrum-css/avatar@6.0.34)
 
@@ -293,14 +293,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="6.0.33"></a>
-##6.0.33
+## 6.0.33
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@6.0.32...@spectrum-css/avatar@6.0.33)
 
 **Note:** Version bump only for package @spectrum-css/avatar
 
 <a name="6.0.32"></a>
-##6.0.32
+## 6.0.32
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@6.0.31...@spectrum-css/avatar@6.0.32)
 

--- a/components/avatar/CHANGELOG.md
+++ b/components/avatar/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="7.0.0"></a>
-# 7.0.0
+## 7.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@6.1.5...@spectrum-css/avatar@7.0.0)
 
@@ -75,7 +75,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/avatar
 
 <a name="6.1.0"></a>
-# 6.1.0
+## 6.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@6.0.62...@spectrum-css/avatar@6.1.0)
 
@@ -556,7 +556,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="6.0.0"></a>
 
-# 6.0.0
+## 6.0.0
 
 🗓 2023-02-06 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@5.0.27...@spectrum-css/avatar@6.0.0)
 
@@ -799,7 +799,7 @@ Co-authored-by: Bernhard Schmidt <bschmidt@adobe.com>
 
 <a name="5.0.0"></a>
 
-# 5.0.0
+## 5.0.0
 
 🗓 2021-10-25 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@4.0.0-alpha.3...@spectrum-css/avatar@5.0.0)
 
@@ -821,7 +821,7 @@ Co-authored-by: Bernhard Schmidt <bschmidt@adobe.com>
 
 <a name="4.0.0"></a>
 
-# 4.0.0
+## 4.0.0
 
 🗓 2021-09-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@4.0.0-alpha.3...@spectrum-css/avatar@4.0.0)
 
@@ -831,7 +831,7 @@ Co-authored-by: Bernhard Schmidt <bschmidt@adobe.com>
 
 <a name="4.0.0-alpha.3"></a>
 
-# 4.0.0-alpha.3
+## 4.0.0-alpha.3
 
 🗓 2021-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@4.0.0-alpha.2...@spectrum-css/avatar@4.0.0-alpha.3)
 
@@ -839,7 +839,7 @@ Co-authored-by: Bernhard Schmidt <bschmidt@adobe.com>
 
 <a name="4.0.0-alpha.2"></a>
 
-# 4.0.0-alpha.2
+## 4.0.0-alpha.2
 
 🗓 2021-06-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@4.0.0-alpha.1...@spectrum-css/avatar@4.0.0-alpha.2)
 
@@ -847,7 +847,7 @@ Co-authored-by: Bernhard Schmidt <bschmidt@adobe.com>
 
 <a name="4.0.0-alpha.1"></a>
 
-# 4.0.0-alpha.1
+## 4.0.0-alpha.1
 
 🗓 2021-05-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@4.0.0-alpha.0...@spectrum-css/avatar@4.0.0-alpha.1)
 
@@ -855,7 +855,7 @@ Co-authored-by: Bernhard Schmidt <bschmidt@adobe.com>
 
 <a name="4.0.0-alpha.0"></a>
 
-# 4.0.0-alpha.0
+## 4.0.0-alpha.0
 
 🗓 2021-04-27 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@3.0.2...@spectrum-css/avatar@4.0.0-alpha.0)
 
@@ -885,7 +885,7 @@ Co-authored-by: Bernhard Schmidt <bschmidt@adobe.com>
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@3.0.0-beta.5...@spectrum-css/avatar@3.0.0)
 
@@ -893,7 +893,7 @@ Co-authored-by: Bernhard Schmidt <bschmidt@adobe.com>
 
 <a name="3.0.0-beta.5"></a>
 
-# 3.0.0-beta.5
+## 3.0.0-beta.5
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@3.0.0-beta.4...@spectrum-css/avatar@3.0.0-beta.5)
 
@@ -901,7 +901,7 @@ Co-authored-by: Bernhard Schmidt <bschmidt@adobe.com>
 
 <a name="3.0.0-beta.4"></a>
 
-# 3.0.0-beta.4
+## 3.0.0-beta.4
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@3.0.0-beta.3...@spectrum-css/avatar@3.0.0-beta.4)
 
@@ -909,7 +909,7 @@ Co-authored-by: Bernhard Schmidt <bschmidt@adobe.com>
 
 <a name="3.0.0-beta.3"></a>
 
-# 3.0.0-beta.3
+## 3.0.0-beta.3
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@3.0.0-beta.2...@spectrum-css/avatar@3.0.0-beta.3)
 
@@ -920,7 +920,7 @@ Co-authored-by: Bernhard Schmidt <bschmidt@adobe.com>
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@3.0.0-beta.1...@spectrum-css/avatar@3.0.0-beta.2)
 
@@ -928,7 +928,7 @@ Co-authored-by: Bernhard Schmidt <bschmidt@adobe.com>
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@3.0.0-beta.0...@spectrum-css/avatar@3.0.0-beta.1)
 
@@ -936,7 +936,7 @@ Co-authored-by: Bernhard Schmidt <bschmidt@adobe.com>
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/avatar@2.0.5...@spectrum-css/avatar@3.0.0-beta.0)
 
@@ -988,7 +988,7 @@ Co-authored-by: Bernhard Schmidt <bschmidt@adobe.com>
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/badge/CHANGELOG.md
+++ b/components/badge/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="4.0.0"></a>
-#4.0.0
+# 4.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/badge@3.2.5...@spectrum-css/badge@4.0.0)
 
@@ -44,42 +44,42 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="3.2.5"></a>
-##3.2.5
+## 3.2.5
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/badge@3.2.4...@spectrum-css/badge@3.2.5)
 
 **Note:** Version bump only for package @spectrum-css/badge
 
 <a name="3.2.4"></a>
-##3.2.4
+## 3.2.4
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/badge@3.2.3...@spectrum-css/badge@3.2.4)
 
 **Note:** Version bump only for package @spectrum-css/badge
 
 <a name="3.2.3"></a>
-##3.2.3
+## 3.2.3
 🗓
 2024-02-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/badge@3.2.2...@spectrum-css/badge@3.2.3)
 
 **Note:** Version bump only for package @spectrum-css/badge
 
 <a name="3.2.2"></a>
-##3.2.2
+## 3.2.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/badge@3.2.1...@spectrum-css/badge@3.2.2)
 
 **Note:** Version bump only for package @spectrum-css/badge
 
 <a name="3.2.1"></a>
-##3.2.1
+## 3.2.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/badge
 
 <a name="3.2.0"></a>
-#3.2.0
+# 3.2.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/badge@3.1.18...@spectrum-css/badge@3.2.0)
 
@@ -88,98 +88,98 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="3.1.18"></a>
-##3.1.18
+## 3.1.18
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/badge@3.1.17...@spectrum-css/badge@3.1.18)
 
 **Note:** Version bump only for package @spectrum-css/badge
 
 <a name="3.1.17"></a>
-##3.1.17
+## 3.1.17
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/badge@3.1.16...@spectrum-css/badge@3.1.17)
 
 **Note:** Version bump only for package @spectrum-css/badge
 
 <a name="3.1.16"></a>
-##3.1.16
+## 3.1.16
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/badge@3.1.14...@spectrum-css/badge@3.1.16)
 
 **Note:** Version bump only for package @spectrum-css/badge
 
 <a name="3.1.15"></a>
-##3.1.15
+## 3.1.15
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/badge@3.1.14...@spectrum-css/badge@3.1.15)
 
 **Note:** Version bump only for package @spectrum-css/badge
 
 <a name="3.1.14"></a>
-##3.1.14
+## 3.1.14
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/badge@3.1.13...@spectrum-css/badge@3.1.14)
 
 **Note:** Version bump only for package @spectrum-css/badge
 
 <a name="3.1.13"></a>
-##3.1.13
+## 3.1.13
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/badge@3.1.12...@spectrum-css/badge@3.1.13)
 
 **Note:** Version bump only for package @spectrum-css/badge
 
 <a name="3.1.12"></a>
-##3.1.12
+## 3.1.12
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/badge@3.1.11...@spectrum-css/badge@3.1.12)
 
 **Note:** Version bump only for package @spectrum-css/badge
 
 <a name="3.1.11"></a>
-##3.1.11
+## 3.1.11
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/badge@3.1.10...@spectrum-css/badge@3.1.11)
 
 **Note:** Version bump only for package @spectrum-css/badge
 
 <a name="3.1.10"></a>
-##3.1.10
+## 3.1.10
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/badge@3.1.9...@spectrum-css/badge@3.1.10)
 
 **Note:** Version bump only for package @spectrum-css/badge
 
 <a name="3.1.9"></a>
-##3.1.9
+## 3.1.9
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/badge@3.1.8...@spectrum-css/badge@3.1.9)
 
 **Note:** Version bump only for package @spectrum-css/badge
 
 <a name="3.1.8"></a>
-##3.1.8
+## 3.1.8
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/badge@3.1.7...@spectrum-css/badge@3.1.8)
 
 **Note:** Version bump only for package @spectrum-css/badge
 
 <a name="3.1.7"></a>
-##3.1.7
+## 3.1.7
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/badge@3.1.6...@spectrum-css/badge@3.1.7)
 
 **Note:** Version bump only for package @spectrum-css/badge
 
 <a name="3.1.6"></a>
-##3.1.6
+## 3.1.6
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/badge@3.1.5...@spectrum-css/badge@3.1.6)
 
 **Note:** Version bump only for package @spectrum-css/badge
 
 <a name="3.1.5"></a>
-##3.1.5
+## 3.1.5
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/badge@3.1.4...@spectrum-css/badge@3.1.5)
 
@@ -188,35 +188,35 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="3.1.4"></a>
-##3.1.4
+## 3.1.4
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/badge@3.1.3...@spectrum-css/badge@3.1.4)
 
 **Note:** Version bump only for package @spectrum-css/badge
 
 <a name="3.1.3"></a>
-##3.1.3
+## 3.1.3
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/badge@3.1.1...@spectrum-css/badge@3.1.3)
 
 **Note:** Version bump only for package @spectrum-css/badge
 
 <a name="3.1.2"></a>
-##3.1.2
+## 3.1.2
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/badge@3.1.1...@spectrum-css/badge@3.1.2)
 
 **Note:** Version bump only for package @spectrum-css/badge
 
 <a name="3.1.1"></a>
-##3.1.1
+## 3.1.1
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/badge@3.1.0...@spectrum-css/badge@3.1.1)
 
 **Note:** Version bump only for package @spectrum-css/badge
 
 <a name="3.1.0"></a>
-#3.1.0
+# 3.1.0
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/badge@3.0.45...@spectrum-css/badge@3.1.0)
 
@@ -225,70 +225,70 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **badge,tokens:**add non-semantic colors ([#2077](https://github.com/adobe/spectrum-css/issues/2077))([1bac588](https://github.com/adobe/spectrum-css/commit/1bac588))
 
 <a name="3.0.45"></a>
-##3.0.45
+## 3.0.45
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/badge@3.0.44...@spectrum-css/badge@3.0.45)
 
 **Note:** Version bump only for package @spectrum-css/badge
 
 <a name="3.0.44"></a>
-##3.0.44
+## 3.0.44
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/badge@3.0.43...@spectrum-css/badge@3.0.44)
 
 **Note:** Version bump only for package @spectrum-css/badge
 
 <a name="3.0.43"></a>
-##3.0.43
+## 3.0.43
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/badge@3.0.42...@spectrum-css/badge@3.0.43)
 
 **Note:** Version bump only for package @spectrum-css/badge
 
 <a name="3.0.42"></a>
-##3.0.42
+## 3.0.42
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/badge@3.0.41...@spectrum-css/badge@3.0.42)
 
 **Note:** Version bump only for package @spectrum-css/badge
 
 <a name="3.0.41"></a>
-##3.0.41
+## 3.0.41
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/badge@3.0.40...@spectrum-css/badge@3.0.41)
 
 **Note:** Version bump only for package @spectrum-css/badge
 
 <a name="3.0.40"></a>
-##3.0.40
+## 3.0.40
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/badge@3.0.39...@spectrum-css/badge@3.0.40)
 
 **Note:** Version bump only for package @spectrum-css/badge
 
 <a name="3.0.39"></a>
-##3.0.39
+## 3.0.39
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/badge@3.0.38...@spectrum-css/badge@3.0.39)
 
 **Note:** Version bump only for package @spectrum-css/badge
 
 <a name="3.0.38"></a>
-##3.0.38
+## 3.0.38
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/badge@3.0.37...@spectrum-css/badge@3.0.38)
 
 **Note:** Version bump only for package @spectrum-css/badge
 
 <a name="3.0.37"></a>
-##3.0.37
+## 3.0.37
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/badge@3.0.36...@spectrum-css/badge@3.0.37)
 
 **Note:** Version bump only for package @spectrum-css/badge
 
 <a name="3.0.36"></a>
-##3.0.36
+## 3.0.36
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/badge@3.0.35...@spectrum-css/badge@3.0.36)
 
@@ -297,14 +297,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="3.0.35"></a>
-##3.0.35
+## 3.0.35
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/badge@3.0.34...@spectrum-css/badge@3.0.35)
 
 **Note:** Version bump only for package @spectrum-css/badge
 
 <a name="3.0.34"></a>
-##3.0.34
+## 3.0.34
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/badge@3.0.33...@spectrum-css/badge@3.0.34)
 

--- a/components/badge/CHANGELOG.md
+++ b/components/badge/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="4.0.0"></a>
-# 4.0.0
+## 4.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/badge@3.2.5...@spectrum-css/badge@4.0.0)
 
@@ -79,7 +79,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/badge
 
 <a name="3.2.0"></a>
-# 3.2.0
+## 3.2.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/badge@3.1.18...@spectrum-css/badge@3.2.0)
 
@@ -216,7 +216,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/badge
 
 <a name="3.1.0"></a>
-# 3.1.0
+## 3.1.0
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/badge@3.0.45...@spectrum-css/badge@3.1.0)
 
@@ -576,7 +576,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2023-02-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/badge@2.0.9...@spectrum-css/badge@3.0.0)
 
@@ -662,7 +662,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2022-10-25 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/badge@1.0.20...@spectrum-css/badge@2.0.0)
 
@@ -989,7 +989,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/breadcrumb/CHANGELOG.md
+++ b/components/breadcrumb/CHANGELOG.md
@@ -31,7 +31,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="9.0.0"></a>
-# 9.0.0
+## 9.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@8.2.5...@spectrum-css/breadcrumb@9.0.0)
 
@@ -81,7 +81,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/breadcrumb
 
 <a name="8.2.0"></a>
-# 8.2.0
+## 8.2.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@8.1.1...@spectrum-css/breadcrumb@8.2.0)
 
@@ -97,7 +97,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*deprecate logical transform plugin ([#2437](https://github.com/adobe/spectrum-css/issues/2437))([ff5dda6](https://github.com/adobe/spectrum-css/commit/ff5dda6))
 
 <a name="8.1.0"></a>
-# 8.1.0
+## 8.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@8.0.17...@spectrum-css/breadcrumb@8.1.0)
 
@@ -229,7 +229,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/breadcrumb
 
 <a name="8.0.0"></a>
-# 8.0.0
+## 8.0.0
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@7.0.47...@spectrum-css/breadcrumb@8.0.0)
 
@@ -608,7 +608,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="7.0.0"></a>
 
-# 7.0.0
+## 7.0.0
 
 🗓 2023-02-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@6.0.2...@spectrum-css/breadcrumb@7.0.0)
 
@@ -636,7 +636,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="6.0.0"></a>
 
-# 6.0.0
+## 6.0.0
 
 🗓 2023-01-27 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@5.0.5...@spectrum-css/breadcrumb@6.0.0)
 
@@ -688,7 +688,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="5.0.0"></a>
 
-# 5.0.0
+## 5.0.0
 
 🗓 2022-06-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@4.0.21...@spectrum-css/breadcrumb@5.0.0)
 
@@ -886,7 +886,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="4.0.0"></a>
 
-# 4.0.0
+## 4.0.0
 
 🗓 2021-09-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@4.0.0-alpha.3...@spectrum-css/breadcrumb@4.0.0)
 
@@ -896,7 +896,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="4.0.0-alpha.3"></a>
 
-# 4.0.0-alpha.3
+## 4.0.0-alpha.3
 
 🗓 2021-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@4.0.0-alpha.2...@spectrum-css/breadcrumb@4.0.0-alpha.3)
 
@@ -904,7 +904,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="4.0.0-alpha.2"></a>
 
-# 4.0.0-alpha.2
+## 4.0.0-alpha.2
 
 🗓 2021-06-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@4.0.0-alpha.1...@spectrum-css/breadcrumb@4.0.0-alpha.2)
 
@@ -912,7 +912,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="4.0.0-alpha.1"></a>
 
-# 4.0.0-alpha.1
+## 4.0.0-alpha.1
 
 🗓 2021-05-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@4.0.0-alpha.0...@spectrum-css/breadcrumb@4.0.0-alpha.1)
 
@@ -920,7 +920,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="4.0.0-alpha.0"></a>
 
-# 4.0.0-alpha.0
+## 4.0.0-alpha.0
 
 🗓 2021-04-27 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@3.0.2...@spectrum-css/breadcrumb@4.0.0-alpha.0)
 
@@ -954,7 +954,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@3.0.0-beta.6...@spectrum-css/breadcrumb@3.0.0)
 
@@ -962,7 +962,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.6"></a>
 
-# 3.0.0-beta.6
+## 3.0.0-beta.6
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@3.0.0-beta.5...@spectrum-css/breadcrumb@3.0.0-beta.6)
 
@@ -980,7 +980,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.5"></a>
 
-# 3.0.0-beta.5
+## 3.0.0-beta.5
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@3.0.0-beta.4...@spectrum-css/breadcrumb@3.0.0-beta.5)
 
@@ -988,7 +988,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.4"></a>
 
-# 3.0.0-beta.4
+## 3.0.0-beta.4
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@3.0.0-beta.3...@spectrum-css/breadcrumb@3.0.0-beta.4)
 
@@ -998,7 +998,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.3"></a>
 
-# 3.0.0-beta.3
+## 3.0.0-beta.3
 
 🗓 2020-06-19 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@3.0.0-beta.2...@spectrum-css/breadcrumb@3.0.0-beta.3)
 
@@ -1006,7 +1006,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@3.0.0-beta.1...@spectrum-css/breadcrumb@3.0.0-beta.2)
 
@@ -1021,7 +1021,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@3.0.0-beta.0...@spectrum-css/breadcrumb@3.0.0-beta.1)
 
@@ -1029,7 +1029,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@2.0.5...@spectrum-css/breadcrumb@3.0.0-beta.0)
 
@@ -1079,7 +1079,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/breadcrumb/CHANGELOG.md
+++ b/components/breadcrumb/CHANGELOG.md
@@ -31,7 +31,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="9.0.0"></a>
-#9.0.0
+# 9.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@8.2.5...@spectrum-css/breadcrumb@9.0.0)
 
@@ -46,49 +46,49 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="8.2.5"></a>
-##8.2.5
+## 8.2.5
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@8.2.4...@spectrum-css/breadcrumb@8.2.5)
 
 **Note:** Version bump only for package @spectrum-css/breadcrumb
 
 <a name="8.2.4"></a>
-##8.2.4
+## 8.2.4
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@8.2.3...@spectrum-css/breadcrumb@8.2.4)
 
 **Note:** Version bump only for package @spectrum-css/breadcrumb
 
 <a name="8.2.3"></a>
-##8.2.3
+## 8.2.3
 🗓
 2024-02-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@8.2.2...@spectrum-css/breadcrumb@8.2.3)
 
 **Note:** Version bump only for package @spectrum-css/breadcrumb
 
 <a name="8.2.2"></a>
-##8.2.2
+## 8.2.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@8.2.1...@spectrum-css/breadcrumb@8.2.2)
 
 **Note:** Version bump only for package @spectrum-css/breadcrumb
 
 <a name="8.2.1"></a>
-##8.2.1
+## 8.2.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/breadcrumb
 
 <a name="8.2.0"></a>
-#8.2.0
+# 8.2.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@8.1.1...@spectrum-css/breadcrumb@8.2.0)
 
 **Note:** Version bump only for package @spectrum-css/breadcrumb
 
 <a name="8.1.1"></a>
-##8.1.1
+## 8.1.1
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@8.1.0...@spectrum-css/breadcrumb@8.1.1)
 
@@ -97,7 +97,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*deprecate logical transform plugin ([#2437](https://github.com/adobe/spectrum-css/issues/2437))([ff5dda6](https://github.com/adobe/spectrum-css/commit/ff5dda6))
 
 <a name="8.1.0"></a>
-#8.1.0
+# 8.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@8.0.17...@spectrum-css/breadcrumb@8.1.0)
 
@@ -106,14 +106,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="8.0.17"></a>
-##8.0.17
+## 8.0.17
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@8.0.16...@spectrum-css/breadcrumb@8.0.17)
 
 **Note:** Version bump only for package @spectrum-css/breadcrumb
 
 <a name="8.0.16"></a>
-##8.0.16
+## 8.0.16
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@8.0.15...@spectrum-css/breadcrumb@8.0.16)
 
@@ -122,84 +122,84 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **breadcrumb:**focus outline only on keyboard focus([1f72c3e](https://github.com/adobe/spectrum-css/commit/1f72c3e))
 
 <a name="8.0.15"></a>
-##8.0.15
+## 8.0.15
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@8.0.13...@spectrum-css/breadcrumb@8.0.15)
 
 **Note:** Version bump only for package @spectrum-css/breadcrumb
 
 <a name="8.0.14"></a>
-##8.0.14
+## 8.0.14
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@8.0.13...@spectrum-css/breadcrumb@8.0.14)
 
 **Note:** Version bump only for package @spectrum-css/breadcrumb
 
 <a name="8.0.13"></a>
-##8.0.13
+## 8.0.13
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@8.0.12...@spectrum-css/breadcrumb@8.0.13)
 
 **Note:** Version bump only for package @spectrum-css/breadcrumb
 
 <a name="8.0.12"></a>
-##8.0.12
+## 8.0.12
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@8.0.11...@spectrum-css/breadcrumb@8.0.12)
 
 **Note:** Version bump only for package @spectrum-css/breadcrumb
 
 <a name="8.0.11"></a>
-##8.0.11
+## 8.0.11
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@8.0.10...@spectrum-css/breadcrumb@8.0.11)
 
 **Note:** Version bump only for package @spectrum-css/breadcrumb
 
 <a name="8.0.10"></a>
-##8.0.10
+## 8.0.10
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@8.0.9...@spectrum-css/breadcrumb@8.0.10)
 
 **Note:** Version bump only for package @spectrum-css/breadcrumb
 
 <a name="8.0.9"></a>
-##8.0.9
+## 8.0.9
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@8.0.8...@spectrum-css/breadcrumb@8.0.9)
 
 **Note:** Version bump only for package @spectrum-css/breadcrumb
 
 <a name="8.0.8"></a>
-##8.0.8
+## 8.0.8
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@8.0.7...@spectrum-css/breadcrumb@8.0.8)
 
 **Note:** Version bump only for package @spectrum-css/breadcrumb
 
 <a name="8.0.7"></a>
-##8.0.7
+## 8.0.7
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@8.0.6...@spectrum-css/breadcrumb@8.0.7)
 
 **Note:** Version bump only for package @spectrum-css/breadcrumb
 
 <a name="8.0.6"></a>
-##8.0.6
+## 8.0.6
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@8.0.5...@spectrum-css/breadcrumb@8.0.6)
 
 **Note:** Version bump only for package @spectrum-css/breadcrumb
 
 <a name="8.0.5"></a>
-##8.0.5
+## 8.0.5
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@8.0.4...@spectrum-css/breadcrumb@8.0.5)
 
 **Note:** Version bump only for package @spectrum-css/breadcrumb
 
 <a name="8.0.4"></a>
-##8.0.4
+## 8.0.4
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@8.0.3...@spectrum-css/breadcrumb@8.0.4)
 
@@ -208,28 +208,28 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="8.0.3"></a>
-##8.0.3
+## 8.0.3
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@8.0.2...@spectrum-css/breadcrumb@8.0.3)
 
 **Note:** Version bump only for package @spectrum-css/breadcrumb
 
 <a name="8.0.2"></a>
-##8.0.2
+## 8.0.2
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@8.0.0...@spectrum-css/breadcrumb@8.0.2)
 
 **Note:** Version bump only for package @spectrum-css/breadcrumb
 
 <a name="8.0.1"></a>
-##8.0.1
+## 8.0.1
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@8.0.0...@spectrum-css/breadcrumb@8.0.1)
 
 **Note:** Version bump only for package @spectrum-css/breadcrumb
 
 <a name="8.0.0"></a>
-#8.0.0
+# 8.0.0
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@7.0.47...@spectrum-css/breadcrumb@8.0.0)
 
@@ -242,77 +242,77 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
     		use native focus-visible pseudo class for focus styling
 
 <a name="7.0.47"></a>
-##7.0.47
+## 7.0.47
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@7.0.46...@spectrum-css/breadcrumb@7.0.47)
 
 **Note:** Version bump only for package @spectrum-css/breadcrumb
 
 <a name="7.0.46"></a>
-##7.0.46
+## 7.0.46
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@7.0.45...@spectrum-css/breadcrumb@7.0.46)
 
 **Note:** Version bump only for package @spectrum-css/breadcrumb
 
 <a name="7.0.45"></a>
-##7.0.45
+## 7.0.45
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@7.0.44...@spectrum-css/breadcrumb@7.0.45)
 
 **Note:** Version bump only for package @spectrum-css/breadcrumb
 
 <a name="7.0.44"></a>
-##7.0.44
+## 7.0.44
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@7.0.43...@spectrum-css/breadcrumb@7.0.44)
 
 **Note:** Version bump only for package @spectrum-css/breadcrumb
 
 <a name="7.0.43"></a>
-##7.0.43
+## 7.0.43
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@7.0.42...@spectrum-css/breadcrumb@7.0.43)
 
 **Note:** Version bump only for package @spectrum-css/breadcrumb
 
 <a name="7.0.42"></a>
-##7.0.42
+## 7.0.42
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@7.0.41...@spectrum-css/breadcrumb@7.0.42)
 
 **Note:** Version bump only for package @spectrum-css/breadcrumb
 
 <a name="7.0.41"></a>
-##7.0.41
+## 7.0.41
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@7.0.40...@spectrum-css/breadcrumb@7.0.41)
 
 **Note:** Version bump only for package @spectrum-css/breadcrumb
 
 <a name="7.0.40"></a>
-##7.0.40
+## 7.0.40
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@7.0.39...@spectrum-css/breadcrumb@7.0.40)
 
 **Note:** Version bump only for package @spectrum-css/breadcrumb
 
 <a name="7.0.39"></a>
-##7.0.39
+## 7.0.39
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@7.0.38...@spectrum-css/breadcrumb@7.0.39)
 
 **Note:** Version bump only for package @spectrum-css/breadcrumb
 
 <a name="7.0.38"></a>
-##7.0.38
+## 7.0.38
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@7.0.37...@spectrum-css/breadcrumb@7.0.38)
 
 **Note:** Version bump only for package @spectrum-css/breadcrumb
 
 <a name="7.0.37"></a>
-##7.0.37
+## 7.0.37
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@7.0.36...@spectrum-css/breadcrumb@7.0.37)
 
@@ -321,14 +321,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="7.0.36"></a>
-##7.0.36
+## 7.0.36
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@7.0.35...@spectrum-css/breadcrumb@7.0.36)
 
 **Note:** Version bump only for package @spectrum-css/breadcrumb
 
 <a name="7.0.35"></a>
-##7.0.35
+## 7.0.35
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/breadcrumb@7.0.34...@spectrum-css/breadcrumb@7.0.35)
 

--- a/components/button/CHANGELOG.md
+++ b/components/button/CHANGELOG.md
@@ -31,7 +31,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="13.0.0"></a>
-# 13.0.0
+## 13.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@12.0.2...@spectrum-css/button@13.0.0)
 
@@ -68,7 +68,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/button
 
 <a name="12.0.0"></a>
-# 12.0.0
+## 12.0.0
 🗓
 2024-02-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@11.3.1...@spectrum-css/button@12.0.0)
 
@@ -123,7 +123,7 @@ intended workflow sizes.
 **Note:** Version bump only for package @spectrum-css/button
 
 <a name="11.3.0"></a>
-# 11.3.0
+## 11.3.0
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@11.2.1...@spectrum-css/button@11.3.0)
 
@@ -139,14 +139,14 @@ intended workflow sizes.
 **Note:** Version bump only for package @spectrum-css/button
 
 <a name="11.2.0"></a>
-# 11.2.0
+## 11.2.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@11.1.0...@spectrum-css/button@11.2.0)
 
 **Note:** Version bump only for package @spectrum-css/button
 
 <a name="11.1.0"></a>
-# 11.1.0
+## 11.1.0
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@11.0.19...@spectrum-css/button@11.1.0)
 
@@ -294,7 +294,7 @@ intended workflow sizes.
 **Note:** Version bump only for package @spectrum-css/button
 
 <a name="11.0.0"></a>
-# 11.0.0
+## 11.0.0
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@10.1.14...@spectrum-css/button@11.0.0)
 
@@ -411,7 +411,7 @@ intended workflow sizes.
 
 <a name="10.1.0"></a>
 
-# 10.1.0
+## 10.1.0
 
 🗓 2023-05-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@10.0.11...@spectrum-css/button@10.1.0)
 
@@ -509,7 +509,7 @@ intended workflow sizes.
 
 <a name="10.0.0"></a>
 
-# 10.0.0
+## 10.0.0
 
 🗓 2023-04-25 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@9.1.6...@spectrum-css/button@10.0.0)
 
@@ -580,7 +580,7 @@ Additional changes:
 
 <a name="9.1.0"></a>
 
-# 9.1.0
+## 9.1.0
 
 🗓 2023-04-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@9.0.14...@spectrum-css/button@9.1.0)
 
@@ -702,7 +702,7 @@ Additional changes:
 
 <a name="9.0.0"></a>
 
-# 9.0.0
+## 9.0.0
 
 🗓 2023-02-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@8.0.0...@spectrum-css/button@9.0.0)
 
@@ -714,7 +714,7 @@ Additional changes:
 
 <a name="8.0.0"></a>
 
-# 8.0.0
+## 8.0.0
 
 🗓 2023-02-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@6.0.21...@spectrum-css/button@8.0.0)
 
@@ -726,7 +726,7 @@ Additional changes:
 
 <a name="7.0.0"></a>
 
-# 7.0.0
+## 7.0.0
 
 🗓 2023-01-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@7.0.0-beta.6...@spectrum-css/button@7.0.0)
 
@@ -738,7 +738,7 @@ Additional changes:
 
 <a name="7.0.0-beta.5"></a>
 
-# 7.0.0-beta.5
+## 7.0.0-beta.5
 
 🗓 2023-01-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@6.0.20...@spectrum-css/button@7.0.0-beta.5)
 
@@ -925,7 +925,7 @@ Additional changes:
 
 <a name="6.0.0"></a>
 
-# 6.0.0
+## 6.0.0
 
 🗓 2022-01-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@4.1.4...@spectrum-css/button@6.0.0)
 
@@ -948,7 +948,7 @@ Additional changes:
 
 <a name="5.0.0"></a>
 
-# 5.0.0
+## 5.0.0
 
 🗓 2022-01-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@5.0.0-beta.0...@spectrum-css/button@5.0.0)
 
@@ -958,7 +958,7 @@ Additional changes:
 
 <a name="5.0.0-beta.0"></a>
 
-# 5.0.0-beta.0
+## 5.0.0-beta.0
 
 🗓 2021-12-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@4.1.4...@spectrum-css/button@5.0.0-beta.0)
 
@@ -1011,7 +1011,7 @@ Additional changes:
 
 <a name="4.1.0"></a>
 
-# 4.1.0
+## 4.1.0
 
 🗓 2021-11-08 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@4.0.0-alpha.2...@spectrum-css/button@4.1.0)
 
@@ -1038,7 +1038,7 @@ Additional changes:
 
 <a name="4.0.0"></a>
 
-# 4.0.0
+## 4.0.0
 
 🗓 2021-09-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@4.0.0-alpha.2...@spectrum-css/button@4.0.0)
 
@@ -1049,7 +1049,7 @@ Additional changes:
 
 <a name="4.0.0-alpha.2"></a>
 
-# 4.0.0-alpha.2
+## 4.0.0-alpha.2
 
 🗓 2021-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@4.0.0-alpha.1...@spectrum-css/button@4.0.0-alpha.2)
 
@@ -1057,7 +1057,7 @@ Additional changes:
 
 <a name="4.0.0-alpha.1"></a>
 
-# 4.0.0-alpha.1
+## 4.0.0-alpha.1
 
 🗓 2021-06-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@4.0.0-alpha.0...@spectrum-css/button@4.0.0-alpha.1)
 
@@ -1068,7 +1068,7 @@ Additional changes:
 
 <a name="4.0.0-alpha.0"></a>
 
-# 4.0.0-alpha.0
+## 4.0.0-alpha.0
 
 🗓 2021-05-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@3.0.3-alpha.0...@spectrum-css/button@4.0.0-alpha.0)
 
@@ -1110,7 +1110,7 @@ Additional changes:
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@3.0.0-beta.6...@spectrum-css/button@3.0.0)
 
@@ -1118,7 +1118,7 @@ Additional changes:
 
 <a name="3.0.0-beta.6"></a>
 
-# 3.0.0-beta.6
+## 3.0.0-beta.6
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@3.0.0-beta.5...@spectrum-css/button@3.0.0-beta.6)
 
@@ -1148,7 +1148,7 @@ Additional changes:
 
 <a name="3.0.0-beta.5"></a>
 
-# 3.0.0-beta.5
+## 3.0.0-beta.5
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@3.0.0-beta.4...@spectrum-css/button@3.0.0-beta.5)
 
@@ -1156,7 +1156,7 @@ Additional changes:
 
 <a name="3.0.0-beta.4"></a>
 
-# 3.0.0-beta.4
+## 3.0.0-beta.4
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@3.0.0-beta.3...@spectrum-css/button@3.0.0-beta.4)
 
@@ -1171,7 +1171,7 @@ Additional changes:
 
 <a name="3.0.0-beta.3"></a>
 
-# 3.0.0-beta.3
+## 3.0.0-beta.3
 
 🗓 2020-06-19 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@3.0.0-beta.2...@spectrum-css/button@3.0.0-beta.3)
 
@@ -1181,7 +1181,7 @@ Additional changes:
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@3.0.0-beta.1...@spectrum-css/button@3.0.0-beta.2)
 
@@ -1205,7 +1205,7 @@ fix: correct Quiet Emphasized Action Button
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@3.0.0-beta.0...@spectrum-css/button@3.0.0-beta.1)
 
@@ -1213,7 +1213,7 @@ fix: correct Quiet Emphasized Action Button
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@2.2.0...@spectrum-css/button@3.0.0-beta.0)
 
@@ -1223,7 +1223,7 @@ fix: correct Quiet Emphasized Action Button
 
 <a name="2.2.0"></a>
 
-# 2.2.0
+## 2.2.0
 
 🗓 2020-03-06 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@2.1.0...@spectrum-css/button@2.2.0)
 
@@ -1233,7 +1233,7 @@ fix: correct Quiet Emphasized Action Button
 
 <a name="2.1.0"></a>
 
-# 2.1.0
+## 2.1.0
 
 🗓 2020-02-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@2.0.3...@spectrum-css/button@2.1.0)
 
@@ -1271,7 +1271,7 @@ fix: correct Quiet Emphasized Action Button
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/button/CHANGELOG.md
+++ b/components/button/CHANGELOG.md
@@ -31,7 +31,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="13.0.0"></a>
-#13.0.0
+# 13.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@12.0.2...@spectrum-css/button@13.0.0)
 
@@ -54,21 +54,21 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * Imports added to index.css and themes/express.css
 
 <a name="12.0.2"></a>
-##12.0.2
+## 12.0.2
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@12.0.1...@spectrum-css/button@12.0.2)
 
 **Note:** Version bump only for package @spectrum-css/button
 
 <a name="12.0.1"></a>
-##12.0.1
+## 12.0.1
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@12.0.0...@spectrum-css/button@12.0.1)
 
 **Note:** Version bump only for package @spectrum-css/button
 
 <a name="12.0.0"></a>
-#12.0.0
+# 12.0.0
 🗓
 2024-02-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@11.3.1...@spectrum-css/button@12.0.0)
 
@@ -116,14 +116,14 @@ the icon, in case of alignment issues with icons that are not the
 intended workflow sizes.
 
 <a name="11.3.1"></a>
-##11.3.1
+## 11.3.1
 🗓
 2024-02-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@11.3.0...@spectrum-css/button@11.3.1)
 
 **Note:** Version bump only for package @spectrum-css/button
 
 <a name="11.3.0"></a>
-#11.3.0
+# 11.3.0
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@11.2.1...@spectrum-css/button@11.3.0)
 
@@ -132,21 +132,21 @@ intended workflow sizes.
 - **button:**pending state([0b82dd9](https://github.com/adobe/spectrum-css/commit/0b82dd9))
 
 <a name="11.2.1"></a>
-##11.2.1
+## 11.2.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/button
 
 <a name="11.2.0"></a>
-#11.2.0
+# 11.2.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@11.1.0...@spectrum-css/button@11.2.0)
 
 **Note:** Version bump only for package @spectrum-css/button
 
 <a name="11.1.0"></a>
-#11.1.0
+# 11.1.0
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@11.0.19...@spectrum-css/button@11.1.0)
 
@@ -159,112 +159,112 @@ intended workflow sizes.
 - **commons:**rename and deprecate mods referencing global tokens ([#2423](https://github.com/adobe/spectrum-css/issues/2423))([3a49432](https://github.com/adobe/spectrum-css/commit/3a49432))
 
 <a name="11.0.19"></a>
-##11.0.19
+## 11.0.19
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@11.0.18...@spectrum-css/button@11.0.19)
 
 **Note:** Version bump only for package @spectrum-css/button
 
 <a name="11.0.18"></a>
-##11.0.18
+## 11.0.18
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@11.0.17...@spectrum-css/button@11.0.18)
 
 **Note:** Version bump only for package @spectrum-css/button
 
 <a name="11.0.17"></a>
-##11.0.17
+## 11.0.17
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@11.0.16...@spectrum-css/button@11.0.17)
 
 **Note:** Version bump only for package @spectrum-css/button
 
 <a name="11.0.16"></a>
-##11.0.16
+## 11.0.16
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@11.0.14...@spectrum-css/button@11.0.16)
 
 **Note:** Version bump only for package @spectrum-css/button
 
 <a name="11.0.15"></a>
-##11.0.15
+## 11.0.15
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@11.0.14...@spectrum-css/button@11.0.15)
 
 **Note:** Version bump only for package @spectrum-css/button
 
 <a name="11.0.14"></a>
-##11.0.14
+## 11.0.14
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@11.0.13...@spectrum-css/button@11.0.14)
 
 **Note:** Version bump only for package @spectrum-css/button
 
 <a name="11.0.13"></a>
-##11.0.13
+## 11.0.13
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@11.0.12...@spectrum-css/button@11.0.13)
 
 **Note:** Version bump only for package @spectrum-css/button
 
 <a name="11.0.12"></a>
-##11.0.12
+## 11.0.12
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@11.0.11...@spectrum-css/button@11.0.12)
 
 **Note:** Version bump only for package @spectrum-css/button
 
 <a name="11.0.11"></a>
-##11.0.11
+## 11.0.11
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@11.0.10...@spectrum-css/button@11.0.11)
 
 **Note:** Version bump only for package @spectrum-css/button
 
 <a name="11.0.10"></a>
-##11.0.10
+## 11.0.10
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@11.0.9...@spectrum-css/button@11.0.10)
 
 **Note:** Version bump only for package @spectrum-css/button
 
 <a name="11.0.9"></a>
-##11.0.9
+## 11.0.9
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@11.0.8...@spectrum-css/button@11.0.9)
 
 **Note:** Version bump only for package @spectrum-css/button
 
 <a name="11.0.8"></a>
-##11.0.8
+## 11.0.8
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@11.0.7...@spectrum-css/button@11.0.8)
 
 **Note:** Version bump only for package @spectrum-css/button
 
 <a name="11.0.7"></a>
-##11.0.7
+## 11.0.7
 🗓
 2023-09-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@11.0.6...@spectrum-css/button@11.0.7)
 
 **Note:** Version bump only for package @spectrum-css/button
 
 <a name="11.0.6"></a>
-##11.0.6
+## 11.0.6
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@11.0.5...@spectrum-css/button@11.0.6)
 
 **Note:** Version bump only for package @spectrum-css/button
 
 <a name="11.0.5"></a>
-##11.0.5
+## 11.0.5
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@11.0.4...@spectrum-css/button@11.0.5)
 
 **Note:** Version bump only for package @spectrum-css/button
 
 <a name="11.0.4"></a>
-##11.0.4
+## 11.0.4
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@11.0.3...@spectrum-css/button@11.0.4)
 
@@ -273,28 +273,28 @@ intended workflow sizes.
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="11.0.3"></a>
-##11.0.3
+## 11.0.3
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@11.0.2...@spectrum-css/button@11.0.3)
 
 **Note:** Version bump only for package @spectrum-css/button
 
 <a name="11.0.2"></a>
-##11.0.2
+## 11.0.2
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@11.0.0...@spectrum-css/button@11.0.2)
 
 **Note:** Version bump only for package @spectrum-css/button
 
 <a name="11.0.1"></a>
-##11.0.1
+## 11.0.1
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@11.0.0...@spectrum-css/button@11.0.1)
 
 **Note:** Version bump only for package @spectrum-css/button
 
 <a name="11.0.0"></a>
-#11.0.0
+# 11.0.0
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@10.1.14...@spectrum-css/button@11.0.0)
 
@@ -307,42 +307,42 @@ intended workflow sizes.
     		use native focus-visible pseudo class for focus styling on button and basebutton
 
 <a name="10.1.14"></a>
-##10.1.14
+## 10.1.14
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@10.1.13...@spectrum-css/button@10.1.14)
 
 **Note:** Version bump only for package @spectrum-css/button
 
 <a name="10.1.13"></a>
-##10.1.13
+## 10.1.13
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@10.1.12...@spectrum-css/button@10.1.13)
 
 **Note:** Version bump only for package @spectrum-css/button
 
 <a name="10.1.12"></a>
-##10.1.12
+## 10.1.12
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@10.1.11...@spectrum-css/button@10.1.12)
 
 **Note:** Version bump only for package @spectrum-css/button
 
 <a name="10.1.11"></a>
-##10.1.11
+## 10.1.11
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@10.1.10...@spectrum-css/button@10.1.11)
 
 **Note:** Version bump only for package @spectrum-css/button
 
 <a name="10.1.10"></a>
-##10.1.10
+## 10.1.10
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@10.1.9...@spectrum-css/button@10.1.10)
 
 **Note:** Version bump only for package @spectrum-css/button
 
 <a name="10.1.9"></a>
-##10.1.9
+## 10.1.9
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@10.1.8...@spectrum-css/button@10.1.9)
 
@@ -351,35 +351,35 @@ intended workflow sizes.
 - **button:**add explicit highcontrast variables for disabled color ([#1985](https://github.com/adobe/spectrum-css/issues/1985))([8697c37](https://github.com/adobe/spectrum-css/commit/8697c37))
 
 <a name="10.1.8"></a>
-##10.1.8
+## 10.1.8
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@10.1.7...@spectrum-css/button@10.1.8)
 
 **Note:** Version bump only for package @spectrum-css/button
 
 <a name="10.1.7"></a>
-##10.1.7
+## 10.1.7
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@10.1.6...@spectrum-css/button@10.1.7)
 
 **Note:** Version bump only for package @spectrum-css/button
 
 <a name="10.1.6"></a>
-##10.1.6
+## 10.1.6
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@10.1.5...@spectrum-css/button@10.1.6)
 
 **Note:** Version bump only for package @spectrum-css/button
 
 <a name="10.1.5"></a>
-##10.1.5
+## 10.1.5
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@10.1.4...@spectrum-css/button@10.1.5)
 
 **Note:** Version bump only for package @spectrum-css/button
 
 <a name="10.1.4"></a>
-##10.1.4
+## 10.1.4
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@10.1.3...@spectrum-css/button@10.1.4)
 
@@ -388,14 +388,14 @@ intended workflow sizes.
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="10.1.3"></a>
-##10.1.3
+## 10.1.3
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@10.1.2...@spectrum-css/button@10.1.3)
 
 **Note:** Version bump only for package @spectrum-css/button
 
 <a name="10.1.2"></a>
-##10.1.2
+## 10.1.2
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/button@10.1.1...@spectrum-css/button@10.1.2)
 

--- a/components/buttongroup/CHANGELOG.md
+++ b/components/buttongroup/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="7.0.0"></a>
-# 7.0.0
+## 7.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@6.2.5...@spectrum-css/buttongroup@7.0.0)
 
@@ -79,7 +79,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/buttongroup
 
 <a name="6.2.0"></a>
-# 6.2.0
+## 6.2.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@6.1.16...@spectrum-css/buttongroup@6.2.0)
 
@@ -202,7 +202,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/buttongroup
 
 <a name="6.1.0"></a>
-# 6.1.0
+## 6.1.0
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@6.0.62...@spectrum-css/buttongroup@6.1.0)
 
@@ -703,7 +703,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="6.0.0"></a>
 
-# 6.0.0
+## 6.0.0
 
 🗓 2022-10-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@5.0.13...@spectrum-css/buttongroup@6.0.0)
 
@@ -821,7 +821,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="5.0.0"></a>
 
-# 5.0.0
+## 5.0.0
 
 🗓 2022-01-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@3.0.10...@spectrum-css/buttongroup@5.0.0)
 
@@ -839,7 +839,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="4.0.0"></a>
 
-# 4.0.0
+## 4.0.0
 
 🗓 2022-01-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@4.0.0-beta.0...@spectrum-css/buttongroup@4.0.0)
 
@@ -847,7 +847,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="4.0.0-beta.0"></a>
 
-# 4.0.0-beta.0
+## 4.0.0-beta.0
 
 🗓 2021-12-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@3.0.10...@spectrum-css/buttongroup@4.0.0-beta.0)
 
@@ -967,7 +967,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@3.0.0-beta.6...@spectrum-css/buttongroup@3.0.0)
 
@@ -975,7 +975,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.6"></a>
 
-# 3.0.0-beta.6
+## 3.0.0-beta.6
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@3.0.0-beta.5...@spectrum-css/buttongroup@3.0.0-beta.6)
 
@@ -990,7 +990,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.5"></a>
 
-# 3.0.0-beta.5
+## 3.0.0-beta.5
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@3.0.0-beta.4...@spectrum-css/buttongroup@3.0.0-beta.5)
 
@@ -998,7 +998,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.4"></a>
 
-# 3.0.0-beta.4
+## 3.0.0-beta.4
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@3.0.0-beta.3...@spectrum-css/buttongroup@3.0.0-beta.4)
 
@@ -1006,7 +1006,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.3"></a>
 
-# 3.0.0-beta.3
+## 3.0.0-beta.3
 
 🗓 2020-06-19 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@3.0.0-beta.2...@spectrum-css/buttongroup@3.0.0-beta.3)
 
@@ -1014,7 +1014,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@3.0.0-beta.1...@spectrum-css/buttongroup@3.0.0-beta.2)
 
@@ -1038,7 +1038,7 @@ fix: correct Quiet Emphasized Action Button
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@3.0.0-beta.0...@spectrum-css/buttongroup@3.0.0-beta.1)
 
@@ -1046,7 +1046,7 @@ fix: correct Quiet Emphasized Action Button
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@2.2.1...@spectrum-css/buttongroup@3.0.0-beta.0)
 
@@ -1064,7 +1064,7 @@ fix: correct Quiet Emphasized Action Button
 
 <a name="2.2.0"></a>
 
-# 2.2.0
+## 2.2.0
 
 🗓 2020-02-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@2.1.0...@spectrum-css/buttongroup@2.2.0)
 
@@ -1074,7 +1074,7 @@ fix: correct Quiet Emphasized Action Button
 
 <a name="2.1.0"></a>
 
-# 2.1.0
+## 2.1.0
 
 🗓 2020-01-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@2.0.3...@spectrum-css/buttongroup@2.1.0)
 
@@ -1108,7 +1108,7 @@ fix: correct Quiet Emphasized Action Button
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/buttongroup/CHANGELOG.md
+++ b/components/buttongroup/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="7.0.0"></a>
-#7.0.0
+# 7.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@6.2.5...@spectrum-css/buttongroup@7.0.0)
 
@@ -44,42 +44,42 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="6.2.5"></a>
-##6.2.5
+## 6.2.5
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@6.2.4...@spectrum-css/buttongroup@6.2.5)
 
 **Note:** Version bump only for package @spectrum-css/buttongroup
 
 <a name="6.2.4"></a>
-##6.2.4
+## 6.2.4
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@6.2.3...@spectrum-css/buttongroup@6.2.4)
 
 **Note:** Version bump only for package @spectrum-css/buttongroup
 
 <a name="6.2.3"></a>
-##6.2.3
+## 6.2.3
 🗓
 2024-02-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@6.2.2...@spectrum-css/buttongroup@6.2.3)
 
 **Note:** Version bump only for package @spectrum-css/buttongroup
 
 <a name="6.2.2"></a>
-##6.2.2
+## 6.2.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@6.2.1...@spectrum-css/buttongroup@6.2.2)
 
 **Note:** Version bump only for package @spectrum-css/buttongroup
 
 <a name="6.2.1"></a>
-##6.2.1
+## 6.2.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/buttongroup
 
 <a name="6.2.0"></a>
-#6.2.0
+# 6.2.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@6.1.16...@spectrum-css/buttongroup@6.2.0)
 
@@ -88,105 +88,105 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="6.1.16"></a>
-##6.1.16
+## 6.1.16
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@6.1.15...@spectrum-css/buttongroup@6.1.16)
 
 **Note:** Version bump only for package @spectrum-css/buttongroup
 
 <a name="6.1.15"></a>
-##6.1.15
+## 6.1.15
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@6.1.14...@spectrum-css/buttongroup@6.1.15)
 
 **Note:** Version bump only for package @spectrum-css/buttongroup
 
 <a name="6.1.14"></a>
-##6.1.14
+## 6.1.14
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@6.1.12...@spectrum-css/buttongroup@6.1.14)
 
 **Note:** Version bump only for package @spectrum-css/buttongroup
 
 <a name="6.1.13"></a>
-##6.1.13
+## 6.1.13
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@6.1.12...@spectrum-css/buttongroup@6.1.13)
 
 **Note:** Version bump only for package @spectrum-css/buttongroup
 
 <a name="6.1.12"></a>
-##6.1.12
+## 6.1.12
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@6.1.11...@spectrum-css/buttongroup@6.1.12)
 
 **Note:** Version bump only for package @spectrum-css/buttongroup
 
 <a name="6.1.11"></a>
-##6.1.11
+## 6.1.11
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@6.1.10...@spectrum-css/buttongroup@6.1.11)
 
 **Note:** Version bump only for package @spectrum-css/buttongroup
 
 <a name="6.1.10"></a>
-##6.1.10
+## 6.1.10
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@6.1.9...@spectrum-css/buttongroup@6.1.10)
 
 **Note:** Version bump only for package @spectrum-css/buttongroup
 
 <a name="6.1.9"></a>
-##6.1.9
+## 6.1.9
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@6.1.8...@spectrum-css/buttongroup@6.1.9)
 
 **Note:** Version bump only for package @spectrum-css/buttongroup
 
 <a name="6.1.8"></a>
-##6.1.8
+## 6.1.8
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@6.1.7...@spectrum-css/buttongroup@6.1.8)
 
 **Note:** Version bump only for package @spectrum-css/buttongroup
 
 <a name="6.1.7"></a>
-##6.1.7
+## 6.1.7
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@6.1.6...@spectrum-css/buttongroup@6.1.7)
 
 **Note:** Version bump only for package @spectrum-css/buttongroup
 
 <a name="6.1.6"></a>
-##6.1.6
+## 6.1.6
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@6.1.5...@spectrum-css/buttongroup@6.1.6)
 
 **Note:** Version bump only for package @spectrum-css/buttongroup
 
 <a name="6.1.5"></a>
-##6.1.5
+## 6.1.5
 🗓
 2023-09-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@6.1.4...@spectrum-css/buttongroup@6.1.5)
 
 **Note:** Version bump only for package @spectrum-css/buttongroup
 
 <a name="6.1.4"></a>
-##6.1.4
+## 6.1.4
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@6.1.3...@spectrum-css/buttongroup@6.1.4)
 
 **Note:** Version bump only for package @spectrum-css/buttongroup
 
 <a name="6.1.3"></a>
-##6.1.3
+## 6.1.3
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@6.1.2...@spectrum-css/buttongroup@6.1.3)
 
 **Note:** Version bump only for package @spectrum-css/buttongroup
 
 <a name="6.1.2"></a>
-##6.1.2
+## 6.1.2
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@6.1.1...@spectrum-css/buttongroup@6.1.2)
 
@@ -195,14 +195,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="6.1.1"></a>
-##6.1.1
+## 6.1.1
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@6.1.0...@spectrum-css/buttongroup@6.1.1)
 
 **Note:** Version bump only for package @spectrum-css/buttongroup
 
 <a name="6.1.0"></a>
-#6.1.0
+# 6.1.0
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@6.0.62...@spectrum-css/buttongroup@6.1.0)
 
@@ -211,91 +211,91 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **buttongroup:**add justify-content support([825f176](https://github.com/adobe/spectrum-css/commit/825f176))
 
 <a name="6.0.63"></a>
-##6.0.63
+## 6.0.63
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@6.0.62...@spectrum-css/buttongroup@6.0.63)
 
 **Note:** Version bump only for package @spectrum-css/buttongroup
 
 <a name="6.0.62"></a>
-##6.0.62
+## 6.0.62
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@6.0.61...@spectrum-css/buttongroup@6.0.62)
 
 **Note:** Version bump only for package @spectrum-css/buttongroup
 
 <a name="6.0.61"></a>
-##6.0.61
+## 6.0.61
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@6.0.60...@spectrum-css/buttongroup@6.0.61)
 
 **Note:** Version bump only for package @spectrum-css/buttongroup
 
 <a name="6.0.60"></a>
-##6.0.60
+## 6.0.60
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@6.0.59...@spectrum-css/buttongroup@6.0.60)
 
 **Note:** Version bump only for package @spectrum-css/buttongroup
 
 <a name="6.0.59"></a>
-##6.0.59
+## 6.0.59
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@6.0.58...@spectrum-css/buttongroup@6.0.59)
 
 **Note:** Version bump only for package @spectrum-css/buttongroup
 
 <a name="6.0.58"></a>
-##6.0.58
+## 6.0.58
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@6.0.57...@spectrum-css/buttongroup@6.0.58)
 
 **Note:** Version bump only for package @spectrum-css/buttongroup
 
 <a name="6.0.57"></a>
-##6.0.57
+## 6.0.57
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@6.0.56...@spectrum-css/buttongroup@6.0.57)
 
 **Note:** Version bump only for package @spectrum-css/buttongroup
 
 <a name="6.0.56"></a>
-##6.0.56
+## 6.0.56
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@6.0.55...@spectrum-css/buttongroup@6.0.56)
 
 **Note:** Version bump only for package @spectrum-css/buttongroup
 
 <a name="6.0.55"></a>
-##6.0.55
+## 6.0.55
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@6.0.54...@spectrum-css/buttongroup@6.0.55)
 
 **Note:** Version bump only for package @spectrum-css/buttongroup
 
 <a name="6.0.54"></a>
-##6.0.54
+## 6.0.54
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@6.0.53...@spectrum-css/buttongroup@6.0.54)
 
 **Note:** Version bump only for package @spectrum-css/buttongroup
 
 <a name="6.0.53"></a>
-##6.0.53
+## 6.0.53
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@6.0.52...@spectrum-css/buttongroup@6.0.53)
 
 **Note:** Version bump only for package @spectrum-css/buttongroup
 
 <a name="6.0.52"></a>
-##6.0.52
+## 6.0.52
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@6.0.51...@spectrum-css/buttongroup@6.0.52)
 
 **Note:** Version bump only for package @spectrum-css/buttongroup
 
 <a name="6.0.51"></a>
-##6.0.51
+## 6.0.51
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@6.0.50...@spectrum-css/buttongroup@6.0.51)
 
@@ -304,14 +304,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="6.0.50"></a>
-##6.0.50
+## 6.0.50
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@6.0.49...@spectrum-css/buttongroup@6.0.50)
 
 **Note:** Version bump only for package @spectrum-css/buttongroup
 
 <a name="6.0.49"></a>
-##6.0.49
+## 6.0.49
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/buttongroup@6.0.48...@spectrum-css/buttongroup@6.0.49)
 

--- a/components/calendar/CHANGELOG.md
+++ b/components/calendar/CHANGELOG.md
@@ -35,7 +35,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-# 5.0.0
+## 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@4.2.5...@spectrum-css/calendar@5.0.0)
 
@@ -89,7 +89,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/calendar
 
 <a name="4.2.0"></a>
-# 4.2.0
+## 4.2.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@4.1.1...@spectrum-css/calendar@4.2.0)
 
@@ -105,7 +105,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*deprecate logical transform plugin ([#2437](https://github.com/adobe/spectrum-css/issues/2437))([ff5dda6](https://github.com/adobe/spectrum-css/commit/ff5dda6))
 
 <a name="4.1.0"></a>
-# 4.1.0
+## 4.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@4.0.22...@spectrum-css/calendar@4.1.0)
 
@@ -278,7 +278,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/calendar
 
 <a name="4.0.0"></a>
-# 4.0.0
+## 4.0.0
 🗓
 2023-07-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@3.2.7...@spectrum-css/calendar@4.0.0)
 
@@ -340,7 +340,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/calendar
 
 <a name="3.2.0"></a>
-# 3.2.0
+## 3.2.0
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@3.1.24...@spectrum-css/calendar@3.2.0)
 
@@ -541,7 +541,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.1.0"></a>
 
-# 3.1.0
+## 3.1.0
 
 🗓 2023-03-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@3.0.38...@spectrum-css/calendar@3.1.0)
 
@@ -896,7 +896,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@3.0.0-beta.6...@spectrum-css/calendar@3.0.0)
 
@@ -904,7 +904,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.6"></a>
 
-# 3.0.0-beta.6
+## 3.0.0-beta.6
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@3.0.0-beta.5...@spectrum-css/calendar@3.0.0-beta.6)
 
@@ -915,7 +915,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.5"></a>
 
-# 3.0.0-beta.5
+## 3.0.0-beta.5
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@3.0.0-beta.4...@spectrum-css/calendar@3.0.0-beta.5)
 
@@ -925,7 +925,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.4"></a>
 
-# 3.0.0-beta.4
+## 3.0.0-beta.4
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@3.0.0-beta.3...@spectrum-css/calendar@3.0.0-beta.4)
 
@@ -936,7 +936,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.3"></a>
 
-# 3.0.0-beta.3
+## 3.0.0-beta.3
 
 🗓 2020-06-19 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@3.0.0-beta.2...@spectrum-css/calendar@3.0.0-beta.3)
 
@@ -944,7 +944,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@3.0.0-beta.1...@spectrum-css/calendar@3.0.0-beta.2)
 
@@ -952,7 +952,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@3.0.0-beta.0...@spectrum-css/calendar@3.0.0-beta.1)
 
@@ -960,7 +960,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@2.0.5...@spectrum-css/calendar@3.0.0-beta.0)
 
@@ -1019,7 +1019,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/calendar/CHANGELOG.md
+++ b/components/calendar/CHANGELOG.md
@@ -35,7 +35,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-#5.0.0
+# 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@4.2.5...@spectrum-css/calendar@5.0.0)
 
@@ -54,49 +54,49 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="4.2.5"></a>
-##4.2.5
+## 4.2.5
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@4.2.4...@spectrum-css/calendar@4.2.5)
 
 **Note:** Version bump only for package @spectrum-css/calendar
 
 <a name="4.2.4"></a>
-##4.2.4
+## 4.2.4
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@4.2.3...@spectrum-css/calendar@4.2.4)
 
 **Note:** Version bump only for package @spectrum-css/calendar
 
 <a name="4.2.3"></a>
-##4.2.3
+## 4.2.3
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@4.2.2...@spectrum-css/calendar@4.2.3)
 
 **Note:** Version bump only for package @spectrum-css/calendar
 
 <a name="4.2.2"></a>
-##4.2.2
+## 4.2.2
 🗓
 2024-02-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@4.2.1...@spectrum-css/calendar@4.2.2)
 
 **Note:** Version bump only for package @spectrum-css/calendar
 
 <a name="4.2.1"></a>
-##4.2.1
+## 4.2.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/calendar
 
 <a name="4.2.0"></a>
-#4.2.0
+# 4.2.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@4.1.1...@spectrum-css/calendar@4.2.0)
 
 **Note:** Version bump only for package @spectrum-css/calendar
 
 <a name="4.1.1"></a>
-##4.1.1
+## 4.1.1
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@4.1.0...@spectrum-css/calendar@4.1.1)
 
@@ -105,7 +105,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*deprecate logical transform plugin ([#2437](https://github.com/adobe/spectrum-css/issues/2437))([ff5dda6](https://github.com/adobe/spectrum-css/commit/ff5dda6))
 
 <a name="4.1.0"></a>
-#4.1.0
+# 4.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@4.0.22...@spectrum-css/calendar@4.1.0)
 
@@ -118,105 +118,105 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **calendar:**use display instead of visibility([78f5129](https://github.com/adobe/spectrum-css/commit/78f5129))
 
 <a name="4.0.22"></a>
-##4.0.22
+## 4.0.22
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@4.0.21...@spectrum-css/calendar@4.0.22)
 
 **Note:** Version bump only for package @spectrum-css/calendar
 
 <a name="4.0.21"></a>
-##4.0.21
+## 4.0.21
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@4.0.20...@spectrum-css/calendar@4.0.21)
 
 **Note:** Version bump only for package @spectrum-css/calendar
 
 <a name="4.0.20"></a>
-##4.0.20
+## 4.0.20
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@4.0.18...@spectrum-css/calendar@4.0.20)
 
 **Note:** Version bump only for package @spectrum-css/calendar
 
 <a name="4.0.19"></a>
-##4.0.19
+## 4.0.19
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@4.0.18...@spectrum-css/calendar@4.0.19)
 
 **Note:** Version bump only for package @spectrum-css/calendar
 
 <a name="4.0.18"></a>
-##4.0.18
+## 4.0.18
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@4.0.17...@spectrum-css/calendar@4.0.18)
 
 **Note:** Version bump only for package @spectrum-css/calendar
 
 <a name="4.0.17"></a>
-##4.0.17
+## 4.0.17
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@4.0.16...@spectrum-css/calendar@4.0.17)
 
 **Note:** Version bump only for package @spectrum-css/calendar
 
 <a name="4.0.16"></a>
-##4.0.16
+## 4.0.16
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@4.0.15...@spectrum-css/calendar@4.0.16)
 
 **Note:** Version bump only for package @spectrum-css/calendar
 
 <a name="4.0.15"></a>
-##4.0.15
+## 4.0.15
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@4.0.14...@spectrum-css/calendar@4.0.15)
 
 **Note:** Version bump only for package @spectrum-css/calendar
 
 <a name="4.0.14"></a>
-##4.0.14
+## 4.0.14
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@4.0.13...@spectrum-css/calendar@4.0.14)
 
 **Note:** Version bump only for package @spectrum-css/calendar
 
 <a name="4.0.13"></a>
-##4.0.13
+## 4.0.13
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@4.0.12...@spectrum-css/calendar@4.0.13)
 
 **Note:** Version bump only for package @spectrum-css/calendar
 
 <a name="4.0.12"></a>
-##4.0.12
+## 4.0.12
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@4.0.11...@spectrum-css/calendar@4.0.12)
 
 **Note:** Version bump only for package @spectrum-css/calendar
 
 <a name="4.0.11"></a>
-##4.0.11
+## 4.0.11
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@4.0.10...@spectrum-css/calendar@4.0.11)
 
 **Note:** Version bump only for package @spectrum-css/calendar
 
 <a name="4.0.10"></a>
-##4.0.10
+## 4.0.10
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@4.0.9...@spectrum-css/calendar@4.0.10)
 
 **Note:** Version bump only for package @spectrum-css/calendar
 
 <a name="4.0.9"></a>
-##4.0.9
+## 4.0.9
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@4.0.8...@spectrum-css/calendar@4.0.9)
 
 **Note:** Version bump only for package @spectrum-css/calendar
 
 <a name="4.0.8"></a>
-##4.0.8
+## 4.0.8
 🗓
 2023-08-25 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@4.0.7...@spectrum-css/calendar@4.0.8)
 
@@ -229,56 +229,56 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="4.0.7"></a>
-##4.0.7
+## 4.0.7
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@4.0.6...@spectrum-css/calendar@4.0.7)
 
 **Note:** Version bump only for package @spectrum-css/calendar
 
 <a name="4.0.6"></a>
-##4.0.6
+## 4.0.6
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@4.0.4...@spectrum-css/calendar@4.0.6)
 
 **Note:** Version bump only for package @spectrum-css/calendar
 
 <a name="4.0.5"></a>
-##4.0.5
+## 4.0.5
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@4.0.4...@spectrum-css/calendar@4.0.5)
 
 **Note:** Version bump only for package @spectrum-css/calendar
 
 <a name="4.0.4"></a>
-##4.0.4
+## 4.0.4
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@4.0.3...@spectrum-css/calendar@4.0.4)
 
 **Note:** Version bump only for package @spectrum-css/calendar
 
 <a name="4.0.3"></a>
-##4.0.3
+## 4.0.3
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@4.0.2...@spectrum-css/calendar@4.0.3)
 
 **Note:** Version bump only for package @spectrum-css/calendar
 
 <a name="4.0.2"></a>
-##4.0.2
+## 4.0.2
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@4.0.1...@spectrum-css/calendar@4.0.2)
 
 **Note:** Version bump only for package @spectrum-css/calendar
 
 <a name="4.0.1"></a>
-##4.0.1
+## 4.0.1
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@4.0.0...@spectrum-css/calendar@4.0.1)
 
 **Note:** Version bump only for package @spectrum-css/calendar
 
 <a name="4.0.0"></a>
-#4.0.0
+# 4.0.0
 🗓
 2023-07-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@3.2.7...@spectrum-css/calendar@4.0.0)
 
@@ -291,56 +291,56 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
     		migrates Calendar to use `@adobe/spectrum-tokens`
 
 <a name="3.2.7"></a>
-##3.2.7
+## 3.2.7
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@3.2.6...@spectrum-css/calendar@3.2.7)
 
 **Note:** Version bump only for package @spectrum-css/calendar
 
 <a name="3.2.6"></a>
-##3.2.6
+## 3.2.6
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@3.2.5...@spectrum-css/calendar@3.2.6)
 
 **Note:** Version bump only for package @spectrum-css/calendar
 
 <a name="3.2.5"></a>
-##3.2.5
+## 3.2.5
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@3.2.4...@spectrum-css/calendar@3.2.5)
 
 **Note:** Version bump only for package @spectrum-css/calendar
 
 <a name="3.2.4"></a>
-##3.2.4
+## 3.2.4
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@3.2.3...@spectrum-css/calendar@3.2.4)
 
 **Note:** Version bump only for package @spectrum-css/calendar
 
 <a name="3.2.3"></a>
-##3.2.3
+## 3.2.3
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@3.2.2...@spectrum-css/calendar@3.2.3)
 
 **Note:** Version bump only for package @spectrum-css/calendar
 
 <a name="3.2.2"></a>
-##3.2.2
+## 3.2.2
 🗓
 2023-06-28 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@3.2.1...@spectrum-css/calendar@3.2.2)
 
 **Note:** Version bump only for package @spectrum-css/calendar
 
 <a name="3.2.1"></a>
-##3.2.1
+## 3.2.1
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@3.2.0...@spectrum-css/calendar@3.2.1)
 
 **Note:** Version bump only for package @spectrum-css/calendar
 
 <a name="3.2.0"></a>
-#3.2.0
+# 3.2.0
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@3.1.24...@spectrum-css/calendar@3.2.0)
 
@@ -349,7 +349,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*update to Storybook v7 ([#1935](https://github.com/adobe/spectrum-css/issues/1935))([6dcf09b](https://github.com/adobe/spectrum-css/commit/6dcf09b))
 
 <a name="3.1.24"></a>
-##3.1.24
+## 3.1.24
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@3.1.23...@spectrum-css/calendar@3.1.24)
 
@@ -358,14 +358,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="3.1.23"></a>
-##3.1.23
+## 3.1.23
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@3.1.22...@spectrum-css/calendar@3.1.23)
 
 **Note:** Version bump only for package @spectrum-css/calendar
 
 <a name="3.1.22"></a>
-##3.1.22
+## 3.1.22
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/calendar@3.1.21...@spectrum-css/calendar@3.1.22)
 

--- a/components/card/CHANGELOG.md
+++ b/components/card/CHANGELOG.md
@@ -37,7 +37,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="8.0.0"></a>
-#8.0.0
+# 8.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@7.0.2...@spectrum-css/card@8.0.0)
 
@@ -56,21 +56,21 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * Imports added to index.css and themes/express.css
 
 <a name="7.0.2"></a>
-##7.0.2
+## 7.0.2
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@7.0.1...@spectrum-css/card@7.0.2)
 
 **Note:** Version bump only for package @spectrum-css/card
 
 <a name="7.0.1"></a>
-##7.0.1
+## 7.0.1
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@7.0.0...@spectrum-css/card@7.0.1)
 
 **Note:** Version bump only for package @spectrum-css/card
 
 <a name="7.0.0"></a>
-#7.0.0
+# 7.0.0
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@6.4.1...@spectrum-css/card@7.0.0)
 
@@ -87,21 +87,21 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 This component has been deprecated. Use an action bar to allow users to perform actions on either a single or multiple items at the same time, instead.
 
 <a name="6.4.1"></a>
-##6.4.1
+## 6.4.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/card
 
 <a name="6.4.0"></a>
-#6.4.0
+# 6.4.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@6.3.1...@spectrum-css/card@6.4.0)
 
 **Note:** Version bump only for package @spectrum-css/card
 
 <a name="6.3.1"></a>
-##6.3.1
+## 6.3.1
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@6.3.0...@spectrum-css/card@6.3.1)
 
@@ -112,7 +112,7 @@ This component has been deprecated. Use an action bar to allow users to perform 
   **card:**revert misnamed instance of background color mod([80b3b78](https://github.com/adobe/spectrum-css/commit/80b3b78))
 
 <a name="6.3.0"></a>
-#6.3.0
+# 6.3.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@6.2.2...@spectrum-css/card@6.3.0)
 
@@ -121,14 +121,14 @@ This component has been deprecated. Use an action bar to allow users to perform 
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="6.2.2"></a>
-##6.2.2
+## 6.2.2
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@6.2.1...@spectrum-css/card@6.2.2)
 
 **Note:** Version bump only for package @spectrum-css/card
 
 <a name="6.2.1"></a>
-##6.2.1
+## 6.2.1
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@6.2.0...@spectrum-css/card@6.2.1)
 
@@ -137,7 +137,7 @@ This component has been deprecated. Use an action bar to allow users to perform 
 - **card:**focus outline only on keyboard focus([268e3cc](https://github.com/adobe/spectrum-css/commit/268e3cc))
 
 <a name="6.2.0"></a>
-#6.2.0
+# 6.2.0
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@6.0.24...@spectrum-css/card@6.2.0)
 
@@ -146,7 +146,7 @@ This component has been deprecated. Use an action bar to allow users to perform 
 - **card:**add additional mod properties ([#2279](https://github.com/adobe/spectrum-css/issues/2279))([a290816](https://github.com/adobe/spectrum-css/commit/a290816))
 
 <a name="6.1.0"></a>
-#6.1.0
+# 6.1.0
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@6.0.24...@spectrum-css/card@6.1.0)
 
@@ -155,175 +155,175 @@ This component has been deprecated. Use an action bar to allow users to perform 
 - **card:**add additional mod properties ([#2279](https://github.com/adobe/spectrum-css/issues/2279))([a290816](https://github.com/adobe/spectrum-css/commit/a290816))
 
 <a name="6.0.24"></a>
-##6.0.24
+## 6.0.24
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@6.0.23...@spectrum-css/card@6.0.24)
 
 **Note:** Version bump only for package @spectrum-css/card
 
 <a name="6.0.23"></a>
-##6.0.23
+## 6.0.23
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@6.0.22...@spectrum-css/card@6.0.23)
 
 **Note:** Version bump only for package @spectrum-css/card
 
 <a name="6.0.22"></a>
-##6.0.22
+## 6.0.22
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@6.0.21...@spectrum-css/card@6.0.22)
 
 **Note:** Version bump only for package @spectrum-css/card
 
 <a name="6.0.21"></a>
-##6.0.21
+## 6.0.21
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@6.0.20...@spectrum-css/card@6.0.21)
 
 **Note:** Version bump only for package @spectrum-css/card
 
 <a name="6.0.20"></a>
-##6.0.20
+## 6.0.20
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@6.0.19...@spectrum-css/card@6.0.20)
 
 **Note:** Version bump only for package @spectrum-css/card
 
 <a name="6.0.19"></a>
-##6.0.19
+## 6.0.19
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@6.0.18...@spectrum-css/card@6.0.19)
 
 **Note:** Version bump only for package @spectrum-css/card
 
 <a name="6.0.18"></a>
-##6.0.18
+## 6.0.18
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@6.0.17...@spectrum-css/card@6.0.18)
 
 **Note:** Version bump only for package @spectrum-css/card
 
 <a name="6.0.17"></a>
-##6.0.17
+## 6.0.17
 🗓
 2023-09-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@6.0.16...@spectrum-css/card@6.0.17)
 
 **Note:** Version bump only for package @spectrum-css/card
 
 <a name="6.0.16"></a>
-##6.0.16
+## 6.0.16
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@6.0.15...@spectrum-css/card@6.0.16)
 
 **Note:** Version bump only for package @spectrum-css/card
 
 <a name="6.0.15"></a>
-##6.0.15
+## 6.0.15
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@6.0.14...@spectrum-css/card@6.0.15)
 
 **Note:** Version bump only for package @spectrum-css/card
 
 <a name="6.0.14"></a>
-##6.0.14
+## 6.0.14
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@6.0.13...@spectrum-css/card@6.0.14)
 
 **Note:** Version bump only for package @spectrum-css/card
 
 <a name="6.0.13"></a>
-##6.0.13
+## 6.0.13
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@6.0.12...@spectrum-css/card@6.0.13)
 
 **Note:** Version bump only for package @spectrum-css/card
 
 <a name="6.0.12"></a>
-##6.0.12
+## 6.0.12
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@6.0.10...@spectrum-css/card@6.0.12)
 
 **Note:** Version bump only for package @spectrum-css/card
 
 <a name="6.0.11"></a>
-##6.0.11
+## 6.0.11
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@6.0.10...@spectrum-css/card@6.0.11)
 
 **Note:** Version bump only for package @spectrum-css/card
 
 <a name="6.0.10"></a>
-##6.0.10
+## 6.0.10
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@6.0.9...@spectrum-css/card@6.0.10)
 
 **Note:** Version bump only for package @spectrum-css/card
 
 <a name="6.0.9"></a>
-##6.0.9
+## 6.0.9
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@6.0.8...@spectrum-css/card@6.0.9)
 
 **Note:** Version bump only for package @spectrum-css/card
 
 <a name="6.0.8"></a>
-##6.0.8
+## 6.0.8
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@6.0.7...@spectrum-css/card@6.0.8)
 
 **Note:** Version bump only for package @spectrum-css/card
 
 <a name="6.0.7"></a>
-##6.0.7
+## 6.0.7
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@6.0.6...@spectrum-css/card@6.0.7)
 
 **Note:** Version bump only for package @spectrum-css/card
 
 <a name="6.0.6"></a>
-##6.0.6
+## 6.0.6
 🗓
 2023-07-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@6.0.5...@spectrum-css/card@6.0.6)
 
 **Note:** Version bump only for package @spectrum-css/card
 
 <a name="6.0.5"></a>
-##6.0.5
+## 6.0.5
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@6.0.4...@spectrum-css/card@6.0.5)
 
 **Note:** Version bump only for package @spectrum-css/card
 
 <a name="6.0.4"></a>
-##6.0.4
+## 6.0.4
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@6.0.3...@spectrum-css/card@6.0.4)
 
 **Note:** Version bump only for package @spectrum-css/card
 
 <a name="6.0.3"></a>
-##6.0.3
+## 6.0.3
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@6.0.2...@spectrum-css/card@6.0.3)
 
 **Note:** Version bump only for package @spectrum-css/card
 
 <a name="6.0.2"></a>
-##6.0.2
+## 6.0.2
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@6.0.1...@spectrum-css/card@6.0.2)
 
 **Note:** Version bump only for package @spectrum-css/card
 
 <a name="6.0.1"></a>
-##6.0.1
+## 6.0.1
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@6.0.0...@spectrum-css/card@6.0.1)
 
 **Note:** Version bump only for package @spectrum-css/card
 
 <a name="6.0.0"></a>
-#6.0.0
+# 6.0.0
 🗓
 2023-06-28 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@5.0.41...@spectrum-css/card@6.0.0)
 
@@ -336,21 +336,21 @@ This component has been deprecated. Use an action bar to allow users to perform 
     		migrates the Card component to use `@adobe/spectrum-tokens`
 
 <a name="5.0.41"></a>
-##5.0.41
+## 5.0.41
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@5.0.40...@spectrum-css/card@5.0.41)
 
 **Note:** Version bump only for package @spectrum-css/card
 
 <a name="5.0.40"></a>
-##5.0.40
+## 5.0.40
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@5.0.39...@spectrum-css/card@5.0.40)
 
 **Note:** Version bump only for package @spectrum-css/card
 
 <a name="5.0.39"></a>
-##5.0.39
+## 5.0.39
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@5.0.38...@spectrum-css/card@5.0.39)
 
@@ -359,14 +359,14 @@ This component has been deprecated. Use an action bar to allow users to perform 
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="5.0.38"></a>
-##5.0.38
+## 5.0.38
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@5.0.37...@spectrum-css/card@5.0.38)
 
 **Note:** Version bump only for package @spectrum-css/card
 
 <a name="5.0.37"></a>
-##5.0.37
+## 5.0.37
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@5.0.36...@spectrum-css/card@5.0.37)
 

--- a/components/card/CHANGELOG.md
+++ b/components/card/CHANGELOG.md
@@ -37,7 +37,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="8.0.0"></a>
-# 8.0.0
+## 8.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@7.0.2...@spectrum-css/card@8.0.0)
 
@@ -70,7 +70,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/card
 
 <a name="7.0.0"></a>
-# 7.0.0
+## 7.0.0
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@6.4.1...@spectrum-css/card@7.0.0)
 
@@ -94,7 +94,7 @@ This component has been deprecated. Use an action bar to allow users to perform 
 **Note:** Version bump only for package @spectrum-css/card
 
 <a name="6.4.0"></a>
-# 6.4.0
+## 6.4.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@6.3.1...@spectrum-css/card@6.4.0)
 
@@ -112,7 +112,7 @@ This component has been deprecated. Use an action bar to allow users to perform 
   **card:**revert misnamed instance of background color mod([80b3b78](https://github.com/adobe/spectrum-css/commit/80b3b78))
 
 <a name="6.3.0"></a>
-# 6.3.0
+## 6.3.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@6.2.2...@spectrum-css/card@6.3.0)
 
@@ -137,7 +137,7 @@ This component has been deprecated. Use an action bar to allow users to perform 
 - **card:**focus outline only on keyboard focus([268e3cc](https://github.com/adobe/spectrum-css/commit/268e3cc))
 
 <a name="6.2.0"></a>
-# 6.2.0
+## 6.2.0
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@6.0.24...@spectrum-css/card@6.2.0)
 
@@ -146,7 +146,7 @@ This component has been deprecated. Use an action bar to allow users to perform 
 - **card:**add additional mod properties ([#2279](https://github.com/adobe/spectrum-css/issues/2279))([a290816](https://github.com/adobe/spectrum-css/commit/a290816))
 
 <a name="6.1.0"></a>
-# 6.1.0
+## 6.1.0
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@6.0.24...@spectrum-css/card@6.1.0)
 
@@ -323,7 +323,7 @@ This component has been deprecated. Use an action bar to allow users to perform 
 **Note:** Version bump only for package @spectrum-css/card
 
 <a name="6.0.0"></a>
-# 6.0.0
+## 6.0.0
 🗓
 2023-06-28 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@5.0.41...@spectrum-css/card@6.0.0)
 
@@ -664,7 +664,7 @@ This component has been deprecated. Use an action bar to allow users to perform 
 
 <a name="5.0.0"></a>
 
-# 5.0.0
+## 5.0.0
 
 🗓 2022-06-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@4.0.22...@spectrum-css/card@5.0.0)
 
@@ -868,7 +868,7 @@ This component has been deprecated. Use an action bar to allow users to perform 
 
 <a name="4.0.0"></a>
 
-# 4.0.0
+## 4.0.0
 
 🗓 2021-09-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@4.0.0-alpha.4...@spectrum-css/card@4.0.0)
 
@@ -879,7 +879,7 @@ This component has been deprecated. Use an action bar to allow users to perform 
 
 <a name="4.0.0-alpha.4"></a>
 
-# 4.0.0-alpha.4
+## 4.0.0-alpha.4
 
 🗓 2021-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@4.0.0-alpha.3...@spectrum-css/card@4.0.0-alpha.4)
 
@@ -887,7 +887,7 @@ This component has been deprecated. Use an action bar to allow users to perform 
 
 <a name="4.0.0-alpha.3"></a>
 
-# 4.0.0-alpha.3
+## 4.0.0-alpha.3
 
 🗓 2021-07-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@4.0.0-alpha.2...@spectrum-css/card@4.0.0-alpha.3)
 
@@ -902,7 +902,7 @@ This component has been deprecated. Use an action bar to allow users to perform 
 
 <a name="4.0.0-alpha.2"></a>
 
-# 4.0.0-alpha.2
+## 4.0.0-alpha.2
 
 🗓 2021-06-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@4.0.0-alpha.1...@spectrum-css/card@4.0.0-alpha.2)
 
@@ -910,7 +910,7 @@ This component has been deprecated. Use an action bar to allow users to perform 
 
 <a name="4.0.0-alpha.1"></a>
 
-# 4.0.0-alpha.1
+## 4.0.0-alpha.1
 
 🗓 2021-05-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@4.0.0-alpha.0...@spectrum-css/card@4.0.0-alpha.1)
 
@@ -918,7 +918,7 @@ This component has been deprecated. Use an action bar to allow users to perform 
 
 <a name="4.0.0-alpha.0"></a>
 
-# 4.0.0-alpha.0
+## 4.0.0-alpha.0
 
 🗓 2021-04-27 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@3.0.2...@spectrum-css/card@4.0.0-alpha.0)
 
@@ -953,7 +953,7 @@ This component has been deprecated. Use an action bar to allow users to perform 
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@3.0.0-beta.6...@spectrum-css/card@3.0.0)
 
@@ -967,7 +967,7 @@ This component has been deprecated. Use an action bar to allow users to perform 
 
 <a name="3.0.0-beta.6"></a>
 
-# 3.0.0-beta.6
+## 3.0.0-beta.6
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@3.0.0-beta.5...@spectrum-css/card@3.0.0-beta.6)
 
@@ -988,7 +988,7 @@ This component has been deprecated. Use an action bar to allow users to perform 
 
 <a name="3.0.0-beta.5"></a>
 
-# 3.0.0-beta.5
+## 3.0.0-beta.5
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@3.0.0-beta.4...@spectrum-css/card@3.0.0-beta.5)
 
@@ -1000,7 +1000,7 @@ This component has been deprecated. Use an action bar to allow users to perform 
 
 <a name="3.0.0-beta.4"></a>
 
-# 3.0.0-beta.4
+## 3.0.0-beta.4
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@3.0.0-beta.3...@spectrum-css/card@3.0.0-beta.4)
 
@@ -1008,7 +1008,7 @@ This component has been deprecated. Use an action bar to allow users to perform 
 
 <a name="3.0.0-beta.3"></a>
 
-# 3.0.0-beta.3
+## 3.0.0-beta.3
 
 🗓 2020-06-19 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@3.0.0-beta.2...@spectrum-css/card@3.0.0-beta.3)
 
@@ -1016,7 +1016,7 @@ This component has been deprecated. Use an action bar to allow users to perform 
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@3.0.0-beta.1...@spectrum-css/card@3.0.0-beta.2)
 
@@ -1024,7 +1024,7 @@ This component has been deprecated. Use an action bar to allow users to perform 
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@3.0.0-beta.0...@spectrum-css/card@3.0.0-beta.1)
 
@@ -1032,7 +1032,7 @@ This component has been deprecated. Use an action bar to allow users to perform 
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/card@2.0.6...@spectrum-css/card@3.0.0-beta.0)
 
@@ -1094,7 +1094,7 @@ This component has been deprecated. Use an action bar to allow users to perform 
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/checkbox/CHANGELOG.md
+++ b/components/checkbox/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="9.0.0"></a>
-#9.0.0
+# 9.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@8.1.5...@spectrum-css/checkbox@9.0.0)
 
@@ -48,49 +48,49 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="8.1.5"></a>
-##8.1.5
+## 8.1.5
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@8.1.4...@spectrum-css/checkbox@8.1.5)
 
 **Note:** Version bump only for package @spectrum-css/checkbox
 
 <a name="8.1.4"></a>
-##8.1.4
+## 8.1.4
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@8.1.3...@spectrum-css/checkbox@8.1.4)
 
 **Note:** Version bump only for package @spectrum-css/checkbox
 
 <a name="8.1.3"></a>
-##8.1.3
+## 8.1.3
 🗓
 2024-02-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@8.1.2...@spectrum-css/checkbox@8.1.3)
 
 **Note:** Version bump only for package @spectrum-css/checkbox
 
 <a name="8.1.2"></a>
-##8.1.2
+## 8.1.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@8.1.1...@spectrum-css/checkbox@8.1.2)
 
 **Note:** Version bump only for package @spectrum-css/checkbox
 
 <a name="8.1.1"></a>
-##8.1.1
+## 8.1.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/checkbox
 
 <a name="8.1.0"></a>
-#8.1.0
+# 8.1.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@8.0.6...@spectrum-css/checkbox@8.1.0)
 
 **Note:** Version bump only for package @spectrum-css/checkbox
 
 <a name="8.0.6"></a>
-##8.0.6
+## 8.0.6
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@8.0.5...@spectrum-css/checkbox@8.0.6)
 
@@ -99,42 +99,42 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **checkbox:**address typo([174d386](https://github.com/adobe/spectrum-css/commit/174d386))
 
 <a name="8.0.5"></a>
-##8.0.5
+## 8.0.5
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@8.0.4...@spectrum-css/checkbox@8.0.5)
 
 **Note:** Version bump only for package @spectrum-css/checkbox
 
 <a name="8.0.4"></a>
-##8.0.4
+## 8.0.4
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@8.0.3...@spectrum-css/checkbox@8.0.4)
 
 **Note:** Version bump only for package @spectrum-css/checkbox
 
 <a name="8.0.3"></a>
-##8.0.3
+## 8.0.3
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@8.0.2...@spectrum-css/checkbox@8.0.3)
 
 **Note:** Version bump only for package @spectrum-css/checkbox
 
 <a name="8.0.2"></a>
-##8.0.2
+## 8.0.2
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@8.0.0...@spectrum-css/checkbox@8.0.2)
 
 **Note:** Version bump only for package @spectrum-css/checkbox
 
 <a name="8.0.1"></a>
-##8.0.1
+## 8.0.1
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@8.0.0...@spectrum-css/checkbox@8.0.1)
 
 **Note:** Version bump only for package @spectrum-css/checkbox
 
 <a name="8.0.0"></a>
-#8.0.0
+# 8.0.0
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@7.0.16...@spectrum-css/checkbox@8.0.0)
 
@@ -147,70 +147,70 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
     		migrate asset card to updated token system
 
 <a name="7.0.16"></a>
-##7.0.16
+## 7.0.16
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@7.0.15...@spectrum-css/checkbox@7.0.16)
 
 **Note:** Version bump only for package @spectrum-css/checkbox
 
 <a name="7.0.15"></a>
-##7.0.15
+## 7.0.15
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@7.0.14...@spectrum-css/checkbox@7.0.15)
 
 **Note:** Version bump only for package @spectrum-css/checkbox
 
 <a name="7.0.14"></a>
-##7.0.14
+## 7.0.14
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@7.0.13...@spectrum-css/checkbox@7.0.14)
 
 **Note:** Version bump only for package @spectrum-css/checkbox
 
 <a name="7.0.13"></a>
-##7.0.13
+## 7.0.13
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@7.0.12...@spectrum-css/checkbox@7.0.13)
 
 **Note:** Version bump only for package @spectrum-css/checkbox
 
 <a name="7.0.12"></a>
-##7.0.12
+## 7.0.12
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@7.0.11...@spectrum-css/checkbox@7.0.12)
 
 **Note:** Version bump only for package @spectrum-css/checkbox
 
 <a name="7.0.11"></a>
-##7.0.11
+## 7.0.11
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@7.0.10...@spectrum-css/checkbox@7.0.11)
 
 **Note:** Version bump only for package @spectrum-css/checkbox
 
 <a name="7.0.10"></a>
-##7.0.10
+## 7.0.10
 🗓
 2023-09-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@7.0.9...@spectrum-css/checkbox@7.0.10)
 
 **Note:** Version bump only for package @spectrum-css/checkbox
 
 <a name="7.0.9"></a>
-##7.0.9
+## 7.0.9
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@7.0.8...@spectrum-css/checkbox@7.0.9)
 
 **Note:** Version bump only for package @spectrum-css/checkbox
 
 <a name="7.0.8"></a>
-##7.0.8
+## 7.0.8
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@7.0.7...@spectrum-css/checkbox@7.0.8)
 
 **Note:** Version bump only for package @spectrum-css/checkbox
 
 <a name="7.0.7"></a>
-##7.0.7
+## 7.0.7
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@7.0.6...@spectrum-css/checkbox@7.0.7)
 
@@ -219,49 +219,49 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="7.0.6"></a>
-##7.0.6
+## 7.0.6
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@7.0.5...@spectrum-css/checkbox@7.0.6)
 
 **Note:** Version bump only for package @spectrum-css/checkbox
 
 <a name="7.0.5"></a>
-##7.0.5
+## 7.0.5
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@7.0.3...@spectrum-css/checkbox@7.0.5)
 
 **Note:** Version bump only for package @spectrum-css/checkbox
 
 <a name="7.0.4"></a>
-##7.0.4
+## 7.0.4
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@7.0.3...@spectrum-css/checkbox@7.0.4)
 
 **Note:** Version bump only for package @spectrum-css/checkbox
 
 <a name="7.0.3"></a>
-##7.0.3
+## 7.0.3
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@7.0.2...@spectrum-css/checkbox@7.0.3)
 
 **Note:** Version bump only for package @spectrum-css/checkbox
 
 <a name="7.0.2"></a>
-##7.0.2
+## 7.0.2
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@7.0.1...@spectrum-css/checkbox@7.0.2)
 
 **Note:** Version bump only for package @spectrum-css/checkbox
 
 <a name="7.0.1"></a>
-##7.0.1
+## 7.0.1
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@7.0.0...@spectrum-css/checkbox@7.0.1)
 
 **Note:** Version bump only for package @spectrum-css/checkbox
 
 <a name="7.0.0"></a>
-#7.0.0
+# 7.0.0
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@6.1.10...@spectrum-css/checkbox@7.0.0)
 
@@ -306,14 +306,14 @@ needed system color updates noticed while looking at that code.
   on top of default Canvas.
 
 <a name="6.1.10"></a>
-##6.1.10
+## 6.1.10
 🗓
 2023-07-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@6.1.9...@spectrum-css/checkbox@6.1.10)
 
 **Note:** Version bump only for package @spectrum-css/checkbox
 
 <a name="6.1.9"></a>
-##6.1.9
+## 6.1.9
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@6.1.8...@spectrum-css/checkbox@6.1.9)
 
@@ -322,14 +322,14 @@ needed system color updates noticed while looking at that code.
 \*icon sizing in Storybook story templates ([#2037](https://github.com/adobe/spectrum-css/issues/2037))([c90c8a3](https://github.com/adobe/spectrum-css/commit/c90c8a3))
 
 <a name="6.1.8"></a>
-##6.1.8
+## 6.1.8
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@6.1.7...@spectrum-css/checkbox@6.1.8)
 
 **Note:** Version bump only for package @spectrum-css/checkbox
 
 <a name="6.1.7"></a>
-##6.1.7
+## 6.1.7
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@6.1.6...@spectrum-css/checkbox@6.1.7)
 
@@ -339,35 +339,35 @@ needed system color updates noticed while looking at that code.
   **checkbox:**use language code, not coding language name ([#2005](https://github.com/adobe/spectrum-css/issues/2005))([56c7cfc](https://github.com/adobe/spectrum-css/commit/56c7cfc))
 
 <a name="6.1.6"></a>
-##6.1.6
+## 6.1.6
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@6.1.5...@spectrum-css/checkbox@6.1.6)
 
 **Note:** Version bump only for package @spectrum-css/checkbox
 
 <a name="6.1.5"></a>
-##6.1.5
+## 6.1.5
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@6.1.4...@spectrum-css/checkbox@6.1.5)
 
 **Note:** Version bump only for package @spectrum-css/checkbox
 
 <a name="6.1.4"></a>
-##6.1.4
+## 6.1.4
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@6.1.3...@spectrum-css/checkbox@6.1.4)
 
 **Note:** Version bump only for package @spectrum-css/checkbox
 
 <a name="6.1.3"></a>
-##6.1.3
+## 6.1.3
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@6.1.2...@spectrum-css/checkbox@6.1.3)
 
 **Note:** Version bump only for package @spectrum-css/checkbox
 
 <a name="6.1.2"></a>
-##6.1.2
+## 6.1.2
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@6.1.1...@spectrum-css/checkbox@6.1.2)
 
@@ -376,14 +376,14 @@ needed system color updates noticed while looking at that code.
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="6.1.1"></a>
-##6.1.1
+## 6.1.1
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@6.1.0...@spectrum-css/checkbox@6.1.1)
 
 **Note:** Version bump only for package @spectrum-css/checkbox
 
 <a name="6.1.0"></a>
-#6.1.0
+# 6.1.0
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@6.0.34...@spectrum-css/checkbox@6.1.0)
 

--- a/components/checkbox/CHANGELOG.md
+++ b/components/checkbox/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="9.0.0"></a>
-# 9.0.0
+## 9.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@8.1.5...@spectrum-css/checkbox@9.0.0)
 
@@ -83,7 +83,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/checkbox
 
 <a name="8.1.0"></a>
-# 8.1.0
+## 8.1.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@8.0.6...@spectrum-css/checkbox@8.1.0)
 
@@ -134,7 +134,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/checkbox
 
 <a name="8.0.0"></a>
-# 8.0.0
+## 8.0.0
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@7.0.16...@spectrum-css/checkbox@8.0.0)
 
@@ -261,7 +261,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/checkbox
 
 <a name="7.0.0"></a>
-# 7.0.0
+## 7.0.0
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@6.1.10...@spectrum-css/checkbox@7.0.0)
 
@@ -383,7 +383,7 @@ needed system color updates noticed while looking at that code.
 **Note:** Version bump only for package @spectrum-css/checkbox
 
 <a name="6.1.0"></a>
-# 6.1.0
+## 6.1.0
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@6.0.34...@spectrum-css/checkbox@6.1.0)
 
@@ -667,7 +667,7 @@ needed system color updates noticed while looking at that code.
 
 <a name="6.0.0"></a>
 
-# 6.0.0
+## 6.0.0
 
 🗓 2023-02-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@5.0.11...@spectrum-css/checkbox@6.0.0)
 
@@ -769,7 +769,7 @@ needed system color updates noticed while looking at that code.
 
 <a name="5.0.0"></a>
 
-# 5.0.0
+## 5.0.0
 
 🗓 2022-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@4.0.2...@spectrum-css/checkbox@5.0.0)
 
@@ -803,7 +803,7 @@ needed system color updates noticed while looking at that code.
 
 <a name="4.0.0"></a>
 
-# 4.0.0
+## 4.0.0
 
 🗓 2022-10-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@3.1.3...@spectrum-css/checkbox@4.0.0)
 
@@ -842,7 +842,7 @@ Co-authored-by: Garth Braithwaite <garthdb@gmail.com>
 
 <a name="3.1.0"></a>
 
-# 3.1.0
+## 3.1.0
 
 🗓 2022-04-08 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@3.0.19...@spectrum-css/checkbox@3.1.0)
 
@@ -1045,7 +1045,7 @@ Co-authored-by: Garth Braithwaite <garthdb@gmail.com>
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@3.0.0-beta.6...@spectrum-css/checkbox@3.0.0)
 
@@ -1059,7 +1059,7 @@ Co-authored-by: Garth Braithwaite <garthdb@gmail.com>
 
 <a name="3.0.0-beta.6"></a>
 
-# 3.0.0-beta.6
+## 3.0.0-beta.6
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@3.0.0-beta.5...@spectrum-css/checkbox@3.0.0-beta.6)
 
@@ -1083,7 +1083,7 @@ docs: add docs explaining quiet/emphasized Checkbox/Radio
 
 <a name="3.0.0-beta.5"></a>
 
-# 3.0.0-beta.5
+## 3.0.0-beta.5
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@3.0.0-beta.4...@spectrum-css/checkbox@3.0.0-beta.5)
 
@@ -1095,7 +1095,7 @@ docs: add docs explaining quiet/emphasized Checkbox/Radio
 
 <a name="3.0.0-beta.4"></a>
 
-# 3.0.0-beta.4
+## 3.0.0-beta.4
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@3.0.0-beta.3...@spectrum-css/checkbox@3.0.0-beta.4)
 
@@ -1124,7 +1124,7 @@ docs: add docs explaining quiet/emphasized Checkbox
 
 <a name="3.0.0-beta.3"></a>
 
-# 3.0.0-beta.3
+## 3.0.0-beta.3
 
 🗓 2020-06-19 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@3.0.0-beta.2...@spectrum-css/checkbox@3.0.0-beta.3)
 
@@ -1132,7 +1132,7 @@ docs: add docs explaining quiet/emphasized Checkbox
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@3.0.0-beta.1...@spectrum-css/checkbox@3.0.0-beta.2)
 
@@ -1140,7 +1140,7 @@ docs: add docs explaining quiet/emphasized Checkbox
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@3.0.0-beta.0...@spectrum-css/checkbox@3.0.0-beta.1)
 
@@ -1148,7 +1148,7 @@ docs: add docs explaining quiet/emphasized Checkbox
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@2.1.0...@spectrum-css/checkbox@3.0.0-beta.0)
 
@@ -1158,7 +1158,7 @@ docs: add docs explaining quiet/emphasized Checkbox
 
 <a name="2.1.0"></a>
 
-# 2.1.0
+## 2.1.0
 
 🗓 2020-03-06 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/checkbox@2.0.5...@spectrum-css/checkbox@2.1.0)
 
@@ -1214,7 +1214,7 @@ docs: add docs explaining quiet/emphasized Checkbox
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/clearbutton/CHANGELOG.md
+++ b/components/clearbutton/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="6.0.0"></a>
-#6.0.0
+# 6.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/clearbutton@5.1.4...@spectrum-css/clearbutton@6.0.0)
 
@@ -44,140 +44,140 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="5.1.4"></a>
-##5.1.4
+## 5.1.4
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/clearbutton@5.1.3...@spectrum-css/clearbutton@5.1.4)
 
 **Note:** Version bump only for package @spectrum-css/clearbutton
 
 <a name="5.1.3"></a>
-##5.1.3
+## 5.1.3
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/clearbutton@5.1.2...@spectrum-css/clearbutton@5.1.3)
 
 **Note:** Version bump only for package @spectrum-css/clearbutton
 
 <a name="5.1.2"></a>
-##5.1.2
+## 5.1.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/clearbutton@5.1.1...@spectrum-css/clearbutton@5.1.2)
 
 **Note:** Version bump only for package @spectrum-css/clearbutton
 
 <a name="5.1.1"></a>
-##5.1.1
+## 5.1.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/clearbutton
 
 <a name="5.1.0"></a>
-#5.1.0
+# 5.1.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/clearbutton@5.0.16...@spectrum-css/clearbutton@5.1.0)
 
 **Note:** Version bump only for package @spectrum-css/clearbutton
 
 <a name="5.0.16"></a>
-##5.0.16
+## 5.0.16
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/clearbutton@5.0.15...@spectrum-css/clearbutton@5.0.16)
 
 **Note:** Version bump only for package @spectrum-css/clearbutton
 
 <a name="5.0.15"></a>
-##5.0.15
+## 5.0.15
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/clearbutton@5.0.14...@spectrum-css/clearbutton@5.0.15)
 
 **Note:** Version bump only for package @spectrum-css/clearbutton
 
 <a name="5.0.14"></a>
-##5.0.14
+## 5.0.14
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/clearbutton@5.0.13...@spectrum-css/clearbutton@5.0.14)
 
 **Note:** Version bump only for package @spectrum-css/clearbutton
 
 <a name="5.0.13"></a>
-##5.0.13
+## 5.0.13
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/clearbutton@5.0.11...@spectrum-css/clearbutton@5.0.13)
 
 **Note:** Version bump only for package @spectrum-css/clearbutton
 
 <a name="5.0.12"></a>
-##5.0.12
+## 5.0.12
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/clearbutton@5.0.11...@spectrum-css/clearbutton@5.0.12)
 
 **Note:** Version bump only for package @spectrum-css/clearbutton
 
 <a name="5.0.11"></a>
-##5.0.11
+## 5.0.11
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/clearbutton@5.0.10...@spectrum-css/clearbutton@5.0.11)
 
 **Note:** Version bump only for package @spectrum-css/clearbutton
 
 <a name="5.0.10"></a>
-##5.0.10
+## 5.0.10
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/clearbutton@5.0.9...@spectrum-css/clearbutton@5.0.10)
 
 **Note:** Version bump only for package @spectrum-css/clearbutton
 
 <a name="5.0.9"></a>
-##5.0.9
+## 5.0.9
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/clearbutton@5.0.8...@spectrum-css/clearbutton@5.0.9)
 
 **Note:** Version bump only for package @spectrum-css/clearbutton
 
 <a name="5.0.8"></a>
-##5.0.8
+## 5.0.8
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/clearbutton@5.0.7...@spectrum-css/clearbutton@5.0.8)
 
 **Note:** Version bump only for package @spectrum-css/clearbutton
 
 <a name="5.0.7"></a>
-##5.0.7
+## 5.0.7
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/clearbutton@5.0.6...@spectrum-css/clearbutton@5.0.7)
 
 **Note:** Version bump only for package @spectrum-css/clearbutton
 
 <a name="5.0.6"></a>
-##5.0.6
+## 5.0.6
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/clearbutton@5.0.5...@spectrum-css/clearbutton@5.0.6)
 
 **Note:** Version bump only for package @spectrum-css/clearbutton
 
 <a name="5.0.5"></a>
-##5.0.5
+## 5.0.5
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/clearbutton@5.0.4...@spectrum-css/clearbutton@5.0.5)
 
 **Note:** Version bump only for package @spectrum-css/clearbutton
 
 <a name="5.0.4"></a>
-##5.0.4
+## 5.0.4
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/clearbutton@5.0.3...@spectrum-css/clearbutton@5.0.4)
 
 **Note:** Version bump only for package @spectrum-css/clearbutton
 
 <a name="5.0.3"></a>
-##5.0.3
+## 5.0.3
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/clearbutton@5.0.2...@spectrum-css/clearbutton@5.0.3)
 
 **Note:** Version bump only for package @spectrum-css/clearbutton
 
 <a name="5.0.2"></a>
-##5.0.2
+## 5.0.2
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/clearbutton@5.0.1...@spectrum-css/clearbutton@5.0.2)
 
@@ -186,14 +186,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="5.0.1"></a>
-##5.0.1
+## 5.0.1
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/clearbutton@5.0.0...@spectrum-css/clearbutton@5.0.1)
 
 **Note:** Version bump only for package @spectrum-css/clearbutton
 
 <a name="5.0.0"></a>
-#5.0.0
+# 5.0.0
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/clearbutton@2.0.0...@spectrum-css/clearbutton@5.0.0)
 

--- a/components/clearbutton/CHANGELOG.md
+++ b/components/clearbutton/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="6.0.0"></a>
-# 6.0.0
+## 6.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/clearbutton@5.1.4...@spectrum-css/clearbutton@6.0.0)
 
@@ -72,7 +72,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/clearbutton
 
 <a name="5.1.0"></a>
-# 5.1.0
+## 5.1.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/clearbutton@5.0.16...@spectrum-css/clearbutton@5.1.0)
 
@@ -193,7 +193,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/clearbutton
 
 <a name="5.0.0"></a>
-# 5.0.0
+## 5.0.0
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/clearbutton@2.0.0...@spectrum-css/clearbutton@5.0.0)
 
@@ -214,7 +214,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="4.0.0"></a>
 
-# 4.0.0
+## 4.0.0
 
 🗓 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/clearbutton@2.0.0...@spectrum-css/clearbutton@4.0.0)
 
@@ -232,13 +232,13 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 **Deprecated tag**: exists solely on npm and does not appear in the git repository. This was an accidental release that went out without a build.
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/clearbutton@1.2.38...@spectrum-css/clearbutton@2.0.0)
 
@@ -560,7 +560,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="1.2.0"></a>
 
-# 1.2.0
+## 1.2.0
 
 🗓 2022-01-05
 
@@ -575,7 +575,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="1.1.0"></a>
 
-# 1.1.0
+## 1.1.0
 
 🗓 2022-01-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/clearbutton@1.1.0-beta.0...@spectrum-css/clearbutton@1.1.0)
 
@@ -583,7 +583,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="1.1.0-beta.0"></a>
 
-# 1.1.0-beta.0
+## 1.1.0-beta.0
 
 🗓 2021-12-14
 

--- a/components/closebutton/CHANGELOG.md
+++ b/components/closebutton/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-# 5.0.0
+## 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/closebutton@4.2.5...@spectrum-css/closebutton@5.0.0)
 
@@ -79,14 +79,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/closebutton
 
 <a name="4.2.0"></a>
-# 4.2.0
+## 4.2.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/closebutton@4.1.0...@spectrum-css/closebutton@4.2.0)
 
 **Note:** Version bump only for package @spectrum-css/closebutton
 
 <a name="4.1.0"></a>
-# 4.1.0
+## 4.1.0
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/closebutton@4.0.18...@spectrum-css/closebutton@4.1.0)
 
@@ -227,7 +227,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/closebutton
 
 <a name="4.0.0"></a>
-# 4.0.0
+## 4.0.0
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/closebutton@3.1.14...@spectrum-css/closebutton@4.0.0)
 
@@ -346,7 +346,7 @@ remove duplicate focus indicator styling
 
 <a name="3.1.0"></a>
 
-# 3.1.0
+## 3.1.0
 
 🗓 2023-05-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/closebutton@3.0.43...@spectrum-css/closebutton@3.1.0)
 
@@ -700,7 +700,7 @@ remove duplicate focus indicator styling
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2022-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/closebutton@2.0.7...@spectrum-css/closebutton@3.0.0)
 
@@ -774,7 +774,7 @@ remove duplicate focus indicator styling
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2022-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/closebutton@1.2.13...@spectrum-css/closebutton@2.0.0)
 
@@ -898,7 +898,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="1.2.0"></a>
 
-# 1.2.0
+## 1.2.0
 
 🗓 2022-01-05
 
@@ -915,7 +915,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="1.1.0"></a>
 
-# 1.1.0
+## 1.1.0
 
 🗓 2022-01-05
 

--- a/components/closebutton/CHANGELOG.md
+++ b/components/closebutton/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-#5.0.0
+# 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/closebutton@4.2.5...@spectrum-css/closebutton@5.0.0)
 
@@ -44,49 +44,49 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="4.2.5"></a>
-##4.2.5
+## 4.2.5
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/closebutton@4.2.4...@spectrum-css/closebutton@4.2.5)
 
 **Note:** Version bump only for package @spectrum-css/closebutton
 
 <a name="4.2.4"></a>
-##4.2.4
+## 4.2.4
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/closebutton@4.2.3...@spectrum-css/closebutton@4.2.4)
 
 **Note:** Version bump only for package @spectrum-css/closebutton
 
 <a name="4.2.3"></a>
-##4.2.3
+## 4.2.3
 🗓
 2024-02-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/closebutton@4.2.2...@spectrum-css/closebutton@4.2.3)
 
 **Note:** Version bump only for package @spectrum-css/closebutton
 
 <a name="4.2.2"></a>
-##4.2.2
+## 4.2.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/closebutton@4.2.1...@spectrum-css/closebutton@4.2.2)
 
 **Note:** Version bump only for package @spectrum-css/closebutton
 
 <a name="4.2.1"></a>
-##4.2.1
+## 4.2.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/closebutton
 
 <a name="4.2.0"></a>
-#4.2.0
+# 4.2.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/closebutton@4.1.0...@spectrum-css/closebutton@4.2.0)
 
 **Note:** Version bump only for package @spectrum-css/closebutton
 
 <a name="4.1.0"></a>
-#4.1.0
+# 4.1.0
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/closebutton@4.0.18...@spectrum-css/closebutton@4.1.0)
 
@@ -99,105 +99,105 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **commons:**rename and deprecate mods referencing global tokens ([#2423](https://github.com/adobe/spectrum-css/issues/2423))([3a49432](https://github.com/adobe/spectrum-css/commit/3a49432))
 
 <a name="4.0.18"></a>
-##4.0.18
+## 4.0.18
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/closebutton@4.0.17...@spectrum-css/closebutton@4.0.18)
 
 **Note:** Version bump only for package @spectrum-css/closebutton
 
 <a name="4.0.17"></a>
-##4.0.17
+## 4.0.17
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/closebutton@4.0.16...@spectrum-css/closebutton@4.0.17)
 
 **Note:** Version bump only for package @spectrum-css/closebutton
 
 <a name="4.0.16"></a>
-##4.0.16
+## 4.0.16
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/closebutton@4.0.15...@spectrum-css/closebutton@4.0.16)
 
 **Note:** Version bump only for package @spectrum-css/closebutton
 
 <a name="4.0.15"></a>
-##4.0.15
+## 4.0.15
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/closebutton@4.0.13...@spectrum-css/closebutton@4.0.15)
 
 **Note:** Version bump only for package @spectrum-css/closebutton
 
 <a name="4.0.14"></a>
-##4.0.14
+## 4.0.14
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/closebutton@4.0.13...@spectrum-css/closebutton@4.0.14)
 
 **Note:** Version bump only for package @spectrum-css/closebutton
 
 <a name="4.0.13"></a>
-##4.0.13
+## 4.0.13
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/closebutton@4.0.12...@spectrum-css/closebutton@4.0.13)
 
 **Note:** Version bump only for package @spectrum-css/closebutton
 
 <a name="4.0.12"></a>
-##4.0.12
+## 4.0.12
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/closebutton@4.0.11...@spectrum-css/closebutton@4.0.12)
 
 **Note:** Version bump only for package @spectrum-css/closebutton
 
 <a name="4.0.11"></a>
-##4.0.11
+## 4.0.11
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/closebutton@4.0.10...@spectrum-css/closebutton@4.0.11)
 
 **Note:** Version bump only for package @spectrum-css/closebutton
 
 <a name="4.0.10"></a>
-##4.0.10
+## 4.0.10
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/closebutton@4.0.9...@spectrum-css/closebutton@4.0.10)
 
 **Note:** Version bump only for package @spectrum-css/closebutton
 
 <a name="4.0.9"></a>
-##4.0.9
+## 4.0.9
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/closebutton@4.0.8...@spectrum-css/closebutton@4.0.9)
 
 **Note:** Version bump only for package @spectrum-css/closebutton
 
 <a name="4.0.8"></a>
-##4.0.8
+## 4.0.8
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/closebutton@4.0.7...@spectrum-css/closebutton@4.0.8)
 
 **Note:** Version bump only for package @spectrum-css/closebutton
 
 <a name="4.0.7"></a>
-##4.0.7
+## 4.0.7
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/closebutton@4.0.6...@spectrum-css/closebutton@4.0.7)
 
 **Note:** Version bump only for package @spectrum-css/closebutton
 
 <a name="4.0.6"></a>
-##4.0.6
+## 4.0.6
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/closebutton@4.0.5...@spectrum-css/closebutton@4.0.6)
 
 **Note:** Version bump only for package @spectrum-css/closebutton
 
 <a name="4.0.5"></a>
-##4.0.5
+## 4.0.5
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/closebutton@4.0.4...@spectrum-css/closebutton@4.0.5)
 
 **Note:** Version bump only for package @spectrum-css/closebutton
 
 <a name="4.0.4"></a>
-##4.0.4
+## 4.0.4
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/closebutton@4.0.3...@spectrum-css/closebutton@4.0.4)
 
@@ -206,28 +206,28 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="4.0.3"></a>
-##4.0.3
+## 4.0.3
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/closebutton@4.0.2...@spectrum-css/closebutton@4.0.3)
 
 **Note:** Version bump only for package @spectrum-css/closebutton
 
 <a name="4.0.2"></a>
-##4.0.2
+## 4.0.2
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/closebutton@4.0.0...@spectrum-css/closebutton@4.0.2)
 
 **Note:** Version bump only for package @spectrum-css/closebutton
 
 <a name="4.0.1"></a>
-##4.0.1
+## 4.0.1
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/closebutton@4.0.0...@spectrum-css/closebutton@4.0.1)
 
 **Note:** Version bump only for package @spectrum-css/closebutton
 
 <a name="4.0.0"></a>
-#4.0.0
+# 4.0.0
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/closebutton@3.1.14...@spectrum-css/closebutton@4.0.0)
 
@@ -242,28 +242,28 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 remove duplicate focus indicator styling
 
 <a name="3.1.14"></a>
-##3.1.14
+## 3.1.14
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/closebutton@3.1.13...@spectrum-css/closebutton@3.1.14)
 
 **Note:** Version bump only for package @spectrum-css/closebutton
 
 <a name="3.1.13"></a>
-##3.1.13
+## 3.1.13
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/closebutton@3.1.12...@spectrum-css/closebutton@3.1.13)
 
 **Note:** Version bump only for package @spectrum-css/closebutton
 
 <a name="3.1.12"></a>
-##3.1.12
+## 3.1.12
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/closebutton@3.1.11...@spectrum-css/closebutton@3.1.12)
 
 **Note:** Version bump only for package @spectrum-css/closebutton
 
 <a name="3.1.11"></a>
-##3.1.11
+## 3.1.11
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/closebutton@3.1.10...@spectrum-css/closebutton@3.1.11)
 
@@ -272,49 +272,49 @@ remove duplicate focus indicator styling
 \*icon sizing in Storybook story templates ([#2037](https://github.com/adobe/spectrum-css/issues/2037))([c90c8a3](https://github.com/adobe/spectrum-css/commit/c90c8a3))
 
 <a name="3.1.10"></a>
-##3.1.10
+## 3.1.10
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/closebutton@3.1.9...@spectrum-css/closebutton@3.1.10)
 
 **Note:** Version bump only for package @spectrum-css/closebutton
 
 <a name="3.1.9"></a>
-##3.1.9
+## 3.1.9
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/closebutton@3.1.8...@spectrum-css/closebutton@3.1.9)
 
 **Note:** Version bump only for package @spectrum-css/closebutton
 
 <a name="3.1.8"></a>
-##3.1.8
+## 3.1.8
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/closebutton@3.1.7...@spectrum-css/closebutton@3.1.8)
 
 **Note:** Version bump only for package @spectrum-css/closebutton
 
 <a name="3.1.7"></a>
-##3.1.7
+## 3.1.7
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/closebutton@3.1.6...@spectrum-css/closebutton@3.1.7)
 
 **Note:** Version bump only for package @spectrum-css/closebutton
 
 <a name="3.1.6"></a>
-##3.1.6
+## 3.1.6
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/closebutton@3.1.5...@spectrum-css/closebutton@3.1.6)
 
 **Note:** Version bump only for package @spectrum-css/closebutton
 
 <a name="3.1.5"></a>
-##3.1.5
+## 3.1.5
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/closebutton@3.1.4...@spectrum-css/closebutton@3.1.5)
 
 **Note:** Version bump only for package @spectrum-css/closebutton
 
 <a name="3.1.4"></a>
-##3.1.4
+## 3.1.4
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/closebutton@3.1.3...@spectrum-css/closebutton@3.1.4)
 
@@ -323,14 +323,14 @@ remove duplicate focus indicator styling
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="3.1.3"></a>
-##3.1.3
+## 3.1.3
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/closebutton@3.1.2...@spectrum-css/closebutton@3.1.3)
 
 **Note:** Version bump only for package @spectrum-css/closebutton
 
 <a name="3.1.2"></a>
-##3.1.2
+## 3.1.2
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/closebutton@3.1.1...@spectrum-css/closebutton@3.1.2)
 

--- a/components/coachindicator/CHANGELOG.md
+++ b/components/coachindicator/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="2.0.0"></a>
-# 2.0.0
+## 2.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachindicator@1.1.5...@spectrum-css/coachindicator@2.0.0)
 
@@ -77,7 +77,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/coachindicator
 
 <a name="1.1.0"></a>
-# 1.1.0
+## 1.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachindicator@1.0.1...@spectrum-css/coachindicator@1.1.0)
 
@@ -93,7 +93,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/coachindicator
 
 <a name="1.0.0"></a>
-# 1.0.0
+## 1.0.0
 🗓
 2023-12-04
 

--- a/components/coachindicator/CHANGELOG.md
+++ b/components/coachindicator/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="2.0.0"></a>
-#2.0.0
+# 2.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachindicator@1.1.5...@spectrum-css/coachindicator@2.0.0)
 
@@ -40,28 +40,28 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="1.1.5"></a>
-##1.1.5
+## 1.1.5
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachindicator@1.1.4...@spectrum-css/coachindicator@1.1.5)
 
 **Note:** Version bump only for package @spectrum-css/coachindicator
 
 <a name="1.1.4"></a>
-##1.1.4
+## 1.1.4
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachindicator@1.1.3...@spectrum-css/coachindicator@1.1.4)
 
 **Note:** Version bump only for package @spectrum-css/coachindicator
 
 <a name="1.1.3"></a>
-##1.1.3
+## 1.1.3
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachindicator@1.1.2...@spectrum-css/coachindicator@1.1.3)
 
 **Note:** Version bump only for package @spectrum-css/coachindicator
 
 <a name="1.1.2"></a>
-##1.1.2
+## 1.1.2
 🗓
 2024-02-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachindicator@1.1.1...@spectrum-css/coachindicator@1.1.2)
 
@@ -70,14 +70,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **coachindicator:**address issues with coach indicator rings position ([#2483](https://github.com/adobe/spectrum-css/issues/2483))([9965188](https://github.com/adobe/spectrum-css/commit/9965188))
 
 <a name="1.1.1"></a>
-##1.1.1
+## 1.1.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/coachindicator
 
 <a name="1.1.0"></a>
-#1.1.0
+# 1.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachindicator@1.0.1...@spectrum-css/coachindicator@1.1.0)
 
@@ -86,14 +86,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="1.0.1"></a>
-##1.0.1
+## 1.0.1
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachindicator@1.0.0...@spectrum-css/coachindicator@1.0.1)
 
 **Note:** Version bump only for package @spectrum-css/coachindicator
 
 <a name="1.0.0"></a>
-#1.0.0
+# 1.0.0
 🗓
 2023-12-04
 

--- a/components/coachmark/CHANGELOG.md
+++ b/components/coachmark/CHANGELOG.md
@@ -39,7 +39,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="7.0.0"></a>
-#7.0.0
+# 7.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@6.1.5...@spectrum-css/coachmark@7.0.0)
 
@@ -54,28 +54,28 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="6.1.5"></a>
-##6.1.5
+## 6.1.5
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@6.1.4...@spectrum-css/coachmark@6.1.5)
 
 **Note:** Version bump only for package @spectrum-css/coachmark
 
 <a name="6.1.4"></a>
-##6.1.4
+## 6.1.4
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@6.1.3...@spectrum-css/coachmark@6.1.4)
 
 **Note:** Version bump only for package @spectrum-css/coachmark
 
 <a name="6.1.3"></a>
-##6.1.3
+## 6.1.3
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@6.1.2...@spectrum-css/coachmark@6.1.3)
 
 **Note:** Version bump only for package @spectrum-css/coachmark
 
 <a name="6.1.2"></a>
-##6.1.2
+## 6.1.2
 🗓
 2024-02-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@6.1.1...@spectrum-css/coachmark@6.1.2)
 
@@ -84,14 +84,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **coachmark:**update font family tokens ([#2478](https://github.com/adobe/spectrum-css/issues/2478))([0a3a946](https://github.com/adobe/spectrum-css/commit/0a3a946))
 
 <a name="6.1.1"></a>
-##6.1.1
+## 6.1.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/coachmark
 
 <a name="6.1.0"></a>
-#6.1.0
+# 6.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@6.0.1...@spectrum-css/coachmark@6.1.0)
 
@@ -100,14 +100,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="6.0.1"></a>
-##6.0.1
+## 6.0.1
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@6.0.0...@spectrum-css/coachmark@6.0.1)
 
 **Note:** Version bump only for package @spectrum-css/coachmark
 
 <a name="6.0.0"></a>
-#6.0.0
+# 6.0.0
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@5.0.75...@spectrum-css/coachmark@6.0.0)
 
@@ -122,91 +122,91 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
       	**coachmark:** migrates Coach Mark to `@adobe/spectrum-tokens`
 
 <a name="5.0.75"></a>
-##5.0.75
+## 5.0.75
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@5.0.73...@spectrum-css/coachmark@5.0.75)
 
 **Note:** Version bump only for package @spectrum-css/coachmark
 
 <a name="5.0.74"></a>
-##5.0.74
+## 5.0.74
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@5.0.73...@spectrum-css/coachmark@5.0.74)
 
 **Note:** Version bump only for package @spectrum-css/coachmark
 
 <a name="5.0.73"></a>
-##5.0.73
+## 5.0.73
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@5.0.72...@spectrum-css/coachmark@5.0.73)
 
 **Note:** Version bump only for package @spectrum-css/coachmark
 
 <a name="5.0.72"></a>
-##5.0.72
+## 5.0.72
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@5.0.71...@spectrum-css/coachmark@5.0.72)
 
 **Note:** Version bump only for package @spectrum-css/coachmark
 
 <a name="5.0.71"></a>
-##5.0.71
+## 5.0.71
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@5.0.70...@spectrum-css/coachmark@5.0.71)
 
 **Note:** Version bump only for package @spectrum-css/coachmark
 
 <a name="5.0.70"></a>
-##5.0.70
+## 5.0.70
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@5.0.69...@spectrum-css/coachmark@5.0.70)
 
 **Note:** Version bump only for package @spectrum-css/coachmark
 
 <a name="5.0.69"></a>
-##5.0.69
+## 5.0.69
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@5.0.68...@spectrum-css/coachmark@5.0.69)
 
 **Note:** Version bump only for package @spectrum-css/coachmark
 
 <a name="5.0.68"></a>
-##5.0.68
+## 5.0.68
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@5.0.67...@spectrum-css/coachmark@5.0.68)
 
 **Note:** Version bump only for package @spectrum-css/coachmark
 
 <a name="5.0.67"></a>
-##5.0.67
+## 5.0.67
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@5.0.66...@spectrum-css/coachmark@5.0.67)
 
 **Note:** Version bump only for package @spectrum-css/coachmark
 
 <a name="5.0.66"></a>
-##5.0.66
+## 5.0.66
 🗓
 2023-09-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@5.0.65...@spectrum-css/coachmark@5.0.66)
 
 **Note:** Version bump only for package @spectrum-css/coachmark
 
 <a name="5.0.65"></a>
-##5.0.65
+## 5.0.65
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@5.0.64...@spectrum-css/coachmark@5.0.65)
 
 **Note:** Version bump only for package @spectrum-css/coachmark
 
 <a name="5.0.64"></a>
-##5.0.64
+## 5.0.64
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@5.0.63...@spectrum-css/coachmark@5.0.64)
 
 **Note:** Version bump only for package @spectrum-css/coachmark
 
 <a name="5.0.63"></a>
-##5.0.63
+## 5.0.63
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@5.0.62...@spectrum-css/coachmark@5.0.63)
 
@@ -215,105 +215,105 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="5.0.62"></a>
-##5.0.62
+## 5.0.62
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@5.0.61...@spectrum-css/coachmark@5.0.62)
 
 **Note:** Version bump only for package @spectrum-css/coachmark
 
 <a name="5.0.61"></a>
-##5.0.61
+## 5.0.61
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@5.0.59...@spectrum-css/coachmark@5.0.61)
 
 **Note:** Version bump only for package @spectrum-css/coachmark
 
 <a name="5.0.60"></a>
-##5.0.60
+## 5.0.60
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@5.0.59...@spectrum-css/coachmark@5.0.60)
 
 **Note:** Version bump only for package @spectrum-css/coachmark
 
 <a name="5.0.59"></a>
-##5.0.59
+## 5.0.59
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@5.0.58...@spectrum-css/coachmark@5.0.59)
 
 **Note:** Version bump only for package @spectrum-css/coachmark
 
 <a name="5.0.58"></a>
-##5.0.58
+## 5.0.58
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@5.0.57...@spectrum-css/coachmark@5.0.58)
 
 **Note:** Version bump only for package @spectrum-css/coachmark
 
 <a name="5.0.57"></a>
-##5.0.57
+## 5.0.57
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@5.0.56...@spectrum-css/coachmark@5.0.57)
 
 **Note:** Version bump only for package @spectrum-css/coachmark
 
 <a name="5.0.56"></a>
-##5.0.56
+## 5.0.56
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@5.0.55...@spectrum-css/coachmark@5.0.56)
 
 **Note:** Version bump only for package @spectrum-css/coachmark
 
 <a name="5.0.55"></a>
-##5.0.55
+## 5.0.55
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@5.0.54...@spectrum-css/coachmark@5.0.55)
 
 **Note:** Version bump only for package @spectrum-css/coachmark
 
 <a name="5.0.54"></a>
-##5.0.54
+## 5.0.54
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@5.0.53...@spectrum-css/coachmark@5.0.54)
 
 **Note:** Version bump only for package @spectrum-css/coachmark
 
 <a name="5.0.53"></a>
-##5.0.53
+## 5.0.53
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@5.0.52...@spectrum-css/coachmark@5.0.53)
 
 **Note:** Version bump only for package @spectrum-css/coachmark
 
 <a name="5.0.52"></a>
-##5.0.52
+## 5.0.52
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@5.0.51...@spectrum-css/coachmark@5.0.52)
 
 **Note:** Version bump only for package @spectrum-css/coachmark
 
 <a name="5.0.51"></a>
-##5.0.51
+## 5.0.51
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@5.0.50...@spectrum-css/coachmark@5.0.51)
 
 **Note:** Version bump only for package @spectrum-css/coachmark
 
 <a name="5.0.50"></a>
-##5.0.50
+## 5.0.50
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@5.0.49...@spectrum-css/coachmark@5.0.50)
 
 **Note:** Version bump only for package @spectrum-css/coachmark
 
 <a name="5.0.49"></a>
-##5.0.49
+## 5.0.49
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@5.0.48...@spectrum-css/coachmark@5.0.49)
 
 **Note:** Version bump only for package @spectrum-css/coachmark
 
 <a name="5.0.48"></a>
-##5.0.48
+## 5.0.48
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@5.0.47...@spectrum-css/coachmark@5.0.48)
 
@@ -322,14 +322,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="5.0.47"></a>
-##5.0.47
+## 5.0.47
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@5.0.46...@spectrum-css/coachmark@5.0.47)
 
 **Note:** Version bump only for package @spectrum-css/coachmark
 
 <a name="5.0.46"></a>
-##5.0.46
+## 5.0.46
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@5.0.45...@spectrum-css/coachmark@5.0.46)
 

--- a/components/coachmark/CHANGELOG.md
+++ b/components/coachmark/CHANGELOG.md
@@ -39,7 +39,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="7.0.0"></a>
-# 7.0.0
+## 7.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@6.1.5...@spectrum-css/coachmark@7.0.0)
 
@@ -91,7 +91,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/coachmark
 
 <a name="6.1.0"></a>
-# 6.1.0
+## 6.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@6.0.1...@spectrum-css/coachmark@6.1.0)
 
@@ -107,7 +107,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/coachmark
 
 <a name="6.0.0"></a>
-# 6.0.0
+## 6.0.0
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@5.0.75...@spectrum-css/coachmark@6.0.0)
 
@@ -697,7 +697,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="5.0.0"></a>
 
-# 5.0.0
+## 5.0.0
 
 🗓 2022-01-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@3.0.10...@spectrum-css/coachmark@5.0.0)
 
@@ -715,7 +715,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="4.0.0"></a>
 
-# 4.0.0
+## 4.0.0
 
 🗓 2022-01-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@4.0.0-beta.0...@spectrum-css/coachmark@4.0.0)
 
@@ -723,7 +723,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="4.0.0-beta.0"></a>
 
-# 4.0.0-beta.0
+## 4.0.0-beta.0
 
 🗓 2021-12-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@3.0.10...@spectrum-css/coachmark@4.0.0-beta.0)
 
@@ -843,7 +843,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@3.0.0-beta.6...@spectrum-css/coachmark@3.0.0)
 
@@ -851,7 +851,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.6"></a>
 
-# 3.0.0-beta.6
+## 3.0.0-beta.6
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@3.0.0-beta.5...@spectrum-css/coachmark@3.0.0-beta.6)
 
@@ -866,7 +866,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.5"></a>
 
-# 3.0.0-beta.5
+## 3.0.0-beta.5
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@3.0.0-beta.4...@spectrum-css/coachmark@3.0.0-beta.5)
 
@@ -874,7 +874,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.4"></a>
 
-# 3.0.0-beta.4
+## 3.0.0-beta.4
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@3.0.0-beta.3...@spectrum-css/coachmark@3.0.0-beta.4)
 
@@ -882,7 +882,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.3"></a>
 
-# 3.0.0-beta.3
+## 3.0.0-beta.3
 
 🗓 2020-06-19 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@3.0.0-beta.2...@spectrum-css/coachmark@3.0.0-beta.3)
 
@@ -890,7 +890,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@3.0.0-beta.1...@spectrum-css/coachmark@3.0.0-beta.2)
 
@@ -898,7 +898,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@3.0.0-beta.0...@spectrum-css/coachmark@3.0.0-beta.1)
 
@@ -906,7 +906,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/coachmark@2.0.5...@spectrum-css/coachmark@3.0.0-beta.0)
 
@@ -956,7 +956,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/colorarea/CHANGELOG.md
+++ b/components/colorarea/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-# 5.0.0
+## 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@4.1.5...@spectrum-css/colorarea@5.0.0)
 
@@ -79,7 +79,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/colorarea
 
 <a name="4.1.0"></a>
-# 4.1.0
+## 4.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@4.0.51...@spectrum-css/colorarea@4.1.0)
 
@@ -469,7 +469,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="4.0.0"></a>
 
-# 4.0.0
+## 4.0.0
 
 🗓 2023-04-19 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@3.0.10...@spectrum-css/colorarea@4.0.0)
 
@@ -561,7 +561,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2023-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@2.0.2...@spectrum-css/colorarea@3.0.0)
 
@@ -589,7 +589,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2023-02-28 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@1.0.30...@spectrum-css/colorarea@2.0.0)
 
@@ -891,7 +891,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="1.0.0"></a>
 
-# 1.0.0
+## 1.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@1.0.0-beta.4...@spectrum-css/colorarea@1.0.0)
 
@@ -899,7 +899,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="1.0.0-beta.4"></a>
 
-# 1.0.0-beta.4
+## 1.0.0-beta.4
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@1.0.0-beta.3...@spectrum-css/colorarea@1.0.0-beta.4)
 
@@ -909,7 +909,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="1.0.0-beta.3"></a>
 
-# 1.0.0-beta.3
+## 1.0.0-beta.3
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@1.0.0-beta.2...@spectrum-css/colorarea@1.0.0-beta.3)
 
@@ -917,7 +917,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="1.0.0-beta.2"></a>
 
-# 1.0.0-beta.2
+## 1.0.0-beta.2
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@1.0.0-beta.1...@spectrum-css/colorarea@1.0.0-beta.2)
 
@@ -925,7 +925,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="1.0.0-beta.1"></a>
 
-# 1.0.0-beta.1
+## 1.0.0-beta.1
 
 🗓 2020-05-14
 

--- a/components/colorarea/CHANGELOG.md
+++ b/components/colorarea/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-#5.0.0
+# 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@4.1.5...@spectrum-css/colorarea@5.0.0)
 
@@ -44,42 +44,42 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="4.1.5"></a>
-##4.1.5
+## 4.1.5
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@4.1.4...@spectrum-css/colorarea@4.1.5)
 
 **Note:** Version bump only for package @spectrum-css/colorarea
 
 <a name="4.1.4"></a>
-##4.1.4
+## 4.1.4
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@4.1.3...@spectrum-css/colorarea@4.1.4)
 
 **Note:** Version bump only for package @spectrum-css/colorarea
 
 <a name="4.1.3"></a>
-##4.1.3
+## 4.1.3
 🗓
 2024-02-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@4.1.2...@spectrum-css/colorarea@4.1.3)
 
 **Note:** Version bump only for package @spectrum-css/colorarea
 
 <a name="4.1.2"></a>
-##4.1.2
+## 4.1.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@4.1.1...@spectrum-css/colorarea@4.1.2)
 
 **Note:** Version bump only for package @spectrum-css/colorarea
 
 <a name="4.1.1"></a>
-##4.1.1
+## 4.1.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/colorarea
 
 <a name="4.1.0"></a>
-#4.1.0
+# 4.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@4.0.51...@spectrum-css/colorarea@4.1.0)
 
@@ -88,98 +88,98 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="4.0.51"></a>
-##4.0.51
+## 4.0.51
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@4.0.50...@spectrum-css/colorarea@4.0.51)
 
 **Note:** Version bump only for package @spectrum-css/colorarea
 
 <a name="4.0.50"></a>
-##4.0.50
+## 4.0.50
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@4.0.49...@spectrum-css/colorarea@4.0.50)
 
 **Note:** Version bump only for package @spectrum-css/colorarea
 
 <a name="4.0.49"></a>
-##4.0.49
+## 4.0.49
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@4.0.47...@spectrum-css/colorarea@4.0.49)
 
 **Note:** Version bump only for package @spectrum-css/colorarea
 
 <a name="4.0.48"></a>
-##4.0.48
+## 4.0.48
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@4.0.47...@spectrum-css/colorarea@4.0.48)
 
 **Note:** Version bump only for package @spectrum-css/colorarea
 
 <a name="4.0.47"></a>
-##4.0.47
+## 4.0.47
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@4.0.46...@spectrum-css/colorarea@4.0.47)
 
 **Note:** Version bump only for package @spectrum-css/colorarea
 
 <a name="4.0.46"></a>
-##4.0.46
+## 4.0.46
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@4.0.45...@spectrum-css/colorarea@4.0.46)
 
 **Note:** Version bump only for package @spectrum-css/colorarea
 
 <a name="4.0.45"></a>
-##4.0.45
+## 4.0.45
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@4.0.44...@spectrum-css/colorarea@4.0.45)
 
 **Note:** Version bump only for package @spectrum-css/colorarea
 
 <a name="4.0.44"></a>
-##4.0.44
+## 4.0.44
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@4.0.43...@spectrum-css/colorarea@4.0.44)
 
 **Note:** Version bump only for package @spectrum-css/colorarea
 
 <a name="4.0.43"></a>
-##4.0.43
+## 4.0.43
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@4.0.42...@spectrum-css/colorarea@4.0.43)
 
 **Note:** Version bump only for package @spectrum-css/colorarea
 
 <a name="4.0.42"></a>
-##4.0.42
+## 4.0.42
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@4.0.41...@spectrum-css/colorarea@4.0.42)
 
 **Note:** Version bump only for package @spectrum-css/colorarea
 
 <a name="4.0.41"></a>
-##4.0.41
+## 4.0.41
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@4.0.40...@spectrum-css/colorarea@4.0.41)
 
 **Note:** Version bump only for package @spectrum-css/colorarea
 
 <a name="4.0.40"></a>
-##4.0.40
+## 4.0.40
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@4.0.39...@spectrum-css/colorarea@4.0.40)
 
 **Note:** Version bump only for package @spectrum-css/colorarea
 
 <a name="4.0.39"></a>
-##4.0.39
+## 4.0.39
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@4.0.38...@spectrum-css/colorarea@4.0.39)
 
 **Note:** Version bump only for package @spectrum-css/colorarea
 
 <a name="4.0.38"></a>
-##4.0.38
+## 4.0.38
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@4.0.37...@spectrum-css/colorarea@4.0.38)
 
@@ -188,70 +188,70 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="4.0.37"></a>
-##4.0.37
+## 4.0.37
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@4.0.36...@spectrum-css/colorarea@4.0.37)
 
 **Note:** Version bump only for package @spectrum-css/colorarea
 
 <a name="4.0.36"></a>
-##4.0.36
+## 4.0.36
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@4.0.34...@spectrum-css/colorarea@4.0.36)
 
 **Note:** Version bump only for package @spectrum-css/colorarea
 
 <a name="4.0.35"></a>
-##4.0.35
+## 4.0.35
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@4.0.34...@spectrum-css/colorarea@4.0.35)
 
 **Note:** Version bump only for package @spectrum-css/colorarea
 
 <a name="4.0.34"></a>
-##4.0.34
+## 4.0.34
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@4.0.33...@spectrum-css/colorarea@4.0.34)
 
 **Note:** Version bump only for package @spectrum-css/colorarea
 
 <a name="4.0.33"></a>
-##4.0.33
+## 4.0.33
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@4.0.32...@spectrum-css/colorarea@4.0.33)
 
 **Note:** Version bump only for package @spectrum-css/colorarea
 
 <a name="4.0.32"></a>
-##4.0.32
+## 4.0.32
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@4.0.31...@spectrum-css/colorarea@4.0.32)
 
 **Note:** Version bump only for package @spectrum-css/colorarea
 
 <a name="4.0.31"></a>
-##4.0.31
+## 4.0.31
 🗓
 2023-08-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@4.0.30...@spectrum-css/colorarea@4.0.31)
 
 **Note:** Version bump only for package @spectrum-css/colorarea
 
 <a name="4.0.30"></a>
-##4.0.30
+## 4.0.30
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@4.0.29...@spectrum-css/colorarea@4.0.30)
 
 **Note:** Version bump only for package @spectrum-css/colorarea
 
 <a name="4.0.29"></a>
-##4.0.29
+## 4.0.29
 🗓
 2023-07-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@4.0.28...@spectrum-css/colorarea@4.0.29)
 
 **Note:** Version bump only for package @spectrum-css/colorarea
 
 <a name="4.0.28"></a>
-##4.0.28
+## 4.0.28
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@4.0.27...@spectrum-css/colorarea@4.0.28)
 
@@ -260,56 +260,56 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **colorarea:**return z-index ([#2041](https://github.com/adobe/spectrum-css/issues/2041))([0980f0d](https://github.com/adobe/spectrum-css/commit/0980f0d))
 
 <a name="4.0.27"></a>
-##4.0.27
+## 4.0.27
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@4.0.26...@spectrum-css/colorarea@4.0.27)
 
 **Note:** Version bump only for package @spectrum-css/colorarea
 
 <a name="4.0.26"></a>
-##4.0.26
+## 4.0.26
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@4.0.25...@spectrum-css/colorarea@4.0.26)
 
 **Note:** Version bump only for package @spectrum-css/colorarea
 
 <a name="4.0.25"></a>
-##4.0.25
+## 4.0.25
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@4.0.24...@spectrum-css/colorarea@4.0.25)
 
 **Note:** Version bump only for package @spectrum-css/colorarea
 
 <a name="4.0.24"></a>
-##4.0.24
+## 4.0.24
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@4.0.23...@spectrum-css/colorarea@4.0.24)
 
 **Note:** Version bump only for package @spectrum-css/colorarea
 
 <a name="4.0.23"></a>
-##4.0.23
+## 4.0.23
 🗓
 2023-06-28 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@4.0.22...@spectrum-css/colorarea@4.0.23)
 
 **Note:** Version bump only for package @spectrum-css/colorarea
 
 <a name="4.0.22"></a>
-##4.0.22
+## 4.0.22
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@4.0.21...@spectrum-css/colorarea@4.0.22)
 
 **Note:** Version bump only for package @spectrum-css/colorarea
 
 <a name="4.0.21"></a>
-##4.0.21
+## 4.0.21
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@4.0.20...@spectrum-css/colorarea@4.0.21)
 
 **Note:** Version bump only for package @spectrum-css/colorarea
 
 <a name="4.0.20"></a>
-##4.0.20
+## 4.0.20
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@4.0.19...@spectrum-css/colorarea@4.0.20)
 
@@ -318,14 +318,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="4.0.19"></a>
-##4.0.19
+## 4.0.19
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@4.0.18...@spectrum-css/colorarea@4.0.19)
 
 **Note:** Version bump only for package @spectrum-css/colorarea
 
 <a name="4.0.18"></a>
-##4.0.18
+## 4.0.18
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorarea@4.0.17...@spectrum-css/colorarea@4.0.18)
 

--- a/components/colorhandle/CHANGELOG.md
+++ b/components/colorhandle/CHANGELOG.md
@@ -31,7 +31,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="8.0.0"></a>
-# 8.0.0
+## 8.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@7.1.4...@spectrum-css/colorhandle@8.0.0)
 
@@ -74,7 +74,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/colorhandle
 
 <a name="7.1.0"></a>
-# 7.1.0
+## 7.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@7.0.17...@spectrum-css/colorhandle@7.1.0)
 
@@ -204,7 +204,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/colorhandle
 
 <a name="7.0.0"></a>
-# 7.0.0
+## 7.0.0
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@6.1.2...@spectrum-css/colorhandle@7.0.0)
 
@@ -233,7 +233,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/colorhandle
 
 <a name="6.1.0"></a>
-# 6.1.0
+## 6.1.0
 🗓
 2023-08-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@6.0.2...@spectrum-css/colorhandle@6.1.0)
 
@@ -258,7 +258,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/colorhandle
 
 <a name="6.0.0"></a>
-# 6.0.0
+## 6.0.0
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@5.0.15...@spectrum-css/colorhandle@6.0.0)
 
@@ -422,7 +422,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="5.0.0"></a>
 
-# 5.0.0
+## 5.0.0
 
 🗓 2023-05-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@4.0.11...@spectrum-css/colorhandle@5.0.0)
 
@@ -527,7 +527,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="4.0.0"></a>
 
-# 4.0.0
+## 4.0.0
 
 🗓 2023-04-19 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@4.0.0-beta.2...@spectrum-css/colorhandle@4.0.0)
 
@@ -535,7 +535,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="4.0.0-beta.2"></a>
 
-# 4.0.0-beta.2
+## 4.0.0-beta.2
 
 🗓 2023-04-19 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@3.0.6...@spectrum-css/colorhandle@4.0.0-beta.2)
 
@@ -595,7 +595,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2023-02-28 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@2.0.16...@spectrum-css/colorhandle@3.0.0)
 
@@ -735,7 +735,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2022-02-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@1.0.13...@spectrum-css/colorhandle@2.0.0)
 
@@ -910,7 +910,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="1.0.0"></a>
 
-# 1.0.0
+## 1.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@1.0.0-beta.4...@spectrum-css/colorhandle@1.0.0)
 
@@ -918,7 +918,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="1.0.0-beta.4"></a>
 
-# 1.0.0-beta.4
+## 1.0.0-beta.4
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@1.0.0-beta.3...@spectrum-css/colorhandle@1.0.0-beta.4)
 
@@ -928,7 +928,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="1.0.0-beta.3"></a>
 
-# 1.0.0-beta.3
+## 1.0.0-beta.3
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@1.0.0-beta.2...@spectrum-css/colorhandle@1.0.0-beta.3)
 
@@ -936,7 +936,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="1.0.0-beta.2"></a>
 
-# 1.0.0-beta.2
+## 1.0.0-beta.2
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@1.0.0-beta.1...@spectrum-css/colorhandle@1.0.0-beta.2)
 
@@ -944,7 +944,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="1.0.0-beta.1"></a>
 
-# 1.0.0-beta.1
+## 1.0.0-beta.1
 
 🗓 2020-05-14
 

--- a/components/colorhandle/CHANGELOG.md
+++ b/components/colorhandle/CHANGELOG.md
@@ -31,7 +31,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="8.0.0"></a>
-#8.0.0
+# 8.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@7.1.4...@spectrum-css/colorhandle@8.0.0)
 
@@ -46,35 +46,35 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="7.1.4"></a>
-##7.1.4
+## 7.1.4
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@7.1.3...@spectrum-css/colorhandle@7.1.4)
 
 **Note:** Version bump only for package @spectrum-css/colorhandle
 
 <a name="7.1.3"></a>
-##7.1.3
+## 7.1.3
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@7.1.2...@spectrum-css/colorhandle@7.1.3)
 
 **Note:** Version bump only for package @spectrum-css/colorhandle
 
 <a name="7.1.2"></a>
-##7.1.2
+## 7.1.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@7.1.1...@spectrum-css/colorhandle@7.1.2)
 
 **Note:** Version bump only for package @spectrum-css/colorhandle
 
 <a name="7.1.1"></a>
-##7.1.1
+## 7.1.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/colorhandle
 
 <a name="7.1.0"></a>
-#7.1.0
+# 7.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@7.0.17...@spectrum-css/colorhandle@7.1.0)
 
@@ -83,98 +83,98 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="7.0.17"></a>
-##7.0.17
+## 7.0.17
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@7.0.16...@spectrum-css/colorhandle@7.0.17)
 
 **Note:** Version bump only for package @spectrum-css/colorhandle
 
 <a name="7.0.16"></a>
-##7.0.16
+## 7.0.16
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@7.0.15...@spectrum-css/colorhandle@7.0.16)
 
 **Note:** Version bump only for package @spectrum-css/colorhandle
 
 <a name="7.0.15"></a>
-##7.0.15
+## 7.0.15
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@7.0.13...@spectrum-css/colorhandle@7.0.15)
 
 **Note:** Version bump only for package @spectrum-css/colorhandle
 
 <a name="7.0.14"></a>
-##7.0.14
+## 7.0.14
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@7.0.13...@spectrum-css/colorhandle@7.0.14)
 
 **Note:** Version bump only for package @spectrum-css/colorhandle
 
 <a name="7.0.13"></a>
-##7.0.13
+## 7.0.13
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@7.0.12...@spectrum-css/colorhandle@7.0.13)
 
 **Note:** Version bump only for package @spectrum-css/colorhandle
 
 <a name="7.0.12"></a>
-##7.0.12
+## 7.0.12
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@7.0.11...@spectrum-css/colorhandle@7.0.12)
 
 **Note:** Version bump only for package @spectrum-css/colorhandle
 
 <a name="7.0.11"></a>
-##7.0.11
+## 7.0.11
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@7.0.10...@spectrum-css/colorhandle@7.0.11)
 
 **Note:** Version bump only for package @spectrum-css/colorhandle
 
 <a name="7.0.10"></a>
-##7.0.10
+## 7.0.10
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@7.0.9...@spectrum-css/colorhandle@7.0.10)
 
 **Note:** Version bump only for package @spectrum-css/colorhandle
 
 <a name="7.0.9"></a>
-##7.0.9
+## 7.0.9
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@7.0.8...@spectrum-css/colorhandle@7.0.9)
 
 **Note:** Version bump only for package @spectrum-css/colorhandle
 
 <a name="7.0.8"></a>
-##7.0.8
+## 7.0.8
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@7.0.7...@spectrum-css/colorhandle@7.0.8)
 
 **Note:** Version bump only for package @spectrum-css/colorhandle
 
 <a name="7.0.7"></a>
-##7.0.7
+## 7.0.7
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@7.0.6...@spectrum-css/colorhandle@7.0.7)
 
 **Note:** Version bump only for package @spectrum-css/colorhandle
 
 <a name="7.0.6"></a>
-##7.0.6
+## 7.0.6
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@7.0.5...@spectrum-css/colorhandle@7.0.6)
 
 **Note:** Version bump only for package @spectrum-css/colorhandle
 
 <a name="7.0.5"></a>
-##7.0.5
+## 7.0.5
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@7.0.4...@spectrum-css/colorhandle@7.0.5)
 
 **Note:** Version bump only for package @spectrum-css/colorhandle
 
 <a name="7.0.4"></a>
-##7.0.4
+## 7.0.4
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@7.0.3...@spectrum-css/colorhandle@7.0.4)
 
@@ -183,28 +183,28 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="7.0.3"></a>
-##7.0.3
+## 7.0.3
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@7.0.2...@spectrum-css/colorhandle@7.0.3)
 
 **Note:** Version bump only for package @spectrum-css/colorhandle
 
 <a name="7.0.2"></a>
-##7.0.2
+## 7.0.2
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@7.0.0...@spectrum-css/colorhandle@7.0.2)
 
 **Note:** Version bump only for package @spectrum-css/colorhandle
 
 <a name="7.0.1"></a>
-##7.0.1
+## 7.0.1
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@7.0.0...@spectrum-css/colorhandle@7.0.1)
 
 **Note:** Version bump only for package @spectrum-css/colorhandle
 
 <a name="7.0.0"></a>
-#7.0.0
+# 7.0.0
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@6.1.2...@spectrum-css/colorhandle@7.0.0)
 
@@ -217,7 +217,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
     		use focus-visible pseudo class for focus styling
 
 <a name="6.1.2"></a>
-##6.1.2
+## 6.1.2
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@6.1.1...@spectrum-css/colorhandle@6.1.2)
 
@@ -226,14 +226,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **colorhandle:**updates animation([0dd3b76](https://github.com/adobe/spectrum-css/commit/0dd3b76))
 
 <a name="6.1.1"></a>
-##6.1.1
+## 6.1.1
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@6.1.0...@spectrum-css/colorhandle@6.1.1)
 
 **Note:** Version bump only for package @spectrum-css/colorhandle
 
 <a name="6.1.0"></a>
-#6.1.0
+# 6.1.0
 🗓
 2023-08-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@6.0.2...@spectrum-css/colorhandle@6.1.0)
 
@@ -242,7 +242,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **colorhandle:**add --mod-colorhandle-hitarea-border-radius([6752132](https://github.com/adobe/spectrum-css/commit/6752132))
 
 <a name="6.0.2"></a>
-##6.0.2
+## 6.0.2
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@6.0.1...@spectrum-css/colorhandle@6.0.2)
 
@@ -251,14 +251,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **opacitycheckboard:**add to component stories ([#2056](https://github.com/adobe/spectrum-css/issues/2056))([a1411f6](https://github.com/adobe/spectrum-css/commit/a1411f6))
 
 <a name="6.0.1"></a>
-##6.0.1
+## 6.0.1
 🗓
 2023-07-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@6.0.0...@spectrum-css/colorhandle@6.0.1)
 
 **Note:** Version bump only for package @spectrum-css/colorhandle
 
 <a name="6.0.0"></a>
-#6.0.0
+# 6.0.0
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@5.0.15...@spectrum-css/colorhandle@6.0.0)
 
@@ -307,35 +307,35 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - chore: update yarn.lock file after rebase
 
 <a name="5.0.15"></a>
-##5.0.15
+## 5.0.15
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@5.0.14...@spectrum-css/colorhandle@5.0.15)
 
 **Note:** Version bump only for package @spectrum-css/colorhandle
 
 <a name="5.0.14"></a>
-##5.0.14
+## 5.0.14
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@5.0.13...@spectrum-css/colorhandle@5.0.14)
 
 **Note:** Version bump only for package @spectrum-css/colorhandle
 
 <a name="5.0.13"></a>
-##5.0.13
+## 5.0.13
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@5.0.12...@spectrum-css/colorhandle@5.0.13)
 
 **Note:** Version bump only for package @spectrum-css/colorhandle
 
 <a name="5.0.12"></a>
-##5.0.12
+## 5.0.12
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@5.0.11...@spectrum-css/colorhandle@5.0.12)
 
 **Note:** Version bump only for package @spectrum-css/colorhandle
 
 <a name="5.0.11"></a>
-##5.0.11
+## 5.0.11
 🗓
 2023-06-28 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@5.0.10...@spectrum-css/colorhandle@5.0.11)
 
@@ -344,21 +344,21 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **colorloupe:**border bug ([#1958](https://github.com/adobe/spectrum-css/issues/1958))([559696f](https://github.com/adobe/spectrum-css/commit/559696f))
 
 <a name="5.0.10"></a>
-##5.0.10
+## 5.0.10
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@5.0.9...@spectrum-css/colorhandle@5.0.10)
 
 **Note:** Version bump only for package @spectrum-css/colorhandle
 
 <a name="5.0.9"></a>
-##5.0.9
+## 5.0.9
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@5.0.8...@spectrum-css/colorhandle@5.0.9)
 
 **Note:** Version bump only for package @spectrum-css/colorhandle
 
 <a name="5.0.8"></a>
-##5.0.8
+## 5.0.8
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@5.0.7...@spectrum-css/colorhandle@5.0.8)
 
@@ -367,14 +367,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="5.0.7"></a>
-##5.0.7
+## 5.0.7
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@5.0.6...@spectrum-css/colorhandle@5.0.7)
 
 **Note:** Version bump only for package @spectrum-css/colorhandle
 
 <a name="5.0.6"></a>
-##5.0.6
+## 5.0.6
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorhandle@5.0.5...@spectrum-css/colorhandle@5.0.6)
 

--- a/components/colorloupe/CHANGELOG.md
+++ b/components/colorloupe/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-#5.0.0
+# 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@4.2.4...@spectrum-css/colorloupe@5.0.0)
 
@@ -40,35 +40,35 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="4.2.4"></a>
-##4.2.4
+## 4.2.4
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@4.2.3...@spectrum-css/colorloupe@4.2.4)
 
 **Note:** Version bump only for package @spectrum-css/colorloupe
 
 <a name="4.2.3"></a>
-##4.2.3
+## 4.2.3
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@4.2.2...@spectrum-css/colorloupe@4.2.3)
 
 **Note:** Version bump only for package @spectrum-css/colorloupe
 
 <a name="4.2.2"></a>
-##4.2.2
+## 4.2.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@4.2.1...@spectrum-css/colorloupe@4.2.2)
 
 **Note:** Version bump only for package @spectrum-css/colorloupe
 
 <a name="4.2.1"></a>
-##4.2.1
+## 4.2.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/colorloupe
 
 <a name="4.2.0"></a>
-#4.2.0
+# 4.2.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@4.1.28...@spectrum-css/colorloupe@4.2.0)
 
@@ -77,98 +77,98 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="4.1.28"></a>
-##4.1.28
+## 4.1.28
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@4.1.27...@spectrum-css/colorloupe@4.1.28)
 
 **Note:** Version bump only for package @spectrum-css/colorloupe
 
 <a name="4.1.27"></a>
-##4.1.27
+## 4.1.27
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@4.1.26...@spectrum-css/colorloupe@4.1.27)
 
 **Note:** Version bump only for package @spectrum-css/colorloupe
 
 <a name="4.1.26"></a>
-##4.1.26
+## 4.1.26
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@4.1.24...@spectrum-css/colorloupe@4.1.26)
 
 **Note:** Version bump only for package @spectrum-css/colorloupe
 
 <a name="4.1.25"></a>
-##4.1.25
+## 4.1.25
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@4.1.24...@spectrum-css/colorloupe@4.1.25)
 
 **Note:** Version bump only for package @spectrum-css/colorloupe
 
 <a name="4.1.24"></a>
-##4.1.24
+## 4.1.24
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@4.1.23...@spectrum-css/colorloupe@4.1.24)
 
 **Note:** Version bump only for package @spectrum-css/colorloupe
 
 <a name="4.1.23"></a>
-##4.1.23
+## 4.1.23
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@4.1.22...@spectrum-css/colorloupe@4.1.23)
 
 **Note:** Version bump only for package @spectrum-css/colorloupe
 
 <a name="4.1.22"></a>
-##4.1.22
+## 4.1.22
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@4.1.21...@spectrum-css/colorloupe@4.1.22)
 
 **Note:** Version bump only for package @spectrum-css/colorloupe
 
 <a name="4.1.21"></a>
-##4.1.21
+## 4.1.21
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@4.1.20...@spectrum-css/colorloupe@4.1.21)
 
 **Note:** Version bump only for package @spectrum-css/colorloupe
 
 <a name="4.1.20"></a>
-##4.1.20
+## 4.1.20
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@4.1.19...@spectrum-css/colorloupe@4.1.20)
 
 **Note:** Version bump only for package @spectrum-css/colorloupe
 
 <a name="4.1.19"></a>
-##4.1.19
+## 4.1.19
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@4.1.18...@spectrum-css/colorloupe@4.1.19)
 
 **Note:** Version bump only for package @spectrum-css/colorloupe
 
 <a name="4.1.18"></a>
-##4.1.18
+## 4.1.18
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@4.1.17...@spectrum-css/colorloupe@4.1.18)
 
 **Note:** Version bump only for package @spectrum-css/colorloupe
 
 <a name="4.1.17"></a>
-##4.1.17
+## 4.1.17
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@4.1.16...@spectrum-css/colorloupe@4.1.17)
 
 **Note:** Version bump only for package @spectrum-css/colorloupe
 
 <a name="4.1.16"></a>
-##4.1.16
+## 4.1.16
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@4.1.15...@spectrum-css/colorloupe@4.1.16)
 
 **Note:** Version bump only for package @spectrum-css/colorloupe
 
 <a name="4.1.15"></a>
-##4.1.15
+## 4.1.15
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@4.1.14...@spectrum-css/colorloupe@4.1.15)
 
@@ -177,91 +177,91 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="4.1.14"></a>
-##4.1.14
+## 4.1.14
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@4.1.13...@spectrum-css/colorloupe@4.1.14)
 
 **Note:** Version bump only for package @spectrum-css/colorloupe
 
 <a name="4.1.13"></a>
-##4.1.13
+## 4.1.13
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@4.1.11...@spectrum-css/colorloupe@4.1.13)
 
 **Note:** Version bump only for package @spectrum-css/colorloupe
 
 <a name="4.1.12"></a>
-##4.1.12
+## 4.1.12
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@4.1.11...@spectrum-css/colorloupe@4.1.12)
 
 **Note:** Version bump only for package @spectrum-css/colorloupe
 
 <a name="4.1.11"></a>
-##4.1.11
+## 4.1.11
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@4.1.10...@spectrum-css/colorloupe@4.1.11)
 
 **Note:** Version bump only for package @spectrum-css/colorloupe
 
 <a name="4.1.10"></a>
-##4.1.10
+## 4.1.10
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@4.1.9...@spectrum-css/colorloupe@4.1.10)
 
 **Note:** Version bump only for package @spectrum-css/colorloupe
 
 <a name="4.1.9"></a>
-##4.1.9
+## 4.1.9
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@4.1.8...@spectrum-css/colorloupe@4.1.9)
 
 **Note:** Version bump only for package @spectrum-css/colorloupe
 
 <a name="4.1.8"></a>
-##4.1.8
+## 4.1.8
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@4.1.7...@spectrum-css/colorloupe@4.1.8)
 
 **Note:** Version bump only for package @spectrum-css/colorloupe
 
 <a name="4.1.7"></a>
-##4.1.7
+## 4.1.7
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@4.1.6...@spectrum-css/colorloupe@4.1.7)
 
 **Note:** Version bump only for package @spectrum-css/colorloupe
 
 <a name="4.1.6"></a>
-##4.1.6
+## 4.1.6
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@4.1.5...@spectrum-css/colorloupe@4.1.6)
 
 **Note:** Version bump only for package @spectrum-css/colorloupe
 
 <a name="4.1.5"></a>
-##4.1.5
+## 4.1.5
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@4.1.4...@spectrum-css/colorloupe@4.1.5)
 
 **Note:** Version bump only for package @spectrum-css/colorloupe
 
 <a name="4.1.4"></a>
-##4.1.4
+## 4.1.4
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@4.1.3...@spectrum-css/colorloupe@4.1.4)
 
 **Note:** Version bump only for package @spectrum-css/colorloupe
 
 <a name="4.1.3"></a>
-##4.1.3
+## 4.1.3
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@4.1.2...@spectrum-css/colorloupe@4.1.3)
 
 **Note:** Version bump only for package @spectrum-css/colorloupe
 
 <a name="4.1.2"></a>
-##4.1.2
+## 4.1.2
 🗓
 2023-06-28 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@4.1.1...@spectrum-css/colorloupe@4.1.2)
 
@@ -270,14 +270,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **colorloupe:**border bug ([#1958](https://github.com/adobe/spectrum-css/issues/1958))([559696f](https://github.com/adobe/spectrum-css/commit/559696f))
 
 <a name="4.1.1"></a>
-##4.1.1
+## 4.1.1
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@4.1.0...@spectrum-css/colorloupe@4.1.1)
 
 **Note:** Version bump only for package @spectrum-css/colorloupe
 
 <a name="4.1.0"></a>
-#4.1.0
+# 4.1.0
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@4.0.8...@spectrum-css/colorloupe@4.1.0)
 
@@ -286,7 +286,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*update to Storybook v7 ([#1935](https://github.com/adobe/spectrum-css/issues/1935))([6dcf09b](https://github.com/adobe/spectrum-css/commit/6dcf09b))
 
 <a name="4.0.8"></a>
-##4.0.8
+## 4.0.8
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@4.0.7...@spectrum-css/colorloupe@4.0.8)
 
@@ -295,14 +295,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="4.0.7"></a>
-##4.0.7
+## 4.0.7
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@4.0.6...@spectrum-css/colorloupe@4.0.7)
 
 **Note:** Version bump only for package @spectrum-css/colorloupe
 
 <a name="4.0.6"></a>
-##4.0.6
+## 4.0.6
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@4.0.5...@spectrum-css/colorloupe@4.0.6)
 

--- a/components/colorloupe/CHANGELOG.md
+++ b/components/colorloupe/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-# 5.0.0
+## 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@4.2.4...@spectrum-css/colorloupe@5.0.0)
 
@@ -68,7 +68,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/colorloupe
 
 <a name="4.2.0"></a>
-# 4.2.0
+## 4.2.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@4.1.28...@spectrum-css/colorloupe@4.2.0)
 
@@ -277,7 +277,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/colorloupe
 
 <a name="4.1.0"></a>
-# 4.1.0
+## 4.1.0
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@4.0.8...@spectrum-css/colorloupe@4.1.0)
 
@@ -350,7 +350,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="4.0.0"></a>
 
-# 4.0.0
+## 4.0.0
 
 🗓 2023-05-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@3.0.11...@spectrum-css/colorloupe@4.0.0)
 
@@ -455,7 +455,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2023-04-19 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@2.0.20...@spectrum-css/colorloupe@3.0.0)
 
@@ -629,7 +629,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2022-02-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@1.0.13...@spectrum-css/colorloupe@2.0.0)
 
@@ -814,7 +814,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="1.0.0"></a>
 
-# 1.0.0
+## 1.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@1.0.0-beta.4...@spectrum-css/colorloupe@1.0.0)
 
@@ -822,7 +822,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="1.0.0-beta.4"></a>
 
-# 1.0.0-beta.4
+## 1.0.0-beta.4
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@1.0.0-beta.3...@spectrum-css/colorloupe@1.0.0-beta.4)
 
@@ -832,7 +832,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="1.0.0-beta.3"></a>
 
-# 1.0.0-beta.3
+## 1.0.0-beta.3
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@1.0.0-beta.2...@spectrum-css/colorloupe@1.0.0-beta.3)
 
@@ -840,7 +840,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="1.0.0-beta.2"></a>
 
-# 1.0.0-beta.2
+## 1.0.0-beta.2
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorloupe@1.0.0-beta.1...@spectrum-css/colorloupe@1.0.0-beta.2)
 
@@ -850,7 +850,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="1.0.0-beta.1"></a>
 
-# 1.0.0-beta.1
+## 1.0.0-beta.1
 
 🗓 2020-05-14
 

--- a/components/colorslider/CHANGELOG.md
+++ b/components/colorslider/CHANGELOG.md
@@ -31,7 +31,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="6.0.0"></a>
-#6.0.0
+# 6.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@5.1.5...@spectrum-css/colorslider@6.0.0)
 
@@ -46,42 +46,42 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="5.1.5"></a>
-##5.1.5
+## 5.1.5
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@5.1.4...@spectrum-css/colorslider@5.1.5)
 
 **Note:** Version bump only for package @spectrum-css/colorslider
 
 <a name="5.1.4"></a>
-##5.1.4
+## 5.1.4
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@5.1.3...@spectrum-css/colorslider@5.1.4)
 
 **Note:** Version bump only for package @spectrum-css/colorslider
 
 <a name="5.1.3"></a>
-##5.1.3
+## 5.1.3
 🗓
 2024-02-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@5.1.2...@spectrum-css/colorslider@5.1.3)
 
 **Note:** Version bump only for package @spectrum-css/colorslider
 
 <a name="5.1.2"></a>
-##5.1.2
+## 5.1.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@5.1.1...@spectrum-css/colorslider@5.1.2)
 
 **Note:** Version bump only for package @spectrum-css/colorslider
 
 <a name="5.1.1"></a>
-##5.1.1
+## 5.1.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/colorslider
 
 <a name="5.1.0"></a>
-#5.1.0
+# 5.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@5.0.14...@spectrum-css/colorslider@5.1.0)
 
@@ -90,105 +90,105 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="5.0.14"></a>
-##5.0.14
+## 5.0.14
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@5.0.13...@spectrum-css/colorslider@5.0.14)
 
 **Note:** Version bump only for package @spectrum-css/colorslider
 
 <a name="5.0.13"></a>
-##5.0.13
+## 5.0.13
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@5.0.12...@spectrum-css/colorslider@5.0.13)
 
 **Note:** Version bump only for package @spectrum-css/colorslider
 
 <a name="5.0.12"></a>
-##5.0.12
+## 5.0.12
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@5.0.10...@spectrum-css/colorslider@5.0.12)
 
 **Note:** Version bump only for package @spectrum-css/colorslider
 
 <a name="5.0.11"></a>
-##5.0.11
+## 5.0.11
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@5.0.10...@spectrum-css/colorslider@5.0.11)
 
 **Note:** Version bump only for package @spectrum-css/colorslider
 
 <a name="5.0.10"></a>
-##5.0.10
+## 5.0.10
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@5.0.9...@spectrum-css/colorslider@5.0.10)
 
 **Note:** Version bump only for package @spectrum-css/colorslider
 
 <a name="5.0.9"></a>
-##5.0.9
+## 5.0.9
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@5.0.8...@spectrum-css/colorslider@5.0.9)
 
 **Note:** Version bump only for package @spectrum-css/colorslider
 
 <a name="5.0.8"></a>
-##5.0.8
+## 5.0.8
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@5.0.7...@spectrum-css/colorslider@5.0.8)
 
 **Note:** Version bump only for package @spectrum-css/colorslider
 
 <a name="5.0.7"></a>
-##5.0.7
+## 5.0.7
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@5.0.6...@spectrum-css/colorslider@5.0.7)
 
 **Note:** Version bump only for package @spectrum-css/colorslider
 
 <a name="5.0.6"></a>
-##5.0.6
+## 5.0.6
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@5.0.5...@spectrum-css/colorslider@5.0.6)
 
 **Note:** Version bump only for package @spectrum-css/colorslider
 
 <a name="5.0.5"></a>
-##5.0.5
+## 5.0.5
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@5.0.4...@spectrum-css/colorslider@5.0.5)
 
 **Note:** Version bump only for package @spectrum-css/colorslider
 
 <a name="5.0.4"></a>
-##5.0.4
+## 5.0.4
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@5.0.3...@spectrum-css/colorslider@5.0.4)
 
 **Note:** Version bump only for package @spectrum-css/colorslider
 
 <a name="5.0.3"></a>
-##5.0.3
+## 5.0.3
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@5.0.2...@spectrum-css/colorslider@5.0.3)
 
 **Note:** Version bump only for package @spectrum-css/colorslider
 
 <a name="5.0.2"></a>
-##5.0.2
+## 5.0.2
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@5.0.1...@spectrum-css/colorslider@5.0.2)
 
 **Note:** Version bump only for package @spectrum-css/colorslider
 
 <a name="5.0.1"></a>
-##5.0.1
+## 5.0.1
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@5.0.0...@spectrum-css/colorslider@5.0.1)
 
 **Note:** Version bump only for package @spectrum-css/colorslider
 
 <a name="5.0.0"></a>
-#5.0.0
+# 5.0.0
 🗓
 2023-08-25 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@4.0.9...@spectrum-css/colorslider@5.0.0)
 
@@ -371,70 +371,70 @@ Update devDependencies to use latest version of tokens package.
 - chore(colorslider): manual version increase for beta release
 
 <a name="4.0.9"></a>
-##4.0.9
+## 4.0.9
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@4.0.8...@spectrum-css/colorslider@4.0.9)
 
 **Note:** Version bump only for package @spectrum-css/colorslider
 
 <a name="4.0.8"></a>
-##4.0.8
+## 4.0.8
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@4.0.6...@spectrum-css/colorslider@4.0.8)
 
 **Note:** Version bump only for package @spectrum-css/colorslider
 
 <a name="4.0.7"></a>
-##4.0.7
+## 4.0.7
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@4.0.6...@spectrum-css/colorslider@4.0.7)
 
 **Note:** Version bump only for package @spectrum-css/colorslider
 
 <a name="4.0.6"></a>
-##4.0.6
+## 4.0.6
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@4.0.5...@spectrum-css/colorslider@4.0.6)
 
 **Note:** Version bump only for package @spectrum-css/colorslider
 
 <a name="4.0.5"></a>
-##4.0.5
+## 4.0.5
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@4.0.4...@spectrum-css/colorslider@4.0.5)
 
 **Note:** Version bump only for package @spectrum-css/colorslider
 
 <a name="4.0.4"></a>
-##4.0.4
+## 4.0.4
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@4.0.3...@spectrum-css/colorslider@4.0.4)
 
 **Note:** Version bump only for package @spectrum-css/colorslider
 
 <a name="4.0.3"></a>
-##4.0.3
+## 4.0.3
 🗓
 2023-08-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@4.0.2...@spectrum-css/colorslider@4.0.3)
 
 **Note:** Version bump only for package @spectrum-css/colorslider
 
 <a name="4.0.2"></a>
-##4.0.2
+## 4.0.2
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@4.0.1...@spectrum-css/colorslider@4.0.2)
 
 **Note:** Version bump only for package @spectrum-css/colorslider
 
 <a name="4.0.1"></a>
-##4.0.1
+## 4.0.1
 🗓
 2023-07-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@4.0.0...@spectrum-css/colorslider@4.0.1)
 
 **Note:** Version bump only for package @spectrum-css/colorslider
 
 <a name="4.0.0"></a>
-#4.0.0
+# 4.0.0
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@3.0.23...@spectrum-css/colorslider@4.0.0)
 
@@ -483,35 +483,35 @@ Update devDependencies to use latest version of tokens package.
 - chore: update yarn.lock file after rebase
 
 <a name="3.0.23"></a>
-##3.0.23
+## 3.0.23
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@3.0.22...@spectrum-css/colorslider@3.0.23)
 
 **Note:** Version bump only for package @spectrum-css/colorslider
 
 <a name="3.0.22"></a>
-##3.0.22
+## 3.0.22
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@3.0.21...@spectrum-css/colorslider@3.0.22)
 
 **Note:** Version bump only for package @spectrum-css/colorslider
 
 <a name="3.0.21"></a>
-##3.0.21
+## 3.0.21
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@3.0.20...@spectrum-css/colorslider@3.0.21)
 
 **Note:** Version bump only for package @spectrum-css/colorslider
 
 <a name="3.0.20"></a>
-##3.0.20
+## 3.0.20
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@3.0.19...@spectrum-css/colorslider@3.0.20)
 
 **Note:** Version bump only for package @spectrum-css/colorslider
 
 <a name="3.0.19"></a>
-##3.0.19
+## 3.0.19
 🗓
 2023-06-28 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@3.0.18...@spectrum-css/colorslider@3.0.19)
 
@@ -520,21 +520,21 @@ Update devDependencies to use latest version of tokens package.
 - **colorloupe:**border bug ([#1958](https://github.com/adobe/spectrum-css/issues/1958))([559696f](https://github.com/adobe/spectrum-css/commit/559696f))
 
 <a name="3.0.18"></a>
-##3.0.18
+## 3.0.18
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@3.0.17...@spectrum-css/colorslider@3.0.18)
 
 **Note:** Version bump only for package @spectrum-css/colorslider
 
 <a name="3.0.17"></a>
-##3.0.17
+## 3.0.17
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@3.0.16...@spectrum-css/colorslider@3.0.17)
 
 **Note:** Version bump only for package @spectrum-css/colorslider
 
 <a name="3.0.16"></a>
-##3.0.16
+## 3.0.16
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@3.0.15...@spectrum-css/colorslider@3.0.16)
 
@@ -543,14 +543,14 @@ Update devDependencies to use latest version of tokens package.
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="3.0.15"></a>
-##3.0.15
+## 3.0.15
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@3.0.14...@spectrum-css/colorslider@3.0.15)
 
 **Note:** Version bump only for package @spectrum-css/colorslider
 
 <a name="3.0.14"></a>
-##3.0.14
+## 3.0.14
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@3.0.13...@spectrum-css/colorslider@3.0.14)
 

--- a/components/colorslider/CHANGELOG.md
+++ b/components/colorslider/CHANGELOG.md
@@ -31,7 +31,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="6.0.0"></a>
-# 6.0.0
+## 6.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@5.1.5...@spectrum-css/colorslider@6.0.0)
 
@@ -81,7 +81,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/colorslider
 
 <a name="5.1.0"></a>
-# 5.1.0
+## 5.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@5.0.14...@spectrum-css/colorslider@5.1.0)
 
@@ -188,7 +188,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/colorslider
 
 <a name="5.0.0"></a>
-# 5.0.0
+## 5.0.0
 🗓
 2023-08-25 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@4.0.9...@spectrum-css/colorslider@5.0.0)
 
@@ -434,7 +434,7 @@ Update devDependencies to use latest version of tokens package.
 **Note:** Version bump only for package @spectrum-css/colorslider
 
 <a name="4.0.0"></a>
-# 4.0.0
+## 4.0.0
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@3.0.23...@spectrum-css/colorslider@4.0.0)
 
@@ -662,7 +662,7 @@ Update devDependencies to use latest version of tokens package.
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2023-04-19 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@2.0.24...@spectrum-css/colorslider@3.0.0)
 
@@ -866,7 +866,7 @@ Update devDependencies to use latest version of tokens package.
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2022-02-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@1.0.13...@spectrum-css/colorslider@2.0.0)
 
@@ -1041,7 +1041,7 @@ Update devDependencies to use latest version of tokens package.
 
 <a name="1.0.0"></a>
 
-# 1.0.0
+## 1.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@1.0.0-beta.5...@spectrum-css/colorslider@1.0.0)
 
@@ -1049,7 +1049,7 @@ Update devDependencies to use latest version of tokens package.
 
 <a name="1.0.0-beta.5"></a>
 
-# 1.0.0-beta.5
+## 1.0.0-beta.5
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@1.0.0-beta.4...@spectrum-css/colorslider@1.0.0-beta.5)
 
@@ -1059,7 +1059,7 @@ Update devDependencies to use latest version of tokens package.
 
 <a name="1.0.0-beta.4"></a>
 
-# 1.0.0-beta.4
+## 1.0.0-beta.4
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@1.0.0-beta.3...@spectrum-css/colorslider@1.0.0-beta.4)
 
@@ -1067,7 +1067,7 @@ Update devDependencies to use latest version of tokens package.
 
 <a name="1.0.0-beta.3"></a>
 
-# 1.0.0-beta.3
+## 1.0.0-beta.3
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@1.0.0-beta.2...@spectrum-css/colorslider@1.0.0-beta.3)
 
@@ -1077,7 +1077,7 @@ Update devDependencies to use latest version of tokens package.
 
 <a name="1.0.0-beta.2"></a>
 
-# 1.0.0-beta.2
+## 1.0.0-beta.2
 
 🗓 2020-06-19 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorslider@1.0.0-beta.1...@spectrum-css/colorslider@1.0.0-beta.2)
 
@@ -1085,7 +1085,7 @@ Update devDependencies to use latest version of tokens package.
 
 <a name="1.0.0-beta.1"></a>
 
-# 1.0.0-beta.1
+## 1.0.0-beta.1
 
 🗓 2020-05-14
 

--- a/components/colorwheel/CHANGELOG.md
+++ b/components/colorwheel/CHANGELOG.md
@@ -33,7 +33,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="4.0.0"></a>
-#4.0.0
+# 4.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@3.1.5...@spectrum-css/colorwheel@4.0.0)
 
@@ -48,42 +48,42 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="3.1.5"></a>
-##3.1.5
+## 3.1.5
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@3.1.4...@spectrum-css/colorwheel@3.1.5)
 
 **Note:** Version bump only for package @spectrum-css/colorwheel
 
 <a name="3.1.4"></a>
-##3.1.4
+## 3.1.4
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@3.1.3...@spectrum-css/colorwheel@3.1.4)
 
 **Note:** Version bump only for package @spectrum-css/colorwheel
 
 <a name="3.1.3"></a>
-##3.1.3
+## 3.1.3
 🗓
 2024-02-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@3.1.2...@spectrum-css/colorwheel@3.1.3)
 
 **Note:** Version bump only for package @spectrum-css/colorwheel
 
 <a name="3.1.2"></a>
-##3.1.2
+## 3.1.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@3.1.1...@spectrum-css/colorwheel@3.1.2)
 
 **Note:** Version bump only for package @spectrum-css/colorwheel
 
 <a name="3.1.1"></a>
-##3.1.1
+## 3.1.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/colorwheel
 
 <a name="3.1.0"></a>
-#3.1.0
+# 3.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@3.0.51...@spectrum-css/colorwheel@3.1.0)
 
@@ -92,98 +92,98 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="3.0.51"></a>
-##3.0.51
+## 3.0.51
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@3.0.50...@spectrum-css/colorwheel@3.0.51)
 
 **Note:** Version bump only for package @spectrum-css/colorwheel
 
 <a name="3.0.50"></a>
-##3.0.50
+## 3.0.50
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@3.0.49...@spectrum-css/colorwheel@3.0.50)
 
 **Note:** Version bump only for package @spectrum-css/colorwheel
 
 <a name="3.0.49"></a>
-##3.0.49
+## 3.0.49
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@3.0.47...@spectrum-css/colorwheel@3.0.49)
 
 **Note:** Version bump only for package @spectrum-css/colorwheel
 
 <a name="3.0.48"></a>
-##3.0.48
+## 3.0.48
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@3.0.47...@spectrum-css/colorwheel@3.0.48)
 
 **Note:** Version bump only for package @spectrum-css/colorwheel
 
 <a name="3.0.47"></a>
-##3.0.47
+## 3.0.47
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@3.0.46...@spectrum-css/colorwheel@3.0.47)
 
 **Note:** Version bump only for package @spectrum-css/colorwheel
 
 <a name="3.0.46"></a>
-##3.0.46
+## 3.0.46
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@3.0.45...@spectrum-css/colorwheel@3.0.46)
 
 **Note:** Version bump only for package @spectrum-css/colorwheel
 
 <a name="3.0.45"></a>
-##3.0.45
+## 3.0.45
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@3.0.44...@spectrum-css/colorwheel@3.0.45)
 
 **Note:** Version bump only for package @spectrum-css/colorwheel
 
 <a name="3.0.44"></a>
-##3.0.44
+## 3.0.44
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@3.0.43...@spectrum-css/colorwheel@3.0.44)
 
 **Note:** Version bump only for package @spectrum-css/colorwheel
 
 <a name="3.0.43"></a>
-##3.0.43
+## 3.0.43
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@3.0.42...@spectrum-css/colorwheel@3.0.43)
 
 **Note:** Version bump only for package @spectrum-css/colorwheel
 
 <a name="3.0.42"></a>
-##3.0.42
+## 3.0.42
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@3.0.41...@spectrum-css/colorwheel@3.0.42)
 
 **Note:** Version bump only for package @spectrum-css/colorwheel
 
 <a name="3.0.41"></a>
-##3.0.41
+## 3.0.41
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@3.0.40...@spectrum-css/colorwheel@3.0.41)
 
 **Note:** Version bump only for package @spectrum-css/colorwheel
 
 <a name="3.0.40"></a>
-##3.0.40
+## 3.0.40
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@3.0.39...@spectrum-css/colorwheel@3.0.40)
 
 **Note:** Version bump only for package @spectrum-css/colorwheel
 
 <a name="3.0.39"></a>
-##3.0.39
+## 3.0.39
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@3.0.38...@spectrum-css/colorwheel@3.0.39)
 
 **Note:** Version bump only for package @spectrum-css/colorwheel
 
 <a name="3.0.38"></a>
-##3.0.38
+## 3.0.38
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@3.0.37...@spectrum-css/colorwheel@3.0.38)
 
@@ -192,126 +192,126 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="3.0.37"></a>
-##3.0.37
+## 3.0.37
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@3.0.36...@spectrum-css/colorwheel@3.0.37)
 
 **Note:** Version bump only for package @spectrum-css/colorwheel
 
 <a name="3.0.36"></a>
-##3.0.36
+## 3.0.36
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@3.0.34...@spectrum-css/colorwheel@3.0.36)
 
 **Note:** Version bump only for package @spectrum-css/colorwheel
 
 <a name="3.0.35"></a>
-##3.0.35
+## 3.0.35
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@3.0.34...@spectrum-css/colorwheel@3.0.35)
 
 **Note:** Version bump only for package @spectrum-css/colorwheel
 
 <a name="3.0.34"></a>
-##3.0.34
+## 3.0.34
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@3.0.33...@spectrum-css/colorwheel@3.0.34)
 
 **Note:** Version bump only for package @spectrum-css/colorwheel
 
 <a name="3.0.33"></a>
-##3.0.33
+## 3.0.33
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@3.0.32...@spectrum-css/colorwheel@3.0.33)
 
 **Note:** Version bump only for package @spectrum-css/colorwheel
 
 <a name="3.0.32"></a>
-##3.0.32
+## 3.0.32
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@3.0.31...@spectrum-css/colorwheel@3.0.32)
 
 **Note:** Version bump only for package @spectrum-css/colorwheel
 
 <a name="3.0.31"></a>
-##3.0.31
+## 3.0.31
 🗓
 2023-08-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@3.0.30...@spectrum-css/colorwheel@3.0.31)
 
 **Note:** Version bump only for package @spectrum-css/colorwheel
 
 <a name="3.0.30"></a>
-##3.0.30
+## 3.0.30
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@3.0.29...@spectrum-css/colorwheel@3.0.30)
 
 **Note:** Version bump only for package @spectrum-css/colorwheel
 
 <a name="3.0.29"></a>
-##3.0.29
+## 3.0.29
 🗓
 2023-07-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@3.0.28...@spectrum-css/colorwheel@3.0.29)
 
 **Note:** Version bump only for package @spectrum-css/colorwheel
 
 <a name="3.0.28"></a>
-##3.0.28
+## 3.0.28
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@3.0.27...@spectrum-css/colorwheel@3.0.28)
 
 **Note:** Version bump only for package @spectrum-css/colorwheel
 
 <a name="3.0.27"></a>
-##3.0.27
+## 3.0.27
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@3.0.26...@spectrum-css/colorwheel@3.0.27)
 
 **Note:** Version bump only for package @spectrum-css/colorwheel
 
 <a name="3.0.26"></a>
-##3.0.26
+## 3.0.26
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@3.0.25...@spectrum-css/colorwheel@3.0.26)
 
 **Note:** Version bump only for package @spectrum-css/colorwheel
 
 <a name="3.0.25"></a>
-##3.0.25
+## 3.0.25
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@3.0.24...@spectrum-css/colorwheel@3.0.25)
 
 **Note:** Version bump only for package @spectrum-css/colorwheel
 
 <a name="3.0.24"></a>
-##3.0.24
+## 3.0.24
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@3.0.23...@spectrum-css/colorwheel@3.0.24)
 
 **Note:** Version bump only for package @spectrum-css/colorwheel
 
 <a name="3.0.23"></a>
-##3.0.23
+## 3.0.23
 🗓
 2023-06-28 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@3.0.22...@spectrum-css/colorwheel@3.0.23)
 
 **Note:** Version bump only for package @spectrum-css/colorwheel
 
 <a name="3.0.22"></a>
-##3.0.22
+## 3.0.22
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@3.0.21...@spectrum-css/colorwheel@3.0.22)
 
 **Note:** Version bump only for package @spectrum-css/colorwheel
 
 <a name="3.0.21"></a>
-##3.0.21
+## 3.0.21
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@3.0.20...@spectrum-css/colorwheel@3.0.21)
 
 **Note:** Version bump only for package @spectrum-css/colorwheel
 
 <a name="3.0.20"></a>
-##3.0.20
+## 3.0.20
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@3.0.19...@spectrum-css/colorwheel@3.0.20)
 
@@ -320,14 +320,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="3.0.19"></a>
-##3.0.19
+## 3.0.19
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@3.0.18...@spectrum-css/colorwheel@3.0.19)
 
 **Note:** Version bump only for package @spectrum-css/colorwheel
 
 <a name="3.0.18"></a>
-##3.0.18
+## 3.0.18
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@3.0.17...@spectrum-css/colorwheel@3.0.18)
 

--- a/components/colorwheel/CHANGELOG.md
+++ b/components/colorwheel/CHANGELOG.md
@@ -33,7 +33,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="4.0.0"></a>
-# 4.0.0
+## 4.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@3.1.5...@spectrum-css/colorwheel@4.0.0)
 
@@ -83,7 +83,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/colorwheel
 
 <a name="3.1.0"></a>
-# 3.1.0
+## 3.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@3.0.51...@spectrum-css/colorwheel@3.1.0)
 
@@ -471,7 +471,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2023-04-19 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@2.0.12...@spectrum-css/colorwheel@3.0.0)
 
@@ -581,7 +581,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2023-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@1.0.32...@spectrum-css/colorwheel@2.0.0)
 
@@ -899,7 +899,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="1.0.0"></a>
 
-# 1.0.0
+## 1.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@1.0.0-beta.4...@spectrum-css/colorwheel@1.0.0)
 
@@ -907,7 +907,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="1.0.0-beta.4"></a>
 
-# 1.0.0-beta.4
+## 1.0.0-beta.4
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@1.0.0-beta.3...@spectrum-css/colorwheel@1.0.0-beta.4)
 
@@ -917,7 +917,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="1.0.0-beta.3"></a>
 
-# 1.0.0-beta.3
+## 1.0.0-beta.3
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@1.0.0-beta.2...@spectrum-css/colorwheel@1.0.0-beta.3)
 
@@ -925,7 +925,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="1.0.0-beta.2"></a>
 
-# 1.0.0-beta.2
+## 1.0.0-beta.2
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/colorwheel@1.0.0-beta.1...@spectrum-css/colorwheel@1.0.0-beta.2)
 
@@ -933,7 +933,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="1.0.0-beta.1"></a>
 
-# 1.0.0-beta.1
+## 1.0.0-beta.1
 
 🗓 2020-05-14
 

--- a/components/combobox/CHANGELOG.md
+++ b/components/combobox/CHANGELOG.md
@@ -43,7 +43,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="3.0.0"></a>
-#3.0.0
+# 3.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/combobox@2.1.6...@spectrum-css/combobox@3.0.0)
 
@@ -62,168 +62,168 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="2.1.6"></a>
-##2.1.6
+## 2.1.6
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/combobox@2.1.5...@spectrum-css/combobox@2.1.6)
 
 **Note:** Version bump only for package @spectrum-css/combobox
 
 <a name="2.1.5"></a>
-##2.1.5
+## 2.1.5
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/combobox@2.1.4...@spectrum-css/combobox@2.1.5)
 
 **Note:** Version bump only for package @spectrum-css/combobox
 
 <a name="2.1.4"></a>
-##2.1.4
+## 2.1.4
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/combobox@2.1.3...@spectrum-css/combobox@2.1.4)
 
 **Note:** Version bump only for package @spectrum-css/combobox
 
 <a name="2.1.3"></a>
-##2.1.3
+## 2.1.3
 🗓
 2024-02-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/combobox@2.1.2...@spectrum-css/combobox@2.1.3)
 
 **Note:** Version bump only for package @spectrum-css/combobox
 
 <a name="2.1.2"></a>
-##2.1.2
+## 2.1.2
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/combobox
 
 <a name="2.1.1"></a>
-##2.1.1
+## 2.1.1
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/combobox@2.1.0...@spectrum-css/combobox@2.1.1)
 
 **Note:** Version bump only for package @spectrum-css/combobox
 
 <a name="2.1.0"></a>
-#2.1.0
+# 2.1.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/combobox@2.0.48...@spectrum-css/combobox@2.1.0)
 
 **Note:** Version bump only for package @spectrum-css/combobox
 
 <a name="2.0.48"></a>
-##2.0.48
+## 2.0.48
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/combobox@2.0.47...@spectrum-css/combobox@2.0.48)
 
 **Note:** Version bump only for package @spectrum-css/combobox
 
 <a name="2.0.47"></a>
-##2.0.47
+## 2.0.47
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/combobox@2.0.46...@spectrum-css/combobox@2.0.47)
 
 **Note:** Version bump only for package @spectrum-css/combobox
 
 <a name="2.0.46"></a>
-##2.0.46
+## 2.0.46
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/combobox@2.0.45...@spectrum-css/combobox@2.0.46)
 
 **Note:** Version bump only for package @spectrum-css/combobox
 
 <a name="2.0.45"></a>
-##2.0.45
+## 2.0.45
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/combobox@2.0.43...@spectrum-css/combobox@2.0.45)
 
 **Note:** Version bump only for package @spectrum-css/combobox
 
 <a name="2.0.44"></a>
-##2.0.44
+## 2.0.44
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/combobox@2.0.43...@spectrum-css/combobox@2.0.44)
 
 **Note:** Version bump only for package @spectrum-css/combobox
 
 <a name="2.0.43"></a>
-##2.0.43
+## 2.0.43
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/combobox@2.0.42...@spectrum-css/combobox@2.0.43)
 
 **Note:** Version bump only for package @spectrum-css/combobox
 
 <a name="2.0.42"></a>
-##2.0.42
+## 2.0.42
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/combobox@2.0.41...@spectrum-css/combobox@2.0.42)
 
 **Note:** Version bump only for package @spectrum-css/combobox
 
 <a name="2.0.41"></a>
-##2.0.41
+## 2.0.41
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/combobox@2.0.40...@spectrum-css/combobox@2.0.41)
 
 **Note:** Version bump only for package @spectrum-css/combobox
 
 <a name="2.0.40"></a>
-##2.0.40
+## 2.0.40
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/combobox@2.0.39...@spectrum-css/combobox@2.0.40)
 
 **Note:** Version bump only for package @spectrum-css/combobox
 
 <a name="2.0.39"></a>
-##2.0.39
+## 2.0.39
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/combobox@2.0.38...@spectrum-css/combobox@2.0.39)
 
 **Note:** Version bump only for package @spectrum-css/combobox
 
 <a name="2.0.38"></a>
-##2.0.38
+## 2.0.38
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/combobox@2.0.37...@spectrum-css/combobox@2.0.38)
 
 **Note:** Version bump only for package @spectrum-css/combobox
 
 <a name="2.0.37"></a>
-##2.0.37
+## 2.0.37
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/combobox@2.0.36...@spectrum-css/combobox@2.0.37)
 
 **Note:** Version bump only for package @spectrum-css/combobox
 
 <a name="2.0.36"></a>
-##2.0.36
+## 2.0.36
 🗓
 2023-09-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/combobox@2.0.35...@spectrum-css/combobox@2.0.36)
 
 **Note:** Version bump only for package @spectrum-css/combobox
 
 <a name="2.0.35"></a>
-##2.0.35
+## 2.0.35
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/combobox@2.0.34...@spectrum-css/combobox@2.0.35)
 
 **Note:** Version bump only for package @spectrum-css/combobox
 
 <a name="2.0.34"></a>
-##2.0.34
+## 2.0.34
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/combobox@2.0.33...@spectrum-css/combobox@2.0.34)
 
 **Note:** Version bump only for package @spectrum-css/combobox
 
 <a name="2.0.33"></a>
-##2.0.33
+## 2.0.33
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/combobox@2.0.32...@spectrum-css/combobox@2.0.33)
 
 **Note:** Version bump only for package @spectrum-css/combobox
 
 <a name="2.0.32"></a>
-##2.0.32
+## 2.0.32
 🗓
 2023-08-25 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/combobox@2.0.31...@spectrum-css/combobox@2.0.32)
 
@@ -232,63 +232,63 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="2.0.31"></a>
-##2.0.31
+## 2.0.31
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/combobox@2.0.30...@spectrum-css/combobox@2.0.31)
 
 **Note:** Version bump only for package @spectrum-css/combobox
 
 <a name="2.0.30"></a>
-##2.0.30
+## 2.0.30
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/combobox@2.0.28...@spectrum-css/combobox@2.0.30)
 
 **Note:** Version bump only for package @spectrum-css/combobox
 
 <a name="2.0.29"></a>
-##2.0.29
+## 2.0.29
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/combobox@2.0.28...@spectrum-css/combobox@2.0.29)
 
 **Note:** Version bump only for package @spectrum-css/combobox
 
 <a name="2.0.28"></a>
-##2.0.28
+## 2.0.28
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/combobox@2.0.27...@spectrum-css/combobox@2.0.28)
 
 **Note:** Version bump only for package @spectrum-css/combobox
 
 <a name="2.0.27"></a>
-##2.0.27
+## 2.0.27
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/combobox@2.0.26...@spectrum-css/combobox@2.0.27)
 
 **Note:** Version bump only for package @spectrum-css/combobox
 
 <a name="2.0.26"></a>
-##2.0.26
+## 2.0.26
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/combobox@2.0.25...@spectrum-css/combobox@2.0.26)
 
 **Note:** Version bump only for package @spectrum-css/combobox
 
 <a name="2.0.25"></a>
-##2.0.25
+## 2.0.25
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/combobox@2.0.24...@spectrum-css/combobox@2.0.25)
 
 **Note:** Version bump only for package @spectrum-css/combobox
 
 <a name="2.0.24"></a>
-##2.0.24
+## 2.0.24
 🗓
 2023-07-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/combobox@2.0.23...@spectrum-css/combobox@2.0.24)
 
 **Note:** Version bump only for package @spectrum-css/combobox
 
 <a name="2.0.23"></a>
-##2.0.23
+## 2.0.23
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/combobox@2.0.22...@spectrum-css/combobox@2.0.23)
 
@@ -297,56 +297,56 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*icon sizing in Storybook story templates ([#2037](https://github.com/adobe/spectrum-css/issues/2037))([c90c8a3](https://github.com/adobe/spectrum-css/commit/c90c8a3))
 
 <a name="2.0.22"></a>
-##2.0.22
+## 2.0.22
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/combobox@2.0.21...@spectrum-css/combobox@2.0.22)
 
 **Note:** Version bump only for package @spectrum-css/combobox
 
 <a name="2.0.21"></a>
-##2.0.21
+## 2.0.21
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/combobox@2.0.20...@spectrum-css/combobox@2.0.21)
 
 **Note:** Version bump only for package @spectrum-css/combobox
 
 <a name="2.0.20"></a>
-##2.0.20
+## 2.0.20
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/combobox@2.0.19...@spectrum-css/combobox@2.0.20)
 
 **Note:** Version bump only for package @spectrum-css/combobox
 
 <a name="2.0.19"></a>
-##2.0.19
+## 2.0.19
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/combobox@2.0.18...@spectrum-css/combobox@2.0.19)
 
 **Note:** Version bump only for package @spectrum-css/combobox
 
 <a name="2.0.18"></a>
-##2.0.18
+## 2.0.18
 🗓
 2023-06-28 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/combobox@2.0.17...@spectrum-css/combobox@2.0.18)
 
 **Note:** Version bump only for package @spectrum-css/combobox
 
 <a name="2.0.17"></a>
-##2.0.17
+## 2.0.17
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/combobox@2.0.16...@spectrum-css/combobox@2.0.17)
 
 **Note:** Version bump only for package @spectrum-css/combobox
 
 <a name="2.0.16"></a>
-##2.0.16
+## 2.0.16
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/combobox@2.0.15...@spectrum-css/combobox@2.0.16)
 
 **Note:** Version bump only for package @spectrum-css/combobox
 
 <a name="2.0.15"></a>
-##2.0.15
+## 2.0.15
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/combobox@2.0.14...@spectrum-css/combobox@2.0.15)
 
@@ -355,14 +355,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="2.0.14"></a>
-##2.0.14
+## 2.0.14
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/combobox@2.0.13...@spectrum-css/combobox@2.0.14)
 
 **Note:** Version bump only for package @spectrum-css/combobox
 
 <a name="2.0.13"></a>
-##2.0.13
+## 2.0.13
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/combobox@2.0.12...@spectrum-css/combobox@2.0.13)
 

--- a/components/combobox/CHANGELOG.md
+++ b/components/combobox/CHANGELOG.md
@@ -43,7 +43,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="3.0.0"></a>
-# 3.0.0
+## 3.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/combobox@2.1.6...@spectrum-css/combobox@3.0.0)
 
@@ -104,7 +104,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/combobox
 
 <a name="2.1.0"></a>
-# 2.1.0
+## 2.1.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/combobox@2.0.48...@spectrum-css/combobox@2.1.0)
 
@@ -468,7 +468,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2023-05-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/combobox@1.0.16...@spectrum-css/combobox@2.0.0)
 

--- a/components/commons/CHANGELOG.md
+++ b/components/commons/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="10.0.0"></a>
-# 10.0.0
+## 10.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/commons@9.1.2...@spectrum-css/commons@10.0.0)
 
@@ -39,7 +39,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/commons
 
 <a name="9.1.0"></a>
-# 9.1.0
+## 9.1.0
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/commons@9.0.2...@spectrum-css/commons@9.1.0)
 
@@ -66,7 +66,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/commons
 
 <a name="9.0.0"></a>
-# 9.0.0
+## 9.0.0
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/commons@8.0.1...@spectrum-css/commons@9.0.0)
 
@@ -90,7 +90,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/commons
 
 <a name="8.0.0"></a>
-# 8.0.0
+## 8.0.0
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/commons@7.0.8...@spectrum-css/commons@8.0.0)
 
@@ -168,7 +168,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="7.0.0"></a>
 
-# 7.0.0
+## 7.0.0
 
 🗓 2023-02-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/commons@6.0.0...@spectrum-css/commons@7.0.0)
 
@@ -180,7 +180,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="6.0.0"></a>
 
-# 6.0.0
+## 6.0.0
 
 🗓 2023-02-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/commons@4.0.2...@spectrum-css/commons@6.0.0)
 
@@ -192,7 +192,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="5.0.0"></a>
 
-# 5.0.0
+## 5.0.0
 
 🗓 2023-01-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/commons@5.0.0-beta.0...@spectrum-css/commons@5.0.0)
 
@@ -204,7 +204,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="4.1.0-beta.0"></a>
 
-# 4.1.0-beta.0
+## 4.1.0-beta.0
 
 🗓 2023-01-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/commons@4.0.2...@spectrum-css/commons@4.1.0-beta.0)
 
@@ -230,7 +230,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="4.0.0"></a>
 
-# 4.0.0
+## 4.0.0
 
 🗓 2022-11-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/commons@3.0.6...@spectrum-css/commons@4.0.0)
 
@@ -315,7 +315,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/commons@2.1.0...@spectrum-css/commons@3.0.0)
 
@@ -330,7 +330,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="2.1.0"></a>
 
-# 2.1.0
+## 2.1.0
 
 🗓 2020-02-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/commons@2.0.0...@spectrum-css/commons@2.1.0)
 
@@ -340,7 +340,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/commons/CHANGELOG.md
+++ b/components/commons/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="10.0.0"></a>
-#10.0.0
+# 10.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/commons@9.1.2...@spectrum-css/commons@10.0.0)
 
@@ -25,21 +25,21 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="9.1.2"></a>
-##9.1.2
+## 9.1.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/commons@9.1.1...@spectrum-css/commons@9.1.2)
 
 **Note:** Version bump only for package @spectrum-css/commons
 
 <a name="9.1.1"></a>
-##9.1.1
+## 9.1.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/commons
 
 <a name="9.1.0"></a>
-#9.1.0
+# 9.1.0
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/commons@9.0.2...@spectrum-css/commons@9.1.0)
 
@@ -52,21 +52,21 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **commons:**rename and deprecate mods referencing global tokens ([#2423](https://github.com/adobe/spectrum-css/issues/2423))([3a49432](https://github.com/adobe/spectrum-css/commit/3a49432))
 
 <a name="9.0.2"></a>
-##9.0.2
+## 9.0.2
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/commons@9.0.1...@spectrum-css/commons@9.0.2)
 
 **Note:** Version bump only for package @spectrum-css/commons
 
 <a name="9.0.1"></a>
-##9.0.1
+## 9.0.1
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/commons@9.0.0...@spectrum-css/commons@9.0.1)
 
 **Note:** Version bump only for package @spectrum-css/commons
 
 <a name="9.0.0"></a>
-#9.0.0
+# 9.0.0
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/commons@8.0.1...@spectrum-css/commons@9.0.0)
 
@@ -83,14 +83,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - docs: regenerate mods
 
 <a name="8.0.1"></a>
-##8.0.1
+## 8.0.1
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/commons@8.0.0...@spectrum-css/commons@8.0.1)
 
 **Note:** Version bump only for package @spectrum-css/commons
 
 <a name="8.0.0"></a>
-#8.0.0
+# 8.0.0
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/commons@7.0.8...@spectrum-css/commons@8.0.0)
 
@@ -103,7 +103,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
     		use native focus-visible pseudo class for focus styling on button and basebutton
 
 <a name="7.0.8"></a>
-##7.0.8
+## 7.0.8
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/commons@7.0.7...@spectrum-css/commons@7.0.8)
 
@@ -112,7 +112,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="7.0.7"></a>
-##7.0.7
+## 7.0.7
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/commons@7.0.6...@spectrum-css/commons@7.0.7)
 

--- a/components/contextualhelp/CHANGELOG.md
+++ b/components/contextualhelp/CHANGELOG.md
@@ -33,7 +33,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="3.0.0"></a>
-# 3.0.0
+## 3.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/contextualhelp@2.1.5...@spectrum-css/contextualhelp@3.0.0)
 
@@ -83,7 +83,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/contextualhelp
 
 <a name="2.1.0"></a>
-# 2.1.0
+## 2.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/contextualhelp@2.0.45...@spectrum-css/contextualhelp@2.1.0)
 
@@ -425,7 +425,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2023-05-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/contextualhelp@1.0.13...@spectrum-css/contextualhelp@2.0.0)
 
@@ -547,7 +547,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="1.0.0"></a>
 
-# 1.0.0
+## 1.0.0
 
 🗓 2023-03-27
 

--- a/components/contextualhelp/CHANGELOG.md
+++ b/components/contextualhelp/CHANGELOG.md
@@ -33,7 +33,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="3.0.0"></a>
-#3.0.0
+# 3.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/contextualhelp@2.1.5...@spectrum-css/contextualhelp@3.0.0)
 
@@ -48,42 +48,42 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="2.1.5"></a>
-##2.1.5
+## 2.1.5
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/contextualhelp@2.1.4...@spectrum-css/contextualhelp@2.1.5)
 
 **Note:** Version bump only for package @spectrum-css/contextualhelp
 
 <a name="2.1.4"></a>
-##2.1.4
+## 2.1.4
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/contextualhelp@2.1.3...@spectrum-css/contextualhelp@2.1.4)
 
 **Note:** Version bump only for package @spectrum-css/contextualhelp
 
 <a name="2.1.3"></a>
-##2.1.3
+## 2.1.3
 🗓
 2024-02-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/contextualhelp@2.1.2...@spectrum-css/contextualhelp@2.1.3)
 
 **Note:** Version bump only for package @spectrum-css/contextualhelp
 
 <a name="2.1.2"></a>
-##2.1.2
+## 2.1.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/contextualhelp@2.1.1...@spectrum-css/contextualhelp@2.1.2)
 
 **Note:** Version bump only for package @spectrum-css/contextualhelp
 
 <a name="2.1.1"></a>
-##2.1.1
+## 2.1.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/contextualhelp
 
 <a name="2.1.0"></a>
-#2.1.0
+# 2.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/contextualhelp@2.0.45...@spectrum-css/contextualhelp@2.1.0)
 
@@ -92,35 +92,35 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="2.0.45"></a>
-##2.0.45
+## 2.0.45
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/contextualhelp@2.0.44...@spectrum-css/contextualhelp@2.0.45)
 
 **Note:** Version bump only for package @spectrum-css/contextualhelp
 
 <a name="2.0.44"></a>
-##2.0.44
+## 2.0.44
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/contextualhelp@2.0.43...@spectrum-css/contextualhelp@2.0.44)
 
 **Note:** Version bump only for package @spectrum-css/contextualhelp
 
 <a name="2.0.43"></a>
-##2.0.43
+## 2.0.43
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/contextualhelp@2.0.41...@spectrum-css/contextualhelp@2.0.43)
 
 **Note:** Version bump only for package @spectrum-css/contextualhelp
 
 <a name="2.0.42"></a>
-##2.0.42
+## 2.0.42
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/contextualhelp@2.0.41...@spectrum-css/contextualhelp@2.0.42)
 
 **Note:** Version bump only for package @spectrum-css/contextualhelp
 
 <a name="2.0.41"></a>
-##2.0.41
+## 2.0.41
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/contextualhelp@2.0.40...@spectrum-css/contextualhelp@2.0.41)
 
@@ -129,70 +129,70 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **contextualhelp:**use spectrum-tokens var for font-size([7f29eda](https://github.com/adobe/spectrum-css/commit/7f29eda))
 
 <a name="2.0.40"></a>
-##2.0.40
+## 2.0.40
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/contextualhelp@2.0.39...@spectrum-css/contextualhelp@2.0.40)
 
 **Note:** Version bump only for package @spectrum-css/contextualhelp
 
 <a name="2.0.39"></a>
-##2.0.39
+## 2.0.39
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/contextualhelp@2.0.38...@spectrum-css/contextualhelp@2.0.39)
 
 **Note:** Version bump only for package @spectrum-css/contextualhelp
 
 <a name="2.0.38"></a>
-##2.0.38
+## 2.0.38
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/contextualhelp@2.0.37...@spectrum-css/contextualhelp@2.0.38)
 
 **Note:** Version bump only for package @spectrum-css/contextualhelp
 
 <a name="2.0.37"></a>
-##2.0.37
+## 2.0.37
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/contextualhelp@2.0.36...@spectrum-css/contextualhelp@2.0.37)
 
 **Note:** Version bump only for package @spectrum-css/contextualhelp
 
 <a name="2.0.36"></a>
-##2.0.36
+## 2.0.36
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/contextualhelp@2.0.35...@spectrum-css/contextualhelp@2.0.36)
 
 **Note:** Version bump only for package @spectrum-css/contextualhelp
 
 <a name="2.0.35"></a>
-##2.0.35
+## 2.0.35
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/contextualhelp@2.0.34...@spectrum-css/contextualhelp@2.0.35)
 
 **Note:** Version bump only for package @spectrum-css/contextualhelp
 
 <a name="2.0.34"></a>
-##2.0.34
+## 2.0.34
 🗓
 2023-09-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/contextualhelp@2.0.33...@spectrum-css/contextualhelp@2.0.34)
 
 **Note:** Version bump only for package @spectrum-css/contextualhelp
 
 <a name="2.0.33"></a>
-##2.0.33
+## 2.0.33
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/contextualhelp@2.0.32...@spectrum-css/contextualhelp@2.0.33)
 
 **Note:** Version bump only for package @spectrum-css/contextualhelp
 
 <a name="2.0.32"></a>
-##2.0.32
+## 2.0.32
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/contextualhelp@2.0.31...@spectrum-css/contextualhelp@2.0.32)
 
 **Note:** Version bump only for package @spectrum-css/contextualhelp
 
 <a name="2.0.31"></a>
-##2.0.31
+## 2.0.31
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/contextualhelp@2.0.30...@spectrum-css/contextualhelp@2.0.31)
 
@@ -201,119 +201,119 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="2.0.30"></a>
-##2.0.30
+## 2.0.30
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/contextualhelp@2.0.29...@spectrum-css/contextualhelp@2.0.30)
 
 **Note:** Version bump only for package @spectrum-css/contextualhelp
 
 <a name="2.0.29"></a>
-##2.0.29
+## 2.0.29
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/contextualhelp@2.0.27...@spectrum-css/contextualhelp@2.0.29)
 
 **Note:** Version bump only for package @spectrum-css/contextualhelp
 
 <a name="2.0.28"></a>
-##2.0.28
+## 2.0.28
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/contextualhelp@2.0.27...@spectrum-css/contextualhelp@2.0.28)
 
 **Note:** Version bump only for package @spectrum-css/contextualhelp
 
 <a name="2.0.27"></a>
-##2.0.27
+## 2.0.27
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/contextualhelp@2.0.26...@spectrum-css/contextualhelp@2.0.27)
 
 **Note:** Version bump only for package @spectrum-css/contextualhelp
 
 <a name="2.0.26"></a>
-##2.0.26
+## 2.0.26
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/contextualhelp@2.0.25...@spectrum-css/contextualhelp@2.0.26)
 
 **Note:** Version bump only for package @spectrum-css/contextualhelp
 
 <a name="2.0.25"></a>
-##2.0.25
+## 2.0.25
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/contextualhelp@2.0.24...@spectrum-css/contextualhelp@2.0.25)
 
 **Note:** Version bump only for package @spectrum-css/contextualhelp
 
 <a name="2.0.24"></a>
-##2.0.24
+## 2.0.24
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/contextualhelp@2.0.23...@spectrum-css/contextualhelp@2.0.24)
 
 **Note:** Version bump only for package @spectrum-css/contextualhelp
 
 <a name="2.0.23"></a>
-##2.0.23
+## 2.0.23
 🗓
 2023-07-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/contextualhelp@2.0.22...@spectrum-css/contextualhelp@2.0.23)
 
 **Note:** Version bump only for package @spectrum-css/contextualhelp
 
 <a name="2.0.22"></a>
-##2.0.22
+## 2.0.22
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/contextualhelp@2.0.21...@spectrum-css/contextualhelp@2.0.22)
 
 **Note:** Version bump only for package @spectrum-css/contextualhelp
 
 <a name="2.0.21"></a>
-##2.0.21
+## 2.0.21
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/contextualhelp@2.0.20...@spectrum-css/contextualhelp@2.0.21)
 
 **Note:** Version bump only for package @spectrum-css/contextualhelp
 
 <a name="2.0.20"></a>
-##2.0.20
+## 2.0.20
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/contextualhelp@2.0.19...@spectrum-css/contextualhelp@2.0.20)
 
 **Note:** Version bump only for package @spectrum-css/contextualhelp
 
 <a name="2.0.19"></a>
-##2.0.19
+## 2.0.19
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/contextualhelp@2.0.18...@spectrum-css/contextualhelp@2.0.19)
 
 **Note:** Version bump only for package @spectrum-css/contextualhelp
 
 <a name="2.0.18"></a>
-##2.0.18
+## 2.0.18
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/contextualhelp@2.0.17...@spectrum-css/contextualhelp@2.0.18)
 
 **Note:** Version bump only for package @spectrum-css/contextualhelp
 
 <a name="2.0.17"></a>
-##2.0.17
+## 2.0.17
 🗓
 2023-06-28 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/contextualhelp@2.0.16...@spectrum-css/contextualhelp@2.0.17)
 
 **Note:** Version bump only for package @spectrum-css/contextualhelp
 
 <a name="2.0.16"></a>
-##2.0.16
+## 2.0.16
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/contextualhelp@2.0.15...@spectrum-css/contextualhelp@2.0.16)
 
 **Note:** Version bump only for package @spectrum-css/contextualhelp
 
 <a name="2.0.15"></a>
-##2.0.15
+## 2.0.15
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/contextualhelp@2.0.14...@spectrum-css/contextualhelp@2.0.15)
 
 **Note:** Version bump only for package @spectrum-css/contextualhelp
 
 <a name="2.0.14"></a>
-##2.0.14
+## 2.0.14
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/contextualhelp@2.0.13...@spectrum-css/contextualhelp@2.0.14)
 
@@ -322,14 +322,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="2.0.13"></a>
-##2.0.13
+## 2.0.13
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/contextualhelp@2.0.12...@spectrum-css/contextualhelp@2.0.13)
 
 **Note:** Version bump only for package @spectrum-css/contextualhelp
 
 <a name="2.0.12"></a>
-##2.0.12
+## 2.0.12
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/contextualhelp@2.0.11...@spectrum-css/contextualhelp@2.0.12)
 

--- a/components/datepicker/CHANGELOG.md
+++ b/components/datepicker/CHANGELOG.md
@@ -47,7 +47,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="3.0.0"></a>
-# 3.0.0
+## 3.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/datepicker@2.1.4...@spectrum-css/datepicker@3.0.0)
 
@@ -94,7 +94,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/datepicker
 
 <a name="2.1.0"></a>
-# 2.1.0
+## 2.1.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/datepicker@2.0.5...@spectrum-css/datepicker@2.1.0)
 
@@ -136,7 +136,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/datepicker
 
 <a name="2.0.0"></a>
-# 2.0.0
+## 2.0.0
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/datepicker@1.0.55...@spectrum-css/datepicker@2.0.0)
 

--- a/components/datepicker/CHANGELOG.md
+++ b/components/datepicker/CHANGELOG.md
@@ -47,7 +47,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="3.0.0"></a>
-#3.0.0
+# 3.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/datepicker@2.1.4...@spectrum-css/datepicker@3.0.0)
 
@@ -66,77 +66,77 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="2.1.4"></a>
-##2.1.4
+## 2.1.4
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/datepicker@2.1.3...@spectrum-css/datepicker@2.1.4)
 
 **Note:** Version bump only for package @spectrum-css/datepicker
 
 <a name="2.1.3"></a>
-##2.1.3
+## 2.1.3
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/datepicker@2.1.2...@spectrum-css/datepicker@2.1.3)
 
 **Note:** Version bump only for package @spectrum-css/datepicker
 
 <a name="2.1.2"></a>
-##2.1.2
+## 2.1.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/datepicker@2.1.1...@spectrum-css/datepicker@2.1.2)
 
 **Note:** Version bump only for package @spectrum-css/datepicker
 
 <a name="2.1.1"></a>
-##2.1.1
+## 2.1.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/datepicker
 
 <a name="2.1.0"></a>
-#2.1.0
+# 2.1.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/datepicker@2.0.5...@spectrum-css/datepicker@2.1.0)
 
 **Note:** Version bump only for package @spectrum-css/datepicker
 
 <a name="2.0.5"></a>
-##2.0.5
+## 2.0.5
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/datepicker@2.0.4...@spectrum-css/datepicker@2.0.5)
 
 **Note:** Version bump only for package @spectrum-css/datepicker
 
 <a name="2.0.4"></a>
-##2.0.4
+## 2.0.4
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/datepicker@2.0.3...@spectrum-css/datepicker@2.0.4)
 
 **Note:** Version bump only for package @spectrum-css/datepicker
 
 <a name="2.0.3"></a>
-##2.0.3
+## 2.0.3
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/datepicker@2.0.2...@spectrum-css/datepicker@2.0.3)
 
 **Note:** Version bump only for package @spectrum-css/datepicker
 
 <a name="2.0.2"></a>
-##2.0.2
+## 2.0.2
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/datepicker@2.0.0...@spectrum-css/datepicker@2.0.2)
 
 **Note:** Version bump only for package @spectrum-css/datepicker
 
 <a name="2.0.1"></a>
-##2.0.1
+## 2.0.1
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/datepicker@2.0.0...@spectrum-css/datepicker@2.0.1)
 
 **Note:** Version bump only for package @spectrum-css/datepicker
 
 <a name="2.0.0"></a>
-#2.0.0
+# 2.0.0
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/datepicker@1.0.55...@spectrum-css/datepicker@2.0.0)
 
@@ -215,77 +215,77 @@ Additionally:
 - fix(datepicker): add back isValid and isRequired
 
 <a name="1.0.55"></a>
-##1.0.55
+## 1.0.55
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/datepicker@1.0.54...@spectrum-css/datepicker@1.0.55)
 
 **Note:** Version bump only for package @spectrum-css/datepicker
 
 <a name="1.0.54"></a>
-##1.0.54
+## 1.0.54
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/datepicker@1.0.53...@spectrum-css/datepicker@1.0.54)
 
 **Note:** Version bump only for package @spectrum-css/datepicker
 
 <a name="1.0.53"></a>
-##1.0.53
+## 1.0.53
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/datepicker@1.0.52...@spectrum-css/datepicker@1.0.53)
 
 **Note:** Version bump only for package @spectrum-css/datepicker
 
 <a name="1.0.52"></a>
-##1.0.52
+## 1.0.52
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/datepicker@1.0.51...@spectrum-css/datepicker@1.0.52)
 
 **Note:** Version bump only for package @spectrum-css/datepicker
 
 <a name="1.0.51"></a>
-##1.0.51
+## 1.0.51
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/datepicker@1.0.50...@spectrum-css/datepicker@1.0.51)
 
 **Note:** Version bump only for package @spectrum-css/datepicker
 
 <a name="1.0.50"></a>
-##1.0.50
+## 1.0.50
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/datepicker@1.0.49...@spectrum-css/datepicker@1.0.50)
 
 **Note:** Version bump only for package @spectrum-css/datepicker
 
 <a name="1.0.49"></a>
-##1.0.49
+## 1.0.49
 🗓
 2023-09-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/datepicker@1.0.48...@spectrum-css/datepicker@1.0.49)
 
 **Note:** Version bump only for package @spectrum-css/datepicker
 
 <a name="1.0.48"></a>
-##1.0.48
+## 1.0.48
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/datepicker@1.0.47...@spectrum-css/datepicker@1.0.48)
 
 **Note:** Version bump only for package @spectrum-css/datepicker
 
 <a name="1.0.47"></a>
-##1.0.47
+## 1.0.47
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/datepicker@1.0.46...@spectrum-css/datepicker@1.0.47)
 
 **Note:** Version bump only for package @spectrum-css/datepicker
 
 <a name="1.0.46"></a>
-##1.0.46
+## 1.0.46
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/datepicker@1.0.45...@spectrum-css/datepicker@1.0.46)
 
 **Note:** Version bump only for package @spectrum-css/datepicker
 
 <a name="1.0.45"></a>
-##1.0.45
+## 1.0.45
 🗓
 2023-08-25 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/datepicker@1.0.44...@spectrum-css/datepicker@1.0.45)
 
@@ -294,119 +294,119 @@ Additionally:
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="1.0.44"></a>
-##1.0.44
+## 1.0.44
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/datepicker@1.0.43...@spectrum-css/datepicker@1.0.44)
 
 **Note:** Version bump only for package @spectrum-css/datepicker
 
 <a name="1.0.43"></a>
-##1.0.43
+## 1.0.43
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/datepicker@1.0.41...@spectrum-css/datepicker@1.0.43)
 
 **Note:** Version bump only for package @spectrum-css/datepicker
 
 <a name="1.0.42"></a>
-##1.0.42
+## 1.0.42
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/datepicker@1.0.41...@spectrum-css/datepicker@1.0.42)
 
 **Note:** Version bump only for package @spectrum-css/datepicker
 
 <a name="1.0.41"></a>
-##1.0.41
+## 1.0.41
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/datepicker@1.0.40...@spectrum-css/datepicker@1.0.41)
 
 **Note:** Version bump only for package @spectrum-css/datepicker
 
 <a name="1.0.40"></a>
-##1.0.40
+## 1.0.40
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/datepicker@1.0.39...@spectrum-css/datepicker@1.0.40)
 
 **Note:** Version bump only for package @spectrum-css/datepicker
 
 <a name="1.0.39"></a>
-##1.0.39
+## 1.0.39
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/datepicker@1.0.38...@spectrum-css/datepicker@1.0.39)
 
 **Note:** Version bump only for package @spectrum-css/datepicker
 
 <a name="1.0.38"></a>
-##1.0.38
+## 1.0.38
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/datepicker@1.0.37...@spectrum-css/datepicker@1.0.38)
 
 **Note:** Version bump only for package @spectrum-css/datepicker
 
 <a name="1.0.37"></a>
-##1.0.37
+## 1.0.37
 🗓
 2023-07-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/datepicker@1.0.36...@spectrum-css/datepicker@1.0.37)
 
 **Note:** Version bump only for package @spectrum-css/datepicker
 
 <a name="1.0.36"></a>
-##1.0.36
+## 1.0.36
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/datepicker@1.0.35...@spectrum-css/datepicker@1.0.36)
 
 **Note:** Version bump only for package @spectrum-css/datepicker
 
 <a name="1.0.35"></a>
-##1.0.35
+## 1.0.35
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/datepicker@1.0.34...@spectrum-css/datepicker@1.0.35)
 
 **Note:** Version bump only for package @spectrum-css/datepicker
 
 <a name="1.0.34"></a>
-##1.0.34
+## 1.0.34
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/datepicker@1.0.33...@spectrum-css/datepicker@1.0.34)
 
 **Note:** Version bump only for package @spectrum-css/datepicker
 
 <a name="1.0.33"></a>
-##1.0.33
+## 1.0.33
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/datepicker@1.0.32...@spectrum-css/datepicker@1.0.33)
 
 **Note:** Version bump only for package @spectrum-css/datepicker
 
 <a name="1.0.32"></a>
-##1.0.32
+## 1.0.32
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/datepicker@1.0.31...@spectrum-css/datepicker@1.0.32)
 
 **Note:** Version bump only for package @spectrum-css/datepicker
 
 <a name="1.0.31"></a>
-##1.0.31
+## 1.0.31
 🗓
 2023-06-28 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/datepicker@1.0.30...@spectrum-css/datepicker@1.0.31)
 
 **Note:** Version bump only for package @spectrum-css/datepicker
 
 <a name="1.0.30"></a>
-##1.0.30
+## 1.0.30
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/datepicker@1.0.29...@spectrum-css/datepicker@1.0.30)
 
 **Note:** Version bump only for package @spectrum-css/datepicker
 
 <a name="1.0.29"></a>
-##1.0.29
+## 1.0.29
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/datepicker@1.0.28...@spectrum-css/datepicker@1.0.29)
 
 **Note:** Version bump only for package @spectrum-css/datepicker
 
 <a name="1.0.28"></a>
-##1.0.28
+## 1.0.28
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/datepicker@1.0.27...@spectrum-css/datepicker@1.0.28)
 
@@ -415,14 +415,14 @@ Additionally:
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="1.0.27"></a>
-##1.0.27
+## 1.0.27
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/datepicker@1.0.26...@spectrum-css/datepicker@1.0.27)
 
 **Note:** Version bump only for package @spectrum-css/datepicker
 
 <a name="1.0.26"></a>
-##1.0.26
+## 1.0.26
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/datepicker@1.0.25...@spectrum-css/datepicker@1.0.26)
 

--- a/components/dial/CHANGELOG.md
+++ b/components/dial/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="3.0.0"></a>
-#3.0.0
+# 3.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dial@2.2.4...@spectrum-css/dial@3.0.0)
 
@@ -40,42 +40,42 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="2.2.4"></a>
-##2.2.4
+## 2.2.4
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dial@2.2.3...@spectrum-css/dial@2.2.4)
 
 **Note:** Version bump only for package @spectrum-css/dial
 
 <a name="2.2.3"></a>
-##2.2.3
+## 2.2.3
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dial@2.2.2...@spectrum-css/dial@2.2.3)
 
 **Note:** Version bump only for package @spectrum-css/dial
 
 <a name="2.2.2"></a>
-##2.2.2
+## 2.2.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dial@2.2.1...@spectrum-css/dial@2.2.2)
 
 **Note:** Version bump only for package @spectrum-css/dial
 
 <a name="2.2.1"></a>
-##2.2.1
+## 2.2.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/dial
 
 <a name="2.2.0"></a>
-#2.2.0
+# 2.2.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dial@2.1.0...@spectrum-css/dial@2.2.0)
 
 **Note:** Version bump only for package @spectrum-css/dial
 
 <a name="2.1.0"></a>
-#2.1.0
+# 2.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dial@2.0.5...@spectrum-css/dial@2.1.0)
 
@@ -84,42 +84,42 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="2.0.5"></a>
-##2.0.5
+## 2.0.5
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dial@2.0.4...@spectrum-css/dial@2.0.5)
 
 **Note:** Version bump only for package @spectrum-css/dial
 
 <a name="2.0.4"></a>
-##2.0.4
+## 2.0.4
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dial@2.0.3...@spectrum-css/dial@2.0.4)
 
 **Note:** Version bump only for package @spectrum-css/dial
 
 <a name="2.0.3"></a>
-##2.0.3
+## 2.0.3
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dial@2.0.1...@spectrum-css/dial@2.0.3)
 
 **Note:** Version bump only for package @spectrum-css/dial
 
 <a name="2.0.2"></a>
-##2.0.2
+## 2.0.2
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dial@2.0.1...@spectrum-css/dial@2.0.2)
 
 **Note:** Version bump only for package @spectrum-css/dial
 
 <a name="2.0.1"></a>
-##2.0.1
+## 2.0.1
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dial@2.0.0...@spectrum-css/dial@2.0.1)
 
 **Note:** Version bump only for package @spectrum-css/dial
 
 <a name="2.0.0"></a>
-#2.0.0
+# 2.0.0
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dial@1.0.55...@spectrum-css/dial@2.0.0)
 
@@ -166,14 +166,14 @@ Uses correct colors & removes duplicate properties
 - chore(dial): adds focus-visible
 
 <a name="1.0.55"></a>
-##1.0.55
+## 1.0.55
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dial@1.0.54...@spectrum-css/dial@1.0.55)
 
 **Note:** Version bump only for package @spectrum-css/dial
 
 <a name="1.0.54"></a>
-##1.0.54
+## 1.0.54
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dial@1.0.53...@spectrum-css/dial@1.0.54)
 
@@ -182,49 +182,49 @@ Uses correct colors & removes duplicate properties
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="1.0.53"></a>
-##1.0.53
+## 1.0.53
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dial@1.0.52...@spectrum-css/dial@1.0.53)
 
 **Note:** Version bump only for package @spectrum-css/dial
 
 <a name="1.0.52"></a>
-##1.0.52
+## 1.0.52
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dial@1.0.51...@spectrum-css/dial@1.0.52)
 
 **Note:** Version bump only for package @spectrum-css/dial
 
 <a name="1.0.51"></a>
-##1.0.51
+## 1.0.51
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dial@1.0.50...@spectrum-css/dial@1.0.51)
 
 **Note:** Version bump only for package @spectrum-css/dial
 
 <a name="1.0.50"></a>
-##1.0.50
+## 1.0.50
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dial@1.0.49...@spectrum-css/dial@1.0.50)
 
 **Note:** Version bump only for package @spectrum-css/dial
 
 <a name="1.0.49"></a>
-##1.0.49
+## 1.0.49
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dial@1.0.48...@spectrum-css/dial@1.0.49)
 
 **Note:** Version bump only for package @spectrum-css/dial
 
 <a name="1.0.48"></a>
-##1.0.48
+## 1.0.48
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dial@1.0.47...@spectrum-css/dial@1.0.48)
 
 **Note:** Version bump only for package @spectrum-css/dial
 
 <a name="1.0.47"></a>
-##1.0.47
+## 1.0.47
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dial@1.0.46...@spectrum-css/dial@1.0.47)
 
@@ -233,14 +233,14 @@ Uses correct colors & removes duplicate properties
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="1.0.46"></a>
-##1.0.46
+## 1.0.46
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dial@1.0.45...@spectrum-css/dial@1.0.46)
 
 **Note:** Version bump only for package @spectrum-css/dial
 
 <a name="1.0.45"></a>
-##1.0.45
+## 1.0.45
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dial@1.0.44...@spectrum-css/dial@1.0.45)
 

--- a/components/dial/CHANGELOG.md
+++ b/components/dial/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="3.0.0"></a>
-# 3.0.0
+## 3.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dial@2.2.4...@spectrum-css/dial@3.0.0)
 
@@ -68,14 +68,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/dial
 
 <a name="2.2.0"></a>
-# 2.2.0
+## 2.2.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dial@2.1.0...@spectrum-css/dial@2.2.0)
 
 **Note:** Version bump only for package @spectrum-css/dial
 
 <a name="2.1.0"></a>
-# 2.1.0
+## 2.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dial@2.0.5...@spectrum-css/dial@2.1.0)
 
@@ -119,7 +119,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/dial
 
 <a name="2.0.0"></a>
-# 2.0.0
+## 2.0.0
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dial@1.0.55...@spectrum-css/dial@2.0.0)
 
@@ -636,7 +636,7 @@ Uses correct colors & removes duplicate properties
 
 <a name="1.0.0"></a>
 
-# 1.0.0
+## 1.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dial@1.0.0-beta.4...@spectrum-css/dial@1.0.0)
 
@@ -644,7 +644,7 @@ Uses correct colors & removes duplicate properties
 
 <a name="1.0.0-beta.4"></a>
 
-# 1.0.0-beta.4
+## 1.0.0-beta.4
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dial@1.0.0-beta.3...@spectrum-css/dial@1.0.0-beta.4)
 
@@ -654,7 +654,7 @@ Uses correct colors & removes duplicate properties
 
 <a name="1.0.0-beta.3"></a>
 
-# 1.0.0-beta.3
+## 1.0.0-beta.3
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dial@1.0.0-beta.2...@spectrum-css/dial@1.0.0-beta.3)
 
@@ -662,7 +662,7 @@ Uses correct colors & removes duplicate properties
 
 <a name="1.0.0-beta.2"></a>
 
-# 1.0.0-beta.2
+## 1.0.0-beta.2
 
 🗓 2020-09-23
 

--- a/components/dialog/CHANGELOG.md
+++ b/components/dialog/CHANGELOG.md
@@ -35,7 +35,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="10.0.0"></a>
-#10.0.0
+# 10.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@9.2.4...@spectrum-css/dialog@10.0.0)
 
@@ -54,35 +54,35 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="9.2.4"></a>
-##9.2.4
+## 9.2.4
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@9.2.3...@spectrum-css/dialog@9.2.4)
 
 **Note:** Version bump only for package @spectrum-css/dialog
 
 <a name="9.2.3"></a>
-##9.2.3
+## 9.2.3
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@9.2.2...@spectrum-css/dialog@9.2.3)
 
 **Note:** Version bump only for package @spectrum-css/dialog
 
 <a name="9.2.2"></a>
-##9.2.2
+## 9.2.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@9.2.1...@spectrum-css/dialog@9.2.2)
 
 **Note:** Version bump only for package @spectrum-css/dialog
 
 <a name="9.2.1"></a>
-##9.2.1
+## 9.2.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/dialog
 
 <a name="9.2.0"></a>
-#9.2.0
+# 9.2.0
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@9.1.0...@spectrum-css/dialog@9.2.0)
 
@@ -91,7 +91,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **overlay,commons:**deprecate overlay; migrate references to commons ([#2429](https://github.com/adobe/spectrum-css/issues/2429))([7eecd96](https://github.com/adobe/spectrum-css/commit/7eecd96))
 
 <a name="9.1.0"></a>
-#9.1.0
+# 9.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@9.0.5...@spectrum-css/dialog@9.1.0)
 
@@ -100,42 +100,42 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="9.0.5"></a>
-##9.0.5
+## 9.0.5
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@9.0.4...@spectrum-css/dialog@9.0.5)
 
 **Note:** Version bump only for package @spectrum-css/dialog
 
 <a name="9.0.4"></a>
-##9.0.4
+## 9.0.4
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@9.0.3...@spectrum-css/dialog@9.0.4)
 
 **Note:** Version bump only for package @spectrum-css/dialog
 
 <a name="9.0.3"></a>
-##9.0.3
+## 9.0.3
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@9.0.1...@spectrum-css/dialog@9.0.3)
 
 **Note:** Version bump only for package @spectrum-css/dialog
 
 <a name="9.0.2"></a>
-##9.0.2
+## 9.0.2
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@9.0.1...@spectrum-css/dialog@9.0.2)
 
 **Note:** Version bump only for package @spectrum-css/dialog
 
 <a name="9.0.1"></a>
-##9.0.1
+## 9.0.1
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@9.0.0...@spectrum-css/dialog@9.0.1)
 
 **Note:** Version bump only for package @spectrum-css/dialog
 
 <a name="9.0.0"></a>
-#9.0.0
+# 9.0.0
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@8.0.8...@spectrum-css/dialog@9.0.0)
 
@@ -153,63 +153,63 @@ Additionally:
 - docs(dialog): regenerate mods file
 
 <a name="8.0.8"></a>
-##8.0.8
+## 8.0.8
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@8.0.7...@spectrum-css/dialog@8.0.8)
 
 **Note:** Version bump only for package @spectrum-css/dialog
 
 <a name="8.0.7"></a>
-##8.0.7
+## 8.0.7
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@8.0.6...@spectrum-css/dialog@8.0.7)
 
 **Note:** Version bump only for package @spectrum-css/dialog
 
 <a name="8.0.6"></a>
-##8.0.6
+## 8.0.6
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@8.0.5...@spectrum-css/dialog@8.0.6)
 
 **Note:** Version bump only for package @spectrum-css/dialog
 
 <a name="8.0.5"></a>
-##8.0.5
+## 8.0.5
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@8.0.4...@spectrum-css/dialog@8.0.5)
 
 **Note:** Version bump only for package @spectrum-css/dialog
 
 <a name="8.0.4"></a>
-##8.0.4
+## 8.0.4
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@8.0.3...@spectrum-css/dialog@8.0.4)
 
 **Note:** Version bump only for package @spectrum-css/dialog
 
 <a name="8.0.3"></a>
-##8.0.3
+## 8.0.3
 🗓
 2023-09-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@8.0.2...@spectrum-css/dialog@8.0.3)
 
 **Note:** Version bump only for package @spectrum-css/dialog
 
 <a name="8.0.2"></a>
-##8.0.2
+## 8.0.2
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@8.0.1...@spectrum-css/dialog@8.0.2)
 
 **Note:** Version bump only for package @spectrum-css/dialog
 
 <a name="8.0.1"></a>
-##8.0.1
+## 8.0.1
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@8.0.0...@spectrum-css/dialog@8.0.1)
 
 **Note:** Version bump only for package @spectrum-css/dialog
 
 <a name="8.0.0"></a>
-#8.0.0
+# 8.0.0
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@7.0.1...@spectrum-css/dialog@8.0.0)
 
@@ -254,14 +254,14 @@ Additionally:
 - chore(underlay): remove skin import
 
 <a name="7.0.1"></a>
-##7.0.1
+## 7.0.1
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@7.0.0...@spectrum-css/dialog@7.0.1)
 
 **Note:** Version bump only for package @spectrum-css/dialog
 
 <a name="7.0.0"></a>
-#7.0.0
+# 7.0.0
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@6.0.67...@spectrum-css/dialog@7.0.0)
 
@@ -274,98 +274,98 @@ Additionally:
     		Alert variants of Dialog have been removed and placed inside of Alert Dialog
 
 <a name="6.0.68"></a>
-##6.0.68
+## 6.0.68
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@6.0.67...@spectrum-css/dialog@6.0.68)
 
 **Note:** Version bump only for package @spectrum-css/dialog
 
 <a name="6.0.67"></a>
-##6.0.67
+## 6.0.67
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@6.0.66...@spectrum-css/dialog@6.0.67)
 
 **Note:** Version bump only for package @spectrum-css/dialog
 
 <a name="6.0.66"></a>
-##6.0.66
+## 6.0.66
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@6.0.65...@spectrum-css/dialog@6.0.66)
 
 **Note:** Version bump only for package @spectrum-css/dialog
 
 <a name="6.0.65"></a>
-##6.0.65
+## 6.0.65
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@6.0.64...@spectrum-css/dialog@6.0.65)
 
 **Note:** Version bump only for package @spectrum-css/dialog
 
 <a name="6.0.64"></a>
-##6.0.64
+## 6.0.64
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@6.0.63...@spectrum-css/dialog@6.0.64)
 
 **Note:** Version bump only for package @spectrum-css/dialog
 
 <a name="6.0.63"></a>
-##6.0.63
+## 6.0.63
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@6.0.62...@spectrum-css/dialog@6.0.63)
 
 **Note:** Version bump only for package @spectrum-css/dialog
 
 <a name="6.0.62"></a>
-##6.0.62
+## 6.0.62
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@6.0.61...@spectrum-css/dialog@6.0.62)
 
 **Note:** Version bump only for package @spectrum-css/dialog
 
 <a name="6.0.61"></a>
-##6.0.61
+## 6.0.61
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@6.0.60...@spectrum-css/dialog@6.0.61)
 
 **Note:** Version bump only for package @spectrum-css/dialog
 
 <a name="6.0.60"></a>
-##6.0.60
+## 6.0.60
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@6.0.59...@spectrum-css/dialog@6.0.60)
 
 **Note:** Version bump only for package @spectrum-css/dialog
 
 <a name="6.0.59"></a>
-##6.0.59
+## 6.0.59
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@6.0.58...@spectrum-css/dialog@6.0.59)
 
 **Note:** Version bump only for package @spectrum-css/dialog
 
 <a name="6.0.58"></a>
-##6.0.58
+## 6.0.58
 🗓
 2023-06-28 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@6.0.57...@spectrum-css/dialog@6.0.58)
 
 **Note:** Version bump only for package @spectrum-css/dialog
 
 <a name="6.0.57"></a>
-##6.0.57
+## 6.0.57
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@6.0.56...@spectrum-css/dialog@6.0.57)
 
 **Note:** Version bump only for package @spectrum-css/dialog
 
 <a name="6.0.56"></a>
-##6.0.56
+## 6.0.56
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@6.0.55...@spectrum-css/dialog@6.0.56)
 
 **Note:** Version bump only for package @spectrum-css/dialog
 
 <a name="6.0.55"></a>
-##6.0.55
+## 6.0.55
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@6.0.54...@spectrum-css/dialog@6.0.55)
 
@@ -374,14 +374,14 @@ Additionally:
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="6.0.54"></a>
-##6.0.54
+## 6.0.54
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@6.0.53...@spectrum-css/dialog@6.0.54)
 
 **Note:** Version bump only for package @spectrum-css/dialog
 
 <a name="6.0.53"></a>
-##6.0.53
+## 6.0.53
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@6.0.52...@spectrum-css/dialog@6.0.53)
 

--- a/components/dialog/CHANGELOG.md
+++ b/components/dialog/CHANGELOG.md
@@ -35,7 +35,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="10.0.0"></a>
-# 10.0.0
+## 10.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@9.2.4...@spectrum-css/dialog@10.0.0)
 
@@ -82,7 +82,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/dialog
 
 <a name="9.2.0"></a>
-# 9.2.0
+## 9.2.0
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@9.1.0...@spectrum-css/dialog@9.2.0)
 
@@ -91,7 +91,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **overlay,commons:**deprecate overlay; migrate references to commons ([#2429](https://github.com/adobe/spectrum-css/issues/2429))([7eecd96](https://github.com/adobe/spectrum-css/commit/7eecd96))
 
 <a name="9.1.0"></a>
-# 9.1.0
+## 9.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@9.0.5...@spectrum-css/dialog@9.1.0)
 
@@ -135,7 +135,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/dialog
 
 <a name="9.0.0"></a>
-# 9.0.0
+## 9.0.0
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@8.0.8...@spectrum-css/dialog@9.0.0)
 
@@ -209,7 +209,7 @@ Additionally:
 **Note:** Version bump only for package @spectrum-css/dialog
 
 <a name="8.0.0"></a>
-# 8.0.0
+## 8.0.0
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@7.0.1...@spectrum-css/dialog@8.0.0)
 
@@ -261,7 +261,7 @@ Additionally:
 **Note:** Version bump only for package @spectrum-css/dialog
 
 <a name="7.0.0"></a>
-# 7.0.0
+## 7.0.0
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@6.0.67...@spectrum-css/dialog@7.0.0)
 
@@ -807,7 +807,7 @@ Additionally:
 
 <a name="6.0.0"></a>
 
-# 6.0.0
+## 6.0.0
 
 🗓 2022-02-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@5.0.1...@spectrum-css/dialog@6.0.0)
 
@@ -829,7 +829,7 @@ Additionally:
 
 <a name="5.0.0"></a>
 
-# 5.0.0
+## 5.0.0
 
 🗓 2022-01-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@3.0.12...@spectrum-css/dialog@5.0.0)
 
@@ -847,7 +847,7 @@ Additionally:
 
 <a name="4.0.0"></a>
 
-# 4.0.0
+## 4.0.0
 
 🗓 2022-01-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@4.0.0-beta.0...@spectrum-css/dialog@4.0.0)
 
@@ -855,7 +855,7 @@ Additionally:
 
 <a name="4.0.0-beta.0"></a>
 
-# 4.0.0-beta.0
+## 4.0.0-beta.0
 
 🗓 2021-12-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@3.0.12...@spectrum-css/dialog@4.0.0-beta.0)
 
@@ -992,7 +992,7 @@ Additionally:
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@3.0.0-beta.6...@spectrum-css/dialog@3.0.0)
 
@@ -1000,7 +1000,7 @@ Additionally:
 
 <a name="3.0.0-beta.6"></a>
 
-# 3.0.0-beta.6
+## 3.0.0-beta.6
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@3.0.0-beta.5...@spectrum-css/dialog@3.0.0-beta.6)
 
@@ -1025,7 +1025,7 @@ Additionally:
 
 <a name="3.0.0-beta.5"></a>
 
-# 3.0.0-beta.5
+## 3.0.0-beta.5
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@3.0.0-beta.4...@spectrum-css/dialog@3.0.0-beta.5)
 
@@ -1033,7 +1033,7 @@ Additionally:
 
 <a name="3.0.0-beta.4"></a>
 
-# 3.0.0-beta.4
+## 3.0.0-beta.4
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@3.0.0-beta.3...@spectrum-css/dialog@3.0.0-beta.4)
 
@@ -1051,7 +1051,7 @@ Additionally:
 
 <a name="3.0.0-beta.3"></a>
 
-# 3.0.0-beta.3
+## 3.0.0-beta.3
 
 🗓 2020-06-19 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@3.0.0-beta.2...@spectrum-css/dialog@3.0.0-beta.3)
 
@@ -1059,7 +1059,7 @@ Additionally:
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@3.0.0-beta.1...@spectrum-css/dialog@3.0.0-beta.2)
 
@@ -1067,7 +1067,7 @@ Additionally:
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@3.0.0-beta.0...@spectrum-css/dialog@3.0.0-beta.1)
 
@@ -1075,7 +1075,7 @@ Additionally:
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dialog@2.0.5...@spectrum-css/dialog@3.0.0-beta.0)
 
@@ -1129,7 +1129,7 @@ Additionally:
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/divider/CHANGELOG.md
+++ b/components/divider/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="3.0.0"></a>
-# 3.0.0
+## 3.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/divider@2.2.5...@spectrum-css/divider@3.0.0)
 
@@ -75,7 +75,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/divider
 
 <a name="2.2.0"></a>
-# 2.2.0
+## 2.2.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/divider@2.1.35...@spectrum-css/divider@2.2.0)
 
@@ -339,7 +339,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="2.1.0"></a>
 
-# 2.1.0
+## 2.1.0
 
 🗓 2023-05-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/divider@2.0.42...@spectrum-css/divider@2.1.0)
 
@@ -685,7 +685,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2022-10-06 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/divider@1.0.27...@spectrum-css/divider@2.0.0)
 
@@ -950,7 +950,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="1.0.0"></a>
 
-# 1.0.0
+## 1.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/divider@1.0.0-beta.3...@spectrum-css/divider@1.0.0)
 
@@ -958,7 +958,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="1.0.0-beta.3"></a>
 
-# 1.0.0-beta.3
+## 1.0.0-beta.3
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/divider@1.0.0-beta.2...@spectrum-css/divider@1.0.0-beta.3)
 
@@ -980,7 +980,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="1.0.0-beta.2"></a>
 
-# 1.0.0-beta.2
+## 1.0.0-beta.2
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/divider@1.0.0-beta.1...@spectrum-css/divider@1.0.0-beta.2)
 
@@ -992,7 +992,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="1.0.0-beta.1"></a>
 
-# 1.0.0-beta.1
+## 1.0.0-beta.1
 
 🗓 2020-09-23
 
@@ -1010,7 +1010,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0-beta.3"></a>
 
-# 3.0.0-beta.3
+## 3.0.0-beta.3
 
 🗓 2020-06-19 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rule@3.0.0-beta.2...@spectrum-css/rule@3.0.0-beta.3)
 
@@ -1018,7 +1018,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rule@3.0.0-beta.1...@spectrum-css/rule@3.0.0-beta.2)
 
@@ -1026,7 +1026,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rule@3.0.0-beta.0...@spectrum-css/rule@3.0.0-beta.1)
 
@@ -1034,7 +1034,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rule@2.0.6...@spectrum-css/rule@3.0.0-beta.0)
 
@@ -1095,7 +1095,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/divider/CHANGELOG.md
+++ b/components/divider/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="3.0.0"></a>
-#3.0.0
+# 3.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/divider@2.2.5...@spectrum-css/divider@3.0.0)
 
@@ -40,42 +40,42 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="2.2.5"></a>
-##2.2.5
+## 2.2.5
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/divider@2.2.4...@spectrum-css/divider@2.2.5)
 
 **Note:** Version bump only for package @spectrum-css/divider
 
 <a name="2.2.4"></a>
-##2.2.4
+## 2.2.4
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/divider@2.2.3...@spectrum-css/divider@2.2.4)
 
 **Note:** Version bump only for package @spectrum-css/divider
 
 <a name="2.2.3"></a>
-##2.2.3
+## 2.2.3
 🗓
 2024-02-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/divider@2.2.2...@spectrum-css/divider@2.2.3)
 
 **Note:** Version bump only for package @spectrum-css/divider
 
 <a name="2.2.2"></a>
-##2.2.2
+## 2.2.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/divider@2.2.1...@spectrum-css/divider@2.2.2)
 
 **Note:** Version bump only for package @spectrum-css/divider
 
 <a name="2.2.1"></a>
-##2.2.1
+## 2.2.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/divider
 
 <a name="2.2.0"></a>
-#2.2.0
+# 2.2.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/divider@2.1.35...@spectrum-css/divider@2.2.0)
 
@@ -84,98 +84,98 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="2.1.35"></a>
-##2.1.35
+## 2.1.35
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/divider@2.1.34...@spectrum-css/divider@2.1.35)
 
 **Note:** Version bump only for package @spectrum-css/divider
 
 <a name="2.1.34"></a>
-##2.1.34
+## 2.1.34
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/divider@2.1.33...@spectrum-css/divider@2.1.34)
 
 **Note:** Version bump only for package @spectrum-css/divider
 
 <a name="2.1.33"></a>
-##2.1.33
+## 2.1.33
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/divider@2.1.31...@spectrum-css/divider@2.1.33)
 
 **Note:** Version bump only for package @spectrum-css/divider
 
 <a name="2.1.32"></a>
-##2.1.32
+## 2.1.32
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/divider@2.1.31...@spectrum-css/divider@2.1.32)
 
 **Note:** Version bump only for package @spectrum-css/divider
 
 <a name="2.1.31"></a>
-##2.1.31
+## 2.1.31
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/divider@2.1.30...@spectrum-css/divider@2.1.31)
 
 **Note:** Version bump only for package @spectrum-css/divider
 
 <a name="2.1.30"></a>
-##2.1.30
+## 2.1.30
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/divider@2.1.29...@spectrum-css/divider@2.1.30)
 
 **Note:** Version bump only for package @spectrum-css/divider
 
 <a name="2.1.29"></a>
-##2.1.29
+## 2.1.29
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/divider@2.1.28...@spectrum-css/divider@2.1.29)
 
 **Note:** Version bump only for package @spectrum-css/divider
 
 <a name="2.1.28"></a>
-##2.1.28
+## 2.1.28
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/divider@2.1.27...@spectrum-css/divider@2.1.28)
 
 **Note:** Version bump only for package @spectrum-css/divider
 
 <a name="2.1.27"></a>
-##2.1.27
+## 2.1.27
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/divider@2.1.26...@spectrum-css/divider@2.1.27)
 
 **Note:** Version bump only for package @spectrum-css/divider
 
 <a name="2.1.26"></a>
-##2.1.26
+## 2.1.26
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/divider@2.1.25...@spectrum-css/divider@2.1.26)
 
 **Note:** Version bump only for package @spectrum-css/divider
 
 <a name="2.1.25"></a>
-##2.1.25
+## 2.1.25
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/divider@2.1.24...@spectrum-css/divider@2.1.25)
 
 **Note:** Version bump only for package @spectrum-css/divider
 
 <a name="2.1.24"></a>
-##2.1.24
+## 2.1.24
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/divider@2.1.23...@spectrum-css/divider@2.1.24)
 
 **Note:** Version bump only for package @spectrum-css/divider
 
 <a name="2.1.23"></a>
-##2.1.23
+## 2.1.23
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/divider@2.1.22...@spectrum-css/divider@2.1.23)
 
 **Note:** Version bump only for package @spectrum-css/divider
 
 <a name="2.1.22"></a>
-##2.1.22
+## 2.1.22
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/divider@2.1.21...@spectrum-css/divider@2.1.22)
 
@@ -184,112 +184,112 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="2.1.21"></a>
-##2.1.21
+## 2.1.21
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/divider@2.1.20...@spectrum-css/divider@2.1.21)
 
 **Note:** Version bump only for package @spectrum-css/divider
 
 <a name="2.1.20"></a>
-##2.1.20
+## 2.1.20
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/divider@2.1.18...@spectrum-css/divider@2.1.20)
 
 **Note:** Version bump only for package @spectrum-css/divider
 
 <a name="2.1.19"></a>
-##2.1.19
+## 2.1.19
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/divider@2.1.18...@spectrum-css/divider@2.1.19)
 
 **Note:** Version bump only for package @spectrum-css/divider
 
 <a name="2.1.18"></a>
-##2.1.18
+## 2.1.18
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/divider@2.1.17...@spectrum-css/divider@2.1.18)
 
 **Note:** Version bump only for package @spectrum-css/divider
 
 <a name="2.1.17"></a>
-##2.1.17
+## 2.1.17
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/divider@2.1.16...@spectrum-css/divider@2.1.17)
 
 **Note:** Version bump only for package @spectrum-css/divider
 
 <a name="2.1.16"></a>
-##2.1.16
+## 2.1.16
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/divider@2.1.15...@spectrum-css/divider@2.1.16)
 
 **Note:** Version bump only for package @spectrum-css/divider
 
 <a name="2.1.15"></a>
-##2.1.15
+## 2.1.15
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/divider@2.1.14...@spectrum-css/divider@2.1.15)
 
 **Note:** Version bump only for package @spectrum-css/divider
 
 <a name="2.1.14"></a>
-##2.1.14
+## 2.1.14
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/divider@2.1.13...@spectrum-css/divider@2.1.14)
 
 **Note:** Version bump only for package @spectrum-css/divider
 
 <a name="2.1.13"></a>
-##2.1.13
+## 2.1.13
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/divider@2.1.12...@spectrum-css/divider@2.1.13)
 
 **Note:** Version bump only for package @spectrum-css/divider
 
 <a name="2.1.12"></a>
-##2.1.12
+## 2.1.12
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/divider@2.1.11...@spectrum-css/divider@2.1.12)
 
 **Note:** Version bump only for package @spectrum-css/divider
 
 <a name="2.1.11"></a>
-##2.1.11
+## 2.1.11
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/divider@2.1.10...@spectrum-css/divider@2.1.11)
 
 **Note:** Version bump only for package @spectrum-css/divider
 
 <a name="2.1.10"></a>
-##2.1.10
+## 2.1.10
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/divider@2.1.9...@spectrum-css/divider@2.1.10)
 
 **Note:** Version bump only for package @spectrum-css/divider
 
 <a name="2.1.9"></a>
-##2.1.9
+## 2.1.9
 🗓
 2023-06-28 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/divider@2.1.8...@spectrum-css/divider@2.1.9)
 
 **Note:** Version bump only for package @spectrum-css/divider
 
 <a name="2.1.8"></a>
-##2.1.8
+## 2.1.8
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/divider@2.1.7...@spectrum-css/divider@2.1.8)
 
 **Note:** Version bump only for package @spectrum-css/divider
 
 <a name="2.1.7"></a>
-##2.1.7
+## 2.1.7
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/divider@2.1.6...@spectrum-css/divider@2.1.7)
 
 **Note:** Version bump only for package @spectrum-css/divider
 
 <a name="2.1.6"></a>
-##2.1.6
+## 2.1.6
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/divider@2.1.5...@spectrum-css/divider@2.1.6)
 
@@ -298,14 +298,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="2.1.5"></a>
-##2.1.5
+## 2.1.5
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/divider@2.1.4...@spectrum-css/divider@2.1.5)
 
 **Note:** Version bump only for package @spectrum-css/divider
 
 <a name="2.1.4"></a>
-##2.1.4
+## 2.1.4
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/divider@2.1.3...@spectrum-css/divider@2.1.4)
 

--- a/components/dropindicator/CHANGELOG.md
+++ b/components/dropindicator/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-# 5.0.0
+## 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropindicator@4.1.4...@spectrum-css/dropindicator@5.0.0)
 
@@ -72,7 +72,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/dropindicator
 
 <a name="4.1.0"></a>
-# 4.1.0
+## 4.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropindicator@4.0.4...@spectrum-css/dropindicator@4.1.0)
 
@@ -109,7 +109,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/dropindicator
 
 <a name="4.0.0"></a>
-# 4.0.0
+## 4.0.0
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropindicator@3.0.54...@spectrum-css/dropindicator@4.0.0)
 
@@ -585,7 +585,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropindicator@3.0.0-beta.5...@spectrum-css/dropindicator@3.0.0)
 
@@ -593,7 +593,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.5"></a>
 
-# 3.0.0-beta.5
+## 3.0.0-beta.5
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropindicator@3.0.0-beta.4...@spectrum-css/dropindicator@3.0.0-beta.5)
 
@@ -601,7 +601,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.4"></a>
 
-# 3.0.0-beta.4
+## 3.0.0-beta.4
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropindicator@3.0.0-beta.3...@spectrum-css/dropindicator@3.0.0-beta.4)
 
@@ -609,7 +609,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.3"></a>
 
-# 3.0.0-beta.3
+## 3.0.0-beta.3
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropindicator@3.0.0-beta.2...@spectrum-css/dropindicator@3.0.0-beta.3)
 
@@ -617,7 +617,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropindicator@3.0.0-beta.1...@spectrum-css/dropindicator@3.0.0-beta.2)
 
@@ -625,7 +625,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropindicator@3.0.0-beta.0...@spectrum-css/dropindicator@3.0.0-beta.1)
 
@@ -633,7 +633,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropindicator@2.0.5...@spectrum-css/dropindicator@3.0.0-beta.0)
 
@@ -683,7 +683,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/dropindicator/CHANGELOG.md
+++ b/components/dropindicator/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-#5.0.0
+# 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropindicator@4.1.4...@spectrum-css/dropindicator@5.0.0)
 
@@ -44,35 +44,35 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="4.1.4"></a>
-##4.1.4
+## 4.1.4
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropindicator@4.1.3...@spectrum-css/dropindicator@4.1.4)
 
 **Note:** Version bump only for package @spectrum-css/dropindicator
 
 <a name="4.1.3"></a>
-##4.1.3
+## 4.1.3
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropindicator@4.1.2...@spectrum-css/dropindicator@4.1.3)
 
 **Note:** Version bump only for package @spectrum-css/dropindicator
 
 <a name="4.1.2"></a>
-##4.1.2
+## 4.1.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropindicator@4.1.1...@spectrum-css/dropindicator@4.1.2)
 
 **Note:** Version bump only for package @spectrum-css/dropindicator
 
 <a name="4.1.1"></a>
-##4.1.1
+## 4.1.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/dropindicator
 
 <a name="4.1.0"></a>
-#4.1.0
+# 4.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropindicator@4.0.4...@spectrum-css/dropindicator@4.1.0)
 
@@ -81,35 +81,35 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="4.0.4"></a>
-##4.0.4
+## 4.0.4
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropindicator@4.0.3...@spectrum-css/dropindicator@4.0.4)
 
 **Note:** Version bump only for package @spectrum-css/dropindicator
 
 <a name="4.0.3"></a>
-##4.0.3
+## 4.0.3
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropindicator@4.0.2...@spectrum-css/dropindicator@4.0.3)
 
 **Note:** Version bump only for package @spectrum-css/dropindicator
 
 <a name="4.0.2"></a>
-##4.0.2
+## 4.0.2
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropindicator@4.0.0...@spectrum-css/dropindicator@4.0.2)
 
 **Note:** Version bump only for package @spectrum-css/dropindicator
 
 <a name="4.0.1"></a>
-##4.0.1
+## 4.0.1
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropindicator@4.0.0...@spectrum-css/dropindicator@4.0.1)
 
 **Note:** Version bump only for package @spectrum-css/dropindicator
 
 <a name="4.0.0"></a>
-#4.0.0
+# 4.0.0
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropindicator@3.0.54...@spectrum-css/dropindicator@4.0.0)
 
@@ -122,14 +122,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
     		migrates DropIndicator to use `@adobe/spectrum-tokens`
 
 <a name="3.0.54"></a>
-##3.0.54
+## 3.0.54
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropindicator@3.0.53...@spectrum-css/dropindicator@3.0.54)
 
 **Note:** Version bump only for package @spectrum-css/dropindicator
 
 <a name="3.0.53"></a>
-##3.0.53
+## 3.0.53
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropindicator@3.0.52...@spectrum-css/dropindicator@3.0.53)
 
@@ -138,42 +138,42 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="3.0.52"></a>
-##3.0.52
+## 3.0.52
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropindicator@3.0.51...@spectrum-css/dropindicator@3.0.52)
 
 **Note:** Version bump only for package @spectrum-css/dropindicator
 
 <a name="3.0.51"></a>
-##3.0.51
+## 3.0.51
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropindicator@3.0.50...@spectrum-css/dropindicator@3.0.51)
 
 **Note:** Version bump only for package @spectrum-css/dropindicator
 
 <a name="3.0.50"></a>
-##3.0.50
+## 3.0.50
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropindicator@3.0.49...@spectrum-css/dropindicator@3.0.50)
 
 **Note:** Version bump only for package @spectrum-css/dropindicator
 
 <a name="3.0.49"></a>
-##3.0.49
+## 3.0.49
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropindicator@3.0.48...@spectrum-css/dropindicator@3.0.49)
 
 **Note:** Version bump only for package @spectrum-css/dropindicator
 
 <a name="3.0.48"></a>
-##3.0.48
+## 3.0.48
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropindicator@3.0.47...@spectrum-css/dropindicator@3.0.48)
 
 **Note:** Version bump only for package @spectrum-css/dropindicator
 
 <a name="3.0.47"></a>
-##3.0.47
+## 3.0.47
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropindicator@3.0.46...@spectrum-css/dropindicator@3.0.47)
 
@@ -182,14 +182,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="3.0.46"></a>
-##3.0.46
+## 3.0.46
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropindicator@3.0.45...@spectrum-css/dropindicator@3.0.46)
 
 **Note:** Version bump only for package @spectrum-css/dropindicator
 
 <a name="3.0.45"></a>
-##3.0.45
+## 3.0.45
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropindicator@3.0.44...@spectrum-css/dropindicator@3.0.45)
 

--- a/components/dropzone/CHANGELOG.md
+++ b/components/dropzone/CHANGELOG.md
@@ -33,7 +33,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="6.0.0"></a>
-#6.0.0
+# 6.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@5.2.5...@spectrum-css/dropzone@6.0.0)
 
@@ -48,49 +48,49 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="5.2.5"></a>
-##5.2.5
+## 5.2.5
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@5.2.4...@spectrum-css/dropzone@5.2.5)
 
 **Note:** Version bump only for package @spectrum-css/dropzone
 
 <a name="5.2.4"></a>
-##5.2.4
+## 5.2.4
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@5.2.3...@spectrum-css/dropzone@5.2.4)
 
 **Note:** Version bump only for package @spectrum-css/dropzone
 
 <a name="5.2.3"></a>
-##5.2.3
+## 5.2.3
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@5.2.2...@spectrum-css/dropzone@5.2.3)
 
 **Note:** Version bump only for package @spectrum-css/dropzone
 
 <a name="5.2.2"></a>
-##5.2.2
+## 5.2.2
 🗓
 2024-02-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@5.2.1...@spectrum-css/dropzone@5.2.2)
 
 **Note:** Version bump only for package @spectrum-css/dropzone
 
 <a name="5.2.1"></a>
-##5.2.1
+## 5.2.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/dropzone
 
 <a name="5.2.0"></a>
-#5.2.0
+# 5.2.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@5.1.0...@spectrum-css/dropzone@5.2.0)
 
 **Note:** Version bump only for package @spectrum-css/dropzone
 
 <a name="5.1.0"></a>
-#5.1.0
+# 5.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@5.0.31...@spectrum-css/dropzone@5.1.0)
 
@@ -99,14 +99,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="5.0.31"></a>
-##5.0.31
+## 5.0.31
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@5.0.30...@spectrum-css/dropzone@5.0.31)
 
 **Note:** Version bump only for package @spectrum-css/dropzone
 
 <a name="5.0.30"></a>
-##5.0.30
+## 5.0.30
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@5.0.29...@spectrum-css/dropzone@5.0.30)
 
@@ -115,7 +115,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **dropzone:**focus outline only on keyboard focus([b683376](https://github.com/adobe/spectrum-css/commit/b683376))
 
 <a name="5.0.29"></a>
-##5.0.29
+## 5.0.29
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@5.0.27...@spectrum-css/dropzone@5.0.29)
 
@@ -124,77 +124,77 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **dropzone:**prefer background-color on parent instead of pseudo element([c71fd14](https://github.com/adobe/spectrum-css/commit/c71fd14))
 
 <a name="5.0.28"></a>
-##5.0.28
+## 5.0.28
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@5.0.27...@spectrum-css/dropzone@5.0.28)
 
 **Note:** Version bump only for package @spectrum-css/dropzone
 
 <a name="5.0.27"></a>
-##5.0.27
+## 5.0.27
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@5.0.26...@spectrum-css/dropzone@5.0.27)
 
 **Note:** Version bump only for package @spectrum-css/dropzone
 
 <a name="5.0.26"></a>
-##5.0.26
+## 5.0.26
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@5.0.25...@spectrum-css/dropzone@5.0.26)
 
 **Note:** Version bump only for package @spectrum-css/dropzone
 
 <a name="5.0.25"></a>
-##5.0.25
+## 5.0.25
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@5.0.24...@spectrum-css/dropzone@5.0.25)
 
 **Note:** Version bump only for package @spectrum-css/dropzone
 
 <a name="5.0.24"></a>
-##5.0.24
+## 5.0.24
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@5.0.23...@spectrum-css/dropzone@5.0.24)
 
 **Note:** Version bump only for package @spectrum-css/dropzone
 
 <a name="5.0.23"></a>
-##5.0.23
+## 5.0.23
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@5.0.22...@spectrum-css/dropzone@5.0.23)
 
 **Note:** Version bump only for package @spectrum-css/dropzone
 
 <a name="5.0.22"></a>
-##5.0.22
+## 5.0.22
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@5.0.21...@spectrum-css/dropzone@5.0.22)
 
 **Note:** Version bump only for package @spectrum-css/dropzone
 
 <a name="5.0.21"></a>
-##5.0.21
+## 5.0.21
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@5.0.20...@spectrum-css/dropzone@5.0.21)
 
 **Note:** Version bump only for package @spectrum-css/dropzone
 
 <a name="5.0.20"></a>
-##5.0.20
+## 5.0.20
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@5.0.19...@spectrum-css/dropzone@5.0.20)
 
 **Note:** Version bump only for package @spectrum-css/dropzone
 
 <a name="5.0.19"></a>
-##5.0.19
+## 5.0.19
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@5.0.18...@spectrum-css/dropzone@5.0.19)
 
 **Note:** Version bump only for package @spectrum-css/dropzone
 
 <a name="5.0.18"></a>
-##5.0.18
+## 5.0.18
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@5.0.17...@spectrum-css/dropzone@5.0.18)
 
@@ -203,105 +203,105 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="5.0.17"></a>
-##5.0.17
+## 5.0.17
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@5.0.16...@spectrum-css/dropzone@5.0.17)
 
 **Note:** Version bump only for package @spectrum-css/dropzone
 
 <a name="5.0.16"></a>
-##5.0.16
+## 5.0.16
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@5.0.14...@spectrum-css/dropzone@5.0.16)
 
 **Note:** Version bump only for package @spectrum-css/dropzone
 
 <a name="5.0.15"></a>
-##5.0.15
+## 5.0.15
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@5.0.14...@spectrum-css/dropzone@5.0.15)
 
 **Note:** Version bump only for package @spectrum-css/dropzone
 
 <a name="5.0.14"></a>
-##5.0.14
+## 5.0.14
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@5.0.13...@spectrum-css/dropzone@5.0.14)
 
 **Note:** Version bump only for package @spectrum-css/dropzone
 
 <a name="5.0.13"></a>
-##5.0.13
+## 5.0.13
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@5.0.12...@spectrum-css/dropzone@5.0.13)
 
 **Note:** Version bump only for package @spectrum-css/dropzone
 
 <a name="5.0.12"></a>
-##5.0.12
+## 5.0.12
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@5.0.11...@spectrum-css/dropzone@5.0.12)
 
 **Note:** Version bump only for package @spectrum-css/dropzone
 
 <a name="5.0.11"></a>
-##5.0.11
+## 5.0.11
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@5.0.10...@spectrum-css/dropzone@5.0.11)
 
 **Note:** Version bump only for package @spectrum-css/dropzone
 
 <a name="5.0.10"></a>
-##5.0.10
+## 5.0.10
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@5.0.9...@spectrum-css/dropzone@5.0.10)
 
 **Note:** Version bump only for package @spectrum-css/dropzone
 
 <a name="5.0.9"></a>
-##5.0.9
+## 5.0.9
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@5.0.8...@spectrum-css/dropzone@5.0.9)
 
 **Note:** Version bump only for package @spectrum-css/dropzone
 
 <a name="5.0.8"></a>
-##5.0.8
+## 5.0.8
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@5.0.7...@spectrum-css/dropzone@5.0.8)
 
 **Note:** Version bump only for package @spectrum-css/dropzone
 
 <a name="5.0.7"></a>
-##5.0.7
+## 5.0.7
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@5.0.6...@spectrum-css/dropzone@5.0.7)
 
 **Note:** Version bump only for package @spectrum-css/dropzone
 
 <a name="5.0.6"></a>
-##5.0.6
+## 5.0.6
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@5.0.5...@spectrum-css/dropzone@5.0.6)
 
 **Note:** Version bump only for package @spectrum-css/dropzone
 
 <a name="5.0.5"></a>
-##5.0.5
+## 5.0.5
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@5.0.4...@spectrum-css/dropzone@5.0.5)
 
 **Note:** Version bump only for package @spectrum-css/dropzone
 
 <a name="5.0.4"></a>
-##5.0.4
+## 5.0.4
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@5.0.3...@spectrum-css/dropzone@5.0.4)
 
 **Note:** Version bump only for package @spectrum-css/dropzone
 
 <a name="5.0.3"></a>
-##5.0.3
+## 5.0.3
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@5.0.2...@spectrum-css/dropzone@5.0.3)
 
@@ -310,14 +310,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="5.0.2"></a>
-##5.0.2
+## 5.0.2
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@5.0.1...@spectrum-css/dropzone@5.0.2)
 
 **Note:** Version bump only for package @spectrum-css/dropzone
 
 <a name="5.0.1"></a>
-##5.0.1
+## 5.0.1
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@5.0.0...@spectrum-css/dropzone@5.0.1)
 

--- a/components/dropzone/CHANGELOG.md
+++ b/components/dropzone/CHANGELOG.md
@@ -33,7 +33,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="6.0.0"></a>
-# 6.0.0
+## 6.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@5.2.5...@spectrum-css/dropzone@6.0.0)
 
@@ -83,14 +83,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/dropzone
 
 <a name="5.2.0"></a>
-# 5.2.0
+## 5.2.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@5.1.0...@spectrum-css/dropzone@5.2.0)
 
 **Note:** Version bump only for package @spectrum-css/dropzone
 
 <a name="5.1.0"></a>
-# 5.1.0
+## 5.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@5.0.31...@spectrum-css/dropzone@5.1.0)
 
@@ -325,7 +325,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="5.0.0"></a>
 
-# 5.0.0
+## 5.0.0
 
 🗓 2023-05-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@4.0.16...@spectrum-css/dropzone@5.0.0)
 
@@ -467,7 +467,7 @@ Also updates IllustratedMessage and ActionButton to share `--mod-` properties.
 
 <a name="4.0.0"></a>
 
-# 4.0.0
+## 4.0.0
 
 🗓 2023-04-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@3.0.40...@spectrum-css/dropzone@4.0.0)
 
@@ -840,7 +840,7 @@ Also updates IllustratedMessage and ActionButton to share `--mod-` properties.
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@3.0.0-beta.5...@spectrum-css/dropzone@3.0.0)
 
@@ -848,7 +848,7 @@ Also updates IllustratedMessage and ActionButton to share `--mod-` properties.
 
 <a name="3.0.0-beta.5"></a>
 
-# 3.0.0-beta.5
+## 3.0.0-beta.5
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@3.0.0-beta.4...@spectrum-css/dropzone@3.0.0-beta.5)
 
@@ -856,7 +856,7 @@ Also updates IllustratedMessage and ActionButton to share `--mod-` properties.
 
 <a name="3.0.0-beta.4"></a>
 
-# 3.0.0-beta.4
+## 3.0.0-beta.4
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@3.0.0-beta.3...@spectrum-css/dropzone@3.0.0-beta.4)
 
@@ -868,7 +868,7 @@ Also updates IllustratedMessage and ActionButton to share `--mod-` properties.
 
 <a name="3.0.0-beta.3"></a>
 
-# 3.0.0-beta.3
+## 3.0.0-beta.3
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@3.0.0-beta.2...@spectrum-css/dropzone@3.0.0-beta.3)
 
@@ -876,7 +876,7 @@ Also updates IllustratedMessage and ActionButton to share `--mod-` properties.
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@3.0.0-beta.1...@spectrum-css/dropzone@3.0.0-beta.2)
 
@@ -884,7 +884,7 @@ Also updates IllustratedMessage and ActionButton to share `--mod-` properties.
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@3.0.0-beta.0...@spectrum-css/dropzone@3.0.0-beta.1)
 
@@ -892,7 +892,7 @@ Also updates IllustratedMessage and ActionButton to share `--mod-` properties.
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@2.1.1...@spectrum-css/dropzone@3.0.0-beta.0)
 
@@ -908,7 +908,7 @@ Also updates IllustratedMessage and ActionButton to share `--mod-` properties.
 
 <a name="2.1.0"></a>
 
-# 2.1.0
+## 2.1.0
 
 🗓 2020-02-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropzone@2.0.3...@spectrum-css/dropzone@2.1.0)
 
@@ -942,7 +942,7 @@ Also updates IllustratedMessage and ActionButton to share `--mod-` properties.
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/fieldgroup/CHANGELOG.md
+++ b/components/fieldgroup/CHANGELOG.md
@@ -33,7 +33,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-#5.0.0
+# 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@4.2.4...@spectrum-css/fieldgroup@5.0.0)
 
@@ -48,35 +48,35 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="4.2.4"></a>
-##4.2.4
+## 4.2.4
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@4.2.3...@spectrum-css/fieldgroup@4.2.4)
 
 **Note:** Version bump only for package @spectrum-css/fieldgroup
 
 <a name="4.2.3"></a>
-##4.2.3
+## 4.2.3
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@4.2.2...@spectrum-css/fieldgroup@4.2.3)
 
 **Note:** Version bump only for package @spectrum-css/fieldgroup
 
 <a name="4.2.2"></a>
-##4.2.2
+## 4.2.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@4.2.1...@spectrum-css/fieldgroup@4.2.2)
 
 **Note:** Version bump only for package @spectrum-css/fieldgroup
 
 <a name="4.2.1"></a>
-##4.2.1
+## 4.2.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/fieldgroup
 
 <a name="4.2.0"></a>
-#4.2.0
+# 4.2.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@4.1.1...@spectrum-css/fieldgroup@4.2.0)
 
@@ -85,14 +85,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="4.1.1"></a>
-##4.1.1
+## 4.1.1
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@4.1.0...@spectrum-css/fieldgroup@4.1.1)
 
 **Note:** Version bump only for package @spectrum-css/fieldgroup
 
 <a name="4.1.0"></a>
-#4.1.0
+# 4.1.0
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@4.0.80...@spectrum-css/fieldgroup@4.1.0)
 
@@ -101,98 +101,98 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **fieldlabel:**form - replace table layout with grid ([#2269](https://github.com/adobe/spectrum-css/issues/2269))([25591fc](https://github.com/adobe/spectrum-css/commit/25591fc)), closes[#2271](https://github.com/adobe/spectrum-css/issues/2271)
 
 <a name="4.0.80"></a>
-##4.0.80
+## 4.0.80
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@4.0.78...@spectrum-css/fieldgroup@4.0.80)
 
 **Note:** Version bump only for package @spectrum-css/fieldgroup
 
 <a name="4.0.79"></a>
-##4.0.79
+## 4.0.79
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@4.0.78...@spectrum-css/fieldgroup@4.0.79)
 
 **Note:** Version bump only for package @spectrum-css/fieldgroup
 
 <a name="4.0.78"></a>
-##4.0.78
+## 4.0.78
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@4.0.77...@spectrum-css/fieldgroup@4.0.78)
 
 **Note:** Version bump only for package @spectrum-css/fieldgroup
 
 <a name="4.0.77"></a>
-##4.0.77
+## 4.0.77
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@4.0.76...@spectrum-css/fieldgroup@4.0.77)
 
 **Note:** Version bump only for package @spectrum-css/fieldgroup
 
 <a name="4.0.76"></a>
-##4.0.76
+## 4.0.76
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@4.0.75...@spectrum-css/fieldgroup@4.0.76)
 
 **Note:** Version bump only for package @spectrum-css/fieldgroup
 
 <a name="4.0.75"></a>
-##4.0.75
+## 4.0.75
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@4.0.74...@spectrum-css/fieldgroup@4.0.75)
 
 **Note:** Version bump only for package @spectrum-css/fieldgroup
 
 <a name="4.0.74"></a>
-##4.0.74
+## 4.0.74
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@4.0.73...@spectrum-css/fieldgroup@4.0.74)
 
 **Note:** Version bump only for package @spectrum-css/fieldgroup
 
 <a name="4.0.73"></a>
-##4.0.73
+## 4.0.73
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@4.0.72...@spectrum-css/fieldgroup@4.0.73)
 
 **Note:** Version bump only for package @spectrum-css/fieldgroup
 
 <a name="4.0.72"></a>
-##4.0.72
+## 4.0.72
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@4.0.71...@spectrum-css/fieldgroup@4.0.72)
 
 **Note:** Version bump only for package @spectrum-css/fieldgroup
 
 <a name="4.0.71"></a>
-##4.0.71
+## 4.0.71
 🗓
 2023-09-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@4.0.70...@spectrum-css/fieldgroup@4.0.71)
 
 **Note:** Version bump only for package @spectrum-css/fieldgroup
 
 <a name="4.0.70"></a>
-##4.0.70
+## 4.0.70
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@4.0.69...@spectrum-css/fieldgroup@4.0.70)
 
 **Note:** Version bump only for package @spectrum-css/fieldgroup
 
 <a name="4.0.69"></a>
-##4.0.69
+## 4.0.69
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@4.0.68...@spectrum-css/fieldgroup@4.0.69)
 
 **Note:** Version bump only for package @spectrum-css/fieldgroup
 
 <a name="4.0.68"></a>
-##4.0.68
+## 4.0.68
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@4.0.67...@spectrum-css/fieldgroup@4.0.68)
 
 **Note:** Version bump only for package @spectrum-css/fieldgroup
 
 <a name="4.0.67"></a>
-##4.0.67
+## 4.0.67
 🗓
 2023-08-25 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@4.0.66...@spectrum-css/fieldgroup@4.0.67)
 
@@ -201,112 +201,112 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="4.0.66"></a>
-##4.0.66
+## 4.0.66
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@4.0.65...@spectrum-css/fieldgroup@4.0.66)
 
 **Note:** Version bump only for package @spectrum-css/fieldgroup
 
 <a name="4.0.65"></a>
-##4.0.65
+## 4.0.65
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@4.0.63...@spectrum-css/fieldgroup@4.0.65)
 
 **Note:** Version bump only for package @spectrum-css/fieldgroup
 
 <a name="4.0.64"></a>
-##4.0.64
+## 4.0.64
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@4.0.63...@spectrum-css/fieldgroup@4.0.64)
 
 **Note:** Version bump only for package @spectrum-css/fieldgroup
 
 <a name="4.0.63"></a>
-##4.0.63
+## 4.0.63
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@4.0.62...@spectrum-css/fieldgroup@4.0.63)
 
 **Note:** Version bump only for package @spectrum-css/fieldgroup
 
 <a name="4.0.62"></a>
-##4.0.62
+## 4.0.62
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@4.0.61...@spectrum-css/fieldgroup@4.0.62)
 
 **Note:** Version bump only for package @spectrum-css/fieldgroup
 
 <a name="4.0.61"></a>
-##4.0.61
+## 4.0.61
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@4.0.60...@spectrum-css/fieldgroup@4.0.61)
 
 **Note:** Version bump only for package @spectrum-css/fieldgroup
 
 <a name="4.0.60"></a>
-##4.0.60
+## 4.0.60
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@4.0.59...@spectrum-css/fieldgroup@4.0.60)
 
 **Note:** Version bump only for package @spectrum-css/fieldgroup
 
 <a name="4.0.59"></a>
-##4.0.59
+## 4.0.59
 🗓
 2023-07-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@4.0.58...@spectrum-css/fieldgroup@4.0.59)
 
 **Note:** Version bump only for package @spectrum-css/fieldgroup
 
 <a name="4.0.58"></a>
-##4.0.58
+## 4.0.58
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@4.0.57...@spectrum-css/fieldgroup@4.0.58)
 
 **Note:** Version bump only for package @spectrum-css/fieldgroup
 
 <a name="4.0.57"></a>
-##4.0.57
+## 4.0.57
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@4.0.56...@spectrum-css/fieldgroup@4.0.57)
 
 **Note:** Version bump only for package @spectrum-css/fieldgroup
 
 <a name="4.0.56"></a>
-##4.0.56
+## 4.0.56
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@4.0.55...@spectrum-css/fieldgroup@4.0.56)
 
 **Note:** Version bump only for package @spectrum-css/fieldgroup
 
 <a name="4.0.55"></a>
-##4.0.55
+## 4.0.55
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@4.0.54...@spectrum-css/fieldgroup@4.0.55)
 
 **Note:** Version bump only for package @spectrum-css/fieldgroup
 
 <a name="4.0.54"></a>
-##4.0.54
+## 4.0.54
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@4.0.53...@spectrum-css/fieldgroup@4.0.54)
 
 **Note:** Version bump only for package @spectrum-css/fieldgroup
 
 <a name="4.0.53"></a>
-##4.0.53
+## 4.0.53
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@4.0.52...@spectrum-css/fieldgroup@4.0.53)
 
 **Note:** Version bump only for package @spectrum-css/fieldgroup
 
 <a name="4.0.52"></a>
-##4.0.52
+## 4.0.52
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@4.0.51...@spectrum-css/fieldgroup@4.0.52)
 
 **Note:** Version bump only for package @spectrum-css/fieldgroup
 
 <a name="4.0.51"></a>
-##4.0.51
+## 4.0.51
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@4.0.50...@spectrum-css/fieldgroup@4.0.51)
 
@@ -315,14 +315,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="4.0.50"></a>
-##4.0.50
+## 4.0.50
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@4.0.49...@spectrum-css/fieldgroup@4.0.50)
 
 **Note:** Version bump only for package @spectrum-css/fieldgroup
 
 <a name="4.0.49"></a>
-##4.0.49
+## 4.0.49
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@4.0.48...@spectrum-css/fieldgroup@4.0.49)
 

--- a/components/fieldgroup/CHANGELOG.md
+++ b/components/fieldgroup/CHANGELOG.md
@@ -33,7 +33,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-# 5.0.0
+## 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@4.2.4...@spectrum-css/fieldgroup@5.0.0)
 
@@ -76,7 +76,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/fieldgroup
 
 <a name="4.2.0"></a>
-# 4.2.0
+## 4.2.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@4.1.1...@spectrum-css/fieldgroup@4.2.0)
 
@@ -92,7 +92,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/fieldgroup
 
 <a name="4.1.0"></a>
-# 4.1.0
+## 4.1.0
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@4.0.80...@spectrum-css/fieldgroup@4.1.0)
 
@@ -714,7 +714,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="4.0.0"></a>
 
-# 4.0.0
+## 4.0.0
 
 🗓 2022-11-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@3.1.4...@spectrum-css/fieldgroup@4.0.0)
 
@@ -760,7 +760,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.1.0"></a>
 
-# 3.1.0
+## 3.1.0
 
 🗓 2022-04-08 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@3.0.19...@spectrum-css/fieldgroup@3.1.0)
 
@@ -958,7 +958,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@3.0.0-beta.6...@spectrum-css/fieldgroup@3.0.0)
 
@@ -972,7 +972,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0-beta.6"></a>
 
-# 3.0.0-beta.6
+## 3.0.0-beta.6
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@3.0.0-beta.5...@spectrum-css/fieldgroup@3.0.0-beta.6)
 
@@ -983,7 +983,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0-beta.5"></a>
 
-# 3.0.0-beta.5
+## 3.0.0-beta.5
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@3.0.0-beta.4...@spectrum-css/fieldgroup@3.0.0-beta.5)
 
@@ -991,7 +991,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0-beta.4"></a>
 
-# 3.0.0-beta.4
+## 3.0.0-beta.4
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@3.0.0-beta.3...@spectrum-css/fieldgroup@3.0.0-beta.4)
 
@@ -1010,7 +1010,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0-beta.3"></a>
 
-# 3.0.0-beta.3
+## 3.0.0-beta.3
 
 🗓 2020-06-19 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@3.0.0-beta.2...@spectrum-css/fieldgroup@3.0.0-beta.3)
 
@@ -1018,7 +1018,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@3.0.0-beta.1...@spectrum-css/fieldgroup@3.0.0-beta.2)
 
@@ -1026,7 +1026,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@3.0.0-beta.0...@spectrum-css/fieldgroup@3.0.0-beta.1)
 
@@ -1034,7 +1034,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldgroup@2.0.6...@spectrum-css/fieldgroup@3.0.0-beta.0)
 
@@ -1090,7 +1090,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/fieldlabel/CHANGELOG.md
+++ b/components/fieldlabel/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="8.0.0"></a>
-#8.0.0
+# 8.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.3.6...@spectrum-css/fieldlabel@8.0.0)
 
@@ -44,35 +44,35 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="7.3.6"></a>
-##7.3.6
+## 7.3.6
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.3.5...@spectrum-css/fieldlabel@7.3.6)
 
 **Note:** Version bump only for package @spectrum-css/fieldlabel
 
 <a name="7.3.5"></a>
-##7.3.5
+## 7.3.5
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.3.4...@spectrum-css/fieldlabel@7.3.5)
 
 **Note:** Version bump only for package @spectrum-css/fieldlabel
 
 <a name="7.3.4"></a>
-##7.3.4
+## 7.3.4
 🗓
 2024-02-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.3.3...@spectrum-css/fieldlabel@7.3.4)
 
 **Note:** Version bump only for package @spectrum-css/fieldlabel
 
 <a name="7.3.3"></a>
-##7.3.3
+## 7.3.3
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.3.2...@spectrum-css/fieldlabel@7.3.3)
 
 **Note:** Version bump only for package @spectrum-css/fieldlabel
 
 <a name="7.3.2"></a>
-##7.3.2
+## 7.3.2
 🗓
 2024-02-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.3.1...@spectrum-css/fieldlabel@7.3.2)
 
@@ -81,14 +81,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **picker:**quiet side label picker positioning ([#2465](https://github.com/adobe/spectrum-css/issues/2465))([537f0b8](https://github.com/adobe/spectrum-css/commit/537f0b8))
 
 <a name="7.3.1"></a>
-##7.3.1
+## 7.3.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/fieldlabel
 
 <a name="7.3.0"></a>
-#7.3.0
+# 7.3.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.2.1...@spectrum-css/fieldlabel@7.3.0)
 
@@ -97,14 +97,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="7.2.1"></a>
-##7.2.1
+## 7.2.1
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.2.0...@spectrum-css/fieldlabel@7.2.1)
 
 **Note:** Version bump only for package @spectrum-css/fieldlabel
 
 <a name="7.2.0"></a>
-#7.2.0
+# 7.2.0
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.1.5...@spectrum-css/fieldlabel@7.2.0)
 
@@ -113,42 +113,42 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **fieldlabel:**form - replace table layout with grid ([#2269](https://github.com/adobe/spectrum-css/issues/2269))([25591fc](https://github.com/adobe/spectrum-css/commit/25591fc)), closes[#2271](https://github.com/adobe/spectrum-css/issues/2271)
 
 <a name="7.1.5"></a>
-##7.1.5
+## 7.1.5
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.1.3...@spectrum-css/fieldlabel@7.1.5)
 
 **Note:** Version bump only for package @spectrum-css/fieldlabel
 
 <a name="7.1.4"></a>
-##7.1.4
+## 7.1.4
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.1.3...@spectrum-css/fieldlabel@7.1.4)
 
 **Note:** Version bump only for package @spectrum-css/fieldlabel
 
 <a name="7.1.3"></a>
-##7.1.3
+## 7.1.3
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.1.2...@spectrum-css/fieldlabel@7.1.3)
 
 **Note:** Version bump only for package @spectrum-css/fieldlabel
 
 <a name="7.1.2"></a>
-##7.1.2
+## 7.1.2
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.1.1...@spectrum-css/fieldlabel@7.1.2)
 
 **Note:** Version bump only for package @spectrum-css/fieldlabel
 
 <a name="7.1.1"></a>
-##7.1.1
+## 7.1.1
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.1.0...@spectrum-css/fieldlabel@7.1.1)
 
 **Note:** Version bump only for package @spectrum-css/fieldlabel
 
 <a name="7.1.0"></a>
-#7.1.0
+# 7.1.0
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.0.35...@spectrum-css/fieldlabel@7.1.0)
 
@@ -157,56 +157,56 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **fieldlabel:**required asterisk vertical alignment ([#2166](https://github.com/adobe/spectrum-css/issues/2166))([de7599e](https://github.com/adobe/spectrum-css/commit/de7599e))
 
 <a name="7.0.35"></a>
-##7.0.35
+## 7.0.35
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.0.34...@spectrum-css/fieldlabel@7.0.35)
 
 **Note:** Version bump only for package @spectrum-css/fieldlabel
 
 <a name="7.0.34"></a>
-##7.0.34
+## 7.0.34
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.0.33...@spectrum-css/fieldlabel@7.0.34)
 
 **Note:** Version bump only for package @spectrum-css/fieldlabel
 
 <a name="7.0.33"></a>
-##7.0.33
+## 7.0.33
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.0.32...@spectrum-css/fieldlabel@7.0.33)
 
 **Note:** Version bump only for package @spectrum-css/fieldlabel
 
 <a name="7.0.32"></a>
-##7.0.32
+## 7.0.32
 🗓
 2023-09-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.0.31...@spectrum-css/fieldlabel@7.0.32)
 
 **Note:** Version bump only for package @spectrum-css/fieldlabel
 
 <a name="7.0.31"></a>
-##7.0.31
+## 7.0.31
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.0.30...@spectrum-css/fieldlabel@7.0.31)
 
 **Note:** Version bump only for package @spectrum-css/fieldlabel
 
 <a name="7.0.30"></a>
-##7.0.30
+## 7.0.30
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.0.29...@spectrum-css/fieldlabel@7.0.30)
 
 **Note:** Version bump only for package @spectrum-css/fieldlabel
 
 <a name="7.0.29"></a>
-##7.0.29
+## 7.0.29
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.0.28...@spectrum-css/fieldlabel@7.0.29)
 
 **Note:** Version bump only for package @spectrum-css/fieldlabel
 
 <a name="7.0.28"></a>
-##7.0.28
+## 7.0.28
 🗓
 2023-08-25 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.0.27...@spectrum-css/fieldlabel@7.0.28)
 
@@ -215,77 +215,77 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="7.0.27"></a>
-##7.0.27
+## 7.0.27
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.0.26...@spectrum-css/fieldlabel@7.0.27)
 
 **Note:** Version bump only for package @spectrum-css/fieldlabel
 
 <a name="7.0.26"></a>
-##7.0.26
+## 7.0.26
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.0.24...@spectrum-css/fieldlabel@7.0.26)
 
 **Note:** Version bump only for package @spectrum-css/fieldlabel
 
 <a name="7.0.25"></a>
-##7.0.25
+## 7.0.25
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.0.24...@spectrum-css/fieldlabel@7.0.25)
 
 **Note:** Version bump only for package @spectrum-css/fieldlabel
 
 <a name="7.0.24"></a>
-##7.0.24
+## 7.0.24
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.0.23...@spectrum-css/fieldlabel@7.0.24)
 
 **Note:** Version bump only for package @spectrum-css/fieldlabel
 
 <a name="7.0.23"></a>
-##7.0.23
+## 7.0.23
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.0.22...@spectrum-css/fieldlabel@7.0.23)
 
 **Note:** Version bump only for package @spectrum-css/fieldlabel
 
 <a name="7.0.22"></a>
-##7.0.22
+## 7.0.22
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.0.21...@spectrum-css/fieldlabel@7.0.22)
 
 **Note:** Version bump only for package @spectrum-css/fieldlabel
 
 <a name="7.0.21"></a>
-##7.0.21
+## 7.0.21
 🗓
 2023-08-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.0.20...@spectrum-css/fieldlabel@7.0.21)
 
 **Note:** Version bump only for package @spectrum-css/fieldlabel
 
 <a name="7.0.20"></a>
-##7.0.20
+## 7.0.20
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.0.19...@spectrum-css/fieldlabel@7.0.20)
 
 **Note:** Version bump only for package @spectrum-css/fieldlabel
 
 <a name="7.0.19"></a>
-##7.0.19
+## 7.0.19
 🗓
 2023-07-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.0.18...@spectrum-css/fieldlabel@7.0.19)
 
 **Note:** Version bump only for package @spectrum-css/fieldlabel
 
 <a name="7.0.18"></a>
-##7.0.18
+## 7.0.18
 🗓
 2023-07-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.0.17...@spectrum-css/fieldlabel@7.0.18)
 
 **Note:** Version bump only for package @spectrum-css/fieldlabel
 
 <a name="7.0.17"></a>
-##7.0.17
+## 7.0.17
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.0.16...@spectrum-css/fieldlabel@7.0.17)
 
@@ -294,56 +294,56 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*icon sizing in Storybook story templates ([#2037](https://github.com/adobe/spectrum-css/issues/2037))([c90c8a3](https://github.com/adobe/spectrum-css/commit/c90c8a3))
 
 <a name="7.0.16"></a>
-##7.0.16
+## 7.0.16
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.0.15...@spectrum-css/fieldlabel@7.0.16)
 
 **Note:** Version bump only for package @spectrum-css/fieldlabel
 
 <a name="7.0.15"></a>
-##7.0.15
+## 7.0.15
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.0.14...@spectrum-css/fieldlabel@7.0.15)
 
 **Note:** Version bump only for package @spectrum-css/fieldlabel
 
 <a name="7.0.14"></a>
-##7.0.14
+## 7.0.14
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.0.13...@spectrum-css/fieldlabel@7.0.14)
 
 **Note:** Version bump only for package @spectrum-css/fieldlabel
 
 <a name="7.0.13"></a>
-##7.0.13
+## 7.0.13
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.0.12...@spectrum-css/fieldlabel@7.0.13)
 
 **Note:** Version bump only for package @spectrum-css/fieldlabel
 
 <a name="7.0.12"></a>
-##7.0.12
+## 7.0.12
 🗓
 2023-06-28 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.0.11...@spectrum-css/fieldlabel@7.0.12)
 
 **Note:** Version bump only for package @spectrum-css/fieldlabel
 
 <a name="7.0.11"></a>
-##7.0.11
+## 7.0.11
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.0.10...@spectrum-css/fieldlabel@7.0.11)
 
 **Note:** Version bump only for package @spectrum-css/fieldlabel
 
 <a name="7.0.10"></a>
-##7.0.10
+## 7.0.10
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.0.9...@spectrum-css/fieldlabel@7.0.10)
 
 **Note:** Version bump only for package @spectrum-css/fieldlabel
 
 <a name="7.0.9"></a>
-##7.0.9
+## 7.0.9
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.0.8...@spectrum-css/fieldlabel@7.0.9)
 
@@ -352,14 +352,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="7.0.8"></a>
-##7.0.8
+## 7.0.8
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.0.7...@spectrum-css/fieldlabel@7.0.8)
 
 **Note:** Version bump only for package @spectrum-css/fieldlabel
 
 <a name="7.0.7"></a>
-##7.0.7
+## 7.0.7
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.0.6...@spectrum-css/fieldlabel@7.0.7)
 

--- a/components/fieldlabel/CHANGELOG.md
+++ b/components/fieldlabel/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="8.0.0"></a>
-# 8.0.0
+## 8.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.3.6...@spectrum-css/fieldlabel@8.0.0)
 
@@ -88,7 +88,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/fieldlabel
 
 <a name="7.3.0"></a>
-# 7.3.0
+## 7.3.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.2.1...@spectrum-css/fieldlabel@7.3.0)
 
@@ -104,7 +104,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/fieldlabel
 
 <a name="7.2.0"></a>
-# 7.2.0
+## 7.2.0
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.1.5...@spectrum-css/fieldlabel@7.2.0)
 
@@ -148,7 +148,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/fieldlabel
 
 <a name="7.1.0"></a>
-# 7.1.0
+## 7.1.0
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@7.0.35...@spectrum-css/fieldlabel@7.1.0)
 
@@ -415,7 +415,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="7.0.0"></a>
 
-# 7.0.0
+## 7.0.0
 
 🗓 2023-05-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@6.0.35...@spectrum-css/fieldlabel@7.0.0)
 
@@ -709,7 +709,7 @@ Additionally, this adds some `min-height` custom properties and adjusts the `min
 
 <a name="6.0.0"></a>
 
-# 6.0.0
+## 6.0.0
 
 🗓 2023-02-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@5.0.15...@spectrum-css/fieldlabel@6.0.0)
 
@@ -847,7 +847,7 @@ Additionally, this adds some `min-height` custom properties and adjusts the `min
 
 <a name="5.0.0"></a>
 
-# 5.0.0
+## 5.0.0
 
 🗓 2022-10-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@4.0.29...@spectrum-css/fieldlabel@5.0.0)
 
@@ -1108,7 +1108,7 @@ Co-authored-by: Patrick Fulton <pfulton@users.noreply.github.com>
 
 <a name="4.0.0"></a>
 
-# 4.0.0
+## 4.0.0
 
 🗓 2021-09-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@4.0.0-alpha.4...@spectrum-css/fieldlabel@4.0.0)
 
@@ -1118,7 +1118,7 @@ Co-authored-by: Patrick Fulton <pfulton@users.noreply.github.com>
 
 <a name="4.0.0-alpha.4"></a>
 
-# 4.0.0-alpha.4
+## 4.0.0-alpha.4
 
 🗓 2021-08-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@4.0.0-alpha.3...@spectrum-css/fieldlabel@4.0.0-alpha.4)
 
@@ -1126,7 +1126,7 @@ Co-authored-by: Patrick Fulton <pfulton@users.noreply.github.com>
 
 <a name="4.0.0-alpha.3"></a>
 
-# 4.0.0-alpha.3
+## 4.0.0-alpha.3
 
 🗓 2021-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@4.0.0-alpha.2...@spectrum-css/fieldlabel@4.0.0-alpha.3)
 
@@ -1134,7 +1134,7 @@ Co-authored-by: Patrick Fulton <pfulton@users.noreply.github.com>
 
 <a name="4.0.0-alpha.2"></a>
 
-# 4.0.0-alpha.2
+## 4.0.0-alpha.2
 
 🗓 2021-08-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@4.0.0-alpha.1...@spectrum-css/fieldlabel@4.0.0-alpha.2)
 
@@ -1142,7 +1142,7 @@ Co-authored-by: Patrick Fulton <pfulton@users.noreply.github.com>
 
 <a name="4.0.0-alpha.1"></a>
 
-# 4.0.0-alpha.1
+## 4.0.0-alpha.1
 
 🗓 2021-07-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@4.0.0-alpha.0...@spectrum-css/fieldlabel@4.0.0-alpha.1)
 
@@ -1150,7 +1150,7 @@ Co-authored-by: Patrick Fulton <pfulton@users.noreply.github.com>
 
 <a name="4.0.0-alpha.0"></a>
 
-# 4.0.0-alpha.0
+## 4.0.0-alpha.0
 
 🗓 2021-07-19 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@3.0.3-alpha.2...@spectrum-css/fieldlabel@4.0.0-alpha.0)
 
@@ -1204,7 +1204,7 @@ Co-authored-by: Patrick Fulton <pfulton@users.noreply.github.com>
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@3.0.0-beta.7...@spectrum-css/fieldlabel@3.0.0)
 
@@ -1219,7 +1219,7 @@ Co-authored-by: Patrick Fulton <pfulton@users.noreply.github.com>
 
 <a name="3.0.0-beta.7"></a>
 
-# 3.0.0-beta.7
+## 3.0.0-beta.7
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@3.0.0-beta.6...@spectrum-css/fieldlabel@3.0.0-beta.7)
 
@@ -1240,7 +1240,7 @@ Co-authored-by: Patrick Fulton <pfulton@users.noreply.github.com>
 
 <a name="3.0.0-beta.6"></a>
 
-# 3.0.0-beta.6
+## 3.0.0-beta.6
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@3.0.0-beta.5...@spectrum-css/fieldlabel@3.0.0-beta.6)
 
@@ -1248,7 +1248,7 @@ Co-authored-by: Patrick Fulton <pfulton@users.noreply.github.com>
 
 <a name="3.0.0-beta.5"></a>
 
-# 3.0.0-beta.5
+## 3.0.0-beta.5
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@3.0.0-beta.4...@spectrum-css/fieldlabel@3.0.0-beta.5)
 
@@ -1268,7 +1268,7 @@ Co-authored-by: Patrick Fulton <pfulton@users.noreply.github.com>
 
 <a name="3.0.0-beta.4"></a>
 
-# 3.0.0-beta.4
+## 3.0.0-beta.4
 
 🗓 2020-06-19 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@3.0.0-beta.3...@spectrum-css/fieldlabel@3.0.0-beta.4)
 
@@ -1276,7 +1276,7 @@ Co-authored-by: Patrick Fulton <pfulton@users.noreply.github.com>
 
 <a name="3.0.0-beta.3"></a>
 
-# 3.0.0-beta.3
+## 3.0.0-beta.3
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@3.0.0-beta.2...@spectrum-css/fieldlabel@3.0.0-beta.3)
 
@@ -1286,7 +1286,7 @@ Co-authored-by: Patrick Fulton <pfulton@users.noreply.github.com>
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@3.0.0-beta.1...@spectrum-css/fieldlabel@3.0.0-beta.2)
 
@@ -1294,7 +1294,7 @@ Co-authored-by: Patrick Fulton <pfulton@users.noreply.github.com>
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@3.0.0-beta.0...@spectrum-css/fieldlabel@3.0.0-beta.1)
 
@@ -1308,7 +1308,7 @@ Co-authored-by: Patrick Fulton <pfulton@users.noreply.github.com>
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/fieldlabel@2.0.6...@spectrum-css/fieldlabel@3.0.0-beta.0)
 
@@ -1366,7 +1366,7 @@ Co-authored-by: Patrick Fulton <pfulton@users.noreply.github.com>
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/floatingactionbutton/CHANGELOG.md
+++ b/components/floatingactionbutton/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="2.0.0"></a>
-# 2.0.0
+## 2.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/floatingactionbutton@1.2.5...@spectrum-css/floatingactionbutton@2.0.0)
 
@@ -75,14 +75,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/floatingactionbutton
 
 <a name="1.2.0"></a>
-# 1.2.0
+## 1.2.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/floatingactionbutton@1.1.0...@spectrum-css/floatingactionbutton@1.2.0)
 
 **Note:** Version bump only for package @spectrum-css/floatingactionbutton
 
 <a name="1.1.0"></a>
-# 1.1.0
+## 1.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/floatingactionbutton@1.0.37...@spectrum-css/floatingactionbutton@1.1.0)
 
@@ -365,7 +365,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="1.0.0"></a>
 
-# 1.0.0
+## 1.0.0
 
 🗓 2023-05-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/floatingactionbutton@1.0.0-alpha.1...@spectrum-css/floatingactionbutton@1.0.0)
 
@@ -373,7 +373,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="1.0.0-alpha.1"></a>
 
-# 1.0.0-alpha.1
+## 1.0.0-alpha.1
 
 🗓 2023-05-04
 

--- a/components/floatingactionbutton/CHANGELOG.md
+++ b/components/floatingactionbutton/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="2.0.0"></a>
-#2.0.0
+# 2.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/floatingactionbutton@1.2.5...@spectrum-css/floatingactionbutton@2.0.0)
 
@@ -40,49 +40,49 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="1.2.5"></a>
-##1.2.5
+## 1.2.5
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/floatingactionbutton@1.2.4...@spectrum-css/floatingactionbutton@1.2.5)
 
 **Note:** Version bump only for package @spectrum-css/floatingactionbutton
 
 <a name="1.2.4"></a>
-##1.2.4
+## 1.2.4
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/floatingactionbutton@1.2.3...@spectrum-css/floatingactionbutton@1.2.4)
 
 **Note:** Version bump only for package @spectrum-css/floatingactionbutton
 
 <a name="1.2.3"></a>
-##1.2.3
+## 1.2.3
 🗓
 2024-02-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/floatingactionbutton@1.2.2...@spectrum-css/floatingactionbutton@1.2.3)
 
 **Note:** Version bump only for package @spectrum-css/floatingactionbutton
 
 <a name="1.2.2"></a>
-##1.2.2
+## 1.2.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/floatingactionbutton@1.2.1...@spectrum-css/floatingactionbutton@1.2.2)
 
 **Note:** Version bump only for package @spectrum-css/floatingactionbutton
 
 <a name="1.2.1"></a>
-##1.2.1
+## 1.2.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/floatingactionbutton
 
 <a name="1.2.0"></a>
-#1.2.0
+# 1.2.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/floatingactionbutton@1.1.0...@spectrum-css/floatingactionbutton@1.2.0)
 
 **Note:** Version bump only for package @spectrum-css/floatingactionbutton
 
 <a name="1.1.0"></a>
-#1.1.0
+# 1.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/floatingactionbutton@1.0.37...@spectrum-css/floatingactionbutton@1.1.0)
 
@@ -91,14 +91,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="1.0.37"></a>
-##1.0.37
+## 1.0.37
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/floatingactionbutton@1.0.36...@spectrum-css/floatingactionbutton@1.0.37)
 
 **Note:** Version bump only for package @spectrum-css/floatingactionbutton
 
 <a name="1.0.36"></a>
-##1.0.36
+## 1.0.36
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/floatingactionbutton@1.0.35...@spectrum-css/floatingactionbutton@1.0.36)
 
@@ -107,84 +107,84 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **floatingactionbutton:**focus outline only on keyboard focus([dd5b8dd](https://github.com/adobe/spectrum-css/commit/dd5b8dd))
 
 <a name="1.0.35"></a>
-##1.0.35
+## 1.0.35
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/floatingactionbutton@1.0.33...@spectrum-css/floatingactionbutton@1.0.35)
 
 **Note:** Version bump only for package @spectrum-css/floatingactionbutton
 
 <a name="1.0.34"></a>
-##1.0.34
+## 1.0.34
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/floatingactionbutton@1.0.33...@spectrum-css/floatingactionbutton@1.0.34)
 
 **Note:** Version bump only for package @spectrum-css/floatingactionbutton
 
 <a name="1.0.33"></a>
-##1.0.33
+## 1.0.33
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/floatingactionbutton@1.0.32...@spectrum-css/floatingactionbutton@1.0.33)
 
 **Note:** Version bump only for package @spectrum-css/floatingactionbutton
 
 <a name="1.0.32"></a>
-##1.0.32
+## 1.0.32
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/floatingactionbutton@1.0.31...@spectrum-css/floatingactionbutton@1.0.32)
 
 **Note:** Version bump only for package @spectrum-css/floatingactionbutton
 
 <a name="1.0.31"></a>
-##1.0.31
+## 1.0.31
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/floatingactionbutton@1.0.30...@spectrum-css/floatingactionbutton@1.0.31)
 
 **Note:** Version bump only for package @spectrum-css/floatingactionbutton
 
 <a name="1.0.30"></a>
-##1.0.30
+## 1.0.30
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/floatingactionbutton@1.0.29...@spectrum-css/floatingactionbutton@1.0.30)
 
 **Note:** Version bump only for package @spectrum-css/floatingactionbutton
 
 <a name="1.0.29"></a>
-##1.0.29
+## 1.0.29
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/floatingactionbutton@1.0.28...@spectrum-css/floatingactionbutton@1.0.29)
 
 **Note:** Version bump only for package @spectrum-css/floatingactionbutton
 
 <a name="1.0.28"></a>
-##1.0.28
+## 1.0.28
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/floatingactionbutton@1.0.27...@spectrum-css/floatingactionbutton@1.0.28)
 
 **Note:** Version bump only for package @spectrum-css/floatingactionbutton
 
 <a name="1.0.27"></a>
-##1.0.27
+## 1.0.27
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/floatingactionbutton@1.0.26...@spectrum-css/floatingactionbutton@1.0.27)
 
 **Note:** Version bump only for package @spectrum-css/floatingactionbutton
 
 <a name="1.0.26"></a>
-##1.0.26
+## 1.0.26
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/floatingactionbutton@1.0.25...@spectrum-css/floatingactionbutton@1.0.26)
 
 **Note:** Version bump only for package @spectrum-css/floatingactionbutton
 
 <a name="1.0.25"></a>
-##1.0.25
+## 1.0.25
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/floatingactionbutton@1.0.24...@spectrum-css/floatingactionbutton@1.0.25)
 
 **Note:** Version bump only for package @spectrum-css/floatingactionbutton
 
 <a name="1.0.24"></a>
-##1.0.24
+## 1.0.24
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/floatingactionbutton@1.0.23...@spectrum-css/floatingactionbutton@1.0.24)
 
@@ -193,105 +193,105 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="1.0.23"></a>
-##1.0.23
+## 1.0.23
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/floatingactionbutton@1.0.22...@spectrum-css/floatingactionbutton@1.0.23)
 
 **Note:** Version bump only for package @spectrum-css/floatingactionbutton
 
 <a name="1.0.22"></a>
-##1.0.22
+## 1.0.22
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/floatingactionbutton@1.0.20...@spectrum-css/floatingactionbutton@1.0.22)
 
 **Note:** Version bump only for package @spectrum-css/floatingactionbutton
 
 <a name="1.0.21"></a>
-##1.0.21
+## 1.0.21
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/floatingactionbutton@1.0.20...@spectrum-css/floatingactionbutton@1.0.21)
 
 **Note:** Version bump only for package @spectrum-css/floatingactionbutton
 
 <a name="1.0.20"></a>
-##1.0.20
+## 1.0.20
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/floatingactionbutton@1.0.19...@spectrum-css/floatingactionbutton@1.0.20)
 
 **Note:** Version bump only for package @spectrum-css/floatingactionbutton
 
 <a name="1.0.19"></a>
-##1.0.19
+## 1.0.19
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/floatingactionbutton@1.0.18...@spectrum-css/floatingactionbutton@1.0.19)
 
 **Note:** Version bump only for package @spectrum-css/floatingactionbutton
 
 <a name="1.0.18"></a>
-##1.0.18
+## 1.0.18
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/floatingactionbutton@1.0.17...@spectrum-css/floatingactionbutton@1.0.18)
 
 **Note:** Version bump only for package @spectrum-css/floatingactionbutton
 
 <a name="1.0.17"></a>
-##1.0.17
+## 1.0.17
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/floatingactionbutton@1.0.16...@spectrum-css/floatingactionbutton@1.0.17)
 
 **Note:** Version bump only for package @spectrum-css/floatingactionbutton
 
 <a name="1.0.16"></a>
-##1.0.16
+## 1.0.16
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/floatingactionbutton@1.0.15...@spectrum-css/floatingactionbutton@1.0.16)
 
 **Note:** Version bump only for package @spectrum-css/floatingactionbutton
 
 <a name="1.0.15"></a>
-##1.0.15
+## 1.0.15
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/floatingactionbutton@1.0.14...@spectrum-css/floatingactionbutton@1.0.15)
 
 **Note:** Version bump only for package @spectrum-css/floatingactionbutton
 
 <a name="1.0.14"></a>
-##1.0.14
+## 1.0.14
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/floatingactionbutton@1.0.13...@spectrum-css/floatingactionbutton@1.0.14)
 
 **Note:** Version bump only for package @spectrum-css/floatingactionbutton
 
 <a name="1.0.13"></a>
-##1.0.13
+## 1.0.13
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/floatingactionbutton@1.0.12...@spectrum-css/floatingactionbutton@1.0.13)
 
 **Note:** Version bump only for package @spectrum-css/floatingactionbutton
 
 <a name="1.0.12"></a>
-##1.0.12
+## 1.0.12
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/floatingactionbutton@1.0.11...@spectrum-css/floatingactionbutton@1.0.12)
 
 **Note:** Version bump only for package @spectrum-css/floatingactionbutton
 
 <a name="1.0.11"></a>
-##1.0.11
+## 1.0.11
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/floatingactionbutton@1.0.10...@spectrum-css/floatingactionbutton@1.0.11)
 
 **Note:** Version bump only for package @spectrum-css/floatingactionbutton
 
 <a name="1.0.10"></a>
-##1.0.10
+## 1.0.10
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/floatingactionbutton@1.0.9...@spectrum-css/floatingactionbutton@1.0.10)
 
 **Note:** Version bump only for package @spectrum-css/floatingactionbutton
 
 <a name="1.0.9"></a>
-##1.0.9
+## 1.0.9
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/floatingactionbutton@1.0.8...@spectrum-css/floatingactionbutton@1.0.9)
 
@@ -300,14 +300,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="1.0.8"></a>
-##1.0.8
+## 1.0.8
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/floatingactionbutton@1.0.7...@spectrum-css/floatingactionbutton@1.0.8)
 
 **Note:** Version bump only for package @spectrum-css/floatingactionbutton
 
 <a name="1.0.7"></a>
-##1.0.7
+## 1.0.7
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/floatingactionbutton@1.0.6...@spectrum-css/floatingactionbutton@1.0.7)
 

--- a/components/helptext/CHANGELOG.md
+++ b/components/helptext/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-# 5.0.0
+## 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/helptext@4.1.5...@spectrum-css/helptext@5.0.0)
 
@@ -79,7 +79,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/helptext
 
 <a name="4.1.0"></a>
-# 4.1.0
+## 4.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/helptext@4.0.64...@spectrum-css/helptext@4.1.0)
 
@@ -574,7 +574,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="4.0.0"></a>
 
-# 4.0.0
+## 4.0.0
 
 🗓 2023-02-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/helptext@3.0.13...@spectrum-css/helptext@4.0.0)
 
@@ -692,7 +692,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2022-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/helptext@2.0.9...@spectrum-css/helptext@3.0.0)
 
@@ -780,7 +780,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2022-07-25 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/helptext@1.0.20...@spectrum-css/helptext@2.0.0)
 
@@ -792,7 +792,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="2.0.0-beta.1"></a>
 
-# 2.0.0-beta.1
+## 2.0.0-beta.1
 
 🗓 2022-07-25 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/helptext@2.0.0-beta.0...@spectrum-css/helptext@2.0.0-beta.1)
 
@@ -800,7 +800,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="2.0.0-beta.0"></a>
 
-# 2.0.0-beta.0
+## 2.0.0-beta.0
 
 🗓 2022-07-25 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/helptext@1.0.20...@spectrum-css/helptext@2.0.0-beta.0)
 
@@ -974,7 +974,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="1.0.0"></a>
 
-# 1.0.0
+## 1.0.0
 
 🗓 2021-09-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/helptext@1.0.0-alpha.3...@spectrum-css/helptext@1.0.0)
 
@@ -984,7 +984,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="1.0.0-alpha.3"></a>
 
-# 1.0.0-alpha.3
+## 1.0.0-alpha.3
 
 🗓 2021-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/helptext@1.0.0-alpha.2...@spectrum-css/helptext@1.0.0-alpha.3)
 
@@ -992,7 +992,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="1.0.0-alpha.2"></a>
 
-# 1.0.0-alpha.2
+## 1.0.0-alpha.2
 
 🗓 2021-08-05
 

--- a/components/helptext/CHANGELOG.md
+++ b/components/helptext/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-#5.0.0
+# 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/helptext@4.1.5...@spectrum-css/helptext@5.0.0)
 
@@ -44,42 +44,42 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="4.1.5"></a>
-##4.1.5
+## 4.1.5
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/helptext@4.1.4...@spectrum-css/helptext@4.1.5)
 
 **Note:** Version bump only for package @spectrum-css/helptext
 
 <a name="4.1.4"></a>
-##4.1.4
+## 4.1.4
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/helptext@4.1.3...@spectrum-css/helptext@4.1.4)
 
 **Note:** Version bump only for package @spectrum-css/helptext
 
 <a name="4.1.3"></a>
-##4.1.3
+## 4.1.3
 🗓
 2024-02-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/helptext@4.1.2...@spectrum-css/helptext@4.1.3)
 
 **Note:** Version bump only for package @spectrum-css/helptext
 
 <a name="4.1.2"></a>
-##4.1.2
+## 4.1.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/helptext@4.1.1...@spectrum-css/helptext@4.1.2)
 
 **Note:** Version bump only for package @spectrum-css/helptext
 
 <a name="4.1.1"></a>
-##4.1.1
+## 4.1.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/helptext
 
 <a name="4.1.0"></a>
-#4.1.0
+# 4.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/helptext@4.0.64...@spectrum-css/helptext@4.1.0)
 
@@ -88,98 +88,98 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="4.0.64"></a>
-##4.0.64
+## 4.0.64
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/helptext@4.0.63...@spectrum-css/helptext@4.0.64)
 
 **Note:** Version bump only for package @spectrum-css/helptext
 
 <a name="4.0.63"></a>
-##4.0.63
+## 4.0.63
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/helptext@4.0.62...@spectrum-css/helptext@4.0.63)
 
 **Note:** Version bump only for package @spectrum-css/helptext
 
 <a name="4.0.62"></a>
-##4.0.62
+## 4.0.62
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/helptext@4.0.60...@spectrum-css/helptext@4.0.62)
 
 **Note:** Version bump only for package @spectrum-css/helptext
 
 <a name="4.0.61"></a>
-##4.0.61
+## 4.0.61
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/helptext@4.0.60...@spectrum-css/helptext@4.0.61)
 
 **Note:** Version bump only for package @spectrum-css/helptext
 
 <a name="4.0.60"></a>
-##4.0.60
+## 4.0.60
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/helptext@4.0.59...@spectrum-css/helptext@4.0.60)
 
 **Note:** Version bump only for package @spectrum-css/helptext
 
 <a name="4.0.59"></a>
-##4.0.59
+## 4.0.59
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/helptext@4.0.58...@spectrum-css/helptext@4.0.59)
 
 **Note:** Version bump only for package @spectrum-css/helptext
 
 <a name="4.0.58"></a>
-##4.0.58
+## 4.0.58
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/helptext@4.0.57...@spectrum-css/helptext@4.0.58)
 
 **Note:** Version bump only for package @spectrum-css/helptext
 
 <a name="4.0.57"></a>
-##4.0.57
+## 4.0.57
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/helptext@4.0.56...@spectrum-css/helptext@4.0.57)
 
 **Note:** Version bump only for package @spectrum-css/helptext
 
 <a name="4.0.56"></a>
-##4.0.56
+## 4.0.56
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/helptext@4.0.55...@spectrum-css/helptext@4.0.56)
 
 **Note:** Version bump only for package @spectrum-css/helptext
 
 <a name="4.0.55"></a>
-##4.0.55
+## 4.0.55
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/helptext@4.0.54...@spectrum-css/helptext@4.0.55)
 
 **Note:** Version bump only for package @spectrum-css/helptext
 
 <a name="4.0.54"></a>
-##4.0.54
+## 4.0.54
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/helptext@4.0.53...@spectrum-css/helptext@4.0.54)
 
 **Note:** Version bump only for package @spectrum-css/helptext
 
 <a name="4.0.53"></a>
-##4.0.53
+## 4.0.53
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/helptext@4.0.52...@spectrum-css/helptext@4.0.53)
 
 **Note:** Version bump only for package @spectrum-css/helptext
 
 <a name="4.0.52"></a>
-##4.0.52
+## 4.0.52
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/helptext@4.0.51...@spectrum-css/helptext@4.0.52)
 
 **Note:** Version bump only for package @spectrum-css/helptext
 
 <a name="4.0.51"></a>
-##4.0.51
+## 4.0.51
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/helptext@4.0.50...@spectrum-css/helptext@4.0.51)
 
@@ -188,105 +188,105 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="4.0.50"></a>
-##4.0.50
+## 4.0.50
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/helptext@4.0.49...@spectrum-css/helptext@4.0.50)
 
 **Note:** Version bump only for package @spectrum-css/helptext
 
 <a name="4.0.49"></a>
-##4.0.49
+## 4.0.49
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/helptext@4.0.47...@spectrum-css/helptext@4.0.49)
 
 **Note:** Version bump only for package @spectrum-css/helptext
 
 <a name="4.0.48"></a>
-##4.0.48
+## 4.0.48
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/helptext@4.0.47...@spectrum-css/helptext@4.0.48)
 
 **Note:** Version bump only for package @spectrum-css/helptext
 
 <a name="4.0.47"></a>
-##4.0.47
+## 4.0.47
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/helptext@4.0.46...@spectrum-css/helptext@4.0.47)
 
 **Note:** Version bump only for package @spectrum-css/helptext
 
 <a name="4.0.46"></a>
-##4.0.46
+## 4.0.46
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/helptext@4.0.45...@spectrum-css/helptext@4.0.46)
 
 **Note:** Version bump only for package @spectrum-css/helptext
 
 <a name="4.0.45"></a>
-##4.0.45
+## 4.0.45
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/helptext@4.0.44...@spectrum-css/helptext@4.0.45)
 
 **Note:** Version bump only for package @spectrum-css/helptext
 
 <a name="4.0.44"></a>
-##4.0.44
+## 4.0.44
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/helptext@4.0.43...@spectrum-css/helptext@4.0.44)
 
 **Note:** Version bump only for package @spectrum-css/helptext
 
 <a name="4.0.43"></a>
-##4.0.43
+## 4.0.43
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/helptext@4.0.42...@spectrum-css/helptext@4.0.43)
 
 **Note:** Version bump only for package @spectrum-css/helptext
 
 <a name="4.0.42"></a>
-##4.0.42
+## 4.0.42
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/helptext@4.0.41...@spectrum-css/helptext@4.0.42)
 
 **Note:** Version bump only for package @spectrum-css/helptext
 
 <a name="4.0.41"></a>
-##4.0.41
+## 4.0.41
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/helptext@4.0.40...@spectrum-css/helptext@4.0.41)
 
 **Note:** Version bump only for package @spectrum-css/helptext
 
 <a name="4.0.40"></a>
-##4.0.40
+## 4.0.40
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/helptext@4.0.39...@spectrum-css/helptext@4.0.40)
 
 **Note:** Version bump only for package @spectrum-css/helptext
 
 <a name="4.0.39"></a>
-##4.0.39
+## 4.0.39
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/helptext@4.0.38...@spectrum-css/helptext@4.0.39)
 
 **Note:** Version bump only for package @spectrum-css/helptext
 
 <a name="4.0.38"></a>
-##4.0.38
+## 4.0.38
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/helptext@4.0.37...@spectrum-css/helptext@4.0.38)
 
 **Note:** Version bump only for package @spectrum-css/helptext
 
 <a name="4.0.37"></a>
-##4.0.37
+## 4.0.37
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/helptext@4.0.36...@spectrum-css/helptext@4.0.37)
 
 **Note:** Version bump only for package @spectrum-css/helptext
 
 <a name="4.0.36"></a>
-##4.0.36
+## 4.0.36
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/helptext@4.0.35...@spectrum-css/helptext@4.0.36)
 
@@ -295,14 +295,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="4.0.35"></a>
-##4.0.35
+## 4.0.35
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/helptext@4.0.34...@spectrum-css/helptext@4.0.35)
 
 **Note:** Version bump only for package @spectrum-css/helptext
 
 <a name="4.0.34"></a>
-##4.0.34
+## 4.0.34
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/helptext@4.0.33...@spectrum-css/helptext@4.0.34)
 

--- a/components/icon/CHANGELOG.md
+++ b/components/icon/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="7.0.0"></a>
-#7.0.0
+# 7.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/icon@6.0.5...@spectrum-css/icon@7.0.0)
 
@@ -40,42 +40,42 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="6.0.5"></a>
-##6.0.5
+## 6.0.5
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/icon@6.0.4...@spectrum-css/icon@6.0.5)
 
 **Note:** Version bump only for package @spectrum-css/icon
 
 <a name="6.0.4"></a>
-##6.0.4
+## 6.0.4
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/icon@6.0.3...@spectrum-css/icon@6.0.4)
 
 **Note:** Version bump only for package @spectrum-css/icon
 
 <a name="6.0.3"></a>
-##6.0.3
+## 6.0.3
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/icon@6.0.2...@spectrum-css/icon@6.0.3)
 
 **Note:** Version bump only for package @spectrum-css/icon
 
 <a name="6.0.2"></a>
-##6.0.2
+## 6.0.2
 🗓
 2024-02-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/icon@6.0.1...@spectrum-css/icon@6.0.2)
 
 **Note:** Version bump only for package @spectrum-css/icon
 
 <a name="6.0.1"></a>
-##6.0.1
+## 6.0.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/icon
 
 <a name="6.0.0"></a>
-#6.0.0
+# 6.0.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/icon@5.1.0...@spectrum-css/icon@6.0.0)
 
@@ -200,7 +200,7 @@ Update required tokens version with a minimum of the latest release that
 includes the new custom-vars for the xxl and xxs workflow icon sizes.
 
 <a name="5.1.0"></a>
-#5.1.0
+# 5.1.0
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/icon@5.0.1...@spectrum-css/icon@5.1.0)
 
@@ -209,14 +209,14 @@ includes the new custom-vars for the xxl and xxs workflow icon sizes.
 - **overlay,commons:**deprecate overlay; migrate references to commons ([#2429](https://github.com/adobe/spectrum-css/issues/2429))([7eecd96](https://github.com/adobe/spectrum-css/commit/7eecd96))
 
 <a name="5.0.1"></a>
-##5.0.1
+## 5.0.1
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/icon@5.0.0...@spectrum-css/icon@5.0.1)
 
 **Note:** Version bump only for package @spectrum-css/icon
 
 <a name="5.0.0"></a>
-#5.0.0
+# 5.0.0
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/icon@4.0.5...@spectrum-css/icon@5.0.0)
 
@@ -231,28 +231,28 @@ includes the new custom-vars for the xxl and xxs workflow icon sizes.
 - NEW: @spectrum-css/ui-icons package for all SVG icons in the UI set.
 
 <a name="4.0.5"></a>
-##4.0.5
+## 4.0.5
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/icon@4.0.3...@spectrum-css/icon@4.0.5)
 
 **Note:** Version bump only for package @spectrum-css/icon
 
 <a name="4.0.4"></a>
-##4.0.4
+## 4.0.4
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/icon@4.0.3...@spectrum-css/icon@4.0.4)
 
 **Note:** Version bump only for package @spectrum-css/icon
 
 <a name="4.0.3"></a>
-##4.0.3
+## 4.0.3
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/icon@4.0.2...@spectrum-css/icon@4.0.3)
 
 **Note:** Version bump only for package @spectrum-css/icon
 
 <a name="4.0.2"></a>
-##4.0.2
+## 4.0.2
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/icon@4.0.1...@spectrum-css/icon@4.0.2)
 
@@ -261,14 +261,14 @@ includes the new custom-vars for the xxl and xxs workflow icon sizes.
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="4.0.1"></a>
-##4.0.1
+## 4.0.1
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/icon@4.0.0...@spectrum-css/icon@4.0.1)
 
 **Note:** Version bump only for package @spectrum-css/icon
 
 <a name="4.0.0"></a>
-#4.0.0
+# 4.0.0
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/icon@3.0.50...@spectrum-css/icon@4.0.0)
 
@@ -379,7 +379,7 @@ This reverts commit a404f9505d8125277ed5eda0312289a0468a527f.
 - chore(sidenav): manual version increase for beta release
 
 <a name="3.0.50"></a>
-##3.0.50
+## 3.0.50
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/icon@3.0.49...@spectrum-css/icon@3.0.50)
 
@@ -388,21 +388,21 @@ This reverts commit a404f9505d8125277ed5eda0312289a0468a527f.
 \*icon sizing in Storybook story templates ([#2037](https://github.com/adobe/spectrum-css/issues/2037))([c90c8a3](https://github.com/adobe/spectrum-css/commit/c90c8a3))
 
 <a name="3.0.49"></a>
-##3.0.49
+## 3.0.49
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/icon@3.0.48...@spectrum-css/icon@3.0.49)
 
 **Note:** Version bump only for package @spectrum-css/icon
 
 <a name="3.0.48"></a>
-##3.0.48
+## 3.0.48
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/icon@3.0.47...@spectrum-css/icon@3.0.48)
 
 **Note:** Version bump only for package @spectrum-css/icon
 
 <a name="3.0.47"></a>
-##3.0.47
+## 3.0.47
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/icon@3.0.46...@spectrum-css/icon@3.0.47)
 
@@ -411,14 +411,14 @@ This reverts commit a404f9505d8125277ed5eda0312289a0468a527f.
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="3.0.46"></a>
-##3.0.46
+## 3.0.46
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/icon@3.0.45...@spectrum-css/icon@3.0.46)
 
 **Note:** Version bump only for package @spectrum-css/icon
 
 <a name="3.0.45"></a>
-##3.0.45
+## 3.0.45
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/icon@3.0.44...@spectrum-css/icon@3.0.45)
 

--- a/components/icon/CHANGELOG.md
+++ b/components/icon/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="7.0.0"></a>
-# 7.0.0
+## 7.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/icon@6.0.5...@spectrum-css/icon@7.0.0)
 
@@ -75,7 +75,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/icon
 
 <a name="6.0.0"></a>
-# 6.0.0
+## 6.0.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/icon@5.1.0...@spectrum-css/icon@6.0.0)
 
@@ -200,7 +200,7 @@ Update required tokens version with a minimum of the latest release that
 includes the new custom-vars for the xxl and xxs workflow icon sizes.
 
 <a name="5.1.0"></a>
-# 5.1.0
+## 5.1.0
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/icon@5.0.1...@spectrum-css/icon@5.1.0)
 
@@ -216,7 +216,7 @@ includes the new custom-vars for the xxl and xxs workflow icon sizes.
 **Note:** Version bump only for package @spectrum-css/icon
 
 <a name="5.0.0"></a>
-# 5.0.0
+## 5.0.0
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/icon@4.0.5...@spectrum-css/icon@5.0.0)
 
@@ -268,7 +268,7 @@ includes the new custom-vars for the xxl and xxs workflow icon sizes.
 **Note:** Version bump only for package @spectrum-css/icon
 
 <a name="4.0.0"></a>
-# 4.0.0
+## 4.0.0
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/icon@3.0.50...@spectrum-css/icon@4.0.0)
 
@@ -817,7 +817,7 @@ This reverts commit a404f9505d8125277ed5eda0312289a0468a527f.
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/icon@3.0.0-beta.2...@spectrum-css/icon@3.0.0)
 
@@ -825,7 +825,7 @@ This reverts commit a404f9505d8125277ed5eda0312289a0468a527f.
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/icon@3.0.0-beta.1...@spectrum-css/icon@3.0.0-beta.2)
 
@@ -845,7 +845,7 @@ This reverts commit a404f9505d8125277ed5eda0312289a0468a527f.
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/icon@3.0.0-beta.0...@spectrum-css/icon@3.0.0-beta.1)
 
@@ -853,7 +853,7 @@ This reverts commit a404f9505d8125277ed5eda0312289a0468a527f.
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/icon@2.1.1...@spectrum-css/icon@3.0.0-beta.0)
 
@@ -879,7 +879,7 @@ This reverts commit a404f9505d8125277ed5eda0312289a0468a527f.
 
 <a name="2.1.0"></a>
 
-# 2.1.0
+## 2.1.0
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/icon@2.0.5...@spectrum-css/icon@2.1.0)
 
@@ -929,7 +929,7 @@ This reverts commit a404f9505d8125277ed5eda0312289a0468a527f.
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/illustratedmessage/CHANGELOG.md
+++ b/components/illustratedmessage/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="7.0.0"></a>
-#7.0.0
+# 7.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@6.1.5...@spectrum-css/illustratedmessage@7.0.0)
 
@@ -44,42 +44,42 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="6.1.5"></a>
-##6.1.5
+## 6.1.5
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@6.1.4...@spectrum-css/illustratedmessage@6.1.5)
 
 **Note:** Version bump only for package @spectrum-css/illustratedmessage
 
 <a name="6.1.4"></a>
-##6.1.4
+## 6.1.4
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@6.1.3...@spectrum-css/illustratedmessage@6.1.4)
 
 **Note:** Version bump only for package @spectrum-css/illustratedmessage
 
 <a name="6.1.3"></a>
-##6.1.3
+## 6.1.3
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@6.1.2...@spectrum-css/illustratedmessage@6.1.3)
 
 **Note:** Version bump only for package @spectrum-css/illustratedmessage
 
 <a name="6.1.2"></a>
-##6.1.2
+## 6.1.2
 🗓
 2024-02-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@6.1.1...@spectrum-css/illustratedmessage@6.1.2)
 
 **Note:** Version bump only for package @spectrum-css/illustratedmessage
 
 <a name="6.1.1"></a>
-##6.1.1
+## 6.1.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/illustratedmessage
 
 <a name="6.1.0"></a>
-#6.1.0
+# 6.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@6.0.31...@spectrum-css/illustratedmessage@6.1.0)
 
@@ -88,98 +88,98 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="6.0.31"></a>
-##6.0.31
+## 6.0.31
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@6.0.30...@spectrum-css/illustratedmessage@6.0.31)
 
 **Note:** Version bump only for package @spectrum-css/illustratedmessage
 
 <a name="6.0.30"></a>
-##6.0.30
+## 6.0.30
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@6.0.29...@spectrum-css/illustratedmessage@6.0.30)
 
 **Note:** Version bump only for package @spectrum-css/illustratedmessage
 
 <a name="6.0.29"></a>
-##6.0.29
+## 6.0.29
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@6.0.27...@spectrum-css/illustratedmessage@6.0.29)
 
 **Note:** Version bump only for package @spectrum-css/illustratedmessage
 
 <a name="6.0.28"></a>
-##6.0.28
+## 6.0.28
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@6.0.27...@spectrum-css/illustratedmessage@6.0.28)
 
 **Note:** Version bump only for package @spectrum-css/illustratedmessage
 
 <a name="6.0.27"></a>
-##6.0.27
+## 6.0.27
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@6.0.26...@spectrum-css/illustratedmessage@6.0.27)
 
 **Note:** Version bump only for package @spectrum-css/illustratedmessage
 
 <a name="6.0.26"></a>
-##6.0.26
+## 6.0.26
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@6.0.25...@spectrum-css/illustratedmessage@6.0.26)
 
 **Note:** Version bump only for package @spectrum-css/illustratedmessage
 
 <a name="6.0.25"></a>
-##6.0.25
+## 6.0.25
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@6.0.24...@spectrum-css/illustratedmessage@6.0.25)
 
 **Note:** Version bump only for package @spectrum-css/illustratedmessage
 
 <a name="6.0.24"></a>
-##6.0.24
+## 6.0.24
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@6.0.23...@spectrum-css/illustratedmessage@6.0.24)
 
 **Note:** Version bump only for package @spectrum-css/illustratedmessage
 
 <a name="6.0.23"></a>
-##6.0.23
+## 6.0.23
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@6.0.22...@spectrum-css/illustratedmessage@6.0.23)
 
 **Note:** Version bump only for package @spectrum-css/illustratedmessage
 
 <a name="6.0.22"></a>
-##6.0.22
+## 6.0.22
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@6.0.21...@spectrum-css/illustratedmessage@6.0.22)
 
 **Note:** Version bump only for package @spectrum-css/illustratedmessage
 
 <a name="6.0.21"></a>
-##6.0.21
+## 6.0.21
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@6.0.20...@spectrum-css/illustratedmessage@6.0.21)
 
 **Note:** Version bump only for package @spectrum-css/illustratedmessage
 
 <a name="6.0.20"></a>
-##6.0.20
+## 6.0.20
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@6.0.19...@spectrum-css/illustratedmessage@6.0.20)
 
 **Note:** Version bump only for package @spectrum-css/illustratedmessage
 
 <a name="6.0.19"></a>
-##6.0.19
+## 6.0.19
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@6.0.18...@spectrum-css/illustratedmessage@6.0.19)
 
 **Note:** Version bump only for package @spectrum-css/illustratedmessage
 
 <a name="6.0.18"></a>
-##6.0.18
+## 6.0.18
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@6.0.17...@spectrum-css/illustratedmessage@6.0.18)
 
@@ -188,105 +188,105 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="6.0.17"></a>
-##6.0.17
+## 6.0.17
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@6.0.16...@spectrum-css/illustratedmessage@6.0.17)
 
 **Note:** Version bump only for package @spectrum-css/illustratedmessage
 
 <a name="6.0.16"></a>
-##6.0.16
+## 6.0.16
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@6.0.14...@spectrum-css/illustratedmessage@6.0.16)
 
 **Note:** Version bump only for package @spectrum-css/illustratedmessage
 
 <a name="6.0.15"></a>
-##6.0.15
+## 6.0.15
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@6.0.14...@spectrum-css/illustratedmessage@6.0.15)
 
 **Note:** Version bump only for package @spectrum-css/illustratedmessage
 
 <a name="6.0.14"></a>
-##6.0.14
+## 6.0.14
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@6.0.13...@spectrum-css/illustratedmessage@6.0.14)
 
 **Note:** Version bump only for package @spectrum-css/illustratedmessage
 
 <a name="6.0.13"></a>
-##6.0.13
+## 6.0.13
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@6.0.12...@spectrum-css/illustratedmessage@6.0.13)
 
 **Note:** Version bump only for package @spectrum-css/illustratedmessage
 
 <a name="6.0.12"></a>
-##6.0.12
+## 6.0.12
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@6.0.11...@spectrum-css/illustratedmessage@6.0.12)
 
 **Note:** Version bump only for package @spectrum-css/illustratedmessage
 
 <a name="6.0.11"></a>
-##6.0.11
+## 6.0.11
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@6.0.10...@spectrum-css/illustratedmessage@6.0.11)
 
 **Note:** Version bump only for package @spectrum-css/illustratedmessage
 
 <a name="6.0.10"></a>
-##6.0.10
+## 6.0.10
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@6.0.9...@spectrum-css/illustratedmessage@6.0.10)
 
 **Note:** Version bump only for package @spectrum-css/illustratedmessage
 
 <a name="6.0.9"></a>
-##6.0.9
+## 6.0.9
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@6.0.8...@spectrum-css/illustratedmessage@6.0.9)
 
 **Note:** Version bump only for package @spectrum-css/illustratedmessage
 
 <a name="6.0.8"></a>
-##6.0.8
+## 6.0.8
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@6.0.7...@spectrum-css/illustratedmessage@6.0.8)
 
 **Note:** Version bump only for package @spectrum-css/illustratedmessage
 
 <a name="6.0.7"></a>
-##6.0.7
+## 6.0.7
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@6.0.6...@spectrum-css/illustratedmessage@6.0.7)
 
 **Note:** Version bump only for package @spectrum-css/illustratedmessage
 
 <a name="6.0.6"></a>
-##6.0.6
+## 6.0.6
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@6.0.5...@spectrum-css/illustratedmessage@6.0.6)
 
 **Note:** Version bump only for package @spectrum-css/illustratedmessage
 
 <a name="6.0.5"></a>
-##6.0.5
+## 6.0.5
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@6.0.4...@spectrum-css/illustratedmessage@6.0.5)
 
 **Note:** Version bump only for package @spectrum-css/illustratedmessage
 
 <a name="6.0.4"></a>
-##6.0.4
+## 6.0.4
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@6.0.3...@spectrum-css/illustratedmessage@6.0.4)
 
 **Note:** Version bump only for package @spectrum-css/illustratedmessage
 
 <a name="6.0.3"></a>
-##6.0.3
+## 6.0.3
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@6.0.2...@spectrum-css/illustratedmessage@6.0.3)
 
@@ -295,14 +295,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="6.0.2"></a>
-##6.0.2
+## 6.0.2
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@6.0.1...@spectrum-css/illustratedmessage@6.0.2)
 
 **Note:** Version bump only for package @spectrum-css/illustratedmessage
 
 <a name="6.0.1"></a>
-##6.0.1
+## 6.0.1
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@6.0.0...@spectrum-css/illustratedmessage@6.0.1)
 

--- a/components/illustratedmessage/CHANGELOG.md
+++ b/components/illustratedmessage/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="7.0.0"></a>
-# 7.0.0
+## 7.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@6.1.5...@spectrum-css/illustratedmessage@7.0.0)
 
@@ -79,7 +79,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/illustratedmessage
 
 <a name="6.1.0"></a>
-# 6.1.0
+## 6.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@6.0.31...@spectrum-css/illustratedmessage@6.1.0)
 
@@ -310,7 +310,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="6.0.0"></a>
 
-# 6.0.0
+## 6.0.0
 
 🗓 2023-05-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@5.0.18...@spectrum-css/illustratedmessage@6.0.0)
 
@@ -468,7 +468,7 @@ Also updates IllustratedMessage and ActionButton to share `--mod-` properties.
 
 <a name="5.0.0"></a>
 
-# 5.0.0
+## 5.0.0
 
 🗓 2023-04-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@4.0.19...@spectrum-css/illustratedmessage@5.0.0)
 
@@ -637,7 +637,7 @@ Also updates IllustratedMessage and ActionButton to share `--mod-` properties.
 
 <a name="4.0.0"></a>
 
-# 4.0.0
+## 4.0.0
 
 🗓 2022-03-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@3.0.17...@spectrum-css/illustratedmessage@4.0.0)
 
@@ -833,7 +833,7 @@ Also updates IllustratedMessage and ActionButton to share `--mod-` properties.
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@3.0.0-beta.5...@spectrum-css/illustratedmessage@3.0.0)
 
@@ -841,7 +841,7 @@ Also updates IllustratedMessage and ActionButton to share `--mod-` properties.
 
 <a name="3.0.0-beta.5"></a>
 
-# 3.0.0-beta.5
+## 3.0.0-beta.5
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@3.0.0-beta.4...@spectrum-css/illustratedmessage@3.0.0-beta.5)
 
@@ -849,7 +849,7 @@ Also updates IllustratedMessage and ActionButton to share `--mod-` properties.
 
 <a name="3.0.0-beta.4"></a>
 
-# 3.0.0-beta.4
+## 3.0.0-beta.4
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@3.0.0-beta.3...@spectrum-css/illustratedmessage@3.0.0-beta.4)
 
@@ -861,7 +861,7 @@ Also updates IllustratedMessage and ActionButton to share `--mod-` properties.
 
 <a name="3.0.0-beta.3"></a>
 
-# 3.0.0-beta.3
+## 3.0.0-beta.3
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@3.0.0-beta.2...@spectrum-css/illustratedmessage@3.0.0-beta.3)
 
@@ -869,7 +869,7 @@ Also updates IllustratedMessage and ActionButton to share `--mod-` properties.
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@3.0.0-beta.1...@spectrum-css/illustratedmessage@3.0.0-beta.2)
 
@@ -877,7 +877,7 @@ Also updates IllustratedMessage and ActionButton to share `--mod-` properties.
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@3.0.0-beta.0...@spectrum-css/illustratedmessage@3.0.0-beta.1)
 
@@ -885,7 +885,7 @@ Also updates IllustratedMessage and ActionButton to share `--mod-` properties.
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@2.1.1...@spectrum-css/illustratedmessage@3.0.0-beta.0)
 
@@ -903,7 +903,7 @@ Also updates IllustratedMessage and ActionButton to share `--mod-` properties.
 
 <a name="2.1.0"></a>
 
-# 2.1.0
+## 2.1.0
 
 🗓 2020-02-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/illustratedmessage@2.0.3...@spectrum-css/illustratedmessage@2.1.0)
 
@@ -937,7 +937,7 @@ Also updates IllustratedMessage and ActionButton to share `--mod-` properties.
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/infieldbutton/CHANGELOG.md
+++ b/components/infieldbutton/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-# 5.0.0
+## 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/infieldbutton@4.2.4...@spectrum-css/infieldbutton@5.0.0)
 
@@ -72,14 +72,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/infieldbutton
 
 <a name="4.2.0"></a>
-# 4.2.0
+## 4.2.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/infieldbutton@4.1.0...@spectrum-css/infieldbutton@4.2.0)
 
 **Note:** Version bump only for package @spectrum-css/infieldbutton
 
 <a name="4.1.0"></a>
-# 4.1.0
+## 4.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/infieldbutton@4.0.6...@spectrum-css/infieldbutton@4.1.0)
 
@@ -139,7 +139,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/infieldbutton
 
 <a name="4.0.0"></a>
-# 4.0.0
+## 4.0.0
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/infieldbutton@3.0.14...@spectrum-css/infieldbutton@4.0.0)
 
@@ -362,7 +362,7 @@ ellipsis at medium size, instead of 3. Was a matter of 1 or 2 pixels.
 **Note:** Version bump only for package @spectrum-css/infieldbutton
 
 <a name="3.0.0"></a>
-# 3.0.0
+## 3.0.0
 🗓
 2023-07-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/infieldbutton@2.0.27...@spectrum-css/infieldbutton@3.0.0)
 
@@ -592,7 +592,7 @@ docs(infieldbutton): remove small stacked variant from docs
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2022-10-25 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/infieldbutton@1.1.9...@spectrum-css/infieldbutton@2.0.0)
 
@@ -676,7 +676,7 @@ docs(infieldbutton): remove small stacked variant from docs
 
 <a name="1.1.0"></a>
 
-# 1.1.0
+## 1.1.0
 
 🗓 2022-02-16
 

--- a/components/infieldbutton/CHANGELOG.md
+++ b/components/infieldbutton/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-#5.0.0
+# 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/infieldbutton@4.2.4...@spectrum-css/infieldbutton@5.0.0)
 
@@ -44,42 +44,42 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="4.2.4"></a>
-##4.2.4
+## 4.2.4
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/infieldbutton@4.2.3...@spectrum-css/infieldbutton@4.2.4)
 
 **Note:** Version bump only for package @spectrum-css/infieldbutton
 
 <a name="4.2.3"></a>
-##4.2.3
+## 4.2.3
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/infieldbutton@4.2.2...@spectrum-css/infieldbutton@4.2.3)
 
 **Note:** Version bump only for package @spectrum-css/infieldbutton
 
 <a name="4.2.2"></a>
-##4.2.2
+## 4.2.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/infieldbutton@4.2.1...@spectrum-css/infieldbutton@4.2.2)
 
 **Note:** Version bump only for package @spectrum-css/infieldbutton
 
 <a name="4.2.1"></a>
-##4.2.1
+## 4.2.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/infieldbutton
 
 <a name="4.2.0"></a>
-#4.2.0
+# 4.2.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/infieldbutton@4.1.0...@spectrum-css/infieldbutton@4.2.0)
 
 **Note:** Version bump only for package @spectrum-css/infieldbutton
 
 <a name="4.1.0"></a>
-#4.1.0
+# 4.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/infieldbutton@4.0.6...@spectrum-css/infieldbutton@4.1.0)
 
@@ -94,7 +94,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
   **stepper:**infieldbutton isnt focusable in stepper([4529874](https://github.com/adobe/spectrum-css/commit/4529874))
 
 <a name="4.0.6"></a>
-##4.0.6
+## 4.0.6
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/infieldbutton@4.0.5...@spectrum-css/infieldbutton@4.0.6)
 
@@ -104,42 +104,42 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
   **stepper:**no longer touches InfieldButton classes ([#2300](https://github.com/adobe/spectrum-css/issues/2300))([a82b8ad](https://github.com/adobe/spectrum-css/commit/a82b8ad))
 
 <a name="4.0.5"></a>
-##4.0.5
+## 4.0.5
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/infieldbutton@4.0.4...@spectrum-css/infieldbutton@4.0.5)
 
 **Note:** Version bump only for package @spectrum-css/infieldbutton
 
 <a name="4.0.4"></a>
-##4.0.4
+## 4.0.4
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/infieldbutton@4.0.2...@spectrum-css/infieldbutton@4.0.4)
 
 **Note:** Version bump only for package @spectrum-css/infieldbutton
 
 <a name="4.0.3"></a>
-##4.0.3
+## 4.0.3
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/infieldbutton@4.0.2...@spectrum-css/infieldbutton@4.0.3)
 
 **Note:** Version bump only for package @spectrum-css/infieldbutton
 
 <a name="4.0.2"></a>
-##4.0.2
+## 4.0.2
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/infieldbutton@4.0.1...@spectrum-css/infieldbutton@4.0.2)
 
 **Note:** Version bump only for package @spectrum-css/infieldbutton
 
 <a name="4.0.1"></a>
-##4.0.1
+## 4.0.1
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/infieldbutton@4.0.0...@spectrum-css/infieldbutton@4.0.1)
 
 **Note:** Version bump only for package @spectrum-css/infieldbutton
 
 <a name="4.0.0"></a>
-#4.0.0
+# 4.0.0
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/infieldbutton@3.0.14...@spectrum-css/infieldbutton@4.0.0)
 
@@ -262,49 +262,49 @@ Also needed to add border width to calc, so that 4 chars appear before
 ellipsis at medium size, instead of 3. Was a matter of 1 or 2 pixels.
 
 <a name="3.0.14"></a>
-##3.0.14
+## 3.0.14
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/infieldbutton@3.0.13...@spectrum-css/infieldbutton@3.0.14)
 
 **Note:** Version bump only for package @spectrum-css/infieldbutton
 
 <a name="3.0.13"></a>
-##3.0.13
+## 3.0.13
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/infieldbutton@3.0.12...@spectrum-css/infieldbutton@3.0.13)
 
 **Note:** Version bump only for package @spectrum-css/infieldbutton
 
 <a name="3.0.12"></a>
-##3.0.12
+## 3.0.12
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/infieldbutton@3.0.11...@spectrum-css/infieldbutton@3.0.12)
 
 **Note:** Version bump only for package @spectrum-css/infieldbutton
 
 <a name="3.0.11"></a>
-##3.0.11
+## 3.0.11
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/infieldbutton@3.0.10...@spectrum-css/infieldbutton@3.0.11)
 
 **Note:** Version bump only for package @spectrum-css/infieldbutton
 
 <a name="3.0.10"></a>
-##3.0.10
+## 3.0.10
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/infieldbutton@3.0.9...@spectrum-css/infieldbutton@3.0.10)
 
 **Note:** Version bump only for package @spectrum-css/infieldbutton
 
 <a name="3.0.9"></a>
-##3.0.9
+## 3.0.9
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/infieldbutton@3.0.8...@spectrum-css/infieldbutton@3.0.9)
 
 **Note:** Version bump only for package @spectrum-css/infieldbutton
 
 <a name="3.0.8"></a>
-##3.0.8
+## 3.0.8
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/infieldbutton@3.0.7...@spectrum-css/infieldbutton@3.0.8)
 
@@ -313,56 +313,56 @@ ellipsis at medium size, instead of 3. Was a matter of 1 or 2 pixels.
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="3.0.7"></a>
-##3.0.7
+## 3.0.7
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/infieldbutton@3.0.6...@spectrum-css/infieldbutton@3.0.7)
 
 **Note:** Version bump only for package @spectrum-css/infieldbutton
 
 <a name="3.0.6"></a>
-##3.0.6
+## 3.0.6
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/infieldbutton@3.0.4...@spectrum-css/infieldbutton@3.0.6)
 
 **Note:** Version bump only for package @spectrum-css/infieldbutton
 
 <a name="3.0.5"></a>
-##3.0.5
+## 3.0.5
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/infieldbutton@3.0.4...@spectrum-css/infieldbutton@3.0.5)
 
 **Note:** Version bump only for package @spectrum-css/infieldbutton
 
 <a name="3.0.4"></a>
-##3.0.4
+## 3.0.4
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/infieldbutton@3.0.3...@spectrum-css/infieldbutton@3.0.4)
 
 **Note:** Version bump only for package @spectrum-css/infieldbutton
 
 <a name="3.0.3"></a>
-##3.0.3
+## 3.0.3
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/infieldbutton@3.0.2...@spectrum-css/infieldbutton@3.0.3)
 
 **Note:** Version bump only for package @spectrum-css/infieldbutton
 
 <a name="3.0.2"></a>
-##3.0.2
+## 3.0.2
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/infieldbutton@3.0.1...@spectrum-css/infieldbutton@3.0.2)
 
 **Note:** Version bump only for package @spectrum-css/infieldbutton
 
 <a name="3.0.1"></a>
-##3.0.1
+## 3.0.1
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/infieldbutton@3.0.0...@spectrum-css/infieldbutton@3.0.1)
 
 **Note:** Version bump only for package @spectrum-css/infieldbutton
 
 <a name="3.0.0"></a>
-#3.0.0
+# 3.0.0
 🗓
 2023-07-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/infieldbutton@2.0.27...@spectrum-css/infieldbutton@3.0.0)
 
@@ -377,7 +377,7 @@ ellipsis at medium size, instead of 3. Was a matter of 1 or 2 pixels.
 docs(infieldbutton): remove small stacked variant from docs
 
 <a name="2.0.27"></a>
-##2.0.27
+## 2.0.27
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/infieldbutton@2.0.26...@spectrum-css/infieldbutton@2.0.27)
 
@@ -386,21 +386,21 @@ docs(infieldbutton): remove small stacked variant from docs
 \*icon sizing in Storybook story templates ([#2037](https://github.com/adobe/spectrum-css/issues/2037))([c90c8a3](https://github.com/adobe/spectrum-css/commit/c90c8a3))
 
 <a name="2.0.26"></a>
-##2.0.26
+## 2.0.26
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/infieldbutton@2.0.25...@spectrum-css/infieldbutton@2.0.26)
 
 **Note:** Version bump only for package @spectrum-css/infieldbutton
 
 <a name="2.0.25"></a>
-##2.0.25
+## 2.0.25
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/infieldbutton@2.0.24...@spectrum-css/infieldbutton@2.0.25)
 
 **Note:** Version bump only for package @spectrum-css/infieldbutton
 
 <a name="2.0.24"></a>
-##2.0.24
+## 2.0.24
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/infieldbutton@2.0.23...@spectrum-css/infieldbutton@2.0.24)
 
@@ -409,14 +409,14 @@ docs(infieldbutton): remove small stacked variant from docs
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="2.0.23"></a>
-##2.0.23
+## 2.0.23
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/infieldbutton@2.0.22...@spectrum-css/infieldbutton@2.0.23)
 
 **Note:** Version bump only for package @spectrum-css/infieldbutton
 
 <a name="2.0.22"></a>
-##2.0.22
+## 2.0.22
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/infieldbutton@2.0.21...@spectrum-css/infieldbutton@2.0.22)
 

--- a/components/inlinealert/CHANGELOG.md
+++ b/components/inlinealert/CHANGELOG.md
@@ -31,7 +31,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="8.0.0"></a>
-#8.0.0
+# 8.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@7.1.6...@spectrum-css/inlinealert@8.0.0)
 
@@ -46,49 +46,49 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="7.1.6"></a>
-##7.1.6
+## 7.1.6
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@7.1.5...@spectrum-css/inlinealert@7.1.6)
 
 **Note:** Version bump only for package @spectrum-css/inlinealert
 
 <a name="7.1.5"></a>
-##7.1.5
+## 7.1.5
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@7.1.4...@spectrum-css/inlinealert@7.1.5)
 
 **Note:** Version bump only for package @spectrum-css/inlinealert
 
 <a name="7.1.4"></a>
-##7.1.4
+## 7.1.4
 🗓
 2024-02-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@7.1.3...@spectrum-css/inlinealert@7.1.4)
 
 **Note:** Version bump only for package @spectrum-css/inlinealert
 
 <a name="7.1.3"></a>
-##7.1.3
+## 7.1.3
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@7.1.2...@spectrum-css/inlinealert@7.1.3)
 
 **Note:** Version bump only for package @spectrum-css/inlinealert
 
 <a name="7.1.2"></a>
-##7.1.2
+## 7.1.2
 🗓
 2024-02-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@7.1.1...@spectrum-css/inlinealert@7.1.2)
 
 **Note:** Version bump only for package @spectrum-css/inlinealert
 
 <a name="7.1.1"></a>
-##7.1.1
+## 7.1.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/inlinealert
 
 <a name="7.1.0"></a>
-#7.1.0
+# 7.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@7.0.56...@spectrum-css/inlinealert@7.1.0)
 
@@ -97,105 +97,105 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="7.0.56"></a>
-##7.0.56
+## 7.0.56
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@7.0.55...@spectrum-css/inlinealert@7.0.56)
 
 **Note:** Version bump only for package @spectrum-css/inlinealert
 
 <a name="7.0.55"></a>
-##7.0.55
+## 7.0.55
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@7.0.54...@spectrum-css/inlinealert@7.0.55)
 
 **Note:** Version bump only for package @spectrum-css/inlinealert
 
 <a name="7.0.54"></a>
-##7.0.54
+## 7.0.54
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@7.0.52...@spectrum-css/inlinealert@7.0.54)
 
 **Note:** Version bump only for package @spectrum-css/inlinealert
 
 <a name="7.0.53"></a>
-##7.0.53
+## 7.0.53
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@7.0.52...@spectrum-css/inlinealert@7.0.53)
 
 **Note:** Version bump only for package @spectrum-css/inlinealert
 
 <a name="7.0.52"></a>
-##7.0.52
+## 7.0.52
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@7.0.51...@spectrum-css/inlinealert@7.0.52)
 
 **Note:** Version bump only for package @spectrum-css/inlinealert
 
 <a name="7.0.51"></a>
-##7.0.51
+## 7.0.51
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@7.0.50...@spectrum-css/inlinealert@7.0.51)
 
 **Note:** Version bump only for package @spectrum-css/inlinealert
 
 <a name="7.0.50"></a>
-##7.0.50
+## 7.0.50
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@7.0.49...@spectrum-css/inlinealert@7.0.50)
 
 **Note:** Version bump only for package @spectrum-css/inlinealert
 
 <a name="7.0.49"></a>
-##7.0.49
+## 7.0.49
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@7.0.48...@spectrum-css/inlinealert@7.0.49)
 
 **Note:** Version bump only for package @spectrum-css/inlinealert
 
 <a name="7.0.48"></a>
-##7.0.48
+## 7.0.48
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@7.0.47...@spectrum-css/inlinealert@7.0.48)
 
 **Note:** Version bump only for package @spectrum-css/inlinealert
 
 <a name="7.0.47"></a>
-##7.0.47
+## 7.0.47
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@7.0.46...@spectrum-css/inlinealert@7.0.47)
 
 **Note:** Version bump only for package @spectrum-css/inlinealert
 
 <a name="7.0.46"></a>
-##7.0.46
+## 7.0.46
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@7.0.45...@spectrum-css/inlinealert@7.0.46)
 
 **Note:** Version bump only for package @spectrum-css/inlinealert
 
 <a name="7.0.45"></a>
-##7.0.45
+## 7.0.45
 🗓
 2023-09-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@7.0.44...@spectrum-css/inlinealert@7.0.45)
 
 **Note:** Version bump only for package @spectrum-css/inlinealert
 
 <a name="7.0.44"></a>
-##7.0.44
+## 7.0.44
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@7.0.43...@spectrum-css/inlinealert@7.0.44)
 
 **Note:** Version bump only for package @spectrum-css/inlinealert
 
 <a name="7.0.43"></a>
-##7.0.43
+## 7.0.43
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@7.0.42...@spectrum-css/inlinealert@7.0.43)
 
 **Note:** Version bump only for package @spectrum-css/inlinealert
 
 <a name="7.0.42"></a>
-##7.0.42
+## 7.0.42
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@7.0.41...@spectrum-css/inlinealert@7.0.42)
 
@@ -204,105 +204,105 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="7.0.41"></a>
-##7.0.41
+## 7.0.41
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@7.0.40...@spectrum-css/inlinealert@7.0.41)
 
 **Note:** Version bump only for package @spectrum-css/inlinealert
 
 <a name="7.0.40"></a>
-##7.0.40
+## 7.0.40
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@7.0.38...@spectrum-css/inlinealert@7.0.40)
 
 **Note:** Version bump only for package @spectrum-css/inlinealert
 
 <a name="7.0.39"></a>
-##7.0.39
+## 7.0.39
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@7.0.38...@spectrum-css/inlinealert@7.0.39)
 
 **Note:** Version bump only for package @spectrum-css/inlinealert
 
 <a name="7.0.38"></a>
-##7.0.38
+## 7.0.38
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@7.0.37...@spectrum-css/inlinealert@7.0.38)
 
 **Note:** Version bump only for package @spectrum-css/inlinealert
 
 <a name="7.0.37"></a>
-##7.0.37
+## 7.0.37
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@7.0.36...@spectrum-css/inlinealert@7.0.37)
 
 **Note:** Version bump only for package @spectrum-css/inlinealert
 
 <a name="7.0.36"></a>
-##7.0.36
+## 7.0.36
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@7.0.35...@spectrum-css/inlinealert@7.0.36)
 
 **Note:** Version bump only for package @spectrum-css/inlinealert
 
 <a name="7.0.35"></a>
-##7.0.35
+## 7.0.35
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@7.0.34...@spectrum-css/inlinealert@7.0.35)
 
 **Note:** Version bump only for package @spectrum-css/inlinealert
 
 <a name="7.0.34"></a>
-##7.0.34
+## 7.0.34
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@7.0.33...@spectrum-css/inlinealert@7.0.34)
 
 **Note:** Version bump only for package @spectrum-css/inlinealert
 
 <a name="7.0.33"></a>
-##7.0.33
+## 7.0.33
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@7.0.32...@spectrum-css/inlinealert@7.0.33)
 
 **Note:** Version bump only for package @spectrum-css/inlinealert
 
 <a name="7.0.32"></a>
-##7.0.32
+## 7.0.32
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@7.0.31...@spectrum-css/inlinealert@7.0.32)
 
 **Note:** Version bump only for package @spectrum-css/inlinealert
 
 <a name="7.0.31"></a>
-##7.0.31
+## 7.0.31
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@7.0.30...@spectrum-css/inlinealert@7.0.31)
 
 **Note:** Version bump only for package @spectrum-css/inlinealert
 
 <a name="7.0.30"></a>
-##7.0.30
+## 7.0.30
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@7.0.29...@spectrum-css/inlinealert@7.0.30)
 
 **Note:** Version bump only for package @spectrum-css/inlinealert
 
 <a name="7.0.29"></a>
-##7.0.29
+## 7.0.29
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@7.0.28...@spectrum-css/inlinealert@7.0.29)
 
 **Note:** Version bump only for package @spectrum-css/inlinealert
 
 <a name="7.0.28"></a>
-##7.0.28
+## 7.0.28
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@7.0.27...@spectrum-css/inlinealert@7.0.28)
 
 **Note:** Version bump only for package @spectrum-css/inlinealert
 
 <a name="7.0.27"></a>
-##7.0.27
+## 7.0.27
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@7.0.26...@spectrum-css/inlinealert@7.0.27)
 
@@ -311,14 +311,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="7.0.26"></a>
-##7.0.26
+## 7.0.26
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@7.0.25...@spectrum-css/inlinealert@7.0.26)
 
 **Note:** Version bump only for package @spectrum-css/inlinealert
 
 <a name="7.0.25"></a>
-##7.0.25
+## 7.0.25
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@7.0.24...@spectrum-css/inlinealert@7.0.25)
 

--- a/components/inlinealert/CHANGELOG.md
+++ b/components/inlinealert/CHANGELOG.md
@@ -31,7 +31,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="8.0.0"></a>
-# 8.0.0
+## 8.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@7.1.6...@spectrum-css/inlinealert@8.0.0)
 
@@ -88,7 +88,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/inlinealert
 
 <a name="7.1.0"></a>
-# 7.1.0
+## 7.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@7.0.56...@spectrum-css/inlinealert@7.1.0)
 
@@ -518,7 +518,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="7.0.0"></a>
 
-# 7.0.0
+## 7.0.0
 
 🗓 2023-03-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@6.0.11...@spectrum-css/inlinealert@7.0.0)
 
@@ -620,7 +620,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="6.0.0"></a>
 
-# 6.0.0
+## 6.0.0
 
 🗓 2023-02-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@5.0.16...@spectrum-css/inlinealert@6.0.0)
 
@@ -762,7 +762,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="5.0.0"></a>
 
-# 5.0.0
+## 5.0.0
 
 🗓 2022-10-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@4.0.13...@spectrum-css/inlinealert@5.0.0)
 
@@ -880,7 +880,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="4.0.0"></a>
 
-# 4.0.0
+## 4.0.0
 
 🗓 2022-01-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@2.0.6...@spectrum-css/inlinealert@4.0.0)
 
@@ -898,7 +898,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2022-01-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@3.0.0-beta.0...@spectrum-css/inlinealert@3.0.0)
 
@@ -906,7 +906,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2021-12-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@2.0.6...@spectrum-css/inlinealert@3.0.0-beta.0)
 
@@ -972,7 +972,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2021-09-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@2.0.0-alpha.2...@spectrum-css/inlinealert@2.0.0)
 
@@ -982,7 +982,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="2.0.0-alpha.2"></a>
 
-# 2.0.0-alpha.2
+## 2.0.0-alpha.2
 
 🗓 2021-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@2.0.0-alpha.1...@spectrum-css/inlinealert@2.0.0-alpha.2)
 
@@ -990,7 +990,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="2.0.0-alpha.1"></a>
 
-# 2.0.0-alpha.1
+## 2.0.0-alpha.1
 
 🗓 2021-06-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@2.0.0-alpha.0...@spectrum-css/inlinealert@2.0.0-alpha.1)
 
@@ -998,7 +998,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="2.0.0-alpha.0"></a>
 
-# 2.0.0-alpha.0
+## 2.0.0-alpha.0
 
 🗓 2021-05-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/inlinealert@1.1.1-alpha.0...@spectrum-css/inlinealert@2.0.0-alpha.0)
 
@@ -1023,7 +1023,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="1.1.0"></a>
 
-# 1.1.0
+## 1.1.0
 
 🗓 2021-04-15
 
@@ -1033,7 +1033,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0-beta.3"></a>
 
-# 3.0.0-beta.3
+## 3.0.0-beta.3
 
 🗓 2020-06-19 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alert@3.0.0-beta.2...@spectrum-css/alert@3.0.0-beta.3)
 
@@ -1041,7 +1041,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alert@3.0.0-beta.1...@spectrum-css/alert@3.0.0-beta.2)
 
@@ -1049,7 +1049,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alert@3.0.0-beta.0...@spectrum-css/alert@3.0.0-beta.1)
 
@@ -1057,7 +1057,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/alert@2.0.5...@spectrum-css/alert@3.0.0-beta.0)
 
@@ -1108,7 +1108,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/link/CHANGELOG.md
+++ b/components/link/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-#5.0.0
+# 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/link@4.2.5...@spectrum-css/link@5.0.0)
 
@@ -40,49 +40,49 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="4.2.5"></a>
-##4.2.5
+## 4.2.5
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/link@4.2.4...@spectrum-css/link@4.2.5)
 
 **Note:** Version bump only for package @spectrum-css/link
 
 <a name="4.2.4"></a>
-##4.2.4
+## 4.2.4
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/link@4.2.3...@spectrum-css/link@4.2.4)
 
 **Note:** Version bump only for package @spectrum-css/link
 
 <a name="4.2.3"></a>
-##4.2.3
+## 4.2.3
 🗓
 2024-02-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/link@4.2.2...@spectrum-css/link@4.2.3)
 
 **Note:** Version bump only for package @spectrum-css/link
 
 <a name="4.2.2"></a>
-##4.2.2
+## 4.2.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/link@4.2.1...@spectrum-css/link@4.2.2)
 
 **Note:** Version bump only for package @spectrum-css/link
 
 <a name="4.2.1"></a>
-##4.2.1
+## 4.2.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/link
 
 <a name="4.2.0"></a>
-#4.2.0
+# 4.2.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/link@4.1.0...@spectrum-css/link@4.2.0)
 
 **Note:** Version bump only for package @spectrum-css/link
 
 <a name="4.1.0"></a>
-#4.1.0
+# 4.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/link@4.0.75...@spectrum-css/link@4.1.0)
 
@@ -91,98 +91,98 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="4.0.75"></a>
-##4.0.75
+## 4.0.75
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/link@4.0.74...@spectrum-css/link@4.0.75)
 
 **Note:** Version bump only for package @spectrum-css/link
 
 <a name="4.0.74"></a>
-##4.0.74
+## 4.0.74
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/link@4.0.73...@spectrum-css/link@4.0.74)
 
 **Note:** Version bump only for package @spectrum-css/link
 
 <a name="4.0.73"></a>
-##4.0.73
+## 4.0.73
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/link@4.0.71...@spectrum-css/link@4.0.73)
 
 **Note:** Version bump only for package @spectrum-css/link
 
 <a name="4.0.72"></a>
-##4.0.72
+## 4.0.72
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/link@4.0.71...@spectrum-css/link@4.0.72)
 
 **Note:** Version bump only for package @spectrum-css/link
 
 <a name="4.0.71"></a>
-##4.0.71
+## 4.0.71
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/link@4.0.70...@spectrum-css/link@4.0.71)
 
 **Note:** Version bump only for package @spectrum-css/link
 
 <a name="4.0.70"></a>
-##4.0.70
+## 4.0.70
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/link@4.0.69...@spectrum-css/link@4.0.70)
 
 **Note:** Version bump only for package @spectrum-css/link
 
 <a name="4.0.69"></a>
-##4.0.69
+## 4.0.69
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/link@4.0.68...@spectrum-css/link@4.0.69)
 
 **Note:** Version bump only for package @spectrum-css/link
 
 <a name="4.0.68"></a>
-##4.0.68
+## 4.0.68
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/link@4.0.67...@spectrum-css/link@4.0.68)
 
 **Note:** Version bump only for package @spectrum-css/link
 
 <a name="4.0.67"></a>
-##4.0.67
+## 4.0.67
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/link@4.0.66...@spectrum-css/link@4.0.67)
 
 **Note:** Version bump only for package @spectrum-css/link
 
 <a name="4.0.66"></a>
-##4.0.66
+## 4.0.66
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/link@4.0.65...@spectrum-css/link@4.0.66)
 
 **Note:** Version bump only for package @spectrum-css/link
 
 <a name="4.0.65"></a>
-##4.0.65
+## 4.0.65
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/link@4.0.64...@spectrum-css/link@4.0.65)
 
 **Note:** Version bump only for package @spectrum-css/link
 
 <a name="4.0.64"></a>
-##4.0.64
+## 4.0.64
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/link@4.0.63...@spectrum-css/link@4.0.64)
 
 **Note:** Version bump only for package @spectrum-css/link
 
 <a name="4.0.63"></a>
-##4.0.63
+## 4.0.63
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/link@4.0.62...@spectrum-css/link@4.0.63)
 
 **Note:** Version bump only for package @spectrum-css/link
 
 <a name="4.0.62"></a>
-##4.0.62
+## 4.0.62
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/link@4.0.61...@spectrum-css/link@4.0.62)
 
@@ -191,105 +191,105 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="4.0.61"></a>
-##4.0.61
+## 4.0.61
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/link@4.0.60...@spectrum-css/link@4.0.61)
 
 **Note:** Version bump only for package @spectrum-css/link
 
 <a name="4.0.60"></a>
-##4.0.60
+## 4.0.60
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/link@4.0.58...@spectrum-css/link@4.0.60)
 
 **Note:** Version bump only for package @spectrum-css/link
 
 <a name="4.0.59"></a>
-##4.0.59
+## 4.0.59
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/link@4.0.58...@spectrum-css/link@4.0.59)
 
 **Note:** Version bump only for package @spectrum-css/link
 
 <a name="4.0.58"></a>
-##4.0.58
+## 4.0.58
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/link@4.0.57...@spectrum-css/link@4.0.58)
 
 **Note:** Version bump only for package @spectrum-css/link
 
 <a name="4.0.57"></a>
-##4.0.57
+## 4.0.57
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/link@4.0.56...@spectrum-css/link@4.0.57)
 
 **Note:** Version bump only for package @spectrum-css/link
 
 <a name="4.0.56"></a>
-##4.0.56
+## 4.0.56
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/link@4.0.55...@spectrum-css/link@4.0.56)
 
 **Note:** Version bump only for package @spectrum-css/link
 
 <a name="4.0.55"></a>
-##4.0.55
+## 4.0.55
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/link@4.0.54...@spectrum-css/link@4.0.55)
 
 **Note:** Version bump only for package @spectrum-css/link
 
 <a name="4.0.54"></a>
-##4.0.54
+## 4.0.54
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/link@4.0.53...@spectrum-css/link@4.0.54)
 
 **Note:** Version bump only for package @spectrum-css/link
 
 <a name="4.0.53"></a>
-##4.0.53
+## 4.0.53
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/link@4.0.52...@spectrum-css/link@4.0.53)
 
 **Note:** Version bump only for package @spectrum-css/link
 
 <a name="4.0.52"></a>
-##4.0.52
+## 4.0.52
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/link@4.0.51...@spectrum-css/link@4.0.52)
 
 **Note:** Version bump only for package @spectrum-css/link
 
 <a name="4.0.51"></a>
-##4.0.51
+## 4.0.51
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/link@4.0.50...@spectrum-css/link@4.0.51)
 
 **Note:** Version bump only for package @spectrum-css/link
 
 <a name="4.0.50"></a>
-##4.0.50
+## 4.0.50
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/link@4.0.49...@spectrum-css/link@4.0.50)
 
 **Note:** Version bump only for package @spectrum-css/link
 
 <a name="4.0.49"></a>
-##4.0.49
+## 4.0.49
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/link@4.0.48...@spectrum-css/link@4.0.49)
 
 **Note:** Version bump only for package @spectrum-css/link
 
 <a name="4.0.48"></a>
-##4.0.48
+## 4.0.48
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/link@4.0.47...@spectrum-css/link@4.0.48)
 
 **Note:** Version bump only for package @spectrum-css/link
 
 <a name="4.0.47"></a>
-##4.0.47
+## 4.0.47
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/link@4.0.46...@spectrum-css/link@4.0.47)
 
@@ -298,14 +298,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="4.0.46"></a>
-##4.0.46
+## 4.0.46
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/link@4.0.45...@spectrum-css/link@4.0.46)
 
 **Note:** Version bump only for package @spectrum-css/link
 
 <a name="4.0.45"></a>
-##4.0.45
+## 4.0.45
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/link@4.0.44...@spectrum-css/link@4.0.45)
 

--- a/components/link/CHANGELOG.md
+++ b/components/link/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-# 5.0.0
+## 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/link@4.2.5...@spectrum-css/link@5.0.0)
 
@@ -75,14 +75,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/link
 
 <a name="4.2.0"></a>
-# 4.2.0
+## 4.2.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/link@4.1.0...@spectrum-css/link@4.2.0)
 
 **Note:** Version bump only for package @spectrum-css/link
 
 <a name="4.1.0"></a>
-# 4.1.0
+## 4.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/link@4.0.75...@spectrum-css/link@4.1.0)
 
@@ -669,7 +669,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="4.0.0"></a>
 
-# 4.0.0
+## 4.0.0
 
 🗓 2022-11-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/link@3.1.23...@spectrum-css/link@4.0.0)
 
@@ -906,7 +906,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.1.0"></a>
 
-# 3.1.0
+## 3.1.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/link@3.1.0-beta.0...@spectrum-css/link@3.1.0)
 
@@ -916,7 +916,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.1.0-beta.0"></a>
 
-# 3.1.0-beta.0
+## 3.1.0-beta.0
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/link@3.0.1-beta.1...@spectrum-css/link@3.1.0-beta.0)
 
@@ -948,7 +948,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/link@2.0.6...@spectrum-css/link@3.0.0)
 
@@ -1014,7 +1014,7 @@ Co-authored-by: Larry Davis <lawdavis@adobe.com>
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/logicbutton/CHANGELOG.md
+++ b/components/logicbutton/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="4.0.0"></a>
-#4.0.0
+# 4.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/logicbutton@3.3.4...@spectrum-css/logicbutton@4.0.0)
 
@@ -44,42 +44,42 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * Imports added to index.css and themes/express.css
 
 <a name="3.3.4"></a>
-##3.3.4
+## 3.3.4
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/logicbutton@3.3.3...@spectrum-css/logicbutton@3.3.4)
 
 **Note:** Version bump only for package @spectrum-css/logicbutton
 
 <a name="3.3.3"></a>
-##3.3.3
+## 3.3.3
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/logicbutton@3.3.2...@spectrum-css/logicbutton@3.3.3)
 
 **Note:** Version bump only for package @spectrum-css/logicbutton
 
 <a name="3.3.2"></a>
-##3.3.2
+## 3.3.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/logicbutton@3.3.1...@spectrum-css/logicbutton@3.3.2)
 
 **Note:** Version bump only for package @spectrum-css/logicbutton
 
 <a name="3.3.1"></a>
-##3.3.1
+## 3.3.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/logicbutton
 
 <a name="3.3.0"></a>
-#3.3.0
+# 3.3.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/logicbutton@3.2.0...@spectrum-css/logicbutton@3.3.0)
 
 **Note:** Version bump only for package @spectrum-css/logicbutton
 
 <a name="3.2.0"></a>
-#3.2.0
+# 3.2.0
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/logicbutton@3.1.0...@spectrum-css/logicbutton@3.2.0)
 
@@ -92,7 +92,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **commons:**rename and deprecate mods referencing global tokens ([#2423](https://github.com/adobe/spectrum-css/issues/2423))([3a49432](https://github.com/adobe/spectrum-css/commit/3a49432))
 
 <a name="3.1.0"></a>
-#3.1.0
+# 3.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/logicbutton@3.0.5...@spectrum-css/logicbutton@3.1.0)
 
@@ -101,42 +101,42 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="3.0.5"></a>
-##3.0.5
+## 3.0.5
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/logicbutton@3.0.4...@spectrum-css/logicbutton@3.0.5)
 
 **Note:** Version bump only for package @spectrum-css/logicbutton
 
 <a name="3.0.4"></a>
-##3.0.4
+## 3.0.4
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/logicbutton@3.0.3...@spectrum-css/logicbutton@3.0.4)
 
 **Note:** Version bump only for package @spectrum-css/logicbutton
 
 <a name="3.0.3"></a>
-##3.0.3
+## 3.0.3
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/logicbutton@3.0.1...@spectrum-css/logicbutton@3.0.3)
 
 **Note:** Version bump only for package @spectrum-css/logicbutton
 
 <a name="3.0.2"></a>
-##3.0.2
+## 3.0.2
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/logicbutton@3.0.1...@spectrum-css/logicbutton@3.0.2)
 
 **Note:** Version bump only for package @spectrum-css/logicbutton
 
 <a name="3.0.1"></a>
-##3.0.1
+## 3.0.1
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/logicbutton@3.0.0...@spectrum-css/logicbutton@3.0.1)
 
 **Note:** Version bump only for package @spectrum-css/logicbutton
 
 <a name="3.0.0"></a>
-#3.0.0
+# 3.0.0
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/logicbutton@2.0.2...@spectrum-css/logicbutton@3.0.0)
 
@@ -169,14 +169,14 @@ Additionally:
 Adds some extra room between the example buttons in the docs site.
 
 <a name="2.0.2"></a>
-##2.0.2
+## 2.0.2
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/logicbutton@2.0.1...@spectrum-css/logicbutton@2.0.2)
 
 **Note:** Version bump only for package @spectrum-css/logicbutton
 
 <a name="2.0.1"></a>
-##2.0.1
+## 2.0.1
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/logicbutton@2.0.0...@spectrum-css/logicbutton@2.0.1)
 
@@ -185,7 +185,7 @@ Adds some extra room between the example buttons in the docs site.
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="2.0.0"></a>
-#2.0.0
+# 2.0.0
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/logicbutton@1.2.36...@spectrum-css/logicbutton@2.0.0)
 
@@ -198,28 +198,28 @@ Adds some extra room between the example buttons in the docs site.
     		use focus-visible psuedo class for focus styling
 
 <a name="1.2.36"></a>
-##1.2.36
+## 1.2.36
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/logicbutton@1.2.35...@spectrum-css/logicbutton@1.2.36)
 
 **Note:** Version bump only for package @spectrum-css/logicbutton
 
 <a name="1.2.35"></a>
-##1.2.35
+## 1.2.35
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/logicbutton@1.2.34...@spectrum-css/logicbutton@1.2.35)
 
 **Note:** Version bump only for package @spectrum-css/logicbutton
 
 <a name="1.2.34"></a>
-##1.2.34
+## 1.2.34
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/logicbutton@1.2.33...@spectrum-css/logicbutton@1.2.34)
 
 **Note:** Version bump only for package @spectrum-css/logicbutton
 
 <a name="1.2.33"></a>
-##1.2.33
+## 1.2.33
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/logicbutton@1.2.32...@spectrum-css/logicbutton@1.2.33)
 
@@ -228,14 +228,14 @@ Adds some extra room between the example buttons in the docs site.
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="1.2.32"></a>
-##1.2.32
+## 1.2.32
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/logicbutton@1.2.31...@spectrum-css/logicbutton@1.2.32)
 
 **Note:** Version bump only for package @spectrum-css/logicbutton
 
 <a name="1.2.31"></a>
-##1.2.31
+## 1.2.31
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/logicbutton@1.2.30...@spectrum-css/logicbutton@1.2.31)
 

--- a/components/logicbutton/CHANGELOG.md
+++ b/components/logicbutton/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="4.0.0"></a>
-# 4.0.0
+## 4.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/logicbutton@3.3.4...@spectrum-css/logicbutton@4.0.0)
 
@@ -72,14 +72,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/logicbutton
 
 <a name="3.3.0"></a>
-# 3.3.0
+## 3.3.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/logicbutton@3.2.0...@spectrum-css/logicbutton@3.3.0)
 
 **Note:** Version bump only for package @spectrum-css/logicbutton
 
 <a name="3.2.0"></a>
-# 3.2.0
+## 3.2.0
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/logicbutton@3.1.0...@spectrum-css/logicbutton@3.2.0)
 
@@ -92,7 +92,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **commons:**rename and deprecate mods referencing global tokens ([#2423](https://github.com/adobe/spectrum-css/issues/2423))([3a49432](https://github.com/adobe/spectrum-css/commit/3a49432))
 
 <a name="3.1.0"></a>
-# 3.1.0
+## 3.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/logicbutton@3.0.5...@spectrum-css/logicbutton@3.1.0)
 
@@ -136,7 +136,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/logicbutton
 
 <a name="3.0.0"></a>
-# 3.0.0
+## 3.0.0
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/logicbutton@2.0.2...@spectrum-css/logicbutton@3.0.0)
 
@@ -185,7 +185,7 @@ Adds some extra room between the example buttons in the docs site.
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="2.0.0"></a>
-# 2.0.0
+## 2.0.0
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/logicbutton@1.2.36...@spectrum-css/logicbutton@2.0.0)
 
@@ -483,7 +483,7 @@ Adds some extra room between the example buttons in the docs site.
 
 <a name="1.2.0"></a>
 
-# 1.2.0
+## 1.2.0
 
 🗓 2022-01-05
 
@@ -499,7 +499,7 @@ Adds some extra room between the example buttons in the docs site.
 
 <a name="1.1.0"></a>
 
-# 1.1.0
+## 1.1.0
 
 🗓 2022-01-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/logicbutton@1.1.0-beta.0...@spectrum-css/logicbutton@1.1.0)
 
@@ -507,7 +507,7 @@ Adds some extra room between the example buttons in the docs site.
 
 <a name="1.1.0-beta.0"></a>
 
-# 1.1.0-beta.0
+## 1.1.0-beta.0
 
 🗓 2021-12-14
 

--- a/components/menu/CHANGELOG.md
+++ b/components/menu/CHANGELOG.md
@@ -51,7 +51,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="7.0.0"></a>
-#7.0.0
+# 7.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@6.1.5...@spectrum-css/menu@7.0.0)
 
@@ -66,7 +66,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="6.1.5"></a>
-##6.1.5
+## 6.1.5
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@6.1.4...@spectrum-css/menu@6.1.5)
 
@@ -75,35 +75,35 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **menu:**disabled color for value text and add disabled stories ([#2579](https://github.com/adobe/spectrum-css/issues/2579))([f0fae60](https://github.com/adobe/spectrum-css/commit/f0fae60))
 
 <a name="6.1.4"></a>
-##6.1.4
+## 6.1.4
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@6.1.3...@spectrum-css/menu@6.1.4)
 
 **Note:** Version bump only for package @spectrum-css/menu
 
 <a name="6.1.3"></a>
-##6.1.3
+## 6.1.3
 🗓
 2024-02-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@6.1.2...@spectrum-css/menu@6.1.3)
 
 **Note:** Version bump only for package @spectrum-css/menu
 
 <a name="6.1.2"></a>
-##6.1.2
+## 6.1.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@6.1.1...@spectrum-css/menu@6.1.2)
 
 **Note:** Version bump only for package @spectrum-css/menu
 
 <a name="6.1.1"></a>
-##6.1.1
+## 6.1.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/menu
 
 <a name="6.1.0"></a>
-#6.1.0
+# 6.1.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@6.0.0...@spectrum-css/menu@6.1.0)
 
@@ -112,7 +112,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **menu:**use higher specificity to provide correct styling for disabled states([36e0183](https://github.com/adobe/spectrum-css/commit/36e0183))
 
 <a name="6.0.0"></a>
-#6.0.0
+# 6.0.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@5.2.1...@spectrum-css/menu@6.0.0)
 
@@ -146,14 +146,14 @@ Additionally:
 - fix(menu): post rebase issues
 
 <a name="5.2.1"></a>
-##5.2.1
+## 5.2.1
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@5.2.0...@spectrum-css/menu@5.2.1)
 
 **Note:** Version bump only for package @spectrum-css/menu
 
 <a name="5.2.0"></a>
-#5.2.0
+# 5.2.0
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@5.1.5...@spectrum-css/menu@5.2.0)
 
@@ -166,28 +166,28 @@ Additionally:
 - **menu:**updated sizing of tray submenu back icon([3a5aebd](https://github.com/adobe/spectrum-css/commit/3a5aebd))
 
 <a name="5.1.5"></a>
-##5.1.5
+## 5.1.5
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@5.1.3...@spectrum-css/menu@5.1.5)
 
 **Note:** Version bump only for package @spectrum-css/menu
 
 <a name="5.1.4"></a>
-##5.1.4
+## 5.1.4
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@5.1.3...@spectrum-css/menu@5.1.4)
 
 **Note:** Version bump only for package @spectrum-css/menu
 
 <a name="5.1.3"></a>
-##5.1.3
+## 5.1.3
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@5.1.2...@spectrum-css/menu@5.1.3)
 
 **Note:** Version bump only for package @spectrum-css/menu
 
 <a name="5.1.2"></a>
-##5.1.2
+## 5.1.2
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@5.1.1...@spectrum-css/menu@5.1.2)
 
@@ -196,14 +196,14 @@ Additionally:
 - **menu:**drill-in disabled menu item chevron ([#2199](https://github.com/adobe/spectrum-css/issues/2199))([2dba5d9](https://github.com/adobe/spectrum-css/commit/2dba5d9)), closes[#2176](https://github.com/adobe/spectrum-css/issues/2176)
 
 <a name="5.1.1"></a>
-##5.1.1
+## 5.1.1
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@5.1.0...@spectrum-css/menu@5.1.1)
 
 **Note:** Version bump only for package @spectrum-css/menu
 
 <a name="5.1.0"></a>
-#5.1.0
+# 5.1.0
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@5.0.12...@spectrum-css/menu@5.1.0)
 
@@ -212,42 +212,42 @@ Additionally:
 - **menu:**add multi-select and switch ([#2152](https://github.com/adobe/spectrum-css/issues/2152))([6e95f44](https://github.com/adobe/spectrum-css/commit/6e95f44))
 
 <a name="5.0.12"></a>
-##5.0.12
+## 5.0.12
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@5.0.11...@spectrum-css/menu@5.0.12)
 
 **Note:** Version bump only for package @spectrum-css/menu
 
 <a name="5.0.11"></a>
-##5.0.11
+## 5.0.11
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@5.0.10...@spectrum-css/menu@5.0.11)
 
 **Note:** Version bump only for package @spectrum-css/menu
 
 <a name="5.0.10"></a>
-##5.0.10
+## 5.0.10
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@5.0.9...@spectrum-css/menu@5.0.10)
 
 **Note:** Version bump only for package @spectrum-css/menu
 
 <a name="5.0.9"></a>
-##5.0.9
+## 5.0.9
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@5.0.8...@spectrum-css/menu@5.0.9)
 
 **Note:** Version bump only for package @spectrum-css/menu
 
 <a name="5.0.8"></a>
-##5.0.8
+## 5.0.8
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@5.0.7...@spectrum-css/menu@5.0.8)
 
 **Note:** Version bump only for package @spectrum-css/menu
 
 <a name="5.0.7"></a>
-##5.0.7
+## 5.0.7
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@5.0.6...@spectrum-css/menu@5.0.7)
 
@@ -256,49 +256,49 @@ Additionally:
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="5.0.6"></a>
-##5.0.6
+## 5.0.6
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@5.0.5...@spectrum-css/menu@5.0.6)
 
 **Note:** Version bump only for package @spectrum-css/menu
 
 <a name="5.0.5"></a>
-##5.0.5
+## 5.0.5
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@5.0.3...@spectrum-css/menu@5.0.5)
 
 **Note:** Version bump only for package @spectrum-css/menu
 
 <a name="5.0.4"></a>
-##5.0.4
+## 5.0.4
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@5.0.3...@spectrum-css/menu@5.0.4)
 
 **Note:** Version bump only for package @spectrum-css/menu
 
 <a name="5.0.3"></a>
-##5.0.3
+## 5.0.3
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@5.0.2...@spectrum-css/menu@5.0.3)
 
 **Note:** Version bump only for package @spectrum-css/menu
 
 <a name="5.0.2"></a>
-##5.0.2
+## 5.0.2
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@5.0.1...@spectrum-css/menu@5.0.2)
 
 **Note:** Version bump only for package @spectrum-css/menu
 
 <a name="5.0.1"></a>
-##5.0.1
+## 5.0.1
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@5.0.0...@spectrum-css/menu@5.0.1)
 
 **Note:** Version bump only for package @spectrum-css/menu
 
 <a name="5.0.0"></a>
-#5.0.0
+# 5.0.0
 🗓
 2023-08-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@4.0.50...@spectrum-css/menu@5.0.0)
 
@@ -497,70 +497,70 @@ Adds new standard section about -mod custom properties.
 - chore(menu): manual version increase + update tokens dep
 
 <a name="4.0.50"></a>
-##4.0.50
+## 4.0.50
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@4.0.49...@spectrum-css/menu@4.0.50)
 
 **Note:** Version bump only for package @spectrum-css/menu
 
 <a name="4.0.49"></a>
-##4.0.49
+## 4.0.49
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@4.0.48...@spectrum-css/menu@4.0.49)
 
 **Note:** Version bump only for package @spectrum-css/menu
 
 <a name="4.0.48"></a>
-##4.0.48
+## 4.0.48
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@4.0.47...@spectrum-css/menu@4.0.48)
 
 **Note:** Version bump only for package @spectrum-css/menu
 
 <a name="4.0.47"></a>
-##4.0.47
+## 4.0.47
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@4.0.46...@spectrum-css/menu@4.0.47)
 
 **Note:** Version bump only for package @spectrum-css/menu
 
 <a name="4.0.46"></a>
-##4.0.46
+## 4.0.46
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@4.0.45...@spectrum-css/menu@4.0.46)
 
 **Note:** Version bump only for package @spectrum-css/menu
 
 <a name="4.0.45"></a>
-##4.0.45
+## 4.0.45
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@4.0.44...@spectrum-css/menu@4.0.45)
 
 **Note:** Version bump only for package @spectrum-css/menu
 
 <a name="4.0.44"></a>
-##4.0.44
+## 4.0.44
 🗓
 2023-06-28 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@4.0.43...@spectrum-css/menu@4.0.44)
 
 **Note:** Version bump only for package @spectrum-css/menu
 
 <a name="4.0.43"></a>
-##4.0.43
+## 4.0.43
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@4.0.42...@spectrum-css/menu@4.0.43)
 
 **Note:** Version bump only for package @spectrum-css/menu
 
 <a name="4.0.42"></a>
-##4.0.42
+## 4.0.42
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@4.0.41...@spectrum-css/menu@4.0.42)
 
 **Note:** Version bump only for package @spectrum-css/menu
 
 <a name="4.0.41"></a>
-##4.0.41
+## 4.0.41
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@4.0.40...@spectrum-css/menu@4.0.41)
 
@@ -569,14 +569,14 @@ Adds new standard section about -mod custom properties.
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="4.0.40"></a>
-##4.0.40
+## 4.0.40
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@4.0.39...@spectrum-css/menu@4.0.40)
 
 **Note:** Version bump only for package @spectrum-css/menu
 
 <a name="4.0.39"></a>
-##4.0.39
+## 4.0.39
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@4.0.38...@spectrum-css/menu@4.0.39)
 

--- a/components/menu/CHANGELOG.md
+++ b/components/menu/CHANGELOG.md
@@ -51,7 +51,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="7.0.0"></a>
-# 7.0.0
+## 7.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@6.1.5...@spectrum-css/menu@7.0.0)
 
@@ -103,7 +103,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/menu
 
 <a name="6.1.0"></a>
-# 6.1.0
+## 6.1.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@6.0.0...@spectrum-css/menu@6.1.0)
 
@@ -112,7 +112,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **menu:**use higher specificity to provide correct styling for disabled states([36e0183](https://github.com/adobe/spectrum-css/commit/36e0183))
 
 <a name="6.0.0"></a>
-# 6.0.0
+## 6.0.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@5.2.1...@spectrum-css/menu@6.0.0)
 
@@ -153,7 +153,7 @@ Additionally:
 **Note:** Version bump only for package @spectrum-css/menu
 
 <a name="5.2.0"></a>
-# 5.2.0
+## 5.2.0
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@5.1.5...@spectrum-css/menu@5.2.0)
 
@@ -203,7 +203,7 @@ Additionally:
 **Note:** Version bump only for package @spectrum-css/menu
 
 <a name="5.1.0"></a>
-# 5.1.0
+## 5.1.0
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@5.0.12...@spectrum-css/menu@5.1.0)
 
@@ -298,7 +298,7 @@ Additionally:
 **Note:** Version bump only for package @spectrum-css/menu
 
 <a name="5.0.0"></a>
-# 5.0.0
+## 5.0.0
 🗓
 2023-08-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@4.0.50...@spectrum-css/menu@5.0.0)
 
@@ -890,7 +890,7 @@ Adds new standard section about -mod custom properties.
 
 <a name="4.0.0"></a>
 
-# 4.0.0
+## 4.0.0
 
 🗓 2022-04-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@3.0.21...@spectrum-css/menu@4.0.0)
 
@@ -1136,7 +1136,7 @@ Adds new standard section about -mod custom properties.
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@3.0.0-beta.5...@spectrum-css/menu@3.0.0)
 
@@ -1144,7 +1144,7 @@ Adds new standard section about -mod custom properties.
 
 <a name="3.0.0-beta.5"></a>
 
-# 3.0.0-beta.5
+## 3.0.0-beta.5
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@3.0.0-beta.4...@spectrum-css/menu@3.0.0-beta.5)
 
@@ -1157,7 +1157,7 @@ Adds new standard section about -mod custom properties.
 
 <a name="3.0.0-beta.4"></a>
 
-# 3.0.0-beta.4
+## 3.0.0-beta.4
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@3.0.0-beta.3...@spectrum-css/menu@3.0.0-beta.4)
 
@@ -1165,7 +1165,7 @@ Adds new standard section about -mod custom properties.
 
 <a name="3.0.0-beta.3"></a>
 
-# 3.0.0-beta.3
+## 3.0.0-beta.3
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@3.0.0-beta.2...@spectrum-css/menu@3.0.0-beta.3)
 
@@ -1177,7 +1177,7 @@ Adds new standard section about -mod custom properties.
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@3.0.0-beta.1...@spectrum-css/menu@3.0.0-beta.2)
 
@@ -1185,7 +1185,7 @@ Adds new standard section about -mod custom properties.
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@3.0.0-beta.0...@spectrum-css/menu@3.0.0-beta.1)
 
@@ -1193,7 +1193,7 @@ Adds new standard section about -mod custom properties.
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@2.1.5...@spectrum-css/menu@3.0.0-beta.0)
 
@@ -1247,7 +1247,7 @@ Adds new standard section about -mod custom properties.
 
 <a name="2.1.0"></a>
 
-# 2.1.0
+## 2.1.0
 
 🗓 2019-11-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/menu@2.0.0...@spectrum-css/menu@2.1.0)
 
@@ -1257,7 +1257,7 @@ Adds new standard section about -mod custom properties.
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/miller/CHANGELOG.md
+++ b/components/miller/CHANGELOG.md
@@ -33,7 +33,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="6.0.0"></a>
-# 6.0.0
+## 6.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@5.1.4...@spectrum-css/miller@6.0.0)
 
@@ -76,7 +76,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/miller
 
 <a name="5.1.0"></a>
-# 5.1.0
+## 5.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@5.0.4...@spectrum-css/miller@5.1.0)
 
@@ -113,7 +113,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/miller
 
 <a name="5.0.0"></a>
-# 5.0.0
+## 5.0.0
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@4.0.0...@spectrum-css/miller@5.0.0)
 
@@ -160,7 +160,7 @@ Additionally:
 - chore(assetlist): id for storybook checkbox
 
 <a name="4.0.0"></a>
-# 4.0.0
+## 4.0.0
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@3.0.85...@spectrum-css/miller@4.0.0)
 
@@ -876,7 +876,7 @@ Additionally:
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@3.0.0-beta.6...@spectrum-css/miller@3.0.0)
 
@@ -890,7 +890,7 @@ Additionally:
 
 <a name="3.0.0-beta.6"></a>
 
-# 3.0.0-beta.6
+## 3.0.0-beta.6
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@3.0.0-beta.5...@spectrum-css/miller@3.0.0-beta.6)
 
@@ -900,7 +900,7 @@ Additionally:
 
 <a name="3.0.0-beta.5"></a>
 
-# 3.0.0-beta.5
+## 3.0.0-beta.5
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@3.0.0-beta.4...@spectrum-css/miller@3.0.0-beta.5)
 
@@ -908,7 +908,7 @@ Additionally:
 
 <a name="3.0.0-beta.4"></a>
 
-# 3.0.0-beta.4
+## 3.0.0-beta.4
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@3.0.0-beta.3...@spectrum-css/miller@3.0.0-beta.4)
 
@@ -916,7 +916,7 @@ Additionally:
 
 <a name="3.0.0-beta.3"></a>
 
-# 3.0.0-beta.3
+## 3.0.0-beta.3
 
 🗓 2020-06-19 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@3.0.0-beta.2...@spectrum-css/miller@3.0.0-beta.3)
 
@@ -924,7 +924,7 @@ Additionally:
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@3.0.0-beta.1...@spectrum-css/miller@3.0.0-beta.2)
 
@@ -932,7 +932,7 @@ Additionally:
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@3.0.0-beta.0...@spectrum-css/miller@3.0.0-beta.1)
 
@@ -940,7 +940,7 @@ Additionally:
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@2.0.6...@spectrum-css/miller@3.0.0-beta.0)
 
@@ -998,7 +998,7 @@ Additionally:
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/miller/CHANGELOG.md
+++ b/components/miller/CHANGELOG.md
@@ -33,7 +33,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="6.0.0"></a>
-#6.0.0
+# 6.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@5.1.4...@spectrum-css/miller@6.0.0)
 
@@ -48,35 +48,35 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="5.1.4"></a>
-##5.1.4
+## 5.1.4
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@5.1.3...@spectrum-css/miller@5.1.4)
 
 **Note:** Version bump only for package @spectrum-css/miller
 
 <a name="5.1.3"></a>
-##5.1.3
+## 5.1.3
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@5.1.2...@spectrum-css/miller@5.1.3)
 
 **Note:** Version bump only for package @spectrum-css/miller
 
 <a name="5.1.2"></a>
-##5.1.2
+## 5.1.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@5.1.1...@spectrum-css/miller@5.1.2)
 
 **Note:** Version bump only for package @spectrum-css/miller
 
 <a name="5.1.1"></a>
-##5.1.1
+## 5.1.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/miller
 
 <a name="5.1.0"></a>
-#5.1.0
+# 5.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@5.0.4...@spectrum-css/miller@5.1.0)
 
@@ -85,35 +85,35 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="5.0.4"></a>
-##5.0.4
+## 5.0.4
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@5.0.3...@spectrum-css/miller@5.0.4)
 
 **Note:** Version bump only for package @spectrum-css/miller
 
 <a name="5.0.3"></a>
-##5.0.3
+## 5.0.3
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@5.0.2...@spectrum-css/miller@5.0.3)
 
 **Note:** Version bump only for package @spectrum-css/miller
 
 <a name="5.0.2"></a>
-##5.0.2
+## 5.0.2
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@5.0.0...@spectrum-css/miller@5.0.2)
 
 **Note:** Version bump only for package @spectrum-css/miller
 
 <a name="5.0.1"></a>
-##5.0.1
+## 5.0.1
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@5.0.0...@spectrum-css/miller@5.0.1)
 
 **Note:** Version bump only for package @spectrum-css/miller
 
 <a name="5.0.0"></a>
-#5.0.0
+# 5.0.0
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@4.0.0...@spectrum-css/miller@5.0.0)
 
@@ -160,7 +160,7 @@ Additionally:
 - chore(assetlist): id for storybook checkbox
 
 <a name="4.0.0"></a>
-#4.0.0
+# 4.0.0
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@3.0.85...@spectrum-css/miller@4.0.0)
 
@@ -182,63 +182,63 @@ Additionally:
 - docs(miller): generate mods
 
 <a name="3.0.85"></a>
-##3.0.85
+## 3.0.85
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@3.0.84...@spectrum-css/miller@3.0.85)
 
 **Note:** Version bump only for package @spectrum-css/miller
 
 <a name="3.0.84"></a>
-##3.0.84
+## 3.0.84
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@3.0.83...@spectrum-css/miller@3.0.84)
 
 **Note:** Version bump only for package @spectrum-css/miller
 
 <a name="3.0.83"></a>
-##3.0.83
+## 3.0.83
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@3.0.82...@spectrum-css/miller@3.0.83)
 
 **Note:** Version bump only for package @spectrum-css/miller
 
 <a name="3.0.82"></a>
-##3.0.82
+## 3.0.82
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@3.0.81...@spectrum-css/miller@3.0.82)
 
 **Note:** Version bump only for package @spectrum-css/miller
 
 <a name="3.0.81"></a>
-##3.0.81
+## 3.0.81
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@3.0.80...@spectrum-css/miller@3.0.81)
 
 **Note:** Version bump only for package @spectrum-css/miller
 
 <a name="3.0.80"></a>
-##3.0.80
+## 3.0.80
 🗓
 2023-09-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@3.0.79...@spectrum-css/miller@3.0.80)
 
 **Note:** Version bump only for package @spectrum-css/miller
 
 <a name="3.0.79"></a>
-##3.0.79
+## 3.0.79
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@3.0.78...@spectrum-css/miller@3.0.79)
 
 **Note:** Version bump only for package @spectrum-css/miller
 
 <a name="3.0.78"></a>
-##3.0.78
+## 3.0.78
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@3.0.77...@spectrum-css/miller@3.0.78)
 
 **Note:** Version bump only for package @spectrum-css/miller
 
 <a name="3.0.77"></a>
-##3.0.77
+## 3.0.77
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@3.0.76...@spectrum-css/miller@3.0.77)
 
@@ -247,112 +247,112 @@ Additionally:
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="3.0.76"></a>
-##3.0.76
+## 3.0.76
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@3.0.75...@spectrum-css/miller@3.0.76)
 
 **Note:** Version bump only for package @spectrum-css/miller
 
 <a name="3.0.75"></a>
-##3.0.75
+## 3.0.75
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@3.0.73...@spectrum-css/miller@3.0.75)
 
 **Note:** Version bump only for package @spectrum-css/miller
 
 <a name="3.0.74"></a>
-##3.0.74
+## 3.0.74
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@3.0.73...@spectrum-css/miller@3.0.74)
 
 **Note:** Version bump only for package @spectrum-css/miller
 
 <a name="3.0.73"></a>
-##3.0.73
+## 3.0.73
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@3.0.72...@spectrum-css/miller@3.0.73)
 
 **Note:** Version bump only for package @spectrum-css/miller
 
 <a name="3.0.72"></a>
-##3.0.72
+## 3.0.72
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@3.0.71...@spectrum-css/miller@3.0.72)
 
 **Note:** Version bump only for package @spectrum-css/miller
 
 <a name="3.0.71"></a>
-##3.0.71
+## 3.0.71
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@3.0.70...@spectrum-css/miller@3.0.71)
 
 **Note:** Version bump only for package @spectrum-css/miller
 
 <a name="3.0.70"></a>
-##3.0.70
+## 3.0.70
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@3.0.69...@spectrum-css/miller@3.0.70)
 
 **Note:** Version bump only for package @spectrum-css/miller
 
 <a name="3.0.69"></a>
-##3.0.69
+## 3.0.69
 🗓
 2023-07-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@3.0.68...@spectrum-css/miller@3.0.69)
 
 **Note:** Version bump only for package @spectrum-css/miller
 
 <a name="3.0.68"></a>
-##3.0.68
+## 3.0.68
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@3.0.67...@spectrum-css/miller@3.0.68)
 
 **Note:** Version bump only for package @spectrum-css/miller
 
 <a name="3.0.67"></a>
-##3.0.67
+## 3.0.67
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@3.0.66...@spectrum-css/miller@3.0.67)
 
 **Note:** Version bump only for package @spectrum-css/miller
 
 <a name="3.0.66"></a>
-##3.0.66
+## 3.0.66
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@3.0.65...@spectrum-css/miller@3.0.66)
 
 **Note:** Version bump only for package @spectrum-css/miller
 
 <a name="3.0.65"></a>
-##3.0.65
+## 3.0.65
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@3.0.64...@spectrum-css/miller@3.0.65)
 
 **Note:** Version bump only for package @spectrum-css/miller
 
 <a name="3.0.64"></a>
-##3.0.64
+## 3.0.64
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@3.0.63...@spectrum-css/miller@3.0.64)
 
 **Note:** Version bump only for package @spectrum-css/miller
 
 <a name="3.0.63"></a>
-##3.0.63
+## 3.0.63
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@3.0.62...@spectrum-css/miller@3.0.63)
 
 **Note:** Version bump only for package @spectrum-css/miller
 
 <a name="3.0.62"></a>
-##3.0.62
+## 3.0.62
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@3.0.61...@spectrum-css/miller@3.0.62)
 
 **Note:** Version bump only for package @spectrum-css/miller
 
 <a name="3.0.61"></a>
-##3.0.61
+## 3.0.61
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@3.0.60...@spectrum-css/miller@3.0.61)
 
@@ -361,14 +361,14 @@ Additionally:
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="3.0.60"></a>
-##3.0.60
+## 3.0.60
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@3.0.59...@spectrum-css/miller@3.0.60)
 
 **Note:** Version bump only for package @spectrum-css/miller
 
 <a name="3.0.59"></a>
-##3.0.59
+## 3.0.59
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/miller@3.0.58...@spectrum-css/miller@3.0.59)
 

--- a/components/modal/CHANGELOG.md
+++ b/components/modal/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-#5.0.0
+# 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/modal@4.2.6...@spectrum-css/modal@5.0.0)
 
@@ -40,49 +40,49 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="4.2.6"></a>
-##4.2.6
+## 4.2.6
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/modal@4.2.5...@spectrum-css/modal@4.2.6)
 
 **Note:** Version bump only for package @spectrum-css/modal
 
 <a name="4.2.5"></a>
-##4.2.5
+## 4.2.5
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/modal@4.2.4...@spectrum-css/modal@4.2.5)
 
 **Note:** Version bump only for package @spectrum-css/modal
 
 <a name="4.2.4"></a>
-##4.2.4
+## 4.2.4
 🗓
 2024-02-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/modal@4.2.3...@spectrum-css/modal@4.2.4)
 
 **Note:** Version bump only for package @spectrum-css/modal
 
 <a name="4.2.3"></a>
-##4.2.3
+## 4.2.3
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/modal@4.2.2...@spectrum-css/modal@4.2.3)
 
 **Note:** Version bump only for package @spectrum-css/modal
 
 <a name="4.2.2"></a>
-##4.2.2
+## 4.2.2
 🗓
 2024-02-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/modal@4.2.1...@spectrum-css/modal@4.2.2)
 
 **Note:** Version bump only for package @spectrum-css/modal
 
 <a name="4.2.1"></a>
-##4.2.1
+## 4.2.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/modal
 
 <a name="4.2.0"></a>
-#4.2.0
+# 4.2.0
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/modal@4.1.0...@spectrum-css/modal@4.2.0)
 
@@ -92,7 +92,7 @@ _migrate build packages to postcss v8 ([#2460](https://github.com/adobe/spectrum
 **overlay,commons:**deprecate overlay; migrate references to commons ([#2429](https://github.com/adobe/spectrum-css/issues/2429))([7eecd96](https://github.com/adobe/spectrum-css/commit/7eecd96))
 
 <a name="4.1.0"></a>
-#4.1.0
+# 4.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/modal@4.0.5...@spectrum-css/modal@4.1.0)
 
@@ -101,42 +101,42 @@ _migrate build packages to postcss v8 ([#2460](https://github.com/adobe/spectrum
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="4.0.5"></a>
-##4.0.5
+## 4.0.5
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/modal@4.0.4...@spectrum-css/modal@4.0.5)
 
 **Note:** Version bump only for package @spectrum-css/modal
 
 <a name="4.0.4"></a>
-##4.0.4
+## 4.0.4
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/modal@4.0.3...@spectrum-css/modal@4.0.4)
 
 **Note:** Version bump only for package @spectrum-css/modal
 
 <a name="4.0.3"></a>
-##4.0.3
+## 4.0.3
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/modal@4.0.1...@spectrum-css/modal@4.0.3)
 
 **Note:** Version bump only for package @spectrum-css/modal
 
 <a name="4.0.2"></a>
-##4.0.2
+## 4.0.2
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/modal@4.0.1...@spectrum-css/modal@4.0.2)
 
 **Note:** Version bump only for package @spectrum-css/modal
 
 <a name="4.0.1"></a>
-##4.0.1
+## 4.0.1
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/modal@4.0.0...@spectrum-css/modal@4.0.1)
 
 **Note:** Version bump only for package @spectrum-css/modal
 
 <a name="4.0.0"></a>
-#4.0.0
+# 4.0.0
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/modal@3.1.0...@spectrum-css/modal@4.0.0)
 
@@ -171,7 +171,7 @@ chore: updated css properties
 - docs(modal): regenerate mods
 
 <a name="3.1.0"></a>
-#3.1.0
+# 3.1.0
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/modal@3.0.49...@spectrum-css/modal@3.1.0)
 
@@ -180,35 +180,35 @@ chore: updated css properties
 - **modal:**sizing and formatting updates([137b55d](https://github.com/adobe/spectrum-css/commit/137b55d))
 
 <a name="3.0.49"></a>
-##3.0.49
+## 3.0.49
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/modal@3.0.48...@spectrum-css/modal@3.0.49)
 
 **Note:** Version bump only for package @spectrum-css/modal
 
 <a name="3.0.48"></a>
-##3.0.48
+## 3.0.48
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/modal@3.0.47...@spectrum-css/modal@3.0.48)
 
 **Note:** Version bump only for package @spectrum-css/modal
 
 <a name="3.0.47"></a>
-##3.0.47
+## 3.0.47
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/modal@3.0.46...@spectrum-css/modal@3.0.47)
 
 **Note:** Version bump only for package @spectrum-css/modal
 
 <a name="3.0.46"></a>
-##3.0.46
+## 3.0.46
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/modal@3.0.45...@spectrum-css/modal@3.0.46)
 
 **Note:** Version bump only for package @spectrum-css/modal
 
 <a name="3.0.45"></a>
-##3.0.45
+## 3.0.45
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/modal@3.0.44...@spectrum-css/modal@3.0.45)
 
@@ -217,14 +217,14 @@ chore: updated css properties
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="3.0.44"></a>
-##3.0.44
+## 3.0.44
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/modal@3.0.43...@spectrum-css/modal@3.0.44)
 
 **Note:** Version bump only for package @spectrum-css/modal
 
 <a name="3.0.43"></a>
-##3.0.43
+## 3.0.43
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/modal@3.0.42...@spectrum-css/modal@3.0.43)
 

--- a/components/modal/CHANGELOG.md
+++ b/components/modal/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-# 5.0.0
+## 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/modal@4.2.6...@spectrum-css/modal@5.0.0)
 
@@ -82,7 +82,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/modal
 
 <a name="4.2.0"></a>
-# 4.2.0
+## 4.2.0
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/modal@4.1.0...@spectrum-css/modal@4.2.0)
 
@@ -92,7 +92,7 @@ _migrate build packages to postcss v8 ([#2460](https://github.com/adobe/spectrum
 **overlay,commons:**deprecate overlay; migrate references to commons ([#2429](https://github.com/adobe/spectrum-css/issues/2429))([7eecd96](https://github.com/adobe/spectrum-css/commit/7eecd96))
 
 <a name="4.1.0"></a>
-# 4.1.0
+## 4.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/modal@4.0.5...@spectrum-css/modal@4.1.0)
 
@@ -136,7 +136,7 @@ _migrate build packages to postcss v8 ([#2460](https://github.com/adobe/spectrum
 **Note:** Version bump only for package @spectrum-css/modal
 
 <a name="4.0.0"></a>
-# 4.0.0
+## 4.0.0
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/modal@3.1.0...@spectrum-css/modal@4.0.0)
 
@@ -171,7 +171,7 @@ chore: updated css properties
 - docs(modal): regenerate mods
 
 <a name="3.1.0"></a>
-# 3.1.0
+## 3.1.0
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/modal@3.0.49...@spectrum-css/modal@3.1.0)
 
@@ -620,7 +620,7 @@ chore: updated css properties
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/modal@3.0.0-beta.3...@spectrum-css/modal@3.0.0)
 
@@ -628,7 +628,7 @@ chore: updated css properties
 
 <a name="3.0.0-beta.3"></a>
 
-# 3.0.0-beta.3
+## 3.0.0-beta.3
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/modal@3.0.0-beta.2...@spectrum-css/modal@3.0.0-beta.3)
 
@@ -636,7 +636,7 @@ chore: updated css properties
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/modal@3.0.0-beta.1...@spectrum-css/modal@3.0.0-beta.2)
 
@@ -644,7 +644,7 @@ chore: updated css properties
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-09-23
 

--- a/components/opacitycheckerboard/CHANGELOG.md
+++ b/components/opacitycheckerboard/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="2.0.0"></a>
-# 2.0.0
+## 2.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/opacitycheckerboard@1.1.5...@spectrum-css/opacitycheckerboard@2.0.0)
 
@@ -75,7 +75,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/opacitycheckerboard
 
 <a name="1.1.0"></a>
-# 1.1.0
+## 1.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/opacitycheckerboard@1.0.9...@spectrum-css/opacitycheckerboard@1.1.0)
 
@@ -155,7 +155,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/opacitycheckerboard
 
 <a name="1.0.0"></a>
-# 1.0.0
+## 1.0.0
 🗓
 2023-07-24
 

--- a/components/opacitycheckerboard/CHANGELOG.md
+++ b/components/opacitycheckerboard/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="2.0.0"></a>
-#2.0.0
+# 2.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/opacitycheckerboard@1.1.5...@spectrum-css/opacitycheckerboard@2.0.0)
 
@@ -40,42 +40,42 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="1.1.5"></a>
-##1.1.5
+## 1.1.5
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/opacitycheckerboard@1.1.4...@spectrum-css/opacitycheckerboard@1.1.5)
 
 **Note:** Version bump only for package @spectrum-css/opacitycheckerboard
 
 <a name="1.1.4"></a>
-##1.1.4
+## 1.1.4
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/opacitycheckerboard@1.1.3...@spectrum-css/opacitycheckerboard@1.1.4)
 
 **Note:** Version bump only for package @spectrum-css/opacitycheckerboard
 
 <a name="1.1.3"></a>
-##1.1.3
+## 1.1.3
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/opacitycheckerboard@1.1.2...@spectrum-css/opacitycheckerboard@1.1.3)
 
 **Note:** Version bump only for package @spectrum-css/opacitycheckerboard
 
 <a name="1.1.2"></a>
-##1.1.2
+## 1.1.2
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/opacitycheckerboard
 
 <a name="1.1.1"></a>
-##1.1.1
+## 1.1.1
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/opacitycheckerboard@1.1.0...@spectrum-css/opacitycheckerboard@1.1.1)
 
 **Note:** Version bump only for package @spectrum-css/opacitycheckerboard
 
 <a name="1.1.0"></a>
-#1.1.0
+# 1.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/opacitycheckerboard@1.0.9...@spectrum-css/opacitycheckerboard@1.1.0)
 
@@ -84,35 +84,35 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="1.0.9"></a>
-##1.0.9
+## 1.0.9
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/opacitycheckerboard@1.0.8...@spectrum-css/opacitycheckerboard@1.0.9)
 
 **Note:** Version bump only for package @spectrum-css/opacitycheckerboard
 
 <a name="1.0.8"></a>
-##1.0.8
+## 1.0.8
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/opacitycheckerboard@1.0.7...@spectrum-css/opacitycheckerboard@1.0.8)
 
 **Note:** Version bump only for package @spectrum-css/opacitycheckerboard
 
 <a name="1.0.7"></a>
-##1.0.7
+## 1.0.7
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/opacitycheckerboard@1.0.5...@spectrum-css/opacitycheckerboard@1.0.7)
 
 **Note:** Version bump only for package @spectrum-css/opacitycheckerboard
 
 <a name="1.0.6"></a>
-##1.0.6
+## 1.0.6
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/opacitycheckerboard@1.0.5...@spectrum-css/opacitycheckerboard@1.0.6)
 
 **Note:** Version bump only for package @spectrum-css/opacitycheckerboard
 
 <a name="1.0.5"></a>
-##1.0.5
+## 1.0.5
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/opacitycheckerboard@1.0.4...@spectrum-css/opacitycheckerboard@1.0.5)
 
@@ -125,21 +125,21 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="1.0.4"></a>
-##1.0.4
+## 1.0.4
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/opacitycheckerboard@1.0.3...@spectrum-css/opacitycheckerboard@1.0.4)
 
 **Note:** Version bump only for package @spectrum-css/opacitycheckerboard
 
 <a name="1.0.3"></a>
-##1.0.3
+## 1.0.3
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/opacitycheckerboard@1.0.2...@spectrum-css/opacitycheckerboard@1.0.3)
 
 **Note:** Version bump only for package @spectrum-css/opacitycheckerboard
 
 <a name="1.0.2"></a>
-##1.0.2
+## 1.0.2
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/opacitycheckerboard@1.0.1...@spectrum-css/opacitycheckerboard@1.0.2)
 
@@ -148,14 +148,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **opacitycheckboard:**add to component stories ([#2056](https://github.com/adobe/spectrum-css/issues/2056))([a1411f6](https://github.com/adobe/spectrum-css/commit/a1411f6))
 
 <a name="1.0.1"></a>
-##1.0.1
+## 1.0.1
 🗓
 2023-07-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/opacitycheckerboard@1.0.0...@spectrum-css/opacitycheckerboard@1.0.1)
 
 **Note:** Version bump only for package @spectrum-css/opacitycheckerboard
 
 <a name="1.0.0"></a>
-#1.0.0
+# 1.0.0
 🗓
 2023-07-24
 

--- a/components/page/CHANGELOG.md
+++ b/components/page/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="8.0.0"></a>
-#8.0.0
+# 8.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/page@7.1.4...@spectrum-css/page@8.0.0)
 
@@ -40,35 +40,35 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="7.1.4"></a>
-##7.1.4
+## 7.1.4
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/page@7.1.3...@spectrum-css/page@7.1.4)
 
 **Note:** Version bump only for package @spectrum-css/page
 
 <a name="7.1.3"></a>
-##7.1.3
+## 7.1.3
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/page@7.1.2...@spectrum-css/page@7.1.3)
 
 **Note:** Version bump only for package @spectrum-css/page
 
 <a name="7.1.2"></a>
-##7.1.2
+## 7.1.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/page@7.1.1...@spectrum-css/page@7.1.2)
 
 **Note:** Version bump only for package @spectrum-css/page
 
 <a name="7.1.1"></a>
-##7.1.1
+## 7.1.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/page
 
 <a name="7.1.0"></a>
-#7.1.0
+# 7.1.0
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/page@6.1.0...@spectrum-css/page@7.1.0)
 
@@ -88,7 +88,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 replace & with :root ([1eadd4f](https://github.com/adobe/spectrum-css/commit/bd6c40eb5a4b43df94dff1f325502e5cd08b7f5f))
 
 <a name="6.1.0"></a>
-#6.1.0
+# 6.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/page@6.0.10...@spectrum-css/page@6.1.0)
 
@@ -97,77 +97,77 @@ replace & with :root ([1eadd4f](https://github.com/adobe/spectrum-css/commit/bd6
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="6.0.10"></a>
-##6.0.10
+## 6.0.10
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/page@6.0.9...@spectrum-css/page@6.0.10)
 
 **Note:** Version bump only for package @spectrum-css/page
 
 <a name="6.0.9"></a>
-##6.0.9
+## 6.0.9
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/page@6.0.8...@spectrum-css/page@6.0.9)
 
 **Note:** Version bump only for package @spectrum-css/page
 
 <a name="6.0.8"></a>
-##6.0.8
+## 6.0.8
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/page@6.0.6...@spectrum-css/page@6.0.8)
 
 **Note:** Version bump only for package @spectrum-css/page
 
 <a name="6.0.7"></a>
-##6.0.7
+## 6.0.7
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/page@6.0.6...@spectrum-css/page@6.0.7)
 
 **Note:** Version bump only for package @spectrum-css/page
 
 <a name="6.0.6"></a>
-##6.0.6
+## 6.0.6
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/page@6.0.5...@spectrum-css/page@6.0.6)
 
 **Note:** Version bump only for package @spectrum-css/page
 
 <a name="6.0.5"></a>
-##6.0.5
+## 6.0.5
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/page@6.0.4...@spectrum-css/page@6.0.5)
 
 **Note:** Version bump only for package @spectrum-css/page
 
 <a name="6.0.4"></a>
-##6.0.4
+## 6.0.4
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/page@6.0.3...@spectrum-css/page@6.0.4)
 
 **Note:** Version bump only for package @spectrum-css/page
 
 <a name="6.0.3"></a>
-##6.0.3
+## 6.0.3
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/page@6.0.2...@spectrum-css/page@6.0.3)
 
 **Note:** Version bump only for package @spectrum-css/page
 
 <a name="6.0.2"></a>
-##6.0.2
+## 6.0.2
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/page@6.0.1...@spectrum-css/page@6.0.2)
 
 **Note:** Version bump only for package @spectrum-css/page
 
 <a name="6.0.1"></a>
-##6.0.1
+## 6.0.1
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/page@6.0.0...@spectrum-css/page@6.0.1)
 
 **Note:** Version bump only for package @spectrum-css/page
 
 <a name="6.0.0"></a>
-#6.0.0
+# 6.0.0
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/page@5.0.33...@spectrum-css/page@6.0.0)
 
@@ -180,21 +180,21 @@ replace & with :root ([1eadd4f](https://github.com/adobe/spectrum-css/commit/bd6
     		migrates the Page component to use `@adobe/spectrum-tokens`
 
 <a name="5.0.33"></a>
-##5.0.33
+## 5.0.33
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/page@5.0.32...@spectrum-css/page@5.0.33)
 
 **Note:** Version bump only for package @spectrum-css/page
 
 <a name="5.0.32"></a>
-##5.0.32
+## 5.0.32
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/page@5.0.31...@spectrum-css/page@5.0.32)
 
 **Note:** Version bump only for package @spectrum-css/page
 
 <a name="5.0.31"></a>
-##5.0.31
+## 5.0.31
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/page@5.0.30...@spectrum-css/page@5.0.31)
 
@@ -203,14 +203,14 @@ replace & with :root ([1eadd4f](https://github.com/adobe/spectrum-css/commit/bd6
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="5.0.30"></a>
-##5.0.30
+## 5.0.30
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/page@5.0.29...@spectrum-css/page@5.0.30)
 
 **Note:** Version bump only for package @spectrum-css/page
 
 <a name="5.0.29"></a>
-##5.0.29
+## 5.0.29
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/page@5.0.28...@spectrum-css/page@5.0.29)
 

--- a/components/page/CHANGELOG.md
+++ b/components/page/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="8.0.0"></a>
-# 8.0.0
+## 8.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/page@7.1.4...@spectrum-css/page@8.0.0)
 
@@ -68,7 +68,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/page
 
 <a name="7.1.0"></a>
-# 7.1.0
+## 7.1.0
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/page@6.1.0...@spectrum-css/page@7.1.0)
 
@@ -78,7 +78,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="7.0.0"></a>
 
-# 7.0.0
+## 7.0.0
 
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/page@6.1.0...@spectrum-css/page@7.0.0)
@@ -88,7 +88,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 replace & with :root ([1eadd4f](https://github.com/adobe/spectrum-css/commit/bd6c40eb5a4b43df94dff1f325502e5cd08b7f5f))
 
 <a name="6.1.0"></a>
-# 6.1.0
+## 6.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/page@6.0.10...@spectrum-css/page@6.1.0)
 
@@ -167,7 +167,7 @@ replace & with :root ([1eadd4f](https://github.com/adobe/spectrum-css/commit/bd6
 **Note:** Version bump only for package @spectrum-css/page
 
 <a name="6.0.0"></a>
-# 6.0.0
+## 6.0.0
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/page@5.0.33...@spectrum-css/page@6.0.0)
 
@@ -442,7 +442,7 @@ replace & with :root ([1eadd4f](https://github.com/adobe/spectrum-css/commit/bd6
 
 <a name="5.0.0"></a>
 
-# 5.0.0
+## 5.0.0
 
 🗓 2022-01-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/page@3.0.9...@spectrum-css/page@5.0.0)
 
@@ -456,7 +456,7 @@ replace & with :root ([1eadd4f](https://github.com/adobe/spectrum-css/commit/bd6
 
 <a name="4.0.0"></a>
 
-# 4.0.0
+## 4.0.0
 
 🗓 2022-01-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/page@4.0.0-beta.0...@spectrum-css/page@4.0.0)
 
@@ -464,7 +464,7 @@ replace & with :root ([1eadd4f](https://github.com/adobe/spectrum-css/commit/bd6
 
 <a name="4.0.0-beta.0"></a>
 
-# 4.0.0-beta.0
+## 4.0.0-beta.0
 
 🗓 2021-12-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/page@3.0.9...@spectrum-css/page@4.0.0-beta.0)
 
@@ -582,7 +582,7 @@ replace & with :root ([1eadd4f](https://github.com/adobe/spectrum-css/commit/bd6
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/page@3.0.0-beta.0...@spectrum-css/page@3.0.0)
 
@@ -590,7 +590,7 @@ replace & with :root ([1eadd4f](https://github.com/adobe/spectrum-css/commit/bd6
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/page@2.0.8-beta.1...@spectrum-css/page@3.0.0-beta.0)
 
@@ -677,7 +677,7 @@ replace & with :root ([1eadd4f](https://github.com/adobe/spectrum-css/commit/bd6
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/pagination/CHANGELOG.md
+++ b/components/pagination/CHANGELOG.md
@@ -35,7 +35,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="8.0.0"></a>
-# 8.0.0
+## 8.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@7.1.6...@spectrum-css/pagination@8.0.0)
 
@@ -94,7 +94,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*deprecate logical transform plugin ([#2437](https://github.com/adobe/spectrum-css/issues/2437))([ff5dda6](https://github.com/adobe/spectrum-css/commit/ff5dda6))
 
 <a name="7.1.0"></a>
-# 7.1.0
+## 7.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@7.0.5...@spectrum-css/pagination@7.1.0)
 
@@ -138,7 +138,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/pagination
 
 <a name="7.0.0"></a>
-# 7.0.0
+## 7.0.0
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@6.0.50...@spectrum-css/pagination@7.0.0)
 
@@ -564,7 +564,7 @@ Add the "Button style" version of Pagination from the docs to Storybook.
 
 <a name="6.0.0"></a>
 
-# 6.0.0
+## 6.0.0
 
 🗓 2023-04-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@5.0.29...@spectrum-css/pagination@6.0.0)
 
@@ -810,7 +810,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="5.0.0"></a>
 
-# 5.0.0
+## 5.0.0
 
 🗓 2022-01-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@3.0.11...@spectrum-css/pagination@5.0.0)
 
@@ -828,7 +828,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="4.0.0"></a>
 
-# 4.0.0
+## 4.0.0
 
 🗓 2022-01-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@4.0.0-beta.0...@spectrum-css/pagination@4.0.0)
 
@@ -836,7 +836,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="4.0.0-beta.0"></a>
 
-# 4.0.0-beta.0
+## 4.0.0-beta.0
 
 🗓 2021-12-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@3.0.11...@spectrum-css/pagination@4.0.0-beta.0)
 
@@ -980,7 +980,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@3.0.0-beta.7...@spectrum-css/pagination@3.0.0)
 
@@ -988,7 +988,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="3.0.0-beta.7"></a>
 
-# 3.0.0-beta.7
+## 3.0.0-beta.7
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@3.0.0-beta.6...@spectrum-css/pagination@3.0.0-beta.7)
 
@@ -1005,7 +1005,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="3.0.0-beta.6"></a>
 
-# 3.0.0-beta.6
+## 3.0.0-beta.6
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@3.0.0-beta.5...@spectrum-css/pagination@3.0.0-beta.6)
 
@@ -1013,7 +1013,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="3.0.0-beta.5"></a>
 
-# 3.0.0-beta.5
+## 3.0.0-beta.5
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@3.0.0-beta.4...@spectrum-css/pagination@3.0.0-beta.5)
 
@@ -1021,7 +1021,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="3.0.0-beta.4"></a>
 
-# 3.0.0-beta.4
+## 3.0.0-beta.4
 
 🗓 2020-06-19 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@3.0.0-beta.3...@spectrum-css/pagination@3.0.0-beta.4)
 
@@ -1029,7 +1029,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="3.0.0-beta.3"></a>
 
-# 3.0.0-beta.3
+## 3.0.0-beta.3
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@3.0.0-beta.2...@spectrum-css/pagination@3.0.0-beta.3)
 
@@ -1039,7 +1039,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@3.0.0-beta.1...@spectrum-css/pagination@3.0.0-beta.2)
 
@@ -1047,7 +1047,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@3.0.0-beta.0...@spectrum-css/pagination@3.0.0-beta.1)
 
@@ -1055,7 +1055,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@2.0.6...@spectrum-css/pagination@3.0.0-beta.0)
 
@@ -1117,7 +1117,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/pagination/CHANGELOG.md
+++ b/components/pagination/CHANGELOG.md
@@ -35,7 +35,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="8.0.0"></a>
-#8.0.0
+# 8.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@7.1.6...@spectrum-css/pagination@8.0.0)
 
@@ -50,42 +50,42 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="7.1.6"></a>
-##7.1.6
+## 7.1.6
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@7.1.5...@spectrum-css/pagination@7.1.6)
 
 **Note:** Version bump only for package @spectrum-css/pagination
 
 <a name="7.1.5"></a>
-##7.1.5
+## 7.1.5
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@7.1.4...@spectrum-css/pagination@7.1.5)
 
 **Note:** Version bump only for package @spectrum-css/pagination
 
 <a name="7.1.4"></a>
-##7.1.4
+## 7.1.4
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@7.1.3...@spectrum-css/pagination@7.1.4)
 
 **Note:** Version bump only for package @spectrum-css/pagination
 
 <a name="7.1.3"></a>
-##7.1.3
+## 7.1.3
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/pagination
 
 <a name="7.1.2"></a>
-##7.1.2
+## 7.1.2
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@7.1.1...@spectrum-css/pagination@7.1.2)
 
 **Note:** Version bump only for package @spectrum-css/pagination
 
 <a name="7.1.1"></a>
-##7.1.1
+## 7.1.1
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@7.1.0...@spectrum-css/pagination@7.1.1)
 
@@ -94,7 +94,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*deprecate logical transform plugin ([#2437](https://github.com/adobe/spectrum-css/issues/2437))([ff5dda6](https://github.com/adobe/spectrum-css/commit/ff5dda6))
 
 <a name="7.1.0"></a>
-#7.1.0
+# 7.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@7.0.5...@spectrum-css/pagination@7.1.0)
 
@@ -103,42 +103,42 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="7.0.5"></a>
-##7.0.5
+## 7.0.5
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@7.0.4...@spectrum-css/pagination@7.0.5)
 
 **Note:** Version bump only for package @spectrum-css/pagination
 
 <a name="7.0.4"></a>
-##7.0.4
+## 7.0.4
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@7.0.3...@spectrum-css/pagination@7.0.4)
 
 **Note:** Version bump only for package @spectrum-css/pagination
 
 <a name="7.0.3"></a>
-##7.0.3
+## 7.0.3
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@7.0.1...@spectrum-css/pagination@7.0.3)
 
 **Note:** Version bump only for package @spectrum-css/pagination
 
 <a name="7.0.2"></a>
-##7.0.2
+## 7.0.2
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@7.0.1...@spectrum-css/pagination@7.0.2)
 
 **Note:** Version bump only for package @spectrum-css/pagination
 
 <a name="7.0.1"></a>
-##7.0.1
+## 7.0.1
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@7.0.0...@spectrum-css/pagination@7.0.1)
 
 **Note:** Version bump only for package @spectrum-css/pagination
 
 <a name="7.0.0"></a>
-#7.0.0
+# 7.0.0
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@6.0.50...@spectrum-css/pagination@7.0.0)
 
@@ -184,70 +184,70 @@ docs(pagination): add button style pagination to storybook
 Add the "Button style" version of Pagination from the docs to Storybook.
 
 <a name="6.0.50"></a>
-##6.0.50
+## 6.0.50
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@6.0.49...@spectrum-css/pagination@6.0.50)
 
 **Note:** Version bump only for package @spectrum-css/pagination
 
 <a name="6.0.49"></a>
-##6.0.49
+## 6.0.49
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@6.0.48...@spectrum-css/pagination@6.0.49)
 
 **Note:** Version bump only for package @spectrum-css/pagination
 
 <a name="6.0.48"></a>
-##6.0.48
+## 6.0.48
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@6.0.47...@spectrum-css/pagination@6.0.48)
 
 **Note:** Version bump only for package @spectrum-css/pagination
 
 <a name="6.0.47"></a>
-##6.0.47
+## 6.0.47
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@6.0.46...@spectrum-css/pagination@6.0.47)
 
 **Note:** Version bump only for package @spectrum-css/pagination
 
 <a name="6.0.46"></a>
-##6.0.46
+## 6.0.46
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@6.0.45...@spectrum-css/pagination@6.0.46)
 
 **Note:** Version bump only for package @spectrum-css/pagination
 
 <a name="6.0.45"></a>
-##6.0.45
+## 6.0.45
 🗓
 2023-09-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@6.0.44...@spectrum-css/pagination@6.0.45)
 
 **Note:** Version bump only for package @spectrum-css/pagination
 
 <a name="6.0.44"></a>
-##6.0.44
+## 6.0.44
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@6.0.43...@spectrum-css/pagination@6.0.44)
 
 **Note:** Version bump only for package @spectrum-css/pagination
 
 <a name="6.0.43"></a>
-##6.0.43
+## 6.0.43
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@6.0.42...@spectrum-css/pagination@6.0.43)
 
 **Note:** Version bump only for package @spectrum-css/pagination
 
 <a name="6.0.42"></a>
-##6.0.42
+## 6.0.42
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@6.0.41...@spectrum-css/pagination@6.0.42)
 
 **Note:** Version bump only for package @spectrum-css/pagination
 
 <a name="6.0.41"></a>
-##6.0.41
+## 6.0.41
 🗓
 2023-08-25 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@6.0.40...@spectrum-css/pagination@6.0.41)
 
@@ -256,56 +256,56 @@ Add the "Button style" version of Pagination from the docs to Storybook.
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="6.0.40"></a>
-##6.0.40
+## 6.0.40
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@6.0.39...@spectrum-css/pagination@6.0.40)
 
 **Note:** Version bump only for package @spectrum-css/pagination
 
 <a name="6.0.39"></a>
-##6.0.39
+## 6.0.39
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@6.0.37...@spectrum-css/pagination@6.0.39)
 
 **Note:** Version bump only for package @spectrum-css/pagination
 
 <a name="6.0.38"></a>
-##6.0.38
+## 6.0.38
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@6.0.37...@spectrum-css/pagination@6.0.38)
 
 **Note:** Version bump only for package @spectrum-css/pagination
 
 <a name="6.0.37"></a>
-##6.0.37
+## 6.0.37
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@6.0.36...@spectrum-css/pagination@6.0.37)
 
 **Note:** Version bump only for package @spectrum-css/pagination
 
 <a name="6.0.36"></a>
-##6.0.36
+## 6.0.36
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@6.0.35...@spectrum-css/pagination@6.0.36)
 
 **Note:** Version bump only for package @spectrum-css/pagination
 
 <a name="6.0.35"></a>
-##6.0.35
+## 6.0.35
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@6.0.34...@spectrum-css/pagination@6.0.35)
 
 **Note:** Version bump only for package @spectrum-css/pagination
 
 <a name="6.0.34"></a>
-##6.0.34
+## 6.0.34
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@6.0.33...@spectrum-css/pagination@6.0.34)
 
 **Note:** Version bump only for package @spectrum-css/pagination
 
 <a name="6.0.33"></a>
-##6.0.33
+## 6.0.33
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@6.0.32...@spectrum-css/pagination@6.0.33)
 
@@ -314,49 +314,49 @@ Add the "Button style" version of Pagination from the docs to Storybook.
 \*icon sizing in Storybook story templates ([#2037](https://github.com/adobe/spectrum-css/issues/2037))([c90c8a3](https://github.com/adobe/spectrum-css/commit/c90c8a3))
 
 <a name="6.0.32"></a>
-##6.0.32
+## 6.0.32
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@6.0.31...@spectrum-css/pagination@6.0.32)
 
 **Note:** Version bump only for package @spectrum-css/pagination
 
 <a name="6.0.31"></a>
-##6.0.31
+## 6.0.31
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@6.0.30...@spectrum-css/pagination@6.0.31)
 
 **Note:** Version bump only for package @spectrum-css/pagination
 
 <a name="6.0.30"></a>
-##6.0.30
+## 6.0.30
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@6.0.29...@spectrum-css/pagination@6.0.30)
 
 **Note:** Version bump only for package @spectrum-css/pagination
 
 <a name="6.0.29"></a>
-##6.0.29
+## 6.0.29
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@6.0.28...@spectrum-css/pagination@6.0.29)
 
 **Note:** Version bump only for package @spectrum-css/pagination
 
 <a name="6.0.28"></a>
-##6.0.28
+## 6.0.28
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@6.0.27...@spectrum-css/pagination@6.0.28)
 
 **Note:** Version bump only for package @spectrum-css/pagination
 
 <a name="6.0.27"></a>
-##6.0.27
+## 6.0.27
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@6.0.26...@spectrum-css/pagination@6.0.27)
 
 **Note:** Version bump only for package @spectrum-css/pagination
 
 <a name="6.0.26"></a>
-##6.0.26
+## 6.0.26
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@6.0.25...@spectrum-css/pagination@6.0.26)
 
@@ -365,14 +365,14 @@ Add the "Button style" version of Pagination from the docs to Storybook.
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="6.0.25"></a>
-##6.0.25
+## 6.0.25
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@6.0.24...@spectrum-css/pagination@6.0.25)
 
 **Note:** Version bump only for package @spectrum-css/pagination
 
 <a name="6.0.24"></a>
-##6.0.24
+## 6.0.24
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pagination@6.0.23...@spectrum-css/pagination@6.0.24)
 

--- a/components/picker/CHANGELOG.md
+++ b/components/picker/CHANGELOG.md
@@ -43,7 +43,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="8.0.0"></a>
-#8.0.0
+# 8.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@7.2.7...@spectrum-css/picker@8.0.0)
 
@@ -67,35 +67,35 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * Imports added to index.css and themes/express.css
 
 <a name="7.2.7"></a>
-##7.2.7
+## 7.2.7
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@7.2.6...@spectrum-css/picker@7.2.7)
 
 **Note:** Version bump only for package @spectrum-css/picker
 
 <a name="7.2.6"></a>
-##7.2.6
+## 7.2.6
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@7.2.5...@spectrum-css/picker@7.2.6)
 
 **Note:** Version bump only for package @spectrum-css/picker
 
 <a name="7.2.5"></a>
-##7.2.5
+## 7.2.5
 🗓
 2024-02-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@7.2.4...@spectrum-css/picker@7.2.5)
 
 **Note:** Version bump only for package @spectrum-css/picker
 
 <a name="7.2.4"></a>
-##7.2.4
+## 7.2.4
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@7.2.3...@spectrum-css/picker@7.2.4)
 
 **Note:** Version bump only for package @spectrum-css/picker
 
 <a name="7.2.3"></a>
-##7.2.3
+## 7.2.3
 🗓
 2024-02-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@7.2.2...@spectrum-css/picker@7.2.3)
 
@@ -104,28 +104,28 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **picker:**quiet side label picker positioning ([#2465](https://github.com/adobe/spectrum-css/issues/2465))([537f0b8](https://github.com/adobe/spectrum-css/commit/537f0b8))
 
 <a name="7.2.2"></a>
-##7.2.2
+## 7.2.2
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/picker
 
 <a name="7.2.1"></a>
-##7.2.1
+## 7.2.1
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@7.2.0...@spectrum-css/picker@7.2.1)
 
 **Note:** Version bump only for package @spectrum-css/picker
 
 <a name="7.2.0"></a>
-#7.2.0
+# 7.2.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@7.1.0...@spectrum-css/picker@7.2.0)
 
 **Note:** Version bump only for package @spectrum-css/picker
 
 <a name="7.1.0"></a>
-#7.1.0
+# 7.1.0
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@7.0.19...@spectrum-css/picker@7.1.0)
 
@@ -139,7 +139,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
   **picker:**rename is-focused class to is-keyboardFocused ([#2377](https://github.com/adobe/spectrum-css/issues/2377))([60b44bb](https://github.com/adobe/spectrum-css/commit/60b44bb))
 
 <a name="7.0.19"></a>
-##7.0.19
+## 7.0.19
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@7.0.18...@spectrum-css/picker@7.0.19)
 
@@ -149,105 +149,105 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
   **picker:**high contrast and other color fixes ([#2326](https://github.com/adobe/spectrum-css/issues/2326))([c80bbd6](https://github.com/adobe/spectrum-css/commit/c80bbd6))
 
 <a name="7.0.18"></a>
-##7.0.18
+## 7.0.18
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@7.0.17...@spectrum-css/picker@7.0.18)
 
 **Note:** Version bump only for package @spectrum-css/picker
 
 <a name="7.0.17"></a>
-##7.0.17
+## 7.0.17
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@7.0.16...@spectrum-css/picker@7.0.17)
 
 **Note:** Version bump only for package @spectrum-css/picker
 
 <a name="7.0.16"></a>
-##7.0.16
+## 7.0.16
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@7.0.14...@spectrum-css/picker@7.0.16)
 
 **Note:** Version bump only for package @spectrum-css/picker
 
 <a name="7.0.15"></a>
-##7.0.15
+## 7.0.15
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@7.0.14...@spectrum-css/picker@7.0.15)
 
 **Note:** Version bump only for package @spectrum-css/picker
 
 <a name="7.0.14"></a>
-##7.0.14
+## 7.0.14
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@7.0.13...@spectrum-css/picker@7.0.14)
 
 **Note:** Version bump only for package @spectrum-css/picker
 
 <a name="7.0.13"></a>
-##7.0.13
+## 7.0.13
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@7.0.12...@spectrum-css/picker@7.0.13)
 
 **Note:** Version bump only for package @spectrum-css/picker
 
 <a name="7.0.12"></a>
-##7.0.12
+## 7.0.12
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@7.0.11...@spectrum-css/picker@7.0.12)
 
 **Note:** Version bump only for package @spectrum-css/picker
 
 <a name="7.0.11"></a>
-##7.0.11
+## 7.0.11
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@7.0.10...@spectrum-css/picker@7.0.11)
 
 **Note:** Version bump only for package @spectrum-css/picker
 
 <a name="7.0.10"></a>
-##7.0.10
+## 7.0.10
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@7.0.9...@spectrum-css/picker@7.0.10)
 
 **Note:** Version bump only for package @spectrum-css/picker
 
 <a name="7.0.9"></a>
-##7.0.9
+## 7.0.9
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@7.0.8...@spectrum-css/picker@7.0.9)
 
 **Note:** Version bump only for package @spectrum-css/picker
 
 <a name="7.0.8"></a>
-##7.0.8
+## 7.0.8
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@7.0.7...@spectrum-css/picker@7.0.8)
 
 **Note:** Version bump only for package @spectrum-css/picker
 
 <a name="7.0.7"></a>
-##7.0.7
+## 7.0.7
 🗓
 2023-09-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@7.0.6...@spectrum-css/picker@7.0.7)
 
 **Note:** Version bump only for package @spectrum-css/picker
 
 <a name="7.0.6"></a>
-##7.0.6
+## 7.0.6
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@7.0.5...@spectrum-css/picker@7.0.6)
 
 **Note:** Version bump only for package @spectrum-css/picker
 
 <a name="7.0.5"></a>
-##7.0.5
+## 7.0.5
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@7.0.4...@spectrum-css/picker@7.0.5)
 
 **Note:** Version bump only for package @spectrum-css/picker
 
 <a name="7.0.4"></a>
-##7.0.4
+## 7.0.4
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@7.0.3...@spectrum-css/picker@7.0.4)
 
@@ -256,28 +256,28 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="7.0.3"></a>
-##7.0.3
+## 7.0.3
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@7.0.2...@spectrum-css/picker@7.0.3)
 
 **Note:** Version bump only for package @spectrum-css/picker
 
 <a name="7.0.2"></a>
-##7.0.2
+## 7.0.2
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@7.0.0...@spectrum-css/picker@7.0.2)
 
 **Note:** Version bump only for package @spectrum-css/picker
 
 <a name="7.0.1"></a>
-##7.0.1
+## 7.0.1
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@7.0.0...@spectrum-css/picker@7.0.1)
 
 **Note:** Version bump only for package @spectrum-css/picker
 
 <a name="7.0.0"></a>
-#7.0.0
+# 7.0.0
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@6.0.2...@spectrum-css/picker@7.0.0)
 
@@ -290,7 +290,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
     		Remove focus-ring pseudo class in favor of focus-visible
 
 <a name="6.0.2"></a>
-##6.0.2
+## 6.0.2
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@6.0.1...@spectrum-css/picker@6.0.2)
 
@@ -299,14 +299,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **picker:**add separate mod for label font-weight ([#2079](https://github.com/adobe/spectrum-css/issues/2079))([1f8e486](https://github.com/adobe/spectrum-css/commit/1f8e486))
 
 <a name="6.0.1"></a>
-##6.0.1
+## 6.0.1
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@6.0.0...@spectrum-css/picker@6.0.1)
 
 **Note:** Version bump only for package @spectrum-css/picker
 
 <a name="6.0.0"></a>
-#6.0.0
+# 6.0.0
 🗓
 2023-08-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@5.0.1...@spectrum-css/picker@6.0.0)
 
@@ -334,14 +334,14 @@ Additionally:
 - docs: update mods
 
 <a name="5.0.1"></a>
-##5.0.1
+## 5.0.1
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@5.0.0...@spectrum-css/picker@5.0.1)
 
 **Note:** Version bump only for package @spectrum-css/picker
 
 <a name="5.0.0"></a>
-#5.0.0
+# 5.0.0
 🗓
 2023-07-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@4.0.22...@spectrum-css/picker@5.0.0)
 
@@ -413,7 +413,7 @@ removes padding from uiicononly class to allow for larger icons in slots
 - chore(pickerbutton): manual version increase for beta release
 
 <a name="4.0.22"></a>
-##4.0.22
+## 4.0.22
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@4.0.21...@spectrum-css/picker@4.0.22)
 
@@ -422,56 +422,56 @@ removes padding from uiicononly class to allow for larger icons in slots
 \*icon sizing in Storybook story templates ([#2037](https://github.com/adobe/spectrum-css/issues/2037))([c90c8a3](https://github.com/adobe/spectrum-css/commit/c90c8a3))
 
 <a name="4.0.21"></a>
-##4.0.21
+## 4.0.21
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@4.0.20...@spectrum-css/picker@4.0.21)
 
 **Note:** Version bump only for package @spectrum-css/picker
 
 <a name="4.0.20"></a>
-##4.0.20
+## 4.0.20
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@4.0.19...@spectrum-css/picker@4.0.20)
 
 **Note:** Version bump only for package @spectrum-css/picker
 
 <a name="4.0.19"></a>
-##4.0.19
+## 4.0.19
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@4.0.18...@spectrum-css/picker@4.0.19)
 
 **Note:** Version bump only for package @spectrum-css/picker
 
 <a name="4.0.18"></a>
-##4.0.18
+## 4.0.18
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@4.0.17...@spectrum-css/picker@4.0.18)
 
 **Note:** Version bump only for package @spectrum-css/picker
 
 <a name="4.0.17"></a>
-##4.0.17
+## 4.0.17
 🗓
 2023-06-28 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@4.0.16...@spectrum-css/picker@4.0.17)
 
 **Note:** Version bump only for package @spectrum-css/picker
 
 <a name="4.0.16"></a>
-##4.0.16
+## 4.0.16
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@4.0.15...@spectrum-css/picker@4.0.16)
 
 **Note:** Version bump only for package @spectrum-css/picker
 
 <a name="4.0.15"></a>
-##4.0.15
+## 4.0.15
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@4.0.14...@spectrum-css/picker@4.0.15)
 
 **Note:** Version bump only for package @spectrum-css/picker
 
 <a name="4.0.14"></a>
-##4.0.14
+## 4.0.14
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@4.0.13...@spectrum-css/picker@4.0.14)
 
@@ -480,14 +480,14 @@ removes padding from uiicononly class to allow for larger icons in slots
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="4.0.13"></a>
-##4.0.13
+## 4.0.13
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@4.0.12...@spectrum-css/picker@4.0.13)
 
 **Note:** Version bump only for package @spectrum-css/picker
 
 <a name="4.0.12"></a>
-##4.0.12
+## 4.0.12
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@4.0.11...@spectrum-css/picker@4.0.12)
 

--- a/components/picker/CHANGELOG.md
+++ b/components/picker/CHANGELOG.md
@@ -43,7 +43,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="8.0.0"></a>
-# 8.0.0
+## 8.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@7.2.7...@spectrum-css/picker@8.0.0)
 
@@ -118,14 +118,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/picker
 
 <a name="7.2.0"></a>
-# 7.2.0
+## 7.2.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@7.1.0...@spectrum-css/picker@7.2.0)
 
 **Note:** Version bump only for package @spectrum-css/picker
 
 <a name="7.1.0"></a>
-# 7.1.0
+## 7.1.0
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@7.0.19...@spectrum-css/picker@7.1.0)
 
@@ -277,7 +277,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/picker
 
 <a name="7.0.0"></a>
-# 7.0.0
+## 7.0.0
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@6.0.2...@spectrum-css/picker@7.0.0)
 
@@ -306,7 +306,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/picker
 
 <a name="6.0.0"></a>
-# 6.0.0
+## 6.0.0
 🗓
 2023-08-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@5.0.1...@spectrum-css/picker@6.0.0)
 
@@ -341,7 +341,7 @@ Additionally:
 **Note:** Version bump only for package @spectrum-css/picker
 
 <a name="5.0.0"></a>
-# 5.0.0
+## 5.0.0
 🗓
 2023-07-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@4.0.22...@spectrum-css/picker@5.0.0)
 
@@ -585,7 +585,7 @@ removes padding from uiicononly class to allow for larger icons in slots
 
 <a name="4.0.0"></a>
 
-# 4.0.0
+## 4.0.0
 
 🗓 2023-05-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@3.0.12...@spectrum-css/picker@4.0.0)
 
@@ -713,7 +713,7 @@ Additionally:
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2023-04-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@2.0.11...@spectrum-css/picker@3.0.0)
 
@@ -817,7 +817,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2023-02-06 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@1.2.21...@spectrum-css/picker@2.0.0)
 
@@ -1006,7 +1006,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="1.2.0"></a>
 
-# 1.2.0
+## 1.2.0
 
 🗓 2022-03-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@1.1.14...@spectrum-css/picker@1.2.0)
 
@@ -1142,7 +1142,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="1.1.0"></a>
 
-# 1.1.0
+## 1.1.0
 
 🗓 2021-11-08 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@1.0.4...@spectrum-css/picker@1.1.0)
 
@@ -1234,7 +1234,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="1.0.0"></a>
 
-# 1.0.0
+## 1.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@1.0.0-beta.3...@spectrum-css/picker@1.0.0)
 
@@ -1249,7 +1249,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="1.0.0-beta.3"></a>
 
-# 1.0.0-beta.3
+## 1.0.0-beta.3
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@1.0.0-beta.2...@spectrum-css/picker@1.0.0-beta.3)
 
@@ -1279,7 +1279,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="1.0.0-beta.2"></a>
 
-# 1.0.0-beta.2
+## 1.0.0-beta.2
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/picker@1.0.0-beta.1...@spectrum-css/picker@1.0.0-beta.2)
 
@@ -1287,7 +1287,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="1.0.0-beta.1"></a>
 
-# 1.0.0-beta.1
+## 1.0.0-beta.1
 
 🗓 2020-09-23
 
@@ -1302,7 +1302,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="3.0.0-beta.3"></a>
 
-# 3.0.0-beta.3
+## 3.0.0-beta.3
 
 🗓 2020-06-19 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropdown@3.0.0-beta.2...@spectrum-css/dropdown@3.0.0-beta.3)
 
@@ -1310,7 +1310,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropdown@3.0.0-beta.1...@spectrum-css/dropdown@3.0.0-beta.2)
 
@@ -1318,7 +1318,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropdown@3.0.0-beta.0...@spectrum-css/dropdown@3.0.0-beta.1)
 
@@ -1326,7 +1326,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropdown@2.1.5...@spectrum-css/dropdown@3.0.0-beta.0)
 
@@ -1379,7 +1379,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="2.1.0"></a>
 
-# 2.1.0
+## 2.1.0
 
 🗓 2019-11-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/dropdown@2.0.0...@spectrum-css/dropdown@2.1.0)
 
@@ -1389,7 +1389,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/pickerbutton/CHANGELOG.md
+++ b/components/pickerbutton/CHANGELOG.md
@@ -33,7 +33,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-# 5.0.0
+## 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@4.1.5...@spectrum-css/pickerbutton@5.0.0)
 
@@ -87,7 +87,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/pickerbutton
 
 <a name="4.1.0"></a>
-# 4.1.0
+## 4.1.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@4.0.23...@spectrum-css/pickerbutton@4.1.0)
 
@@ -257,7 +257,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/pickerbutton
 
 <a name="4.0.0"></a>
-# 4.0.0
+## 4.0.0
 🗓
 2023-07-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@3.0.34...@spectrum-css/pickerbutton@4.0.0)
 
@@ -595,7 +595,7 @@ removes padding from uiicononly class to allow for larger icons in slots
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2023-03-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@2.0.12...@spectrum-css/pickerbutton@3.0.0)
 
@@ -724,7 +724,7 @@ removes padding from uiicononly class to allow for larger icons in slots
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2022-10-25 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@1.1.22...@spectrum-css/pickerbutton@2.0.0)
 
@@ -928,7 +928,7 @@ removes padding from uiicononly class to allow for larger icons in slots
 
 <a name="1.1.0"></a>
 
-# 1.1.0
+## 1.1.0
 
 🗓 2021-11-16
 

--- a/components/pickerbutton/CHANGELOG.md
+++ b/components/pickerbutton/CHANGELOG.md
@@ -33,7 +33,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-#5.0.0
+# 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@4.1.5...@spectrum-css/pickerbutton@5.0.0)
 
@@ -52,154 +52,154 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="4.1.5"></a>
-##4.1.5
+## 4.1.5
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@4.1.4...@spectrum-css/pickerbutton@4.1.5)
 
 **Note:** Version bump only for package @spectrum-css/pickerbutton
 
 <a name="4.1.4"></a>
-##4.1.4
+## 4.1.4
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@4.1.3...@spectrum-css/pickerbutton@4.1.4)
 
 **Note:** Version bump only for package @spectrum-css/pickerbutton
 
 <a name="4.1.3"></a>
-##4.1.3
+## 4.1.3
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@4.1.2...@spectrum-css/pickerbutton@4.1.3)
 
 **Note:** Version bump only for package @spectrum-css/pickerbutton
 
 <a name="4.1.2"></a>
-##4.1.2
+## 4.1.2
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/pickerbutton
 
 <a name="4.1.1"></a>
-##4.1.1
+## 4.1.1
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@4.1.0...@spectrum-css/pickerbutton@4.1.1)
 
 **Note:** Version bump only for package @spectrum-css/pickerbutton
 
 <a name="4.1.0"></a>
-#4.1.0
+# 4.1.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@4.0.23...@spectrum-css/pickerbutton@4.1.0)
 
 **Note:** Version bump only for package @spectrum-css/pickerbutton
 
 <a name="4.0.23"></a>
-##4.0.23
+## 4.0.23
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@4.0.22...@spectrum-css/pickerbutton@4.0.23)
 
 **Note:** Version bump only for package @spectrum-css/pickerbutton
 
 <a name="4.0.22"></a>
-##4.0.22
+## 4.0.22
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@4.0.21...@spectrum-css/pickerbutton@4.0.22)
 
 **Note:** Version bump only for package @spectrum-css/pickerbutton
 
 <a name="4.0.21"></a>
-##4.0.21
+## 4.0.21
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@4.0.20...@spectrum-css/pickerbutton@4.0.21)
 
 **Note:** Version bump only for package @spectrum-css/pickerbutton
 
 <a name="4.0.20"></a>
-##4.0.20
+## 4.0.20
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@4.0.18...@spectrum-css/pickerbutton@4.0.20)
 
 **Note:** Version bump only for package @spectrum-css/pickerbutton
 
 <a name="4.0.19"></a>
-##4.0.19
+## 4.0.19
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@4.0.18...@spectrum-css/pickerbutton@4.0.19)
 
 **Note:** Version bump only for package @spectrum-css/pickerbutton
 
 <a name="4.0.18"></a>
-##4.0.18
+## 4.0.18
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@4.0.17...@spectrum-css/pickerbutton@4.0.18)
 
 **Note:** Version bump only for package @spectrum-css/pickerbutton
 
 <a name="4.0.17"></a>
-##4.0.17
+## 4.0.17
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@4.0.16...@spectrum-css/pickerbutton@4.0.17)
 
 **Note:** Version bump only for package @spectrum-css/pickerbutton
 
 <a name="4.0.16"></a>
-##4.0.16
+## 4.0.16
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@4.0.15...@spectrum-css/pickerbutton@4.0.16)
 
 **Note:** Version bump only for package @spectrum-css/pickerbutton
 
 <a name="4.0.15"></a>
-##4.0.15
+## 4.0.15
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@4.0.14...@spectrum-css/pickerbutton@4.0.15)
 
 **Note:** Version bump only for package @spectrum-css/pickerbutton
 
 <a name="4.0.14"></a>
-##4.0.14
+## 4.0.14
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@4.0.13...@spectrum-css/pickerbutton@4.0.14)
 
 **Note:** Version bump only for package @spectrum-css/pickerbutton
 
 <a name="4.0.13"></a>
-##4.0.13
+## 4.0.13
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@4.0.12...@spectrum-css/pickerbutton@4.0.13)
 
 **Note:** Version bump only for package @spectrum-css/pickerbutton
 
 <a name="4.0.12"></a>
-##4.0.12
+## 4.0.12
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@4.0.11...@spectrum-css/pickerbutton@4.0.12)
 
 **Note:** Version bump only for package @spectrum-css/pickerbutton
 
 <a name="4.0.11"></a>
-##4.0.11
+## 4.0.11
 🗓
 2023-09-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@4.0.10...@spectrum-css/pickerbutton@4.0.11)
 
 **Note:** Version bump only for package @spectrum-css/pickerbutton
 
 <a name="4.0.10"></a>
-##4.0.10
+## 4.0.10
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@4.0.9...@spectrum-css/pickerbutton@4.0.10)
 
 **Note:** Version bump only for package @spectrum-css/pickerbutton
 
 <a name="4.0.9"></a>
-##4.0.9
+## 4.0.9
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@4.0.8...@spectrum-css/pickerbutton@4.0.9)
 
 **Note:** Version bump only for package @spectrum-css/pickerbutton
 
 <a name="4.0.8"></a>
-##4.0.8
+## 4.0.8
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@4.0.7...@spectrum-css/pickerbutton@4.0.8)
 
@@ -208,56 +208,56 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="4.0.7"></a>
-##4.0.7
+## 4.0.7
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@4.0.6...@spectrum-css/pickerbutton@4.0.7)
 
 **Note:** Version bump only for package @spectrum-css/pickerbutton
 
 <a name="4.0.6"></a>
-##4.0.6
+## 4.0.6
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@4.0.4...@spectrum-css/pickerbutton@4.0.6)
 
 **Note:** Version bump only for package @spectrum-css/pickerbutton
 
 <a name="4.0.5"></a>
-##4.0.5
+## 4.0.5
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@4.0.4...@spectrum-css/pickerbutton@4.0.5)
 
 **Note:** Version bump only for package @spectrum-css/pickerbutton
 
 <a name="4.0.4"></a>
-##4.0.4
+## 4.0.4
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@4.0.3...@spectrum-css/pickerbutton@4.0.4)
 
 **Note:** Version bump only for package @spectrum-css/pickerbutton
 
 <a name="4.0.3"></a>
-##4.0.3
+## 4.0.3
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@4.0.2...@spectrum-css/pickerbutton@4.0.3)
 
 **Note:** Version bump only for package @spectrum-css/pickerbutton
 
 <a name="4.0.2"></a>
-##4.0.2
+## 4.0.2
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@4.0.1...@spectrum-css/pickerbutton@4.0.2)
 
 **Note:** Version bump only for package @spectrum-css/pickerbutton
 
 <a name="4.0.1"></a>
-##4.0.1
+## 4.0.1
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@4.0.0...@spectrum-css/pickerbutton@4.0.1)
 
 **Note:** Version bump only for package @spectrum-css/pickerbutton
 
 <a name="4.0.0"></a>
-#4.0.0
+# 4.0.0
 🗓
 2023-07-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@3.0.34...@spectrum-css/pickerbutton@4.0.0)
 
@@ -329,7 +329,7 @@ removes padding from uiicononly class to allow for larger icons in slots
 - chore(pickerbutton): manual version increase for beta release
 
 <a name="3.0.34"></a>
-##3.0.34
+## 3.0.34
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@3.0.33...@spectrum-css/pickerbutton@3.0.34)
 
@@ -338,56 +338,56 @@ removes padding from uiicononly class to allow for larger icons in slots
 \*icon sizing in Storybook story templates ([#2037](https://github.com/adobe/spectrum-css/issues/2037))([c90c8a3](https://github.com/adobe/spectrum-css/commit/c90c8a3))
 
 <a name="3.0.33"></a>
-##3.0.33
+## 3.0.33
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@3.0.32...@spectrum-css/pickerbutton@3.0.33)
 
 **Note:** Version bump only for package @spectrum-css/pickerbutton
 
 <a name="3.0.32"></a>
-##3.0.32
+## 3.0.32
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@3.0.31...@spectrum-css/pickerbutton@3.0.32)
 
 **Note:** Version bump only for package @spectrum-css/pickerbutton
 
 <a name="3.0.31"></a>
-##3.0.31
+## 3.0.31
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@3.0.30...@spectrum-css/pickerbutton@3.0.31)
 
 **Note:** Version bump only for package @spectrum-css/pickerbutton
 
 <a name="3.0.30"></a>
-##3.0.30
+## 3.0.30
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@3.0.29...@spectrum-css/pickerbutton@3.0.30)
 
 **Note:** Version bump only for package @spectrum-css/pickerbutton
 
 <a name="3.0.29"></a>
-##3.0.29
+## 3.0.29
 🗓
 2023-06-28 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@3.0.28...@spectrum-css/pickerbutton@3.0.29)
 
 **Note:** Version bump only for package @spectrum-css/pickerbutton
 
 <a name="3.0.28"></a>
-##3.0.28
+## 3.0.28
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@3.0.27...@spectrum-css/pickerbutton@3.0.28)
 
 **Note:** Version bump only for package @spectrum-css/pickerbutton
 
 <a name="3.0.27"></a>
-##3.0.27
+## 3.0.27
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@3.0.26...@spectrum-css/pickerbutton@3.0.27)
 
 **Note:** Version bump only for package @spectrum-css/pickerbutton
 
 <a name="3.0.26"></a>
-##3.0.26
+## 3.0.26
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@3.0.25...@spectrum-css/pickerbutton@3.0.26)
 
@@ -396,14 +396,14 @@ removes padding from uiicononly class to allow for larger icons in slots
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="3.0.25"></a>
-##3.0.25
+## 3.0.25
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@3.0.24...@spectrum-css/pickerbutton@3.0.25)
 
 **Note:** Version bump only for package @spectrum-css/pickerbutton
 
 <a name="3.0.24"></a>
-##3.0.24
+## 3.0.24
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/pickerbutton@3.0.23...@spectrum-css/pickerbutton@3.0.24)
 

--- a/components/popover/CHANGELOG.md
+++ b/components/popover/CHANGELOG.md
@@ -49,7 +49,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="7.0.0"></a>
-# 7.0.0
+## 7.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@6.2.5...@spectrum-css/popover@7.0.0)
 
@@ -103,7 +103,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/popover
 
 <a name="6.2.0"></a>
-# 6.2.0
+## 6.2.0
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@6.1.0...@spectrum-css/popover@6.2.0)
 
@@ -113,7 +113,7 @@ _migrate build packages to postcss v8 ([#2460](https://github.com/adobe/spectrum
 **overlay,commons:**deprecate overlay; migrate references to commons ([#2429](https://github.com/adobe/spectrum-css/issues/2429))([7eecd96](https://github.com/adobe/spectrum-css/commit/7eecd96))
 
 <a name="6.1.0"></a>
-# 6.1.0
+## 6.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@6.0.84...@spectrum-css/popover@6.1.0)
 
@@ -775,7 +775,7 @@ _migrate build packages to postcss v8 ([#2460](https://github.com/adobe/spectrum
 
 <a name="6.0.0"></a>
 
-# 6.0.0
+## 6.0.0
 
 🗓 2022-11-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@5.0.18...@spectrum-css/popover@6.0.0)
 
@@ -934,7 +934,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="5.0.0"></a>
 
-# 5.0.0
+## 5.0.0
 
 🗓 2022-01-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@3.0.11...@spectrum-css/popover@5.0.0)
 
@@ -952,7 +952,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="4.0.0"></a>
 
-# 4.0.0
+## 4.0.0
 
 🗓 2022-01-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@4.0.0-beta.0...@spectrum-css/popover@4.0.0)
 
@@ -960,7 +960,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="4.0.0-beta.0"></a>
 
-# 4.0.0-beta.0
+## 4.0.0-beta.0
 
 🗓 2021-12-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@3.0.11...@spectrum-css/popover@4.0.0-beta.0)
 
@@ -1104,7 +1104,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@3.0.0-beta.6...@spectrum-css/popover@3.0.0)
 
@@ -1112,7 +1112,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0-beta.6"></a>
 
-# 3.0.0-beta.6
+## 3.0.0-beta.6
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@3.0.0-beta.5...@spectrum-css/popover@3.0.0-beta.6)
 
@@ -1133,7 +1133,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0-beta.5"></a>
 
-# 3.0.0-beta.5
+## 3.0.0-beta.5
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@3.0.0-beta.4...@spectrum-css/popover@3.0.0-beta.5)
 
@@ -1141,7 +1141,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0-beta.4"></a>
 
-# 3.0.0-beta.4
+## 3.0.0-beta.4
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@3.0.0-beta.3...@spectrum-css/popover@3.0.0-beta.4)
 
@@ -1155,7 +1155,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0-beta.3"></a>
 
-# 3.0.0-beta.3
+## 3.0.0-beta.3
 
 🗓 2020-06-19 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@3.0.0-beta.2...@spectrum-css/popover@3.0.0-beta.3)
 
@@ -1163,7 +1163,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@3.0.0-beta.1...@spectrum-css/popover@3.0.0-beta.2)
 
@@ -1171,7 +1171,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@3.0.0-beta.0...@spectrum-css/popover@3.0.0-beta.1)
 
@@ -1179,7 +1179,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@2.0.6...@spectrum-css/popover@3.0.0-beta.0)
 
@@ -1239,7 +1239,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/popover/CHANGELOG.md
+++ b/components/popover/CHANGELOG.md
@@ -49,7 +49,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="7.0.0"></a>
-#7.0.0
+# 7.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@6.2.5...@spectrum-css/popover@7.0.0)
 
@@ -68,42 +68,42 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="6.2.5"></a>
-##6.2.5
+## 6.2.5
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@6.2.4...@spectrum-css/popover@6.2.5)
 
 **Note:** Version bump only for package @spectrum-css/popover
 
 <a name="6.2.4"></a>
-##6.2.4
+## 6.2.4
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@6.2.3...@spectrum-css/popover@6.2.4)
 
 **Note:** Version bump only for package @spectrum-css/popover
 
 <a name="6.2.3"></a>
-##6.2.3
+## 6.2.3
 🗓
 2024-02-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@6.2.2...@spectrum-css/popover@6.2.3)
 
 **Note:** Version bump only for package @spectrum-css/popover
 
 <a name="6.2.2"></a>
-##6.2.2
+## 6.2.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@6.2.1...@spectrum-css/popover@6.2.2)
 
 **Note:** Version bump only for package @spectrum-css/popover
 
 <a name="6.2.1"></a>
-##6.2.1
+## 6.2.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/popover
 
 <a name="6.2.0"></a>
-#6.2.0
+# 6.2.0
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@6.1.0...@spectrum-css/popover@6.2.0)
 
@@ -113,7 +113,7 @@ _migrate build packages to postcss v8 ([#2460](https://github.com/adobe/spectrum
 **overlay,commons:**deprecate overlay; migrate references to commons ([#2429](https://github.com/adobe/spectrum-css/issues/2429))([7eecd96](https://github.com/adobe/spectrum-css/commit/7eecd96))
 
 <a name="6.1.0"></a>
-#6.1.0
+# 6.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@6.0.84...@spectrum-css/popover@6.1.0)
 
@@ -122,14 +122,14 @@ _migrate build packages to postcss v8 ([#2460](https://github.com/adobe/spectrum
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="6.0.84"></a>
-##6.0.84
+## 6.0.84
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@6.0.83...@spectrum-css/popover@6.0.84)
 
 **Note:** Version bump only for package @spectrum-css/popover
 
 <a name="6.0.83"></a>
-##6.0.83
+## 6.0.83
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@6.0.82...@spectrum-css/popover@6.0.83)
 
@@ -140,35 +140,35 @@ _migrate build packages to postcss v8 ([#2460](https://github.com/adobe/spectrum
   **popover:**offset from source, animation distance matches spec([632c668](https://github.com/adobe/spectrum-css/commit/632c668))
 
 <a name="6.0.82"></a>
-##6.0.82
+## 6.0.82
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@6.0.80...@spectrum-css/popover@6.0.82)
 
 **Note:** Version bump only for package @spectrum-css/popover
 
 <a name="6.0.81"></a>
-##6.0.81
+## 6.0.81
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@6.0.80...@spectrum-css/popover@6.0.81)
 
 **Note:** Version bump only for package @spectrum-css/popover
 
 <a name="6.0.80"></a>
-##6.0.80
+## 6.0.80
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@6.0.79...@spectrum-css/popover@6.0.80)
 
 **Note:** Version bump only for package @spectrum-css/popover
 
 <a name="6.0.79"></a>
-##6.0.79
+## 6.0.79
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@6.0.78...@spectrum-css/popover@6.0.79)
 
 **Note:** Version bump only for package @spectrum-css/popover
 
 <a name="6.0.78"></a>
-##6.0.78
+## 6.0.78
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@6.0.77...@spectrum-css/popover@6.0.78)
 
@@ -177,56 +177,56 @@ _migrate build packages to postcss v8 ([#2460](https://github.com/adobe/spectrum
 - **popover:**correct use of alert dialog with in popover ([#2179](https://github.com/adobe/spectrum-css/issues/2179))([39e9f04](https://github.com/adobe/spectrum-css/commit/39e9f04))
 
 <a name="6.0.77"></a>
-##6.0.77
+## 6.0.77
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@6.0.76...@spectrum-css/popover@6.0.77)
 
 **Note:** Version bump only for package @spectrum-css/popover
 
 <a name="6.0.76"></a>
-##6.0.76
+## 6.0.76
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@6.0.75...@spectrum-css/popover@6.0.76)
 
 **Note:** Version bump only for package @spectrum-css/popover
 
 <a name="6.0.75"></a>
-##6.0.75
+## 6.0.75
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@6.0.74...@spectrum-css/popover@6.0.75)
 
 **Note:** Version bump only for package @spectrum-css/popover
 
 <a name="6.0.74"></a>
-##6.0.74
+## 6.0.74
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@6.0.73...@spectrum-css/popover@6.0.74)
 
 **Note:** Version bump only for package @spectrum-css/popover
 
 <a name="6.0.73"></a>
-##6.0.73
+## 6.0.73
 🗓
 2023-09-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@6.0.72...@spectrum-css/popover@6.0.73)
 
 **Note:** Version bump only for package @spectrum-css/popover
 
 <a name="6.0.72"></a>
-##6.0.72
+## 6.0.72
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@6.0.71...@spectrum-css/popover@6.0.72)
 
 **Note:** Version bump only for package @spectrum-css/popover
 
 <a name="6.0.71"></a>
-##6.0.71
+## 6.0.71
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@6.0.70...@spectrum-css/popover@6.0.71)
 
 **Note:** Version bump only for package @spectrum-css/popover
 
 <a name="6.0.70"></a>
-##6.0.70
+## 6.0.70
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@6.0.69...@spectrum-css/popover@6.0.70)
 
@@ -235,56 +235,56 @@ _migrate build packages to postcss v8 ([#2460](https://github.com/adobe/spectrum
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="6.0.69"></a>
-##6.0.69
+## 6.0.69
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@6.0.68...@spectrum-css/popover@6.0.69)
 
 **Note:** Version bump only for package @spectrum-css/popover
 
 <a name="6.0.68"></a>
-##6.0.68
+## 6.0.68
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@6.0.66...@spectrum-css/popover@6.0.68)
 
 **Note:** Version bump only for package @spectrum-css/popover
 
 <a name="6.0.67"></a>
-##6.0.67
+## 6.0.67
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@6.0.66...@spectrum-css/popover@6.0.67)
 
 **Note:** Version bump only for package @spectrum-css/popover
 
 <a name="6.0.66"></a>
-##6.0.66
+## 6.0.66
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@6.0.65...@spectrum-css/popover@6.0.66)
 
 **Note:** Version bump only for package @spectrum-css/popover
 
 <a name="6.0.65"></a>
-##6.0.65
+## 6.0.65
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@6.0.64...@spectrum-css/popover@6.0.65)
 
 **Note:** Version bump only for package @spectrum-css/popover
 
 <a name="6.0.64"></a>
-##6.0.64
+## 6.0.64
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@6.0.63...@spectrum-css/popover@6.0.64)
 
 **Note:** Version bump only for package @spectrum-css/popover
 
 <a name="6.0.63"></a>
-##6.0.63
+## 6.0.63
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@6.0.62...@spectrum-css/popover@6.0.63)
 
 **Note:** Version bump only for package @spectrum-css/popover
 
 <a name="6.0.62"></a>
-##6.0.62
+## 6.0.62
 🗓
 2023-07-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@6.0.61...@spectrum-css/popover@6.0.62)
 
@@ -293,63 +293,63 @@ _migrate build packages to postcss v8 ([#2460](https://github.com/adobe/spectrum
 - **popover:**add highcontrast variables and additional height in docs([930e29f](https://github.com/adobe/spectrum-css/commit/930e29f))
 
 <a name="6.0.61"></a>
-##6.0.61
+## 6.0.61
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@6.0.60...@spectrum-css/popover@6.0.61)
 
 **Note:** Version bump only for package @spectrum-css/popover
 
 <a name="6.0.60"></a>
-##6.0.60
+## 6.0.60
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@6.0.59...@spectrum-css/popover@6.0.60)
 
 **Note:** Version bump only for package @spectrum-css/popover
 
 <a name="6.0.59"></a>
-##6.0.59
+## 6.0.59
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@6.0.58...@spectrum-css/popover@6.0.59)
 
 **Note:** Version bump only for package @spectrum-css/popover
 
 <a name="6.0.58"></a>
-##6.0.58
+## 6.0.58
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@6.0.57...@spectrum-css/popover@6.0.58)
 
 **Note:** Version bump only for package @spectrum-css/popover
 
 <a name="6.0.57"></a>
-##6.0.57
+## 6.0.57
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@6.0.56...@spectrum-css/popover@6.0.57)
 
 **Note:** Version bump only for package @spectrum-css/popover
 
 <a name="6.0.56"></a>
-##6.0.56
+## 6.0.56
 🗓
 2023-06-28 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@6.0.55...@spectrum-css/popover@6.0.56)
 
 **Note:** Version bump only for package @spectrum-css/popover
 
 <a name="6.0.55"></a>
-##6.0.55
+## 6.0.55
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@6.0.54...@spectrum-css/popover@6.0.55)
 
 **Note:** Version bump only for package @spectrum-css/popover
 
 <a name="6.0.54"></a>
-##6.0.54
+## 6.0.54
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@6.0.53...@spectrum-css/popover@6.0.54)
 
 **Note:** Version bump only for package @spectrum-css/popover
 
 <a name="6.0.53"></a>
-##6.0.53
+## 6.0.53
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@6.0.52...@spectrum-css/popover@6.0.53)
 
@@ -358,14 +358,14 @@ _migrate build packages to postcss v8 ([#2460](https://github.com/adobe/spectrum
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="6.0.52"></a>
-##6.0.52
+## 6.0.52
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@6.0.51...@spectrum-css/popover@6.0.52)
 
 **Note:** Version bump only for package @spectrum-css/popover
 
 <a name="6.0.51"></a>
-##6.0.51
+## 6.0.51
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/popover@6.0.50...@spectrum-css/popover@6.0.51)
 

--- a/components/progressbar/CHANGELOG.md
+++ b/components/progressbar/CHANGELOG.md
@@ -35,7 +35,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="4.0.0"></a>
-# 4.0.0
+## 4.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@3.1.5...@spectrum-css/progressbar@4.0.0)
 
@@ -85,7 +85,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/progressbar
 
 <a name="3.1.0"></a>
-# 3.1.0
+## 3.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@3.0.81...@spectrum-css/progressbar@3.1.0)
 
@@ -716,7 +716,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2023-02-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@2.0.12...@spectrum-css/progressbar@3.0.0)
 
@@ -826,7 +826,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2022-11-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@1.0.33...@spectrum-css/progressbar@2.0.0)
 
@@ -1177,7 +1177,7 @@ Co-authored-by: Bernhard Schmidt <52184321+bernhard-adobe@users.noreply.github.c
 
 <a name="1.0.0"></a>
 
-# 1.0.0
+## 1.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@1.0.0-beta.3...@spectrum-css/progressbar@1.0.0)
 
@@ -1185,7 +1185,7 @@ Co-authored-by: Bernhard Schmidt <52184321+bernhard-adobe@users.noreply.github.c
 
 <a name="1.0.0-beta.3"></a>
 
-# 1.0.0-beta.3
+## 1.0.0-beta.3
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@1.0.0-beta.2...@spectrum-css/progressbar@1.0.0-beta.3)
 
@@ -1213,7 +1213,7 @@ Co-authored-by: Bernhard Schmidt <52184321+bernhard-adobe@users.noreply.github.c
 
 <a name="1.0.0-beta.2"></a>
 
-# 1.0.0-beta.2
+## 1.0.0-beta.2
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@1.0.0-beta.1...@spectrum-css/progressbar@1.0.0-beta.2)
 
@@ -1221,7 +1221,7 @@ Co-authored-by: Bernhard Schmidt <52184321+bernhard-adobe@users.noreply.github.c
 
 <a name="1.0.0-beta.1"></a>
 
-# 1.0.0-beta.1
+## 1.0.0-beta.1
 
 🗓 2020-09-23
 
@@ -1231,7 +1231,7 @@ Co-authored-by: Bernhard Schmidt <52184321+bernhard-adobe@users.noreply.github.c
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/barloader@3.0.0-beta.1...@spectrum-css/barloader@3.0.0-beta.2)
 
@@ -1239,7 +1239,7 @@ Co-authored-by: Bernhard Schmidt <52184321+bernhard-adobe@users.noreply.github.c
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/barloader@3.0.0-beta.0...@spectrum-css/barloader@3.0.0-beta.1)
 
@@ -1247,7 +1247,7 @@ Co-authored-by: Bernhard Schmidt <52184321+bernhard-adobe@users.noreply.github.c
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/barloader@2.0.5...@spectrum-css/barloader@3.0.0-beta.0)
 
@@ -1299,7 +1299,7 @@ Co-authored-by: Bernhard Schmidt <52184321+bernhard-adobe@users.noreply.github.c
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/progressbar/CHANGELOG.md
+++ b/components/progressbar/CHANGELOG.md
@@ -35,7 +35,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="4.0.0"></a>
-#4.0.0
+# 4.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@3.1.5...@spectrum-css/progressbar@4.0.0)
 
@@ -50,42 +50,42 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="3.1.5"></a>
-##3.1.5
+## 3.1.5
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@3.1.4...@spectrum-css/progressbar@3.1.5)
 
 **Note:** Version bump only for package @spectrum-css/progressbar
 
 <a name="3.1.4"></a>
-##3.1.4
+## 3.1.4
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@3.1.3...@spectrum-css/progressbar@3.1.4)
 
 **Note:** Version bump only for package @spectrum-css/progressbar
 
 <a name="3.1.3"></a>
-##3.1.3
+## 3.1.3
 🗓
 2024-02-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@3.1.2...@spectrum-css/progressbar@3.1.3)
 
 **Note:** Version bump only for package @spectrum-css/progressbar
 
 <a name="3.1.2"></a>
-##3.1.2
+## 3.1.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@3.1.1...@spectrum-css/progressbar@3.1.2)
 
 **Note:** Version bump only for package @spectrum-css/progressbar
 
 <a name="3.1.1"></a>
-##3.1.1
+## 3.1.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/progressbar
 
 <a name="3.1.0"></a>
-#3.1.0
+# 3.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@3.0.81...@spectrum-css/progressbar@3.1.0)
 
@@ -94,112 +94,112 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="3.0.81"></a>
-##3.0.81
+## 3.0.81
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@3.0.80...@spectrum-css/progressbar@3.0.81)
 
 **Note:** Version bump only for package @spectrum-css/progressbar
 
 <a name="3.0.80"></a>
-##3.0.80
+## 3.0.80
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@3.0.79...@spectrum-css/progressbar@3.0.80)
 
 **Note:** Version bump only for package @spectrum-css/progressbar
 
 <a name="3.0.79"></a>
-##3.0.79
+## 3.0.79
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@3.0.77...@spectrum-css/progressbar@3.0.79)
 
 **Note:** Version bump only for package @spectrum-css/progressbar
 
 <a name="3.0.78"></a>
-##3.0.78
+## 3.0.78
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@3.0.77...@spectrum-css/progressbar@3.0.78)
 
 **Note:** Version bump only for package @spectrum-css/progressbar
 
 <a name="3.0.77"></a>
-##3.0.77
+## 3.0.77
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@3.0.76...@spectrum-css/progressbar@3.0.77)
 
 **Note:** Version bump only for package @spectrum-css/progressbar
 
 <a name="3.0.76"></a>
-##3.0.76
+## 3.0.76
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@3.0.75...@spectrum-css/progressbar@3.0.76)
 
 **Note:** Version bump only for package @spectrum-css/progressbar
 
 <a name="3.0.75"></a>
-##3.0.75
+## 3.0.75
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@3.0.74...@spectrum-css/progressbar@3.0.75)
 
 **Note:** Version bump only for package @spectrum-css/progressbar
 
 <a name="3.0.74"></a>
-##3.0.74
+## 3.0.74
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@3.0.73...@spectrum-css/progressbar@3.0.74)
 
 **Note:** Version bump only for package @spectrum-css/progressbar
 
 <a name="3.0.73"></a>
-##3.0.73
+## 3.0.73
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@3.0.72...@spectrum-css/progressbar@3.0.73)
 
 **Note:** Version bump only for package @spectrum-css/progressbar
 
 <a name="3.0.72"></a>
-##3.0.72
+## 3.0.72
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@3.0.71...@spectrum-css/progressbar@3.0.72)
 
 **Note:** Version bump only for package @spectrum-css/progressbar
 
 <a name="3.0.71"></a>
-##3.0.71
+## 3.0.71
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@3.0.70...@spectrum-css/progressbar@3.0.71)
 
 **Note:** Version bump only for package @spectrum-css/progressbar
 
 <a name="3.0.70"></a>
-##3.0.70
+## 3.0.70
 🗓
 2023-09-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@3.0.69...@spectrum-css/progressbar@3.0.70)
 
 **Note:** Version bump only for package @spectrum-css/progressbar
 
 <a name="3.0.69"></a>
-##3.0.69
+## 3.0.69
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@3.0.68...@spectrum-css/progressbar@3.0.69)
 
 **Note:** Version bump only for package @spectrum-css/progressbar
 
 <a name="3.0.68"></a>
-##3.0.68
+## 3.0.68
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@3.0.67...@spectrum-css/progressbar@3.0.68)
 
 **Note:** Version bump only for package @spectrum-css/progressbar
 
 <a name="3.0.67"></a>
-##3.0.67
+## 3.0.67
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@3.0.66...@spectrum-css/progressbar@3.0.67)
 
 **Note:** Version bump only for package @spectrum-css/progressbar
 
 <a name="3.0.66"></a>
-##3.0.66
+## 3.0.66
 🗓
 2023-08-25 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@3.0.65...@spectrum-css/progressbar@3.0.66)
 
@@ -212,133 +212,133 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="3.0.65"></a>
-##3.0.65
+## 3.0.65
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@3.0.64...@spectrum-css/progressbar@3.0.65)
 
 **Note:** Version bump only for package @spectrum-css/progressbar
 
 <a name="3.0.64"></a>
-##3.0.64
+## 3.0.64
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@3.0.62...@spectrum-css/progressbar@3.0.64)
 
 **Note:** Version bump only for package @spectrum-css/progressbar
 
 <a name="3.0.63"></a>
-##3.0.63
+## 3.0.63
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@3.0.62...@spectrum-css/progressbar@3.0.63)
 
 **Note:** Version bump only for package @spectrum-css/progressbar
 
 <a name="3.0.62"></a>
-##3.0.62
+## 3.0.62
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@3.0.61...@spectrum-css/progressbar@3.0.62)
 
 **Note:** Version bump only for package @spectrum-css/progressbar
 
 <a name="3.0.61"></a>
-##3.0.61
+## 3.0.61
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@3.0.60...@spectrum-css/progressbar@3.0.61)
 
 **Note:** Version bump only for package @spectrum-css/progressbar
 
 <a name="3.0.60"></a>
-##3.0.60
+## 3.0.60
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@3.0.59...@spectrum-css/progressbar@3.0.60)
 
 **Note:** Version bump only for package @spectrum-css/progressbar
 
 <a name="3.0.59"></a>
-##3.0.59
+## 3.0.59
 🗓
 2023-08-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@3.0.58...@spectrum-css/progressbar@3.0.59)
 
 **Note:** Version bump only for package @spectrum-css/progressbar
 
 <a name="3.0.58"></a>
-##3.0.58
+## 3.0.58
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@3.0.57...@spectrum-css/progressbar@3.0.58)
 
 **Note:** Version bump only for package @spectrum-css/progressbar
 
 <a name="3.0.57"></a>
-##3.0.57
+## 3.0.57
 🗓
 2023-07-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@3.0.56...@spectrum-css/progressbar@3.0.57)
 
 **Note:** Version bump only for package @spectrum-css/progressbar
 
 <a name="3.0.56"></a>
-##3.0.56
+## 3.0.56
 🗓
 2023-07-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@3.0.55...@spectrum-css/progressbar@3.0.56)
 
 **Note:** Version bump only for package @spectrum-css/progressbar
 
 <a name="3.0.55"></a>
-##3.0.55
+## 3.0.55
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@3.0.54...@spectrum-css/progressbar@3.0.55)
 
 **Note:** Version bump only for package @spectrum-css/progressbar
 
 <a name="3.0.54"></a>
-##3.0.54
+## 3.0.54
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@3.0.53...@spectrum-css/progressbar@3.0.54)
 
 **Note:** Version bump only for package @spectrum-css/progressbar
 
 <a name="3.0.53"></a>
-##3.0.53
+## 3.0.53
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@3.0.52...@spectrum-css/progressbar@3.0.53)
 
 **Note:** Version bump only for package @spectrum-css/progressbar
 
 <a name="3.0.52"></a>
-##3.0.52
+## 3.0.52
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@3.0.51...@spectrum-css/progressbar@3.0.52)
 
 **Note:** Version bump only for package @spectrum-css/progressbar
 
 <a name="3.0.51"></a>
-##3.0.51
+## 3.0.51
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@3.0.50...@spectrum-css/progressbar@3.0.51)
 
 **Note:** Version bump only for package @spectrum-css/progressbar
 
 <a name="3.0.50"></a>
-##3.0.50
+## 3.0.50
 🗓
 2023-06-28 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@3.0.49...@spectrum-css/progressbar@3.0.50)
 
 **Note:** Version bump only for package @spectrum-css/progressbar
 
 <a name="3.0.49"></a>
-##3.0.49
+## 3.0.49
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@3.0.48...@spectrum-css/progressbar@3.0.49)
 
 **Note:** Version bump only for package @spectrum-css/progressbar
 
 <a name="3.0.48"></a>
-##3.0.48
+## 3.0.48
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@3.0.47...@spectrum-css/progressbar@3.0.48)
 
 **Note:** Version bump only for package @spectrum-css/progressbar
 
 <a name="3.0.47"></a>
-##3.0.47
+## 3.0.47
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@3.0.46...@spectrum-css/progressbar@3.0.47)
 
@@ -347,14 +347,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="3.0.46"></a>
-##3.0.46
+## 3.0.46
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@3.0.45...@spectrum-css/progressbar@3.0.46)
 
 **Note:** Version bump only for package @spectrum-css/progressbar
 
 <a name="3.0.45"></a>
-##3.0.45
+## 3.0.45
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progressbar@3.0.44...@spectrum-css/progressbar@3.0.45)
 

--- a/components/progresscircle/CHANGELOG.md
+++ b/components/progresscircle/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="3.0.0"></a>
-# 3.0.0
+## 3.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progresscircle@2.2.3...@spectrum-css/progresscircle@3.0.0)
 
@@ -65,7 +65,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/progresscircle
 
 <a name="2.2.0"></a>
-# 2.2.0
+## 2.2.0
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progresscircle@2.1.1...@spectrum-css/progresscircle@2.2.0)
 
@@ -81,7 +81,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/progresscircle
 
 <a name="2.1.0"></a>
-# 2.1.0
+## 2.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progresscircle@2.0.75...@spectrum-css/progresscircle@2.1.0)
 
@@ -664,7 +664,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2022-10-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progresscircle@1.0.23...@spectrum-css/progresscircle@2.0.0)
 
@@ -916,7 +916,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="1.0.0"></a>
 
-# 1.0.0
+## 1.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progresscircle@1.0.0-beta.3...@spectrum-css/progresscircle@1.0.0)
 
@@ -924,7 +924,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="1.0.0-beta.3"></a>
 
-# 1.0.0-beta.3
+## 1.0.0-beta.3
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progresscircle@1.0.0-beta.2...@spectrum-css/progresscircle@1.0.0-beta.3)
 
@@ -932,7 +932,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="1.0.0-beta.2"></a>
 
-# 1.0.0-beta.2
+## 1.0.0-beta.2
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progresscircle@1.0.0-beta.1...@spectrum-css/progresscircle@1.0.0-beta.2)
 
@@ -940,7 +940,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="1.0.0-beta.1"></a>
 
-# 1.0.0-beta.1
+## 1.0.0-beta.1
 
 🗓 2020-09-23
 
@@ -950,7 +950,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/circleloader@3.0.0-beta.1...@spectrum-css/circleloader@3.0.0-beta.2)
 
@@ -958,7 +958,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/circleloader@3.0.0-beta.0...@spectrum-css/circleloader@3.0.0-beta.1)
 
@@ -966,7 +966,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/circleloader@2.0.5...@spectrum-css/circleloader@3.0.0-beta.0)
 
@@ -1016,7 +1016,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/progresscircle/CHANGELOG.md
+++ b/components/progresscircle/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="3.0.0"></a>
-#3.0.0
+# 3.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progresscircle@2.2.3...@spectrum-css/progresscircle@3.0.0)
 
@@ -44,28 +44,28 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * Imports added to index.css and themes/express.css
 
 <a name="2.2.3"></a>
-##2.2.3
+## 2.2.3
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progresscircle@2.2.2...@spectrum-css/progresscircle@2.2.3)
 
 **Note:** Version bump only for package @spectrum-css/progresscircle
 
 <a name="2.2.2"></a>
-##2.2.2
+## 2.2.2
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progresscircle@2.2.1...@spectrum-css/progresscircle@2.2.2)
 
 **Note:** Version bump only for package @spectrum-css/progresscircle
 
 <a name="2.2.1"></a>
-##2.2.1
+## 2.2.1
 🗓
 2024-02-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progresscircle@2.2.0...@spectrum-css/progresscircle@2.2.1)
 
 **Note:** Version bump only for package @spectrum-css/progresscircle
 
 <a name="2.2.0"></a>
-#2.2.0
+# 2.2.0
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progresscircle@2.1.1...@spectrum-css/progresscircle@2.2.0)
 
@@ -74,14 +74,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **button:**pending state([0b82dd9](https://github.com/adobe/spectrum-css/commit/0b82dd9))
 
 <a name="2.1.1"></a>
-##2.1.1
+## 2.1.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/progresscircle
 
 <a name="2.1.0"></a>
-#2.1.0
+# 2.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progresscircle@2.0.75...@spectrum-css/progresscircle@2.1.0)
 
@@ -90,98 +90,98 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="2.0.75"></a>
-##2.0.75
+## 2.0.75
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progresscircle@2.0.74...@spectrum-css/progresscircle@2.0.75)
 
 **Note:** Version bump only for package @spectrum-css/progresscircle
 
 <a name="2.0.74"></a>
-##2.0.74
+## 2.0.74
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progresscircle@2.0.73...@spectrum-css/progresscircle@2.0.74)
 
 **Note:** Version bump only for package @spectrum-css/progresscircle
 
 <a name="2.0.73"></a>
-##2.0.73
+## 2.0.73
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progresscircle@2.0.71...@spectrum-css/progresscircle@2.0.73)
 
 **Note:** Version bump only for package @spectrum-css/progresscircle
 
 <a name="2.0.72"></a>
-##2.0.72
+## 2.0.72
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progresscircle@2.0.71...@spectrum-css/progresscircle@2.0.72)
 
 **Note:** Version bump only for package @spectrum-css/progresscircle
 
 <a name="2.0.71"></a>
-##2.0.71
+## 2.0.71
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progresscircle@2.0.70...@spectrum-css/progresscircle@2.0.71)
 
 **Note:** Version bump only for package @spectrum-css/progresscircle
 
 <a name="2.0.70"></a>
-##2.0.70
+## 2.0.70
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progresscircle@2.0.69...@spectrum-css/progresscircle@2.0.70)
 
 **Note:** Version bump only for package @spectrum-css/progresscircle
 
 <a name="2.0.69"></a>
-##2.0.69
+## 2.0.69
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progresscircle@2.0.68...@spectrum-css/progresscircle@2.0.69)
 
 **Note:** Version bump only for package @spectrum-css/progresscircle
 
 <a name="2.0.68"></a>
-##2.0.68
+## 2.0.68
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progresscircle@2.0.67...@spectrum-css/progresscircle@2.0.68)
 
 **Note:** Version bump only for package @spectrum-css/progresscircle
 
 <a name="2.0.67"></a>
-##2.0.67
+## 2.0.67
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progresscircle@2.0.66...@spectrum-css/progresscircle@2.0.67)
 
 **Note:** Version bump only for package @spectrum-css/progresscircle
 
 <a name="2.0.66"></a>
-##2.0.66
+## 2.0.66
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progresscircle@2.0.65...@spectrum-css/progresscircle@2.0.66)
 
 **Note:** Version bump only for package @spectrum-css/progresscircle
 
 <a name="2.0.65"></a>
-##2.0.65
+## 2.0.65
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progresscircle@2.0.64...@spectrum-css/progresscircle@2.0.65)
 
 **Note:** Version bump only for package @spectrum-css/progresscircle
 
 <a name="2.0.64"></a>
-##2.0.64
+## 2.0.64
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progresscircle@2.0.63...@spectrum-css/progresscircle@2.0.64)
 
 **Note:** Version bump only for package @spectrum-css/progresscircle
 
 <a name="2.0.63"></a>
-##2.0.63
+## 2.0.63
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progresscircle@2.0.62...@spectrum-css/progresscircle@2.0.63)
 
 **Note:** Version bump only for package @spectrum-css/progresscircle
 
 <a name="2.0.62"></a>
-##2.0.62
+## 2.0.62
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progresscircle@2.0.61...@spectrum-css/progresscircle@2.0.62)
 
@@ -190,105 +190,105 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="2.0.61"></a>
-##2.0.61
+## 2.0.61
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progresscircle@2.0.60...@spectrum-css/progresscircle@2.0.61)
 
 **Note:** Version bump only for package @spectrum-css/progresscircle
 
 <a name="2.0.60"></a>
-##2.0.60
+## 2.0.60
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progresscircle@2.0.58...@spectrum-css/progresscircle@2.0.60)
 
 **Note:** Version bump only for package @spectrum-css/progresscircle
 
 <a name="2.0.59"></a>
-##2.0.59
+## 2.0.59
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progresscircle@2.0.58...@spectrum-css/progresscircle@2.0.59)
 
 **Note:** Version bump only for package @spectrum-css/progresscircle
 
 <a name="2.0.58"></a>
-##2.0.58
+## 2.0.58
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progresscircle@2.0.57...@spectrum-css/progresscircle@2.0.58)
 
 **Note:** Version bump only for package @spectrum-css/progresscircle
 
 <a name="2.0.57"></a>
-##2.0.57
+## 2.0.57
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progresscircle@2.0.56...@spectrum-css/progresscircle@2.0.57)
 
 **Note:** Version bump only for package @spectrum-css/progresscircle
 
 <a name="2.0.56"></a>
-##2.0.56
+## 2.0.56
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progresscircle@2.0.55...@spectrum-css/progresscircle@2.0.56)
 
 **Note:** Version bump only for package @spectrum-css/progresscircle
 
 <a name="2.0.55"></a>
-##2.0.55
+## 2.0.55
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progresscircle@2.0.54...@spectrum-css/progresscircle@2.0.55)
 
 **Note:** Version bump only for package @spectrum-css/progresscircle
 
 <a name="2.0.54"></a>
-##2.0.54
+## 2.0.54
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progresscircle@2.0.53...@spectrum-css/progresscircle@2.0.54)
 
 **Note:** Version bump only for package @spectrum-css/progresscircle
 
 <a name="2.0.53"></a>
-##2.0.53
+## 2.0.53
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progresscircle@2.0.52...@spectrum-css/progresscircle@2.0.53)
 
 **Note:** Version bump only for package @spectrum-css/progresscircle
 
 <a name="2.0.52"></a>
-##2.0.52
+## 2.0.52
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progresscircle@2.0.51...@spectrum-css/progresscircle@2.0.52)
 
 **Note:** Version bump only for package @spectrum-css/progresscircle
 
 <a name="2.0.51"></a>
-##2.0.51
+## 2.0.51
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progresscircle@2.0.50...@spectrum-css/progresscircle@2.0.51)
 
 **Note:** Version bump only for package @spectrum-css/progresscircle
 
 <a name="2.0.50"></a>
-##2.0.50
+## 2.0.50
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progresscircle@2.0.49...@spectrum-css/progresscircle@2.0.50)
 
 **Note:** Version bump only for package @spectrum-css/progresscircle
 
 <a name="2.0.49"></a>
-##2.0.49
+## 2.0.49
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progresscircle@2.0.48...@spectrum-css/progresscircle@2.0.49)
 
 **Note:** Version bump only for package @spectrum-css/progresscircle
 
 <a name="2.0.48"></a>
-##2.0.48
+## 2.0.48
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progresscircle@2.0.47...@spectrum-css/progresscircle@2.0.48)
 
 **Note:** Version bump only for package @spectrum-css/progresscircle
 
 <a name="2.0.47"></a>
-##2.0.47
+## 2.0.47
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progresscircle@2.0.46...@spectrum-css/progresscircle@2.0.47)
 
@@ -297,14 +297,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="2.0.46"></a>
-##2.0.46
+## 2.0.46
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progresscircle@2.0.45...@spectrum-css/progresscircle@2.0.46)
 
 **Note:** Version bump only for package @spectrum-css/progresscircle
 
 <a name="2.0.45"></a>
-##2.0.45
+## 2.0.45
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/progresscircle@2.0.44...@spectrum-css/progresscircle@2.0.45)
 

--- a/components/radio/CHANGELOG.md
+++ b/components/radio/CHANGELOG.md
@@ -41,7 +41,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="9.0.0"></a>
-#9.0.0
+# 9.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@8.1.5...@spectrum-css/radio@9.0.0)
 
@@ -56,63 +56,63 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="8.1.5"></a>
-##8.1.5
+## 8.1.5
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@8.1.4...@spectrum-css/radio@8.1.5)
 
 **Note:** Version bump only for package @spectrum-css/radio
 
 <a name="8.1.4"></a>
-##8.1.4
+## 8.1.4
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@8.1.3...@spectrum-css/radio@8.1.4)
 
 **Note:** Version bump only for package @spectrum-css/radio
 
 <a name="8.1.3"></a>
-##8.1.3
+## 8.1.3
 🗓
 2024-02-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@8.1.2...@spectrum-css/radio@8.1.3)
 
 **Note:** Version bump only for package @spectrum-css/radio
 
 <a name="8.1.2"></a>
-##8.1.2
+## 8.1.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@8.1.1...@spectrum-css/radio@8.1.2)
 
 **Note:** Version bump only for package @spectrum-css/radio
 
 <a name="8.1.1"></a>
-##8.1.1
+## 8.1.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/radio
 
 <a name="8.1.0"></a>
-#8.1.0
+# 8.1.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@8.0.19...@spectrum-css/radio@8.1.0)
 
 **Note:** Version bump only for package @spectrum-css/radio
 
 <a name="8.0.19"></a>
-##8.0.19
+## 8.0.19
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@8.0.18...@spectrum-css/radio@8.0.19)
 
 **Note:** Version bump only for package @spectrum-css/radio
 
 <a name="8.0.18"></a>
-##8.0.18
+## 8.0.18
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@8.0.17...@spectrum-css/radio@8.0.18)
 
 **Note:** Version bump only for package @spectrum-css/radio
 
 <a name="8.0.17"></a>
-##8.0.17
+## 8.0.17
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@8.0.16...@spectrum-css/radio@8.0.17)
 
@@ -121,91 +121,91 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **radio:**focus outline has correct position for rtl ([#2315](https://github.com/adobe/spectrum-css/issues/2315))([d46c017](https://github.com/adobe/spectrum-css/commit/d46c017))
 
 <a name="8.0.16"></a>
-##8.0.16
+## 8.0.16
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@8.0.14...@spectrum-css/radio@8.0.16)
 
 **Note:** Version bump only for package @spectrum-css/radio
 
 <a name="8.0.15"></a>
-##8.0.15
+## 8.0.15
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@8.0.14...@spectrum-css/radio@8.0.15)
 
 **Note:** Version bump only for package @spectrum-css/radio
 
 <a name="8.0.14"></a>
-##8.0.14
+## 8.0.14
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@8.0.13...@spectrum-css/radio@8.0.14)
 
 **Note:** Version bump only for package @spectrum-css/radio
 
 <a name="8.0.13"></a>
-##8.0.13
+## 8.0.13
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@8.0.12...@spectrum-css/radio@8.0.13)
 
 **Note:** Version bump only for package @spectrum-css/radio
 
 <a name="8.0.12"></a>
-##8.0.12
+## 8.0.12
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@8.0.11...@spectrum-css/radio@8.0.12)
 
 **Note:** Version bump only for package @spectrum-css/radio
 
 <a name="8.0.11"></a>
-##8.0.11
+## 8.0.11
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@8.0.10...@spectrum-css/radio@8.0.11)
 
 **Note:** Version bump only for package @spectrum-css/radio
 
 <a name="8.0.10"></a>
-##8.0.10
+## 8.0.10
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@8.0.9...@spectrum-css/radio@8.0.10)
 
 **Note:** Version bump only for package @spectrum-css/radio
 
 <a name="8.0.9"></a>
-##8.0.9
+## 8.0.9
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@8.0.8...@spectrum-css/radio@8.0.9)
 
 **Note:** Version bump only for package @spectrum-css/radio
 
 <a name="8.0.8"></a>
-##8.0.8
+## 8.0.8
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@8.0.7...@spectrum-css/radio@8.0.8)
 
 **Note:** Version bump only for package @spectrum-css/radio
 
 <a name="8.0.7"></a>
-##8.0.7
+## 8.0.7
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@8.0.6...@spectrum-css/radio@8.0.7)
 
 **Note:** Version bump only for package @spectrum-css/radio
 
 <a name="8.0.6"></a>
-##8.0.6
+## 8.0.6
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@8.0.5...@spectrum-css/radio@8.0.6)
 
 **Note:** Version bump only for package @spectrum-css/radio
 
 <a name="8.0.5"></a>
-##8.0.5
+## 8.0.5
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@8.0.4...@spectrum-css/radio@8.0.5)
 
 **Note:** Version bump only for package @spectrum-css/radio
 
 <a name="8.0.4"></a>
-##8.0.4
+## 8.0.4
 🗓
 2023-08-25 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@8.0.3...@spectrum-css/radio@8.0.4)
 
@@ -214,28 +214,28 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="8.0.3"></a>
-##8.0.3
+## 8.0.3
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@8.0.2...@spectrum-css/radio@8.0.3)
 
 **Note:** Version bump only for package @spectrum-css/radio
 
 <a name="8.0.2"></a>
-##8.0.2
+## 8.0.2
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@8.0.0...@spectrum-css/radio@8.0.2)
 
 **Note:** Version bump only for package @spectrum-css/radio
 
 <a name="8.0.1"></a>
-##8.0.1
+## 8.0.1
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@8.0.0...@spectrum-css/radio@8.0.1)
 
 **Note:** Version bump only for package @spectrum-css/radio
 
 <a name="8.0.0"></a>
-#8.0.0
+# 8.0.0
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@7.0.46...@spectrum-css/radio@8.0.0)
 
@@ -248,7 +248,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
     		remove focus-ring in favor of focus-visible
 
 <a name="7.0.46"></a>
-##7.0.46
+## 7.0.46
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@7.0.45...@spectrum-css/radio@7.0.46)
 
@@ -257,70 +257,70 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **radio:**update selected color tokens ([#2045](https://github.com/adobe/spectrum-css/issues/2045))([7914b72](https://github.com/adobe/spectrum-css/commit/7914b72))
 
 <a name="7.0.45"></a>
-##7.0.45
+## 7.0.45
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@7.0.44...@spectrum-css/radio@7.0.45)
 
 **Note:** Version bump only for package @spectrum-css/radio
 
 <a name="7.0.44"></a>
-##7.0.44
+## 7.0.44
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@7.0.43...@spectrum-css/radio@7.0.44)
 
 **Note:** Version bump only for package @spectrum-css/radio
 
 <a name="7.0.43"></a>
-##7.0.43
+## 7.0.43
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@7.0.42...@spectrum-css/radio@7.0.43)
 
 **Note:** Version bump only for package @spectrum-css/radio
 
 <a name="7.0.42"></a>
-##7.0.42
+## 7.0.42
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@7.0.41...@spectrum-css/radio@7.0.42)
 
 **Note:** Version bump only for package @spectrum-css/radio
 
 <a name="7.0.41"></a>
-##7.0.41
+## 7.0.41
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@7.0.40...@spectrum-css/radio@7.0.41)
 
 **Note:** Version bump only for package @spectrum-css/radio
 
 <a name="7.0.40"></a>
-##7.0.40
+## 7.0.40
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@7.0.39...@spectrum-css/radio@7.0.40)
 
 **Note:** Version bump only for package @spectrum-css/radio
 
 <a name="7.0.39"></a>
-##7.0.39
+## 7.0.39
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@7.0.38...@spectrum-css/radio@7.0.39)
 
 **Note:** Version bump only for package @spectrum-css/radio
 
 <a name="7.0.38"></a>
-##7.0.38
+## 7.0.38
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@7.0.37...@spectrum-css/radio@7.0.38)
 
 **Note:** Version bump only for package @spectrum-css/radio
 
 <a name="7.0.37"></a>
-##7.0.37
+## 7.0.37
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@7.0.36...@spectrum-css/radio@7.0.37)
 
 **Note:** Version bump only for package @spectrum-css/radio
 
 <a name="7.0.36"></a>
-##7.0.36
+## 7.0.36
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@7.0.35...@spectrum-css/radio@7.0.36)
 
@@ -329,14 +329,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="7.0.35"></a>
-##7.0.35
+## 7.0.35
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@7.0.34...@spectrum-css/radio@7.0.35)
 
 **Note:** Version bump only for package @spectrum-css/radio
 
 <a name="7.0.34"></a>
-##7.0.34
+## 7.0.34
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@7.0.33...@spectrum-css/radio@7.0.34)
 

--- a/components/radio/CHANGELOG.md
+++ b/components/radio/CHANGELOG.md
@@ -41,7 +41,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="9.0.0"></a>
-# 9.0.0
+## 9.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@8.1.5...@spectrum-css/radio@9.0.0)
 
@@ -91,7 +91,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/radio
 
 <a name="8.1.0"></a>
-# 8.1.0
+## 8.1.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@8.0.19...@spectrum-css/radio@8.1.0)
 
@@ -235,7 +235,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/radio
 
 <a name="8.0.0"></a>
-# 8.0.0
+## 8.0.0
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@7.0.46...@spectrum-css/radio@8.0.0)
 
@@ -608,7 +608,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="7.0.0"></a>
 
-# 7.0.0
+## 7.0.0
 
 🗓 2023-02-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@6.0.10...@spectrum-css/radio@7.0.0)
 
@@ -702,7 +702,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="6.0.0"></a>
 
-# 6.0.0
+## 6.0.0
 
 🗓 2022-11-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@5.0.1...@spectrum-css/radio@6.0.0)
 
@@ -726,7 +726,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="5.0.0"></a>
 
-# 5.0.0
+## 5.0.0
 
 🗓 2022-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@4.0.5...@spectrum-css/radio@5.0.0)
 
@@ -784,7 +784,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="4.0.0"></a>
 
-# 4.0.0
+## 4.0.0
 
 🗓 2022-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@3.0.24...@spectrum-css/radio@4.0.0)
 
@@ -802,7 +802,7 @@ Additionally, it brings the component up-to-date with the latest design spec:
 
 <a name="4.0.0-beta.1"></a>
 
-# 4.0.0-beta.1
+## 4.0.0-beta.1
 
 🗓 2022-08-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@3.0.24...@spectrum-css/radio@4.0.0-beta.1)
 
@@ -820,7 +820,7 @@ Additionally, it brings the component up-to-date with the latest design spec:
 
 <a name="4.0.0-beta.0"></a>
 
-# 4.0.0-beta.0
+## 4.0.0-beta.0
 
 🗓 2022-07-27 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@3.0.24...@spectrum-css/radio@4.0.0-beta.0)
 
@@ -1078,7 +1078,7 @@ Additionally, it brings the component up-to-date with the latest design spec:
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@3.0.0-beta.5...@spectrum-css/radio@3.0.0)
 
@@ -1086,7 +1086,7 @@ Additionally, it brings the component up-to-date with the latest design spec:
 
 <a name="3.0.0-beta.5"></a>
 
-# 3.0.0-beta.5
+## 3.0.0-beta.5
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@3.0.0-beta.4...@spectrum-css/radio@3.0.0-beta.5)
 
@@ -1107,7 +1107,7 @@ docs: add docs explaining quiet/emphasized Checkbox/Radio
 
 <a name="3.0.0-beta.4"></a>
 
-# 3.0.0-beta.4
+## 3.0.0-beta.4
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@3.0.0-beta.3...@spectrum-css/radio@3.0.0-beta.4)
 
@@ -1119,7 +1119,7 @@ docs: add docs explaining quiet/emphasized Checkbox/Radio
 
 <a name="3.0.0-beta.3"></a>
 
-# 3.0.0-beta.3
+## 3.0.0-beta.3
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@3.0.0-beta.2...@spectrum-css/radio@3.0.0-beta.3)
 
@@ -1140,7 +1140,7 @@ docs: add docs explaining quiet/emphasized Checkbox/Radio
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@3.0.0-beta.1...@spectrum-css/radio@3.0.0-beta.2)
 
@@ -1148,7 +1148,7 @@ docs: add docs explaining quiet/emphasized Checkbox/Radio
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@3.0.0-beta.0...@spectrum-css/radio@3.0.0-beta.1)
 
@@ -1156,7 +1156,7 @@ docs: add docs explaining quiet/emphasized Checkbox/Radio
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@2.1.0...@spectrum-css/radio@3.0.0-beta.0)
 
@@ -1170,7 +1170,7 @@ docs: add docs explaining quiet/emphasized Checkbox/Radio
 
 <a name="2.1.0"></a>
 
-# 2.1.0
+## 2.1.0
 
 🗓 2020-03-06 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/radio@2.0.5...@spectrum-css/radio@2.1.0)
 
@@ -1226,7 +1226,7 @@ docs: add docs explaining quiet/emphasized Checkbox/Radio
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/rating/CHANGELOG.md
+++ b/components/rating/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-#5.0.0
+# 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rating@4.2.4...@spectrum-css/rating@5.0.0)
 
@@ -48,42 +48,42 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="4.2.4"></a>
-##4.2.4
+## 4.2.4
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rating@4.2.3...@spectrum-css/rating@4.2.4)
 
 **Note:** Version bump only for package @spectrum-css/rating
 
 <a name="4.2.3"></a>
-##4.2.3
+## 4.2.3
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rating@4.2.2...@spectrum-css/rating@4.2.3)
 
 **Note:** Version bump only for package @spectrum-css/rating
 
 <a name="4.2.2"></a>
-##4.2.2
+## 4.2.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rating@4.2.1...@spectrum-css/rating@4.2.2)
 
 **Note:** Version bump only for package @spectrum-css/rating
 
 <a name="4.2.1"></a>
-##4.2.1
+## 4.2.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/rating
 
 <a name="4.2.0"></a>
-#4.2.0
+# 4.2.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rating@4.1.0...@spectrum-css/rating@4.2.0)
 
 **Note:** Version bump only for package @spectrum-css/rating
 
 <a name="4.1.0"></a>
-#4.1.0
+# 4.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rating@4.0.35...@spectrum-css/rating@4.1.0)
 
@@ -92,98 +92,98 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="4.0.35"></a>
-##4.0.35
+## 4.0.35
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rating@4.0.34...@spectrum-css/rating@4.0.35)
 
 **Note:** Version bump only for package @spectrum-css/rating
 
 <a name="4.0.34"></a>
-##4.0.34
+## 4.0.34
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rating@4.0.33...@spectrum-css/rating@4.0.34)
 
 **Note:** Version bump only for package @spectrum-css/rating
 
 <a name="4.0.33"></a>
-##4.0.33
+## 4.0.33
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rating@4.0.31...@spectrum-css/rating@4.0.33)
 
 **Note:** Version bump only for package @spectrum-css/rating
 
 <a name="4.0.32"></a>
-##4.0.32
+## 4.0.32
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rating@4.0.31...@spectrum-css/rating@4.0.32)
 
 **Note:** Version bump only for package @spectrum-css/rating
 
 <a name="4.0.31"></a>
-##4.0.31
+## 4.0.31
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rating@4.0.30...@spectrum-css/rating@4.0.31)
 
 **Note:** Version bump only for package @spectrum-css/rating
 
 <a name="4.0.30"></a>
-##4.0.30
+## 4.0.30
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rating@4.0.29...@spectrum-css/rating@4.0.30)
 
 **Note:** Version bump only for package @spectrum-css/rating
 
 <a name="4.0.29"></a>
-##4.0.29
+## 4.0.29
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rating@4.0.28...@spectrum-css/rating@4.0.29)
 
 **Note:** Version bump only for package @spectrum-css/rating
 
 <a name="4.0.28"></a>
-##4.0.28
+## 4.0.28
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rating@4.0.27...@spectrum-css/rating@4.0.28)
 
 **Note:** Version bump only for package @spectrum-css/rating
 
 <a name="4.0.27"></a>
-##4.0.27
+## 4.0.27
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rating@4.0.26...@spectrum-css/rating@4.0.27)
 
 **Note:** Version bump only for package @spectrum-css/rating
 
 <a name="4.0.26"></a>
-##4.0.26
+## 4.0.26
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rating@4.0.25...@spectrum-css/rating@4.0.26)
 
 **Note:** Version bump only for package @spectrum-css/rating
 
 <a name="4.0.25"></a>
-##4.0.25
+## 4.0.25
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rating@4.0.24...@spectrum-css/rating@4.0.25)
 
 **Note:** Version bump only for package @spectrum-css/rating
 
 <a name="4.0.24"></a>
-##4.0.24
+## 4.0.24
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rating@4.0.23...@spectrum-css/rating@4.0.24)
 
 **Note:** Version bump only for package @spectrum-css/rating
 
 <a name="4.0.23"></a>
-##4.0.23
+## 4.0.23
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rating@4.0.22...@spectrum-css/rating@4.0.23)
 
 **Note:** Version bump only for package @spectrum-css/rating
 
 <a name="4.0.22"></a>
-##4.0.22
+## 4.0.22
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rating@4.0.21...@spectrum-css/rating@4.0.22)
 
@@ -192,105 +192,105 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="4.0.21"></a>
-##4.0.21
+## 4.0.21
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rating@4.0.20...@spectrum-css/rating@4.0.21)
 
 **Note:** Version bump only for package @spectrum-css/rating
 
 <a name="4.0.20"></a>
-##4.0.20
+## 4.0.20
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rating@4.0.18...@spectrum-css/rating@4.0.20)
 
 **Note:** Version bump only for package @spectrum-css/rating
 
 <a name="4.0.19"></a>
-##4.0.19
+## 4.0.19
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rating@4.0.18...@spectrum-css/rating@4.0.19)
 
 **Note:** Version bump only for package @spectrum-css/rating
 
 <a name="4.0.18"></a>
-##4.0.18
+## 4.0.18
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rating@4.0.17...@spectrum-css/rating@4.0.18)
 
 **Note:** Version bump only for package @spectrum-css/rating
 
 <a name="4.0.17"></a>
-##4.0.17
+## 4.0.17
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rating@4.0.16...@spectrum-css/rating@4.0.17)
 
 **Note:** Version bump only for package @spectrum-css/rating
 
 <a name="4.0.16"></a>
-##4.0.16
+## 4.0.16
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rating@4.0.15...@spectrum-css/rating@4.0.16)
 
 **Note:** Version bump only for package @spectrum-css/rating
 
 <a name="4.0.15"></a>
-##4.0.15
+## 4.0.15
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rating@4.0.14...@spectrum-css/rating@4.0.15)
 
 **Note:** Version bump only for package @spectrum-css/rating
 
 <a name="4.0.14"></a>
-##4.0.14
+## 4.0.14
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rating@4.0.13...@spectrum-css/rating@4.0.14)
 
 **Note:** Version bump only for package @spectrum-css/rating
 
 <a name="4.0.13"></a>
-##4.0.13
+## 4.0.13
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rating@4.0.12...@spectrum-css/rating@4.0.13)
 
 **Note:** Version bump only for package @spectrum-css/rating
 
 <a name="4.0.12"></a>
-##4.0.12
+## 4.0.12
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rating@4.0.11...@spectrum-css/rating@4.0.12)
 
 **Note:** Version bump only for package @spectrum-css/rating
 
 <a name="4.0.11"></a>
-##4.0.11
+## 4.0.11
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rating@4.0.10...@spectrum-css/rating@4.0.11)
 
 **Note:** Version bump only for package @spectrum-css/rating
 
 <a name="4.0.10"></a>
-##4.0.10
+## 4.0.10
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rating@4.0.9...@spectrum-css/rating@4.0.10)
 
 **Note:** Version bump only for package @spectrum-css/rating
 
 <a name="4.0.9"></a>
-##4.0.9
+## 4.0.9
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rating@4.0.8...@spectrum-css/rating@4.0.9)
 
 **Note:** Version bump only for package @spectrum-css/rating
 
 <a name="4.0.8"></a>
-##4.0.8
+## 4.0.8
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rating@4.0.7...@spectrum-css/rating@4.0.8)
 
 **Note:** Version bump only for package @spectrum-css/rating
 
 <a name="4.0.7"></a>
-##4.0.7
+## 4.0.7
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rating@4.0.6...@spectrum-css/rating@4.0.7)
 
@@ -299,14 +299,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="4.0.6"></a>
-##4.0.6
+## 4.0.6
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rating@4.0.5...@spectrum-css/rating@4.0.6)
 
 **Note:** Version bump only for package @spectrum-css/rating
 
 <a name="4.0.5"></a>
-##4.0.5
+## 4.0.5
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rating@4.0.4...@spectrum-css/rating@4.0.5)
 

--- a/components/rating/CHANGELOG.md
+++ b/components/rating/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-# 5.0.0
+## 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rating@4.2.4...@spectrum-css/rating@5.0.0)
 
@@ -76,14 +76,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/rating
 
 <a name="4.2.0"></a>
-# 4.2.0
+## 4.2.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rating@4.1.0...@spectrum-css/rating@4.2.0)
 
 **Note:** Version bump only for package @spectrum-css/rating
 
 <a name="4.1.0"></a>
-# 4.1.0
+## 4.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rating@4.0.35...@spectrum-css/rating@4.1.0)
 
@@ -346,7 +346,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="4.0.0"></a>
 
-# 4.0.0
+## 4.0.0
 
 🗓 2023-05-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rating@3.0.43...@spectrum-css/rating@4.0.0)
 
@@ -754,7 +754,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rating@3.0.0-beta.2...@spectrum-css/rating@3.0.0)
 
@@ -762,7 +762,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rating@3.0.0-beta.1...@spectrum-css/rating@3.0.0-beta.2)
 
@@ -772,7 +772,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rating@3.0.0-beta.0...@spectrum-css/rating@3.0.0-beta.1)
 
@@ -780,7 +780,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/rating@2.0.7...@spectrum-css/rating@3.0.0-beta.0)
 
@@ -854,7 +854,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/search/CHANGELOG.md
+++ b/components/search/CHANGELOG.md
@@ -39,7 +39,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="7.0.0"></a>
-#7.0.0
+# 7.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@6.2.4...@spectrum-css/search@7.0.0)
 
@@ -54,42 +54,42 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="6.2.4"></a>
-##6.2.4
+## 6.2.4
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@6.2.3...@spectrum-css/search@6.2.4)
 
 **Note:** Version bump only for package @spectrum-css/search
 
 <a name="6.2.3"></a>
-##6.2.3
+## 6.2.3
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@6.2.2...@spectrum-css/search@6.2.3)
 
 **Note:** Version bump only for package @spectrum-css/search
 
 <a name="6.2.2"></a>
-##6.2.2
+## 6.2.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@6.2.1...@spectrum-css/search@6.2.2)
 
 **Note:** Version bump only for package @spectrum-css/search
 
 <a name="6.2.1"></a>
-##6.2.1
+## 6.2.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/search
 
 <a name="6.2.0"></a>
-#6.2.0
+# 6.2.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@6.1.0...@spectrum-css/search@6.2.0)
 
 **Note:** Version bump only for package @spectrum-css/search
 
 <a name="6.1.0"></a>
-#6.1.0
+# 6.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@6.0.30...@spectrum-css/search@6.1.0)
 
@@ -98,105 +98,105 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="6.0.30"></a>
-##6.0.30
+## 6.0.30
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@6.0.29...@spectrum-css/search@6.0.30)
 
 **Note:** Version bump only for package @spectrum-css/search
 
 <a name="6.0.29"></a>
-##6.0.29
+## 6.0.29
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@6.0.28...@spectrum-css/search@6.0.29)
 
 **Note:** Version bump only for package @spectrum-css/search
 
 <a name="6.0.28"></a>
-##6.0.28
+## 6.0.28
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@6.0.26...@spectrum-css/search@6.0.28)
 
 **Note:** Version bump only for package @spectrum-css/search
 
 <a name="6.0.27"></a>
-##6.0.27
+## 6.0.27
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@6.0.26...@spectrum-css/search@6.0.27)
 
 **Note:** Version bump only for package @spectrum-css/search
 
 <a name="6.0.26"></a>
-##6.0.26
+## 6.0.26
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@6.0.25...@spectrum-css/search@6.0.26)
 
 **Note:** Version bump only for package @spectrum-css/search
 
 <a name="6.0.25"></a>
-##6.0.25
+## 6.0.25
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@6.0.24...@spectrum-css/search@6.0.25)
 
 **Note:** Version bump only for package @spectrum-css/search
 
 <a name="6.0.24"></a>
-##6.0.24
+## 6.0.24
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@6.0.23...@spectrum-css/search@6.0.24)
 
 **Note:** Version bump only for package @spectrum-css/search
 
 <a name="6.0.23"></a>
-##6.0.23
+## 6.0.23
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@6.0.22...@spectrum-css/search@6.0.23)
 
 **Note:** Version bump only for package @spectrum-css/search
 
 <a name="6.0.22"></a>
-##6.0.22
+## 6.0.22
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@6.0.21...@spectrum-css/search@6.0.22)
 
 **Note:** Version bump only for package @spectrum-css/search
 
 <a name="6.0.21"></a>
-##6.0.21
+## 6.0.21
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@6.0.20...@spectrum-css/search@6.0.21)
 
 **Note:** Version bump only for package @spectrum-css/search
 
 <a name="6.0.20"></a>
-##6.0.20
+## 6.0.20
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@6.0.19...@spectrum-css/search@6.0.20)
 
 **Note:** Version bump only for package @spectrum-css/search
 
 <a name="6.0.19"></a>
-##6.0.19
+## 6.0.19
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@6.0.18...@spectrum-css/search@6.0.19)
 
 **Note:** Version bump only for package @spectrum-css/search
 
 <a name="6.0.18"></a>
-##6.0.18
+## 6.0.18
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@6.0.17...@spectrum-css/search@6.0.18)
 
 **Note:** Version bump only for package @spectrum-css/search
 
 <a name="6.0.17"></a>
-##6.0.17
+## 6.0.17
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@6.0.16...@spectrum-css/search@6.0.17)
 
 **Note:** Version bump only for package @spectrum-css/search
 
 <a name="6.0.16"></a>
-##6.0.16
+## 6.0.16
 🗓
 2023-08-25 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@6.0.15...@spectrum-css/search@6.0.16)
 
@@ -205,112 +205,112 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="6.0.15"></a>
-##6.0.15
+## 6.0.15
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@6.0.14...@spectrum-css/search@6.0.15)
 
 **Note:** Version bump only for package @spectrum-css/search
 
 <a name="6.0.14"></a>
-##6.0.14
+## 6.0.14
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@6.0.12...@spectrum-css/search@6.0.14)
 
 **Note:** Version bump only for package @spectrum-css/search
 
 <a name="6.0.13"></a>
-##6.0.13
+## 6.0.13
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@6.0.12...@spectrum-css/search@6.0.13)
 
 **Note:** Version bump only for package @spectrum-css/search
 
 <a name="6.0.12"></a>
-##6.0.12
+## 6.0.12
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@6.0.11...@spectrum-css/search@6.0.12)
 
 **Note:** Version bump only for package @spectrum-css/search
 
 <a name="6.0.11"></a>
-##6.0.11
+## 6.0.11
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@6.0.10...@spectrum-css/search@6.0.11)
 
 **Note:** Version bump only for package @spectrum-css/search
 
 <a name="6.0.10"></a>
-##6.0.10
+## 6.0.10
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@6.0.9...@spectrum-css/search@6.0.10)
 
 **Note:** Version bump only for package @spectrum-css/search
 
 <a name="6.0.9"></a>
-##6.0.9
+## 6.0.9
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@6.0.8...@spectrum-css/search@6.0.9)
 
 **Note:** Version bump only for package @spectrum-css/search
 
 <a name="6.0.8"></a>
-##6.0.8
+## 6.0.8
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@6.0.7...@spectrum-css/search@6.0.8)
 
 **Note:** Version bump only for package @spectrum-css/search
 
 <a name="6.0.7"></a>
-##6.0.7
+## 6.0.7
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@6.0.6...@spectrum-css/search@6.0.7)
 
 **Note:** Version bump only for package @spectrum-css/search
 
 <a name="6.0.6"></a>
-##6.0.6
+## 6.0.6
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@6.0.5...@spectrum-css/search@6.0.6)
 
 **Note:** Version bump only for package @spectrum-css/search
 
 <a name="6.0.5"></a>
-##6.0.5
+## 6.0.5
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@6.0.4...@spectrum-css/search@6.0.5)
 
 **Note:** Version bump only for package @spectrum-css/search
 
 <a name="6.0.4"></a>
-##6.0.4
+## 6.0.4
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@6.0.3...@spectrum-css/search@6.0.4)
 
 **Note:** Version bump only for package @spectrum-css/search
 
 <a name="6.0.3"></a>
-##6.0.3
+## 6.0.3
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@6.0.2...@spectrum-css/search@6.0.3)
 
 **Note:** Version bump only for package @spectrum-css/search
 
 <a name="6.0.2"></a>
-##6.0.2
+## 6.0.2
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@6.0.1...@spectrum-css/search@6.0.2)
 
 **Note:** Version bump only for package @spectrum-css/search
 
 <a name="6.0.1"></a>
-##6.0.1
+## 6.0.1
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@6.0.0...@spectrum-css/search@6.0.1)
 
 **Note:** Version bump only for package @spectrum-css/search
 
 <a name="6.0.0"></a>
-#6.0.0
+# 6.0.0
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@5.0.23...@spectrum-css/search@6.0.0)
 
@@ -323,7 +323,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
     		migrates Search to use `@adobe/spectrum-tokens`
 
 <a name="5.0.23"></a>
-##5.0.23
+## 5.0.23
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@5.0.22...@spectrum-css/search@5.0.23)
 

--- a/components/search/CHANGELOG.md
+++ b/components/search/CHANGELOG.md
@@ -39,7 +39,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="7.0.0"></a>
-# 7.0.0
+## 7.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@6.2.4...@spectrum-css/search@7.0.0)
 
@@ -82,14 +82,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/search
 
 <a name="6.2.0"></a>
-# 6.2.0
+## 6.2.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@6.1.0...@spectrum-css/search@6.2.0)
 
 **Note:** Version bump only for package @spectrum-css/search
 
 <a name="6.1.0"></a>
-# 6.1.0
+## 6.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@6.0.30...@spectrum-css/search@6.1.0)
 
@@ -310,7 +310,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/search
 
 <a name="6.0.0"></a>
-# 6.0.0
+## 6.0.0
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@5.0.23...@spectrum-css/search@6.0.0)
 
@@ -507,7 +507,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="5.0.0"></a>
 
-# 5.0.0
+## 5.0.0
 
 🗓 2023-04-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@4.2.25...@spectrum-css/search@5.0.0)
 
@@ -721,7 +721,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="4.2.0"></a>
 
-# 4.2.0
+## 4.2.0
 
 🗓 2022-01-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@4.0.1...@spectrum-css/search@4.2.0)
 
@@ -735,7 +735,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="4.1.0"></a>
 
-# 4.1.0
+## 4.1.0
 
 🗓 2022-01-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@4.1.0-beta.0...@spectrum-css/search@4.1.0)
 
@@ -743,7 +743,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="4.1.0-beta.0"></a>
 
-# 4.1.0-beta.0
+## 4.1.0-beta.0
 
 🗓 2021-12-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@4.0.1...@spectrum-css/search@4.1.0-beta.0)
 
@@ -761,7 +761,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="4.0.0"></a>
 
-# 4.0.0
+## 4.0.0
 
 🗓 2021-11-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@3.1.2...@spectrum-css/search@4.0.0)
 
@@ -791,7 +791,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="3.1.0"></a>
 
-# 3.1.0
+## 3.1.0
 
 🗓 2021-11-08 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@3.0.4...@spectrum-css/search@3.1.0)
 
@@ -887,7 +887,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@3.0.0-beta.7...@spectrum-css/search@3.0.0)
 
@@ -895,7 +895,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="3.0.0-beta.7"></a>
 
-# 3.0.0-beta.7
+## 3.0.0-beta.7
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@3.0.0-beta.6...@spectrum-css/search@3.0.0-beta.7)
 
@@ -906,7 +906,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="3.0.0-beta.6"></a>
 
-# 3.0.0-beta.6
+## 3.0.0-beta.6
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@3.0.0-beta.5...@spectrum-css/search@3.0.0-beta.6)
 
@@ -914,7 +914,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="3.0.0-beta.5"></a>
 
-# 3.0.0-beta.5
+## 3.0.0-beta.5
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@3.0.0-beta.4...@spectrum-css/search@3.0.0-beta.5)
 
@@ -922,7 +922,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="3.0.0-beta.4"></a>
 
-# 3.0.0-beta.4
+## 3.0.0-beta.4
 
 🗓 2020-06-19 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@3.0.0-beta.3...@spectrum-css/search@3.0.0-beta.4)
 
@@ -930,7 +930,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="3.0.0-beta.3"></a>
 
-# 3.0.0-beta.3
+## 3.0.0-beta.3
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@3.0.0-beta.2...@spectrum-css/search@3.0.0-beta.3)
 
@@ -938,7 +938,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@3.0.0-beta.1...@spectrum-css/search@3.0.0-beta.2)
 
@@ -946,7 +946,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@3.0.0-beta.0...@spectrum-css/search@3.0.0-beta.1)
 
@@ -960,7 +960,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/search@2.0.6...@spectrum-css/search@3.0.0-beta.0)
 
@@ -1022,7 +1022,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/sidenav/CHANGELOG.md
+++ b/components/sidenav/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-# 5.0.0
+## 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/sidenav@4.2.4...@spectrum-css/sidenav@5.0.0)
 
@@ -72,14 +72,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/sidenav
 
 <a name="4.2.0"></a>
-# 4.2.0
+## 4.2.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/sidenav@4.1.0...@spectrum-css/sidenav@4.2.0)
 
 **Note:** Version bump only for package @spectrum-css/sidenav
 
 <a name="4.1.0"></a>
-# 4.1.0
+## 4.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/sidenav@4.0.19...@spectrum-css/sidenav@4.1.0)
 
@@ -225,7 +225,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/sidenav
 
 <a name="4.0.0"></a>
-# 4.0.0
+## 4.0.0
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/sidenav@3.0.51...@spectrum-css/sidenav@4.0.0)
 
@@ -791,7 +791,7 @@ This reverts commit a404f9505d8125277ed5eda0312289a0468a527f.
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/sidenav@3.0.0-beta.5...@spectrum-css/sidenav@3.0.0)
 
@@ -799,7 +799,7 @@ This reverts commit a404f9505d8125277ed5eda0312289a0468a527f.
 
 <a name="3.0.0-beta.5"></a>
 
-# 3.0.0-beta.5
+## 3.0.0-beta.5
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/sidenav@3.0.0-beta.4...@spectrum-css/sidenav@3.0.0-beta.5)
 
@@ -810,7 +810,7 @@ This reverts commit a404f9505d8125277ed5eda0312289a0468a527f.
 
 <a name="3.0.0-beta.4"></a>
 
-# 3.0.0-beta.4
+## 3.0.0-beta.4
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/sidenav@3.0.0-beta.3...@spectrum-css/sidenav@3.0.0-beta.4)
 
@@ -818,7 +818,7 @@ This reverts commit a404f9505d8125277ed5eda0312289a0468a527f.
 
 <a name="3.0.0-beta.3"></a>
 
-# 3.0.0-beta.3
+## 3.0.0-beta.3
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/sidenav@3.0.0-beta.2...@spectrum-css/sidenav@3.0.0-beta.3)
 
@@ -829,7 +829,7 @@ This reverts commit a404f9505d8125277ed5eda0312289a0468a527f.
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/sidenav@3.0.0-beta.1...@spectrum-css/sidenav@3.0.0-beta.2)
 
@@ -837,7 +837,7 @@ This reverts commit a404f9505d8125277ed5eda0312289a0468a527f.
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/sidenav@3.0.0-beta.0...@spectrum-css/sidenav@3.0.0-beta.1)
 
@@ -845,7 +845,7 @@ This reverts commit a404f9505d8125277ed5eda0312289a0468a527f.
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/sidenav@2.0.5...@spectrum-css/sidenav@3.0.0-beta.0)
 
@@ -895,7 +895,7 @@ This reverts commit a404f9505d8125277ed5eda0312289a0468a527f.
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/sidenav/CHANGELOG.md
+++ b/components/sidenav/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-#5.0.0
+# 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/sidenav@4.2.4...@spectrum-css/sidenav@5.0.0)
 
@@ -44,42 +44,42 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="4.2.4"></a>
-##4.2.4
+## 4.2.4
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/sidenav@4.2.3...@spectrum-css/sidenav@4.2.4)
 
 **Note:** Version bump only for package @spectrum-css/sidenav
 
 <a name="4.2.3"></a>
-##4.2.3
+## 4.2.3
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/sidenav@4.2.2...@spectrum-css/sidenav@4.2.3)
 
 **Note:** Version bump only for package @spectrum-css/sidenav
 
 <a name="4.2.2"></a>
-##4.2.2
+## 4.2.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/sidenav@4.2.1...@spectrum-css/sidenav@4.2.2)
 
 **Note:** Version bump only for package @spectrum-css/sidenav
 
 <a name="4.2.1"></a>
-##4.2.1
+## 4.2.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/sidenav
 
 <a name="4.2.0"></a>
-#4.2.0
+# 4.2.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/sidenav@4.1.0...@spectrum-css/sidenav@4.2.0)
 
 **Note:** Version bump only for package @spectrum-css/sidenav
 
 <a name="4.1.0"></a>
-#4.1.0
+# 4.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/sidenav@4.0.19...@spectrum-css/sidenav@4.1.0)
 
@@ -88,35 +88,35 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="4.0.19"></a>
-##4.0.19
+## 4.0.19
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/sidenav@4.0.18...@spectrum-css/sidenav@4.0.19)
 
 **Note:** Version bump only for package @spectrum-css/sidenav
 
 <a name="4.0.18"></a>
-##4.0.18
+## 4.0.18
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/sidenav@4.0.17...@spectrum-css/sidenav@4.0.18)
 
 **Note:** Version bump only for package @spectrum-css/sidenav
 
 <a name="4.0.17"></a>
-##4.0.17
+## 4.0.17
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/sidenav@4.0.15...@spectrum-css/sidenav@4.0.17)
 
 **Note:** Version bump only for package @spectrum-css/sidenav
 
 <a name="4.0.16"></a>
-##4.0.16
+## 4.0.16
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/sidenav@4.0.15...@spectrum-css/sidenav@4.0.16)
 
 **Note:** Version bump only for package @spectrum-css/sidenav
 
 <a name="4.0.15"></a>
-##4.0.15
+## 4.0.15
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/sidenav@4.0.14...@spectrum-css/sidenav@4.0.15)
 
@@ -125,63 +125,63 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **sidenav:**remove temporary custom tokens ([#2256](https://github.com/adobe/spectrum-css/issues/2256))([af0edde](https://github.com/adobe/spectrum-css/commit/af0edde))
 
 <a name="4.0.14"></a>
-##4.0.14
+## 4.0.14
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/sidenav@4.0.13...@spectrum-css/sidenav@4.0.14)
 
 **Note:** Version bump only for package @spectrum-css/sidenav
 
 <a name="4.0.13"></a>
-##4.0.13
+## 4.0.13
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/sidenav@4.0.12...@spectrum-css/sidenav@4.0.13)
 
 **Note:** Version bump only for package @spectrum-css/sidenav
 
 <a name="4.0.12"></a>
-##4.0.12
+## 4.0.12
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/sidenav@4.0.11...@spectrum-css/sidenav@4.0.12)
 
 **Note:** Version bump only for package @spectrum-css/sidenav
 
 <a name="4.0.11"></a>
-##4.0.11
+## 4.0.11
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/sidenav@4.0.10...@spectrum-css/sidenav@4.0.11)
 
 **Note:** Version bump only for package @spectrum-css/sidenav
 
 <a name="4.0.10"></a>
-##4.0.10
+## 4.0.10
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/sidenav@4.0.9...@spectrum-css/sidenav@4.0.10)
 
 **Note:** Version bump only for package @spectrum-css/sidenav
 
 <a name="4.0.9"></a>
-##4.0.9
+## 4.0.9
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/sidenav@4.0.8...@spectrum-css/sidenav@4.0.9)
 
 **Note:** Version bump only for package @spectrum-css/sidenav
 
 <a name="4.0.8"></a>
-##4.0.8
+## 4.0.8
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/sidenav@4.0.7...@spectrum-css/sidenav@4.0.8)
 
 **Note:** Version bump only for package @spectrum-css/sidenav
 
 <a name="4.0.7"></a>
-##4.0.7
+## 4.0.7
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/sidenav@4.0.6...@spectrum-css/sidenav@4.0.7)
 
 **Note:** Version bump only for package @spectrum-css/sidenav
 
 <a name="4.0.6"></a>
-##4.0.6
+## 4.0.6
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/sidenav@4.0.5...@spectrum-css/sidenav@4.0.6)
 
@@ -190,42 +190,42 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="4.0.5"></a>
-##4.0.5
+## 4.0.5
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/sidenav@4.0.4...@spectrum-css/sidenav@4.0.5)
 
 **Note:** Version bump only for package @spectrum-css/sidenav
 
 <a name="4.0.4"></a>
-##4.0.4
+## 4.0.4
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/sidenav@4.0.2...@spectrum-css/sidenav@4.0.4)
 
 **Note:** Version bump only for package @spectrum-css/sidenav
 
 <a name="4.0.3"></a>
-##4.0.3
+## 4.0.3
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/sidenav@4.0.2...@spectrum-css/sidenav@4.0.3)
 
 **Note:** Version bump only for package @spectrum-css/sidenav
 
 <a name="4.0.2"></a>
-##4.0.2
+## 4.0.2
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/sidenav@4.0.1...@spectrum-css/sidenav@4.0.2)
 
 **Note:** Version bump only for package @spectrum-css/sidenav
 
 <a name="4.0.1"></a>
-##4.0.1
+## 4.0.1
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/sidenav@4.0.0...@spectrum-css/sidenav@4.0.1)
 
 **Note:** Version bump only for package @spectrum-css/sidenav
 
 <a name="4.0.0"></a>
-#4.0.0
+# 4.0.0
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/sidenav@3.0.51...@spectrum-css/sidenav@4.0.0)
 
@@ -336,28 +336,28 @@ This reverts commit a404f9505d8125277ed5eda0312289a0468a527f.
 - chore(sidenav): manual version increase for beta release
 
 <a name="3.0.51"></a>
-##3.0.51
+## 3.0.51
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/sidenav@3.0.50...@spectrum-css/sidenav@3.0.51)
 
 **Note:** Version bump only for package @spectrum-css/sidenav
 
 <a name="3.0.50"></a>
-##3.0.50
+## 3.0.50
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/sidenav@3.0.49...@spectrum-css/sidenav@3.0.50)
 
 **Note:** Version bump only for package @spectrum-css/sidenav
 
 <a name="3.0.49"></a>
-##3.0.49
+## 3.0.49
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/sidenav@3.0.48...@spectrum-css/sidenav@3.0.49)
 
 **Note:** Version bump only for package @spectrum-css/sidenav
 
 <a name="3.0.48"></a>
-##3.0.48
+## 3.0.48
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/sidenav@3.0.47...@spectrum-css/sidenav@3.0.48)
 
@@ -366,14 +366,14 @@ This reverts commit a404f9505d8125277ed5eda0312289a0468a527f.
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="3.0.47"></a>
-##3.0.47
+## 3.0.47
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/sidenav@3.0.46...@spectrum-css/sidenav@3.0.47)
 
 **Note:** Version bump only for package @spectrum-css/sidenav
 
 <a name="3.0.46"></a>
-##3.0.46
+## 3.0.46
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/sidenav@3.0.45...@spectrum-css/sidenav@3.0.46)
 

--- a/components/site/CHANGELOG.md
+++ b/components/site/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-# 5.0.0
+## 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/site@4.2.4...@spectrum-css/site@5.0.0)
 
@@ -68,14 +68,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/site
 
 <a name="4.2.0"></a>
-# 4.2.0
+## 4.2.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/site@4.1.0...@spectrum-css/site@4.2.0)
 
 **Note:** Version bump only for package @spectrum-css/site
 
 <a name="4.1.0"></a>
-# 4.1.0
+## 4.1.0
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/site@4.0.4...@spectrum-css/site@4.1.0)
 
@@ -116,7 +116,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="4.0.0"></a>
-# 4.0.0
+## 4.0.0
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/site@3.0.22...@spectrum-css/site@4.0.0)
 
@@ -304,7 +304,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2022-09-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/site@2.1.13...@spectrum-css/site@3.0.0)
 
@@ -432,7 +432,7 @@ Also, adds t-shirt sizes
 
 <a name="2.1.0"></a>
 
-# 2.1.0
+## 2.1.0
 
 🗓 2021-12-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/site@2.0.9...@spectrum-css/site@2.1.0)
 
@@ -557,7 +557,7 @@ Also, adds t-shirt sizes
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/site@2.0.0-beta.6...@spectrum-css/site@2.0.0)
 
@@ -565,7 +565,7 @@ Also, adds t-shirt sizes
 
 <a name="2.0.0-beta.6"></a>
 
-# 2.0.0-beta.6
+## 2.0.0-beta.6
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/site@2.0.0-beta.5...@spectrum-css/site@2.0.0-beta.6)
 
@@ -575,7 +575,7 @@ Also, adds t-shirt sizes
 
 <a name="2.0.0-beta.5"></a>
 
-# 2.0.0-beta.5
+## 2.0.0-beta.5
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/site@2.0.0-beta.4...@spectrum-css/site@2.0.0-beta.5)
 
@@ -583,7 +583,7 @@ Also, adds t-shirt sizes
 
 <a name="2.0.0-beta.4"></a>
 
-# 2.0.0-beta.4
+## 2.0.0-beta.4
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/site@2.0.0-beta.3...@spectrum-css/site@2.0.0-beta.4)
 
@@ -606,7 +606,7 @@ Also, adds t-shirt sizes
 
 <a name="2.0.0-beta.3"></a>
 
-# 2.0.0-beta.3
+## 2.0.0-beta.3
 
 🗓 2020-06-19 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/site@2.0.0-beta.2...@spectrum-css/site@2.0.0-beta.3)
 
@@ -614,7 +614,7 @@ Also, adds t-shirt sizes
 
 <a name="2.0.0-beta.2"></a>
 
-# 2.0.0-beta.2
+## 2.0.0-beta.2
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/site@2.0.0-beta.1...@spectrum-css/site@2.0.0-beta.2)
 
@@ -624,7 +624,7 @@ Also, adds t-shirt sizes
 
 <a name="2.0.0-beta.1"></a>
 
-# 2.0.0-beta.1
+## 2.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/site@2.0.0-beta.0...@spectrum-css/site@2.0.0-beta.1)
 
@@ -632,7 +632,7 @@ Also, adds t-shirt sizes
 
 <a name="2.0.0-beta.0"></a>
 
-# 2.0.0-beta.0
+## 2.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/site@1.1.1...@spectrum-css/site@2.0.0-beta.0)
 
@@ -650,7 +650,7 @@ Also, adds t-shirt sizes
 
 <a name="1.1.0"></a>
 
-# 1.1.0
+## 1.1.0
 
 🗓 2020-02-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/site@1.0.3...@spectrum-css/site@1.1.0)
 
@@ -684,7 +684,7 @@ Also, adds t-shirt sizes
 
 <a name="1.0.0"></a>
 
-# 1.0.0
+## 1.0.0
 
 🗓 2019-10-08
 

--- a/components/site/CHANGELOG.md
+++ b/components/site/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-#5.0.0
+# 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/site@4.2.4...@spectrum-css/site@5.0.0)
 
@@ -40,42 +40,42 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="4.2.4"></a>
-##4.2.4
+## 4.2.4
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/site@4.2.3...@spectrum-css/site@4.2.4)
 
 **Note:** Version bump only for package @spectrum-css/site
 
 <a name="4.2.3"></a>
-##4.2.3
+## 4.2.3
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/site@4.2.2...@spectrum-css/site@4.2.3)
 
 **Note:** Version bump only for package @spectrum-css/site
 
 <a name="4.2.2"></a>
-##4.2.2
+## 4.2.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/site@4.2.1...@spectrum-css/site@4.2.2)
 
 **Note:** Version bump only for package @spectrum-css/site
 
 <a name="4.2.1"></a>
-##4.2.1
+## 4.2.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/site
 
 <a name="4.2.0"></a>
-#4.2.0
+# 4.2.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/site@4.1.0...@spectrum-css/site@4.2.0)
 
 **Note:** Version bump only for package @spectrum-css/site
 
 <a name="4.1.0"></a>
-#4.1.0
+# 4.1.0
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/site@4.0.4...@spectrum-css/site@4.1.0)
 
@@ -84,21 +84,21 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **asset,cyclebutton,quickaction,site:**deprecate skin.css assets ([#2438](https://github.com/adobe/spectrum-css/issues/2438))([d6de839](https://github.com/adobe/spectrum-css/commit/d6de839))
 
 <a name="4.0.4"></a>
-##4.0.4
+## 4.0.4
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/site@4.0.3...@spectrum-css/site@4.0.4)
 
 **Note:** Version bump only for package @spectrum-css/site
 
 <a name="4.0.3"></a>
-##4.0.3
+## 4.0.3
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/site@4.0.2...@spectrum-css/site@4.0.3)
 
 **Note:** Version bump only for package @spectrum-css/site
 
 <a name="4.0.2"></a>
-##4.0.2
+## 4.0.2
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/site@4.0.0...@spectrum-css/site@4.0.2)
 
@@ -107,7 +107,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="4.0.1"></a>
-##4.0.1
+## 4.0.1
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/site@4.0.0...@spectrum-css/site@4.0.1)
 
@@ -116,7 +116,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="4.0.0"></a>
-#4.0.0
+# 4.0.0
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/site@3.0.22...@spectrum-css/site@4.0.0)
 
@@ -129,14 +129,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
     		replace focus-ring with native focus-visible pseudo class
 
 <a name="3.0.22"></a>
-##3.0.22
+## 3.0.22
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/site@3.0.21...@spectrum-css/site@3.0.22)
 
 **Note:** Version bump only for package @spectrum-css/site
 
 <a name="3.0.21"></a>
-##3.0.21
+## 3.0.21
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/site@3.0.20...@spectrum-css/site@3.0.21)
 
@@ -145,14 +145,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="3.0.20"></a>
-##3.0.20
+## 3.0.20
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/site@3.0.19...@spectrum-css/site@3.0.20)
 
 **Note:** Version bump only for package @spectrum-css/site
 
 <a name="3.0.19"></a>
-##3.0.19
+## 3.0.19
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/site@3.0.18...@spectrum-css/site@3.0.19)
 

--- a/components/slider/CHANGELOG.md
+++ b/components/slider/CHANGELOG.md
@@ -53,7 +53,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-# 5.0.0
+## 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@4.3.5...@spectrum-css/slider@5.0.0)
 
@@ -109,7 +109,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/slider
 
 <a name="4.3.0"></a>
-# 4.3.0
+## 4.3.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@4.2.1...@spectrum-css/slider@4.3.0)
 
@@ -125,7 +125,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*deprecate logical transform plugin ([#2437](https://github.com/adobe/spectrum-css/issues/2437))([ff5dda6](https://github.com/adobe/spectrum-css/commit/ff5dda6))
 
 <a name="4.2.0"></a>
-# 4.2.0
+## 4.2.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@4.1.19...@spectrum-css/slider@4.2.0)
 
@@ -273,7 +273,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/slider
 
 <a name="4.1.0"></a>
-# 4.1.0
+## 4.1.0
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@4.0.19...@spectrum-css/slider@4.1.0)
 
@@ -424,7 +424,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="4.0.0"></a>
 
-# 4.0.0
+## 4.0.0
 
 🗓 2023-05-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@3.1.25...@spectrum-css/slider@4.0.0)
 
@@ -640,7 +640,7 @@ Additionally, this adds some `min-height` custom properties and adjusts the `min
 
 <a name="3.1.0"></a>
 
-# 3.1.0
+## 3.1.0
 
 🗓 2022-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@3.0.15...@spectrum-css/slider@3.1.0)
 
@@ -838,7 +838,7 @@ Additionally, this adds some `min-height` custom properties and adjusts the `min
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@3.0.0-beta.5...@spectrum-css/slider@3.0.0)
 
@@ -846,7 +846,7 @@ Additionally, this adds some `min-height` custom properties and adjusts the `min
 
 <a name="3.0.0-beta.5"></a>
 
-# 3.0.0-beta.5
+## 3.0.0-beta.5
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@3.0.0-beta.4...@spectrum-css/slider@3.0.0-beta.5)
 
@@ -857,7 +857,7 @@ Additionally, this adds some `min-height` custom properties and adjusts the `min
 
 <a name="3.0.0-beta.4"></a>
 
-# 3.0.0-beta.4
+## 3.0.0-beta.4
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@3.0.0-beta.3...@spectrum-css/slider@3.0.0-beta.4)
 
@@ -872,7 +872,7 @@ Additionally, this adds some `min-height` custom properties and adjusts the `min
 
 <a name="3.0.0-beta.3"></a>
 
-# 3.0.0-beta.3
+## 3.0.0-beta.3
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@3.0.0-beta.2...@spectrum-css/slider@3.0.0-beta.3)
 
@@ -891,7 +891,7 @@ Co-authored-by: Larry Davis <lawdavis@adobe.com>
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@3.0.0-beta.1...@spectrum-css/slider@3.0.0-beta.2)
 
@@ -899,7 +899,7 @@ Co-authored-by: Larry Davis <lawdavis@adobe.com>
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@3.0.0-beta.0...@spectrum-css/slider@3.0.0-beta.1)
 
@@ -907,7 +907,7 @@ Co-authored-by: Larry Davis <lawdavis@adobe.com>
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@2.1.0...@spectrum-css/slider@3.0.0-beta.0)
 
@@ -917,7 +917,7 @@ Co-authored-by: Larry Davis <lawdavis@adobe.com>
 
 <a name="2.1.0"></a>
 
-# 2.1.0
+## 2.1.0
 
 🗓 2020-03-06 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@2.0.4...@spectrum-css/slider@2.1.0)
 
@@ -959,7 +959,7 @@ Co-authored-by: Larry Davis <lawdavis@adobe.com>
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/slider/CHANGELOG.md
+++ b/components/slider/CHANGELOG.md
@@ -53,7 +53,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-#5.0.0
+# 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@4.3.5...@spectrum-css/slider@5.0.0)
 
@@ -72,28 +72,28 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="4.3.5"></a>
-##4.3.5
+## 4.3.5
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@4.3.4...@spectrum-css/slider@4.3.5)
 
 **Note:** Version bump only for package @spectrum-css/slider
 
 <a name="4.3.4"></a>
-##4.3.4
+## 4.3.4
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@4.3.3...@spectrum-css/slider@4.3.4)
 
 **Note:** Version bump only for package @spectrum-css/slider
 
 <a name="4.3.3"></a>
-##4.3.3
+## 4.3.3
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@4.3.2...@spectrum-css/slider@4.3.3)
 
 **Note:** Version bump only for package @spectrum-css/slider
 
 <a name="4.3.2"></a>
-##4.3.2
+## 4.3.2
 🗓
 2024-02-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@4.3.1...@spectrum-css/slider@4.3.2)
 
@@ -102,21 +102,21 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **slider:**high contrast improvements for filled variants ([#2325](https://github.com/adobe/spectrum-css/issues/2325))([b78693c](https://github.com/adobe/spectrum-css/commit/b78693c))
 
 <a name="4.3.1"></a>
-##4.3.1
+## 4.3.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/slider
 
 <a name="4.3.0"></a>
-#4.3.0
+# 4.3.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@4.2.1...@spectrum-css/slider@4.3.0)
 
 **Note:** Version bump only for package @spectrum-css/slider
 
 <a name="4.2.1"></a>
-##4.2.1
+## 4.2.1
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@4.2.0...@spectrum-css/slider@4.2.1)
 
@@ -125,7 +125,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*deprecate logical transform plugin ([#2437](https://github.com/adobe/spectrum-css/issues/2437))([ff5dda6](https://github.com/adobe/spectrum-css/commit/ff5dda6))
 
 <a name="4.2.0"></a>
-#4.2.0
+# 4.2.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@4.1.19...@spectrum-css/slider@4.2.0)
 
@@ -134,7 +134,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="4.1.19"></a>
-##4.1.19
+## 4.1.19
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@4.1.18...@spectrum-css/slider@4.1.19)
 
@@ -143,28 +143,28 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **slider:**correct rtl positioning of focus indicator ([#2342](https://github.com/adobe/spectrum-css/issues/2342))([e4f8292](https://github.com/adobe/spectrum-css/commit/e4f8292))
 
 <a name="4.1.18"></a>
-##4.1.18
+## 4.1.18
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@4.1.17...@spectrum-css/slider@4.1.18)
 
 **Note:** Version bump only for package @spectrum-css/slider
 
 <a name="4.1.17"></a>
-##4.1.17
+## 4.1.17
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@4.1.15...@spectrum-css/slider@4.1.17)
 
 **Note:** Version bump only for package @spectrum-css/slider
 
 <a name="4.1.16"></a>
-##4.1.16
+## 4.1.16
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@4.1.15...@spectrum-css/slider@4.1.16)
 
 **Note:** Version bump only for package @spectrum-css/slider
 
 <a name="4.1.15"></a>
-##4.1.15
+## 4.1.15
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@4.1.14...@spectrum-css/slider@4.1.15)
 
@@ -173,70 +173,70 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **slider:**focus state matches spec, supports forced-colors ([#2217](https://github.com/adobe/spectrum-css/issues/2217))([7b9c31b](https://github.com/adobe/spectrum-css/commit/7b9c31b))
 
 <a name="4.1.14"></a>
-##4.1.14
+## 4.1.14
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@4.1.13...@spectrum-css/slider@4.1.14)
 
 **Note:** Version bump only for package @spectrum-css/slider
 
 <a name="4.1.13"></a>
-##4.1.13
+## 4.1.13
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@4.1.12...@spectrum-css/slider@4.1.13)
 
 **Note:** Version bump only for package @spectrum-css/slider
 
 <a name="4.1.12"></a>
-##4.1.12
+## 4.1.12
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@4.1.11...@spectrum-css/slider@4.1.12)
 
 **Note:** Version bump only for package @spectrum-css/slider
 
 <a name="4.1.11"></a>
-##4.1.11
+## 4.1.11
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@4.1.10...@spectrum-css/slider@4.1.11)
 
 **Note:** Version bump only for package @spectrum-css/slider
 
 <a name="4.1.10"></a>
-##4.1.10
+## 4.1.10
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@4.1.9...@spectrum-css/slider@4.1.10)
 
 **Note:** Version bump only for package @spectrum-css/slider
 
 <a name="4.1.9"></a>
-##4.1.9
+## 4.1.9
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@4.1.8...@spectrum-css/slider@4.1.9)
 
 **Note:** Version bump only for package @spectrum-css/slider
 
 <a name="4.1.8"></a>
-##4.1.8
+## 4.1.8
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@4.1.7...@spectrum-css/slider@4.1.8)
 
 **Note:** Version bump only for package @spectrum-css/slider
 
 <a name="4.1.7"></a>
-##4.1.7
+## 4.1.7
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@4.1.6...@spectrum-css/slider@4.1.7)
 
 **Note:** Version bump only for package @spectrum-css/slider
 
 <a name="4.1.6"></a>
-##4.1.6
+## 4.1.6
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@4.1.5...@spectrum-css/slider@4.1.6)
 
 **Note:** Version bump only for package @spectrum-css/slider
 
 <a name="4.1.5"></a>
-##4.1.5
+## 4.1.5
 🗓
 2023-08-25 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@4.1.4...@spectrum-css/slider@4.1.5)
 
@@ -245,35 +245,35 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="4.1.4"></a>
-##4.1.4
+## 4.1.4
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@4.1.3...@spectrum-css/slider@4.1.4)
 
 **Note:** Version bump only for package @spectrum-css/slider
 
 <a name="4.1.3"></a>
-##4.1.3
+## 4.1.3
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@4.1.1...@spectrum-css/slider@4.1.3)
 
 **Note:** Version bump only for package @spectrum-css/slider
 
 <a name="4.1.2"></a>
-##4.1.2
+## 4.1.2
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@4.1.1...@spectrum-css/slider@4.1.2)
 
 **Note:** Version bump only for package @spectrum-css/slider
 
 <a name="4.1.1"></a>
-##4.1.1
+## 4.1.1
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@4.1.0...@spectrum-css/slider@4.1.1)
 
 **Note:** Version bump only for package @spectrum-css/slider
 
 <a name="4.1.0"></a>
-#4.1.0
+# 4.1.0
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@4.0.19...@spectrum-css/slider@4.1.0)
 
@@ -282,77 +282,77 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **slider:**add side label variant ([#2067](https://github.com/adobe/spectrum-css/issues/2067))([0e983d3](https://github.com/adobe/spectrum-css/commit/0e983d3))
 
 <a name="4.0.19"></a>
-##4.0.19
+## 4.0.19
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@4.0.18...@spectrum-css/slider@4.0.19)
 
 **Note:** Version bump only for package @spectrum-css/slider
 
 <a name="4.0.18"></a>
-##4.0.18
+## 4.0.18
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@4.0.17...@spectrum-css/slider@4.0.18)
 
 **Note:** Version bump only for package @spectrum-css/slider
 
 <a name="4.0.17"></a>
-##4.0.17
+## 4.0.17
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@4.0.16...@spectrum-css/slider@4.0.17)
 
 **Note:** Version bump only for package @spectrum-css/slider
 
 <a name="4.0.16"></a>
-##4.0.16
+## 4.0.16
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@4.0.15...@spectrum-css/slider@4.0.16)
 
 **Note:** Version bump only for package @spectrum-css/slider
 
 <a name="4.0.15"></a>
-##4.0.15
+## 4.0.15
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@4.0.14...@spectrum-css/slider@4.0.15)
 
 **Note:** Version bump only for package @spectrum-css/slider
 
 <a name="4.0.14"></a>
-##4.0.14
+## 4.0.14
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@4.0.13...@spectrum-css/slider@4.0.14)
 
 **Note:** Version bump only for package @spectrum-css/slider
 
 <a name="4.0.13"></a>
-##4.0.13
+## 4.0.13
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@4.0.12...@spectrum-css/slider@4.0.13)
 
 **Note:** Version bump only for package @spectrum-css/slider
 
 <a name="4.0.12"></a>
-##4.0.12
+## 4.0.12
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@4.0.11...@spectrum-css/slider@4.0.12)
 
 **Note:** Version bump only for package @spectrum-css/slider
 
 <a name="4.0.11"></a>
-##4.0.11
+## 4.0.11
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@4.0.10...@spectrum-css/slider@4.0.11)
 
 **Note:** Version bump only for package @spectrum-css/slider
 
 <a name="4.0.10"></a>
-##4.0.10
+## 4.0.10
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@4.0.9...@spectrum-css/slider@4.0.10)
 
 **Note:** Version bump only for package @spectrum-css/slider
 
 <a name="4.0.9"></a>
-##4.0.9
+## 4.0.9
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@4.0.8...@spectrum-css/slider@4.0.9)
 
@@ -361,14 +361,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="4.0.8"></a>
-##4.0.8
+## 4.0.8
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@4.0.7...@spectrum-css/slider@4.0.8)
 
 **Note:** Version bump only for package @spectrum-css/slider
 
 <a name="4.0.7"></a>
-##4.0.7
+## 4.0.7
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@4.0.6...@spectrum-css/slider@4.0.7)
 

--- a/components/splitview/CHANGELOG.md
+++ b/components/splitview/CHANGELOG.md
@@ -31,7 +31,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-#5.0.0
+# 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/splitview@4.2.4...@spectrum-css/splitview@5.0.0)
 
@@ -46,42 +46,42 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="4.2.4"></a>
-##4.2.4
+## 4.2.4
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/splitview@4.2.3...@spectrum-css/splitview@4.2.4)
 
 **Note:** Version bump only for package @spectrum-css/splitview
 
 <a name="4.2.3"></a>
-##4.2.3
+## 4.2.3
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/splitview@4.2.2...@spectrum-css/splitview@4.2.3)
 
 **Note:** Version bump only for package @spectrum-css/splitview
 
 <a name="4.2.2"></a>
-##4.2.2
+## 4.2.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/splitview@4.2.1...@spectrum-css/splitview@4.2.2)
 
 **Note:** Version bump only for package @spectrum-css/splitview
 
 <a name="4.2.1"></a>
-##4.2.1
+## 4.2.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/splitview
 
 <a name="4.2.0"></a>
-#4.2.0
+# 4.2.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/splitview@4.1.0...@spectrum-css/splitview@4.2.0)
 
 **Note:** Version bump only for package @spectrum-css/splitview
 
 <a name="4.1.0"></a>
-#4.1.0
+# 4.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/splitview@4.0.10...@spectrum-css/splitview@4.1.0)
 
@@ -90,77 +90,77 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="4.0.10"></a>
-##4.0.10
+## 4.0.10
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/splitview@4.0.9...@spectrum-css/splitview@4.0.10)
 
 **Note:** Version bump only for package @spectrum-css/splitview
 
 <a name="4.0.9"></a>
-##4.0.9
+## 4.0.9
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/splitview@4.0.8...@spectrum-css/splitview@4.0.9)
 
 **Note:** Version bump only for package @spectrum-css/splitview
 
 <a name="4.0.8"></a>
-##4.0.8
+## 4.0.8
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/splitview@4.0.6...@spectrum-css/splitview@4.0.8)
 
 **Note:** Version bump only for package @spectrum-css/splitview
 
 <a name="4.0.7"></a>
-##4.0.7
+## 4.0.7
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/splitview@4.0.6...@spectrum-css/splitview@4.0.7)
 
 **Note:** Version bump only for package @spectrum-css/splitview
 
 <a name="4.0.6"></a>
-##4.0.6
+## 4.0.6
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/splitview@4.0.5...@spectrum-css/splitview@4.0.6)
 
 **Note:** Version bump only for package @spectrum-css/splitview
 
 <a name="4.0.5"></a>
-##4.0.5
+## 4.0.5
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/splitview@4.0.4...@spectrum-css/splitview@4.0.5)
 
 **Note:** Version bump only for package @spectrum-css/splitview
 
 <a name="4.0.4"></a>
-##4.0.4
+## 4.0.4
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/splitview@4.0.3...@spectrum-css/splitview@4.0.4)
 
 **Note:** Version bump only for package @spectrum-css/splitview
 
 <a name="4.0.3"></a>
-##4.0.3
+## 4.0.3
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/splitview@4.0.2...@spectrum-css/splitview@4.0.3)
 
 **Note:** Version bump only for package @spectrum-css/splitview
 
 <a name="4.0.2"></a>
-##4.0.2
+## 4.0.2
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/splitview@4.0.1...@spectrum-css/splitview@4.0.2)
 
 **Note:** Version bump only for package @spectrum-css/splitview
 
 <a name="4.0.1"></a>
-##4.0.1
+## 4.0.1
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/splitview@4.0.0...@spectrum-css/splitview@4.0.1)
 
 **Note:** Version bump only for package @spectrum-css/splitview
 
 <a name="4.0.0"></a>
-#4.0.0
+# 4.0.0
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/splitview@3.0.48...@spectrum-css/splitview@4.0.0)
 
@@ -194,35 +194,35 @@ fix max nesting depth
 - fix(splitview): use vertical gripper width for vertical gripper
 
 <a name="3.0.48"></a>
-##3.0.48
+## 3.0.48
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/splitview@3.0.47...@spectrum-css/splitview@3.0.48)
 
 **Note:** Version bump only for package @spectrum-css/splitview
 
 <a name="3.0.47"></a>
-##3.0.47
+## 3.0.47
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/splitview@3.0.46...@spectrum-css/splitview@3.0.47)
 
 **Note:** Version bump only for package @spectrum-css/splitview
 
 <a name="3.0.46"></a>
-##3.0.46
+## 3.0.46
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/splitview@3.0.45...@spectrum-css/splitview@3.0.46)
 
 **Note:** Version bump only for package @spectrum-css/splitview
 
 <a name="3.0.45"></a>
-##3.0.45
+## 3.0.45
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/splitview@3.0.44...@spectrum-css/splitview@3.0.45)
 
 **Note:** Version bump only for package @spectrum-css/splitview
 
 <a name="3.0.44"></a>
-##3.0.44
+## 3.0.44
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/splitview@3.0.43...@spectrum-css/splitview@3.0.44)
 
@@ -231,14 +231,14 @@ fix max nesting depth
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="3.0.43"></a>
-##3.0.43
+## 3.0.43
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/splitview@3.0.42...@spectrum-css/splitview@3.0.43)
 
 **Note:** Version bump only for package @spectrum-css/splitview
 
 <a name="3.0.42"></a>
-##3.0.42
+## 3.0.42
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/splitview@3.0.41...@spectrum-css/splitview@3.0.42)
 

--- a/components/splitview/CHANGELOG.md
+++ b/components/splitview/CHANGELOG.md
@@ -31,7 +31,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-# 5.0.0
+## 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/splitview@4.2.4...@spectrum-css/splitview@5.0.0)
 
@@ -74,14 +74,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/splitview
 
 <a name="4.2.0"></a>
-# 4.2.0
+## 4.2.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/splitview@4.1.0...@spectrum-css/splitview@4.2.0)
 
 **Note:** Version bump only for package @spectrum-css/splitview
 
 <a name="4.1.0"></a>
-# 4.1.0
+## 4.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/splitview@4.0.10...@spectrum-css/splitview@4.1.0)
 
@@ -160,7 +160,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/splitview
 
 <a name="4.0.0"></a>
-# 4.0.0
+## 4.0.0
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/splitview@3.0.48...@spectrum-css/splitview@4.0.0)
 
@@ -622,7 +622,7 @@ fix max nesting depth
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/splitview@3.0.0-beta.5...@spectrum-css/splitview@3.0.0)
 
@@ -630,7 +630,7 @@ fix max nesting depth
 
 <a name="3.0.0-beta.5"></a>
 
-# 3.0.0-beta.5
+## 3.0.0-beta.5
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/splitview@3.0.0-beta.4...@spectrum-css/splitview@3.0.0-beta.5)
 
@@ -638,7 +638,7 @@ fix max nesting depth
 
 <a name="3.0.0-beta.4"></a>
 
-# 3.0.0-beta.4
+## 3.0.0-beta.4
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/splitview@3.0.0-beta.3...@spectrum-css/splitview@3.0.0-beta.4)
 
@@ -646,7 +646,7 @@ fix max nesting depth
 
 <a name="3.0.0-beta.3"></a>
 
-# 3.0.0-beta.3
+## 3.0.0-beta.3
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/splitview@3.0.0-beta.2...@spectrum-css/splitview@3.0.0-beta.3)
 
@@ -656,7 +656,7 @@ fix max nesting depth
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/splitview@3.0.0-beta.1...@spectrum-css/splitview@3.0.0-beta.2)
 
@@ -664,7 +664,7 @@ fix max nesting depth
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/splitview@3.0.0-beta.0...@spectrum-css/splitview@3.0.0-beta.1)
 
@@ -672,7 +672,7 @@ fix max nesting depth
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/splitview@2.0.5...@spectrum-css/splitview@3.0.0-beta.0)
 
@@ -722,7 +722,7 @@ fix max nesting depth
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/statuslight/CHANGELOG.md
+++ b/components/statuslight/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="7.0.0"></a>
-# 7.0.0
+## 7.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@6.1.6...@spectrum-css/statuslight@7.0.0)
 
@@ -82,7 +82,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/statuslight
 
 <a name="6.1.0"></a>
-# 6.1.0
+## 6.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@6.0.62...@spectrum-css/statuslight@6.1.0)
 
@@ -561,7 +561,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="6.0.0"></a>
 
-# 6.0.0
+## 6.0.0
 
 🗓 2023-02-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@5.0.10...@spectrum-css/statuslight@6.0.0)
 
@@ -655,7 +655,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="5.0.0"></a>
 
-# 5.0.0
+## 5.0.0
 
 🗓 2022-09-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@4.0.14...@spectrum-css/statuslight@5.0.0)
 
@@ -798,7 +798,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="4.0.0"></a>
 
-# 4.0.0
+## 4.0.0
 
 🗓 2021-12-06 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@3.0.8...@spectrum-css/statuslight@4.0.0)
 
@@ -916,7 +916,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@3.0.0-beta.5...@spectrum-css/statuslight@3.0.0)
 
@@ -924,7 +924,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0-beta.5"></a>
 
-# 3.0.0-beta.5
+## 3.0.0-beta.5
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@3.0.0-beta.4...@spectrum-css/statuslight@3.0.0-beta.5)
 
@@ -934,7 +934,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0-beta.4"></a>
 
-# 3.0.0-beta.4
+## 3.0.0-beta.4
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@3.0.0-beta.3...@spectrum-css/statuslight@3.0.0-beta.4)
 
@@ -942,7 +942,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0-beta.3"></a>
 
-# 3.0.0-beta.3
+## 3.0.0-beta.3
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@3.0.0-beta.2...@spectrum-css/statuslight@3.0.0-beta.3)
 
@@ -952,7 +952,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@3.0.0-beta.1...@spectrum-css/statuslight@3.0.0-beta.2)
 
@@ -960,7 +960,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@3.0.0-beta.0...@spectrum-css/statuslight@3.0.0-beta.1)
 
@@ -968,7 +968,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@2.0.6...@spectrum-css/statuslight@3.0.0-beta.0)
 
@@ -1032,7 +1032,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/statuslight/CHANGELOG.md
+++ b/components/statuslight/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="7.0.0"></a>
-#7.0.0
+# 7.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@6.1.6...@spectrum-css/statuslight@7.0.0)
 
@@ -40,49 +40,49 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="6.1.6"></a>
-##6.1.6
+## 6.1.6
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@6.1.5...@spectrum-css/statuslight@6.1.6)
 
 **Note:** Version bump only for package @spectrum-css/statuslight
 
 <a name="6.1.5"></a>
-##6.1.5
+## 6.1.5
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@6.1.4...@spectrum-css/statuslight@6.1.5)
 
 **Note:** Version bump only for package @spectrum-css/statuslight
 
 <a name="6.1.4"></a>
-##6.1.4
+## 6.1.4
 🗓
 2024-02-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@6.1.3...@spectrum-css/statuslight@6.1.4)
 
 **Note:** Version bump only for package @spectrum-css/statuslight
 
 <a name="6.1.3"></a>
-##6.1.3
+## 6.1.3
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@6.1.2...@spectrum-css/statuslight@6.1.3)
 
 **Note:** Version bump only for package @spectrum-css/statuslight
 
 <a name="6.1.2"></a>
-##6.1.2
+## 6.1.2
 🗓
 2024-02-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@6.1.1...@spectrum-css/statuslight@6.1.2)
 
 **Note:** Version bump only for package @spectrum-css/statuslight
 
 <a name="6.1.1"></a>
-##6.1.1
+## 6.1.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/statuslight
 
 <a name="6.1.0"></a>
-#6.1.0
+# 6.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@6.0.62...@spectrum-css/statuslight@6.1.0)
 
@@ -91,98 +91,98 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="6.0.62"></a>
-##6.0.62
+## 6.0.62
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@6.0.61...@spectrum-css/statuslight@6.0.62)
 
 **Note:** Version bump only for package @spectrum-css/statuslight
 
 <a name="6.0.61"></a>
-##6.0.61
+## 6.0.61
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@6.0.60...@spectrum-css/statuslight@6.0.61)
 
 **Note:** Version bump only for package @spectrum-css/statuslight
 
 <a name="6.0.60"></a>
-##6.0.60
+## 6.0.60
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@6.0.58...@spectrum-css/statuslight@6.0.60)
 
 **Note:** Version bump only for package @spectrum-css/statuslight
 
 <a name="6.0.59"></a>
-##6.0.59
+## 6.0.59
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@6.0.58...@spectrum-css/statuslight@6.0.59)
 
 **Note:** Version bump only for package @spectrum-css/statuslight
 
 <a name="6.0.58"></a>
-##6.0.58
+## 6.0.58
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@6.0.57...@spectrum-css/statuslight@6.0.58)
 
 **Note:** Version bump only for package @spectrum-css/statuslight
 
 <a name="6.0.57"></a>
-##6.0.57
+## 6.0.57
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@6.0.56...@spectrum-css/statuslight@6.0.57)
 
 **Note:** Version bump only for package @spectrum-css/statuslight
 
 <a name="6.0.56"></a>
-##6.0.56
+## 6.0.56
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@6.0.55...@spectrum-css/statuslight@6.0.56)
 
 **Note:** Version bump only for package @spectrum-css/statuslight
 
 <a name="6.0.55"></a>
-##6.0.55
+## 6.0.55
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@6.0.54...@spectrum-css/statuslight@6.0.55)
 
 **Note:** Version bump only for package @spectrum-css/statuslight
 
 <a name="6.0.54"></a>
-##6.0.54
+## 6.0.54
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@6.0.53...@spectrum-css/statuslight@6.0.54)
 
 **Note:** Version bump only for package @spectrum-css/statuslight
 
 <a name="6.0.53"></a>
-##6.0.53
+## 6.0.53
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@6.0.52...@spectrum-css/statuslight@6.0.53)
 
 **Note:** Version bump only for package @spectrum-css/statuslight
 
 <a name="6.0.52"></a>
-##6.0.52
+## 6.0.52
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@6.0.51...@spectrum-css/statuslight@6.0.52)
 
 **Note:** Version bump only for package @spectrum-css/statuslight
 
 <a name="6.0.51"></a>
-##6.0.51
+## 6.0.51
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@6.0.50...@spectrum-css/statuslight@6.0.51)
 
 **Note:** Version bump only for package @spectrum-css/statuslight
 
 <a name="6.0.50"></a>
-##6.0.50
+## 6.0.50
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@6.0.49...@spectrum-css/statuslight@6.0.50)
 
 **Note:** Version bump only for package @spectrum-css/statuslight
 
 <a name="6.0.49"></a>
-##6.0.49
+## 6.0.49
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@6.0.48...@spectrum-css/statuslight@6.0.49)
 
@@ -191,105 +191,105 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="6.0.48"></a>
-##6.0.48
+## 6.0.48
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@6.0.47...@spectrum-css/statuslight@6.0.48)
 
 **Note:** Version bump only for package @spectrum-css/statuslight
 
 <a name="6.0.47"></a>
-##6.0.47
+## 6.0.47
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@6.0.45...@spectrum-css/statuslight@6.0.47)
 
 **Note:** Version bump only for package @spectrum-css/statuslight
 
 <a name="6.0.46"></a>
-##6.0.46
+## 6.0.46
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@6.0.45...@spectrum-css/statuslight@6.0.46)
 
 **Note:** Version bump only for package @spectrum-css/statuslight
 
 <a name="6.0.45"></a>
-##6.0.45
+## 6.0.45
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@6.0.44...@spectrum-css/statuslight@6.0.45)
 
 **Note:** Version bump only for package @spectrum-css/statuslight
 
 <a name="6.0.44"></a>
-##6.0.44
+## 6.0.44
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@6.0.43...@spectrum-css/statuslight@6.0.44)
 
 **Note:** Version bump only for package @spectrum-css/statuslight
 
 <a name="6.0.43"></a>
-##6.0.43
+## 6.0.43
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@6.0.42...@spectrum-css/statuslight@6.0.43)
 
 **Note:** Version bump only for package @spectrum-css/statuslight
 
 <a name="6.0.42"></a>
-##6.0.42
+## 6.0.42
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@6.0.41...@spectrum-css/statuslight@6.0.42)
 
 **Note:** Version bump only for package @spectrum-css/statuslight
 
 <a name="6.0.41"></a>
-##6.0.41
+## 6.0.41
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@6.0.40...@spectrum-css/statuslight@6.0.41)
 
 **Note:** Version bump only for package @spectrum-css/statuslight
 
 <a name="6.0.40"></a>
-##6.0.40
+## 6.0.40
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@6.0.39...@spectrum-css/statuslight@6.0.40)
 
 **Note:** Version bump only for package @spectrum-css/statuslight
 
 <a name="6.0.39"></a>
-##6.0.39
+## 6.0.39
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@6.0.38...@spectrum-css/statuslight@6.0.39)
 
 **Note:** Version bump only for package @spectrum-css/statuslight
 
 <a name="6.0.38"></a>
-##6.0.38
+## 6.0.38
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@6.0.37...@spectrum-css/statuslight@6.0.38)
 
 **Note:** Version bump only for package @spectrum-css/statuslight
 
 <a name="6.0.37"></a>
-##6.0.37
+## 6.0.37
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@6.0.36...@spectrum-css/statuslight@6.0.37)
 
 **Note:** Version bump only for package @spectrum-css/statuslight
 
 <a name="6.0.36"></a>
-##6.0.36
+## 6.0.36
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@6.0.35...@spectrum-css/statuslight@6.0.36)
 
 **Note:** Version bump only for package @spectrum-css/statuslight
 
 <a name="6.0.35"></a>
-##6.0.35
+## 6.0.35
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@6.0.34...@spectrum-css/statuslight@6.0.35)
 
 **Note:** Version bump only for package @spectrum-css/statuslight
 
 <a name="6.0.34"></a>
-##6.0.34
+## 6.0.34
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@6.0.33...@spectrum-css/statuslight@6.0.34)
 
@@ -298,14 +298,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="6.0.33"></a>
-##6.0.33
+## 6.0.33
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@6.0.32...@spectrum-css/statuslight@6.0.33)
 
 **Note:** Version bump only for package @spectrum-css/statuslight
 
 <a name="6.0.32"></a>
-##6.0.32
+## 6.0.32
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/statuslight@6.0.31...@spectrum-css/statuslight@6.0.32)
 

--- a/components/steplist/CHANGELOG.md
+++ b/components/steplist/CHANGELOG.md
@@ -31,7 +31,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-#5.0.0
+# 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/steplist@4.1.4...@spectrum-css/steplist@5.0.0)
 
@@ -46,35 +46,35 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="4.1.4"></a>
-##4.1.4
+## 4.1.4
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/steplist@4.1.3...@spectrum-css/steplist@4.1.4)
 
 **Note:** Version bump only for package @spectrum-css/steplist
 
 <a name="4.1.3"></a>
-##4.1.3
+## 4.1.3
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/steplist@4.1.2...@spectrum-css/steplist@4.1.3)
 
 **Note:** Version bump only for package @spectrum-css/steplist
 
 <a name="4.1.2"></a>
-##4.1.2
+## 4.1.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/steplist@4.1.1...@spectrum-css/steplist@4.1.2)
 
 **Note:** Version bump only for package @spectrum-css/steplist
 
 <a name="4.1.1"></a>
-##4.1.1
+## 4.1.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/steplist
 
 <a name="4.1.0"></a>
-#4.1.0
+# 4.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/steplist@4.0.9...@spectrum-css/steplist@4.1.0)
 
@@ -83,14 +83,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="4.0.9"></a>
-##4.0.9
+## 4.0.9
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/steplist@4.0.8...@spectrum-css/steplist@4.0.9)
 
 **Note:** Version bump only for package @spectrum-css/steplist
 
 <a name="4.0.8"></a>
-##4.0.8
+## 4.0.8
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/steplist@4.0.7...@spectrum-css/steplist@4.0.8)
 
@@ -99,56 +99,56 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **steplist:**add WHCM for marker ([#2308](https://github.com/adobe/spectrum-css/issues/2308))([85abafc](https://github.com/adobe/spectrum-css/commit/85abafc))
 
 <a name="4.0.7"></a>
-##4.0.7
+## 4.0.7
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/steplist@4.0.5...@spectrum-css/steplist@4.0.7)
 
 **Note:** Version bump only for package @spectrum-css/steplist
 
 <a name="4.0.6"></a>
-##4.0.6
+## 4.0.6
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/steplist@4.0.5...@spectrum-css/steplist@4.0.6)
 
 **Note:** Version bump only for package @spectrum-css/steplist
 
 <a name="4.0.5"></a>
-##4.0.5
+## 4.0.5
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/steplist@4.0.4...@spectrum-css/steplist@4.0.5)
 
 **Note:** Version bump only for package @spectrum-css/steplist
 
 <a name="4.0.4"></a>
-##4.0.4
+## 4.0.4
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/steplist@4.0.3...@spectrum-css/steplist@4.0.4)
 
 **Note:** Version bump only for package @spectrum-css/steplist
 
 <a name="4.0.3"></a>
-##4.0.3
+## 4.0.3
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/steplist@4.0.2...@spectrum-css/steplist@4.0.3)
 
 **Note:** Version bump only for package @spectrum-css/steplist
 
 <a name="4.0.2"></a>
-##4.0.2
+## 4.0.2
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/steplist@4.0.1...@spectrum-css/steplist@4.0.2)
 
 **Note:** Version bump only for package @spectrum-css/steplist
 
 <a name="4.0.1"></a>
-##4.0.1
+## 4.0.1
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/steplist@4.0.0...@spectrum-css/steplist@4.0.1)
 
 **Note:** Version bump only for package @spectrum-css/steplist
 
 <a name="4.0.0"></a>
-#4.0.0
+# 4.0.0
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/steplist@3.0.78...@spectrum-css/steplist@4.0.0)
 
@@ -161,28 +161,28 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
     		migrates to use spectrum-tokens
 
 <a name="3.0.78"></a>
-##3.0.78
+## 3.0.78
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/steplist@3.0.77...@spectrum-css/steplist@3.0.78)
 
 **Note:** Version bump only for package @spectrum-css/steplist
 
 <a name="3.0.77"></a>
-##3.0.77
+## 3.0.77
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/steplist@3.0.76...@spectrum-css/steplist@3.0.77)
 
 **Note:** Version bump only for package @spectrum-css/steplist
 
 <a name="3.0.76"></a>
-##3.0.76
+## 3.0.76
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/steplist@3.0.75...@spectrum-css/steplist@3.0.76)
 
 **Note:** Version bump only for package @spectrum-css/steplist
 
 <a name="3.0.75"></a>
-##3.0.75
+## 3.0.75
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/steplist@3.0.74...@spectrum-css/steplist@3.0.75)
 
@@ -191,105 +191,105 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="3.0.74"></a>
-##3.0.74
+## 3.0.74
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/steplist@3.0.73...@spectrum-css/steplist@3.0.74)
 
 **Note:** Version bump only for package @spectrum-css/steplist
 
 <a name="3.0.73"></a>
-##3.0.73
+## 3.0.73
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/steplist@3.0.71...@spectrum-css/steplist@3.0.73)
 
 **Note:** Version bump only for package @spectrum-css/steplist
 
 <a name="3.0.72"></a>
-##3.0.72
+## 3.0.72
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/steplist@3.0.71...@spectrum-css/steplist@3.0.72)
 
 **Note:** Version bump only for package @spectrum-css/steplist
 
 <a name="3.0.71"></a>
-##3.0.71
+## 3.0.71
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/steplist@3.0.70...@spectrum-css/steplist@3.0.71)
 
 **Note:** Version bump only for package @spectrum-css/steplist
 
 <a name="3.0.70"></a>
-##3.0.70
+## 3.0.70
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/steplist@3.0.69...@spectrum-css/steplist@3.0.70)
 
 **Note:** Version bump only for package @spectrum-css/steplist
 
 <a name="3.0.69"></a>
-##3.0.69
+## 3.0.69
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/steplist@3.0.68...@spectrum-css/steplist@3.0.69)
 
 **Note:** Version bump only for package @spectrum-css/steplist
 
 <a name="3.0.68"></a>
-##3.0.68
+## 3.0.68
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/steplist@3.0.67...@spectrum-css/steplist@3.0.68)
 
 **Note:** Version bump only for package @spectrum-css/steplist
 
 <a name="3.0.67"></a>
-##3.0.67
+## 3.0.67
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/steplist@3.0.66...@spectrum-css/steplist@3.0.67)
 
 **Note:** Version bump only for package @spectrum-css/steplist
 
 <a name="3.0.66"></a>
-##3.0.66
+## 3.0.66
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/steplist@3.0.65...@spectrum-css/steplist@3.0.66)
 
 **Note:** Version bump only for package @spectrum-css/steplist
 
 <a name="3.0.65"></a>
-##3.0.65
+## 3.0.65
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/steplist@3.0.64...@spectrum-css/steplist@3.0.65)
 
 **Note:** Version bump only for package @spectrum-css/steplist
 
 <a name="3.0.64"></a>
-##3.0.64
+## 3.0.64
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/steplist@3.0.63...@spectrum-css/steplist@3.0.64)
 
 **Note:** Version bump only for package @spectrum-css/steplist
 
 <a name="3.0.63"></a>
-##3.0.63
+## 3.0.63
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/steplist@3.0.62...@spectrum-css/steplist@3.0.63)
 
 **Note:** Version bump only for package @spectrum-css/steplist
 
 <a name="3.0.62"></a>
-##3.0.62
+## 3.0.62
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/steplist@3.0.61...@spectrum-css/steplist@3.0.62)
 
 **Note:** Version bump only for package @spectrum-css/steplist
 
 <a name="3.0.61"></a>
-##3.0.61
+## 3.0.61
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/steplist@3.0.60...@spectrum-css/steplist@3.0.61)
 
 **Note:** Version bump only for package @spectrum-css/steplist
 
 <a name="3.0.60"></a>
-##3.0.60
+## 3.0.60
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/steplist@3.0.59...@spectrum-css/steplist@3.0.60)
 
@@ -298,14 +298,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="3.0.59"></a>
-##3.0.59
+## 3.0.59
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/steplist@3.0.58...@spectrum-css/steplist@3.0.59)
 
 **Note:** Version bump only for package @spectrum-css/steplist
 
 <a name="3.0.58"></a>
-##3.0.58
+## 3.0.58
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/steplist@3.0.57...@spectrum-css/steplist@3.0.58)
 

--- a/components/steplist/CHANGELOG.md
+++ b/components/steplist/CHANGELOG.md
@@ -31,7 +31,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-# 5.0.0
+## 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/steplist@4.1.4...@spectrum-css/steplist@5.0.0)
 
@@ -74,7 +74,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/steplist
 
 <a name="4.1.0"></a>
-# 4.1.0
+## 4.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/steplist@4.0.9...@spectrum-css/steplist@4.1.0)
 
@@ -148,7 +148,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/steplist
 
 <a name="4.0.0"></a>
-# 4.0.0
+## 4.0.0
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/steplist@3.0.78...@spectrum-css/steplist@4.0.0)
 
@@ -805,7 +805,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/steplist@3.0.0-beta.5...@spectrum-css/steplist@3.0.0)
 
@@ -813,7 +813,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.5"></a>
 
-# 3.0.0-beta.5
+## 3.0.0-beta.5
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/steplist@3.0.0-beta.4...@spectrum-css/steplist@3.0.0-beta.5)
 
@@ -821,7 +821,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.4"></a>
 
-# 3.0.0-beta.4
+## 3.0.0-beta.4
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/steplist@3.0.0-beta.3...@spectrum-css/steplist@3.0.0-beta.4)
 
@@ -833,7 +833,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.3"></a>
 
-# 3.0.0-beta.3
+## 3.0.0-beta.3
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/steplist@3.0.0-beta.2...@spectrum-css/steplist@3.0.0-beta.3)
 
@@ -841,7 +841,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/steplist@3.0.0-beta.1...@spectrum-css/steplist@3.0.0-beta.2)
 
@@ -849,7 +849,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/steplist@3.0.0-beta.0...@spectrum-css/steplist@3.0.0-beta.1)
 
@@ -857,7 +857,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/steplist@2.0.5...@spectrum-css/steplist@3.0.0-beta.0)
 
@@ -907,7 +907,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/stepper/CHANGELOG.md
+++ b/components/stepper/CHANGELOG.md
@@ -41,7 +41,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="6.0.0"></a>
-# 6.0.0
+## 6.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@5.1.5...@spectrum-css/stepper@6.0.0)
 
@@ -91,7 +91,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/stepper
 
 <a name="5.1.0"></a>
-# 5.1.0
+## 5.1.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@5.0.7...@spectrum-css/stepper@5.1.0)
 
@@ -158,7 +158,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/stepper
 
 <a name="5.0.0"></a>
-# 5.0.0
+## 5.0.0
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@4.0.59...@spectrum-css/stepper@5.0.0)
 
@@ -741,7 +741,7 @@ ellipsis at medium size, instead of 3. Was a matter of 1 or 2 pixels.
 
 <a name="4.0.0"></a>
 
-# 4.0.0
+## 4.0.0
 
 🗓 2023-03-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@3.0.39...@spectrum-css/stepper@4.0.0)
 
@@ -764,7 +764,7 @@ ellipsis at medium size, instead of 3. Was a matter of 1 or 2 pixels.
 
 <a name="4.0.0-beta.4"></a>
 
-# 4.0.0-beta.4
+## 4.0.0-beta.4
 
 🗓 2023-03-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@3.0.39...@spectrum-css/stepper@4.0.0-beta.4)
 
@@ -1154,7 +1154,7 @@ ellipsis at medium size, instead of 3. Was a matter of 1 or 2 pixels.
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@3.0.0-beta.7...@spectrum-css/stepper@3.0.0)
 
@@ -1162,7 +1162,7 @@ ellipsis at medium size, instead of 3. Was a matter of 1 or 2 pixels.
 
 <a name="3.0.0-beta.7"></a>
 
-# 3.0.0-beta.7
+## 3.0.0-beta.7
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@3.0.0-beta.6...@spectrum-css/stepper@3.0.0-beta.7)
 
@@ -1182,7 +1182,7 @@ ellipsis at medium size, instead of 3. Was a matter of 1 or 2 pixels.
 
 <a name="3.0.0-beta.6"></a>
 
-# 3.0.0-beta.6
+## 3.0.0-beta.6
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@3.0.0-beta.5...@spectrum-css/stepper@3.0.0-beta.6)
 
@@ -1190,7 +1190,7 @@ ellipsis at medium size, instead of 3. Was a matter of 1 or 2 pixels.
 
 <a name="3.0.0-beta.5"></a>
 
-# 3.0.0-beta.5
+## 3.0.0-beta.5
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@3.0.0-beta.4...@spectrum-css/stepper@3.0.0-beta.5)
 
@@ -1198,7 +1198,7 @@ ellipsis at medium size, instead of 3. Was a matter of 1 or 2 pixels.
 
 <a name="3.0.0-beta.4"></a>
 
-# 3.0.0-beta.4
+## 3.0.0-beta.4
 
 🗓 2020-06-19 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@3.0.0-beta.3...@spectrum-css/stepper@3.0.0-beta.4)
 
@@ -1206,7 +1206,7 @@ ellipsis at medium size, instead of 3. Was a matter of 1 or 2 pixels.
 
 <a name="3.0.0-beta.3"></a>
 
-# 3.0.0-beta.3
+## 3.0.0-beta.3
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@3.0.0-beta.2...@spectrum-css/stepper@3.0.0-beta.3)
 
@@ -1214,7 +1214,7 @@ ellipsis at medium size, instead of 3. Was a matter of 1 or 2 pixels.
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@3.0.0-beta.1...@spectrum-css/stepper@3.0.0-beta.2)
 
@@ -1222,7 +1222,7 @@ ellipsis at medium size, instead of 3. Was a matter of 1 or 2 pixels.
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@3.0.0-beta.0...@spectrum-css/stepper@3.0.0-beta.1)
 
@@ -1242,7 +1242,7 @@ ellipsis at medium size, instead of 3. Was a matter of 1 or 2 pixels.
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@2.0.6...@spectrum-css/stepper@3.0.0-beta.0)
 
@@ -1300,7 +1300,7 @@ ellipsis at medium size, instead of 3. Was a matter of 1 or 2 pixels.
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/stepper/CHANGELOG.md
+++ b/components/stepper/CHANGELOG.md
@@ -41,7 +41,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="6.0.0"></a>
-#6.0.0
+# 6.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@5.1.5...@spectrum-css/stepper@6.0.0)
 
@@ -56,49 +56,49 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="5.1.5"></a>
-##5.1.5
+## 5.1.5
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@5.1.4...@spectrum-css/stepper@5.1.5)
 
 **Note:** Version bump only for package @spectrum-css/stepper
 
 <a name="5.1.4"></a>
-##5.1.4
+## 5.1.4
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@5.1.3...@spectrum-css/stepper@5.1.4)
 
 **Note:** Version bump only for package @spectrum-css/stepper
 
 <a name="5.1.3"></a>
-##5.1.3
+## 5.1.3
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@5.1.2...@spectrum-css/stepper@5.1.3)
 
 **Note:** Version bump only for package @spectrum-css/stepper
 
 <a name="5.1.2"></a>
-##5.1.2
+## 5.1.2
 🗓
 2024-02-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@5.1.1...@spectrum-css/stepper@5.1.2)
 
 **Note:** Version bump only for package @spectrum-css/stepper
 
 <a name="5.1.1"></a>
-##5.1.1
+## 5.1.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/stepper
 
 <a name="5.1.0"></a>
-#5.1.0
+# 5.1.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@5.0.7...@spectrum-css/stepper@5.1.0)
 
 **Note:** Version bump only for package @spectrum-css/stepper
 
 <a name="5.0.7"></a>
-##5.0.7
+## 5.0.7
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@5.0.6...@spectrum-css/stepper@5.0.7)
 
@@ -113,7 +113,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
   **stepper:**no longer touches InfieldButton classes([e408272](https://github.com/adobe/spectrum-css/commit/e408272))
 
 <a name="5.0.6"></a>
-##5.0.6
+## 5.0.6
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@5.0.5...@spectrum-css/stepper@5.0.6)
 
@@ -123,42 +123,42 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
   **stepper:**no longer touches InfieldButton classes ([#2300](https://github.com/adobe/spectrum-css/issues/2300))([a82b8ad](https://github.com/adobe/spectrum-css/commit/a82b8ad))
 
 <a name="5.0.5"></a>
-##5.0.5
+## 5.0.5
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@5.0.4...@spectrum-css/stepper@5.0.5)
 
 **Note:** Version bump only for package @spectrum-css/stepper
 
 <a name="5.0.4"></a>
-##5.0.4
+## 5.0.4
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@5.0.2...@spectrum-css/stepper@5.0.4)
 
 **Note:** Version bump only for package @spectrum-css/stepper
 
 <a name="5.0.3"></a>
-##5.0.3
+## 5.0.3
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@5.0.2...@spectrum-css/stepper@5.0.3)
 
 **Note:** Version bump only for package @spectrum-css/stepper
 
 <a name="5.0.2"></a>
-##5.0.2
+## 5.0.2
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@5.0.1...@spectrum-css/stepper@5.0.2)
 
 **Note:** Version bump only for package @spectrum-css/stepper
 
 <a name="5.0.1"></a>
-##5.0.1
+## 5.0.1
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@5.0.0...@spectrum-css/stepper@5.0.1)
 
 **Note:** Version bump only for package @spectrum-css/stepper
 
 <a name="5.0.0"></a>
-#5.0.0
+# 5.0.0
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@4.0.59...@spectrum-css/stepper@5.0.0)
 
@@ -281,56 +281,56 @@ Also needed to add border width to calc, so that 4 chars appear before
 ellipsis at medium size, instead of 3. Was a matter of 1 or 2 pixels.
 
 <a name="4.0.59"></a>
-##4.0.59
+## 4.0.59
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@4.0.58...@spectrum-css/stepper@4.0.59)
 
 **Note:** Version bump only for package @spectrum-css/stepper
 
 <a name="4.0.58"></a>
-##4.0.58
+## 4.0.58
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@4.0.57...@spectrum-css/stepper@4.0.58)
 
 **Note:** Version bump only for package @spectrum-css/stepper
 
 <a name="4.0.57"></a>
-##4.0.57
+## 4.0.57
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@4.0.56...@spectrum-css/stepper@4.0.57)
 
 **Note:** Version bump only for package @spectrum-css/stepper
 
 <a name="4.0.56"></a>
-##4.0.56
+## 4.0.56
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@4.0.55...@spectrum-css/stepper@4.0.56)
 
 **Note:** Version bump only for package @spectrum-css/stepper
 
 <a name="4.0.55"></a>
-##4.0.55
+## 4.0.55
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@4.0.54...@spectrum-css/stepper@4.0.55)
 
 **Note:** Version bump only for package @spectrum-css/stepper
 
 <a name="4.0.54"></a>
-##4.0.54
+## 4.0.54
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@4.0.53...@spectrum-css/stepper@4.0.54)
 
 **Note:** Version bump only for package @spectrum-css/stepper
 
 <a name="4.0.53"></a>
-##4.0.53
+## 4.0.53
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@4.0.52...@spectrum-css/stepper@4.0.53)
 
 **Note:** Version bump only for package @spectrum-css/stepper
 
 <a name="4.0.52"></a>
-##4.0.52
+## 4.0.52
 🗓
 2023-08-25 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@4.0.51...@spectrum-css/stepper@4.0.52)
 
@@ -339,105 +339,105 @@ ellipsis at medium size, instead of 3. Was a matter of 1 or 2 pixels.
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="4.0.51"></a>
-##4.0.51
+## 4.0.51
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@4.0.50...@spectrum-css/stepper@4.0.51)
 
 **Note:** Version bump only for package @spectrum-css/stepper
 
 <a name="4.0.50"></a>
-##4.0.50
+## 4.0.50
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@4.0.48...@spectrum-css/stepper@4.0.50)
 
 **Note:** Version bump only for package @spectrum-css/stepper
 
 <a name="4.0.49"></a>
-##4.0.49
+## 4.0.49
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@4.0.48...@spectrum-css/stepper@4.0.49)
 
 **Note:** Version bump only for package @spectrum-css/stepper
 
 <a name="4.0.48"></a>
-##4.0.48
+## 4.0.48
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@4.0.47...@spectrum-css/stepper@4.0.48)
 
 **Note:** Version bump only for package @spectrum-css/stepper
 
 <a name="4.0.47"></a>
-##4.0.47
+## 4.0.47
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@4.0.46...@spectrum-css/stepper@4.0.47)
 
 **Note:** Version bump only for package @spectrum-css/stepper
 
 <a name="4.0.46"></a>
-##4.0.46
+## 4.0.46
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@4.0.45...@spectrum-css/stepper@4.0.46)
 
 **Note:** Version bump only for package @spectrum-css/stepper
 
 <a name="4.0.45"></a>
-##4.0.45
+## 4.0.45
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@4.0.44...@spectrum-css/stepper@4.0.45)
 
 **Note:** Version bump only for package @spectrum-css/stepper
 
 <a name="4.0.44"></a>
-##4.0.44
+## 4.0.44
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@4.0.43...@spectrum-css/stepper@4.0.44)
 
 **Note:** Version bump only for package @spectrum-css/stepper
 
 <a name="4.0.43"></a>
-##4.0.43
+## 4.0.43
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@4.0.42...@spectrum-css/stepper@4.0.43)
 
 **Note:** Version bump only for package @spectrum-css/stepper
 
 <a name="4.0.42"></a>
-##4.0.42
+## 4.0.42
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@4.0.41...@spectrum-css/stepper@4.0.42)
 
 **Note:** Version bump only for package @spectrum-css/stepper
 
 <a name="4.0.41"></a>
-##4.0.41
+## 4.0.41
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@4.0.40...@spectrum-css/stepper@4.0.41)
 
 **Note:** Version bump only for package @spectrum-css/stepper
 
 <a name="4.0.40"></a>
-##4.0.40
+## 4.0.40
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@4.0.39...@spectrum-css/stepper@4.0.40)
 
 **Note:** Version bump only for package @spectrum-css/stepper
 
 <a name="4.0.39"></a>
-##4.0.39
+## 4.0.39
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@4.0.38...@spectrum-css/stepper@4.0.39)
 
 **Note:** Version bump only for package @spectrum-css/stepper
 
 <a name="4.0.38"></a>
-##4.0.38
+## 4.0.38
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@4.0.37...@spectrum-css/stepper@4.0.38)
 
 **Note:** Version bump only for package @spectrum-css/stepper
 
 <a name="4.0.37"></a>
-##4.0.37
+## 4.0.37
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@4.0.36...@spectrum-css/stepper@4.0.37)
 
@@ -446,14 +446,14 @@ ellipsis at medium size, instead of 3. Was a matter of 1 or 2 pixels.
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="4.0.36"></a>
-##4.0.36
+## 4.0.36
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@4.0.35...@spectrum-css/stepper@4.0.36)
 
 **Note:** Version bump only for package @spectrum-css/stepper
 
 <a name="4.0.35"></a>
-##4.0.35
+## 4.0.35
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/stepper@4.0.34...@spectrum-css/stepper@4.0.35)
 

--- a/components/swatch/CHANGELOG.md
+++ b/components/swatch/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="6.0.0"></a>
-#6.0.0
+# 6.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatch@5.1.5...@spectrum-css/swatch@6.0.0)
 
@@ -44,42 +44,42 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="5.1.5"></a>
-##5.1.5
+## 5.1.5
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatch@5.1.4...@spectrum-css/swatch@5.1.5)
 
 **Note:** Version bump only for package @spectrum-css/swatch
 
 <a name="5.1.4"></a>
-##5.1.4
+## 5.1.4
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatch@5.1.3...@spectrum-css/swatch@5.1.4)
 
 **Note:** Version bump only for package @spectrum-css/swatch
 
 <a name="5.1.3"></a>
-##5.1.3
+## 5.1.3
 🗓
 2024-02-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatch@5.1.2...@spectrum-css/swatch@5.1.3)
 
 **Note:** Version bump only for package @spectrum-css/swatch
 
 <a name="5.1.2"></a>
-##5.1.2
+## 5.1.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatch@5.1.1...@spectrum-css/swatch@5.1.2)
 
 **Note:** Version bump only for package @spectrum-css/swatch
 
 <a name="5.1.1"></a>
-##5.1.1
+## 5.1.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/swatch
 
 <a name="5.1.0"></a>
-#5.1.0
+# 5.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatch@5.0.22...@spectrum-css/swatch@5.1.0)
 
@@ -93,98 +93,98 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
   **swatch:**icons use display instead of visibility([569bd2e](https://github.com/adobe/spectrum-css/commit/569bd2e))
 
 <a name="5.0.22"></a>
-##5.0.22
+## 5.0.22
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatch@5.0.21...@spectrum-css/swatch@5.0.22)
 
 **Note:** Version bump only for package @spectrum-css/swatch
 
 <a name="5.0.21"></a>
-##5.0.21
+## 5.0.21
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatch@5.0.20...@spectrum-css/swatch@5.0.21)
 
 **Note:** Version bump only for package @spectrum-css/swatch
 
 <a name="5.0.20"></a>
-##5.0.20
+## 5.0.20
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatch@5.0.18...@spectrum-css/swatch@5.0.20)
 
 **Note:** Version bump only for package @spectrum-css/swatch
 
 <a name="5.0.19"></a>
-##5.0.19
+## 5.0.19
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatch@5.0.18...@spectrum-css/swatch@5.0.19)
 
 **Note:** Version bump only for package @spectrum-css/swatch
 
 <a name="5.0.18"></a>
-##5.0.18
+## 5.0.18
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatch@5.0.17...@spectrum-css/swatch@5.0.18)
 
 **Note:** Version bump only for package @spectrum-css/swatch
 
 <a name="5.0.17"></a>
-##5.0.17
+## 5.0.17
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatch@5.0.16...@spectrum-css/swatch@5.0.17)
 
 **Note:** Version bump only for package @spectrum-css/swatch
 
 <a name="5.0.16"></a>
-##5.0.16
+## 5.0.16
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatch@5.0.15...@spectrum-css/swatch@5.0.16)
 
 **Note:** Version bump only for package @spectrum-css/swatch
 
 <a name="5.0.15"></a>
-##5.0.15
+## 5.0.15
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatch@5.0.14...@spectrum-css/swatch@5.0.15)
 
 **Note:** Version bump only for package @spectrum-css/swatch
 
 <a name="5.0.14"></a>
-##5.0.14
+## 5.0.14
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatch@5.0.13...@spectrum-css/swatch@5.0.14)
 
 **Note:** Version bump only for package @spectrum-css/swatch
 
 <a name="5.0.13"></a>
-##5.0.13
+## 5.0.13
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatch@5.0.12...@spectrum-css/swatch@5.0.13)
 
 **Note:** Version bump only for package @spectrum-css/swatch
 
 <a name="5.0.12"></a>
-##5.0.12
+## 5.0.12
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatch@5.0.11...@spectrum-css/swatch@5.0.12)
 
 **Note:** Version bump only for package @spectrum-css/swatch
 
 <a name="5.0.11"></a>
-##5.0.11
+## 5.0.11
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatch@5.0.10...@spectrum-css/swatch@5.0.11)
 
 **Note:** Version bump only for package @spectrum-css/swatch
 
 <a name="5.0.10"></a>
-##5.0.10
+## 5.0.10
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatch@5.0.9...@spectrum-css/swatch@5.0.10)
 
 **Note:** Version bump only for package @spectrum-css/swatch
 
 <a name="5.0.9"></a>
-##5.0.9
+## 5.0.9
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatch@5.0.8...@spectrum-css/swatch@5.0.9)
 
@@ -193,49 +193,49 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="5.0.8"></a>
-##5.0.8
+## 5.0.8
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatch@5.0.7...@spectrum-css/swatch@5.0.8)
 
 **Note:** Version bump only for package @spectrum-css/swatch
 
 <a name="5.0.7"></a>
-##5.0.7
+## 5.0.7
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatch@5.0.5...@spectrum-css/swatch@5.0.7)
 
 **Note:** Version bump only for package @spectrum-css/swatch
 
 <a name="5.0.6"></a>
-##5.0.6
+## 5.0.6
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatch@5.0.5...@spectrum-css/swatch@5.0.6)
 
 **Note:** Version bump only for package @spectrum-css/swatch
 
 <a name="5.0.5"></a>
-##5.0.5
+## 5.0.5
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatch@5.0.4...@spectrum-css/swatch@5.0.5)
 
 **Note:** Version bump only for package @spectrum-css/swatch
 
 <a name="5.0.4"></a>
-##5.0.4
+## 5.0.4
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatch@5.0.3...@spectrum-css/swatch@5.0.4)
 
 **Note:** Version bump only for package @spectrum-css/swatch
 
 <a name="5.0.3"></a>
-##5.0.3
+## 5.0.3
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatch@5.0.2...@spectrum-css/swatch@5.0.3)
 
 **Note:** Version bump only for package @spectrum-css/swatch
 
 <a name="5.0.2"></a>
-##5.0.2
+## 5.0.2
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatch@5.0.1...@spectrum-css/swatch@5.0.2)
 
@@ -244,14 +244,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **opacitycheckboard:**add to component stories ([#2056](https://github.com/adobe/spectrum-css/issues/2056))([a1411f6](https://github.com/adobe/spectrum-css/commit/a1411f6))
 
 <a name="5.0.1"></a>
-##5.0.1
+## 5.0.1
 🗓
 2023-07-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatch@5.0.0...@spectrum-css/swatch@5.0.1)
 
 **Note:** Version bump only for package @spectrum-css/swatch
 
 <a name="5.0.0"></a>
-#5.0.0
+# 5.0.0
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatch@4.0.31...@spectrum-css/swatch@5.0.0)
 
@@ -300,35 +300,35 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - chore: update yarn.lock file after rebase
 
 <a name="4.0.31"></a>
-##4.0.31
+## 4.0.31
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatch@4.0.30...@spectrum-css/swatch@4.0.31)
 
 **Note:** Version bump only for package @spectrum-css/swatch
 
 <a name="4.0.30"></a>
-##4.0.30
+## 4.0.30
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatch@4.0.29...@spectrum-css/swatch@4.0.30)
 
 **Note:** Version bump only for package @spectrum-css/swatch
 
 <a name="4.0.29"></a>
-##4.0.29
+## 4.0.29
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatch@4.0.28...@spectrum-css/swatch@4.0.29)
 
 **Note:** Version bump only for package @spectrum-css/swatch
 
 <a name="4.0.28"></a>
-##4.0.28
+## 4.0.28
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatch@4.0.27...@spectrum-css/swatch@4.0.28)
 
 **Note:** Version bump only for package @spectrum-css/swatch
 
 <a name="4.0.27"></a>
-##4.0.27
+## 4.0.27
 🗓
 2023-06-28 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatch@4.0.26...@spectrum-css/swatch@4.0.27)
 
@@ -337,7 +337,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **swatch:**specify forced-color style for disabled swatch borders ([#1980](https://github.com/adobe/spectrum-css/issues/1980))([ef6c016](https://github.com/adobe/spectrum-css/commit/ef6c016))
 
 <a name="4.0.26"></a>
-##4.0.26
+## 4.0.26
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatch@4.0.25...@spectrum-css/swatch@4.0.26)
 
@@ -346,14 +346,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **swatch:**remove override in WHCM for disabled swatch ([#1955](https://github.com/adobe/spectrum-css/issues/1955))([9492040](https://github.com/adobe/spectrum-css/commit/9492040))
 
 <a name="4.0.25"></a>
-##4.0.25
+## 4.0.25
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatch@4.0.24...@spectrum-css/swatch@4.0.25)
 
 **Note:** Version bump only for package @spectrum-css/swatch
 
 <a name="4.0.24"></a>
-##4.0.24
+## 4.0.24
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatch@4.0.23...@spectrum-css/swatch@4.0.24)
 
@@ -362,14 +362,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="4.0.23"></a>
-##4.0.23
+## 4.0.23
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatch@4.0.22...@spectrum-css/swatch@4.0.23)
 
 **Note:** Version bump only for package @spectrum-css/swatch
 
 <a name="4.0.22"></a>
-##4.0.22
+## 4.0.22
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatch@4.0.21...@spectrum-css/swatch@4.0.22)
 

--- a/components/swatch/CHANGELOG.md
+++ b/components/swatch/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="6.0.0"></a>
-# 6.0.0
+## 6.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatch@5.1.5...@spectrum-css/swatch@6.0.0)
 
@@ -79,7 +79,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/swatch
 
 <a name="5.1.0"></a>
-# 5.1.0
+## 5.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatch@5.0.22...@spectrum-css/swatch@5.1.0)
 
@@ -251,7 +251,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/swatch
 
 <a name="5.0.0"></a>
-# 5.0.0
+## 5.0.0
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatch@4.0.31...@spectrum-css/swatch@5.0.0)
 
@@ -545,7 +545,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="4.0.0"></a>
 
-# 4.0.0
+## 4.0.0
 
 🗓 2023-04-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatch@3.0.21...@spectrum-css/swatch@4.0.0)
 
@@ -727,7 +727,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2022-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatch@2.0.0...@spectrum-css/swatch@3.0.0)
 
@@ -743,7 +743,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2022-10-06 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatch@1.1.4...@spectrum-css/swatch@2.0.0)
 
@@ -791,7 +791,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="1.1.0"></a>
 
-# 1.1.0
+## 1.1.0
 
 🗓 2022-04-08
 

--- a/components/swatchgroup/CHANGELOG.md
+++ b/components/swatchgroup/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="3.0.0"></a>
-#3.0.0
+# 3.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatchgroup@2.1.5...@spectrum-css/swatchgroup@3.0.0)
 
@@ -44,42 +44,42 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="2.1.5"></a>
-##2.1.5
+## 2.1.5
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatchgroup@2.1.4...@spectrum-css/swatchgroup@2.1.5)
 
 **Note:** Version bump only for package @spectrum-css/swatchgroup
 
 <a name="2.1.4"></a>
-##2.1.4
+## 2.1.4
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatchgroup@2.1.3...@spectrum-css/swatchgroup@2.1.4)
 
 **Note:** Version bump only for package @spectrum-css/swatchgroup
 
 <a name="2.1.3"></a>
-##2.1.3
+## 2.1.3
 🗓
 2024-02-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatchgroup@2.1.2...@spectrum-css/swatchgroup@2.1.3)
 
 **Note:** Version bump only for package @spectrum-css/swatchgroup
 
 <a name="2.1.2"></a>
-##2.1.2
+## 2.1.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatchgroup@2.1.1...@spectrum-css/swatchgroup@2.1.2)
 
 **Note:** Version bump only for package @spectrum-css/swatchgroup
 
 <a name="2.1.1"></a>
-##2.1.1
+## 2.1.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/swatchgroup
 
 <a name="2.1.0"></a>
-#2.1.0
+# 2.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatchgroup@2.0.78...@spectrum-css/swatchgroup@2.1.0)
 
@@ -88,98 +88,98 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="2.0.78"></a>
-##2.0.78
+## 2.0.78
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatchgroup@2.0.77...@spectrum-css/swatchgroup@2.0.78)
 
 **Note:** Version bump only for package @spectrum-css/swatchgroup
 
 <a name="2.0.77"></a>
-##2.0.77
+## 2.0.77
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatchgroup@2.0.76...@spectrum-css/swatchgroup@2.0.77)
 
 **Note:** Version bump only for package @spectrum-css/swatchgroup
 
 <a name="2.0.76"></a>
-##2.0.76
+## 2.0.76
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatchgroup@2.0.74...@spectrum-css/swatchgroup@2.0.76)
 
 **Note:** Version bump only for package @spectrum-css/swatchgroup
 
 <a name="2.0.75"></a>
-##2.0.75
+## 2.0.75
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatchgroup@2.0.74...@spectrum-css/swatchgroup@2.0.75)
 
 **Note:** Version bump only for package @spectrum-css/swatchgroup
 
 <a name="2.0.74"></a>
-##2.0.74
+## 2.0.74
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatchgroup@2.0.73...@spectrum-css/swatchgroup@2.0.74)
 
 **Note:** Version bump only for package @spectrum-css/swatchgroup
 
 <a name="2.0.73"></a>
-##2.0.73
+## 2.0.73
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatchgroup@2.0.72...@spectrum-css/swatchgroup@2.0.73)
 
 **Note:** Version bump only for package @spectrum-css/swatchgroup
 
 <a name="2.0.72"></a>
-##2.0.72
+## 2.0.72
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatchgroup@2.0.71...@spectrum-css/swatchgroup@2.0.72)
 
 **Note:** Version bump only for package @spectrum-css/swatchgroup
 
 <a name="2.0.71"></a>
-##2.0.71
+## 2.0.71
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatchgroup@2.0.70...@spectrum-css/swatchgroup@2.0.71)
 
 **Note:** Version bump only for package @spectrum-css/swatchgroup
 
 <a name="2.0.70"></a>
-##2.0.70
+## 2.0.70
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatchgroup@2.0.69...@spectrum-css/swatchgroup@2.0.70)
 
 **Note:** Version bump only for package @spectrum-css/swatchgroup
 
 <a name="2.0.69"></a>
-##2.0.69
+## 2.0.69
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatchgroup@2.0.68...@spectrum-css/swatchgroup@2.0.69)
 
 **Note:** Version bump only for package @spectrum-css/swatchgroup
 
 <a name="2.0.68"></a>
-##2.0.68
+## 2.0.68
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatchgroup@2.0.67...@spectrum-css/swatchgroup@2.0.68)
 
 **Note:** Version bump only for package @spectrum-css/swatchgroup
 
 <a name="2.0.67"></a>
-##2.0.67
+## 2.0.67
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatchgroup@2.0.66...@spectrum-css/swatchgroup@2.0.67)
 
 **Note:** Version bump only for package @spectrum-css/swatchgroup
 
 <a name="2.0.66"></a>
-##2.0.66
+## 2.0.66
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatchgroup@2.0.65...@spectrum-css/swatchgroup@2.0.66)
 
 **Note:** Version bump only for package @spectrum-css/swatchgroup
 
 <a name="2.0.65"></a>
-##2.0.65
+## 2.0.65
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatchgroup@2.0.64...@spectrum-css/swatchgroup@2.0.65)
 
@@ -188,119 +188,119 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="2.0.64"></a>
-##2.0.64
+## 2.0.64
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatchgroup@2.0.63...@spectrum-css/swatchgroup@2.0.64)
 
 **Note:** Version bump only for package @spectrum-css/swatchgroup
 
 <a name="2.0.63"></a>
-##2.0.63
+## 2.0.63
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatchgroup@2.0.61...@spectrum-css/swatchgroup@2.0.63)
 
 **Note:** Version bump only for package @spectrum-css/swatchgroup
 
 <a name="2.0.62"></a>
-##2.0.62
+## 2.0.62
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatchgroup@2.0.61...@spectrum-css/swatchgroup@2.0.62)
 
 **Note:** Version bump only for package @spectrum-css/swatchgroup
 
 <a name="2.0.61"></a>
-##2.0.61
+## 2.0.61
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatchgroup@2.0.60...@spectrum-css/swatchgroup@2.0.61)
 
 **Note:** Version bump only for package @spectrum-css/swatchgroup
 
 <a name="2.0.60"></a>
-##2.0.60
+## 2.0.60
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatchgroup@2.0.59...@spectrum-css/swatchgroup@2.0.60)
 
 **Note:** Version bump only for package @spectrum-css/swatchgroup
 
 <a name="2.0.59"></a>
-##2.0.59
+## 2.0.59
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatchgroup@2.0.58...@spectrum-css/swatchgroup@2.0.59)
 
 **Note:** Version bump only for package @spectrum-css/swatchgroup
 
 <a name="2.0.58"></a>
-##2.0.58
+## 2.0.58
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatchgroup@2.0.57...@spectrum-css/swatchgroup@2.0.58)
 
 **Note:** Version bump only for package @spectrum-css/swatchgroup
 
 <a name="2.0.57"></a>
-##2.0.57
+## 2.0.57
 🗓
 2023-07-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatchgroup@2.0.56...@spectrum-css/swatchgroup@2.0.57)
 
 **Note:** Version bump only for package @spectrum-css/swatchgroup
 
 <a name="2.0.56"></a>
-##2.0.56
+## 2.0.56
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatchgroup@2.0.55...@spectrum-css/swatchgroup@2.0.56)
 
 **Note:** Version bump only for package @spectrum-css/swatchgroup
 
 <a name="2.0.55"></a>
-##2.0.55
+## 2.0.55
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatchgroup@2.0.54...@spectrum-css/swatchgroup@2.0.55)
 
 **Note:** Version bump only for package @spectrum-css/swatchgroup
 
 <a name="2.0.54"></a>
-##2.0.54
+## 2.0.54
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatchgroup@2.0.53...@spectrum-css/swatchgroup@2.0.54)
 
 **Note:** Version bump only for package @spectrum-css/swatchgroup
 
 <a name="2.0.53"></a>
-##2.0.53
+## 2.0.53
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatchgroup@2.0.52...@spectrum-css/swatchgroup@2.0.53)
 
 **Note:** Version bump only for package @spectrum-css/swatchgroup
 
 <a name="2.0.52"></a>
-##2.0.52
+## 2.0.52
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatchgroup@2.0.51...@spectrum-css/swatchgroup@2.0.52)
 
 **Note:** Version bump only for package @spectrum-css/swatchgroup
 
 <a name="2.0.51"></a>
-##2.0.51
+## 2.0.51
 🗓
 2023-06-28 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatchgroup@2.0.50...@spectrum-css/swatchgroup@2.0.51)
 
 **Note:** Version bump only for package @spectrum-css/swatchgroup
 
 <a name="2.0.50"></a>
-##2.0.50
+## 2.0.50
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatchgroup@2.0.49...@spectrum-css/swatchgroup@2.0.50)
 
 **Note:** Version bump only for package @spectrum-css/swatchgroup
 
 <a name="2.0.49"></a>
-##2.0.49
+## 2.0.49
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatchgroup@2.0.48...@spectrum-css/swatchgroup@2.0.49)
 
 **Note:** Version bump only for package @spectrum-css/swatchgroup
 
 <a name="2.0.48"></a>
-##2.0.48
+## 2.0.48
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatchgroup@2.0.47...@spectrum-css/swatchgroup@2.0.48)
 
@@ -309,14 +309,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="2.0.47"></a>
-##2.0.47
+## 2.0.47
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatchgroup@2.0.46...@spectrum-css/swatchgroup@2.0.47)
 
 **Note:** Version bump only for package @spectrum-css/swatchgroup
 
 <a name="2.0.46"></a>
-##2.0.46
+## 2.0.46
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatchgroup@2.0.45...@spectrum-css/swatchgroup@2.0.46)
 

--- a/components/swatchgroup/CHANGELOG.md
+++ b/components/swatchgroup/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="3.0.0"></a>
-# 3.0.0
+## 3.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatchgroup@2.1.5...@spectrum-css/swatchgroup@3.0.0)
 
@@ -79,7 +79,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/swatchgroup
 
 <a name="2.1.0"></a>
-# 2.1.0
+## 2.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatchgroup@2.0.78...@spectrum-css/swatchgroup@2.1.0)
 
@@ -684,7 +684,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2022-10-06 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/swatchgroup@1.1.4...@spectrum-css/swatchgroup@2.0.0)
 
@@ -730,7 +730,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="1.1.0"></a>
 
-# 1.1.0
+## 1.1.0
 
 🗓 2022-04-08
 

--- a/components/switch/CHANGELOG.md
+++ b/components/switch/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-#5.0.0
+# 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@4.2.5...@spectrum-css/switch@5.0.0)
 
@@ -40,49 +40,49 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="4.2.5"></a>
-##4.2.5
+## 4.2.5
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@4.2.4...@spectrum-css/switch@4.2.5)
 
 **Note:** Version bump only for package @spectrum-css/switch
 
 <a name="4.2.4"></a>
-##4.2.4
+## 4.2.4
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@4.2.3...@spectrum-css/switch@4.2.4)
 
 **Note:** Version bump only for package @spectrum-css/switch
 
 <a name="4.2.3"></a>
-##4.2.3
+## 4.2.3
 🗓
 2024-02-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@4.2.2...@spectrum-css/switch@4.2.3)
 
 **Note:** Version bump only for package @spectrum-css/switch
 
 <a name="4.2.2"></a>
-##4.2.2
+## 4.2.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@4.2.1...@spectrum-css/switch@4.2.2)
 
 **Note:** Version bump only for package @spectrum-css/switch
 
 <a name="4.2.1"></a>
-##4.2.1
+## 4.2.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/switch
 
 <a name="4.2.0"></a>
-#4.2.0
+# 4.2.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@4.1.0...@spectrum-css/switch@4.2.0)
 
 **Note:** Version bump only for package @spectrum-css/switch
 
 <a name="4.1.0"></a>
-#4.1.0
+# 4.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@4.0.17...@spectrum-css/switch@4.1.0)
 
@@ -91,98 +91,98 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="4.0.17"></a>
-##4.0.17
+## 4.0.17
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@4.0.16...@spectrum-css/switch@4.0.17)
 
 **Note:** Version bump only for package @spectrum-css/switch
 
 <a name="4.0.16"></a>
-##4.0.16
+## 4.0.16
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@4.0.15...@spectrum-css/switch@4.0.16)
 
 **Note:** Version bump only for package @spectrum-css/switch
 
 <a name="4.0.15"></a>
-##4.0.15
+## 4.0.15
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@4.0.13...@spectrum-css/switch@4.0.15)
 
 **Note:** Version bump only for package @spectrum-css/switch
 
 <a name="4.0.14"></a>
-##4.0.14
+## 4.0.14
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@4.0.13...@spectrum-css/switch@4.0.14)
 
 **Note:** Version bump only for package @spectrum-css/switch
 
 <a name="4.0.13"></a>
-##4.0.13
+## 4.0.13
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@4.0.12...@spectrum-css/switch@4.0.13)
 
 **Note:** Version bump only for package @spectrum-css/switch
 
 <a name="4.0.12"></a>
-##4.0.12
+## 4.0.12
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@4.0.11...@spectrum-css/switch@4.0.12)
 
 **Note:** Version bump only for package @spectrum-css/switch
 
 <a name="4.0.11"></a>
-##4.0.11
+## 4.0.11
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@4.0.10...@spectrum-css/switch@4.0.11)
 
 **Note:** Version bump only for package @spectrum-css/switch
 
 <a name="4.0.10"></a>
-##4.0.10
+## 4.0.10
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@4.0.9...@spectrum-css/switch@4.0.10)
 
 **Note:** Version bump only for package @spectrum-css/switch
 
 <a name="4.0.9"></a>
-##4.0.9
+## 4.0.9
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@4.0.8...@spectrum-css/switch@4.0.9)
 
 **Note:** Version bump only for package @spectrum-css/switch
 
 <a name="4.0.8"></a>
-##4.0.8
+## 4.0.8
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@4.0.7...@spectrum-css/switch@4.0.8)
 
 **Note:** Version bump only for package @spectrum-css/switch
 
 <a name="4.0.7"></a>
-##4.0.7
+## 4.0.7
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@4.0.6...@spectrum-css/switch@4.0.7)
 
 **Note:** Version bump only for package @spectrum-css/switch
 
 <a name="4.0.6"></a>
-##4.0.6
+## 4.0.6
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@4.0.5...@spectrum-css/switch@4.0.6)
 
 **Note:** Version bump only for package @spectrum-css/switch
 
 <a name="4.0.5"></a>
-##4.0.5
+## 4.0.5
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@4.0.4...@spectrum-css/switch@4.0.5)
 
 **Note:** Version bump only for package @spectrum-css/switch
 
 <a name="4.0.4"></a>
-##4.0.4
+## 4.0.4
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@4.0.3...@spectrum-css/switch@4.0.4)
 
@@ -191,28 +191,28 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="4.0.3"></a>
-##4.0.3
+## 4.0.3
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@4.0.2...@spectrum-css/switch@4.0.3)
 
 **Note:** Version bump only for package @spectrum-css/switch
 
 <a name="4.0.2"></a>
-##4.0.2
+## 4.0.2
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@4.0.0...@spectrum-css/switch@4.0.2)
 
 **Note:** Version bump only for package @spectrum-css/switch
 
 <a name="4.0.1"></a>
-##4.0.1
+## 4.0.1
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@4.0.0...@spectrum-css/switch@4.0.1)
 
 **Note:** Version bump only for package @spectrum-css/switch
 
 <a name="4.0.0"></a>
-#4.0.0
+# 4.0.0
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@3.1.13...@spectrum-css/switch@4.0.0)
 
@@ -225,7 +225,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
     		use focus-visible pseudo class in place of focus-ring
 
 <a name="3.1.13"></a>
-##3.1.13
+## 3.1.13
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@3.1.12...@spectrum-css/switch@3.1.13)
 
@@ -234,77 +234,77 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **switch:**update selected background color tokens ([#2057](https://github.com/adobe/spectrum-css/issues/2057))([255a47a](https://github.com/adobe/spectrum-css/commit/255a47a))
 
 <a name="3.1.12"></a>
-##3.1.12
+## 3.1.12
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@3.1.11...@spectrum-css/switch@3.1.12)
 
 **Note:** Version bump only for package @spectrum-css/switch
 
 <a name="3.1.11"></a>
-##3.1.11
+## 3.1.11
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@3.1.10...@spectrum-css/switch@3.1.11)
 
 **Note:** Version bump only for package @spectrum-css/switch
 
 <a name="3.1.10"></a>
-##3.1.10
+## 3.1.10
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@3.1.9...@spectrum-css/switch@3.1.10)
 
 **Note:** Version bump only for package @spectrum-css/switch
 
 <a name="3.1.9"></a>
-##3.1.9
+## 3.1.9
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@3.1.8...@spectrum-css/switch@3.1.9)
 
 **Note:** Version bump only for package @spectrum-css/switch
 
 <a name="3.1.8"></a>
-##3.1.8
+## 3.1.8
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@3.1.7...@spectrum-css/switch@3.1.8)
 
 **Note:** Version bump only for package @spectrum-css/switch
 
 <a name="3.1.7"></a>
-##3.1.7
+## 3.1.7
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@3.1.6...@spectrum-css/switch@3.1.7)
 
 **Note:** Version bump only for package @spectrum-css/switch
 
 <a name="3.1.6"></a>
-##3.1.6
+## 3.1.6
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@3.1.5...@spectrum-css/switch@3.1.6)
 
 **Note:** Version bump only for package @spectrum-css/switch
 
 <a name="3.1.5"></a>
-##3.1.5
+## 3.1.5
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@3.1.4...@spectrum-css/switch@3.1.5)
 
 **Note:** Version bump only for package @spectrum-css/switch
 
 <a name="3.1.4"></a>
-##3.1.4
+## 3.1.4
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@3.1.3...@spectrum-css/switch@3.1.4)
 
 **Note:** Version bump only for package @spectrum-css/switch
 
 <a name="3.1.3"></a>
-##3.1.3
+## 3.1.3
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@3.1.2...@spectrum-css/switch@3.1.3)
 
 **Note:** Version bump only for package @spectrum-css/switch
 
 <a name="3.1.2"></a>
-##3.1.2
+## 3.1.2
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@3.1.1...@spectrum-css/switch@3.1.2)
 
@@ -313,14 +313,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="3.1.1"></a>
-##3.1.1
+## 3.1.1
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@3.1.0...@spectrum-css/switch@3.1.1)
 
 **Note:** Version bump only for package @spectrum-css/switch
 
 <a name="3.1.0"></a>
-#3.1.0
+# 3.1.0
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@3.0.38...@spectrum-css/switch@3.1.0)
 

--- a/components/switch/CHANGELOG.md
+++ b/components/switch/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-# 5.0.0
+## 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@4.2.5...@spectrum-css/switch@5.0.0)
 
@@ -75,14 +75,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/switch
 
 <a name="4.2.0"></a>
-# 4.2.0
+## 4.2.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@4.1.0...@spectrum-css/switch@4.2.0)
 
 **Note:** Version bump only for package @spectrum-css/switch
 
 <a name="4.1.0"></a>
-# 4.1.0
+## 4.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@4.0.17...@spectrum-css/switch@4.1.0)
 
@@ -212,7 +212,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/switch
 
 <a name="4.0.0"></a>
-# 4.0.0
+## 4.0.0
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@3.1.13...@spectrum-css/switch@4.0.0)
 
@@ -320,7 +320,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/switch
 
 <a name="3.1.0"></a>
-# 3.1.0
+## 3.1.0
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@3.0.38...@spectrum-css/switch@3.1.0)
 
@@ -634,7 +634,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2022-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@2.0.0...@spectrum-css/switch@3.0.0)
 
@@ -650,7 +650,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2022-09-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@1.0.23...@spectrum-css/switch@2.0.0)
 
@@ -902,7 +902,7 @@ Also, adds t-shirt sizes
 
 <a name="1.0.0"></a>
 
-# 1.0.0
+## 1.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@1.0.0-beta.3...@spectrum-css/switch@1.0.0)
 
@@ -910,7 +910,7 @@ Also, adds t-shirt sizes
 
 <a name="1.0.0-beta.3"></a>
 
-# 1.0.0-beta.3
+## 1.0.0-beta.3
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@1.0.0-beta.2...@spectrum-css/switch@1.0.0-beta.3)
 
@@ -920,7 +920,7 @@ Also, adds t-shirt sizes
 
 <a name="1.0.0-beta.2"></a>
 
-# 1.0.0-beta.2
+## 1.0.0-beta.2
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/switch@1.0.0-beta.1...@spectrum-css/switch@1.0.0-beta.2)
 
@@ -928,7 +928,7 @@ Also, adds t-shirt sizes
 
 <a name="1.0.0-beta.1"></a>
 
-# 1.0.0-beta.1
+## 1.0.0-beta.1
 
 🗓 2020-09-23
 
@@ -938,7 +938,7 @@ Also, adds t-shirt sizes
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toggle@3.0.0-beta.1...@spectrum-css/toggle@3.0.0-beta.2)
 
@@ -946,7 +946,7 @@ Also, adds t-shirt sizes
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toggle@3.0.0-beta.0...@spectrum-css/toggle@3.0.0-beta.1)
 
@@ -954,7 +954,7 @@ Also, adds t-shirt sizes
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toggle@2.1.0...@spectrum-css/toggle@3.0.0-beta.0)
 
@@ -969,7 +969,7 @@ Also, adds t-shirt sizes
 
 <a name="2.1.0"></a>
 
-# 2.1.0
+## 2.1.0
 
 🗓 2020-03-06 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toggle@2.0.5...@spectrum-css/toggle@2.1.0)
 
@@ -1025,7 +1025,7 @@ Also, adds t-shirt sizes
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/table/CHANGELOG.md
+++ b/components/table/CHANGELOG.md
@@ -35,7 +35,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="6.0.0"></a>
-# 6.0.0
+## 6.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@5.2.5...@spectrum-css/table@6.0.0)
 
@@ -85,7 +85,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/table
 
 <a name="5.2.0"></a>
-# 5.2.0
+## 5.2.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@5.1.1...@spectrum-css/table@5.2.0)
 
@@ -102,7 +102,7 @@ _deprecate logical transform plugin ([#2437](https://github.com/adobe/spectrum-c
 **table:**replace leftover global color token ([#2415](https://github.com/adobe/spectrum-css/issues/2415))([35ccf25](https://github.com/adobe/spectrum-css/commit/35ccf25))
 
 <a name="5.1.0"></a>
-# 5.1.0
+## 5.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@5.0.11...@spectrum-css/table@5.1.0)
 
@@ -188,7 +188,7 @@ _deprecate logical transform plugin ([#2437](https://github.com/adobe/spectrum-c
 **Note:** Version bump only for package @spectrum-css/table
 
 <a name="5.0.0"></a>
-# 5.0.0
+## 5.0.0
 🗓
 2023-09-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@4.0.73...@spectrum-css/table@5.0.0)
 
@@ -1259,7 +1259,7 @@ set on the cell instead of the row (previous fix for Firefix bug).
 
 <a name="3.1.0"></a>
 
-# 3.1.0
+## 3.1.0
 
 🗓 2021-09-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@3.0.3-alpha.3...@spectrum-css/table@3.1.0)
 
@@ -1326,7 +1326,7 @@ set on the cell instead of the row (previous fix for Firefix bug).
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@3.0.0-beta.6...@spectrum-css/table@3.0.0)
 
@@ -1340,7 +1340,7 @@ set on the cell instead of the row (previous fix for Firefix bug).
 
 <a name="3.0.0-beta.6"></a>
 
-# 3.0.0-beta.6
+## 3.0.0-beta.6
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@3.0.0-beta.5...@spectrum-css/table@3.0.0-beta.6)
 
@@ -1350,7 +1350,7 @@ set on the cell instead of the row (previous fix for Firefix bug).
 
 <a name="3.0.0-beta.5"></a>
 
-# 3.0.0-beta.5
+## 3.0.0-beta.5
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@3.0.0-beta.4...@spectrum-css/table@3.0.0-beta.5)
 
@@ -1358,7 +1358,7 @@ set on the cell instead of the row (previous fix for Firefix bug).
 
 <a name="3.0.0-beta.4"></a>
 
-# 3.0.0-beta.4
+## 3.0.0-beta.4
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@3.0.0-beta.3...@spectrum-css/table@3.0.0-beta.4)
 
@@ -1368,7 +1368,7 @@ set on the cell instead of the row (previous fix for Firefix bug).
 
 <a name="3.0.0-beta.3"></a>
 
-# 3.0.0-beta.3
+## 3.0.0-beta.3
 
 🗓 2020-06-19 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@3.0.0-beta.2...@spectrum-css/table@3.0.0-beta.3)
 
@@ -1376,7 +1376,7 @@ set on the cell instead of the row (previous fix for Firefix bug).
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@3.0.0-beta.1...@spectrum-css/table@3.0.0-beta.2)
 
@@ -1384,7 +1384,7 @@ set on the cell instead of the row (previous fix for Firefix bug).
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@3.0.0-beta.0...@spectrum-css/table@3.0.0-beta.1)
 
@@ -1392,7 +1392,7 @@ set on the cell instead of the row (previous fix for Firefix bug).
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@2.0.6...@spectrum-css/table@3.0.0-beta.0)
 
@@ -1450,7 +1450,7 @@ set on the cell instead of the row (previous fix for Firefix bug).
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/table/CHANGELOG.md
+++ b/components/table/CHANGELOG.md
@@ -35,7 +35,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="6.0.0"></a>
-#6.0.0
+# 6.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@5.2.5...@spectrum-css/table@6.0.0)
 
@@ -50,49 +50,49 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="5.2.5"></a>
-##5.2.5
+## 5.2.5
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@5.2.4...@spectrum-css/table@5.2.5)
 
 **Note:** Version bump only for package @spectrum-css/table
 
 <a name="5.2.4"></a>
-##5.2.4
+## 5.2.4
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@5.2.3...@spectrum-css/table@5.2.4)
 
 **Note:** Version bump only for package @spectrum-css/table
 
 <a name="5.2.3"></a>
-##5.2.3
+## 5.2.3
 🗓
 2024-02-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@5.2.2...@spectrum-css/table@5.2.3)
 
 **Note:** Version bump only for package @spectrum-css/table
 
 <a name="5.2.2"></a>
-##5.2.2
+## 5.2.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@5.2.1...@spectrum-css/table@5.2.2)
 
 **Note:** Version bump only for package @spectrum-css/table
 
 <a name="5.2.1"></a>
-##5.2.1
+## 5.2.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/table
 
 <a name="5.2.0"></a>
-#5.2.0
+# 5.2.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@5.1.1...@spectrum-css/table@5.2.0)
 
 **Note:** Version bump only for package @spectrum-css/table
 
 <a name="5.1.1"></a>
-##5.1.1
+## 5.1.1
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@5.1.0...@spectrum-css/table@5.1.1)
 
@@ -102,7 +102,7 @@ _deprecate logical transform plugin ([#2437](https://github.com/adobe/spectrum-c
 **table:**replace leftover global color token ([#2415](https://github.com/adobe/spectrum-css/issues/2415))([35ccf25](https://github.com/adobe/spectrum-css/commit/35ccf25))
 
 <a name="5.1.0"></a>
-#5.1.0
+# 5.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@5.0.11...@spectrum-css/table@5.1.0)
 
@@ -111,84 +111,84 @@ _deprecate logical transform plugin ([#2437](https://github.com/adobe/spectrum-c
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="5.0.11"></a>
-##5.0.11
+## 5.0.11
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@5.0.10...@spectrum-css/table@5.0.11)
 
 **Note:** Version bump only for package @spectrum-css/table
 
 <a name="5.0.10"></a>
-##5.0.10
+## 5.0.10
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@5.0.9...@spectrum-css/table@5.0.10)
 
 **Note:** Version bump only for package @spectrum-css/table
 
 <a name="5.0.9"></a>
-##5.0.9
+## 5.0.9
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@5.0.7...@spectrum-css/table@5.0.9)
 
 **Note:** Version bump only for package @spectrum-css/table
 
 <a name="5.0.8"></a>
-##5.0.8
+## 5.0.8
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@5.0.7...@spectrum-css/table@5.0.8)
 
 **Note:** Version bump only for package @spectrum-css/table
 
 <a name="5.0.7"></a>
-##5.0.7
+## 5.0.7
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@5.0.6...@spectrum-css/table@5.0.7)
 
 **Note:** Version bump only for package @spectrum-css/table
 
 <a name="5.0.6"></a>
-##5.0.6
+## 5.0.6
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@5.0.5...@spectrum-css/table@5.0.6)
 
 **Note:** Version bump only for package @spectrum-css/table
 
 <a name="5.0.5"></a>
-##5.0.5
+## 5.0.5
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@5.0.4...@spectrum-css/table@5.0.5)
 
 **Note:** Version bump only for package @spectrum-css/table
 
 <a name="5.0.4"></a>
-##5.0.4
+## 5.0.4
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@5.0.3...@spectrum-css/table@5.0.4)
 
 **Note:** Version bump only for package @spectrum-css/table
 
 <a name="5.0.3"></a>
-##5.0.3
+## 5.0.3
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@5.0.2...@spectrum-css/table@5.0.3)
 
 **Note:** Version bump only for package @spectrum-css/table
 
 <a name="5.0.2"></a>
-##5.0.2
+## 5.0.2
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@5.0.1...@spectrum-css/table@5.0.2)
 
 **Note:** Version bump only for package @spectrum-css/table
 
 <a name="5.0.1"></a>
-##5.0.1
+## 5.0.1
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@5.0.0...@spectrum-css/table@5.0.1)
 
 **Note:** Version bump only for package @spectrum-css/table
 
 <a name="5.0.0"></a>
-#5.0.0
+# 5.0.0
 🗓
 2023-09-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@4.0.73...@spectrum-css/table@5.0.0)
 
@@ -681,21 +681,21 @@ transparent. This is no longer needed as the background color is now
 set on the cell instead of the row (previous fix for Firefix bug).
 
 <a name="4.0.73"></a>
-##4.0.73
+## 4.0.73
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@4.0.72...@spectrum-css/table@4.0.73)
 
 **Note:** Version bump only for package @spectrum-css/table
 
 <a name="4.0.72"></a>
-##4.0.72
+## 4.0.72
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@4.0.71...@spectrum-css/table@4.0.72)
 
 **Note:** Version bump only for package @spectrum-css/table
 
 <a name="4.0.71"></a>
-##4.0.71
+## 4.0.71
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@4.0.70...@spectrum-css/table@4.0.71)
 
@@ -704,112 +704,112 @@ set on the cell instead of the row (previous fix for Firefix bug).
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="4.0.70"></a>
-##4.0.70
+## 4.0.70
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@4.0.69...@spectrum-css/table@4.0.70)
 
 **Note:** Version bump only for package @spectrum-css/table
 
 <a name="4.0.69"></a>
-##4.0.69
+## 4.0.69
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@4.0.67...@spectrum-css/table@4.0.69)
 
 **Note:** Version bump only for package @spectrum-css/table
 
 <a name="4.0.68"></a>
-##4.0.68
+## 4.0.68
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@4.0.67...@spectrum-css/table@4.0.68)
 
 **Note:** Version bump only for package @spectrum-css/table
 
 <a name="4.0.67"></a>
-##4.0.67
+## 4.0.67
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@4.0.66...@spectrum-css/table@4.0.67)
 
 **Note:** Version bump only for package @spectrum-css/table
 
 <a name="4.0.66"></a>
-##4.0.66
+## 4.0.66
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@4.0.65...@spectrum-css/table@4.0.66)
 
 **Note:** Version bump only for package @spectrum-css/table
 
 <a name="4.0.65"></a>
-##4.0.65
+## 4.0.65
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@4.0.64...@spectrum-css/table@4.0.65)
 
 **Note:** Version bump only for package @spectrum-css/table
 
 <a name="4.0.64"></a>
-##4.0.64
+## 4.0.64
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@4.0.63...@spectrum-css/table@4.0.64)
 
 **Note:** Version bump only for package @spectrum-css/table
 
 <a name="4.0.63"></a>
-##4.0.63
+## 4.0.63
 🗓
 2023-07-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@4.0.62...@spectrum-css/table@4.0.63)
 
 **Note:** Version bump only for package @spectrum-css/table
 
 <a name="4.0.62"></a>
-##4.0.62
+## 4.0.62
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@4.0.61...@spectrum-css/table@4.0.62)
 
 **Note:** Version bump only for package @spectrum-css/table
 
 <a name="4.0.61"></a>
-##4.0.61
+## 4.0.61
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@4.0.60...@spectrum-css/table@4.0.61)
 
 **Note:** Version bump only for package @spectrum-css/table
 
 <a name="4.0.60"></a>
-##4.0.60
+## 4.0.60
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@4.0.59...@spectrum-css/table@4.0.60)
 
 **Note:** Version bump only for package @spectrum-css/table
 
 <a name="4.0.59"></a>
-##4.0.59
+## 4.0.59
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@4.0.58...@spectrum-css/table@4.0.59)
 
 **Note:** Version bump only for package @spectrum-css/table
 
 <a name="4.0.58"></a>
-##4.0.58
+## 4.0.58
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@4.0.57...@spectrum-css/table@4.0.58)
 
 **Note:** Version bump only for package @spectrum-css/table
 
 <a name="4.0.57"></a>
-##4.0.57
+## 4.0.57
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@4.0.56...@spectrum-css/table@4.0.57)
 
 **Note:** Version bump only for package @spectrum-css/table
 
 <a name="4.0.56"></a>
-##4.0.56
+## 4.0.56
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@4.0.55...@spectrum-css/table@4.0.56)
 
 **Note:** Version bump only for package @spectrum-css/table
 
 <a name="4.0.55"></a>
-##4.0.55
+## 4.0.55
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@4.0.54...@spectrum-css/table@4.0.55)
 
@@ -818,14 +818,14 @@ set on the cell instead of the row (previous fix for Firefix bug).
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="4.0.54"></a>
-##4.0.54
+## 4.0.54
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@4.0.53...@spectrum-css/table@4.0.54)
 
 **Note:** Version bump only for package @spectrum-css/table
 
 <a name="4.0.53"></a>
-##4.0.53
+## 4.0.53
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/table@4.0.52...@spectrum-css/table@4.0.53)
 

--- a/components/tabs/CHANGELOG.md
+++ b/components/tabs/CHANGELOG.md
@@ -33,7 +33,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-# 5.0.0
+## 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@4.1.4...@spectrum-css/tabs@5.0.0)
 
@@ -80,7 +80,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/tabs
 
 <a name="4.1.0"></a>
-# 4.1.0
+## 4.1.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@4.0.28...@spectrum-css/tabs@4.1.0)
 
@@ -287,7 +287,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/tabs
 
 <a name="4.0.0"></a>
-# 4.0.0
+## 4.0.0
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@3.2.64...@spectrum-css/tabs@4.0.0)
 
@@ -809,7 +809,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.2.0"></a>
 
-# 3.2.0
+## 3.2.0
 
 🗓 2022-01-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@3.1.9...@spectrum-css/tabs@3.2.0)
 
@@ -909,7 +909,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.1.0"></a>
 
-# 3.1.0
+## 3.1.0
 
 🗓 2021-09-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@3.1.0-alpha.1...@spectrum-css/tabs@3.1.0)
 
@@ -919,7 +919,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.1.0-alpha.1"></a>
 
-# 3.1.0-alpha.1
+## 3.1.0-alpha.1
 
 🗓 2021-08-19 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@3.1.0-alpha.0...@spectrum-css/tabs@3.1.0-alpha.1)
 
@@ -929,7 +929,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.1.0-alpha.0"></a>
 
-# 3.1.0-alpha.0
+## 3.1.0-alpha.0
 
 🗓 2021-08-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@3.0.3-alpha.4...@spectrum-css/tabs@3.1.0-alpha.0)
 
@@ -1000,7 +1000,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@3.0.0-beta.6...@spectrum-css/tabs@3.0.0)
 
@@ -1008,7 +1008,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.6"></a>
 
-# 3.0.0-beta.6
+## 3.0.0-beta.6
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@3.0.0-beta.5...@spectrum-css/tabs@3.0.0-beta.6)
 
@@ -1032,7 +1032,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.5"></a>
 
-# 3.0.0-beta.5
+## 3.0.0-beta.5
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@3.0.0-beta.4...@spectrum-css/tabs@3.0.0-beta.5)
 
@@ -1040,7 +1040,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.4"></a>
 
-# 3.0.0-beta.4
+## 3.0.0-beta.4
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@3.0.0-beta.3...@spectrum-css/tabs@3.0.0-beta.4)
 
@@ -1050,7 +1050,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.3"></a>
 
-# 3.0.0-beta.3
+## 3.0.0-beta.3
 
 🗓 2020-06-19 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@3.0.0-beta.2...@spectrum-css/tabs@3.0.0-beta.3)
 
@@ -1058,7 +1058,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@3.0.0-beta.1...@spectrum-css/tabs@3.0.0-beta.2)
 
@@ -1068,7 +1068,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@3.0.0-beta.0...@spectrum-css/tabs@3.0.0-beta.1)
 
@@ -1076,7 +1076,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@2.1.5...@spectrum-css/tabs@3.0.0-beta.0)
 
@@ -1126,7 +1126,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="2.1.0"></a>
 
-# 2.1.0
+## 2.1.0
 
 🗓 2019-11-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@2.0.0...@spectrum-css/tabs@2.1.0)
 
@@ -1136,7 +1136,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/tabs/CHANGELOG.md
+++ b/components/tabs/CHANGELOG.md
@@ -33,7 +33,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-#5.0.0
+# 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@4.1.4...@spectrum-css/tabs@5.0.0)
 
@@ -52,56 +52,56 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * Imports added to index.css and themes/express.css
 
 <a name="4.1.4"></a>
-##4.1.4
+## 4.1.4
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@4.1.3...@spectrum-css/tabs@4.1.4)
 
 **Note:** Version bump only for package @spectrum-css/tabs
 
 <a name="4.1.3"></a>
-##4.1.3
+## 4.1.3
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@4.1.2...@spectrum-css/tabs@4.1.3)
 
 **Note:** Version bump only for package @spectrum-css/tabs
 
 <a name="4.1.2"></a>
-##4.1.2
+## 4.1.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@4.1.1...@spectrum-css/tabs@4.1.2)
 
 **Note:** Version bump only for package @spectrum-css/tabs
 
 <a name="4.1.1"></a>
-##4.1.1
+## 4.1.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/tabs
 
 <a name="4.1.0"></a>
-#4.1.0
+# 4.1.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@4.0.28...@spectrum-css/tabs@4.1.0)
 
 **Note:** Version bump only for package @spectrum-css/tabs
 
 <a name="4.0.28"></a>
-##4.0.28
+## 4.0.28
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@4.0.27...@spectrum-css/tabs@4.0.28)
 
 **Note:** Version bump only for package @spectrum-css/tabs
 
 <a name="4.0.27"></a>
-##4.0.27
+## 4.0.27
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@4.0.26...@spectrum-css/tabs@4.0.27)
 
 **Note:** Version bump only for package @spectrum-css/tabs
 
 <a name="4.0.26"></a>
-##4.0.26
+## 4.0.26
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@4.0.25...@spectrum-css/tabs@4.0.26)
 
@@ -110,91 +110,91 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **tabs:**focus outline only on keyboard focus([ec96da6](https://github.com/adobe/spectrum-css/commit/ec96da6))
 
 <a name="4.0.25"></a>
-##4.0.25
+## 4.0.25
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@4.0.23...@spectrum-css/tabs@4.0.25)
 
 **Note:** Version bump only for package @spectrum-css/tabs
 
 <a name="4.0.24"></a>
-##4.0.24
+## 4.0.24
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@4.0.23...@spectrum-css/tabs@4.0.24)
 
 **Note:** Version bump only for package @spectrum-css/tabs
 
 <a name="4.0.23"></a>
-##4.0.23
+## 4.0.23
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@4.0.22...@spectrum-css/tabs@4.0.23)
 
 **Note:** Version bump only for package @spectrum-css/tabs
 
 <a name="4.0.22"></a>
-##4.0.22
+## 4.0.22
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@4.0.21...@spectrum-css/tabs@4.0.22)
 
 **Note:** Version bump only for package @spectrum-css/tabs
 
 <a name="4.0.21"></a>
-##4.0.21
+## 4.0.21
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@4.0.20...@spectrum-css/tabs@4.0.21)
 
 **Note:** Version bump only for package @spectrum-css/tabs
 
 <a name="4.0.20"></a>
-##4.0.20
+## 4.0.20
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@4.0.19...@spectrum-css/tabs@4.0.20)
 
 **Note:** Version bump only for package @spectrum-css/tabs
 
 <a name="4.0.19"></a>
-##4.0.19
+## 4.0.19
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@4.0.18...@spectrum-css/tabs@4.0.19)
 
 **Note:** Version bump only for package @spectrum-css/tabs
 
 <a name="4.0.18"></a>
-##4.0.18
+## 4.0.18
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@4.0.17...@spectrum-css/tabs@4.0.18)
 
 **Note:** Version bump only for package @spectrum-css/tabs
 
 <a name="4.0.17"></a>
-##4.0.17
+## 4.0.17
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@4.0.16...@spectrum-css/tabs@4.0.17)
 
 **Note:** Version bump only for package @spectrum-css/tabs
 
 <a name="4.0.16"></a>
-##4.0.16
+## 4.0.16
 🗓
 2023-09-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@4.0.15...@spectrum-css/tabs@4.0.16)
 
 **Note:** Version bump only for package @spectrum-css/tabs
 
 <a name="4.0.15"></a>
-##4.0.15
+## 4.0.15
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@4.0.14...@spectrum-css/tabs@4.0.15)
 
 **Note:** Version bump only for package @spectrum-css/tabs
 
 <a name="4.0.14"></a>
-##4.0.14
+## 4.0.14
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@4.0.13...@spectrum-css/tabs@4.0.14)
 
 **Note:** Version bump only for package @spectrum-css/tabs
 
 <a name="4.0.13"></a>
-##4.0.13
+## 4.0.13
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@4.0.12...@spectrum-css/tabs@4.0.13)
 
@@ -203,91 +203,91 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="4.0.12"></a>
-##4.0.12
+## 4.0.12
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@4.0.11...@spectrum-css/tabs@4.0.12)
 
 **Note:** Version bump only for package @spectrum-css/tabs
 
 <a name="4.0.11"></a>
-##4.0.11
+## 4.0.11
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@4.0.9...@spectrum-css/tabs@4.0.11)
 
 **Note:** Version bump only for package @spectrum-css/tabs
 
 <a name="4.0.10"></a>
-##4.0.10
+## 4.0.10
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@4.0.9...@spectrum-css/tabs@4.0.10)
 
 **Note:** Version bump only for package @spectrum-css/tabs
 
 <a name="4.0.9"></a>
-##4.0.9
+## 4.0.9
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@4.0.8...@spectrum-css/tabs@4.0.9)
 
 **Note:** Version bump only for package @spectrum-css/tabs
 
 <a name="4.0.8"></a>
-##4.0.8
+## 4.0.8
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@4.0.7...@spectrum-css/tabs@4.0.8)
 
 **Note:** Version bump only for package @spectrum-css/tabs
 
 <a name="4.0.7"></a>
-##4.0.7
+## 4.0.7
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@4.0.6...@spectrum-css/tabs@4.0.7)
 
 **Note:** Version bump only for package @spectrum-css/tabs
 
 <a name="4.0.6"></a>
-##4.0.6
+## 4.0.6
 🗓
 2023-08-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@4.0.5...@spectrum-css/tabs@4.0.6)
 
 **Note:** Version bump only for package @spectrum-css/tabs
 
 <a name="4.0.5"></a>
-##4.0.5
+## 4.0.5
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@4.0.4...@spectrum-css/tabs@4.0.5)
 
 **Note:** Version bump only for package @spectrum-css/tabs
 
 <a name="4.0.4"></a>
-##4.0.4
+## 4.0.4
 🗓
 2023-07-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@4.0.3...@spectrum-css/tabs@4.0.4)
 
 **Note:** Version bump only for package @spectrum-css/tabs
 
 <a name="4.0.3"></a>
-##4.0.3
+## 4.0.3
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@4.0.2...@spectrum-css/tabs@4.0.3)
 
 **Note:** Version bump only for package @spectrum-css/tabs
 
 <a name="4.0.2"></a>
-##4.0.2
+## 4.0.2
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@4.0.1...@spectrum-css/tabs@4.0.2)
 
 **Note:** Version bump only for package @spectrum-css/tabs
 
 <a name="4.0.1"></a>
-##4.0.1
+## 4.0.1
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@4.0.0...@spectrum-css/tabs@4.0.1)
 
 **Note:** Version bump only for package @spectrum-css/tabs
 
 <a name="4.0.0"></a>
-#4.0.0
+# 4.0.0
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@3.2.64...@spectrum-css/tabs@4.0.0)
 
@@ -300,42 +300,42 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
     		Migrates the Tabs component to use `@adobe/spectrum-tokens`.
 
 <a name="3.2.64"></a>
-##3.2.64
+## 3.2.64
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@3.2.63...@spectrum-css/tabs@3.2.64)
 
 **Note:** Version bump only for package @spectrum-css/tabs
 
 <a name="3.2.63"></a>
-##3.2.63
+## 3.2.63
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@3.2.62...@spectrum-css/tabs@3.2.63)
 
 **Note:** Version bump only for package @spectrum-css/tabs
 
 <a name="3.2.62"></a>
-##3.2.62
+## 3.2.62
 🗓
 2023-06-28 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@3.2.61...@spectrum-css/tabs@3.2.62)
 
 **Note:** Version bump only for package @spectrum-css/tabs
 
 <a name="3.2.61"></a>
-##3.2.61
+## 3.2.61
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@3.2.60...@spectrum-css/tabs@3.2.61)
 
 **Note:** Version bump only for package @spectrum-css/tabs
 
 <a name="3.2.60"></a>
-##3.2.60
+## 3.2.60
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@3.2.59...@spectrum-css/tabs@3.2.60)
 
 **Note:** Version bump only for package @spectrum-css/tabs
 
 <a name="3.2.59"></a>
-##3.2.59
+## 3.2.59
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@3.2.58...@spectrum-css/tabs@3.2.59)
 
@@ -344,14 +344,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="3.2.58"></a>
-##3.2.58
+## 3.2.58
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@3.2.57...@spectrum-css/tabs@3.2.58)
 
 **Note:** Version bump only for package @spectrum-css/tabs
 
 <a name="3.2.57"></a>
-##3.2.57
+## 3.2.57
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tabs@3.2.56...@spectrum-css/tabs@3.2.57)
 

--- a/components/tag/CHANGELOG.md
+++ b/components/tag/CHANGELOG.md
@@ -33,7 +33,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="9.0.0"></a>
-#9.0.0
+# 9.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@8.1.5...@spectrum-css/tag@9.0.0)
 
@@ -48,42 +48,42 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="8.1.5"></a>
-##8.1.5
+## 8.1.5
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@8.1.4...@spectrum-css/tag@8.1.5)
 
 **Note:** Version bump only for package @spectrum-css/tag
 
 <a name="8.1.4"></a>
-##8.1.4
+## 8.1.4
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@8.1.3...@spectrum-css/tag@8.1.4)
 
 **Note:** Version bump only for package @spectrum-css/tag
 
 <a name="8.1.3"></a>
-##8.1.3
+## 8.1.3
 🗓
 2024-02-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@8.1.2...@spectrum-css/tag@8.1.3)
 
 **Note:** Version bump only for package @spectrum-css/tag
 
 <a name="8.1.2"></a>
-##8.1.2
+## 8.1.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@8.1.1...@spectrum-css/tag@8.1.2)
 
 **Note:** Version bump only for package @spectrum-css/tag
 
 <a name="8.1.1"></a>
-##8.1.1
+## 8.1.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/tag
 
 <a name="8.1.0"></a>
-#8.1.0
+# 8.1.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@8.0.17...@spectrum-css/tag@8.1.0)
 
@@ -92,112 +92,112 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **tag:**higher specificity for color definition in hover states([fa8cd37](https://github.com/adobe/spectrum-css/commit/fa8cd37))
 
 <a name="8.0.17"></a>
-##8.0.17
+## 8.0.17
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@8.0.16...@spectrum-css/tag@8.0.17)
 
 **Note:** Version bump only for package @spectrum-css/tag
 
 <a name="8.0.16"></a>
-##8.0.16
+## 8.0.16
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@8.0.15...@spectrum-css/tag@8.0.16)
 
 **Note:** Version bump only for package @spectrum-css/tag
 
 <a name="8.0.15"></a>
-##8.0.15
+## 8.0.15
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@8.0.14...@spectrum-css/tag@8.0.15)
 
 **Note:** Version bump only for package @spectrum-css/tag
 
 <a name="8.0.14"></a>
-##8.0.14
+## 8.0.14
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@8.0.12...@spectrum-css/tag@8.0.14)
 
 **Note:** Version bump only for package @spectrum-css/tag
 
 <a name="8.0.13"></a>
-##8.0.13
+## 8.0.13
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@8.0.12...@spectrum-css/tag@8.0.13)
 
 **Note:** Version bump only for package @spectrum-css/tag
 
 <a name="8.0.12"></a>
-##8.0.12
+## 8.0.12
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@8.0.11...@spectrum-css/tag@8.0.12)
 
 **Note:** Version bump only for package @spectrum-css/tag
 
 <a name="8.0.11"></a>
-##8.0.11
+## 8.0.11
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@8.0.10...@spectrum-css/tag@8.0.11)
 
 **Note:** Version bump only for package @spectrum-css/tag
 
 <a name="8.0.10"></a>
-##8.0.10
+## 8.0.10
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@8.0.9...@spectrum-css/tag@8.0.10)
 
 **Note:** Version bump only for package @spectrum-css/tag
 
 <a name="8.0.9"></a>
-##8.0.9
+## 8.0.9
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@8.0.8...@spectrum-css/tag@8.0.9)
 
 **Note:** Version bump only for package @spectrum-css/tag
 
 <a name="8.0.8"></a>
-##8.0.8
+## 8.0.8
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@8.0.7...@spectrum-css/tag@8.0.8)
 
 **Note:** Version bump only for package @spectrum-css/tag
 
 <a name="8.0.7"></a>
-##8.0.7
+## 8.0.7
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@8.0.6...@spectrum-css/tag@8.0.7)
 
 **Note:** Version bump only for package @spectrum-css/tag
 
 <a name="8.0.6"></a>
-##8.0.6
+## 8.0.6
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@8.0.5...@spectrum-css/tag@8.0.6)
 
 **Note:** Version bump only for package @spectrum-css/tag
 
 <a name="8.0.5"></a>
-##8.0.5
+## 8.0.5
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@8.0.4...@spectrum-css/tag@8.0.5)
 
 **Note:** Version bump only for package @spectrum-css/tag
 
 <a name="8.0.4"></a>
-##8.0.4
+## 8.0.4
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@8.0.3...@spectrum-css/tag@8.0.4)
 
 **Note:** Version bump only for package @spectrum-css/tag
 
 <a name="8.0.3"></a>
-##8.0.3
+## 8.0.3
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@8.0.2...@spectrum-css/tag@8.0.3)
 
 **Note:** Version bump only for package @spectrum-css/tag
 
 <a name="8.0.2"></a>
-##8.0.2
+## 8.0.2
 🗓
 2023-08-25 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@8.0.1...@spectrum-css/tag@8.0.2)
 
@@ -206,14 +206,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="8.0.1"></a>
-##8.0.1
+## 8.0.1
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@8.0.0...@spectrum-css/tag@8.0.1)
 
 **Note:** Version bump only for package @spectrum-css/tag
 
 <a name="8.0.0"></a>
-#8.0.0
+# 8.0.0
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@6.0.1...@spectrum-css/tag@8.0.0)
 
@@ -233,7 +233,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - add aria-labels
 
 <a name="7.0.0"></a>
-#7.0.0
+# 7.0.0
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@6.0.1...@spectrum-css/tag@7.0.0)
 
@@ -253,14 +253,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - add aria-labels
 
 <a name="6.0.1"></a>
-##6.0.1
+## 6.0.1
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@6.0.0...@spectrum-css/tag@6.0.1)
 
 **Note:** Version bump only for package @spectrum-css/tag
 
 <a name="6.0.0"></a>
-#6.0.0
+# 6.0.0
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@5.0.46...@spectrum-css/tag@6.0.0)
 
@@ -279,21 +279,21 @@ Additionally:
 - fix(tag): storybook icon avatar toggle
 
 <a name="5.0.46"></a>
-##5.0.46
+## 5.0.46
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@5.0.45...@spectrum-css/tag@5.0.46)
 
 **Note:** Version bump only for package @spectrum-css/tag
 
 <a name="5.0.45"></a>
-##5.0.45
+## 5.0.45
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@5.0.44...@spectrum-css/tag@5.0.45)
 
 **Note:** Version bump only for package @spectrum-css/tag
 
 <a name="5.0.44"></a>
-##5.0.44
+## 5.0.44
 🗓
 2023-07-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@5.0.43...@spectrum-css/tag@5.0.44)
 
@@ -302,7 +302,7 @@ Additionally:
 - **tag:**update whcm focus ring color ([#2043](https://github.com/adobe/spectrum-css/issues/2043))([e581fbc](https://github.com/adobe/spectrum-css/commit/e581fbc))
 
 <a name="5.0.43"></a>
-##5.0.43
+## 5.0.43
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@5.0.42...@spectrum-css/tag@5.0.43)
 
@@ -311,21 +311,21 @@ Additionally:
 \*icon sizing in Storybook story templates ([#2037](https://github.com/adobe/spectrum-css/issues/2037))([c90c8a3](https://github.com/adobe/spectrum-css/commit/c90c8a3))
 
 <a name="5.0.42"></a>
-##5.0.42
+## 5.0.42
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@5.0.41...@spectrum-css/tag@5.0.42)
 
 **Note:** Version bump only for package @spectrum-css/tag
 
 <a name="5.0.41"></a>
-##5.0.41
+## 5.0.41
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@5.0.40...@spectrum-css/tag@5.0.41)
 
 **Note:** Version bump only for package @spectrum-css/tag
 
 <a name="5.0.40"></a>
-##5.0.40
+## 5.0.40
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@5.0.39...@spectrum-css/tag@5.0.40)
 
@@ -334,28 +334,28 @@ Additionally:
 \*tag focus issue solved ([#1983](https://github.com/adobe/spectrum-css/issues/1983))([37baa4c](https://github.com/adobe/spectrum-css/commit/37baa4c))
 
 <a name="5.0.39"></a>
-##5.0.39
+## 5.0.39
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@5.0.38...@spectrum-css/tag@5.0.39)
 
 **Note:** Version bump only for package @spectrum-css/tag
 
 <a name="5.0.38"></a>
-##5.0.38
+## 5.0.38
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@5.0.37...@spectrum-css/tag@5.0.38)
 
 **Note:** Version bump only for package @spectrum-css/tag
 
 <a name="5.0.37"></a>
-##5.0.37
+## 5.0.37
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@5.0.36...@spectrum-css/tag@5.0.37)
 
 **Note:** Version bump only for package @spectrum-css/tag
 
 <a name="5.0.36"></a>
-##5.0.36
+## 5.0.36
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@5.0.35...@spectrum-css/tag@5.0.36)
 
@@ -364,14 +364,14 @@ Additionally:
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="5.0.35"></a>
-##5.0.35
+## 5.0.35
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@5.0.34...@spectrum-css/tag@5.0.35)
 
 **Note:** Version bump only for package @spectrum-css/tag
 
 <a name="5.0.34"></a>
-##5.0.34
+## 5.0.34
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@5.0.33...@spectrum-css/tag@5.0.34)
 

--- a/components/tag/CHANGELOG.md
+++ b/components/tag/CHANGELOG.md
@@ -33,7 +33,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="9.0.0"></a>
-# 9.0.0
+## 9.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@8.1.5...@spectrum-css/tag@9.0.0)
 
@@ -83,7 +83,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/tag
 
 <a name="8.1.0"></a>
-# 8.1.0
+## 8.1.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@8.0.17...@spectrum-css/tag@8.1.0)
 
@@ -213,7 +213,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/tag
 
 <a name="8.0.0"></a>
-# 8.0.0
+## 8.0.0
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@6.0.1...@spectrum-css/tag@8.0.0)
 
@@ -233,7 +233,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - add aria-labels
 
 <a name="7.0.0"></a>
-# 7.0.0
+## 7.0.0
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@6.0.1...@spectrum-css/tag@7.0.0)
 
@@ -260,7 +260,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/tag
 
 <a name="6.0.0"></a>
-# 6.0.0
+## 6.0.0
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@5.0.46...@spectrum-css/tag@6.0.0)
 
@@ -643,7 +643,7 @@ Additionally:
 
 <a name="5.0.0"></a>
 
-# 5.0.0
+## 5.0.0
 
 🗓 2023-02-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@4.0.9...@spectrum-css/tag@5.0.0)
 
@@ -727,7 +727,7 @@ Additionally:
 
 <a name="4.0.0"></a>
 
-# 4.0.0
+## 4.0.0
 
 🗓 2022-12-08 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@3.3.15...@spectrum-css/tag@4.0.0)
 
@@ -868,7 +868,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.3.0"></a>
 
-# 3.3.0
+## 3.3.0
 
 🗓 2022-01-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@3.1.4...@spectrum-css/tag@3.3.0)
 
@@ -882,7 +882,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.2.0"></a>
 
-# 3.2.0
+## 3.2.0
 
 🗓 2022-01-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@3.2.0-beta.0...@spectrum-css/tag@3.2.0)
 
@@ -890,7 +890,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.2.0-beta.0"></a>
 
-# 3.2.0-beta.0
+## 3.2.0-beta.0
 
 🗓 2021-12-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@3.1.4...@spectrum-css/tag@3.2.0-beta.0)
 
@@ -932,7 +932,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.1.0"></a>
 
-# 3.1.0
+## 3.1.0
 
 🗓 2021-11-08 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@3.0.0...@spectrum-css/tag@3.1.0)
 
@@ -942,7 +942,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2021-10-25 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@2.0.0-alpha.3...@spectrum-css/tag@3.0.0)
 
@@ -960,7 +960,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2021-09-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@2.0.0-alpha.3...@spectrum-css/tag@2.0.0)
 
@@ -970,7 +970,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="2.0.0-alpha.3"></a>
 
-# 2.0.0-alpha.3
+## 2.0.0-alpha.3
 
 🗓 2021-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@2.0.0-alpha.2...@spectrum-css/tag@2.0.0-alpha.3)
 
@@ -978,7 +978,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="2.0.0-alpha.2"></a>
 
-# 2.0.0-alpha.2
+## 2.0.0-alpha.2
 
 🗓 2021-06-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@2.0.0-alpha.1...@spectrum-css/tag@2.0.0-alpha.2)
 
@@ -986,7 +986,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="2.0.0-alpha.1"></a>
 
-# 2.0.0-alpha.1
+## 2.0.0-alpha.1
 
 🗓 2021-05-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tag@2.0.0-alpha.0...@spectrum-css/tag@2.0.0-alpha.1)
 
@@ -994,7 +994,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="2.0.0-alpha.0"></a>
 
-# 2.0.0-alpha.0
+## 2.0.0-alpha.0
 
 🗓 2021-04-27
 

--- a/components/taggroup/CHANGELOG.md
+++ b/components/taggroup/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-#5.0.0
+# 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@4.1.5...@spectrum-css/taggroup@5.0.0)
 
@@ -44,42 +44,42 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="4.1.5"></a>
-##4.1.5
+## 4.1.5
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@4.1.4...@spectrum-css/taggroup@4.1.5)
 
 **Note:** Version bump only for package @spectrum-css/taggroup
 
 <a name="4.1.4"></a>
-##4.1.4
+## 4.1.4
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@4.1.3...@spectrum-css/taggroup@4.1.4)
 
 **Note:** Version bump only for package @spectrum-css/taggroup
 
 <a name="4.1.3"></a>
-##4.1.3
+## 4.1.3
 🗓
 2024-02-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@4.1.2...@spectrum-css/taggroup@4.1.3)
 
 **Note:** Version bump only for package @spectrum-css/taggroup
 
 <a name="4.1.2"></a>
-##4.1.2
+## 4.1.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@4.1.1...@spectrum-css/taggroup@4.1.2)
 
 **Note:** Version bump only for package @spectrum-css/taggroup
 
 <a name="4.1.1"></a>
-##4.1.1
+## 4.1.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/taggroup
 
 <a name="4.1.0"></a>
-#4.1.0
+# 4.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@4.0.14...@spectrum-css/taggroup@4.1.0)
 
@@ -88,105 +88,105 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="4.0.14"></a>
-##4.0.14
+## 4.0.14
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@4.0.13...@spectrum-css/taggroup@4.0.14)
 
 **Note:** Version bump only for package @spectrum-css/taggroup
 
 <a name="4.0.13"></a>
-##4.0.13
+## 4.0.13
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@4.0.12...@spectrum-css/taggroup@4.0.13)
 
 **Note:** Version bump only for package @spectrum-css/taggroup
 
 <a name="4.0.12"></a>
-##4.0.12
+## 4.0.12
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@4.0.10...@spectrum-css/taggroup@4.0.12)
 
 **Note:** Version bump only for package @spectrum-css/taggroup
 
 <a name="4.0.11"></a>
-##4.0.11
+## 4.0.11
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@4.0.10...@spectrum-css/taggroup@4.0.11)
 
 **Note:** Version bump only for package @spectrum-css/taggroup
 
 <a name="4.0.10"></a>
-##4.0.10
+## 4.0.10
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@4.0.9...@spectrum-css/taggroup@4.0.10)
 
 **Note:** Version bump only for package @spectrum-css/taggroup
 
 <a name="4.0.9"></a>
-##4.0.9
+## 4.0.9
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@4.0.8...@spectrum-css/taggroup@4.0.9)
 
 **Note:** Version bump only for package @spectrum-css/taggroup
 
 <a name="4.0.8"></a>
-##4.0.8
+## 4.0.8
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@4.0.7...@spectrum-css/taggroup@4.0.8)
 
 **Note:** Version bump only for package @spectrum-css/taggroup
 
 <a name="4.0.7"></a>
-##4.0.7
+## 4.0.7
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@4.0.6...@spectrum-css/taggroup@4.0.7)
 
 **Note:** Version bump only for package @spectrum-css/taggroup
 
 <a name="4.0.6"></a>
-##4.0.6
+## 4.0.6
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@4.0.5...@spectrum-css/taggroup@4.0.6)
 
 **Note:** Version bump only for package @spectrum-css/taggroup
 
 <a name="4.0.5"></a>
-##4.0.5
+## 4.0.5
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@4.0.4...@spectrum-css/taggroup@4.0.5)
 
 **Note:** Version bump only for package @spectrum-css/taggroup
 
 <a name="4.0.4"></a>
-##4.0.4
+## 4.0.4
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@4.0.3...@spectrum-css/taggroup@4.0.4)
 
 **Note:** Version bump only for package @spectrum-css/taggroup
 
 <a name="4.0.3"></a>
-##4.0.3
+## 4.0.3
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@4.0.2...@spectrum-css/taggroup@4.0.3)
 
 **Note:** Version bump only for package @spectrum-css/taggroup
 
 <a name="4.0.2"></a>
-##4.0.2
+## 4.0.2
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@4.0.1...@spectrum-css/taggroup@4.0.2)
 
 **Note:** Version bump only for package @spectrum-css/taggroup
 
 <a name="4.0.1"></a>
-##4.0.1
+## 4.0.1
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@4.0.0...@spectrum-css/taggroup@4.0.1)
 
 **Note:** Version bump only for package @spectrum-css/taggroup
 
 <a name="4.0.0"></a>
-#4.0.0
+# 4.0.0
 🗓
 2023-08-25 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@3.3.64...@spectrum-css/taggroup@4.0.0)
 
@@ -219,112 +219,112 @@ wrap items to the next line. And adds a story that shows wrapping.
 CSS-500
 
 <a name="3.3.64"></a>
-##3.3.64
+## 3.3.64
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@3.3.63...@spectrum-css/taggroup@3.3.64)
 
 **Note:** Version bump only for package @spectrum-css/taggroup
 
 <a name="3.3.63"></a>
-##3.3.63
+## 3.3.63
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@3.3.61...@spectrum-css/taggroup@3.3.63)
 
 **Note:** Version bump only for package @spectrum-css/taggroup
 
 <a name="3.3.62"></a>
-##3.3.62
+## 3.3.62
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@3.3.61...@spectrum-css/taggroup@3.3.62)
 
 **Note:** Version bump only for package @spectrum-css/taggroup
 
 <a name="3.3.61"></a>
-##3.3.61
+## 3.3.61
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@3.3.60...@spectrum-css/taggroup@3.3.61)
 
 **Note:** Version bump only for package @spectrum-css/taggroup
 
 <a name="3.3.60"></a>
-##3.3.60
+## 3.3.60
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@3.3.59...@spectrum-css/taggroup@3.3.60)
 
 **Note:** Version bump only for package @spectrum-css/taggroup
 
 <a name="3.3.59"></a>
-##3.3.59
+## 3.3.59
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@3.3.58...@spectrum-css/taggroup@3.3.59)
 
 **Note:** Version bump only for package @spectrum-css/taggroup
 
 <a name="3.3.58"></a>
-##3.3.58
+## 3.3.58
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@3.3.57...@spectrum-css/taggroup@3.3.58)
 
 **Note:** Version bump only for package @spectrum-css/taggroup
 
 <a name="3.3.57"></a>
-##3.3.57
+## 3.3.57
 🗓
 2023-07-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@3.3.56...@spectrum-css/taggroup@3.3.57)
 
 **Note:** Version bump only for package @spectrum-css/taggroup
 
 <a name="3.3.56"></a>
-##3.3.56
+## 3.3.56
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@3.3.55...@spectrum-css/taggroup@3.3.56)
 
 **Note:** Version bump only for package @spectrum-css/taggroup
 
 <a name="3.3.55"></a>
-##3.3.55
+## 3.3.55
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@3.3.54...@spectrum-css/taggroup@3.3.55)
 
 **Note:** Version bump only for package @spectrum-css/taggroup
 
 <a name="3.3.54"></a>
-##3.3.54
+## 3.3.54
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@3.3.53...@spectrum-css/taggroup@3.3.54)
 
 **Note:** Version bump only for package @spectrum-css/taggroup
 
 <a name="3.3.53"></a>
-##3.3.53
+## 3.3.53
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@3.3.52...@spectrum-css/taggroup@3.3.53)
 
 **Note:** Version bump only for package @spectrum-css/taggroup
 
 <a name="3.3.52"></a>
-##3.3.52
+## 3.3.52
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@3.3.51...@spectrum-css/taggroup@3.3.52)
 
 **Note:** Version bump only for package @spectrum-css/taggroup
 
 <a name="3.3.51"></a>
-##3.3.51
+## 3.3.51
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@3.3.50...@spectrum-css/taggroup@3.3.51)
 
 **Note:** Version bump only for package @spectrum-css/taggroup
 
 <a name="3.3.50"></a>
-##3.3.50
+## 3.3.50
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@3.3.49...@spectrum-css/taggroup@3.3.50)
 
 **Note:** Version bump only for package @spectrum-css/taggroup
 
 <a name="3.3.49"></a>
-##3.3.49
+## 3.3.49
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@3.3.48...@spectrum-css/taggroup@3.3.49)
 
@@ -333,14 +333,14 @@ CSS-500
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="3.3.48"></a>
-##3.3.48
+## 3.3.48
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@3.3.47...@spectrum-css/taggroup@3.3.48)
 
 **Note:** Version bump only for package @spectrum-css/taggroup
 
 <a name="3.3.47"></a>
-##3.3.47
+## 3.3.47
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@3.3.46...@spectrum-css/taggroup@3.3.47)
 

--- a/components/taggroup/CHANGELOG.md
+++ b/components/taggroup/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-# 5.0.0
+## 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@4.1.5...@spectrum-css/taggroup@5.0.0)
 
@@ -79,7 +79,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/taggroup
 
 <a name="4.1.0"></a>
-# 4.1.0
+## 4.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@4.0.14...@spectrum-css/taggroup@4.1.0)
 
@@ -186,7 +186,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/taggroup
 
 <a name="4.0.0"></a>
-# 4.0.0
+## 4.0.0
 🗓
 2023-08-25 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@3.3.64...@spectrum-css/taggroup@4.0.0)
 
@@ -716,7 +716,7 @@ CSS-500
 
 <a name="3.3.0"></a>
 
-# 3.3.0
+## 3.3.0
 
 🗓 2022-01-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@3.1.4...@spectrum-css/taggroup@3.3.0)
 
@@ -730,7 +730,7 @@ CSS-500
 
 <a name="3.2.0"></a>
 
-# 3.2.0
+## 3.2.0
 
 🗓 2022-01-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@3.2.0-beta.0...@spectrum-css/taggroup@3.2.0)
 
@@ -738,7 +738,7 @@ CSS-500
 
 <a name="3.2.0-beta.0"></a>
 
-# 3.2.0-beta.0
+## 3.2.0-beta.0
 
 🗓 2021-12-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@3.1.4...@spectrum-css/taggroup@3.2.0-beta.0)
 
@@ -780,7 +780,7 @@ CSS-500
 
 <a name="3.1.0"></a>
 
-# 3.1.0
+## 3.1.0
 
 🗓 2021-11-08 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@3.0.0...@spectrum-css/taggroup@3.1.0)
 
@@ -790,7 +790,7 @@ CSS-500
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2021-10-25 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@2.0.1...@spectrum-css/taggroup@3.0.0)
 
@@ -803,7 +803,7 @@ CSS-500
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2021-09-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@2.0.0-alpha.3...@spectrum-css/taggroup@2.0.0)
 
@@ -813,7 +813,7 @@ CSS-500
 
 <a name="2.0.0-alpha.3"></a>
 
-# 2.0.0-alpha.3
+## 2.0.0-alpha.3
 
 🗓 2021-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@2.0.0-alpha.2...@spectrum-css/taggroup@2.0.0-alpha.3)
 
@@ -821,7 +821,7 @@ CSS-500
 
 <a name="2.0.0-alpha.2"></a>
 
-# 2.0.0-alpha.2
+## 2.0.0-alpha.2
 
 🗓 2021-06-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@2.0.0-alpha.1...@spectrum-css/taggroup@2.0.0-alpha.2)
 
@@ -829,7 +829,7 @@ CSS-500
 
 <a name="2.0.0-alpha.1"></a>
 
-# 2.0.0-alpha.1
+## 2.0.0-alpha.1
 
 🗓 2021-05-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/taggroup@2.0.0-alpha.0...@spectrum-css/taggroup@2.0.0-alpha.1)
 
@@ -837,7 +837,7 @@ CSS-500
 
 <a name="2.0.0-alpha.0"></a>
 
-# 2.0.0-alpha.0
+## 2.0.0-alpha.0
 
 🗓 2021-04-27
 
@@ -871,7 +871,7 @@ CSS-500
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tags@3.0.0-beta.6...@spectrum-css/tags@3.0.0)
 
@@ -879,7 +879,7 @@ CSS-500
 
 <a name="3.0.0-beta.6"></a>
 
-# 3.0.0-beta.6
+## 3.0.0-beta.6
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tags@3.0.0-beta.5...@spectrum-css/tags@3.0.0-beta.6)
 
@@ -891,7 +891,7 @@ CSS-500
 
 <a name="3.0.0-beta.5"></a>
 
-# 3.0.0-beta.5
+## 3.0.0-beta.5
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tags@3.0.0-beta.4...@spectrum-css/tags@3.0.0-beta.5)
 
@@ -899,7 +899,7 @@ CSS-500
 
 <a name="3.0.0-beta.4"></a>
 
-# 3.0.0-beta.4
+## 3.0.0-beta.4
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tags@3.0.0-beta.3...@spectrum-css/tags@3.0.0-beta.4)
 
@@ -924,7 +924,7 @@ CSS-500
 
 <a name="3.0.0-beta.3"></a>
 
-# 3.0.0-beta.3
+## 3.0.0-beta.3
 
 🗓 2020-06-19 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tags@3.0.0-beta.2...@spectrum-css/tags@3.0.0-beta.3)
 
@@ -932,7 +932,7 @@ CSS-500
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tags@3.0.0-beta.1...@spectrum-css/tags@3.0.0-beta.2)
 
@@ -940,7 +940,7 @@ CSS-500
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tags@3.0.0-beta.0...@spectrum-css/tags@3.0.0-beta.1)
 
@@ -948,7 +948,7 @@ CSS-500
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tags@2.0.5...@spectrum-css/tags@3.0.0-beta.0)
 
@@ -1000,7 +1000,7 @@ CSS-500
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/textfield/CHANGELOG.md
+++ b/components/textfield/CHANGELOG.md
@@ -41,7 +41,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="7.0.0"></a>
-# 7.0.0
+## 7.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@6.1.6...@spectrum-css/textfield@7.0.0)
 
@@ -105,7 +105,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/textfield
 
 <a name="6.1.0"></a>
-# 6.1.0
+## 6.1.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@6.0.31...@spectrum-css/textfield@6.1.0)
 
@@ -341,7 +341,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="6.0.0"></a>
-# 6.0.0
+## 6.0.0
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@5.1.11...@spectrum-css/textfield@6.0.0)
 
@@ -449,7 +449,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="5.1.0"></a>
 
-# 5.1.0
+## 5.1.0
 
 🗓 2023-05-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@5.0.0...@spectrum-css/textfield@5.1.0)
 
@@ -459,7 +459,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="5.0.0"></a>
 
-# 5.0.0
+## 5.0.0
 
 🗓 2023-05-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@4.1.15...@spectrum-css/textfield@5.0.0)
 
@@ -632,7 +632,7 @@ there, but it was missing a control for testing.
 
 <a name="4.1.0"></a>
 
-# 4.1.0
+## 4.1.0
 
 🗓 2023-03-28 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@4.0.3...@spectrum-css/textfield@4.1.0)
 
@@ -670,7 +670,7 @@ there, but it was missing a control for testing.
 
 <a name="4.0.0"></a>
 
-# 4.0.0
+## 4.0.0
 
 🗓 2023-03-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@3.2.16...@spectrum-css/textfield@4.0.0)
 
@@ -693,7 +693,7 @@ there, but it was missing a control for testing.
 
 <a name="4.0.0-beta.7"></a>
 
-# 4.0.0-beta.7
+## 4.0.0-beta.7
 
 🗓 2023-03-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@3.2.16...@spectrum-css/textfield@4.0.0-beta.7)
 
@@ -912,7 +912,7 @@ there, but it was missing a control for testing.
 
 <a name="3.2.0"></a>
 
-# 3.2.0
+## 3.2.0
 
 🗓 2022-04-08 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@3.1.10...@spectrum-css/textfield@3.2.0)
 
@@ -1012,7 +1012,7 @@ there, but it was missing a control for testing.
 
 <a name="3.1.0"></a>
 
-# 3.1.0
+## 3.1.0
 
 🗓 2021-11-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@3.0.7...@spectrum-css/textfield@3.1.0)
 
@@ -1143,7 +1143,7 @@ there, but it was missing a control for testing.
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@3.0.0-beta.6...@spectrum-css/textfield@3.0.0)
 
@@ -1151,7 +1151,7 @@ there, but it was missing a control for testing.
 
 <a name="3.0.0-beta.6"></a>
 
-# 3.0.0-beta.6
+## 3.0.0-beta.6
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@3.0.0-beta.5...@spectrum-css/textfield@3.0.0-beta.6)
 
@@ -1165,7 +1165,7 @@ there, but it was missing a control for testing.
 
 <a name="3.0.0-beta.5"></a>
 
-# 3.0.0-beta.5
+## 3.0.0-beta.5
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@3.0.0-beta.4...@spectrum-css/textfield@3.0.0-beta.5)
 
@@ -1173,7 +1173,7 @@ there, but it was missing a control for testing.
 
 <a name="3.0.0-beta.4"></a>
 
-# 3.0.0-beta.4
+## 3.0.0-beta.4
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@3.0.0-beta.3...@spectrum-css/textfield@3.0.0-beta.4)
 
@@ -1185,7 +1185,7 @@ there, but it was missing a control for testing.
 
 <a name="3.0.0-beta.3"></a>
 
-# 3.0.0-beta.3
+## 3.0.0-beta.3
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@3.0.0-beta.2...@spectrum-css/textfield@3.0.0-beta.3)
 
@@ -1193,7 +1193,7 @@ there, but it was missing a control for testing.
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@3.0.0-beta.1...@spectrum-css/textfield@3.0.0-beta.2)
 
@@ -1201,7 +1201,7 @@ there, but it was missing a control for testing.
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@3.0.0-beta.0...@spectrum-css/textfield@3.0.0-beta.1)
 
@@ -1220,7 +1220,7 @@ Co-authored-by: Daniel Lu <dlu@livefyre.com>
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@2.0.6...@spectrum-css/textfield@3.0.0-beta.0)
 
@@ -1286,7 +1286,7 @@ Co-authored-by: Daniel Lu <dlu@livefyre.com>
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/textfield/CHANGELOG.md
+++ b/components/textfield/CHANGELOG.md
@@ -41,7 +41,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="7.0.0"></a>
-#7.0.0
+# 7.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@6.1.6...@spectrum-css/textfield@7.0.0)
 
@@ -60,21 +60,21 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="6.1.6"></a>
-##6.1.6
+## 6.1.6
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@6.1.5...@spectrum-css/textfield@6.1.6)
 
 **Note:** Version bump only for package @spectrum-css/textfield
 
 <a name="6.1.5"></a>
-##6.1.5
+## 6.1.5
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@6.1.4...@spectrum-css/textfield@6.1.5)
 
 **Note:** Version bump only for package @spectrum-css/textfield
 
 <a name="6.1.4"></a>
-##6.1.4
+## 6.1.4
 🗓
 2024-02-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@6.1.3...@spectrum-css/textfield@6.1.4)
 
@@ -84,49 +84,49 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
   **textfield:**remove extra padding on nested label and help ([#2519](https://github.com/adobe/spectrum-css/issues/2519))([0250d0e](https://github.com/adobe/spectrum-css/commit/0250d0e))
 
 <a name="6.1.3"></a>
-##6.1.3
+## 6.1.3
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@6.1.2...@spectrum-css/textfield@6.1.3)
 
 **Note:** Version bump only for package @spectrum-css/textfield
 
 <a name="6.1.2"></a>
-##6.1.2
+## 6.1.2
 🗓
 2024-02-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@6.1.1...@spectrum-css/textfield@6.1.2)
 
 **Note:** Version bump only for package @spectrum-css/textfield
 
 <a name="6.1.1"></a>
-##6.1.1
+## 6.1.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/textfield
 
 <a name="6.1.0"></a>
-#6.1.0
+# 6.1.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@6.0.31...@spectrum-css/textfield@6.1.0)
 
 **Note:** Version bump only for package @spectrum-css/textfield
 
 <a name="6.0.31"></a>
-##6.0.31
+## 6.0.31
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@6.0.30...@spectrum-css/textfield@6.0.31)
 
 **Note:** Version bump only for package @spectrum-css/textfield
 
 <a name="6.0.30"></a>
-##6.0.30
+## 6.0.30
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@6.0.29...@spectrum-css/textfield@6.0.30)
 
 **Note:** Version bump only for package @spectrum-css/textfield
 
 <a name="6.0.29"></a>
-##6.0.29
+## 6.0.29
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@6.0.28...@spectrum-css/textfield@6.0.29)
 
@@ -135,91 +135,91 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **textfield:**focus outline only on keyboard focus([e919679](https://github.com/adobe/spectrum-css/commit/e919679))
 
 <a name="6.0.28"></a>
-##6.0.28
+## 6.0.28
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@6.0.26...@spectrum-css/textfield@6.0.28)
 
 **Note:** Version bump only for package @spectrum-css/textfield
 
 <a name="6.0.27"></a>
-##6.0.27
+## 6.0.27
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@6.0.26...@spectrum-css/textfield@6.0.27)
 
 **Note:** Version bump only for package @spectrum-css/textfield
 
 <a name="6.0.26"></a>
-##6.0.26
+## 6.0.26
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@6.0.25...@spectrum-css/textfield@6.0.26)
 
 **Note:** Version bump only for package @spectrum-css/textfield
 
 <a name="6.0.25"></a>
-##6.0.25
+## 6.0.25
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@6.0.24...@spectrum-css/textfield@6.0.25)
 
 **Note:** Version bump only for package @spectrum-css/textfield
 
 <a name="6.0.24"></a>
-##6.0.24
+## 6.0.24
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@6.0.23...@spectrum-css/textfield@6.0.24)
 
 **Note:** Version bump only for package @spectrum-css/textfield
 
 <a name="6.0.23"></a>
-##6.0.23
+## 6.0.23
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@6.0.22...@spectrum-css/textfield@6.0.23)
 
 **Note:** Version bump only for package @spectrum-css/textfield
 
 <a name="6.0.22"></a>
-##6.0.22
+## 6.0.22
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@6.0.21...@spectrum-css/textfield@6.0.22)
 
 **Note:** Version bump only for package @spectrum-css/textfield
 
 <a name="6.0.21"></a>
-##6.0.21
+## 6.0.21
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@6.0.20...@spectrum-css/textfield@6.0.21)
 
 **Note:** Version bump only for package @spectrum-css/textfield
 
 <a name="6.0.20"></a>
-##6.0.20
+## 6.0.20
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@6.0.19...@spectrum-css/textfield@6.0.20)
 
 **Note:** Version bump only for package @spectrum-css/textfield
 
 <a name="6.0.19"></a>
-##6.0.19
+## 6.0.19
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@6.0.18...@spectrum-css/textfield@6.0.19)
 
 **Note:** Version bump only for package @spectrum-css/textfield
 
 <a name="6.0.18"></a>
-##6.0.18
+## 6.0.18
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@6.0.17...@spectrum-css/textfield@6.0.18)
 
 **Note:** Version bump only for package @spectrum-css/textfield
 
 <a name="6.0.17"></a>
-##6.0.17
+## 6.0.17
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@6.0.16...@spectrum-css/textfield@6.0.17)
 
 **Note:** Version bump only for package @spectrum-css/textfield
 
 <a name="6.0.16"></a>
-##6.0.16
+## 6.0.16
 🗓
 2023-08-25 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@6.0.15...@spectrum-css/textfield@6.0.16)
 
@@ -232,56 +232,56 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="6.0.15"></a>
-##6.0.15
+## 6.0.15
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@6.0.14...@spectrum-css/textfield@6.0.15)
 
 **Note:** Version bump only for package @spectrum-css/textfield
 
 <a name="6.0.14"></a>
-##6.0.14
+## 6.0.14
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@6.0.12...@spectrum-css/textfield@6.0.14)
 
 **Note:** Version bump only for package @spectrum-css/textfield
 
 <a name="6.0.13"></a>
-##6.0.13
+## 6.0.13
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@6.0.12...@spectrum-css/textfield@6.0.13)
 
 **Note:** Version bump only for package @spectrum-css/textfield
 
 <a name="6.0.12"></a>
-##6.0.12
+## 6.0.12
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@6.0.11...@spectrum-css/textfield@6.0.12)
 
 **Note:** Version bump only for package @spectrum-css/textfield
 
 <a name="6.0.11"></a>
-##6.0.11
+## 6.0.11
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@6.0.10...@spectrum-css/textfield@6.0.11)
 
 **Note:** Version bump only for package @spectrum-css/textfield
 
 <a name="6.0.10"></a>
-##6.0.10
+## 6.0.10
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@6.0.9...@spectrum-css/textfield@6.0.10)
 
 **Note:** Version bump only for package @spectrum-css/textfield
 
 <a name="6.0.9"></a>
-##6.0.9
+## 6.0.9
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@6.0.8...@spectrum-css/textfield@6.0.9)
 
 **Note:** Version bump only for package @spectrum-css/textfield
 
 <a name="6.0.8"></a>
-##6.0.8
+## 6.0.8
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@6.0.7...@spectrum-css/textfield@6.0.8)
 
@@ -290,49 +290,49 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*icon sizing in Storybook story templates ([#2037](https://github.com/adobe/spectrum-css/issues/2037))([c90c8a3](https://github.com/adobe/spectrum-css/commit/c90c8a3))
 
 <a name="6.0.7"></a>
-##6.0.7
+## 6.0.7
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@6.0.6...@spectrum-css/textfield@6.0.7)
 
 **Note:** Version bump only for package @spectrum-css/textfield
 
 <a name="6.0.6"></a>
-##6.0.6
+## 6.0.6
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@6.0.5...@spectrum-css/textfield@6.0.6)
 
 **Note:** Version bump only for package @spectrum-css/textfield
 
 <a name="6.0.5"></a>
-##6.0.5
+## 6.0.5
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@6.0.4...@spectrum-css/textfield@6.0.5)
 
 **Note:** Version bump only for package @spectrum-css/textfield
 
 <a name="6.0.4"></a>
-##6.0.4
+## 6.0.4
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@6.0.3...@spectrum-css/textfield@6.0.4)
 
 **Note:** Version bump only for package @spectrum-css/textfield
 
 <a name="6.0.3"></a>
-##6.0.3
+## 6.0.3
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@6.0.2...@spectrum-css/textfield@6.0.3)
 
 **Note:** Version bump only for package @spectrum-css/textfield
 
 <a name="6.0.2"></a>
-##6.0.2
+## 6.0.2
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@6.0.1...@spectrum-css/textfield@6.0.2)
 
 **Note:** Version bump only for package @spectrum-css/textfield
 
 <a name="6.0.1"></a>
-##6.0.1
+## 6.0.1
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@6.0.0...@spectrum-css/textfield@6.0.1)
 
@@ -341,7 +341,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="6.0.0"></a>
-#6.0.0
+# 6.0.0
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@5.1.11...@spectrum-css/textfield@6.0.0)
 
@@ -354,7 +354,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
     		migrates Search to use `@adobe/spectrum-tokens`
 
 <a name="5.1.11"></a>
-##5.1.11
+## 5.1.11
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/textfield@5.1.10...@spectrum-css/textfield@5.1.11)
 

--- a/components/thumbnail/CHANGELOG.md
+++ b/components/thumbnail/CHANGELOG.md
@@ -35,7 +35,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="6.0.0"></a>
-#6.0.0
+# 6.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@5.2.4...@spectrum-css/thumbnail@6.0.0)
 
@@ -50,35 +50,35 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="5.2.4"></a>
-##5.2.4
+## 5.2.4
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@5.2.3...@spectrum-css/thumbnail@5.2.4)
 
 **Note:** Version bump only for package @spectrum-css/thumbnail
 
 <a name="5.2.3"></a>
-##5.2.3
+## 5.2.3
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@5.2.2...@spectrum-css/thumbnail@5.2.3)
 
 **Note:** Version bump only for package @spectrum-css/thumbnail
 
 <a name="5.2.2"></a>
-##5.2.2
+## 5.2.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@5.2.1...@spectrum-css/thumbnail@5.2.2)
 
 **Note:** Version bump only for package @spectrum-css/thumbnail
 
 <a name="5.2.1"></a>
-##5.2.1
+## 5.2.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/thumbnail
 
 <a name="5.2.0"></a>
-#5.2.0
+# 5.2.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@5.1.4...@spectrum-css/thumbnail@5.2.0)
 
@@ -87,35 +87,35 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="5.1.4"></a>
-##5.1.4
+## 5.1.4
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@5.1.3...@spectrum-css/thumbnail@5.1.4)
 
 **Note:** Version bump only for package @spectrum-css/thumbnail
 
 <a name="5.1.3"></a>
-##5.1.3
+## 5.1.3
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@5.1.2...@spectrum-css/thumbnail@5.1.3)
 
 **Note:** Version bump only for package @spectrum-css/thumbnail
 
 <a name="5.1.2"></a>
-##5.1.2
+## 5.1.2
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@5.1.0...@spectrum-css/thumbnail@5.1.2)
 
 **Note:** Version bump only for package @spectrum-css/thumbnail
 
 <a name="5.1.1"></a>
-##5.1.1
+## 5.1.1
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@5.1.0...@spectrum-css/thumbnail@5.1.1)
 
 **Note:** Version bump only for package @spectrum-css/thumbnail
 
 <a name="5.1.0"></a>
-#5.1.0
+# 5.1.0
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@5.0.12...@spectrum-css/thumbnail@5.1.0)
 
@@ -124,63 +124,63 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **thumbnail:**add whcm for layer variants ([#2254](https://github.com/adobe/spectrum-css/issues/2254))([7e464f6](https://github.com/adobe/spectrum-css/commit/7e464f6))
 
 <a name="5.0.12"></a>
-##5.0.12
+## 5.0.12
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@5.0.11...@spectrum-css/thumbnail@5.0.12)
 
 **Note:** Version bump only for package @spectrum-css/thumbnail
 
 <a name="5.0.11"></a>
-##5.0.11
+## 5.0.11
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@5.0.10...@spectrum-css/thumbnail@5.0.11)
 
 **Note:** Version bump only for package @spectrum-css/thumbnail
 
 <a name="5.0.10"></a>
-##5.0.10
+## 5.0.10
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@5.0.9...@spectrum-css/thumbnail@5.0.10)
 
 **Note:** Version bump only for package @spectrum-css/thumbnail
 
 <a name="5.0.9"></a>
-##5.0.9
+## 5.0.9
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@5.0.8...@spectrum-css/thumbnail@5.0.9)
 
 **Note:** Version bump only for package @spectrum-css/thumbnail
 
 <a name="5.0.8"></a>
-##5.0.8
+## 5.0.8
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@5.0.7...@spectrum-css/thumbnail@5.0.8)
 
 **Note:** Version bump only for package @spectrum-css/thumbnail
 
 <a name="5.0.7"></a>
-##5.0.7
+## 5.0.7
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@5.0.6...@spectrum-css/thumbnail@5.0.7)
 
 **Note:** Version bump only for package @spectrum-css/thumbnail
 
 <a name="5.0.6"></a>
-##5.0.6
+## 5.0.6
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@5.0.5...@spectrum-css/thumbnail@5.0.6)
 
 **Note:** Version bump only for package @spectrum-css/thumbnail
 
 <a name="5.0.5"></a>
-##5.0.5
+## 5.0.5
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@5.0.4...@spectrum-css/thumbnail@5.0.5)
 
 **Note:** Version bump only for package @spectrum-css/thumbnail
 
 <a name="5.0.4"></a>
-##5.0.4
+## 5.0.4
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@5.0.3...@spectrum-css/thumbnail@5.0.4)
 
@@ -189,28 +189,28 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="5.0.3"></a>
-##5.0.3
+## 5.0.3
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@5.0.2...@spectrum-css/thumbnail@5.0.3)
 
 **Note:** Version bump only for package @spectrum-css/thumbnail
 
 <a name="5.0.2"></a>
-##5.0.2
+## 5.0.2
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@5.0.0...@spectrum-css/thumbnail@5.0.2)
 
 **Note:** Version bump only for package @spectrum-css/thumbnail
 
 <a name="5.0.1"></a>
-##5.0.1
+## 5.0.1
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@5.0.0...@spectrum-css/thumbnail@5.0.1)
 
 **Note:** Version bump only for package @spectrum-css/thumbnail
 
 <a name="5.0.0"></a>
-#5.0.0
+# 5.0.0
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@4.0.4...@spectrum-css/thumbnail@5.0.0)
 
@@ -227,21 +227,21 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
       		remove usage of focus-ring as it is not needed
 
 <a name="4.0.4"></a>
-##4.0.4
+## 4.0.4
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@4.0.3...@spectrum-css/thumbnail@4.0.4)
 
 **Note:** Version bump only for package @spectrum-css/thumbnail
 
 <a name="4.0.3"></a>
-##4.0.3
+## 4.0.3
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@4.0.2...@spectrum-css/thumbnail@4.0.3)
 
 **Note:** Version bump only for package @spectrum-css/thumbnail
 
 <a name="4.0.2"></a>
-##4.0.2
+## 4.0.2
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@4.0.1...@spectrum-css/thumbnail@4.0.2)
 
@@ -250,14 +250,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **opacitycheckboard:**add to component stories ([#2056](https://github.com/adobe/spectrum-css/issues/2056))([a1411f6](https://github.com/adobe/spectrum-css/commit/a1411f6))
 
 <a name="4.0.1"></a>
-##4.0.1
+## 4.0.1
 🗓
 2023-07-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@4.0.0...@spectrum-css/thumbnail@4.0.1)
 
 **Note:** Version bump only for package @spectrum-css/thumbnail
 
 <a name="4.0.0"></a>
-#4.0.0
+# 4.0.0
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@3.0.17...@spectrum-css/thumbnail@4.0.0)
 
@@ -306,42 +306,42 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - chore: update yarn.lock file after rebase
 
 <a name="3.0.17"></a>
-##3.0.17
+## 3.0.17
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@3.0.16...@spectrum-css/thumbnail@3.0.17)
 
 **Note:** Version bump only for package @spectrum-css/thumbnail
 
 <a name="3.0.16"></a>
-##3.0.16
+## 3.0.16
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@3.0.15...@spectrum-css/thumbnail@3.0.16)
 
 **Note:** Version bump only for package @spectrum-css/thumbnail
 
 <a name="3.0.15"></a>
-##3.0.15
+## 3.0.15
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@3.0.14...@spectrum-css/thumbnail@3.0.15)
 
 **Note:** Version bump only for package @spectrum-css/thumbnail
 
 <a name="3.0.14"></a>
-##3.0.14
+## 3.0.14
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@3.0.13...@spectrum-css/thumbnail@3.0.14)
 
 **Note:** Version bump only for package @spectrum-css/thumbnail
 
 <a name="3.0.13"></a>
-##3.0.13
+## 3.0.13
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@3.0.12...@spectrum-css/thumbnail@3.0.13)
 
 **Note:** Version bump only for package @spectrum-css/thumbnail
 
 <a name="3.0.12"></a>
-##3.0.12
+## 3.0.12
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@3.0.11...@spectrum-css/thumbnail@3.0.12)
 
@@ -350,7 +350,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **thumbnail:**border opacity typo ([#1926](https://github.com/adobe/spectrum-css/issues/1926))([9d7bc21](https://github.com/adobe/spectrum-css/commit/9d7bc21))
 
 <a name="3.0.11"></a>
-##3.0.11
+## 3.0.11
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@3.0.10...@spectrum-css/thumbnail@3.0.11)
 
@@ -359,14 +359,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="3.0.10"></a>
-##3.0.10
+## 3.0.10
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@3.0.9...@spectrum-css/thumbnail@3.0.10)
 
 **Note:** Version bump only for package @spectrum-css/thumbnail
 
 <a name="3.0.9"></a>
-##3.0.9
+## 3.0.9
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@3.0.8...@spectrum-css/thumbnail@3.0.9)
 

--- a/components/thumbnail/CHANGELOG.md
+++ b/components/thumbnail/CHANGELOG.md
@@ -35,7 +35,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="6.0.0"></a>
-# 6.0.0
+## 6.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@5.2.4...@spectrum-css/thumbnail@6.0.0)
 
@@ -78,7 +78,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/thumbnail
 
 <a name="5.2.0"></a>
-# 5.2.0
+## 5.2.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@5.1.4...@spectrum-css/thumbnail@5.2.0)
 
@@ -115,7 +115,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/thumbnail
 
 <a name="5.1.0"></a>
-# 5.1.0
+## 5.1.0
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@5.0.12...@spectrum-css/thumbnail@5.1.0)
 
@@ -210,7 +210,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/thumbnail
 
 <a name="5.0.0"></a>
-# 5.0.0
+## 5.0.0
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@4.0.4...@spectrum-css/thumbnail@5.0.0)
 
@@ -257,7 +257,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/thumbnail
 
 <a name="4.0.0"></a>
-# 4.0.0
+## 4.0.0
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@3.0.17...@spectrum-css/thumbnail@4.0.0)
 
@@ -440,7 +440,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2023-05-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@2.0.34...@spectrum-css/thumbnail@3.0.0)
 
@@ -741,7 +741,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2021-11-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@1.0.6...@spectrum-css/thumbnail@2.0.0)
 
@@ -850,7 +850,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="1.0.0"></a>
 
-# 1.0.0
+## 1.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@1.0.0-beta.5...@spectrum-css/thumbnail@1.0.0)
 
@@ -858,7 +858,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="1.0.0-beta.5"></a>
 
-# 1.0.0-beta.5
+## 1.0.0-beta.5
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@1.0.0-beta.4...@spectrum-css/thumbnail@1.0.0-beta.5)
 
@@ -866,7 +866,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="1.0.0-beta.4"></a>
 
-# 1.0.0-beta.4
+## 1.0.0-beta.4
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@1.0.0-beta.3...@spectrum-css/thumbnail@1.0.0-beta.4)
 
@@ -874,7 +874,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="1.0.0-beta.3"></a>
 
-# 1.0.0-beta.3
+## 1.0.0-beta.3
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/thumbnail@1.0.0-beta.2...@spectrum-css/thumbnail@1.0.0-beta.3)
 
@@ -882,7 +882,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="1.0.0-beta.2"></a>
 
-# 1.0.0-beta.2
+## 1.0.0-beta.2
 
 🗓 2020-06-19
 

--- a/components/toast/CHANGELOG.md
+++ b/components/toast/CHANGELOG.md
@@ -33,7 +33,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="10.0.0"></a>
-# 10.0.0
+## 10.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@9.1.25...@spectrum-css/toast@10.0.0)
 
@@ -225,7 +225,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/toast
 
 <a name="9.1.0"></a>
-# 9.1.0
+## 9.1.0
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@9.0.45...@spectrum-css/toast@9.1.0)
 
@@ -585,7 +585,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="9.0.0"></a>
 
-# 9.0.0
+## 9.0.0
 
 🗓 2023-02-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@8.0.15...@spectrum-css/toast@9.0.0)
 
@@ -719,7 +719,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="8.0.0"></a>
 
-# 8.0.0
+## 8.0.0
 
 🗓 2022-09-28 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@7.0.11...@spectrum-css/toast@8.0.0)
 
@@ -825,7 +825,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="7.0.0"></a>
 
-# 7.0.0
+## 7.0.0
 
 🗓 2022-02-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@6.0.2...@spectrum-css/toast@7.0.0)
 
@@ -853,7 +853,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="6.0.0"></a>
 
-# 6.0.0
+## 6.0.0
 
 🗓 2022-01-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@4.1.4...@spectrum-css/toast@6.0.0)
 
@@ -875,7 +875,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="5.0.0"></a>
 
-# 5.0.0
+## 5.0.0
 
 🗓 2022-01-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@5.0.0-beta.0...@spectrum-css/toast@5.0.0)
 
@@ -883,7 +883,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="5.0.0-beta.0"></a>
 
-# 5.0.0-beta.0
+## 5.0.0-beta.0
 
 🗓 2021-12-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@4.1.4...@spectrum-css/toast@5.0.0-beta.0)
 
@@ -933,7 +933,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="4.1.0"></a>
 
-# 4.1.0
+## 4.1.0
 
 🗓 2021-11-08 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@4.0.0-alpha.3...@spectrum-css/toast@4.1.0)
 
@@ -957,7 +957,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="4.0.0"></a>
 
-# 4.0.0
+## 4.0.0
 
 🗓 2021-09-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@4.0.0-alpha.3...@spectrum-css/toast@4.0.0)
 
@@ -967,7 +967,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="4.0.0-alpha.3"></a>
 
-# 4.0.0-alpha.3
+## 4.0.0-alpha.3
 
 🗓 2021-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@4.0.0-alpha.2...@spectrum-css/toast@4.0.0-alpha.3)
 
@@ -975,7 +975,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="4.0.0-alpha.2"></a>
 
-# 4.0.0-alpha.2
+## 4.0.0-alpha.2
 
 🗓 2021-06-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@4.0.0-alpha.1...@spectrum-css/toast@4.0.0-alpha.2)
 
@@ -983,7 +983,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="4.0.0-alpha.1"></a>
 
-# 4.0.0-alpha.1
+## 4.0.0-alpha.1
 
 🗓 2021-05-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@4.0.0-alpha.0...@spectrum-css/toast@4.0.0-alpha.1)
 
@@ -991,7 +991,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="4.0.0-alpha.0"></a>
 
-# 4.0.0-alpha.0
+## 4.0.0-alpha.0
 
 🗓 2021-04-27 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@3.0.2...@spectrum-css/toast@4.0.0-alpha.0)
 
@@ -1021,7 +1021,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@3.0.0-beta.6...@spectrum-css/toast@3.0.0)
 
@@ -1029,7 +1029,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.6"></a>
 
-# 3.0.0-beta.6
+## 3.0.0-beta.6
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@3.0.0-beta.5...@spectrum-css/toast@3.0.0-beta.6)
 
@@ -1044,7 +1044,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.5"></a>
 
-# 3.0.0-beta.5
+## 3.0.0-beta.5
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@3.0.0-beta.4...@spectrum-css/toast@3.0.0-beta.5)
 
@@ -1052,7 +1052,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.4"></a>
 
-# 3.0.0-beta.4
+## 3.0.0-beta.4
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@3.0.0-beta.3...@spectrum-css/toast@3.0.0-beta.4)
 
@@ -1063,7 +1063,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.3"></a>
 
-# 3.0.0-beta.3
+## 3.0.0-beta.3
 
 🗓 2020-06-19 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@3.0.0-beta.2...@spectrum-css/toast@3.0.0-beta.3)
 
@@ -1071,7 +1071,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@3.0.0-beta.1...@spectrum-css/toast@3.0.0-beta.2)
 
@@ -1079,7 +1079,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@3.0.0-beta.0...@spectrum-css/toast@3.0.0-beta.1)
 
@@ -1087,7 +1087,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@2.0.5...@spectrum-css/toast@3.0.0-beta.0)
 
@@ -1137,7 +1137,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/toast/CHANGELOG.md
+++ b/components/toast/CHANGELOG.md
@@ -33,7 +33,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="10.0.0"></a>
-#10.0.0
+# 10.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@9.1.25...@spectrum-css/toast@10.0.0)
 
@@ -48,147 +48,147 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="9.1.25"></a>
-##9.1.25
+## 9.1.25
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@9.1.24...@spectrum-css/toast@9.1.25)
 
 **Note:** Version bump only for package @spectrum-css/toast
 
 <a name="9.1.24"></a>
-##9.1.24
+## 9.1.24
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@9.1.23...@spectrum-css/toast@9.1.24)
 
 **Note:** Version bump only for package @spectrum-css/toast
 
 <a name="9.1.23"></a>
-##9.1.23
+## 9.1.23
 🗓
 2024-02-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@9.1.22...@spectrum-css/toast@9.1.23)
 
 **Note:** Version bump only for package @spectrum-css/toast
 
 <a name="9.1.22"></a>
-##9.1.22
+## 9.1.22
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@9.1.21...@spectrum-css/toast@9.1.22)
 
 **Note:** Version bump only for package @spectrum-css/toast
 
 <a name="9.1.21"></a>
-##9.1.21
+## 9.1.21
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/toast
 
 <a name="9.1.20"></a>
-##9.1.20
+## 9.1.20
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@9.1.19...@spectrum-css/toast@9.1.20)
 
 **Note:** Version bump only for package @spectrum-css/toast
 
 <a name="9.1.19"></a>
-##9.1.19
+## 9.1.19
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@9.1.18...@spectrum-css/toast@9.1.19)
 
 **Note:** Version bump only for package @spectrum-css/toast
 
 <a name="9.1.18"></a>
-##9.1.18
+## 9.1.18
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@9.1.17...@spectrum-css/toast@9.1.18)
 
 **Note:** Version bump only for package @spectrum-css/toast
 
 <a name="9.1.17"></a>
-##9.1.17
+## 9.1.17
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@9.1.15...@spectrum-css/toast@9.1.17)
 
 **Note:** Version bump only for package @spectrum-css/toast
 
 <a name="9.1.16"></a>
-##9.1.16
+## 9.1.16
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@9.1.15...@spectrum-css/toast@9.1.16)
 
 **Note:** Version bump only for package @spectrum-css/toast
 
 <a name="9.1.15"></a>
-##9.1.15
+## 9.1.15
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@9.1.14...@spectrum-css/toast@9.1.15)
 
 **Note:** Version bump only for package @spectrum-css/toast
 
 <a name="9.1.14"></a>
-##9.1.14
+## 9.1.14
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@9.1.13...@spectrum-css/toast@9.1.14)
 
 **Note:** Version bump only for package @spectrum-css/toast
 
 <a name="9.1.13"></a>
-##9.1.13
+## 9.1.13
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@9.1.12...@spectrum-css/toast@9.1.13)
 
 **Note:** Version bump only for package @spectrum-css/toast
 
 <a name="9.1.12"></a>
-##9.1.12
+## 9.1.12
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@9.1.11...@spectrum-css/toast@9.1.12)
 
 **Note:** Version bump only for package @spectrum-css/toast
 
 <a name="9.1.11"></a>
-##9.1.11
+## 9.1.11
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@9.1.10...@spectrum-css/toast@9.1.11)
 
 **Note:** Version bump only for package @spectrum-css/toast
 
 <a name="9.1.10"></a>
-##9.1.10
+## 9.1.10
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@9.1.9...@spectrum-css/toast@9.1.10)
 
 **Note:** Version bump only for package @spectrum-css/toast
 
 <a name="9.1.9"></a>
-##9.1.9
+## 9.1.9
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@9.1.8...@spectrum-css/toast@9.1.9)
 
 **Note:** Version bump only for package @spectrum-css/toast
 
 <a name="9.1.8"></a>
-##9.1.8
+## 9.1.8
 🗓
 2023-09-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@9.1.7...@spectrum-css/toast@9.1.8)
 
 **Note:** Version bump only for package @spectrum-css/toast
 
 <a name="9.1.7"></a>
-##9.1.7
+## 9.1.7
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@9.1.6...@spectrum-css/toast@9.1.7)
 
 **Note:** Version bump only for package @spectrum-css/toast
 
 <a name="9.1.6"></a>
-##9.1.6
+## 9.1.6
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@9.1.5...@spectrum-css/toast@9.1.6)
 
 **Note:** Version bump only for package @spectrum-css/toast
 
 <a name="9.1.5"></a>
-##9.1.5
+## 9.1.5
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@9.1.4...@spectrum-css/toast@9.1.5)
 
@@ -197,35 +197,35 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="9.1.4"></a>
-##9.1.4
+## 9.1.4
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@9.1.3...@spectrum-css/toast@9.1.4)
 
 **Note:** Version bump only for package @spectrum-css/toast
 
 <a name="9.1.3"></a>
-##9.1.3
+## 9.1.3
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@9.1.1...@spectrum-css/toast@9.1.3)
 
 **Note:** Version bump only for package @spectrum-css/toast
 
 <a name="9.1.2"></a>
-##9.1.2
+## 9.1.2
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@9.1.1...@spectrum-css/toast@9.1.2)
 
 **Note:** Version bump only for package @spectrum-css/toast
 
 <a name="9.1.1"></a>
-##9.1.1
+## 9.1.1
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@9.1.0...@spectrum-css/toast@9.1.1)
 
 **Note:** Version bump only for package @spectrum-css/toast
 
 <a name="9.1.0"></a>
-#9.1.0
+# 9.1.0
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@9.0.45...@spectrum-css/toast@9.1.0)
 
@@ -234,70 +234,70 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **toast:**add max width token ([#2066](https://github.com/adobe/spectrum-css/issues/2066))([8d1de3b](https://github.com/adobe/spectrum-css/commit/8d1de3b))
 
 <a name="9.0.45"></a>
-##9.0.45
+## 9.0.45
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@9.0.44...@spectrum-css/toast@9.0.45)
 
 **Note:** Version bump only for package @spectrum-css/toast
 
 <a name="9.0.44"></a>
-##9.0.44
+## 9.0.44
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@9.0.43...@spectrum-css/toast@9.0.44)
 
 **Note:** Version bump only for package @spectrum-css/toast
 
 <a name="9.0.43"></a>
-##9.0.43
+## 9.0.43
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@9.0.42...@spectrum-css/toast@9.0.43)
 
 **Note:** Version bump only for package @spectrum-css/toast
 
 <a name="9.0.42"></a>
-##9.0.42
+## 9.0.42
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@9.0.41...@spectrum-css/toast@9.0.42)
 
 **Note:** Version bump only for package @spectrum-css/toast
 
 <a name="9.0.41"></a>
-##9.0.41
+## 9.0.41
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@9.0.40...@spectrum-css/toast@9.0.41)
 
 **Note:** Version bump only for package @spectrum-css/toast
 
 <a name="9.0.40"></a>
-##9.0.40
+## 9.0.40
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@9.0.39...@spectrum-css/toast@9.0.40)
 
 **Note:** Version bump only for package @spectrum-css/toast
 
 <a name="9.0.39"></a>
-##9.0.39
+## 9.0.39
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@9.0.38...@spectrum-css/toast@9.0.39)
 
 **Note:** Version bump only for package @spectrum-css/toast
 
 <a name="9.0.38"></a>
-##9.0.38
+## 9.0.38
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@9.0.37...@spectrum-css/toast@9.0.38)
 
 **Note:** Version bump only for package @spectrum-css/toast
 
 <a name="9.0.37"></a>
-##9.0.37
+## 9.0.37
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@9.0.36...@spectrum-css/toast@9.0.37)
 
 **Note:** Version bump only for package @spectrum-css/toast
 
 <a name="9.0.36"></a>
-##9.0.36
+## 9.0.36
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@9.0.35...@spectrum-css/toast@9.0.36)
 
@@ -306,14 +306,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="9.0.35"></a>
-##9.0.35
+## 9.0.35
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@9.0.34...@spectrum-css/toast@9.0.35)
 
 **Note:** Version bump only for package @spectrum-css/toast
 
 <a name="9.0.34"></a>
-##9.0.34
+## 9.0.34
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/toast@9.0.33...@spectrum-css/toast@9.0.34)
 

--- a/components/tooltip/CHANGELOG.md
+++ b/components/tooltip/CHANGELOG.md
@@ -35,7 +35,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="6.0.0"></a>
-# 6.0.0
+## 6.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@5.3.5...@spectrum-css/tooltip@6.0.0)
 
@@ -85,14 +85,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/tooltip
 
 <a name="5.3.0"></a>
-# 5.3.0
+## 5.3.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@5.2.0...@spectrum-css/tooltip@5.3.0)
 
 **Note:** Version bump only for package @spectrum-css/tooltip
 
 <a name="5.2.0"></a>
-# 5.2.0
+## 5.2.0
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@5.1.22...@spectrum-css/tooltip@5.2.0)
 
@@ -261,7 +261,7 @@ _migrate build packages to postcss v8 ([#2460](https://github.com/adobe/spectrum
 **Note:** Version bump only for package @spectrum-css/tooltip
 
 <a name="5.1.0"></a>
-# 5.1.0
+## 5.1.0
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@5.0.42...@spectrum-css/tooltip@5.1.0)
 
@@ -601,7 +601,7 @@ _migrate build packages to postcss v8 ([#2460](https://github.com/adobe/spectrum
 
 <a name="5.0.0"></a>
 
-# 5.0.0
+## 5.0.0
 
 🗓 2023-02-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@4.0.10...@spectrum-css/tooltip@5.0.0)
 
@@ -695,7 +695,7 @@ _migrate build packages to postcss v8 ([#2460](https://github.com/adobe/spectrum
 
 <a name="4.0.0"></a>
 
-# 4.0.0
+## 4.0.0
 
 🗓 2022-12-06 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@3.1.20...@spectrum-css/tooltip@4.0.0)
 
@@ -881,7 +881,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.1.0"></a>
 
-# 3.1.0
+## 3.1.0
 
 🗓 2021-11-08 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@3.0.4...@spectrum-css/tooltip@3.1.0)
 
@@ -957,7 +957,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@3.0.0-beta.5...@spectrum-css/tooltip@3.0.0)
 
@@ -965,7 +965,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0-beta.5"></a>
 
-# 3.0.0-beta.5
+## 3.0.0-beta.5
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@3.0.0-beta.4...@spectrum-css/tooltip@3.0.0-beta.5)
 
@@ -975,7 +975,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0-beta.4"></a>
 
-# 3.0.0-beta.4
+## 3.0.0-beta.4
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@3.0.0-beta.3...@spectrum-css/tooltip@3.0.0-beta.4)
 
@@ -983,7 +983,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0-beta.3"></a>
 
-# 3.0.0-beta.3
+## 3.0.0-beta.3
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@3.0.0-beta.2...@spectrum-css/tooltip@3.0.0-beta.3)
 
@@ -994,7 +994,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@3.0.0-beta.1...@spectrum-css/tooltip@3.0.0-beta.2)
 
@@ -1002,7 +1002,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@3.0.0-beta.0...@spectrum-css/tooltip@3.0.0-beta.1)
 
@@ -1010,7 +1010,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@2.0.5...@spectrum-css/tooltip@3.0.0-beta.0)
 
@@ -1060,7 +1060,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/tooltip/CHANGELOG.md
+++ b/components/tooltip/CHANGELOG.md
@@ -35,7 +35,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="6.0.0"></a>
-#6.0.0
+# 6.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@5.3.5...@spectrum-css/tooltip@6.0.0)
 
@@ -50,49 +50,49 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="5.3.5"></a>
-##5.3.5
+## 5.3.5
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@5.3.4...@spectrum-css/tooltip@5.3.5)
 
 **Note:** Version bump only for package @spectrum-css/tooltip
 
 <a name="5.3.4"></a>
-##5.3.4
+## 5.3.4
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@5.3.3...@spectrum-css/tooltip@5.3.4)
 
 **Note:** Version bump only for package @spectrum-css/tooltip
 
 <a name="5.3.3"></a>
-##5.3.3
+## 5.3.3
 🗓
 2024-02-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@5.3.2...@spectrum-css/tooltip@5.3.3)
 
 **Note:** Version bump only for package @spectrum-css/tooltip
 
 <a name="5.3.2"></a>
-##5.3.2
+## 5.3.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@5.3.1...@spectrum-css/tooltip@5.3.2)
 
 **Note:** Version bump only for package @spectrum-css/tooltip
 
 <a name="5.3.1"></a>
-##5.3.1
+## 5.3.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/tooltip
 
 <a name="5.3.0"></a>
-#5.3.0
+# 5.3.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@5.2.0...@spectrum-css/tooltip@5.3.0)
 
 **Note:** Version bump only for package @spectrum-css/tooltip
 
 <a name="5.2.0"></a>
-#5.2.0
+# 5.2.0
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@5.1.22...@spectrum-css/tooltip@5.2.0)
 
@@ -102,42 +102,42 @@ _migrate build packages to postcss v8 ([#2460](https://github.com/adobe/spectrum
 **overlay,commons:**deprecate overlay; migrate references to commons ([#2429](https://github.com/adobe/spectrum-css/issues/2429))([7eecd96](https://github.com/adobe/spectrum-css/commit/7eecd96))
 
 <a name="5.1.22"></a>
-##5.1.22
+## 5.1.22
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@5.1.21...@spectrum-css/tooltip@5.1.22)
 
 **Note:** Version bump only for package @spectrum-css/tooltip
 
 <a name="5.1.21"></a>
-##5.1.21
+## 5.1.21
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@5.1.20...@spectrum-css/tooltip@5.1.21)
 
 **Note:** Version bump only for package @spectrum-css/tooltip
 
 <a name="5.1.20"></a>
-##5.1.20
+## 5.1.20
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@5.1.19...@spectrum-css/tooltip@5.1.20)
 
 **Note:** Version bump only for package @spectrum-css/tooltip
 
 <a name="5.1.19"></a>
-##5.1.19
+## 5.1.19
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@5.1.17...@spectrum-css/tooltip@5.1.19)
 
 **Note:** Version bump only for package @spectrum-css/tooltip
 
 <a name="5.1.18"></a>
-##5.1.18
+## 5.1.18
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@5.1.17...@spectrum-css/tooltip@5.1.18)
 
 **Note:** Version bump only for package @spectrum-css/tooltip
 
 <a name="5.1.17"></a>
-##5.1.17
+## 5.1.17
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@5.1.16...@spectrum-css/tooltip@5.1.17)
 
@@ -147,63 +147,63 @@ _migrate build packages to postcss v8 ([#2460](https://github.com/adobe/spectrum
   **tooltip:**custom animation distance overrides overlay value([f98b8a1](https://github.com/adobe/spectrum-css/commit/f98b8a1))
 
 <a name="5.1.16"></a>
-##5.1.16
+## 5.1.16
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@5.1.15...@spectrum-css/tooltip@5.1.16)
 
 **Note:** Version bump only for package @spectrum-css/tooltip
 
 <a name="5.1.15"></a>
-##5.1.15
+## 5.1.15
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@5.1.14...@spectrum-css/tooltip@5.1.15)
 
 **Note:** Version bump only for package @spectrum-css/tooltip
 
 <a name="5.1.14"></a>
-##5.1.14
+## 5.1.14
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@5.1.13...@spectrum-css/tooltip@5.1.14)
 
 **Note:** Version bump only for package @spectrum-css/tooltip
 
 <a name="5.1.13"></a>
-##5.1.13
+## 5.1.13
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@5.1.12...@spectrum-css/tooltip@5.1.13)
 
 **Note:** Version bump only for package @spectrum-css/tooltip
 
 <a name="5.1.12"></a>
-##5.1.12
+## 5.1.12
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@5.1.11...@spectrum-css/tooltip@5.1.12)
 
 **Note:** Version bump only for package @spectrum-css/tooltip
 
 <a name="5.1.11"></a>
-##5.1.11
+## 5.1.11
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@5.1.10...@spectrum-css/tooltip@5.1.11)
 
 **Note:** Version bump only for package @spectrum-css/tooltip
 
 <a name="5.1.10"></a>
-##5.1.10
+## 5.1.10
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@5.1.9...@spectrum-css/tooltip@5.1.10)
 
 **Note:** Version bump only for package @spectrum-css/tooltip
 
 <a name="5.1.9"></a>
-##5.1.9
+## 5.1.9
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@5.1.8...@spectrum-css/tooltip@5.1.9)
 
 **Note:** Version bump only for package @spectrum-css/tooltip
 
 <a name="5.1.8"></a>
-##5.1.8
+## 5.1.8
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@5.1.7...@spectrum-css/tooltip@5.1.8)
 
@@ -212,56 +212,56 @@ _migrate build packages to postcss v8 ([#2460](https://github.com/adobe/spectrum
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="5.1.7"></a>
-##5.1.7
+## 5.1.7
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@5.1.6...@spectrum-css/tooltip@5.1.7)
 
 **Note:** Version bump only for package @spectrum-css/tooltip
 
 <a name="5.1.6"></a>
-##5.1.6
+## 5.1.6
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@5.1.4...@spectrum-css/tooltip@5.1.6)
 
 **Note:** Version bump only for package @spectrum-css/tooltip
 
 <a name="5.1.5"></a>
-##5.1.5
+## 5.1.5
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@5.1.4...@spectrum-css/tooltip@5.1.5)
 
 **Note:** Version bump only for package @spectrum-css/tooltip
 
 <a name="5.1.4"></a>
-##5.1.4
+## 5.1.4
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@5.1.3...@spectrum-css/tooltip@5.1.4)
 
 **Note:** Version bump only for package @spectrum-css/tooltip
 
 <a name="5.1.3"></a>
-##5.1.3
+## 5.1.3
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@5.1.2...@spectrum-css/tooltip@5.1.3)
 
 **Note:** Version bump only for package @spectrum-css/tooltip
 
 <a name="5.1.2"></a>
-##5.1.2
+## 5.1.2
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@5.1.1...@spectrum-css/tooltip@5.1.2)
 
 **Note:** Version bump only for package @spectrum-css/tooltip
 
 <a name="5.1.1"></a>
-##5.1.1
+## 5.1.1
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@5.1.0...@spectrum-css/tooltip@5.1.1)
 
 **Note:** Version bump only for package @spectrum-css/tooltip
 
 <a name="5.1.0"></a>
-#5.1.0
+# 5.1.0
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@5.0.42...@spectrum-css/tooltip@5.1.0)
 
@@ -271,49 +271,49 @@ _migrate build packages to postcss v8 ([#2460](https://github.com/adobe/spectrum
   **tooltip:**square tip elements and modified hairline gap fix ([#1939](https://github.com/adobe/spectrum-css/issues/1939))([de33f42](https://github.com/adobe/spectrum-css/commit/de33f42)), closes[#1875](https://github.com/adobe/spectrum-css/issues/1875)
 
 <a name="5.0.42"></a>
-##5.0.42
+## 5.0.42
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@5.0.41...@spectrum-css/tooltip@5.0.42)
 
 **Note:** Version bump only for package @spectrum-css/tooltip
 
 <a name="5.0.41"></a>
-##5.0.41
+## 5.0.41
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@5.0.40...@spectrum-css/tooltip@5.0.41)
 
 **Note:** Version bump only for package @spectrum-css/tooltip
 
 <a name="5.0.40"></a>
-##5.0.40
+## 5.0.40
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@5.0.39...@spectrum-css/tooltip@5.0.40)
 
 **Note:** Version bump only for package @spectrum-css/tooltip
 
 <a name="5.0.39"></a>
-##5.0.39
+## 5.0.39
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@5.0.38...@spectrum-css/tooltip@5.0.39)
 
 **Note:** Version bump only for package @spectrum-css/tooltip
 
 <a name="5.0.38"></a>
-##5.0.38
+## 5.0.38
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@5.0.37...@spectrum-css/tooltip@5.0.38)
 
 **Note:** Version bump only for package @spectrum-css/tooltip
 
 <a name="5.0.37"></a>
-##5.0.37
+## 5.0.37
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@5.0.36...@spectrum-css/tooltip@5.0.37)
 
 **Note:** Version bump only for package @spectrum-css/tooltip
 
 <a name="5.0.36"></a>
-##5.0.36
+## 5.0.36
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@5.0.35...@spectrum-css/tooltip@5.0.36)
 
@@ -322,14 +322,14 @@ _migrate build packages to postcss v8 ([#2460](https://github.com/adobe/spectrum
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="5.0.35"></a>
-##5.0.35
+## 5.0.35
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@5.0.34...@spectrum-css/tooltip@5.0.35)
 
 **Note:** Version bump only for package @spectrum-css/tooltip
 
 <a name="5.0.34"></a>
-##5.0.34
+## 5.0.34
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tooltip@5.0.33...@spectrum-css/tooltip@5.0.34)
 

--- a/components/tray/CHANGELOG.md
+++ b/components/tray/CHANGELOG.md
@@ -37,7 +37,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="3.0.0"></a>
-# 3.0.0
+## 3.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@2.2.7...@spectrum-css/tray@3.0.0)
 
@@ -103,7 +103,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/tray
 
 <a name="2.2.0"></a>
-# 2.2.0
+## 2.2.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@2.1.22...@spectrum-css/tray@2.2.0)
 
@@ -268,7 +268,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/tray
 
 <a name="2.1.0"></a>
-# 2.1.0
+## 2.1.0
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@2.0.57...@spectrum-css/tray@2.1.0)
 
@@ -726,7 +726,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2022-12-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@1.0.31...@spectrum-css/tray@2.0.0)
 
@@ -1030,7 +1030,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="1.0.0"></a>
 
-# 1.0.0
+## 1.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@1.0.0-beta.3...@spectrum-css/tray@1.0.0)
 
@@ -1038,7 +1038,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="1.0.0-beta.3"></a>
 
-# 1.0.0-beta.3
+## 1.0.0-beta.3
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@1.0.0-beta.2...@spectrum-css/tray@1.0.0-beta.3)
 
@@ -1053,7 +1053,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="1.0.0-beta.2"></a>
 
-# 1.0.0-beta.2
+## 1.0.0-beta.2
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@1.0.0-beta.1...@spectrum-css/tray@1.0.0-beta.2)
 
@@ -1061,7 +1061,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="1.0.0-beta.1"></a>
 
-# 1.0.0-beta.1
+## 1.0.0-beta.1
 
 🗓 2020-09-23
 

--- a/components/tray/CHANGELOG.md
+++ b/components/tray/CHANGELOG.md
@@ -37,7 +37,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="3.0.0"></a>
-#3.0.0
+# 3.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@2.2.7...@spectrum-css/tray@3.0.0)
 
@@ -52,21 +52,21 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="2.2.7"></a>
-##2.2.7
+## 2.2.7
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@2.2.6...@spectrum-css/tray@2.2.7)
 
 **Note:** Version bump only for package @spectrum-css/tray
 
 <a name="2.2.6"></a>
-##2.2.6
+## 2.2.6
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@2.2.5...@spectrum-css/tray@2.2.6)
 
 **Note:** Version bump only for package @spectrum-css/tray
 
 <a name="2.2.5"></a>
-##2.2.5
+## 2.2.5
 🗓
 2024-02-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@2.2.4...@spectrum-css/tray@2.2.5)
 
@@ -75,35 +75,35 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **tray:**full width at portrait orientation ([#2547](https://github.com/adobe/spectrum-css/issues/2547))([c9a79f2](https://github.com/adobe/spectrum-css/commit/c9a79f2))
 
 <a name="2.2.4"></a>
-##2.2.4
+## 2.2.4
 🗓
 2024-02-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@2.2.3...@spectrum-css/tray@2.2.4)
 
 **Note:** Version bump only for package @spectrum-css/tray
 
 <a name="2.2.3"></a>
-##2.2.3
+## 2.2.3
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@2.2.2...@spectrum-css/tray@2.2.3)
 
 **Note:** Version bump only for package @spectrum-css/tray
 
 <a name="2.2.2"></a>
-##2.2.2
+## 2.2.2
 🗓
 2024-02-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@2.2.1...@spectrum-css/tray@2.2.2)
 
 **Note:** Version bump only for package @spectrum-css/tray
 
 <a name="2.2.1"></a>
-##2.2.1
+## 2.2.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/tray
 
 <a name="2.2.0"></a>
-#2.2.0
+# 2.2.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@2.1.22...@spectrum-css/tray@2.2.0)
 
@@ -112,105 +112,105 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="2.1.22"></a>
-##2.1.22
+## 2.1.22
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@2.1.21...@spectrum-css/tray@2.1.22)
 
 **Note:** Version bump only for package @spectrum-css/tray
 
 <a name="2.1.21"></a>
-##2.1.21
+## 2.1.21
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@2.1.20...@spectrum-css/tray@2.1.21)
 
 **Note:** Version bump only for package @spectrum-css/tray
 
 <a name="2.1.20"></a>
-##2.1.20
+## 2.1.20
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@2.1.18...@spectrum-css/tray@2.1.20)
 
 **Note:** Version bump only for package @spectrum-css/tray
 
 <a name="2.1.19"></a>
-##2.1.19
+## 2.1.19
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@2.1.18...@spectrum-css/tray@2.1.19)
 
 **Note:** Version bump only for package @spectrum-css/tray
 
 <a name="2.1.18"></a>
-##2.1.18
+## 2.1.18
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@2.1.17...@spectrum-css/tray@2.1.18)
 
 **Note:** Version bump only for package @spectrum-css/tray
 
 <a name="2.1.17"></a>
-##2.1.17
+## 2.1.17
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@2.1.16...@spectrum-css/tray@2.1.17)
 
 **Note:** Version bump only for package @spectrum-css/tray
 
 <a name="2.1.16"></a>
-##2.1.16
+## 2.1.16
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@2.1.15...@spectrum-css/tray@2.1.16)
 
 **Note:** Version bump only for package @spectrum-css/tray
 
 <a name="2.1.15"></a>
-##2.1.15
+## 2.1.15
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@2.1.14...@spectrum-css/tray@2.1.15)
 
 **Note:** Version bump only for package @spectrum-css/tray
 
 <a name="2.1.14"></a>
-##2.1.14
+## 2.1.14
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@2.1.13...@spectrum-css/tray@2.1.14)
 
 **Note:** Version bump only for package @spectrum-css/tray
 
 <a name="2.1.13"></a>
-##2.1.13
+## 2.1.13
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@2.1.12...@spectrum-css/tray@2.1.13)
 
 **Note:** Version bump only for package @spectrum-css/tray
 
 <a name="2.1.12"></a>
-##2.1.12
+## 2.1.12
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@2.1.11...@spectrum-css/tray@2.1.12)
 
 **Note:** Version bump only for package @spectrum-css/tray
 
 <a name="2.1.11"></a>
-##2.1.11
+## 2.1.11
 🗓
 2023-09-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@2.1.10...@spectrum-css/tray@2.1.11)
 
 **Note:** Version bump only for package @spectrum-css/tray
 
 <a name="2.1.10"></a>
-##2.1.10
+## 2.1.10
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@2.1.9...@spectrum-css/tray@2.1.10)
 
 **Note:** Version bump only for package @spectrum-css/tray
 
 <a name="2.1.9"></a>
-##2.1.9
+## 2.1.9
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@2.1.8...@spectrum-css/tray@2.1.9)
 
 **Note:** Version bump only for package @spectrum-css/tray
 
 <a name="2.1.8"></a>
-##2.1.8
+## 2.1.8
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@2.1.7...@spectrum-css/tray@2.1.8)
 
@@ -219,56 +219,56 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="2.1.7"></a>
-##2.1.7
+## 2.1.7
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@2.1.6...@spectrum-css/tray@2.1.7)
 
 **Note:** Version bump only for package @spectrum-css/tray
 
 <a name="2.1.6"></a>
-##2.1.6
+## 2.1.6
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@2.1.4...@spectrum-css/tray@2.1.6)
 
 **Note:** Version bump only for package @spectrum-css/tray
 
 <a name="2.1.5"></a>
-##2.1.5
+## 2.1.5
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@2.1.4...@spectrum-css/tray@2.1.5)
 
 **Note:** Version bump only for package @spectrum-css/tray
 
 <a name="2.1.4"></a>
-##2.1.4
+## 2.1.4
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@2.1.3...@spectrum-css/tray@2.1.4)
 
 **Note:** Version bump only for package @spectrum-css/tray
 
 <a name="2.1.3"></a>
-##2.1.3
+## 2.1.3
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@2.1.2...@spectrum-css/tray@2.1.3)
 
 **Note:** Version bump only for package @spectrum-css/tray
 
 <a name="2.1.2"></a>
-##2.1.2
+## 2.1.2
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@2.1.1...@spectrum-css/tray@2.1.2)
 
 **Note:** Version bump only for package @spectrum-css/tray
 
 <a name="2.1.1"></a>
-##2.1.1
+## 2.1.1
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@2.1.0...@spectrum-css/tray@2.1.1)
 
 **Note:** Version bump only for package @spectrum-css/tray
 
 <a name="2.1.0"></a>
-#2.1.0
+# 2.1.0
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@2.0.57...@spectrum-css/tray@2.1.0)
 
@@ -277,56 +277,56 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **tray:**use token for top and bottom edge to content area([ac54820](https://github.com/adobe/spectrum-css/commit/ac54820))
 
 <a name="2.0.57"></a>
-##2.0.57
+## 2.0.57
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@2.0.56...@spectrum-css/tray@2.0.57)
 
 **Note:** Version bump only for package @spectrum-css/tray
 
 <a name="2.0.56"></a>
-##2.0.56
+## 2.0.56
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@2.0.55...@spectrum-css/tray@2.0.56)
 
 **Note:** Version bump only for package @spectrum-css/tray
 
 <a name="2.0.55"></a>
-##2.0.55
+## 2.0.55
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@2.0.54...@spectrum-css/tray@2.0.55)
 
 **Note:** Version bump only for package @spectrum-css/tray
 
 <a name="2.0.54"></a>
-##2.0.54
+## 2.0.54
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@2.0.53...@spectrum-css/tray@2.0.54)
 
 **Note:** Version bump only for package @spectrum-css/tray
 
 <a name="2.0.53"></a>
-##2.0.53
+## 2.0.53
 🗓
 2023-06-28 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@2.0.52...@spectrum-css/tray@2.0.53)
 
 **Note:** Version bump only for package @spectrum-css/tray
 
 <a name="2.0.52"></a>
-##2.0.52
+## 2.0.52
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@2.0.51...@spectrum-css/tray@2.0.52)
 
 **Note:** Version bump only for package @spectrum-css/tray
 
 <a name="2.0.51"></a>
-##2.0.51
+## 2.0.51
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@2.0.50...@spectrum-css/tray@2.0.51)
 
 **Note:** Version bump only for package @spectrum-css/tray
 
 <a name="2.0.50"></a>
-##2.0.50
+## 2.0.50
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@2.0.49...@spectrum-css/tray@2.0.50)
 
@@ -335,14 +335,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="2.0.49"></a>
-##2.0.49
+## 2.0.49
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@2.0.48...@spectrum-css/tray@2.0.49)
 
 **Note:** Version bump only for package @spectrum-css/tray
 
 <a name="2.0.48"></a>
-##2.0.48
+## 2.0.48
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tray@2.0.47...@spectrum-css/tray@2.0.48)
 

--- a/components/treeview/CHANGELOG.md
+++ b/components/treeview/CHANGELOG.md
@@ -37,7 +37,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="10.0.0"></a>
-# 10.0.0
+## 10.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/treeview@9.2.6...@spectrum-css/treeview@10.0.0)
 
@@ -94,7 +94,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/treeview
 
 <a name="9.2.0"></a>
-# 9.2.0
+## 9.2.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/treeview@9.1.1...@spectrum-css/treeview@9.2.0)
 
@@ -110,7 +110,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*deprecate logical transform plugin ([#2437](https://github.com/adobe/spectrum-css/issues/2437))([ff5dda6](https://github.com/adobe/spectrum-css/commit/ff5dda6))
 
 <a name="9.1.0"></a>
-# 9.1.0
+## 9.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/treeview@9.0.8...@spectrum-css/treeview@9.1.0)
 
@@ -175,7 +175,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/treeview
 
 <a name="9.0.0"></a>
-# 9.0.0
+## 9.0.0
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/treeview@8.0.1...@spectrum-css/treeview@9.0.0)
 
@@ -223,7 +223,7 @@ for the hover background color.
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="8.0.0"></a>
-# 8.0.0
+## 8.0.0
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/treeview@7.0.9...@spectrum-css/treeview@8.0.0)
 
@@ -306,7 +306,7 @@ for the hover background color.
 
 <a name="7.0.0"></a>
 
-# 7.0.0
+## 7.0.0
 
 🗓 2023-05-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/treeview@6.0.39...@spectrum-css/treeview@7.0.0)
 
@@ -640,7 +640,7 @@ for the hover background color.
 
 <a name="6.0.0"></a>
 
-# 6.0.0
+## 6.0.0
 
 🗓 2021-11-08 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/treeview@3.0.3-alpha.3...@spectrum-css/treeview@6.0.0)
 
@@ -665,7 +665,7 @@ for the hover background color.
 
 <a name="5.0.0"></a>
 
-# 5.0.0
+## 5.0.0
 
 🗓 2021-10-25 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/treeview@3.0.3-alpha.3...@spectrum-css/treeview@5.0.0)
 
@@ -690,7 +690,7 @@ for the hover background color.
 
 <a name="4.0.0"></a>
 
-# 4.0.0
+## 4.0.0
 
 🗓 2021-09-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/treeview@3.0.3-alpha.3...@spectrum-css/treeview@4.0.0)
 
@@ -764,7 +764,7 @@ for the hover background color.
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/treeview@3.0.0-beta.6...@spectrum-css/treeview@3.0.0)
 
@@ -772,7 +772,7 @@ for the hover background color.
 
 <a name="3.0.0-beta.6"></a>
 
-# 3.0.0-beta.6
+## 3.0.0-beta.6
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/treeview@3.0.0-beta.5...@spectrum-css/treeview@3.0.0-beta.6)
 
@@ -782,7 +782,7 @@ for the hover background color.
 
 <a name="3.0.0-beta.5"></a>
 
-# 3.0.0-beta.5
+## 3.0.0-beta.5
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/treeview@3.0.0-beta.4...@spectrum-css/treeview@3.0.0-beta.5)
 
@@ -790,7 +790,7 @@ for the hover background color.
 
 <a name="3.0.0-beta.4"></a>
 
-# 3.0.0-beta.4
+## 3.0.0-beta.4
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/treeview@3.0.0-beta.3...@spectrum-css/treeview@3.0.0-beta.4)
 
@@ -800,7 +800,7 @@ for the hover background color.
 
 <a name="3.0.0-beta.3"></a>
 
-# 3.0.0-beta.3
+## 3.0.0-beta.3
 
 🗓 2020-06-19 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/treeview@3.0.0-beta.2...@spectrum-css/treeview@3.0.0-beta.3)
 
@@ -877,7 +877,7 @@ Co-authored-by: Jian Liao <jianliao@adobe.com>
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/treeview@3.0.0-beta.1...@spectrum-css/treeview@3.0.0-beta.2)
 
@@ -887,7 +887,7 @@ Co-authored-by: Jian Liao <jianliao@adobe.com>
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/treeview@3.0.0-beta.0...@spectrum-css/treeview@3.0.0-beta.1)
 
@@ -895,7 +895,7 @@ Co-authored-by: Jian Liao <jianliao@adobe.com>
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/treeview@2.0.6...@spectrum-css/treeview@3.0.0-beta.0)
 
@@ -955,7 +955,7 @@ Co-authored-by: Jian Liao <jianliao@adobe.com>
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/treeview/CHANGELOG.md
+++ b/components/treeview/CHANGELOG.md
@@ -37,7 +37,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="10.0.0"></a>
-#10.0.0
+# 10.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/treeview@9.2.6...@spectrum-css/treeview@10.0.0)
 
@@ -52,56 +52,56 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="9.2.6"></a>
-##9.2.6
+## 9.2.6
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/treeview@9.2.5...@spectrum-css/treeview@9.2.6)
 
 **Note:** Version bump only for package @spectrum-css/treeview
 
 <a name="9.2.5"></a>
-##9.2.5
+## 9.2.5
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/treeview@9.2.4...@spectrum-css/treeview@9.2.5)
 
 **Note:** Version bump only for package @spectrum-css/treeview
 
 <a name="9.2.4"></a>
-##9.2.4
+## 9.2.4
 🗓
 2024-02-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/treeview@9.2.3...@spectrum-css/treeview@9.2.4)
 
 **Note:** Version bump only for package @spectrum-css/treeview
 
 <a name="9.2.3"></a>
-##9.2.3
+## 9.2.3
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/treeview@9.2.2...@spectrum-css/treeview@9.2.3)
 
 **Note:** Version bump only for package @spectrum-css/treeview
 
 <a name="9.2.2"></a>
-##9.2.2
+## 9.2.2
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/treeview
 
 <a name="9.2.1"></a>
-##9.2.1
+## 9.2.1
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/treeview@9.2.0...@spectrum-css/treeview@9.2.1)
 
 **Note:** Version bump only for package @spectrum-css/treeview
 
 <a name="9.2.0"></a>
-#9.2.0
+# 9.2.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/treeview@9.1.1...@spectrum-css/treeview@9.2.0)
 
 **Note:** Version bump only for package @spectrum-css/treeview
 
 <a name="9.1.1"></a>
-##9.1.1
+## 9.1.1
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/treeview@9.1.0...@spectrum-css/treeview@9.1.1)
 
@@ -110,7 +110,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*deprecate logical transform plugin ([#2437](https://github.com/adobe/spectrum-css/issues/2437))([ff5dda6](https://github.com/adobe/spectrum-css/commit/ff5dda6))
 
 <a name="9.1.0"></a>
-#9.1.0
+# 9.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/treeview@9.0.8...@spectrum-css/treeview@9.1.0)
 
@@ -119,63 +119,63 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="9.0.8"></a>
-##9.0.8
+## 9.0.8
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/treeview@9.0.7...@spectrum-css/treeview@9.0.8)
 
 **Note:** Version bump only for package @spectrum-css/treeview
 
 <a name="9.0.7"></a>
-##9.0.7
+## 9.0.7
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/treeview@9.0.6...@spectrum-css/treeview@9.0.7)
 
 **Note:** Version bump only for package @spectrum-css/treeview
 
 <a name="9.0.6"></a>
-##9.0.6
+## 9.0.6
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/treeview@9.0.4...@spectrum-css/treeview@9.0.6)
 
 **Note:** Version bump only for package @spectrum-css/treeview
 
 <a name="9.0.5"></a>
-##9.0.5
+## 9.0.5
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/treeview@9.0.4...@spectrum-css/treeview@9.0.5)
 
 **Note:** Version bump only for package @spectrum-css/treeview
 
 <a name="9.0.4"></a>
-##9.0.4
+## 9.0.4
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/treeview@9.0.3...@spectrum-css/treeview@9.0.4)
 
 **Note:** Version bump only for package @spectrum-css/treeview
 
 <a name="9.0.3"></a>
-##9.0.3
+## 9.0.3
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/treeview@9.0.2...@spectrum-css/treeview@9.0.3)
 
 **Note:** Version bump only for package @spectrum-css/treeview
 
 <a name="9.0.2"></a>
-##9.0.2
+## 9.0.2
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/treeview@9.0.1...@spectrum-css/treeview@9.0.2)
 
 **Note:** Version bump only for package @spectrum-css/treeview
 
 <a name="9.0.1"></a>
-##9.0.1
+## 9.0.1
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/treeview@9.0.0...@spectrum-css/treeview@9.0.1)
 
 **Note:** Version bump only for package @spectrum-css/treeview
 
 <a name="9.0.0"></a>
-#9.0.0
+# 9.0.0
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/treeview@8.0.1...@spectrum-css/treeview@9.0.0)
 
@@ -214,7 +214,7 @@ Icon was appearing behind the ::before pseudo that is currently used
 for the hover background color.
 
 <a name="8.0.1"></a>
-##8.0.1
+## 8.0.1
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/treeview@8.0.0...@spectrum-css/treeview@8.0.1)
 
@@ -223,7 +223,7 @@ for the hover background color.
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="8.0.0"></a>
-#8.0.0
+# 8.0.0
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/treeview@7.0.9...@spectrum-css/treeview@8.0.0)
 
@@ -236,14 +236,14 @@ for the hover background color.
     		use focus-visible pseudo class in place of focus-ring
 
 <a name="7.0.9"></a>
-##7.0.9
+## 7.0.9
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/treeview@7.0.8...@spectrum-css/treeview@7.0.9)
 
 **Note:** Version bump only for package @spectrum-css/treeview
 
 <a name="7.0.8"></a>
-##7.0.8
+## 7.0.8
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/treeview@7.0.7...@spectrum-css/treeview@7.0.8)
 
@@ -252,21 +252,21 @@ for the hover background color.
 \*icon sizing in Storybook story templates ([#2037](https://github.com/adobe/spectrum-css/issues/2037))([c90c8a3](https://github.com/adobe/spectrum-css/commit/c90c8a3))
 
 <a name="7.0.7"></a>
-##7.0.7
+## 7.0.7
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/treeview@7.0.6...@spectrum-css/treeview@7.0.7)
 
 **Note:** Version bump only for package @spectrum-css/treeview
 
 <a name="7.0.6"></a>
-##7.0.6
+## 7.0.6
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/treeview@7.0.5...@spectrum-css/treeview@7.0.6)
 
 **Note:** Version bump only for package @spectrum-css/treeview
 
 <a name="7.0.5"></a>
-##7.0.5
+## 7.0.5
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/treeview@7.0.4...@spectrum-css/treeview@7.0.5)
 
@@ -275,14 +275,14 @@ for the hover background color.
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="7.0.4"></a>
-##7.0.4
+## 7.0.4
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/treeview@7.0.3...@spectrum-css/treeview@7.0.4)
 
 **Note:** Version bump only for package @spectrum-css/treeview
 
 <a name="7.0.3"></a>
-##7.0.3
+## 7.0.3
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/treeview@7.0.2...@spectrum-css/treeview@7.0.3)
 

--- a/components/typography/CHANGELOG.md
+++ b/components/typography/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="6.0.0"></a>
-#6.0.0
+# 6.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@5.1.5...@spectrum-css/typography@6.0.0)
 
@@ -40,42 +40,42 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="5.1.5"></a>
-##5.1.5
+## 5.1.5
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@5.1.4...@spectrum-css/typography@5.1.5)
 
 **Note:** Version bump only for package @spectrum-css/typography
 
 <a name="5.1.4"></a>
-##5.1.4
+## 5.1.4
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@5.1.3...@spectrum-css/typography@5.1.4)
 
 **Note:** Version bump only for package @spectrum-css/typography
 
 <a name="5.1.3"></a>
-##5.1.3
+## 5.1.3
 🗓
 2024-02-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@5.1.2...@spectrum-css/typography@5.1.3)
 
 **Note:** Version bump only for package @spectrum-css/typography
 
 <a name="5.1.2"></a>
-##5.1.2
+## 5.1.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@5.1.1...@spectrum-css/typography@5.1.2)
 
 **Note:** Version bump only for package @spectrum-css/typography
 
 <a name="5.1.1"></a>
-##5.1.1
+## 5.1.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/typography
 
 <a name="5.1.0"></a>
-#5.1.0
+# 5.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@5.0.50...@spectrum-css/typography@5.1.0)
 
@@ -84,98 +84,98 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="5.0.50"></a>
-##5.0.50
+## 5.0.50
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@5.0.49...@spectrum-css/typography@5.0.50)
 
 **Note:** Version bump only for package @spectrum-css/typography
 
 <a name="5.0.49"></a>
-##5.0.49
+## 5.0.49
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@5.0.48...@spectrum-css/typography@5.0.49)
 
 **Note:** Version bump only for package @spectrum-css/typography
 
 <a name="5.0.48"></a>
-##5.0.48
+## 5.0.48
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@5.0.46...@spectrum-css/typography@5.0.48)
 
 **Note:** Version bump only for package @spectrum-css/typography
 
 <a name="5.0.47"></a>
-##5.0.47
+## 5.0.47
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@5.0.46...@spectrum-css/typography@5.0.47)
 
 **Note:** Version bump only for package @spectrum-css/typography
 
 <a name="5.0.46"></a>
-##5.0.46
+## 5.0.46
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@5.0.45...@spectrum-css/typography@5.0.46)
 
 **Note:** Version bump only for package @spectrum-css/typography
 
 <a name="5.0.45"></a>
-##5.0.45
+## 5.0.45
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@5.0.44...@spectrum-css/typography@5.0.45)
 
 **Note:** Version bump only for package @spectrum-css/typography
 
 <a name="5.0.44"></a>
-##5.0.44
+## 5.0.44
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@5.0.43...@spectrum-css/typography@5.0.44)
 
 **Note:** Version bump only for package @spectrum-css/typography
 
 <a name="5.0.43"></a>
-##5.0.43
+## 5.0.43
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@5.0.42...@spectrum-css/typography@5.0.43)
 
 **Note:** Version bump only for package @spectrum-css/typography
 
 <a name="5.0.42"></a>
-##5.0.42
+## 5.0.42
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@5.0.41...@spectrum-css/typography@5.0.42)
 
 **Note:** Version bump only for package @spectrum-css/typography
 
 <a name="5.0.41"></a>
-##5.0.41
+## 5.0.41
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@5.0.40...@spectrum-css/typography@5.0.41)
 
 **Note:** Version bump only for package @spectrum-css/typography
 
 <a name="5.0.40"></a>
-##5.0.40
+## 5.0.40
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@5.0.39...@spectrum-css/typography@5.0.40)
 
 **Note:** Version bump only for package @spectrum-css/typography
 
 <a name="5.0.39"></a>
-##5.0.39
+## 5.0.39
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@5.0.38...@spectrum-css/typography@5.0.39)
 
 **Note:** Version bump only for package @spectrum-css/typography
 
 <a name="5.0.38"></a>
-##5.0.38
+## 5.0.38
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@5.0.37...@spectrum-css/typography@5.0.38)
 
 **Note:** Version bump only for package @spectrum-css/typography
 
 <a name="5.0.37"></a>
-##5.0.37
+## 5.0.37
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@5.0.36...@spectrum-css/typography@5.0.37)
 
@@ -184,105 +184,105 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="5.0.36"></a>
-##5.0.36
+## 5.0.36
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@5.0.35...@spectrum-css/typography@5.0.36)
 
 **Note:** Version bump only for package @spectrum-css/typography
 
 <a name="5.0.35"></a>
-##5.0.35
+## 5.0.35
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@5.0.33...@spectrum-css/typography@5.0.35)
 
 **Note:** Version bump only for package @spectrum-css/typography
 
 <a name="5.0.34"></a>
-##5.0.34
+## 5.0.34
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@5.0.33...@spectrum-css/typography@5.0.34)
 
 **Note:** Version bump only for package @spectrum-css/typography
 
 <a name="5.0.33"></a>
-##5.0.33
+## 5.0.33
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@5.0.32...@spectrum-css/typography@5.0.33)
 
 **Note:** Version bump only for package @spectrum-css/typography
 
 <a name="5.0.32"></a>
-##5.0.32
+## 5.0.32
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@5.0.31...@spectrum-css/typography@5.0.32)
 
 **Note:** Version bump only for package @spectrum-css/typography
 
 <a name="5.0.31"></a>
-##5.0.31
+## 5.0.31
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@5.0.30...@spectrum-css/typography@5.0.31)
 
 **Note:** Version bump only for package @spectrum-css/typography
 
 <a name="5.0.30"></a>
-##5.0.30
+## 5.0.30
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@5.0.29...@spectrum-css/typography@5.0.30)
 
 **Note:** Version bump only for package @spectrum-css/typography
 
 <a name="5.0.29"></a>
-##5.0.29
+## 5.0.29
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@5.0.28...@spectrum-css/typography@5.0.29)
 
 **Note:** Version bump only for package @spectrum-css/typography
 
 <a name="5.0.28"></a>
-##5.0.28
+## 5.0.28
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@5.0.27...@spectrum-css/typography@5.0.28)
 
 **Note:** Version bump only for package @spectrum-css/typography
 
 <a name="5.0.27"></a>
-##5.0.27
+## 5.0.27
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@5.0.26...@spectrum-css/typography@5.0.27)
 
 **Note:** Version bump only for package @spectrum-css/typography
 
 <a name="5.0.26"></a>
-##5.0.26
+## 5.0.26
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@5.0.25...@spectrum-css/typography@5.0.26)
 
 **Note:** Version bump only for package @spectrum-css/typography
 
 <a name="5.0.25"></a>
-##5.0.25
+## 5.0.25
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@5.0.24...@spectrum-css/typography@5.0.25)
 
 **Note:** Version bump only for package @spectrum-css/typography
 
 <a name="5.0.24"></a>
-##5.0.24
+## 5.0.24
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@5.0.23...@spectrum-css/typography@5.0.24)
 
 **Note:** Version bump only for package @spectrum-css/typography
 
 <a name="5.0.23"></a>
-##5.0.23
+## 5.0.23
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@5.0.22...@spectrum-css/typography@5.0.23)
 
 **Note:** Version bump only for package @spectrum-css/typography
 
 <a name="5.0.22"></a>
-##5.0.22
+## 5.0.22
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@5.0.21...@spectrum-css/typography@5.0.22)
 
@@ -291,14 +291,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="5.0.21"></a>
-##5.0.21
+## 5.0.21
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@5.0.20...@spectrum-css/typography@5.0.21)
 
 **Note:** Version bump only for package @spectrum-css/typography
 
 <a name="5.0.20"></a>
-##5.0.20
+## 5.0.20
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@5.0.19...@spectrum-css/typography@5.0.20)
 

--- a/components/typography/CHANGELOG.md
+++ b/components/typography/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="6.0.0"></a>
-# 6.0.0
+## 6.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@5.1.5...@spectrum-css/typography@6.0.0)
 
@@ -75,7 +75,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/typography
 
 <a name="5.1.0"></a>
-# 5.1.0
+## 5.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@5.0.50...@spectrum-css/typography@5.1.0)
 
@@ -460,7 +460,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="5.0.0"></a>
 
-# 5.0.0
+## 5.0.0
 
 🗓 2023-04-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@4.0.30...@spectrum-css/typography@5.0.0)
 
@@ -751,7 +751,7 @@ Additionally:
 
 <a name="4.0.0"></a>
 
-# 4.0.0
+## 4.0.0
 
 🗓 2021-09-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@4.0.0-alpha.3...@spectrum-css/typography@4.0.0)
 
@@ -761,7 +761,7 @@ Additionally:
 
 <a name="4.0.0-alpha.3"></a>
 
-# 4.0.0-alpha.3
+## 4.0.0-alpha.3
 
 🗓 2021-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@4.0.0-alpha.2...@spectrum-css/typography@4.0.0-alpha.3)
 
@@ -769,7 +769,7 @@ Additionally:
 
 <a name="4.0.0-alpha.2"></a>
 
-# 4.0.0-alpha.2
+## 4.0.0-alpha.2
 
 🗓 2021-06-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@4.0.0-alpha.1...@spectrum-css/typography@4.0.0-alpha.2)
 
@@ -777,7 +777,7 @@ Additionally:
 
 <a name="4.0.0-alpha.1"></a>
 
-# 4.0.0-alpha.1
+## 4.0.0-alpha.1
 
 🗓 2021-05-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@4.0.0-alpha.0...@spectrum-css/typography@4.0.0-alpha.1)
 
@@ -785,7 +785,7 @@ Additionally:
 
 <a name="4.0.0-alpha.0"></a>
 
-# 4.0.0-alpha.0
+## 4.0.0-alpha.0
 
 🗓 2021-04-27 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@3.0.2...@spectrum-css/typography@4.0.0-alpha.0)
 
@@ -815,7 +815,7 @@ Additionally:
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@3.0.0-beta.1...@spectrum-css/typography@3.0.0)
 
@@ -823,7 +823,7 @@ Additionally:
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@3.0.0-beta.0...@spectrum-css/typography@3.0.0-beta.1)
 
@@ -831,7 +831,7 @@ Additionally:
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@2.1.4-beta.0...@spectrum-css/typography@3.0.0-beta.0)
 
@@ -878,7 +878,7 @@ Additionally:
 
 <a name="2.1.0"></a>
 
-# 2.1.0
+## 2.1.0
 
 🗓 2020-02-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/typography@2.0.3...@spectrum-css/typography@2.1.0)
 
@@ -912,7 +912,7 @@ Additionally:
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/underlay/CHANGELOG.md
+++ b/components/underlay/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="4.0.0"></a>
-# 4.0.0
+## 4.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/underlay@3.2.4...@spectrum-css/underlay@4.0.0)
 
@@ -68,7 +68,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/underlay
 
 <a name="3.2.0"></a>
-# 3.2.0
+## 3.2.0
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/underlay@3.1.0...@spectrum-css/underlay@3.2.0)
 
@@ -77,7 +77,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **overlay,commons:**deprecate overlay; migrate references to commons ([#2429](https://github.com/adobe/spectrum-css/issues/2429))([7eecd96](https://github.com/adobe/spectrum-css/commit/7eecd96))
 
 <a name="3.1.0"></a>
-# 3.1.0
+## 3.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/underlay@3.0.13...@spectrum-css/underlay@3.1.0)
 
@@ -177,7 +177,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/underlay
 
 <a name="3.0.0"></a>
-# 3.0.0
+## 3.0.0
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/underlay@2.1.0...@spectrum-css/underlay@3.0.0)
 
@@ -222,7 +222,7 @@ Additionally:
 - chore(underlay): remove skin import
 
 <a name="2.1.0"></a>
-# 2.1.0
+## 2.1.0
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/underlay@2.0.54...@spectrum-css/underlay@2.1.0)
 
@@ -723,7 +723,7 @@ Additionally:
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/components/underlay/CHANGELOG.md
+++ b/components/underlay/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="4.0.0"></a>
-#4.0.0
+# 4.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/underlay@3.2.4...@spectrum-css/underlay@4.0.0)
 
@@ -40,35 +40,35 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="3.2.4"></a>
-##3.2.4
+## 3.2.4
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/underlay@3.2.3...@spectrum-css/underlay@3.2.4)
 
 **Note:** Version bump only for package @spectrum-css/underlay
 
 <a name="3.2.3"></a>
-##3.2.3
+## 3.2.3
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/underlay@3.2.2...@spectrum-css/underlay@3.2.3)
 
 **Note:** Version bump only for package @spectrum-css/underlay
 
 <a name="3.2.2"></a>
-##3.2.2
+## 3.2.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/underlay@3.2.1...@spectrum-css/underlay@3.2.2)
 
 **Note:** Version bump only for package @spectrum-css/underlay
 
 <a name="3.2.1"></a>
-##3.2.1
+## 3.2.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/underlay
 
 <a name="3.2.0"></a>
-#3.2.0
+# 3.2.0
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/underlay@3.1.0...@spectrum-css/underlay@3.2.0)
 
@@ -77,7 +77,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **overlay,commons:**deprecate overlay; migrate references to commons ([#2429](https://github.com/adobe/spectrum-css/issues/2429))([7eecd96](https://github.com/adobe/spectrum-css/commit/7eecd96))
 
 <a name="3.1.0"></a>
-#3.1.0
+# 3.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/underlay@3.0.13...@spectrum-css/underlay@3.1.0)
 
@@ -86,98 +86,98 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="3.0.13"></a>
-##3.0.13
+## 3.0.13
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/underlay@3.0.12...@spectrum-css/underlay@3.0.13)
 
 **Note:** Version bump only for package @spectrum-css/underlay
 
 <a name="3.0.12"></a>
-##3.0.12
+## 3.0.12
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/underlay@3.0.11...@spectrum-css/underlay@3.0.12)
 
 **Note:** Version bump only for package @spectrum-css/underlay
 
 <a name="3.0.11"></a>
-##3.0.11
+## 3.0.11
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/underlay@3.0.9...@spectrum-css/underlay@3.0.11)
 
 **Note:** Version bump only for package @spectrum-css/underlay
 
 <a name="3.0.10"></a>
-##3.0.10
+## 3.0.10
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/underlay@3.0.9...@spectrum-css/underlay@3.0.10)
 
 **Note:** Version bump only for package @spectrum-css/underlay
 
 <a name="3.0.9"></a>
-##3.0.9
+## 3.0.9
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/underlay@3.0.8...@spectrum-css/underlay@3.0.9)
 
 **Note:** Version bump only for package @spectrum-css/underlay
 
 <a name="3.0.8"></a>
-##3.0.8
+## 3.0.8
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/underlay@3.0.7...@spectrum-css/underlay@3.0.8)
 
 **Note:** Version bump only for package @spectrum-css/underlay
 
 <a name="3.0.7"></a>
-##3.0.7
+## 3.0.7
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/underlay@3.0.6...@spectrum-css/underlay@3.0.7)
 
 **Note:** Version bump only for package @spectrum-css/underlay
 
 <a name="3.0.6"></a>
-##3.0.6
+## 3.0.6
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/underlay@3.0.5...@spectrum-css/underlay@3.0.6)
 
 **Note:** Version bump only for package @spectrum-css/underlay
 
 <a name="3.0.5"></a>
-##3.0.5
+## 3.0.5
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/underlay@3.0.4...@spectrum-css/underlay@3.0.5)
 
 **Note:** Version bump only for package @spectrum-css/underlay
 
 <a name="3.0.4"></a>
-##3.0.4
+## 3.0.4
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/underlay@3.0.3...@spectrum-css/underlay@3.0.4)
 
 **Note:** Version bump only for package @spectrum-css/underlay
 
 <a name="3.0.3"></a>
-##3.0.3
+## 3.0.3
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/underlay@3.0.2...@spectrum-css/underlay@3.0.3)
 
 **Note:** Version bump only for package @spectrum-css/underlay
 
 <a name="3.0.2"></a>
-##3.0.2
+## 3.0.2
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/underlay@3.0.1...@spectrum-css/underlay@3.0.2)
 
 **Note:** Version bump only for package @spectrum-css/underlay
 
 <a name="3.0.1"></a>
-##3.0.1
+## 3.0.1
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/underlay@3.0.0...@spectrum-css/underlay@3.0.1)
 
 **Note:** Version bump only for package @spectrum-css/underlay
 
 <a name="3.0.0"></a>
-#3.0.0
+# 3.0.0
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/underlay@2.1.0...@spectrum-css/underlay@3.0.0)
 
@@ -222,7 +222,7 @@ Additionally:
 - chore(underlay): remove skin import
 
 <a name="2.1.0"></a>
-#2.1.0
+# 2.1.0
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/underlay@2.0.54...@spectrum-css/underlay@2.1.0)
 
@@ -231,21 +231,21 @@ Additionally:
 - **underlay:**background tokens used directory([f557a0f](https://github.com/adobe/spectrum-css/commit/f557a0f))
 
 <a name="2.0.54"></a>
-##2.0.54
+## 2.0.54
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/underlay@2.0.53...@spectrum-css/underlay@2.0.54)
 
 **Note:** Version bump only for package @spectrum-css/underlay
 
 <a name="2.0.53"></a>
-##2.0.53
+## 2.0.53
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/underlay@2.0.52...@spectrum-css/underlay@2.0.53)
 
 **Note:** Version bump only for package @spectrum-css/underlay
 
 <a name="2.0.52"></a>
-##2.0.52
+## 2.0.52
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/underlay@2.0.51...@spectrum-css/underlay@2.0.52)
 
@@ -254,14 +254,14 @@ Additionally:
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="2.0.51"></a>
-##2.0.51
+## 2.0.51
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/underlay@2.0.50...@spectrum-css/underlay@2.0.51)
 
 **Note:** Version bump only for package @spectrum-css/underlay
 
 <a name="2.0.50"></a>
-##2.0.50
+## 2.0.50
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/underlay@2.0.49...@spectrum-css/underlay@2.0.50)
 

--- a/components/well/CHANGELOG.md
+++ b/components/well/CHANGELOG.md
@@ -31,7 +31,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-#5.0.0
+# 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/well@4.1.4...@spectrum-css/well@5.0.0)
 
@@ -46,35 +46,35 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="4.1.4"></a>
-##4.1.4
+## 4.1.4
 🗓
 2024-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/well@4.1.3...@spectrum-css/well@4.1.4)
 
 **Note:** Version bump only for package @spectrum-css/well
 
 <a name="4.1.3"></a>
-##4.1.3
+## 4.1.3
 🗓
 2024-02-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/well@4.1.2...@spectrum-css/well@4.1.3)
 
 **Note:** Version bump only for package @spectrum-css/well
 
 <a name="4.1.2"></a>
-##4.1.2
+## 4.1.2
 🗓
 2024-02-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/well@4.1.1...@spectrum-css/well@4.1.2)
 
 **Note:** Version bump only for package @spectrum-css/well
 
 <a name="4.1.1"></a>
-##4.1.1
+## 4.1.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/well
 
 <a name="4.1.0"></a>
-#4.1.0
+# 4.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/well@4.0.10...@spectrum-css/well@4.1.0)
 
@@ -83,77 +83,77 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*remove theme files without content([1eadd4f](https://github.com/adobe/spectrum-css/commit/1eadd4f))
 
 <a name="4.0.10"></a>
-##4.0.10
+## 4.0.10
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/well@4.0.9...@spectrum-css/well@4.0.10)
 
 **Note:** Version bump only for package @spectrum-css/well
 
 <a name="4.0.9"></a>
-##4.0.9
+## 4.0.9
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/well@4.0.8...@spectrum-css/well@4.0.9)
 
 **Note:** Version bump only for package @spectrum-css/well
 
 <a name="4.0.8"></a>
-##4.0.8
+## 4.0.8
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/well@4.0.6...@spectrum-css/well@4.0.8)
 
 **Note:** Version bump only for package @spectrum-css/well
 
 <a name="4.0.7"></a>
-##4.0.7
+## 4.0.7
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/well@4.0.6...@spectrum-css/well@4.0.7)
 
 **Note:** Version bump only for package @spectrum-css/well
 
 <a name="4.0.6"></a>
-##4.0.6
+## 4.0.6
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/well@4.0.5...@spectrum-css/well@4.0.6)
 
 **Note:** Version bump only for package @spectrum-css/well
 
 <a name="4.0.5"></a>
-##4.0.5
+## 4.0.5
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/well@4.0.4...@spectrum-css/well@4.0.5)
 
 **Note:** Version bump only for package @spectrum-css/well
 
 <a name="4.0.4"></a>
-##4.0.4
+## 4.0.4
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/well@4.0.3...@spectrum-css/well@4.0.4)
 
 **Note:** Version bump only for package @spectrum-css/well
 
 <a name="4.0.3"></a>
-##4.0.3
+## 4.0.3
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/well@4.0.2...@spectrum-css/well@4.0.3)
 
 **Note:** Version bump only for package @spectrum-css/well
 
 <a name="4.0.2"></a>
-##4.0.2
+## 4.0.2
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/well@4.0.1...@spectrum-css/well@4.0.2)
 
 **Note:** Version bump only for package @spectrum-css/well
 
 <a name="4.0.1"></a>
-##4.0.1
+## 4.0.1
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/well@4.0.0...@spectrum-css/well@4.0.1)
 
 **Note:** Version bump only for package @spectrum-css/well
 
 <a name="4.0.0"></a>
-#4.0.0
+# 4.0.0
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/well@3.0.49...@spectrum-css/well@4.0.0)
 
@@ -166,7 +166,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
     		migrates Well to use spectrum-tokens
 
 <a name="3.0.49"></a>
-##3.0.49
+## 3.0.49
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/well@3.0.48...@spectrum-css/well@3.0.49)
 
@@ -175,35 +175,35 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*gulp and build updates ([#2121](https://github.com/adobe/spectrum-css/issues/2121))([03a37f5](https://github.com/adobe/spectrum-css/commit/03a37f5)), closes[#2099](https://github.com/adobe/spectrum-css/issues/2099)
 
 <a name="3.0.48"></a>
-##3.0.48
+## 3.0.48
 🗓
 2023-08-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/well@3.0.47...@spectrum-css/well@3.0.48)
 
 **Note:** Version bump only for package @spectrum-css/well
 
 <a name="3.0.47"></a>
-##3.0.47
+## 3.0.47
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/well@3.0.46...@spectrum-css/well@3.0.47)
 
 **Note:** Version bump only for package @spectrum-css/well
 
 <a name="3.0.46"></a>
-##3.0.46
+## 3.0.46
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/well@3.0.45...@spectrum-css/well@3.0.46)
 
 **Note:** Version bump only for package @spectrum-css/well
 
 <a name="3.0.45"></a>
-##3.0.45
+## 3.0.45
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/well@3.0.44...@spectrum-css/well@3.0.45)
 
 **Note:** Version bump only for package @spectrum-css/well
 
 <a name="3.0.44"></a>
-##3.0.44
+## 3.0.44
 🗓
 2023-06-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/well@3.0.43...@spectrum-css/well@3.0.44)
 
@@ -212,14 +212,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*restore files to pre-formatted state([491dbcb](https://github.com/adobe/spectrum-css/commit/491dbcb))
 
 <a name="3.0.43"></a>
-##3.0.43
+## 3.0.43
 🗓
 2023-06-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/well@3.0.42...@spectrum-css/well@3.0.43)
 
 **Note:** Version bump only for package @spectrum-css/well
 
 <a name="3.0.42"></a>
-##3.0.42
+## 3.0.42
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/well@3.0.41...@spectrum-css/well@3.0.42)
 

--- a/components/well/CHANGELOG.md
+++ b/components/well/CHANGELOG.md
@@ -31,7 +31,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.0.0"></a>
-# 5.0.0
+## 5.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/well@4.1.4...@spectrum-css/well@5.0.0)
 
@@ -74,7 +74,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/well
 
 <a name="4.1.0"></a>
-# 4.1.0
+## 4.1.0
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/well@4.0.10...@spectrum-css/well@4.1.0)
 
@@ -153,7 +153,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/well
 
 <a name="4.0.0"></a>
-# 4.0.0
+## 4.0.0
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/well@3.0.49...@spectrum-css/well@4.0.0)
 
@@ -603,7 +603,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2021-02-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/well@3.0.0-beta.5...@spectrum-css/well@3.0.0)
 
@@ -611,7 +611,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.5"></a>
 
-# 3.0.0-beta.5
+## 3.0.0-beta.5
 
 🗓 2020-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/well@3.0.0-beta.4...@spectrum-css/well@3.0.0-beta.5)
 
@@ -619,7 +619,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.4"></a>
 
-# 3.0.0-beta.4
+## 3.0.0-beta.4
 
 🗓 2020-10-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/well@3.0.0-beta.3...@spectrum-css/well@3.0.0-beta.4)
 
@@ -631,7 +631,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.3"></a>
 
-# 3.0.0-beta.3
+## 3.0.0-beta.3
 
 🗓 2020-09-23 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/well@3.0.0-beta.2...@spectrum-css/well@3.0.0-beta.3)
 
@@ -639,7 +639,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.2"></a>
 
-# 3.0.0-beta.2
+## 3.0.0-beta.2
 
 🗓 2020-05-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/well@3.0.0-beta.1...@spectrum-css/well@3.0.0-beta.2)
 
@@ -647,7 +647,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.1"></a>
 
-# 3.0.0-beta.1
+## 3.0.0-beta.1
 
 🗓 2020-03-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/well@3.0.0-beta.0...@spectrum-css/well@3.0.0-beta.1)
 
@@ -655,7 +655,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="3.0.0-beta.0"></a>
 
-# 3.0.0-beta.0
+## 3.0.0-beta.0
 
 🗓 2020-03-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/well@2.0.5...@spectrum-css/well@3.0.0-beta.0)
 
@@ -707,7 +707,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2019-10-08
 

--- a/generator/CHANGELOG.md
+++ b/generator/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="3.0.0"></a>
-# 3.0.0
+## 3.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/generator@2.1.0...@spectrum-css/generator@3.0.0)
 
@@ -37,7 +37,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="2.1.0"></a>
-# 2.1.0
+## 2.1.0
 🗓
 2024-02-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/generator@2.0.20...@spectrum-css/generator@2.1.0)
 
@@ -182,7 +182,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2023-02-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/generator@1.0.5...@spectrum-css/generator@2.0.0)
 

--- a/generator/CHANGELOG.md
+++ b/generator/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="3.0.0"></a>
-#3.0.0
+# 3.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/generator@2.1.0...@spectrum-css/generator@3.0.0)
 
@@ -37,7 +37,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="2.1.0"></a>
-#2.1.0
+# 2.1.0
 🗓
 2024-02-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/generator@2.0.20...@spectrum-css/generator@2.1.0)
 
@@ -46,70 +46,70 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **preview:**add figma support to storybook [CSS-284] ([#1680](https://github.com/adobe/spectrum-css/issues/1680))([3c6194e](https://github.com/adobe/spectrum-css/commit/3c6194e))
 
 <a name="2.0.20"></a>
-##2.0.20
+## 2.0.20
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/generator
 
 <a name="2.0.19"></a>
-##2.0.19
+## 2.0.19
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/generator@2.0.18...@spectrum-css/generator@2.0.19)
 
 **Note:** Version bump only for package @spectrum-css/generator
 
 <a name="2.0.18"></a>
-##2.0.18
+## 2.0.18
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/generator@2.0.14...@spectrum-css/generator@2.0.18)
 
 **Note:** Version bump only for package @spectrum-css/generator
 
 <a name="2.0.17"></a>
-##2.0.17
+## 2.0.17
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/generator@2.0.14...@spectrum-css/generator@2.0.17)
 
 **Note:** Version bump only for package @spectrum-css/generator
 
 <a name="2.0.14"></a>
-##2.0.14
+## 2.0.14
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/generator@2.0.13...@spectrum-css/generator@2.0.14)
 
 **Note:** Version bump only for package @spectrum-css/generator
 
 <a name="2.0.13"></a>
-##2.0.13
+## 2.0.13
 🗓
 2023-08-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/generator@2.0.12...@spectrum-css/generator@2.0.13)
 
 **Note:** Version bump only for package @spectrum-css/generator
 
 <a name="2.0.12"></a>
-##2.0.12
+## 2.0.12
 🗓
 2023-07-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/generator@2.0.11...@spectrum-css/generator@2.0.12)
 
 **Note:** Version bump only for package @spectrum-css/generator
 
 <a name="2.0.11"></a>
-##2.0.11
+## 2.0.11
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/generator@2.0.10...@spectrum-css/generator@2.0.11)
 
 **Note:** Version bump only for package @spectrum-css/generator
 
 <a name="2.0.10"></a>
-##2.0.10
+## 2.0.10
 🗓
 2023-06-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/generator@2.0.9...@spectrum-css/generator@2.0.10)
 
 **Note:** Version bump only for package @spectrum-css/generator
 
 <a name="2.0.9"></a>
-##2.0.9
+## 2.0.9
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/generator@2.0.8...@spectrum-css/generator@2.0.9)
 
@@ -118,7 +118,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **generator:**restore files to pre-formatted state([189ced1](https://github.com/adobe/spectrum-css/commit/189ced1))
 
 <a name="2.0.8"></a>
-##2.0.8
+## 2.0.8
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/generator@2.0.7...@spectrum-css/generator@2.0.8)
 

--- a/plugins/postcss-combininator/CHANGELOG.md
+++ b/plugins/postcss-combininator/CHANGELOG.md
@@ -37,7 +37,7 @@ Upgrade to PostCSS v8 [bd6c40e](https://github.com/adobe/spectrum-css/commit/bd6
 
 <a name="1.0.0"></a>
 
-# 1.0.0
+## 1.0.0
 
 🗓 2023-03-27 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/postcss-combininator@1.0.0-beta.1...postcss-combininator@1.0.0)
 
@@ -45,7 +45,7 @@ Upgrade to PostCSS v8 [bd6c40e](https://github.com/adobe/spectrum-css/commit/bd6
 
 <a name="1.0.0-beta.2"></a>
 
-# 1.0.0-beta.2
+## 1.0.0-beta.2
 
 🗓 2023-03-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/postcss-combininator@1.0.0-beta.1...postcss-combininator@1.0.0-beta.2)
 
@@ -53,7 +53,7 @@ Upgrade to PostCSS v8 [bd6c40e](https://github.com/adobe/spectrum-css/commit/bd6
 
 <a name="1.0.0-beta.1"></a>
 
-# 1.0.0-beta.1
+## 1.0.0-beta.1
 
 🗓 2022-06-16
 

--- a/plugins/postcss-splitinator/CHANGELOG.md
+++ b/plugins/postcss-splitinator/CHANGELOG.md
@@ -37,7 +37,7 @@ Upgrade to PostCSS v8 [bd6c40e](https://github.com/adobe/spectrum-css/commit/bd6
 
 <a name="1.0.0"></a>
 
-# 1.0.0
+## 1.0.0
 
 🗓 2023-03-27 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/postcss-splitinator@1.0.0-beta.1...postcss-splitinator@1.0.0)
 
@@ -45,7 +45,7 @@ Upgrade to PostCSS v8 [bd6c40e](https://github.com/adobe/spectrum-css/commit/bd6
 
 <a name="1.0.0-beta.2"></a>
 
-# 1.0.0-beta.2
+## 1.0.0-beta.2
 
 🗓 2023-03-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/postcss-splitinator@1.0.0-beta.1...postcss-splitinator@1.0.0-beta.2)
 
@@ -53,7 +53,7 @@ Upgrade to PostCSS v8 [bd6c40e](https://github.com/adobe/spectrum-css/commit/bd6
 
 <a name="1.0.0-beta.1"></a>
 
-# 1.0.0-beta.1
+## 1.0.0-beta.1
 
 🗓 2022-06-16
 

--- a/plugins/stylelint-no-missing-var/CHANGELOG.md
+++ b/plugins/stylelint-no-missing-var/CHANGELOG.md
@@ -17,7 +17,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-tools/stylelint-no-missing-var
 
 <a name="1.3.0"></a>
-# 1.3.0
+## 1.3.0
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-tools/stylelint-no-missing-var@1.2.0...@spectrum-tools/stylelint-no-missing-var@1.3.0)
 
@@ -26,7 +26,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*migrate build packages to postcss v8 ([#2460](https://github.com/adobe/spectrum-css/issues/2460))([bd6c40e](https://github.com/adobe/spectrum-css/commit/bd6c40e))
 
 <a name="1.2.0"></a>
-# 1.2.0
+## 1.2.0
 🗓
 2024-01-16
 
@@ -35,7 +35,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*add stylelint ([#1787](https://github.com/adobe/spectrum-css/issues/1787))([a450904](https://github.com/adobe/spectrum-css/commit/a450904))
 
 <a name="1.1.0"></a>
-# 1.1.0
+## 1.1.0
 🗓
 2023-06-01
 

--- a/plugins/stylelint-no-missing-var/CHANGELOG.md
+++ b/plugins/stylelint-no-missing-var/CHANGELOG.md
@@ -10,14 +10,14 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="1.3.1"></a>
-##1.3.1
+## 1.3.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-tools/stylelint-no-missing-var
 
 <a name="1.3.0"></a>
-#1.3.0
+# 1.3.0
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-tools/stylelint-no-missing-var@1.2.0...@spectrum-tools/stylelint-no-missing-var@1.3.0)
 
@@ -26,7 +26,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*migrate build packages to postcss v8 ([#2460](https://github.com/adobe/spectrum-css/issues/2460))([bd6c40e](https://github.com/adobe/spectrum-css/commit/bd6c40e))
 
 <a name="1.2.0"></a>
-#1.2.0
+# 1.2.0
 🗓
 2024-01-16
 
@@ -35,7 +35,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*add stylelint ([#1787](https://github.com/adobe/spectrum-css/issues/1787))([a450904](https://github.com/adobe/spectrum-css/commit/a450904))
 
 <a name="1.1.0"></a>
-#1.1.0
+# 1.1.0
 🗓
 2023-06-01
 

--- a/plugins/stylelint-no-unknown-custom-properties/CHANGELOG.md
+++ b/plugins/stylelint-no-unknown-custom-properties/CHANGELOG.md
@@ -24,7 +24,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-tools/stylelint-no-unknown-custom-properties
 
 <a name="1.3.0"></a>
-# 1.3.0
+## 1.3.0
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-tools/stylelint-no-unknown-custom-properties@1.2.2...@spectrum-tools/stylelint-no-unknown-custom-properties@1.3.0)
 
@@ -57,7 +57,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="1.2.0"></a>
 
-# 1.2.0
+## 1.2.0
 
 🗓 2021-03-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/postcss-dropunusedvars@1.1.0...postcss-dropunusedvars@1.2.0)
 
@@ -73,7 +73,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="1.1.0"></a>
 
-# 1.1.0
+## 1.1.0
 
 🗓 2020-12-04
 

--- a/plugins/stylelint-no-unknown-custom-properties/CHANGELOG.md
+++ b/plugins/stylelint-no-unknown-custom-properties/CHANGELOG.md
@@ -10,21 +10,21 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="1.3.2"></a>
-##1.3.2
+## 1.3.2
 🗓
 2024-02-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-tools/stylelint-no-unknown-custom-properties@1.3.1...@spectrum-tools/stylelint-no-unknown-custom-properties@1.3.2)
 
 **Note:** Version bump only for package @spectrum-tools/stylelint-no-unknown-custom-properties
 
 <a name="1.3.1"></a>
-##1.3.1
+## 1.3.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-tools/stylelint-no-unknown-custom-properties
 
 <a name="1.3.0"></a>
-#1.3.0
+# 1.3.0
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-tools/stylelint-no-unknown-custom-properties@1.2.2...@spectrum-tools/stylelint-no-unknown-custom-properties@1.3.0)
 
@@ -33,7 +33,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*migrate build packages to postcss v8 ([#2460](https://github.com/adobe/spectrum-css/issues/2460))([bd6c40e](https://github.com/adobe/spectrum-css/commit/bd6c40e))
 
 <a name="1.2.2"></a>
-##1.2.2
+## 1.2.2
 🗓
 2024-01-16
 

--- a/plugins/stylelint-no-unused-custom-properties/CHANGELOG.md
+++ b/plugins/stylelint-no-unused-custom-properties/CHANGELOG.md
@@ -10,14 +10,14 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="1.3.1"></a>
-##1.3.1
+## 1.3.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-tools/stylelint-no-unused-custom-properties
 
 <a name="1.3.0"></a>
-#1.3.0
+# 1.3.0
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-tools/stylelint-no-unused-custom-properties@1.2.2...@spectrum-tools/stylelint-no-unused-custom-properties@1.3.0)
 
@@ -26,7 +26,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*migrate build packages to postcss v8 ([#2460](https://github.com/adobe/spectrum-css/issues/2460))([bd6c40e](https://github.com/adobe/spectrum-css/commit/bd6c40e))
 
 <a name="1.2.2"></a>
-##1.2.2
+## 1.2.2
 🗓
 2024-01-16
 

--- a/plugins/stylelint-no-unused-custom-properties/CHANGELOG.md
+++ b/plugins/stylelint-no-unused-custom-properties/CHANGELOG.md
@@ -17,7 +17,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-tools/stylelint-no-unused-custom-properties
 
 <a name="1.3.0"></a>
-# 1.3.0
+## 1.3.0
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-tools/stylelint-no-unused-custom-properties@1.2.2...@spectrum-tools/stylelint-no-unused-custom-properties@1.3.0)
 
@@ -50,7 +50,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="1.2.0"></a>
 
-# 1.2.0
+## 1.2.0
 
 🗓 2021-03-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/postcss-dropunusedvars@1.1.0...postcss-dropunusedvars@1.2.0)
 
@@ -66,7 +66,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="1.1.0"></a>
 
-# 1.1.0
+## 1.1.0
 
 🗓 2020-12-04
 

--- a/tokens/CHANGELOG.md
+++ b/tokens/CHANGELOG.md
@@ -43,7 +43,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="14.0.0"></a>
-# 14.0.0
+## 14.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@13.2.0...@spectrum-css/tokens@14.0.0)
 
@@ -58,7 +58,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="13.2.0"></a>
-# 13.2.0
+## 13.2.0
 🗓
 2024-02-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@13.1.2...@spectrum-css/tokens@13.2.0)
 
@@ -81,7 +81,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/tokens
 
 <a name="13.1.0"></a>
-# 13.1.0
+## 13.1.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@13.0.9...@spectrum-css/tokens@13.1.0)
 
@@ -144,7 +144,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/tokens
 
 <a name="13.0.0"></a>
-# 13.0.0
+## 13.0.0
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@12.0.0...@spectrum-css/tokens@13.0.0)
 
@@ -164,7 +164,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
       		migrate asset card to updated token system
 
 <a name="12.0.0"></a>
-# 12.0.0
+## 12.0.0
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@11.4.0...@spectrum-css/tokens@12.0.0)
 
@@ -195,7 +195,7 @@ chore: updated css properties
 - docs(modal): regenerate mods
 
 <a name="11.4.0"></a>
-# 11.4.0
+## 11.4.0
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@11.3.7...@spectrum-css/tokens@11.4.0)
 
@@ -255,7 +255,7 @@ chore: updated css properties
 **Note:** Version bump only for package @spectrum-css/tokens
 
 <a name="11.3.0"></a>
-# 11.3.0
+## 11.3.0
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@11.2.2...@spectrum-css/tokens@11.3.0)
 
@@ -278,7 +278,7 @@ chore: updated css properties
 **Note:** Version bump only for package @spectrum-css/tokens
 
 <a name="11.2.0"></a>
-# 11.2.0
+## 11.2.0
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@11.1.0...@spectrum-css/tokens@11.2.0)
 
@@ -291,7 +291,7 @@ chore: updated css properties
 \*revert prettier ([#2074](https://github.com/adobe/spectrum-css/issues/2074))([ebb98df](https://github.com/adobe/spectrum-css/commit/ebb98df))
 
 <a name="11.1.0"></a>
-# 11.1.0
+## 11.1.0
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@11.0.2...@spectrum-css/tokens@11.1.0)
 
@@ -314,7 +314,7 @@ chore: updated css properties
 **Note:** Version bump only for package @spectrum-css/tokens
 
 <a name="11.0.0"></a>
-# 11.0.0
+## 11.0.0
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@10.2.2...@spectrum-css/tokens@11.0.0)
 
@@ -350,7 +350,7 @@ chore: updated css properties
 **Note:** Version bump only for package @spectrum-css/tokens
 
 <a name="10.2.0"></a>
-# 10.2.0
+## 10.2.0
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@10.1.2...@spectrum-css/tokens@10.2.0)
 
@@ -375,7 +375,7 @@ chore: updated css properties
 
 <a name="10.1.0"></a>
 
-# 10.1.0
+## 10.1.0
 
 🗓 2023-05-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@10.0.0...@spectrum-css/tokens@10.1.0)
 
@@ -385,7 +385,7 @@ chore: updated css properties
 
 <a name="10.0.0"></a>
 
-# 10.0.0
+## 10.0.0
 
 🗓 2023-05-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@9.3.0...@spectrum-css/tokens@10.0.0)
 
@@ -402,7 +402,7 @@ chore: updated css properties
 
 <a name="9.3.0"></a>
 
-# 9.3.0
+## 9.3.0
 
 🗓 2023-05-08 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@9.2.0...@spectrum-css/tokens@9.3.0)
 
@@ -412,7 +412,7 @@ chore: updated css properties
 
 <a name="9.2.0"></a>
 
-# 9.2.0
+## 9.2.0
 
 🗓 2023-05-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@9.1.0...@spectrum-css/tokens@9.2.0)
 
@@ -422,7 +422,7 @@ chore: updated css properties
 
 <a name="9.1.0"></a>
 
-# 9.1.0
+## 9.1.0
 
 🗓 2023-05-02 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@9.0.4...@spectrum-css/tokens@9.1.0)
 
@@ -464,7 +464,7 @@ chore: updated css properties
 
 <a name="9.0.0"></a>
 
-# 9.0.0
+## 9.0.0
 
 🗓 2023-04-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@8.1.1...@spectrum-css/tokens@9.0.0)
 
@@ -489,7 +489,7 @@ chore: updated css properties
 
 <a name="8.1.0"></a>
 
-# 8.1.0
+## 8.1.0
 
 🗓 2023-04-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@8.0.4...@spectrum-css/tokens@8.1.0)
 
@@ -531,7 +531,7 @@ chore: updated css properties
 
 <a name="8.0.0"></a>
 
-# 8.0.0
+## 8.0.0
 
 🗓 2023-04-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@7.7.0...@spectrum-css/tokens@8.0.0)
 
@@ -545,7 +545,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="7.7.0"></a>
 
-# 7.7.0
+## 7.7.0
 
 🗓 2023-03-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@7.6.1...@spectrum-css/tokens@7.7.0)
 
@@ -565,7 +565,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="7.6.0"></a>
 
-# 7.6.0
+## 7.6.0
 
 🗓 2023-03-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@7.5.1...@spectrum-css/tokens@7.6.0)
 
@@ -583,7 +583,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="7.5.0"></a>
 
-# 7.5.0
+## 7.5.0
 
 🗓 2023-03-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@7.4.0...@spectrum-css/tokens@7.5.0)
 
@@ -593,7 +593,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="7.4.0"></a>
 
-# 7.4.0
+## 7.4.0
 
 🗓 2023-03-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@7.3.0...@spectrum-css/tokens@7.4.0)
 
@@ -603,7 +603,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="7.3.0"></a>
 
-# 7.3.0
+## 7.3.0
 
 🗓 2023-02-28 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@7.2.0...@spectrum-css/tokens@7.3.0)
 
@@ -613,7 +613,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="7.2.0"></a>
 
-# 7.2.0
+## 7.2.0
 
 🗓 2023-02-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@7.1.0...@spectrum-css/tokens@7.2.0)
 
@@ -623,7 +623,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="7.1.0"></a>
 
-# 7.1.0
+## 7.1.0
 
 🗓 2023-02-21 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@7.0.0...@spectrum-css/tokens@7.1.0)
 
@@ -633,7 +633,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="7.0.0"></a>
 
-# 7.0.0
+## 7.0.0
 
 🗓 2023-02-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@6.3.0...@spectrum-css/tokens@7.0.0)
 
@@ -645,7 +645,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="6.3.0"></a>
 
-# 6.3.0
+## 6.3.0
 
 🗓 2023-01-25 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@6.2.2...@spectrum-css/tokens@6.3.0)
 
@@ -671,7 +671,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="6.2.0"></a>
 
-# 6.2.0
+## 6.2.0
 
 🗓 2023-01-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@6.1.0...@spectrum-css/tokens@6.2.0)
 
@@ -681,7 +681,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="6.1.0"></a>
 
-# 6.1.0
+## 6.1.0
 
 🗓 2022-12-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@6.0.0...@spectrum-css/tokens@6.1.0)
 
@@ -691,7 +691,7 @@ Co-authored-by: castastrophe <castastrophe@users.noreply.github.com>
 
 <a name="6.0.0"></a>
 
-# 6.0.0
+## 6.0.0
 
 🗓 2022-12-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@5.0.0...@spectrum-css/tokens@6.0.0)
 
@@ -707,7 +707,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="5.0.0"></a>
 
-# 5.0.0
+## 5.0.0
 
 🗓 2022-11-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@4.0.0...@spectrum-css/tokens@5.0.0)
 
@@ -719,7 +719,7 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 <a name="4.0.0"></a>
 
-# 4.0.0
+## 4.0.0
 
 🗓 2022-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@3.0.0...@spectrum-css/tokens@4.0.0)
 
@@ -738,7 +738,7 @@ Full release notes can be found here: https://github.com/adobe/spectrum-tokens/r
 
 <a name="3.0.0"></a>
 
-# 3.0.0
+## 3.0.0
 
 🗓 2022-09-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@2.0.0...@spectrum-css/tokens@3.0.0)
 
@@ -752,7 +752,7 @@ Also, adds t-shirt sizes
 
 <a name="2.0.0"></a>
 
-# 2.0.0
+## 2.0.0
 
 🗓 2022-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@1.0.8...@spectrum-css/tokens@2.0.0)
 
@@ -830,7 +830,7 @@ Also, adds t-shirt sizes
 
 <a name="1.0.0"></a>
 
-# 1.0.0
+## 1.0.0
 
 🗓 2022-06-16
 

--- a/tokens/CHANGELOG.md
+++ b/tokens/CHANGELOG.md
@@ -43,7 +43,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="14.0.0"></a>
-#14.0.0
+# 14.0.0
 🗓
 2024-04-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@13.2.0...@spectrum-css/tokens@14.0.0)
 
@@ -58,7 +58,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Imports added to index.css and themes/express.css
 
 <a name="13.2.0"></a>
-#13.2.0
+# 13.2.0
 🗓
 2024-02-20 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@13.1.2...@spectrum-css/tokens@13.2.0)
 
@@ -67,21 +67,21 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **tokens:**use spectrum-tokens@12.24.0([b20ebb6](https://github.com/adobe/spectrum-css/commit/b20ebb6))
 
 <a name="13.1.2"></a>
-##13.1.2
+## 13.1.2
 🗓
 2024-02-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@13.1.1...@spectrum-css/tokens@13.1.2)
 
 **Note:** Version bump only for package @spectrum-css/tokens
 
 <a name="13.1.1"></a>
-##13.1.1
+## 13.1.1
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/tokens
 
 <a name="13.1.0"></a>
-#13.1.0
+# 13.1.0
 🗓
 2024-02-05 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@13.0.9...@spectrum-css/tokens@13.1.0)
 
@@ -90,7 +90,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **tokens:**add icon xxl and xxs tokens([b2d71bc](https://github.com/adobe/spectrum-css/commit/b2d71bc))
 
 <a name="13.0.9"></a>
-##13.0.9
+## 13.0.9
 🗓
 2024-01-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@13.0.8...@spectrum-css/tokens@13.0.9)
 
@@ -99,7 +99,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 \*deprecate logical transform plugin ([#2437](https://github.com/adobe/spectrum-css/issues/2437))([ff5dda6](https://github.com/adobe/spectrum-css/commit/ff5dda6))
 
 <a name="13.0.8"></a>
-##13.0.8
+## 13.0.8
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@13.0.7...@spectrum-css/tokens@13.0.8)
 
@@ -109,42 +109,42 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
   **tokens:**dependency updates([f9395a3](https://github.com/adobe/spectrum-css/commit/f9395a3))
 
 <a name="13.0.7"></a>
-##13.0.7
+## 13.0.7
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@13.0.6...@spectrum-css/tokens@13.0.7)
 
 **Note:** Version bump only for package @spectrum-css/tokens
 
 <a name="13.0.6"></a>
-##13.0.6
+## 13.0.6
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@13.0.5...@spectrum-css/tokens@13.0.6)
 
 **Note:** Version bump only for package @spectrum-css/tokens
 
 <a name="13.0.5"></a>
-##13.0.5
+## 13.0.5
 🗓
 2023-12-04 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@13.0.4...@spectrum-css/tokens@13.0.5)
 
 **Note:** Version bump only for package @spectrum-css/tokens
 
 <a name="13.0.4"></a>
-##13.0.4
+## 13.0.4
 🗓
 2023-11-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@13.0.0...@spectrum-css/tokens@13.0.4)
 
 **Note:** Version bump only for package @spectrum-css/tokens
 
 <a name="13.0.3"></a>
-##13.0.3
+## 13.0.3
 🗓
 2023-11-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@13.0.0...@spectrum-css/tokens@13.0.3)
 
 **Note:** Version bump only for package @spectrum-css/tokens
 
 <a name="13.0.0"></a>
-#13.0.0
+# 13.0.0
 🗓
 2023-11-09 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@12.0.0...@spectrum-css/tokens@13.0.0)
 
@@ -164,7 +164,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
       		migrate asset card to updated token system
 
 <a name="12.0.0"></a>
-#12.0.0
+# 12.0.0
 🗓
 2023-10-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@11.4.0...@spectrum-css/tokens@12.0.0)
 
@@ -195,7 +195,7 @@ chore: updated css properties
 - docs(modal): regenerate mods
 
 <a name="11.4.0"></a>
-#11.4.0
+# 11.4.0
 🗓
 2023-09-26 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@11.3.7...@spectrum-css/tokens@11.4.0)
 
@@ -204,21 +204,21 @@ chore: updated css properties
 - **tokens:**adds ui icons tokens ([#2186](https://github.com/adobe/spectrum-css/issues/2186))([732e573](https://github.com/adobe/spectrum-css/commit/732e573))
 
 <a name="11.3.7"></a>
-##11.3.7
+## 11.3.7
 🗓
 2023-09-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@11.3.6...@spectrum-css/tokens@11.3.7)
 
 **Note:** Version bump only for package @spectrum-css/tokens
 
 <a name="11.3.6"></a>
-##11.3.6
+## 11.3.6
 🗓
 2023-09-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@11.3.5...@spectrum-css/tokens@11.3.6)
 
 **Note:** Version bump only for package @spectrum-css/tokens
 
 <a name="11.3.5"></a>
-##11.3.5
+## 11.3.5
 🗓
 2023-09-13 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@11.3.4...@spectrum-css/tokens@11.3.5)
 
@@ -227,35 +227,35 @@ chore: updated css properties
 - **well:**missing semicolons in custom vars ([#2163](https://github.com/adobe/spectrum-css/issues/2163))([814c49e](https://github.com/adobe/spectrum-css/commit/814c49e))
 
 <a name="11.3.4"></a>
-##11.3.4
+## 11.3.4
 🗓
 2023-09-07 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@11.3.3...@spectrum-css/tokens@11.3.4)
 
 **Note:** Version bump only for package @spectrum-css/tokens
 
 <a name="11.3.3"></a>
-##11.3.3
+## 11.3.3
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@11.3.2...@spectrum-css/tokens@11.3.3)
 
 **Note:** Version bump only for package @spectrum-css/tokens
 
 <a name="11.3.2"></a>
-##11.3.2
+## 11.3.2
 🗓
 2023-08-31 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@11.3.1...@spectrum-css/tokens@11.3.2)
 
 **Note:** Version bump only for package @spectrum-css/tokens
 
 <a name="11.3.1"></a>
-##11.3.1
+## 11.3.1
 🗓
 2023-08-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@11.3.0...@spectrum-css/tokens@11.3.1)
 
 **Note:** Version bump only for package @spectrum-css/tokens
 
 <a name="11.3.0"></a>
-#11.3.0
+# 11.3.0
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@11.2.2...@spectrum-css/tokens@11.3.0)
 
@@ -264,21 +264,21 @@ chore: updated css properties
 - **tokens:**update to spectrum-tokens v12.17.0 ([#2118](https://github.com/adobe/spectrum-css/issues/2118))([57d1d93](https://github.com/adobe/spectrum-css/commit/57d1d93))
 
 <a name="11.2.2"></a>
-##11.2.2
+## 11.2.2
 🗓
 2023-08-22 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@11.2.0...@spectrum-css/tokens@11.2.2)
 
 **Note:** Version bump only for package @spectrum-css/tokens
 
 <a name="11.2.1"></a>
-##11.2.1
+## 11.2.1
 🗓
 2023-08-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@11.2.0...@spectrum-css/tokens@11.2.1)
 
 **Note:** Version bump only for package @spectrum-css/tokens
 
 <a name="11.2.0"></a>
-#11.2.0
+# 11.2.0
 🗓
 2023-08-10 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@11.1.0...@spectrum-css/tokens@11.2.0)
 
@@ -291,7 +291,7 @@ chore: updated css properties
 \*revert prettier ([#2074](https://github.com/adobe/spectrum-css/issues/2074))([ebb98df](https://github.com/adobe/spectrum-css/commit/ebb98df))
 
 <a name="11.1.0"></a>
-#11.1.0
+# 11.1.0
 🗓
 2023-08-03 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@11.0.2...@spectrum-css/tokens@11.1.0)
 
@@ -300,21 +300,21 @@ chore: updated css properties
 - **tokens:**update to spectrum tokens v12.16.0 ([#2064](https://github.com/adobe/spectrum-css/issues/2064))([75ffb63](https://github.com/adobe/spectrum-css/commit/75ffb63))
 
 <a name="11.0.2"></a>
-##11.0.2
+## 11.0.2
 🗓
 2023-07-24 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@11.0.1...@spectrum-css/tokens@11.0.2)
 
 **Note:** Version bump only for package @spectrum-css/tokens
 
 <a name="11.0.1"></a>
-##11.0.1
+## 11.0.1
 🗓
 2023-07-17 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@11.0.0...@spectrum-css/tokens@11.0.1)
 
 **Note:** Version bump only for package @spectrum-css/tokens
 
 <a name="11.0.0"></a>
-#11.0.0
+# 11.0.0
 🗓
 2023-07-14 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@10.2.2...@spectrum-css/tokens@11.0.0)
 
@@ -334,7 +334,7 @@ chore: updated css properties
   syntax that Spectrum CSS had used previously.
 
 <a name="10.2.2"></a>
-##10.2.2
+## 10.2.2
 🗓
 2023-07-11 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@10.2.1...@spectrum-css/tokens@10.2.2)
 
@@ -343,14 +343,14 @@ chore: updated css properties
 \*revert prettier version bump ([#2004](https://github.com/adobe/spectrum-css/issues/2004))([29b179c](https://github.com/adobe/spectrum-css/commit/29b179c))
 
 <a name="10.2.1"></a>
-##10.2.1
+## 10.2.1
 🗓
 2023-06-29 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@10.2.0...@spectrum-css/tokens@10.2.1)
 
 **Note:** Version bump only for package @spectrum-css/tokens
 
 <a name="10.2.0"></a>
-#10.2.0
+# 10.2.0
 🗓
 2023-06-15 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@10.1.2...@spectrum-css/tokens@10.2.0)
 
@@ -359,7 +359,7 @@ chore: updated css properties
 - **tokens:**update to spectrum-tokens v12.12.0([1bf989f](https://github.com/adobe/spectrum-css/commit/1bf989f))
 
 <a name="10.1.2"></a>
-##10.1.2
+## 10.1.2
 🗓
 2023-06-01 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/tokens@10.1.1...@spectrum-css/tokens@10.1.2)
 

--- a/ui-icons/CHANGELOG.md
+++ b/ui-icons/CHANGELOG.md
@@ -4,21 +4,21 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="1.1.2"></a>
-##1.1.2
+## 1.1.2
 🗓
 2024-02-06
 
 **Note:** Version bump only for package @spectrum-css/ui-icons
 
 <a name="1.1.1"></a>
-##1.1.1
+## 1.1.1
 🗓
 2024-01-16 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/ui-icons@1.1.0...@spectrum-css/ui-icons@1.1.1)
 
 **Note:** Version bump only for package @spectrum-css/ui-icons
 
 <a name="1.1.0"></a>
-#1.1.0
+# 1.1.0
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/ui-icons@0.1.0...@spectrum-css/ui-icons@1.1.0)
 
@@ -27,7 +27,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **ui-icons:**graduate to 1.0 release ([#2366](https://github.com/adobe/spectrum-css/issues/2366))([afd369a](https://github.com/adobe/spectrum-css/commit/afd369a))
 
 <a name="0.1.0"></a>
-#0.1.0
+# 0.1.0
 🗓
 2023-12-12
 

--- a/ui-icons/CHANGELOG.md
+++ b/ui-icons/CHANGELOG.md
@@ -18,7 +18,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package @spectrum-css/ui-icons
 
 <a name="1.1.0"></a>
-# 1.1.0
+## 1.1.0
 🗓
 2023-12-12 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/ui-icons@0.1.0...@spectrum-css/ui-icons@1.1.0)
 
@@ -27,7 +27,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **ui-icons:**graduate to 1.0 release ([#2366](https://github.com/adobe/spectrum-css/issues/2366))([afd369a](https://github.com/adobe/spectrum-css/commit/afd369a))
 
 <a name="0.1.0"></a>
-# 0.1.0
+## 0.1.0
 🗓
 2023-12-12
 


### PR DESCRIPTION
## Description

Improves formatting of the version headings within all of the change log markdown files.

### Fix missing space before version number headings

Changelogs written in markdown format were displaying oddly in many places, because some of the headings (written as `##` and `#`) did not have a space afterwards, before the version number text. This was causing the text to not display as a heading. This also prevented the automatic anchor links that appear for the versions in GitHub.

Example before: `##4.2.6`
Example after:  `## 4.2.6`

Example before: `#1.0.1`
Example after:  `# 1.0.1`
    
### Use consistent heading level two for versions

Versions were mixing H1 (`#`) for major and minor version releases, with H2 (`##`) for patch releases. This wasn't the best semantic structure or visual formatting because for example, the H2s for 3.x releases were below an h1 for the 4.0 release. Some of the newer change log entries were also already using H2s for minor versions. Most of the common standards for change log formats that I could find use the same heading level for all versions.

This replaces the H1s in the change log markdown files with H2s, so all of of the version numbers now use H2s.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [x] Only Change Log markdown files are modified
- [x] The content (versions) remain unmodified; only the formatting has changed
- [x] View file(s) in GitHub or preview in VS code, and H2s that were previously showing as plain text are now showing as headings. Formatting of headings looks consistent and correct.

## Screenshots

Examples of how the change logs were appearing previously, with the missing spaces:

Example 1             |  Example 2 (see "5.0")
:-------------------------:|:-------------------------:
![Screenshot 2024-06-03 at 11 51 35 AM](https://github.com/adobe/spectrum-css/assets/965114/e0af05f3-c319-488a-a093-7c1f4aba1eeb)  |  ![Screenshot 2024-06-03 at 2 08 07 PM](https://github.com/adobe/spectrum-css/assets/965114/dffaa22d-8eba-44d1-ad00-8f35b3658560)

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
