### PR TITLE
chore: remove migrated status in storybook

### DIFF
--- a/.storybook/deprecated/searchwithin/searchwithin.stories.js
+++ b/.storybook/deprecated/searchwithin/searchwithin.stories.js
@@ -128,7 +128,6 @@ export default {
 		rootClass: "spectrum-SearchWithin",
 		isOpen: false,
 		isQuiet: false,
-		isDisabled: false,
 		size: "m",
 		label: "All",
 		placeholder: "Search",

--- a/components/accordion/stories/accordion.stories.js
+++ b/components/accordion/stories/accordion.stories.js
@@ -141,9 +141,6 @@ export default {
 		actions: {
 			handles: ["click .spectrum-Accordion-item"],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/actionbar/stories/actionbar.stories.js
+++ b/components/actionbar/stories/actionbar.stories.js
@@ -73,9 +73,6 @@ export default {
 				...ActionButton.parameters.actions.handles,
 			],
 		},
-		status: {
-			type: "migrated",
-		},
 		// Getting the Figma link: https://help.figma.com/hc/en-us/articles/360045003494-Storybook-and-Figma
 		design: {
 			type: "figma",

--- a/components/actionbutton/stories/actionbutton.stories.js
+++ b/components/actionbutton/stories/actionbutton.stories.js
@@ -147,9 +147,6 @@ export default {
 		actions: {
 			handles: ["click .spectrum-ActionButton:not([disabled])"],
 		},
-		status: {
-			type: "migrated",
-		},
 		html: {
 			root: "#render-root"
 		}

--- a/components/actiongroup/stories/actiongroup.stories.js
+++ b/components/actiongroup/stories/actiongroup.stories.js
@@ -65,9 +65,6 @@ export default {
 		actions: {
 			handles: [...ActionButton.parameters.actions.handles],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/actionmenu/stories/actionmenu.stories.js
+++ b/components/actionmenu/stories/actionmenu.stories.js
@@ -72,9 +72,6 @@ export default {
 				...Menu.parameters.actions.handles,
 			],
 		},
-		status: {
-			type: "migrated",
-		},
 		chromatic: { delay: 2000 },
 	},
 	decorators: [

--- a/components/alertbanner/stories/alertbanner.stories.js
+++ b/components/alertbanner/stories/alertbanner.stories.js
@@ -60,9 +60,6 @@ export default {
 		actions: {
 			handles: ["click .spectrum-AlertBanner button"],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/alertdialog/stories/alertdialog.stories.js
+++ b/components/alertdialog/stories/alertdialog.stories.js
@@ -44,9 +44,6 @@ export default {
 		actions: {
 			handles: ["click .spectrum-AlertDialog button"],
 		},
-		status: {
-			type: "migrated",
-		},
 		docs: {
 			story: {
 				height: "300px"

--- a/components/asset/stories/asset.stories.js
+++ b/components/asset/stories/asset.stories.js
@@ -41,11 +41,6 @@ export default {
 		preset: "image",
 		image: "example-ava.png",
 	},
-	parameters: {
-		status: {
-			type: "migrated",
-		},
-	},
 };
 
 const AssetGroup = (args) => html`

--- a/components/assetcard/stories/assetcard.stories.js
+++ b/components/assetcard/stories/assetcard.stories.js
@@ -99,9 +99,6 @@ export default {
 		actions: {
 			handles: [...Checkbox.parameters.actions.handles],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/assetlist/stories/assetlist.stories.js
+++ b/components/assetlist/stories/assetlist.stories.js
@@ -18,9 +18,6 @@ export default {
 		actions: {
 			handles: [...Checkbox.parameters.actions.handles],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/avatar/stories/avatar.stories.js
+++ b/components/avatar/stories/avatar.stories.js
@@ -75,11 +75,6 @@ export default {
 		isDisabled: false,
 		hasLink: true,
 	},
-	parameters: {
-		status: {
-			type: "migrated",
-		},
-	},
 };
 
 export const Default = Template.bind({});

--- a/components/badge/stories/badge.stories.js
+++ b/components/badge/stories/badge.stories.js
@@ -75,9 +75,6 @@ export default {
 		actions: {
 			handles: [],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 	decorators: [
 		(Story, context) => html`<div style="padding: 16px">${Story(context)}</div>`

--- a/components/breadcrumb/stories/breadcrumb.stories.js
+++ b/components/breadcrumb/stories/breadcrumb.stories.js
@@ -36,9 +36,6 @@ export default {
 		actions: {
 			handles: [],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/button/stories/button.stories.js
+++ b/components/button/stories/button.stories.js
@@ -135,9 +135,6 @@ export default {
 		actions: {
 			handles: ["click .spectrum-Button"],
 		},
-		status: {
-			type: "migrated",
-		},
 		html: {
 			root: "#render-root"
 		}

--- a/components/buttongroup/stories/buttongroup.stories.js
+++ b/components/buttongroup/stories/buttongroup.stories.js
@@ -38,9 +38,6 @@ export default {
 		actions: {
 			handles: [],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/calendar/stories/calendar.stories.js
+++ b/components/calendar/stories/calendar.stories.js
@@ -101,9 +101,6 @@ export default {
 				...(ActionButtonStories.parameters.actions.handles ?? [])
 			],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/card/stories/card.stories.js
+++ b/components/card/stories/card.stories.js
@@ -112,9 +112,6 @@ export default {
 				...Checkbox.parameters.actions.handles,
 			],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/checkbox/stories/checkbox.stories.js
+++ b/components/checkbox/stories/checkbox.stories.js
@@ -98,9 +98,6 @@ export default {
 		actions: {
 			handles: ["click input[type=\"checkbox\"]"],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/clearbutton/stories/clearbutton.stories.js
+++ b/components/clearbutton/stories/clearbutton.stories.js
@@ -48,9 +48,6 @@ export default {
 		actions: {
 			handles: [],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/closebutton/stories/closebutton.stories.js
+++ b/components/closebutton/stories/closebutton.stories.js
@@ -46,9 +46,6 @@ export default {
 		actions: {
 			handles: ["click .spectrum-CloseButton"],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/coachindicator/stories/coachindicator.stories.js
+++ b/components/coachindicator/stories/coachindicator.stories.js
@@ -1,5 +1,4 @@
 import { html } from "lit";
-
 import { Template } from "./template";
 
 /**
@@ -37,9 +36,6 @@ export default {
 	parameters: {
 		actions: {
 			handles: [],
-		},
-		status: {
-			type: "migrated",
 		},
 	},
 };

--- a/components/coachmark/stories/coachmark.stories.js
+++ b/components/coachmark/stories/coachmark.stories.js
@@ -51,9 +51,6 @@ export default {
 				...Menu.parameters.actions.handles,
 			],
 		},
-		status: {
-			type: "migrated",
-		},
 		docs: {
 			story: {
 				height: "300px"

--- a/components/colorarea/stories/colorarea.stories.js
+++ b/components/colorarea/stories/colorarea.stories.js
@@ -45,9 +45,6 @@ export default {
 		actions: {
 			handles: [],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/colorhandle/stories/colorhandle.stories.js
+++ b/components/colorhandle/stories/colorhandle.stories.js
@@ -46,9 +46,6 @@ export default {
 		actions: {
 			handles: [],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/colorloupe/stories/colorloupe.stories.js
+++ b/components/colorloupe/stories/colorloupe.stories.js
@@ -28,9 +28,6 @@ export default {
 		actions: {
 			handles: [],
 		},
-		status: {
-			type: "migrated",
-		},
 		docs: {
 			story: {
 				height: "100px"

--- a/components/colorslider/stories/colorslider.stories.js
+++ b/components/colorslider/stories/colorslider.stories.js
@@ -56,9 +56,6 @@ export default {
 		actions: {
 			handles: [],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/colorwheel/stories/colorwheel.stories.js
+++ b/components/colorwheel/stories/colorwheel.stories.js
@@ -46,9 +46,6 @@ export default {
 		actions: {
 			handles: [],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/combobox/stories/combobox.stories.js
+++ b/components/combobox/stories/combobox.stories.js
@@ -160,9 +160,6 @@ export default {
 		actions: {
 			handles: [],
 		},
-		status: {
-			type: "migrated",
-		},
 		docs: {
 			story: {
 				height: "220px"

--- a/components/contextualhelp/stories/contextualhelp.stories.js
+++ b/components/contextualhelp/stories/contextualhelp.stories.js
@@ -85,9 +85,6 @@ export default {
 				...(ActionButtonStories?.parameters?.actions?.handles ?? [])
 			],
 		},
-		status: {
-			type: "migrated",
-		},
 		docs: {
 			story: {
 				height: "200px",

--- a/components/datepicker/stories/datepicker.stories.js
+++ b/components/datepicker/stories/datepicker.stories.js
@@ -111,9 +111,6 @@ export default {
 				...(CalendarStories.parameters.actions.handles ?? [])
 			],
 		},
-		status: {
-			type: "migrated",
-		},
 		docs: {
 			story: {
 				height: "350px"

--- a/components/dial/stories/dial.stories.js
+++ b/components/dial/stories/dial.stories.js
@@ -64,9 +64,6 @@ export default {
 		actions: {
 			handles: [],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/dialog/stories/dialog.stories.js
+++ b/components/dialog/stories/dialog.stories.js
@@ -62,9 +62,6 @@ export default {
 				height: "500px",
 			},
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/divider/stories/divider.stories.js
+++ b/components/divider/stories/divider.stories.js
@@ -43,11 +43,6 @@ export default {
 		size: "m",
 		vertical: false,
 	},
-	parameters: {
-		status: {
-			type: "migrated",
-		},
-	},
 };
 
 export const Default = Template.bind({});

--- a/components/dropindicator/stories/dropindicator.stories.js
+++ b/components/dropindicator/stories/dropindicator.stories.js
@@ -38,9 +38,6 @@ export default {
 		actions: {
 			handles: [],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/dropzone/stories/dropzone.stories.js
+++ b/components/dropzone/stories/dropzone.stories.js
@@ -40,9 +40,6 @@ export default {
 		actions: {
 			handles: [],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/fieldgroup/stories/fieldgroup.stories.js
+++ b/components/fieldgroup/stories/fieldgroup.stories.js
@@ -48,9 +48,6 @@ export default {
 				...Radio.parameters.actions.handles
 			],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/fieldlabel/stories/fieldlabel.stories.js
+++ b/components/fieldlabel/stories/fieldlabel.stories.js
@@ -66,9 +66,6 @@ export default {
 		actions: {
 			handles: [],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/fieldlabel/stories/form.stories.js
+++ b/components/fieldlabel/stories/form.stories.js
@@ -27,9 +27,6 @@ export default {
 		actions: {
 			handles: [],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 	decorators: [
 		(Story, context) => html`<div style="padding: 16px">${Story(context)}</div>`

--- a/components/floatingactionbutton/stories/floatingactionbutton.stories.js
+++ b/components/floatingactionbutton/stories/floatingactionbutton.stories.js
@@ -35,9 +35,6 @@ export default {
 		actions: {
 			handles: [],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/helptext/stories/helptext.stories.js
+++ b/components/helptext/stories/helptext.stories.js
@@ -81,9 +81,6 @@ export default {
 		actions: {
 			handles: [],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/icon/stories/icon.stories.js
+++ b/components/icon/stories/icon.stories.js
@@ -91,11 +91,6 @@ export default {
 		iconName: "ABC",
 		size: "xl",
 	},
-	parameters: {
-		status: {
-			type: "migrated",
-		},
-	},
 };
 
 export const Default = (args) => window.isChromatic() ? TestTemplate(args) : Template({

--- a/components/illustratedmessage/stories/illustratedmessage.stories.js
+++ b/components/illustratedmessage/stories/illustratedmessage.stories.js
@@ -44,9 +44,6 @@ export default {
 		actions: {
 			handles: [],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/inlinealert/stories/inlinealert.stories.js
+++ b/components/inlinealert/stories/inlinealert.stories.js
@@ -60,9 +60,6 @@ export default {
 		actions: {
 			handles: [],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/link/stories/link.stories.js
+++ b/components/link/stories/link.stories.js
@@ -65,9 +65,6 @@ export default {
 		actions: {
 			handles: ["click .spectrum-Link"],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/logicbutton/stories/logicbutton.stories.js
+++ b/components/logicbutton/stories/logicbutton.stories.js
@@ -36,9 +36,6 @@ export default {
 		actions: {
 			handles: [],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/menu/stories/menu.stories.js
+++ b/components/menu/stories/menu.stories.js
@@ -67,9 +67,6 @@ export default {
 		actions: {
 			handles: ["click .spectrum-Menu-item"],
 		},
-		status: {
-			type: "migrated",
-		},
 		docs: {
 			story: {
 				height: "300px"

--- a/components/miller/stories/miller.stories.js
+++ b/components/miller/stories/miller.stories.js
@@ -16,9 +16,6 @@ export default {
 		actions: {
 			handles: [],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/modal/stories/modal.stories.js
+++ b/components/modal/stories/modal.stories.js
@@ -39,9 +39,6 @@ export default {
 		actions: {
 			handles: [],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/opacitycheckerboard/stories/opacitycheckerboard.stories.js
+++ b/components/opacitycheckerboard/stories/opacitycheckerboard.stories.js
@@ -28,9 +28,6 @@ export default {
 		actions: {
 			handles: [],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 	decorators: [
 		(Story, context) => html`<div style=${styleMap({ inlineSize: "100px", blockSize: "100px" })}>${Story(context)}</div>`

--- a/components/pagination/stories/pagination.stories.js
+++ b/components/pagination/stories/pagination.stories.js
@@ -35,9 +35,6 @@ export default {
 				...ActionButton.parameters.actions.handles
 			],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/picker/stories/picker.stories.js
+++ b/components/picker/stories/picker.stories.js
@@ -134,9 +134,6 @@ export default {
 		actions: {
 			handles: [],
 		},
-		status: {
-			type: "migrated",
-		},
 		docs: {
 			story: {
 				height: "300px"

--- a/components/pickerbutton/stories/pickerbutton.stories.js
+++ b/components/pickerbutton/stories/pickerbutton.stories.js
@@ -118,9 +118,6 @@ export default {
 		actions: {
 			handles: [],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/popover/stories/popover.stories.js
+++ b/components/popover/stories/popover.stories.js
@@ -116,9 +116,6 @@ export default {
 		actions: {
 			handles: [],
 		},
-		status: {
-			type: "migrated",
-		},
 		chromatic: { delay: 2000 },
 		docs: {
 			story: {

--- a/components/progressbar/stories/meter.stories.js
+++ b/components/progressbar/stories/meter.stories.js
@@ -58,9 +58,6 @@ export default {
 		actions: {
 			handles: [],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/progressbar/stories/progressbar.stories.js
+++ b/components/progressbar/stories/progressbar.stories.js
@@ -70,9 +70,6 @@ export default {
 		actions: {
 			handles: [],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/progresscircle/stories/progresscircle.stories.js
+++ b/components/progresscircle/stories/progresscircle.stories.js
@@ -50,9 +50,6 @@ export default {
 		actions: {
 			handles: [],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/radio/stories/radio.stories.js
+++ b/components/radio/stories/radio.stories.js
@@ -88,9 +88,6 @@ export default {
 			handles: ["click input[type=\"radio\"]"],
 
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/rating/stories/rating.stories.js
+++ b/components/rating/stories/rating.stories.js
@@ -74,9 +74,6 @@ export default {
 		actions: {
 			handles: [],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/search/stories/search.stories.js
+++ b/components/search/stories/search.stories.js
@@ -49,9 +49,6 @@ export default {
 				"click .spectrum-Search-icon",
 			],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/slider/stories/slider.stories.js
+++ b/components/slider/stories/slider.stories.js
@@ -129,9 +129,6 @@ export default {
 				"change .spectrum-Slider-input",
 			],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/splitview/stories/splitview.stories.js
+++ b/components/splitview/stories/splitview.stories.js
@@ -73,9 +73,6 @@ export default {
 		actions: {
 			handles: [],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/statuslight/stories/statuslight.stories.js
+++ b/components/statuslight/stories/statuslight.stories.js
@@ -67,9 +67,6 @@ export default {
 		actions: {
 			handles: [],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/steplist/stories/steplist.stories.js
+++ b/components/steplist/stories/steplist.stories.js
@@ -54,9 +54,6 @@ export default {
 		actions: {
 			handles: [],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/stepper/stories/stepper.stories.js
+++ b/components/stepper/stories/stepper.stories.js
@@ -88,9 +88,6 @@ export default {
 		actions: {
 			handles: [],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/swatch/stories/swatch.stories.js
+++ b/components/swatch/stories/swatch.stories.js
@@ -67,9 +67,6 @@ export default {
 		actions: {
 			handles: [],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/swatchgroup/stories/swatchgroup.stories.js
+++ b/components/swatchgroup/stories/swatchgroup.stories.js
@@ -63,9 +63,6 @@ export default {
 				...Swatch.parameters?.actions?.handles ?? [],
 			],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/switch/stories/switch.stories.js
+++ b/components/switch/stories/switch.stories.js
@@ -66,9 +66,6 @@ export default {
 		actions: {
 			handles: [],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/table/stories/table.stories.js
+++ b/components/table/stories/table.stories.js
@@ -104,9 +104,6 @@ export default {
 		actions: {
 			handles: [],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/tag/stories/tag.stories.js
+++ b/components/tag/stories/tag.stories.js
@@ -127,9 +127,6 @@ export default {
 		actions: {
 			handles: [],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/taggroup/stories/taggroup.stories.js
+++ b/components/taggroup/stories/taggroup.stories.js
@@ -58,9 +58,6 @@ export default {
 				...(TagStories.parameters.actions.handles ?? [])
 			],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/textfield/stories/textfield.stories.js
+++ b/components/textfield/stories/textfield.stories.js
@@ -193,9 +193,6 @@ export default {
 				"focusout .spectrum-Textfield"
 			],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/thumbnail/stories/thumbnail.stories.js
+++ b/components/thumbnail/stories/thumbnail.stories.js
@@ -126,9 +126,6 @@ export default {
 		actions: {
 			handles: [],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/toast/stories/toast.stories.js
+++ b/components/toast/stories/toast.stories.js
@@ -37,9 +37,6 @@ export default {
 		actions: {
 			handles: ["click .spectrum-Toast button"],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/tooltip/stories/tooltip.stories.js
+++ b/components/tooltip/stories/tooltip.stories.js
@@ -109,9 +109,6 @@ export default {
 		actions: {
 			handles: [],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 	decorators: [
 		(Story, context) => html`

--- a/components/tray/stories/tray.stories.js
+++ b/components/tray/stories/tray.stories.js
@@ -36,9 +36,6 @@ export default {
 		actions: {
 			handles: [],
 		},
-		status: {
-			type: "migrated",
-		},
 		docs: {
 			story: {
 				height: "200px"

--- a/components/treeview/stories/treeview.stories.js
+++ b/components/treeview/stories/treeview.stories.js
@@ -50,9 +50,6 @@ export default {
 		actions: {
 			handles: ["click .spectrum-TreeView-itemLink"],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/typography/stories/typography.stories.js
+++ b/components/typography/stories/typography.stories.js
@@ -76,9 +76,6 @@ export default {
 		actions: {
 			handles: [],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 

--- a/components/well/stories/well.stories.js
+++ b/components/well/stories/well.stories.js
@@ -17,9 +17,6 @@ export default {
 		actions: {
 			handles: [],
 		},
-		status: {
-			type: "migrated",
-		},
 	},
 };
 


### PR DESCRIPTION
## Description

Remove the migrated status from components as it might be confused for the S1 -> S2 migration status rather than the legacy tokens status it represents.

Fixed one duplicate key value which was throwing errors in the build.

## How and where has this been tested?


- [ ] Expect to see the migrated badge removed from all stories

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] ✨ This pull request is ready to merge. ✨
