### PR TITLE
fix(storybook): testing preview for toolbar

### DIFF
--- a/.changeset/sweet-fans-remain.md
+++ b/.changeset/sweet-fans-remain.md
@@ -1,0 +1,11 @@
+---
+"@spectrum-css/preview": patch
+---
+
+Fixes for Storybook instance
+
+- Bring back testing preview global toggle to toolbar after it was accidentally removed in a previous release
+- Chromatic disable snapshot syntax corrected in multiple stories
+- Update when token assets are loaded to correct snapshot inconsistencies
+- Add the vrt-only flag to ForcedColors stories to prevent them from being included in the local Storybook view
+- Fixes to the Coach Indicator story

--- a/.storybook/decorators/contextsWrapper.js
+++ b/.storybook/decorators/contextsWrapper.js
@@ -1,4 +1,3 @@
-import "@spectrum-css/tokens/dist/index.css";
 import { makeDecorator, useEffect } from "@storybook/preview-api";
 
 /**
@@ -44,7 +43,6 @@ export const withContextWrapper = makeDecorator({
 
 			for (const container of containers) {
 				container.classList.toggle("spectrum", true);
-
 				container.classList.toggle("spectrum--express", isExpress);
 
 				for (const c of colors) {

--- a/.storybook/decorators/contextsWrapper.js
+++ b/.storybook/decorators/contextsWrapper.js
@@ -1,3 +1,4 @@
+import "@spectrum-css/tokens/dist/index.css";
 import { makeDecorator, useEffect } from "@storybook/preview-api";
 
 /**

--- a/.storybook/decorators/withTestingPreviewWrapper.js
+++ b/.storybook/decorators/withTestingPreviewWrapper.js
@@ -1,5 +1,4 @@
 import { makeDecorator, useEffect } from "@storybook/preview-api";
-
 import isChromatic from "chromatic/isChromatic";
 
 /**

--- a/.storybook/deprecated/cyclebutton/cyclebutton.stories.js
+++ b/.storybook/deprecated/cyclebutton/cyclebutton.stories.js
@@ -41,7 +41,7 @@ export default {
 		actions: {
 			handles: [...(ActionButtonStories?.parameters?.actions?.handles ?? [])],
 		},
-		chromatic: { disable: true },
+		chromatic: { disableSnapshot: true },
 		status: {
 			type: "deprecated"
 		},

--- a/.storybook/deprecated/quickaction/quickaction.stories.js
+++ b/.storybook/deprecated/quickaction/quickaction.stories.js
@@ -64,13 +64,10 @@ export default {
 		],
 	},
 	parameters: {
-		actions: {
-			handles: [],
-		},
+		chromatic: { disableSnapshot: true },
 		status: {
 			type: "deprecated"
 		},
-		chromatic: { disable: true },
 	},
 };
 

--- a/.storybook/deprecated/searchwithin/searchwithin.stories.js
+++ b/.storybook/deprecated/searchwithin/searchwithin.stories.js
@@ -138,10 +138,7 @@ export default {
 		withSwitch: false,
 	},
 	parameters: {
-		actions: {
-			handles: [],
-		},
-		chromatic: { disable: true },
+		chromatic: { disableSnapshot: true },
 		status: {
 			type: "deprecated"
 		},

--- a/.storybook/deprecated/splitbutton/splitbutton.stories.js
+++ b/.storybook/deprecated/splitbutton/splitbutton.stories.js
@@ -59,10 +59,7 @@ export default {
 		iconName: "ChevronDown100",
 	},
 	parameters: {
-		actions: {
-			handles: [],
-		},
-		chromatic: { disable: true },
+		chromatic: { disableSnapshot: true },
 		status: {
 			type: "deprecated"
 		},

--- a/.storybook/guides/deprecation.mdx
+++ b/.storybook/guides/deprecation.mdx
@@ -35,11 +35,11 @@ Before removing the component from the codebase, we need to flag the component a
     a. Edit the title of any exported stories to be prefixed with the `Deprecated` category, i.e., `title: "Quick actions"`.
     b. Update any local references to point to the package name instead, i.e.,<br/>_Original_:<br/>`import { Template } from "./template";`<br/><br/>_Updated to_:<br/>`import { Template } from "@spectrum-css/quickaction/stories/template.js";`.
     c. In the parameters section, there are 2 important updates to make:
-        - Add `chromatic: { disable: true },` to ensure it no longer runs regression tests.
+        - Add `chromatic: { disableSnapshot: true },` to ensure it no longer runs regression tests.
         - Update the `status` type to `deprecated`:
             ```json
             parameters: {
-                chromatic: { disable: true },
+                chromatic: { disableSnapshot: true },
                 status: { type: "deprecated" }
             },
             ```

--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -1,15 +1,13 @@
+import "@spectrum-css/tokens";
 import { addons } from "@storybook/manager-api";
 import { create } from "@storybook/theming";
-
+import "./assets/index.css";
 import logo from "./assets/logo.svg";
+import "./assets/typekit.js";
 import pkg from "./package.json";
 
-import "@spectrum-css/tokens";
-import "./assets/index.css";
-
-import "./assets/typekit.js";
-
-document.body.classList.add("spectrum", "spectrum--light", "spectrum--medium");
+const root = document.body ?? document.documentElement;
+if (root) root.classList.add("spectrum", "spectrum--light", "spectrum--medium");
 
 addons.setConfig({
 	theme: create({

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -11,7 +11,6 @@ import {
 import DocumentationTemplate from './DocumentationTemplate.mdx';
 import { argTypes, globalTypes } from "./types";
 
-import "@spectrum-css/tokens";
 import "./assets/base.css";
 import "./assets/typekit.js";
 

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,5 +1,8 @@
 
+import "@spectrum-css/tokens/dist/index.css";
 import { setConsoleOptions } from "@storybook/addon-console";
+import "./assets/base.css";
+import "./assets/typekit.js";
 import {
 	withActions,
 	withContextWrapper,
@@ -10,9 +13,6 @@ import {
 } from "./decorators/index.js";
 import DocumentationTemplate from './DocumentationTemplate.mdx';
 import { argTypes, globalTypes } from "./types";
-
-import "./assets/base.css";
-import "./assets/typekit.js";
 
 const panelExclude = setConsoleOptions({}).panelExclude || [];
 setConsoleOptions({
@@ -44,7 +44,13 @@ export const parameters = {
 			includeNames: true,
 		},
 	},
-	// chromatic: { forcedColors: 'active' },
+	chromatic: {
+		// This delay ensures tokens are loaded before the story is rendered
+		// @todo: explore a loader for this to ensure tokens load before stories without an arbitrary delay
+		delay: 500,
+		forcedColors: "none",
+		prefersReducedMotion: "no-preference",
+	},
 	controls: {
 		expanded: true,
 		hideNoControlsWarning: true,

--- a/.storybook/types/global.js
+++ b/.storybook/types/global.js
@@ -30,4 +30,18 @@ export default {
 			dynamicTitle: true,
 		},
 	},
+	testingPreview: {
+		title: "Testing preview",
+		description: "Enable the testing preview",
+		defaultValue: false,
+		type: "boolean",
+		toolbar: {
+			icon: "beaker",
+			items: [
+				{ value: false, title: "Hide test view" },
+				{ value: true, title: "Show test view" },
+			],
+			dynamicTitle: false,
+		},
+	},
 };

--- a/components/actionbar/stories/actionbar.stories.js
+++ b/components/actionbar/stories/actionbar.stories.js
@@ -1,8 +1,7 @@
-import { Template } from "./template";
-
 import { default as ActionButton } from "@spectrum-css/actionbutton/stories/actionbutton.stories.js";
 import { default as CloseButton } from "@spectrum-css/closebutton/stories/closebutton.stories.js";
 import { default as Popover } from "@spectrum-css/popover/stories/popover.stories.js";
+import { Template } from "./template";
 
 /**
  * The action bar component is a floating full width bar that appears upon selection.
@@ -68,9 +67,9 @@ export default {
 	parameters: {
 		actions: {
 			handles: [
-				...Popover.parameters.actions.handles,
-				...CloseButton.parameters.actions.handles,
-				...ActionButton.parameters.actions.handles,
+				...(Popover?.parameters?.actions?.handles ?? []),
+				...(CloseButton?.parameters?.actions?.handles ?? []),
+				...(ActionButton?.parameters?.actions?.handles ?? []),
 			],
 		},
 		// Getting the Figma link: https://help.figma.com/hc/en-us/articles/360045003494-Storybook-and-Figma
@@ -84,9 +83,6 @@ export default {
 export const Default = Template.bind({});
 Default.args = {};
 
-/**
- * Stories for the MDX "Docs" only.
- */
 export const Emphasized = Template.bind({});
 Emphasized.tags = ["docs-only"];
 Emphasized.args = {

--- a/components/actionbutton/stories/actionbutton.stories.js
+++ b/components/actionbutton/stories/actionbutton.stories.js
@@ -148,250 +148,264 @@ export default {
 			handles: ["click .spectrum-ActionButton:not([disabled])"],
 		},
 		html: {
-			root: "#render-root"
-		}
+			root: "#render-root",
+		},
 	},
 	decorators: [
 		(Story, context) => html`
-			<style>
-				.spectrum-Detail { display: inline-block; }
-				.spectrum-Typography > div {
-					border: 1px solid var(--spectrum-gray-200);
-					border-radius: 4px;
-					padding: 0 14px 14px;
-					/* Why seafoam? Because it separates it from the component styles. */
-					--mod-detail-font-color: var(--spectrum-seafoam-900);
-				}
-			</style>
-			<div
-				style=${styleMap({
-					"display": "flex",
-					"flex-direction": "column",
-					"align-items": "flex-start",
-					"gap": "16px",
-					"--mod-detail-margin-end": "4.8px",
-				})}
-			>
-				${Story(context)}
-			</div>
-		`,
+      <style>
+        .spectrum-Detail {
+          display: inline-block;
+        }
+        .spectrum-Typography > div {
+          border: 1px solid var(--spectrum-gray-200);
+          border-radius: 4px;
+          padding: 0 14px 14px;
+          /* Why seafoam? Because it separates it from the component styles. */
+          --mod-detail-font-color: var(--spectrum-seafoam-900);
+        }
+      </style>
+      <div
+        style=${styleMap({
+          display: "flex",
+          "flex-direction": "column",
+          "align-items": "flex-start",
+          gap: "16px",
+          "--mod-detail-margin-end": "4.8px",
+        })}
+      >
+        ${Story(context)}
+      </div>
+    `,
 	],
 };
 
 const ActionButtons = (args) => html` <div
-	style=${styleMap({
-		"display": "flex",
-		"gap": "16px",
-	})}
-	id="render-root"
+  style=${styleMap({
+    display: "flex",
+    gap: "16px",
+  })}
+  id="render-root"
 >
-	${Template({
-		...args,
-		label: "More",
-		iconName: undefined,
-	})}
-	${Template({
-		...args,
-		label: "More",
-	})}
-	${Template(args)}
-	${Template({
-		...args,
-		hasPopup: true,
-	})}
-	<!-- Save truncation for VRTs -->
-	${when(window.isChromatic(), () =>
-		Template({
-			...args,
-			label: "Truncate this long content",
-			iconName: undefined,
-			customStyles: { maxInlineSize: "100px" },
-		})
-	)}
-	${when(window.isChromatic(), () =>
-		Template({
-			...args,
-			label: "Truncate this long content",
-			customStyles: { maxInlineSize: "100px" },
-		})
-	)}
+  ${Template({
+    ...args,
+    label: "More",
+    iconName: undefined,
+  })}
+  ${Template({
+    ...args,
+    label: "More",
+  })}
+  ${Template(args)}
+  ${Template({
+    ...args,
+    hasPopup: true,
+  })}
+  <!-- Save truncation for VRTs -->
+  ${when(window.isChromatic(), () =>
+    Template({
+      ...args,
+      label: "Truncate this long content",
+      iconName: undefined,
+      customStyles: { maxInlineSize: "100px" },
+    })
+  )}
+  ${when(window.isChromatic(), () =>
+    Template({
+      ...args,
+      label: "Truncate this long content",
+      customStyles: { maxInlineSize: "100px" },
+    })
+  )}
 </div>`;
 
 const States = (args) =>
 	html` <div>
-			${Typography({
-				semantics: "detail",
-				size: "s",
-				content: ["Default"],
-			})}
-			${ActionButtons(args)}
-		</div>
-		<div>
-			${Typography({
-				semantics: "detail",
-				size: "s",
-				content: ["Selected"],
-			})}
-			${ActionButtons({
-				...args,
-				isSelected: true,
-			})}
-		</div>
-		<div>
-			${Typography({
-				semantics: "detail",
-				size: "s",
-				content: ["Focused"],
-			})}
-			${ActionButtons({
-				...args,
-				isFocused: true,
-			})}
-		</div>
-		<div>
-			${Typography({
-				semantics: "detail",
-				size: "s",
-				content: ["Hovered"],
-			})}
-			${ActionButtons({
-				...args,
-				isHovered: true,
-			})}
-		</div>
-		<div>
-			${Typography({
-				semantics: "detail",
-				size: "s",
-				content: ["Active"],
-			})}
-			${ActionButtons({
-				...args,
-				isActive: true,
-			})}
-		</div>
-		<div>
-			${Typography({
-				semantics: "detail",
-				size: "s",
-				content: ["Disabled"],
-			})}
-			${ActionButtons({
-				...args,
-				isDisabled: true,
-			})}
-		</div>
-		<div>
-			${Typography({
-				semantics: "detail",
-				size: "s",
-				content: ["Disabled + selected"],
-			})}
-			${ActionButtons({
-				...args,
-				isSelected: true,
-				isDisabled: true,
-			})}
-		</div>`;
+      ${Typography({
+        semantics: "detail",
+        size: "s",
+        content: ["Default"],
+        customClasses: ["chromatic-ignore"],
+      })}
+      ${ActionButtons(args)}
+    </div>
+    <div>
+      ${Typography({
+        semantics: "detail",
+        size: "s",
+        content: ["Selected"],
+        customClasses: ["chromatic-ignore"],
+      })}
+      ${ActionButtons({
+        ...args,
+        isSelected: true,
+      })}
+    </div>
+    <div>
+      ${Typography({
+        semantics: "detail",
+        size: "s",
+        content: ["Focused"],
+        customClasses: ["chromatic-ignore"],
+      })}
+      ${ActionButtons({
+        ...args,
+        isFocused: true,
+      })}
+    </div>
+    <div>
+      ${Typography({
+        semantics: "detail",
+        size: "s",
+        content: ["Hovered"],
+        customClasses: ["chromatic-ignore"],
+      })}
+      ${ActionButtons({
+        ...args,
+        isHovered: true,
+      })}
+    </div>
+    <div>
+      ${Typography({
+        semantics: "detail",
+        size: "s",
+        content: ["Active"],
+        customClasses: ["chromatic-ignore"],
+      })}
+      ${ActionButtons({
+        ...args,
+        isActive: true,
+      })}
+    </div>
+    <div>
+      ${Typography({
+        semantics: "detail",
+        size: "s",
+        content: ["Disabled"],
+        customClasses: ["chromatic-ignore"],
+      })}
+      ${ActionButtons({
+        ...args,
+        isDisabled: true,
+      })}
+    </div>
+    <div>
+      ${Typography({
+        semantics: "detail",
+        size: "s",
+        content: ["Disabled + selected"],
+        customClasses: ["chromatic-ignore"],
+      })}
+      ${ActionButtons({
+        ...args,
+        isSelected: true,
+        isDisabled: true,
+      })}
+    </div>`;
 
 const Sizes = (args) =>
 	html` ${["s", "m", "l", "xl"].map((size) => {
-		return html` <div>
-			${Typography({
-				semantics: "detail",
-				size: "s",
-				content: [
-					{
-						xxs: "Extra-extra-small",
-						xs: "Extra-small",
-						s: "Small",
-						m: "Medium",
-						l: "Large",
-						xl: "Extra-large",
-						xxl: "Extra-extra-large",
-					}[size],
-				],
-			})}
-			${ActionButtons({
-				...args,
-				size,
-			})}
-		</div>`;
-	})}`;
+    return html` <div>
+      ${Typography({
+        semantics: "detail",
+        size: "s",
+        content: [
+          {
+            xxs: "Extra-extra-small",
+            xs: "Extra-small",
+            s: "Small",
+            m: "Medium",
+            l: "Large",
+            xl: "Extra-large",
+            xxl: "Extra-extra-large",
+          }[size],
+        ],
+        customClasses: ["chromatic-ignore"],
+      })}
+      ${ActionButtons({
+        ...args,
+        size,
+      })}
+    </div>`;
+  })}`;
 
 const Variants = (args) =>
 	html` ${window.isChromatic()
-		? html` <div class="spectrum-Typography">
-					${Typography({
-						semantics: "detail",
-						size: "l",
-						content: ["Standard"],
-					})}
-					<div
-						style=${styleMap({
-							"display": "flex",
-							"flex-direction": "column",
-							"gap": "4.8px",
-						})}
-					>
-						${States(args)}
-					</div>
-				</div>
-				<div class="spectrum-Typography">
-					${Typography({
-						semantics: "detail",
-						size: "l",
-						content: ["Emphasized"],
-					})}
-					<div
-						style=${styleMap({
-							"display": "flex",
-							"flex-direction": "column",
-							"gap": "4.8px",
-						})}
-					>
-						${States({
-							...args,
-							isEmphasized: true,
-						})}
-					</div>
-				</div>
-				<div class="spectrum-Typography">
-					${Typography({
-						semantics: "detail",
-						size: "l",
-						content: ["Quiet"],
-					})}
-					<div
-						style=${styleMap({
-							"display": "flex",
-							"flex-direction": "column",
-							"gap": "4.8px",
-						})}
-					>
-						${States({
-							...args,
-							isQuiet: true,
-						})}
-					</div>
-				</div>
-				<div class="spectrum-Typography">
-					${Typography({
-						semantics: "detail",
-						size: "l",
-						content: ["Sizing"],
-					})}
-					<div
-						style=${styleMap({
-							"display": "flex",
-							"flex-direction": "column",
-							"gap": "4.8px",
-						})}
-					>
-						${Sizes(args)}
-					</div>
-				</div>`
-		: ActionButtons(args)}`;
+    ? html` <div class="spectrum-Typography">
+          ${Typography({
+            semantics: "detail",
+            size: "l",
+            content: ["Standard"],
+            customClasses: ["chromatic-ignore"],
+          })}
+          <div
+            style=${styleMap({
+              display: "flex",
+              "flex-direction": "column",
+              gap: "4.8px",
+            })}
+          >
+            ${States(args)}
+          </div>
+        </div>
+        <div class="spectrum-Typography">
+          ${Typography({
+            semantics: "detail",
+            size: "l",
+            content: ["Emphasized"],
+            customClasses: ["chromatic-ignore"],
+          })}
+          <div
+            style=${styleMap({
+              display: "flex",
+              "flex-direction": "column",
+              gap: "4.8px",
+            })}
+          >
+            ${States({
+              ...args,
+              isEmphasized: true,
+            })}
+          </div>
+        </div>
+        <div class="spectrum-Typography">
+          ${Typography({
+            semantics: "detail",
+            size: "l",
+            content: ["Quiet"],
+            customClasses: ["chromatic-ignore"],
+          })}
+          <div
+            style=${styleMap({
+              display: "flex",
+              "flex-direction": "column",
+              gap: "4.8px",
+            })}
+          >
+            ${States({
+              ...args,
+              isQuiet: true,
+            })}
+          </div>
+        </div>
+        <div class="spectrum-Typography">
+          ${Typography({
+            semantics: "detail",
+            size: "l",
+            content: ["Sizing"],
+            customClasses: ["chromatic-ignore"],
+          })}
+          <div
+            style=${styleMap({
+              display: "flex",
+              "flex-direction": "column",
+              gap: "4.8px",
+            })}
+          >
+            ${Sizes(args)}
+          </div>
+        </div>`
+    : ActionButtons(args)}`;
 
 export const Default = Variants.bind({});
 Default.args = {};

--- a/components/actionbutton/stories/actionbutton.stories.js
+++ b/components/actionbutton/stories/actionbutton.stories.js
@@ -409,6 +409,7 @@ StaticWhite.args = {
 };
 
 export const WithForcedColors = Variants.bind({});
+WithForcedColors.tags = ["vrt-only"];
 WithForcedColors.parameters = {
 	chromatic: { forcedColors: "active" },
 };

--- a/components/actiongroup/stories/actiongroup.stories.js
+++ b/components/actiongroup/stories/actiongroup.stories.js
@@ -63,7 +63,9 @@ export default {
 	},
 	parameters: {
 		actions: {
-			handles: [...ActionButton.parameters.actions.handles],
+			handles: [
+				...(ActionButton?.parameters?.actions?.handles ?? []),
+			],
 		},
 	},
 };

--- a/components/actionmenu/stories/actionmenu.stories.js
+++ b/components/actionmenu/stories/actionmenu.stories.js
@@ -67,12 +67,11 @@ export default {
 	parameters: {
 		actions: {
 			handles: [
-				...Popover.parameters.actions.handles,
-				...ActionButton.parameters.actions.handles,
-				...Menu.parameters.actions.handles,
+				...(Popover?.parameters?.actions?.handles ?? []),
+				...(ActionButton?.parameters?.actions?.handles ?? []),
+				...(Menu.parameters?.actions?.handles ?? []),
 			],
 		},
-		chromatic: { delay: 2000 },
 	},
 	decorators: [
 		(Story, context) => html`<div style="padding: 14px">${Story(context)}</div>`
@@ -90,7 +89,7 @@ Default.parameters = {
 	docs: {
 		story: {
 			inline: false,
-			iframeHeight: 250,
+			iframeHeight: "250px",
 		},
 	},
 };

--- a/components/alertdialog/stories/alertdialog.stories.js
+++ b/components/alertdialog/stories/alertdialog.stories.js
@@ -35,6 +35,7 @@ export default {
 			control: "boolean",
 		},
 		variant: { table: { disable: true } },
+		buttons: { table: { disable: true } },
 	},
 	args: {
 		rootClass: "spectrum-AlertDialog",
@@ -68,6 +69,11 @@ Default.args = {
 	content: "Smart filters are nondestructive and will preserve your original images.",
 };
 
+/**
+ * Information alert dialogs communicate important information that a user needs to acknowledge. Before using this kind of alert dialog, make sure it’s the appropriate communication channel for the message instead of a toast or a more lightweight messaging option.
+ *
+ * Note that an alert dialog can have a total of 3 buttons if the secondary outline button label is defined.
+ */
 export const Information = Template.bind({});
 Information.args = {
 	variant: "information",
@@ -88,6 +94,9 @@ Information.args = {
 	content: "If you enjoy our app, would you mind taking a moment to rate it?",
 };
 
+/**
+ * Warning alert dialogs communicate important information to users in relation to an issue that needs to be acknowledged, but does not block the user from moving forward.
+ */
 export const Warning = Template.bind({});
 Warning.args = {
 	variant: "warning",
@@ -105,6 +114,9 @@ Warning.args = {
 	content: "This format has not been verified and may not be viewable for some users. Do you want to continue publishing?",
 };
 
+/**
+ * Error alert dialogs communicate critical information about an issue that a user needs to acknowledge.
+ */
 export const Error = Template.bind({});
 Error.args = {
 	variant: "error",
@@ -123,6 +135,9 @@ Error.args = {
 
 };
 
+/**
+ * Destructive alert dialogs are for when a user needs to confirm an action that will impact their data or experience in a potentially negative way, such as deleting files or contacts.
+ */
 export const Destructive = Template.bind({});
 Destructive.args = {
 	variant: "destructive",
@@ -139,10 +154,6 @@ Destructive.args = {
 	content: "Are you sure you want to delete the 3 selected documents?",
 };
 
-
-/**
- * Stories for the MDX "Docs" only.
- */
 export const Scroll = Template.bind({});
 Scroll.tags = ["docs-only"];
 Scroll.args = {

--- a/components/asset/stories/asset.stories.js
+++ b/components/asset/stories/asset.stories.js
@@ -65,9 +65,6 @@ const AssetGroup = (args) => html`
 
 export const Default = AssetGroup.bind({});
 
-/**
- * Stories for the MDX "Docs" only.
- */
 export const File = Template.bind({});
 File.tags = ["docs-only"];
 File.args = {

--- a/components/assetcard/stories/assetcard.stories.js
+++ b/components/assetcard/stories/assetcard.stories.js
@@ -97,7 +97,7 @@ export default {
 	},
 	parameters: {
 		actions: {
-			handles: [...Checkbox.parameters.actions.handles],
+			handles: [...(Checkbox.parameters?.actions?.handles ?? [])],
 		},
 	},
 };

--- a/components/assetlist/stories/assetlist.stories.js
+++ b/components/assetlist/stories/assetlist.stories.js
@@ -16,7 +16,7 @@ export default {
 	},
 	parameters: {
 		actions: {
-			handles: [...Checkbox.parameters.actions.handles],
+			handles: [...(Checkbox.parameters?.actions?.handles ?? [])],
 		},
 	},
 };

--- a/components/avatar/stories/avatar.stories.js
+++ b/components/avatar/stories/avatar.stories.js
@@ -80,9 +80,7 @@ export default {
 export const Default = Template.bind({});
 Default.args = {};
 
-/**
- * Stories for the MDX "Docs" only.
- */
+
 const AvatarSizes = (args) => html`
 	<div
 		style=${styleMap({

--- a/components/avatar/stories/avatar.stories.js
+++ b/components/avatar/stories/avatar.stories.js
@@ -102,6 +102,7 @@ const AvatarSizes = (args) => html`
 					semantics: "detail",
 					size: "s",
 					content: [size],
+					customClasses: ["chromatic-ignore"],
 				})}
 			</div>
 		`))}

--- a/components/avatar/stories/template.js
+++ b/components/avatar/stories/template.js
@@ -27,13 +27,13 @@ export const Template = ({
 		${when(hasLink, () =>
 			html`
 				<a class="spectrum-Avatar-link" href="#">
-					<img class="${rootClass}-image" src=${image} alt=${ifDefined(altText)} />
+					<img class="${rootClass}-image" data-chromatic="ignore" src=${image} alt=${ifDefined(altText)} />
 				</a>
 				`
 		)}
 		${when(!hasLink, () =>
 			html`
-				<img class="${rootClass}-image" src=${image} alt=${ifDefined(altText)} />
+				<img class="${rootClass}-image" data-chromatic="ignore" src=${image} alt=${ifDefined(altText)} />
 			`
 		)}
 	</div>

--- a/components/badge/stories/badge.stories.js
+++ b/components/badge/stories/badge.stories.js
@@ -71,11 +71,6 @@ export default {
 		label: "Badge",
 		fixed: "none"
 	},
-	parameters: {
-		actions: {
-			handles: [],
-		},
-	},
 	decorators: [
 		(Story, context) => html`<div style="padding: 16px">${Story(context)}</div>`
 	],
@@ -102,9 +97,7 @@ export const Default = BadgeGroup.bind({});
 Default.args = {};
 
 
-/**
- * Stories for the MDX "Docs" only.
- */
+
 const Variants = (args, variants) => html`
 	<div
 		style=${styleMap({

--- a/components/breadcrumb/stories/breadcrumb.stories.js
+++ b/components/breadcrumb/stories/breadcrumb.stories.js
@@ -32,11 +32,6 @@ export default {
 		rootClass: "spectrum-Breadcrumbs",
 		isDragged: false,
 	},
-	parameters: {
-		actions: {
-			handles: [],
-		},
-	},
 };
 
 export const Default = Template.bind({});

--- a/components/button/stories/button.stories.js
+++ b/components/button/stories/button.stories.js
@@ -108,12 +108,12 @@ export default {
 		},
 		staticColor: {
 			name: "Static color",
-			description: "Variants that can be used when a button needs to be placed on top of a colored background or a visual.",
+			description:
+        "Variants that can be used when a button needs to be placed on top of a colored background or a visual.",
 			type: { name: "string" },
 			table: {
 				type: { summary: "string" },
 				category: "Advanced",
-
 			},
 			options: ["white", "black"],
 			control: "select",
@@ -136,33 +136,35 @@ export default {
 			handles: ["click .spectrum-Button"],
 		},
 		html: {
-			root: "#render-root"
-		}
+			root: "#render-root",
+		},
 	},
 	decorators: [
 		(Story, context) => html`
-			<style>
-				.spectrum-Detail { display: inline-block; }
-				.spectrum-Typography > div {
-					border: 1px solid var(--spectrum-gray-200);
-					border-radius: 4px;
-					padding: 0 10px 10px;
-					/* Why seafoam? Because it separates it from the component styles. */
-					--mod-detail-font-color: var(--spectrum-seafoam-900);
-				}
-			</style>
-			<div
-				style=${styleMap({
-					display: "flex",
-					flexDirection: "column",
-					alignItems: "flex-start",
-					gap: "10px",
-					"--mod-detail-margin-end": "6px",
-				})}
-			>
-				${Story(context)}
-			</div>
-		`,
+      <style>
+        .spectrum-Detail {
+          display: inline-block;
+        }
+        .spectrum-Typography > div {
+          border: 1px solid var(--spectrum-gray-200);
+          border-radius: 4px;
+          padding: 0 10px 10px;
+          /* Why seafoam? Because it separates it from the component styles. */
+          --mod-detail-font-color: var(--spectrum-seafoam-900);
+        }
+      </style>
+      <div
+        style=${styleMap({
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "flex-start",
+          gap: "10px",
+          "--mod-detail-margin-end": "6px",
+        })}
+      >
+        ${Story(context)}
+      </div>
+    `,
 	],
 };
 
@@ -170,291 +172,309 @@ export default {
  * Multiple button variations displayed in one story template.
  * Used as the base template for the stories.
  */
-const CustomButton = ({
-	iconName,
-	...args
-}) => html`
-	${Template({
-		...args,
-		iconName: undefined,
-	})}
-	${Template({
-		...args,
-		iconName: iconName ?? "Edit",
-	})}
-	${Template({
-		...args,
-		hideLabel: true,
-		iconName: iconName ?? "Edit",
-	})}
+const CustomButton = ({ iconName, ...args }) => html`
+  ${Template({
+    ...args,
+    iconName: undefined,
+  })}
+  ${Template({
+    ...args,
+    iconName: iconName ?? "Edit",
+  })}
+  ${Template({
+    ...args,
+    hideLabel: true,
+    iconName: iconName ?? "Edit",
+  })}
 `;
 
 const States = (args) =>
 	html` <div>
-			${Typography({
-				semantics: "detail",
-				size: "s",
-				content: ["Default"],
-			})}
-			${Treatment(args)}
-		</div>
-		<div>
-			${Typography({
-				semantics: "detail",
-				size: "s",
-				content: ["Selected"],
-			})}
-			${Treatment({
-				...args,
-				isSelected: true,
-			})}
-		</div>
-		<div>
-			${Typography({
-				semantics: "detail",
-				size: "s",
-				content: ["Focused"],
-			})}
-			${Treatment({
-				...args,
-				isFocused: true,
-			})}
-		</div>
-		<div>
-			${Typography({
-				semantics: "detail",
-				size: "s",
-				content: ["Hovered"],
-			})}
-			${Treatment({
-				...args,
-				isHovered: true,
-			})}
-		</div>
-		<div>
-			${Typography({
-				semantics: "detail",
-				size: "s",
-				content: ["Active"],
-			})}
-			${Treatment({
-				...args,
-				isActive: true,
-			})}
-		</div>
-		<div>
-			${Typography({
-				semantics: "detail",
-				size: "s",
-				content: ["Disabled"],
-			})}
-			${Treatment({
-				...args,
-				isDisabled: true,
-			})}
-		</div>
-		<div>
-			${Typography({
-				semantics: "detail",
-				size: "s",
-				content: ["Disabled + selected"],
-			})}
-			${Treatment({
-				...args,
-				isSelected: true,
-				isDisabled: true,
-			})}
-		</div>
-		<div>
-			${Typography({
-				semantics: "detail",
-				size: "s",
-				content: ["Pending"],
-			})}
-			${Treatment({
-				...args,
-				isPending: true,
-			})}
-		</div>`;
+      ${Typography({
+        semantics: "detail",
+        size: "s",
+        content: ["Default"],
+        customClasses: ["chromatic-ignore"],
+      })}
+      ${Treatment(args)}
+    </div>
+    <div>
+      ${Typography({
+        semantics: "detail",
+        size: "s",
+        content: ["Selected"],
+        customClasses: ["chromatic-ignore"],
+      })}
+      ${Treatment({
+        ...args,
+        isSelected: true,
+      })}
+    </div>
+    <div>
+      ${Typography({
+        semantics: "detail",
+        size: "s",
+        content: ["Focused"],
+        customClasses: ["chromatic-ignore"],
+      })}
+      ${Treatment({
+        ...args,
+        isFocused: true,
+      })}
+    </div>
+    <div>
+      ${Typography({
+        semantics: "detail",
+        size: "s",
+        content: ["Hovered"],
+        customClasses: ["chromatic-ignore"],
+      })}
+      ${Treatment({
+        ...args,
+        isHovered: true,
+      })}
+    </div>
+    <div>
+      ${Typography({
+        semantics: "detail",
+        size: "s",
+        content: ["Active"],
+        customClasses: ["chromatic-ignore"],
+      })}
+      ${Treatment({
+        ...args,
+        isActive: true,
+      })}
+    </div>
+    <div>
+      ${Typography({
+        semantics: "detail",
+        size: "s",
+        content: ["Disabled"],
+        customClasses: ["chromatic-ignore"],
+      })}
+      ${Treatment({
+        ...args,
+        isDisabled: true,
+      })}
+    </div>
+    <div>
+      ${Typography({
+        semantics: "detail",
+        size: "s",
+        content: ["Disabled + selected"],
+        customClasses: ["chromatic-ignore"],
+      })}
+      ${Treatment({
+        ...args,
+        isSelected: true,
+        isDisabled: true,
+      })}
+    </div>
+    <div>
+      ${Typography({
+        semantics: "detail",
+        size: "s",
+        content: ["Pending"],
+        customClasses: ["chromatic-ignore"],
+      })}
+      ${Treatment({
+        ...args,
+        isPending: true,
+      })}
+    </div>`;
 
 const Sizes = (args) =>
 	html` ${["s", "m", "l", "xl"].map((size) => {
-		return html` <div>
-			${Typography({
-				semantics: "detail",
-				size: "s",
-				content: [
-					{
-						xxs: "Extra-extra-small",
-						xs: "Extra-small",
-						s: "Small",
-						m: "Medium",
-						l: "Large",
-						xl: "Extra-large",
-						xxl: "Extra-extra-large",
-					}[size],
-				],
-			})}
-			${Treatment({ ...args, size })}
-		</div>`;
-	})}`;
+    return html` <div>
+      ${Typography({
+        semantics: "detail",
+        size: "s",
+        content: [
+          {
+            xxs: "Extra-extra-small",
+            xs: "Extra-small",
+            s: "Small",
+            m: "Medium",
+            l: "Large",
+            xl: "Extra-large",
+            xxl: "Extra-extra-large",
+          }[size],
+        ],
+        customClasses: ["chromatic-ignore"],
+      })}
+      ${Treatment({ ...args, size })}
+    </div>`;
+  })}`;
 
 const Treatment = (args) =>
-	html`
-<div
-	style=${styleMap({
-		display: "flex",
-		gap: "10px",
-	})}
-	id="render-root"
->
-	${["fill", "outline"].map((treatment) => CustomButton({ ...args, treatment }))}
-</div>`;
+	html` <div
+    style=${styleMap({
+      display: "flex",
+      gap: "10px",
+    })}
+    id="render-root"
+  >
+    ${["fill", "outline"].map((treatment) =>
+      CustomButton({ ...args, treatment })
+    )}
+  </div>`;
 
-const Wrapping = (args) => html`
-	${Template({
-	...args,
-	customStyles: {
-		"max-inline-size": "480px",
-	},
-	iconName: "Edit",
-	label: "An example of text overflow behavior within the button component. When the button text is too long for the horizontal space available, it wraps to form another line.",
+const Wrapping = (args) => html` ${Template({
+  ...args,
+  customStyles: {
+    "max-inline-size": "480px",
+  },
+  iconName: "Edit",
+  label:
+    "An example of text overflow behavior within the button component. When the button text is too long for the horizontal space available, it wraps to form another line.",
 })}
-	${Template({
-	...args,
-	customStyles: {
-		"max-inline-size": "480px",
-	},
-	// Uses a UI icon that is smaller than workflow sizing, to test alignment:
-	iconName: "Cross100",
-	label: "An example of text overflow behavior within the button component. When the button text is too long for the horizontal space available, it wraps to form another line.",
+${Template({
+  ...args,
+  customStyles: {
+    "max-inline-size": "480px",
+  },
+  // Uses a UI icon that is smaller than workflow sizing, to test alignment:
+  iconName: "Cross100",
+  label:
+    "An example of text overflow behavior within the button component. When the button text is too long for the horizontal space available, it wraps to form another line.",
 })}
-	${Template({
-	...args,
-	customStyles: {
-		"max-inline-size": "480px",
-	},
-	// UI icon that is larger than workflow sizing:
-	iconName: "ArrowDown600",
-	label: "An example of text overflow behavior within the button component. When the button text is too long for the horizontal space available, it wraps to form another line.",
+${Template({
+  ...args,
+  customStyles: {
+    "max-inline-size": "480px",
+  },
+  // UI icon that is larger than workflow sizing:
+  iconName: "ArrowDown600",
+  label:
+    "An example of text overflow behavior within the button component. When the button text is too long for the horizontal space available, it wraps to form another line.",
 })}`;
 
 const Variants = (args) =>
 	html` ${window.isChromatic()
-		? html` <div class="spectrum-Typography">
-					${Typography({
-						semantics: "detail",
-						size: "l",
-						content: ["Accent"],
-					})}
-					<div
-						style=${styleMap({
-							display: "flex",
-							flexDirection: "column",
-							gap: "10px",
-						})}
-					>
-						${States(args)}
-					</div>
-				</div>
-				<div class="spectrum-Typography">
-					${Typography({
-						semantics: "detail",
-						size: "l",
-						content: ["Negative"],
-					})}
-					<div
-						style=${styleMap({
-							display: "flex",
-							flexDirection: "column",
-							gap: "10px",
-						})}
-					>
-						${States({
-							...args,
-							variant: "negative"
-						})}
-					</div>
-				</div>
-				<div class="spectrum-Typography">
-					${Typography({
-						semantics: "detail",
-						size: "l",
-						content: ["Primary"],
-					})}
-					<div
-						style=${styleMap({
-							display: "flex",
-							flexDirection: "column",
-							gap: "10px",
-						})}
-					>
-						${States({
-							...args,
-							variant: "primary"
-						})}
-					</div>
-				</div>
-				<div class="spectrum-Typography">
-					${Typography({
-						semantics: "detail",
-						size: "l",
-						content: ["Secondary"],
-					})}
-					<div
-						style=${styleMap({
-							display: "flex",
-							flexDirection: "column",
-							gap: "10px",
-						})}
-					>
-						${States({
-							...args,
-							variant: "secondary"
-						})}
-					</div>
-				</div>
-				<div class="spectrum-Typography">
-					${Typography({
-						semantics: "detail",
-						size: "l",
-						content: ["Sizing"],
-					})}
-					<div
-						style=${styleMap({
-							display: "flex",
-							flexDirection: "column",
-							gap: "10px",
-						})}
-					>
-						${Sizes(args)}
-					</div>
-				</div>
-				<div class="spectrum-Typography">
-					${Typography({
-						semantics: "detail",
-						size: "l",
-						content: ["Wrapping"],
-					})}
-					<div
-						style=${styleMap({
-							"display": "flex",
-							"flex-direction": "column",
-							"gap": "10px",
-							"padding": "6px"
-						})}
-					>
-						${Wrapping(args)}
-					</div>
-				</div>
-		` : html`
-<div
-	style=${styleMap({
-		display: "flex",
-		gap: "10px",
-	})}
-	id="render-root"
->${CustomButton(args)}</div>`}`;
+    ? html`
+        <div class="spectrum-Typography">
+          ${Typography({
+            semantics: "detail",
+            size: "l",
+            content: ["Accent"],
+            customClasses: ["chromatic-ignore"],
+          })}
+          <div
+            style=${styleMap({
+              display: "flex",
+              flexDirection: "column",
+              gap: "10px",
+            })}
+          >
+            ${States(args)}
+          </div>
+        </div>
+        <div class="spectrum-Typography">
+          ${Typography({
+            semantics: "detail",
+            size: "l",
+            content: ["Negative"],
+            customClasses: ["chromatic-ignore"],
+          })}
+          <div
+            style=${styleMap({
+              display: "flex",
+              flexDirection: "column",
+              gap: "10px",
+            })}
+          >
+            ${States({
+              ...args,
+              variant: "negative",
+            })}
+          </div>
+        </div>
+        <div class="spectrum-Typography">
+          ${Typography({
+            semantics: "detail",
+            size: "l",
+            content: ["Primary"],
+            customClasses: ["chromatic-ignore"],
+          })}
+          <div
+            style=${styleMap({
+              display: "flex",
+              flexDirection: "column",
+              gap: "10px",
+            })}
+          >
+            ${States({
+              ...args,
+              variant: "primary",
+            })}
+          </div>
+        </div>
+        <div class="spectrum-Typography">
+          ${Typography({
+            semantics: "detail",
+            size: "l",
+            content: ["Secondary"],
+            customClasses: ["chromatic-ignore"],
+          })}
+          <div
+            style=${styleMap({
+              display: "flex",
+              flexDirection: "column",
+              gap: "10px",
+            })}
+          >
+            ${States({
+              ...args,
+              variant: "secondary",
+            })}
+          </div>
+        </div>
+        <div class="spectrum-Typography">
+          ${Typography({
+            semantics: "detail",
+            size: "l",
+            content: ["Sizing"],
+            customClasses: ["chromatic-ignore"],
+          })}
+          <div
+            style=${styleMap({
+              display: "flex",
+              flexDirection: "column",
+              gap: "10px",
+            })}
+          >
+            ${Sizes(args)}
+          </div>
+        </div>
+        <div class="spectrum-Typography">
+          ${Typography({
+            semantics: "detail",
+            size: "l",
+            content: ["Wrapping"],
+            customClasses: ["chromatic-ignore"],
+          })}
+          <div
+            style=${styleMap({
+              display: "flex",
+              "flex-direction": "column",
+              gap: "10px",
+              padding: "6px",
+            })}
+          >
+            ${Wrapping(args)}
+          </div>
+        </div>
+      `
+    : html` <div
+        style=${styleMap({
+          display: "flex",
+          gap: "10px",
+        })}
+        id="render-root"
+      >
+        ${CustomButton(args)}
+      </div>`}`;
 
 export const Default = Variants.bind({});
 Default.args = {};

--- a/components/buttongroup/stories/buttongroup.stories.js
+++ b/components/buttongroup/stories/buttongroup.stories.js
@@ -34,11 +34,6 @@ export default {
 		iconName: undefined,
 		vertical: false,
 	},
-	parameters: {
-		actions: {
-			handles: [],
-		},
-	},
 };
 
 export const Default = Template.bind({});

--- a/components/buttongroup/stories/buttongroup.stories.js
+++ b/components/buttongroup/stories/buttongroup.stories.js
@@ -33,49 +33,31 @@ export default {
 		size: "m",
 		iconName: undefined,
 		vertical: false,
+		items: [
+			{
+				variant: "secondary",
+				treatment: "outline",
+				label: "No, thanks",
+			},
+			{
+				variant: "secondary",
+				treatment: "outline",
+				label: "Remind me later",
+
+			},
+			{
+				variant: "primary",
+				treatment: "fill",
+				label: "Rate now",
+			},
+		],
 	},
 };
 
 export const Default = Template.bind({});
-Default.args = {
-	items: [
-		{
-			variant: "secondary",
-			treatment: "outline",
-			label: "No, thanks",
-		},
-		{
-			variant: "secondary",
-			treatment: "outline",
-			label: "Remind me later",
-
-		},
-		{
-			variant: "primary",
-			treatment: "fill",
-			label: "Rate now",
-		},
-	],
-};
+Default.args = {};
 
 export const Vertical = Template.bind({});
 Vertical.args = {
 	vertical: true,
-	items: [
-		{
-			variant: "secondary",
-			treatment: "outline",
-			label: "No, thanks",
-		},
-		{
-			variant: "secondary",
-			treatment: "outline",
-			label: "Remind me later",
-		},
-		{
-			variant: "primary",
-			treatment: "fill",
-			label: "Rate now",
-		},
-	],
 };

--- a/components/calendar/stories/calendar.stories.js
+++ b/components/calendar/stories/calendar.stories.js
@@ -132,9 +132,7 @@ Disabled.args = {
 	isDisabled: true
 };
 
-/**
- * Stories for the MDX "Docs" only.
- */
+
 export const AbbreviatedWeekdays = Template.bind({});
 AbbreviatedWeekdays.args = {
 	useDOWAbbrev: true,

--- a/components/calendar/stories/calendar.stories.js
+++ b/components/calendar/stories/calendar.stories.js
@@ -94,6 +94,9 @@ export default {
 		isFocused: false,
 		useDOWAbbrev: false,
 		buttonSize: ActionButtonStories.args.size,
+		month: months[6],
+		selectedDay: new Date(2023, 6, 3),
+		year: 2023,
 	},
 	parameters: {
 		actions: {
@@ -105,36 +108,34 @@ export default {
 };
 
 export const Default = Template.bind({});
-Default.args = {
-	month: months[6],
-	selectedDay: new Date(2023, 6, 3),
-	year: 2023,
-};
+Default.args = {};
 
 export const RangeSelection = Template.bind({});
 RangeSelection.args = {
-	month: months[6],
-	selectedDay: new Date(2023, 6, 3),
 	lastDay: new Date(2023, 6, 7),
-	year: 2023,
 	useDOWAbbrev: true,
 	padded: true,
 };
 
 export const TodayHighlighted = Template.bind({});
-TodayHighlighted.args = {};
+TodayHighlighted.args = {
+	month: undefined,
+	selectedDay: undefined,
+	year: undefined,
+};
 
 export const Disabled = Template.bind({});
+Disabled.tags = ["vrt-only"];
 Disabled.args = {
-	month: months[6],
-	selectedDay: new Date(2023, 6, 3),
-	year: 2023,
 	isDisabled: true
 };
 
 
 export const AbbreviatedWeekdays = Template.bind({});
 AbbreviatedWeekdays.args = {
+	month: undefined,
+	selectedDay: undefined,
+	year: undefined,
 	useDOWAbbrev: true,
 };
 AbbreviatedWeekdays.tags = ["docs-only"];
@@ -144,6 +145,9 @@ AbbreviatedWeekdays.parameters = {
 
 export const Focused = Template.bind({});
 Focused.args = {
+	month: undefined,
+	selectedDay: undefined,
+	year: undefined,
 	isFocused: true,
 };
 Focused.tags = ["docs-only"];

--- a/components/card/stories/card.stories.js
+++ b/components/card/stories/card.stories.js
@@ -108,8 +108,8 @@ export default {
 	parameters: {
 		actions: {
 			handles: [
-				...ActionButton.parameters.actions.handles,
-				...Checkbox.parameters.actions.handles,
+				...(ActionButton.parameters?.actions?.handles ?? []),
+				...(Checkbox.parameters?.actions?.handles ?? []),
 			],
 		},
 	},
@@ -170,9 +170,7 @@ Horizontal.args = {
 	hasQuickAction: false,
 };
 
-/**
- * Stories for the MDX "Docs" only.
- */
+
 export const NoImage = Template.bind({});
 NoImage.args = {
 	title: "Card title",

--- a/components/clearbutton/stories/clearbutton.stories.js
+++ b/components/clearbutton/stories/clearbutton.stories.js
@@ -44,11 +44,6 @@ export default {
 		size: "m",
 		isDisabled: false,
 	},
-	parameters: {
-		actions: {
-			handles: [],
-		},
-	},
 };
 
 export const Default = Template.bind({});

--- a/components/coachindicator/stories/coachindicator.stories.js
+++ b/components/coachindicator/stories/coachindicator.stories.js
@@ -36,11 +36,19 @@ export default {
 export const Default = CoachIndicatorGroup.bind({});
 Default.args = {};
 Default.parameters = {
-	chromatic: { pauseAnimationAtEnd: true },
+	chromatic: {
+		prefersReducedMotion: "reduce",
+		pauseAnimationAtEnd: true,
+	},
 };
 
-export const WithReducedMotion = CoachIndicatorGroup.bind({});
-WithReducedMotion.tags = ["vrt-only"];
-WithReducedMotion.parameters = {
-	chromatic: { prefersReducedMotion: "reduce" },
+export const WithForcedColors = CoachIndicatorGroup.bind({});
+WithForcedColors.tags = ["vrt-only"];
+WithForcedColors.parameters = {
+	// Sets the forced-colors media feature for a specific story.
+	chromatic: {
+		forcedColors: "active",
+		prefersReducedMotion: "reduce"
+	},
 };
+WithForcedColors.args = {};

--- a/components/coachindicator/stories/coachindicator.stories.js
+++ b/components/coachindicator/stories/coachindicator.stories.js
@@ -1,5 +1,4 @@
-import { html } from "lit";
-import { Template } from "./template";
+import { CoachIndicatorGroup } from "./template";
 
 /**
  * The coach indicator component can be used to bring added attention to specific parts of a page.
@@ -24,57 +23,24 @@ export default {
 				type: { summary: "string" },
 				category: "Component",
 			},
-			options: ["default", "dark", "light"],
+			options: ["dark", "light"],
 			control: "select"
 		},
 	},
 	args: {
 		rootClass: "spectrum-CoachIndicator",
 		isQuiet: false,
-		variant: "default",
-	},
-	parameters: {
-		actions: {
-			handles: [],
-		},
 	},
 };
 
-const chromaticGroup = (args) => html`
-	<div>
-		${Template({
-			...args,
-			variant: "default"
-		})}
-		${Template({
-			...args,
-			variant: "dark"
-		})}
-		${Template({
-			...args,
-			variant: "light"
-			})}
-		${Template({
-			...args,
-			variant: "default",
-			isQuiet: true
-		})}
-		${Template({
-			...args,
-			variant: "dark",
-			isQuiet: true
-		})}
-		${Template({
-			...args,
-			variant: "light",
-			isQuiet: true
-			})}
-	</div>
-`;
+export const Default = CoachIndicatorGroup.bind({});
+Default.args = {};
+Default.parameters = {
+	chromatic: { pauseAnimationAtEnd: true },
+};
 
-export const Default = (args) => html`
-	${window.isChromatic() ? chromaticGroup(args) : Template(args)}
-`;
-Default.args = {
-	variant: "default"
+export const WithReducedMotion = CoachIndicatorGroup.bind({});
+WithReducedMotion.tags = ["vrt-only"];
+WithReducedMotion.parameters = {
+	chromatic: { prefersReducedMotion: "reduce" },
 };

--- a/components/coachindicator/stories/template.js
+++ b/components/coachindicator/stories/template.js
@@ -1,5 +1,6 @@
 import { html } from "lit-html";
 import { classMap } from "lit-html/directives/class-map.js";
+import { styleMap } from "lit-html/directives/style-map.js";
 
 import "../index.css";
 
@@ -8,15 +9,64 @@ export const Template = ({
 	isQuiet = false,
 	variant,
 }) => html`
-	<div
-		class=${classMap({
-			[`${rootClass}`]: true,
-			[`${rootClass}--quiet`]: isQuiet,
-			[`${rootClass}--${variant}`]: variant !== "default",
-		})}
-	>
-		<div class="${rootClass}-ring"></div>
-		<div class="${rootClass}-ring"></div>
-		<div class="${rootClass}-ring"></div>
-	</div>
+  <div
+    class=${classMap({
+      [`${rootClass}`]: true,
+      [`${rootClass}--quiet`]: isQuiet,
+      [`${rootClass}--${variant}`]: typeof variant !== "undefined",
+    })}
+  >
+    ${Array.from({ length: 3 }).map(
+      () => html`
+        <div class=${classMap({ [`${rootClass}-ring`]: true })}></div>
+      `
+    )}
+  </div>
 `;
+
+export const CoachIndicatorGroup = (args) => {
+	return html`
+    <div
+      style=${styleMap({
+        display: window.isChromatic() ? "none" : undefined,
+      })}
+    >
+      ${Template(args)}
+    </div>
+    <div
+      style=${styleMap({
+        display: window.isChromatic() ? "flex" : "none",
+      })}
+    >
+      ${Template(args)}
+      ${Template({
+        ...args,
+        variant: "dark",
+      })}
+      ${Template({
+        ...args,
+        variant: "light",
+      })}
+    </div>
+    <div
+      style=${styleMap({
+        display: window.isChromatic() ? "flex" : "none",
+      })}
+    >
+      ${Template({
+        ...args,
+        isQuiet: true,
+      })}
+      ${Template({
+        ...args,
+        variant: "dark",
+        isQuiet: true,
+      })}
+      ${Template({
+        ...args,
+        variant: "light",
+        isQuiet: true,
+      })}
+    </div>
+  `;
+};

--- a/components/coachmark/stories/coachmark.stories.js
+++ b/components/coachmark/stories/coachmark.stories.js
@@ -47,8 +47,8 @@ export default {
 	parameters: {
 		actions: {
 			handles: [
-				...ActionButton.parameters.actions.handles,
-				...Menu.parameters.actions.handles,
+				...(ActionButton.parameters?.actions?.handles ?? []),
+				...(Menu.parameters?.actions?.handles ?? []),
 			],
 		},
 		docs: {
@@ -70,7 +70,7 @@ WithMedia.parameters = {
 	docs: {
 		story: {
 			inline: false,
-			height: 475,
+			iframeHeight: "475px",
 		},
 	},
 };

--- a/components/colorarea/stories/colorarea.stories.js
+++ b/components/colorarea/stories/colorarea.stories.js
@@ -41,11 +41,6 @@ export default {
 		isDisabled: false,
 		isFocused: false,
 	},
-	parameters: {
-		actions: {
-			handles: [],
-		},
-	},
 };
 
 export const Default = Template.bind({});
@@ -58,9 +53,7 @@ CustomSize.args = {
 };
 
 
-/**
- * Stories for the MDX "Docs" only.
- */
+
 export const Disabled = Template.bind({});
 Disabled.args = {
 	isDisabled: true,

--- a/components/colorhandle/stories/colorhandle.stories.js
+++ b/components/colorhandle/stories/colorhandle.stories.js
@@ -52,9 +52,7 @@ export default {
 export const Default = Template.bind({});
 Default.args = {};
 
-/**
- * Stories for the MDX "Docs" only.
- */
+
 export const Disabled = Template.bind({});
 Disabled.args = {
 	isDisabled: true,
@@ -74,7 +72,7 @@ WithColorLoupe.parameters = {
 	docs: {
 		story: {
 			inline: false,
-			iframeHeight: 150,
+			iframeHeight: "150px",
 		},
 	},
 };

--- a/components/colorloupe/stories/colorloupe.stories.js
+++ b/components/colorloupe/stories/colorloupe.stories.js
@@ -25,9 +25,6 @@ export default {
 	},
 	parameters: {
 		chromatic: { diffThreshold: 0.2 },
-		actions: {
-			handles: [],
-		},
 		docs: {
 			story: {
 				height: "100px"

--- a/components/colorslider/stories/colorslider.stories.js
+++ b/components/colorslider/stories/colorslider.stories.js
@@ -52,11 +52,6 @@ export default {
 		gradientStops:
 			["rgb(255, 0, 0) 0%", "rgb(255, 255, 0) 17%", "rgb(0, 255, 0) 33%", "rgb(0, 255, 255) 50%", "rgb(0, 0, 255) 67%", "rgb(255, 0, 255) 83%", "rgb(255, 0, 0) 100%"],
 	},
-	parameters: {
-		actions: {
-			handles: [],
-		},
-	},
 };
 
 export const Default = Template.bind({});

--- a/components/colorwheel/stories/colorwheel.stories.js
+++ b/components/colorwheel/stories/colorwheel.stories.js
@@ -42,19 +42,12 @@ export default {
 		isFocused: false,
 		isWithColorArea: false,
 	},
-	parameters: {
-		actions: {
-			handles: [],
-		},
-	},
 };
 
 export const Default = Template.bind({});
 Default.args = {};
 
-/**
- * Stories for the MDX "Docs" only.
- */
+
 export const Disabled = Template.bind({});
 Disabled.args = {
 	isDisabled: true,

--- a/components/combobox/stories/combobox.stories.js
+++ b/components/combobox/stories/combobox.stories.js
@@ -157,9 +157,6 @@ export default {
 		],
 	},
 	parameters: {
-		actions: {
-			handles: [],
-		},
 		docs: {
 			story: {
 				height: "220px"
@@ -244,9 +241,7 @@ Quiet.args = {
 	isQuiet: true,
 };
 
-/**
- * Stories for the MDX "Docs" only.
- */
+
 
 // Standard
 export const WithLabel = Template.bind({});

--- a/components/contextualhelp/stories/contextualhelp.stories.js
+++ b/components/contextualhelp/stories/contextualhelp.stories.js
@@ -85,11 +85,6 @@ export default {
 				...(ActionButtonStories?.parameters?.actions?.handles ?? [])
 			],
 		},
-		docs: {
-			story: {
-				height: "200px",
-			},
-		},
 	},
 };
 
@@ -117,9 +112,7 @@ TopPopover.args = {
 	body: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
 };
 
-/**
- * Stories for the MDX "Docs" only.
- */
+
 export const HelpDefault = Template.bind({});
 HelpDefault.args = {
 	title: "Permission required",

--- a/components/datepicker/stories/datepicker.stories.js
+++ b/components/datepicker/stories/datepicker.stories.js
@@ -1,18 +1,19 @@
-import { Template } from "./template";
-
 import { default as CalendarStories } from "@spectrum-css/calendar/stories/calendar.stories.js";
-
-const ignoreProps = ["rootClass", "isDisabled"];
+import { Template } from "./template";
 
 /**
  * A date picker displays a text field input with a button next to it, and can display two text fields next to each other for choosing a date range.
+ *
+ * ## Usage notes
+ * - Date picker uses `.spectrum-PickerButton` instead of a `.spectrum-Picker`.
+ * - Workflow icon size is medium. If your markup is still using the small icon, replace `.spectrum-Icon--sizeS` with `.spectrum-Icon--sizeM`.
  */
 export default {
 	title: "Date picker",
 	component: "DatePicker",
 	argTypes: {
 		...Object.entries(CalendarStories.argTypes).reduce((acc, [key]) => {
-			if (ignoreProps.includes(key)) return acc;
+			if (["rootClass", "isDisabled"].includes(key)) return acc;
 			return { ...acc, [key]: { table: { disable: true } } };
 		}, {}),
 		isOpen: {
@@ -86,7 +87,7 @@ export default {
 			type: { name: "boolean" },
 			table: {
 				type: { summary: "boolean" },
-				category: "Advanced",
+				category: "State",
 			},
 			control: "boolean",
 		},
@@ -104,6 +105,10 @@ export default {
 		isDisabled: false,
 		isRequired: false,
 		readOnly: false,
+		month: "March",
+		selectedDay: 1,
+		year: 2023,
+		content: [{}],
 	},
 	parameters: {
 		actions: {
@@ -120,113 +125,98 @@ export default {
 };
 
 export const Default = Template.bind({});
-Default.args = {
-	month: "March",
-	selectedDay: 1,
-	year: 2023,
-	content: [{}],
-};
+Default.args = {};
 
 export const Quiet = Template.bind({});
 Quiet.args = {
-	month: "March",
-	selectedDay: 1,
-	year: 2023,
-	content: [{}],
 	isQuiet: true,
 };
 
 export const Range = Template.bind({});
 Range.args = {
-	month: "March",
-	selectedDay: 1,
-	year: 2023,
 	lastDay: 3,
-	content: [{}],
 	isRange: true,
 	isOpen: false,
 };
+Range.parameters = {
+	docs: {
+		story: {
+			height: "50px"
+		}
+	},
+};
 
-/**
- * Stories for the MDX "Docs" only.
- */
 export const QuietRange = Template.bind({});
 QuietRange.args = {
-	month: "March",
-	selectedDay: 1,
-	year: 2023,
 	lastDay: 3,
-	content: [{}],
 	isRange: true,
 	isQuiet: true,
 	isOpen: false,
 };
 QuietRange.parameters = {
 	chromatic: { disableSnapshot: true },
-};
-QuietRange.tags = ["docs-only"];
-
-export const ReadOnly = Template.bind({});
-ReadOnly.args = {
-	readOnly: true,
-	month: "March",
-	selectedDay: 1,
-	year: 2023,
-	content: [{}],
-};
-ReadOnly.parameters = {
-	chromatic: { disableSnapshot: true },
 	docs: {
 		story: {
-			height: "60px",
+			height: "50px"
 		}
-	}
+	},
 };
-ReadOnly.tags = ["docs-only"];
+QuietRange.tags = ["docs-only"];
 
 export const Invalid = Template.bind({});
 Invalid.args = {
 	isInvalid: true,
-	month: "March",
-	selectedDay: 1,
-	year: 2023,
-	content: [{}],
 	isOpen: false,
 };
 Invalid.parameters = {
 	chromatic: { disableSnapshot: true },
+	docs: {
+		story: {
+			height: "50px"
+		}
+	},
 };
 Invalid.tags = ["docs-only"];
 
 export const QuietInvalid = Template.bind({});
 QuietInvalid.args = {
 	isInvalid: true,
-	month: "March",
-	selectedDay: 1,
-	year: 2023,
-	content: [{}],
 	isQuiet: true,
 	isOpen: false,
 };
 QuietInvalid.parameters = {
 	chromatic: { disableSnapshot: true },
+	docs: {
+		story: {
+			height: "50px"
+		}
+	},
 };
 QuietInvalid.tags = ["docs-only"];
 
+export const ReadOnly = Template.bind({});
+ReadOnly.args = {
+	readOnly: true,
+};
+ReadOnly.parameters = {
+	chromatic: { disableSnapshot: true },
+	docs: {
+		story: {
+			height: "50px",
+		}
+	}
+};
+ReadOnly.tags = ["docs-only"];
 
 export const Disabled = Template.bind({});
 Disabled.args = {
 	isDisabled: true,
-	month: "March",
-	selectedDay: 1,
-	year: 2023,
-	content: [{}],
 };
 Disabled.parameters = {
 	chromatic: { disableSnapshot: true },
 	docs: {
 		story: {
-			height: "60px",
+			height: "50px",
 		}
 	}
 };
@@ -235,17 +225,13 @@ Disabled.tags = ["docs-only"];
 export const QuietDisabled = Template.bind({});
 QuietDisabled.args = {
 	isDisabled: true,
-	month: "March",
-	selectedDay: 1,
-	year: 2023,
-	content: [{}],
 	isQuiet: true,
 };
 QuietDisabled.parameters = {
 	chromatic: { disableSnapshot: true },
 	docs: {
 		story: {
-			height: "60px",
+			height: "50px",
 		}
 	}
 };

--- a/components/dial/stories/dial.stories.js
+++ b/components/dial/stories/dial.stories.js
@@ -60,11 +60,6 @@ export default {
 		isDragged: false,
 		isDisabled: false,
 	},
-	parameters: {
-		actions: {
-			handles: [],
-		},
-	},
 };
 
 export const Default = Template.bind();

--- a/components/dropindicator/stories/dropindicator.stories.js
+++ b/components/dropindicator/stories/dropindicator.stories.js
@@ -34,11 +34,6 @@ export default {
 		direction: "vertical",
 		size: "300px",
 	},
-	parameters: {
-		actions: {
-			handles: [],
-		},
-	},
 };
 
 export const Default = Template.bind({});

--- a/components/dropzone/stories/dropzone.stories.js
+++ b/components/dropzone/stories/dropzone.stories.js
@@ -36,11 +36,6 @@ export default {
 		isDragged: false,
 		isFilled: false,
 	},
-	parameters: {
-		actions: {
-			handles: [],
-		},
-	},
 };
 
 export const Default = (args) => html`

--- a/components/fieldgroup/stories/fieldgroup.stories.js
+++ b/components/fieldgroup/stories/fieldgroup.stories.js
@@ -45,7 +45,7 @@ export default {
 	parameters: {
 		actions: {
 			handles: [
-				...Radio.parameters.actions.handles
+				...(Radio.parameters?.actions?.handles ?? [])
 			],
 		},
 	},

--- a/components/fieldlabel/stories/fieldlabel.stories.js
+++ b/components/fieldlabel/stories/fieldlabel.stories.js
@@ -62,11 +62,6 @@ export default {
 		isDisabled: false,
 		isRequired: false,
 	},
-	parameters: {
-		actions: {
-			handles: [],
-		},
-	},
 };
 
 export const Default = Template.bind({});

--- a/components/fieldlabel/stories/form.stories.js
+++ b/components/fieldlabel/stories/form.stories.js
@@ -23,11 +23,6 @@ export default {
 		rootClass: "spectrum-Form",
 		labelsAbove: false,
 	},
-	parameters: {
-		actions: {
-			handles: [],
-		},
-	},
 	decorators: [
 		(Story, context) => html`<div style="padding: 16px">${Story(context)}</div>`
 	],

--- a/components/floatingactionbutton/stories/floatingactionbutton.stories.js
+++ b/components/floatingactionbutton/stories/floatingactionbutton.stories.js
@@ -31,11 +31,6 @@ export default {
 		variant: "primary",
 		iconName: "AddCircle",
 	},
-	parameters: {
-		actions: {
-			handles: [],
-		},
-	},
 };
 
 export const Default = Template.bind({});

--- a/components/helptext/stories/helptext.stories.js
+++ b/components/helptext/stories/helptext.stories.js
@@ -77,11 +77,6 @@ export default {
 		isDisabled: false,
 		size: "m",
 	},
-	parameters: {
-		actions: {
-			handles: [],
-		},
-	},
 };
 
 export const Default = Template.bind({});

--- a/components/icon/stories/icon.stories.js
+++ b/components/icon/stories/icon.stories.js
@@ -1,45 +1,9 @@
-import iconOpts from "@adobe/spectrum-css-workflow-icons";
-import { IconGroup } from "./template";
+import { html } from "lit";
+import { styleMap } from "lit/directives/style-map.js";
+import { when } from "lit/directives/when.js";
 
-const workflowIcons = (iconOpts || []).map((icon) => icon.replace(/\.svg$/, ""));
-
-/**
- * UI Icons have specific sizes represented by a number.
- * Each size has its own individual file and a CSS class with defined dimensions.
- */
-const uiIconSizes = {
-	"Arrow": ["75","100","200","300","400","500","600"],
-	"Asterisk": ["75","100","200","300"],
-	"Checkmark": ["50","75","100","200","300","400","500","600"],
-	"Chevron": ["50","75","100","200","300","400","500"],
-	"CornerTriangle": ["75","100","200","300"],
-	"Cross": ["75","100","200","300","400","500","600"],
-	"Dash": ["50","75","100","200","300","400","500","600"],
-	"SingleGripper": [],
-	"DoubleGripper": [],
-	"TripleGripper": [],
-};
-
-/**
- * List of UI icon names, corresponding to files.
- */
-const uiIcons = ["Arrow","Asterisk","Checkmark","Chevron","CornerTriangle","Cross","Dash","SingleGripper","DoubleGripper","TripleGripper"];
-
-/**
- * List of all UI icon names for CSS. Chevron and Arrow have directional suffixes
- * for rotating the same base icon, e.g. Arrow becomes ArrowRight, ArrowDown, etc.
- */
-const uiIconsWithDirections = [
-	...uiIcons.filter((c) => !["Chevron", "Arrow"].includes(c)),
-	"ArrowRight",
-	"ArrowLeft",
-	"ArrowUp",
-	"ArrowDown",
-	"ChevronRight",
-	"ChevronLeft",
-	"ChevronUp",
-	"ChevronDown",
-];
+import { Template } from "./template";
+import { uiIconSizes, uiIconsWithDirections, workflowIcons } from "./utilities.js";
 
 /**
  * Create a list of all UI Icons with their sizing numbers.
@@ -66,7 +30,7 @@ export default {
 	argTypes: {
 		reducedMotion: { table: { disable: true } },
 		size: {
-			name: "Workflow icon Size",
+			name: "Workflow Icon Size",
 			type: { name: "string", required: true },
 			table: {
 				type: { summary: "string" },
@@ -119,6 +83,7 @@ export default {
 			},
 			control: "color",
 		},
+		useRef: { table: { disable: true } },
 	},
 	args: {
 		rootClass: "spectrum-Icon",
@@ -128,5 +93,72 @@ export default {
 	},
 };
 
-export const Default = IconGroup.bind({});
+export const Default = (args) => window.isChromatic() ? TestTemplate(args) : Template({
+	...args,
+	iconName: args.iconName ?? args.uiIconName,
+	setName: args.setName ?? (args.uiIconName ? "ui" : "workflow"),
+});
+
 Default.args = {};
+
+/**
+ * Chromatic VRT template that displays multiple icons to cover various options.
+ */
+const TestTemplate = (args) => html`
+	${[
+	{
+		setName: "workflow",
+		iconName: "Alert",
+		fill: "var(--spectrum-negative-content-color-default)",
+	},
+	{
+		setName: "workflow",
+		iconName: "Hand",
+	},
+	{
+		setName: "workflow",
+		iconName: "Help",
+	},
+	{
+		setName: "workflow",
+		iconName: "ArrowLeft",
+	},
+	{
+		setName: "workflow",
+		iconName: "ArrowRight",
+	},
+	{
+		setName: "workflow",
+		iconName: "ChevronDown",
+	}
+].map((row_args) => html`
+		<div
+			style=${styleMap({
+				"display": "flex",
+				"gap": "16px",
+				"margin-bottom": "16px",
+			})}
+		>
+			${["xs","s","m","l","xl","xxl"].map(
+				(size) => Template({ ...args, ...row_args, size })
+			)}
+		</div>`
+	)}
+	<div style="margin-top:32px;">
+		${uiIconsWithDirections.map(iconName => html`
+			<div
+				style=${styleMap({
+					"display": "flex",
+					"gap": "16px",
+				})}
+			>
+				${uiIconSizes[iconName.replace(/(Left|Right|Up|Down)$/, "")]?.map((iconSize) =>
+					Template({ ...args, setName: "ui", iconName: iconName + iconSize })
+				)}
+				${when(uiIconSizes[iconName]?.length == 0, () =>
+					Template({ ...args, setName: "ui", iconName })
+				)}
+			</div>`
+		)}
+	</div>
+`;

--- a/components/icon/stories/icon.stories.js
+++ b/components/icon/stories/icon.stories.js
@@ -1,9 +1,45 @@
-import { html } from "lit";
-import { styleMap } from "lit/directives/style-map.js";
-import { when } from "lit/directives/when.js";
+import iconOpts from "@adobe/spectrum-css-workflow-icons";
+import { IconGroup } from "./template";
 
-import { Template } from "./template";
-import { uiIconSizes, uiIconsWithDirections, workflowIcons } from "./utilities.js";
+const workflowIcons = (iconOpts || []).map((icon) => icon.replace(/\.svg$/, ""));
+
+/**
+ * UI Icons have specific sizes represented by a number.
+ * Each size has its own individual file and a CSS class with defined dimensions.
+ */
+const uiIconSizes = {
+	"Arrow": ["75","100","200","300","400","500","600"],
+	"Asterisk": ["75","100","200","300"],
+	"Checkmark": ["50","75","100","200","300","400","500","600"],
+	"Chevron": ["50","75","100","200","300","400","500"],
+	"CornerTriangle": ["75","100","200","300"],
+	"Cross": ["75","100","200","300","400","500","600"],
+	"Dash": ["50","75","100","200","300","400","500","600"],
+	"SingleGripper": [],
+	"DoubleGripper": [],
+	"TripleGripper": [],
+};
+
+/**
+ * List of UI icon names, corresponding to files.
+ */
+const uiIcons = ["Arrow","Asterisk","Checkmark","Chevron","CornerTriangle","Cross","Dash","SingleGripper","DoubleGripper","TripleGripper"];
+
+/**
+ * List of all UI icon names for CSS. Chevron and Arrow have directional suffixes
+ * for rotating the same base icon, e.g. Arrow becomes ArrowRight, ArrowDown, etc.
+ */
+const uiIconsWithDirections = [
+	...uiIcons.filter((c) => !["Chevron", "Arrow"].includes(c)),
+	"ArrowRight",
+	"ArrowLeft",
+	"ArrowUp",
+	"ArrowDown",
+	"ChevronRight",
+	"ChevronLeft",
+	"ChevronUp",
+	"ChevronDown",
+];
 
 /**
  * Create a list of all UI Icons with their sizing numbers.
@@ -30,7 +66,7 @@ export default {
 	argTypes: {
 		reducedMotion: { table: { disable: true } },
 		size: {
-			name: "Workflow Icon Size",
+			name: "Workflow icon Size",
 			type: { name: "string", required: true },
 			table: {
 				type: { summary: "string" },
@@ -83,7 +119,6 @@ export default {
 			},
 			control: "color",
 		},
-		useRef: { table: { disable: true } },
 	},
 	args: {
 		rootClass: "spectrum-Icon",
@@ -93,72 +128,5 @@ export default {
 	},
 };
 
-export const Default = (args) => window.isChromatic() ? TestTemplate(args) : Template({
-	...args,
-	iconName: args.iconName ?? args.uiIconName,
-	setName: args.setName ?? (args.uiIconName ? "ui" : "workflow"),
-});
-
+export const Default = IconGroup.bind({});
 Default.args = {};
-
-/**
- * Chromatic VRT template that displays multiple icons to cover various options.
- */
-const TestTemplate = (args) => html`
-	${[
-	{
-		setName: "workflow",
-		iconName: "Alert",
-		fill: "var(--spectrum-negative-content-color-default)",
-	},
-	{
-		setName: "workflow",
-		iconName: "Hand",
-	},
-	{
-		setName: "workflow",
-		iconName: "Help",
-	},
-	{
-		setName: "workflow",
-		iconName: "ArrowLeft",
-	},
-	{
-		setName: "workflow",
-		iconName: "ArrowRight",
-	},
-	{
-		setName: "workflow",
-		iconName: "ChevronDown",
-	}
-].map((row_args) => html`
-		<div
-			style=${styleMap({
-				"display": "flex",
-				"gap": "16px",
-				"margin-bottom": "16px",
-			})}
-		>
-			${["xs","s","m","l","xl","xxl"].map(
-				(size) => Template({ ...args, ...row_args, size })
-			)}
-		</div>`
-	)}
-	<div style="margin-top:32px;">
-		${uiIconsWithDirections.map(iconName => html`
-			<div
-				style=${styleMap({
-					"display": "flex",
-					"gap": "16px",
-				})}
-			>
-				${uiIconSizes[iconName.replace(/(Left|Right|Up|Down)$/, "")]?.map((iconSize) =>
-					Template({ ...args, setName: "ui", iconName: iconName + iconSize })
-				)}
-				${when(uiIconSizes[iconName]?.length == 0, () =>
-					Template({ ...args, setName: "ui", iconName })
-				)}
-			</div>`
-		)}
-	</div>
-`;

--- a/components/illustratedmessage/stories/illustratedmessage.stories.js
+++ b/components/illustratedmessage/stories/illustratedmessage.stories.js
@@ -40,11 +40,6 @@ export default {
 	args: {
 		rootClass: "spectrum-IllustratedMessage",
 	},
-	parameters: {
-		actions: {
-			handles: [],
-		},
-	},
 };
 
 export const Default = (args) => html`

--- a/components/infieldbutton/stories/infieldbutton.stories.js
+++ b/components/infieldbutton/stories/infieldbutton.stories.js
@@ -60,11 +60,6 @@ export default {
 		isQuiet: false,
 		isDisabled: false
 	},
-	parameters: {
-		actions: {
-			handles: []
-		}
-	}
 };
 
 export const Default = Template.bind({});

--- a/components/inlinealert/stories/inlinealert.stories.js
+++ b/components/inlinealert/stories/inlinealert.stories.js
@@ -56,11 +56,6 @@ export default {
 		variant: "neutral",
 		isClosable: false,
 	},
-	parameters: {
-		actions: {
-			handles: [],
-		},
-	},
 };
 
 export const Default = (args) => html`

--- a/components/logicbutton/stories/logicbutton.stories.js
+++ b/components/logicbutton/stories/logicbutton.stories.js
@@ -32,11 +32,6 @@ export default {
 		variant: "and",
 		isDisabled: false,
 	},
-	parameters: {
-		actions: {
-			handles: [],
-		},
-	},
 };
 
 export const Default = Template.bind({});

--- a/components/menu/stories/menu.stories.js
+++ b/components/menu/stories/menu.stories.js
@@ -132,6 +132,7 @@ const ChromaticMenuWithVariants = (args) => {
 			semantics: "detail",
 			size: "l",
 			content: [ item.stateTitle ],
+			customClasses: ["chromatic-ignore"],
 		})}
 		<div>
 			${Template({...args, ...item.args})}
@@ -396,7 +397,8 @@ const Sizes = (args) => ["s", "m", "l", "xl"].map((size) => html`
 					l: "Large",
 					xl: "Extra-large",
 				}[size]
-			]
+			],
+			customClasses: ["chromatic-ignore"],
 		})}
 		<div>
 			${Template({...args, size})}
@@ -440,6 +442,7 @@ const States = (args) => {
 				semantics: "detail",
 				size: "s",
 				content: [`${titlePrefix ? titlePrefix + ", ": ""}${stateItem.stateTitle}`],
+				customClasses: ["chromatic-ignore"],
 			})}
 			<div>
 				${Template({...args, ...stateItem.args})}
@@ -509,6 +512,7 @@ const WithValueStates = (args) => {
 			semantics: "detail",
 			size: "s",
 			content: [ valueItem.stateTitle ],
+			customClasses: ["chromatic-ignore"],
 		})}
 			<div>
 				${Template({ ...args, ...valueItem.args })}
@@ -566,6 +570,7 @@ const ChromaticMenuItem = (args) => {
 			semantics: "detail",
 			size: "l",
 			content: [sectionItem.sectionTitle],
+			customClasses: ["chromatic-ignore"],
 		})}
 		<div
 			style=${styleMap({

--- a/components/miller/stories/miller.stories.js
+++ b/components/miller/stories/miller.stories.js
@@ -12,11 +12,6 @@ export default {
 	args: {
 		rootClass: "spectrum-MillerColumns",
 	},
-	parameters: {
-		actions: {
-			handles: [],
-		},
-	},
 };
 
 export const BranchesSelectable = Template.bind({});

--- a/components/modal/stories/modal.stories.js
+++ b/components/modal/stories/modal.stories.js
@@ -35,11 +35,6 @@ export default {
 		isOpen: true,
 		rootClass: "spectrum-Modal",
 	},
-	parameters: {
-		actions: {
-			handles: [],
-		},
-	},
 };
 
 export const Default = Template.bind({});

--- a/components/opacitycheckerboard/stories/opacitycheckerboard.stories.js
+++ b/components/opacitycheckerboard/stories/opacitycheckerboard.stories.js
@@ -24,11 +24,6 @@ export default {
 		rootClass: "spectrum-OpacityCheckerboard",
 		backgroundPosition: "left top"
 	},
-	parameters: {
-		actions: {
-			handles: [],
-		},
-	},
 	decorators: [
 		(Story, context) => html`<div style=${styleMap({ inlineSize: "100px", blockSize: "100px" })}>${Story(context)}</div>`
 	],

--- a/components/pagination/stories/pagination.stories.js
+++ b/components/pagination/stories/pagination.stories.js
@@ -32,7 +32,7 @@ export default {
 	parameters: {
 		actions: {
 			handles: [
-				...ActionButton.parameters.actions.handles
+				...(ActionButton.parameters?.actions?.handles ?? [])
 			],
 		},
 	},

--- a/components/picker/stories/picker.stories.js
+++ b/components/picker/stories/picker.stories.js
@@ -131,9 +131,6 @@ export default {
 		],
 	},
 	parameters: {
-		actions: {
-			handles: [],
-		},
 		docs: {
 			story: {
 				height: "300px"

--- a/components/pickerbutton/stories/pickerbutton.stories.js
+++ b/components/pickerbutton/stories/pickerbutton.stories.js
@@ -114,11 +114,6 @@ export default {
 		iconName: "ChevronDown",
 		position: "right"
 	},
-	parameters: {
-		actions: {
-			handles: [],
-		},
-	},
 };
 
 export const Default = Template.bind({});

--- a/components/pickerbutton/stories/pickerbutton.stories.js
+++ b/components/pickerbutton/stories/pickerbutton.stories.js
@@ -1,6 +1,5 @@
-import { Template } from "./template";
-
 import { default as Icon } from "@spectrum-css/icon/stories/icon.stories.js";
+import { Template } from "./template";
 
 /**
  * The picker button component is used as a dropdown trigger. See Combobox.
@@ -125,16 +124,19 @@ WithLabel.args = {
 };
 
 export const Disabled = Template.bind({});
+Disabled.tags = ["vrt-only"];
 Disabled.args = {
 	isDisabled: true
 };
 
 export const Quiet = Template.bind({});
+Quiet.tags = ["vrt-only"];
 Quiet.args = {
 	isQuiet: true
 };
 
 export const Express = Template.bind({});
+Express.tags = ["vrt-only"];
 Express.args = {
 	express: true
 };

--- a/components/pickerbutton/stories/template.js
+++ b/components/pickerbutton/stories/template.js
@@ -1,12 +1,9 @@
+import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
+import { useArgs } from "@storybook/preview-api";
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { styleMap } from "lit/directives/style-map.js";
-
-import { useArgs } from "@storybook/preview-api";
-
-import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
-
 import "../index.css";
 
 export const Template = ({

--- a/components/popover/stories/popover.stories.js
+++ b/components/popover/stories/popover.stories.js
@@ -149,14 +149,16 @@ const ChromaticTipPlacementVariants = (args) => html`
 				${Typography({
 					semantics: "detail",
 					size: "l",
-					content: [`${option}`],
+					content: [option],
+				customClasses: ["chromatic-ignore"],
 				})}
 				<div>
 					${when(optionDescription() !== null, () => html`
 						${Typography({
 							semantics: "detail",
 							size: "s",
-							content: [`${optionDescription()}`],
+							content: [optionDescription()],
+							customClasses: ["chromatic-ignore"],
 						})}
 					`)}
 				</div>

--- a/components/popover/stories/popover.stories.js
+++ b/components/popover/stories/popover.stories.js
@@ -113,10 +113,6 @@ export default {
 	},
 	parameters: {
 		layout: "centered",
-		actions: {
-			handles: [],
-		},
-		chromatic: { delay: 2000 },
 		docs: {
 			story: {
 				height: "300px"

--- a/components/progressbar/stories/meter.stories.js
+++ b/components/progressbar/stories/meter.stories.js
@@ -54,11 +54,6 @@ export default {
 		size: "s",
 		value: 50,
 	},
-	parameters: {
-		actions: {
-			handles: [],
-		},
-	},
 };
 
 export const Default = Template.bind({});

--- a/components/progressbar/stories/progressbar.stories.js
+++ b/components/progressbar/stories/progressbar.stories.js
@@ -66,11 +66,6 @@ export default {
 		label: "Loading",
 		value: 50,
 	},
-	parameters: {
-		actions: {
-			handles: [],
-		},
-	},
 };
 
 export const Default = Template.bind({});

--- a/components/progresscircle/stories/progresscircle.stories.js
+++ b/components/progresscircle/stories/progresscircle.stories.js
@@ -46,11 +46,6 @@ export default {
 		isIndeterminate: false,
 		staticColor: undefined,
 	},
-	parameters: {
-		actions: {
-			handles: [],
-		},
-	},
 };
 
 const ProgressCircleGroup = (args) => html`

--- a/components/rating/stories/rating.stories.js
+++ b/components/rating/stories/rating.stories.js
@@ -70,11 +70,6 @@ export default {
 		max: 5,
 		value: 3,
 	},
-	parameters: {
-		actions: {
-			handles: [],
-		},
-	},
 };
 
 export const Default = Template.bind({});

--- a/components/sidenav/stories/sidenav.stories.js
+++ b/components/sidenav/stories/sidenav.stories.js
@@ -35,11 +35,6 @@ export default {
 		hasIcon: false,
 		iconName: "Folder"
 	},
-	parameters: {
-		actions: {
-			handles: []
-		}
-	}
 };
 
 export const Default = Template.bind({});

--- a/components/splitview/stories/splitview.stories.js
+++ b/components/splitview/stories/splitview.stories.js
@@ -69,11 +69,6 @@ export default {
 		isResizable: false,
 		componentHeight: "200px",
 	},
-	parameters: {
-		actions: {
-			handles: [],
-		},
-	},
 };
 
 export const Horizontal = Template.bind({});

--- a/components/statuslight/stories/statuslight.stories.js
+++ b/components/statuslight/stories/statuslight.stories.js
@@ -63,11 +63,6 @@ export default {
 		label: "Status",
 		variant: "info",
 	},
-	parameters: {
-		actions: {
-			handles: [],
-		},
-	},
 };
 
 export const Default = (args) => html`

--- a/components/steplist/stories/steplist.stories.js
+++ b/components/steplist/stories/steplist.stories.js
@@ -50,11 +50,6 @@ export default {
 		isInteractive: false,
 		withTooltip: false,
 	},
-	parameters: {
-		actions: {
-			handles: [],
-		},
-	},
 };
 
 export const Default = Template.bind({});

--- a/components/stepper/stories/stepper.stories.js
+++ b/components/stepper/stories/stepper.stories.js
@@ -84,11 +84,6 @@ export default {
 		isDisabled: false,
 		hideStepper: false
 	},
-	parameters: {
-		actions: {
-			handles: [],
-		},
-	},
 };
 
 export const Default = (args) => html`

--- a/components/swatch/stories/swatch.stories.js
+++ b/components/swatch/stories/swatch.stories.js
@@ -63,11 +63,6 @@ export default {
 		rounding: "regular",
 		swatchColor: "rgb(174, 216, 230)"
 	},
-	parameters: {
-		actions: {
-			handles: [],
-		},
-	},
 };
 
 export const Default = Template.bind({});

--- a/components/swatchgroup/stories/swatchgroup.stories.js
+++ b/components/swatchgroup/stories/swatchgroup.stories.js
@@ -60,7 +60,7 @@ export default {
 	parameters: {
 		actions: {
 			handles: [
-				...Swatch.parameters?.actions?.handles ?? [],
+				...(Swatch.parameters?.actions?.handles ?? []),
 			],
 		},
 	},

--- a/components/switch/stories/switch.stories.js
+++ b/components/switch/stories/switch.stories.js
@@ -62,11 +62,6 @@ export default {
 		label: "Switch label",
 		size: "m",
 	},
-	parameters: {
-		actions: {
-			handles: [],
-		},
-	},
 };
 
 export const Default = Template.bind({});

--- a/components/table/stories/table.stories.js
+++ b/components/table/stories/table.stories.js
@@ -100,11 +100,6 @@ export default {
 		isDropTarget: false,
 		useScroller: false,
 	},
-	parameters: {
-		actions: {
-			handles: [],
-		},
-	},
 };
 
 export const Default = Template.bind({});

--- a/components/tabs/stories/tabs.stories.js
+++ b/components/tabs/stories/tabs.stories.js
@@ -20,7 +20,7 @@ export default {
 				category: "Component",
 			},
 			options: ["s", "m", "l", "xl"],
-			control: "select"
+			control: "select",
 		},
 		orientation: {
 			name: "Orientation",
@@ -32,7 +32,7 @@ export default {
 			},
 			options: ["horizontal", "vertical", "overflow"],
 			control: "select",
-			default: "horizontal"
+			default: "horizontal",
 		},
 		isQuiet: {
 			name: "Quiet",
@@ -70,7 +70,7 @@ export default {
 				category: "Component",
 			},
 			control: "boolean",
-		}
+		},
 	},
 	args: {
 		rootClass: "spectrum-Tabs",
@@ -95,60 +95,92 @@ export default {
 				label: "Tab 3",
 				icon: "Document",
 				isDisabled: true,
-			}
+			},
 		],
 	},
 	parameters: {
 		actions: {
 			handles: [".spectrum-Tabs-item"],
-		}
-	}
+		},
+	},
 };
 
 const TabsGroup = (args) => html`
-  <div style="display: flex; flex-direction: ${args.orientation === "horizontal" ? "column" : "row"}; gap: 32px;">
-    ${Template({ ...args, content: [
-      {
-        id: "tab-1",
-        label: "Tab 1",
-        isSelected: true,
-      },
-      {
-        id: "tab-2",
-        label: "Tab 2",
-        isDisabled: true,
-      },
-      {
-        id: "tab-3",
-        label: "Tab 3",
-      }
-    ]})}
-    ${Template(args)}
-    ${Template({ ...args, iconOnly: true })}
+  <div
+    style="display: flex; flex-direction: ${args.orientation === "horizontal"
+      ? "column"
+      : "row"}; gap: 32px;"
+  >
+    ${Template({
+      ...args,
+      content: [
+        {
+          id: "tab-1",
+          label: "Tab 1",
+          isSelected: true,
+        },
+        {
+          id: "tab-2",
+          label: "Tab 2",
+          isDisabled: true,
+        },
+        {
+          id: "tab-3",
+          label: "Tab 3",
+        },
+      ],
+    })}
+    ${Template(args)} ${Template({ ...args, iconOnly: true })}
   </div>
 `;
 
 const Variants = (args) => html`
-  ${window.isChromatic() ? html`
-  <div style="display: grid; gap: 32px;${args.orientation === "overflow" ? " max-inline-size: 100px" : ""}">
-    <div style="display: flex; flex-flow: column nowrap; gap: 8px;">
-      ${Typography({ semantics: "heading", size: "s", content: ["Default"] })}
-      ${TabsGroup(args)}
-    </div>
-    <div style="display: flex; flex-flow: column nowrap; gap: 8px;">
-      ${Typography({ semantics: "heading", size: "s", content: ["Emphasized"] })}
-      ${TabsGroup({ ...args, isEmphasized: true })}
-    </div>
-    <div style="display: flex; flex-flow: column nowrap; gap: 8px;">
-      ${Typography({ semantics: "heading", size: "s", content: ["Quiet"] })}
-      ${TabsGroup({ ...args, isQuiet: true })}
-    </div>
-    <div style="display: flex; flex-flow: column nowrap; gap: 8px;">
-      ${Typography({ semantics: "heading", size: "s", content: ["Quiet + compact"] })}
-      ${TabsGroup({ ...args, isQuiet: true, isCompact: true })}
-    </div>
-  </div>
-` : Template(args)}
+  ${window.isChromatic()
+    ? html`
+        <div
+          style="display: grid; gap: 32px;${args.orientation === "overflow"
+            ? " max-inline-size: 100px"
+            : ""}"
+        >
+          <div style="display: flex; flex-flow: column nowrap; gap: 8px;">
+            ${Typography({
+              semantics: "heading",
+              size: "s",
+              content: ["Default"],
+              customClasses: ["chromatic-ignore"],
+            })}
+            ${TabsGroup(args)}
+          </div>
+          <div style="display: flex; flex-flow: column nowrap; gap: 8px;">
+            ${Typography({
+              semantics: "heading",
+              size: "s",
+              content: ["Emphasized"],
+              customClasses: ["chromatic-ignore"],
+            })}
+            ${TabsGroup({ ...args, isEmphasized: true })}
+          </div>
+          <div style="display: flex; flex-flow: column nowrap; gap: 8px;">
+            ${Typography({
+              semantics: "heading",
+              size: "s",
+              content: ["Quiet"],
+              customClasses: ["chromatic-ignore"],
+            })}
+            ${TabsGroup({ ...args, isQuiet: true })}
+          </div>
+          <div style="display: flex; flex-flow: column nowrap; gap: 8px;">
+            ${Typography({
+              semantics: "heading",
+              size: "s",
+              content: ["Quiet + compact"],
+              customClasses: ["chromatic-ignore"],
+            })}
+            ${TabsGroup({ ...args, isQuiet: true, isCompact: true })}
+          </div>
+        </div>
+      `
+    : Template(args)}
 `;
 
 export const Default = Variants.bind({});
@@ -156,7 +188,7 @@ Default.args = {};
 
 export const Vertical = Variants.bind({});
 Vertical.args = {
-	orientation: "vertical"
+	orientation: "vertical",
 };
 
 export const Overflow = Variants.bind({});

--- a/components/tooltip/stories/tooltip.stories.js
+++ b/components/tooltip/stories/tooltip.stories.js
@@ -154,7 +154,8 @@ const PlacementVariants = (args) => html`
 						${Typography({
 							semantics: "detail",
 							size: "l",
-							content: [`${option}`],
+							content: [option],
+							customClasses: ["chromatic-ignore"],
 						})}
 						<div
 							style=${styleMap({
@@ -167,7 +168,8 @@ const PlacementVariants = (args) => html`
 								${Typography({
 									semantics: "detail",
 									size: "s",
-									content: [`${optionDescription()}`],
+									content: [optionDescription()],
+									customClasses: ["chromatic-ignore"],
 								})}
 							`)}
 							${Template({

--- a/components/tray/stories/tray.stories.js
+++ b/components/tray/stories/tray.stories.js
@@ -32,16 +32,6 @@ export default {
 		isOpen: true,
 		heading: "New Messages",
 	},
-	parameters: {
-		actions: {
-			handles: [],
-		},
-		docs: {
-			story: {
-				height: "200px"
-			}
-		},
-	},
 };
 
 export const Default = ({

--- a/components/underlay/stories/underlay.stories.js
+++ b/components/underlay/stories/underlay.stories.js
@@ -24,7 +24,7 @@ export default {
 		rootClass: "spectrum-Underlay",
 	},
 	parameters: {
-		chromatic: { disable: true },
+		chromatic: { disableSnapshot: true },
 		actions: {
 			handles: []
 		}

--- a/generator/templates/stories/template.js.hbs
+++ b/generator/templates/stories/template.js.hbs
@@ -1,13 +1,14 @@
 import { html } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
-
-import "@spectrum-css/{{ folderName }}//index.css";
+import { styleMap } from "lit/directives/style-map.js";
+import "../index.css";
 
 export const Template = ({
   rootClass = "spectrum-{{ pascalCase name }}",
   size = "m",
   id,
+  testId,
   customClasses = [],
   customStyles = {},
   ...globals
@@ -19,8 +20,32 @@ export const Template = ({
       ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
     })}
     id=${ifDefined(id)}
+    data-test-id=${ifDefined(testId)}
     style=${ifDefined(styleMap(customStyles))}
   >
     <!-- Component mark-up goes here -->
+  </div>
+`;
+
+export const {{ pascalCase name }}Group = (args) => html`
+  <div style=${styleMap({
+    "display": window.isChromatic() ? "none" : undefined,
+  })}>
+    ${Template(args)}
+  </div>
+  <div style=${styleMap({
+    "display": window.isChromatic() ? "flex" : "none",
+    "flex-wrap": "wrap",
+    "gap": "16px"
+  })}>
+    ${Template(args)}
+    ${Template({
+      ...args,
+      // variant1
+    })}
+    ${Template({
+      ...args,
+      // variant2
+    })}
   </div>
 `;

--- a/generator/templates/stories/{{ folderName }}.mdx.hbs
+++ b/generator/templates/stories/{{ folderName }}.mdx.hbs
@@ -1,0 +1,18 @@
+import { ArgTypes, Meta, Description, Primary, Stories, Title } from '@storybook/blocks';
+
+import * as {{ pascalCase name }}Stories from './{{ folderName }}.stories';
+
+<Meta of={{{ pascalCase name }}Stories} title="Docs" />
+
+<Title of={{{ pascalCase name }}Stories} />
+<Description of={{{ pascalCase name }}Stories} />
+
+<Primary of={{{ pascalCase name }}Stories} />
+
+## Properties
+
+The component accepts the following inputs (properties):
+
+<ArgTypes />
+
+<Stories of={{{ pascalCase name }}Stories} includePrimary={ false } />

--- a/generator/templates/stories/{{ folderName }}.stories.js.hbs
+++ b/generator/templates/stories/{{ folderName }}.stories.js.hbs
@@ -1,9 +1,4 @@
-import { html } from "lit";
-import { classMap } from "lit/directives/class-map.js";
-import { ifDefined } from "lit/directives/if-defined.js";
-import { styleMap } from "lit/directives/style-map.js";
-
-import { Template } from "./template.js";
+import { {{ pascalCase name }}Group } from "./template.js";
 
 /**
   * {{ description }}
@@ -31,10 +26,7 @@ export default {
   },
   parameters: {
     actions: {
-      handles: []
-    },
-    status: {
-      type: "migrated"
+      handles: ["click .spectrum-{{ pascalCase name }}"],
     },
     design: {
       type: "figma",
@@ -43,25 +35,11 @@ export default {
   }
 };
 
-const {{ pascalCase name }}Group = (args) => html`
-	${window.isChromatic() ? html`
-		<div style=${styleMap({
-			"display": "flex",
-			"flex-wrap": "wrap",
-			"gap": "16px"
-		})}>
-			${Template(args)}
-			${Template({
-				...args,
-                // variant1
-			})}
-			${Template({
-				...args,
-                // variant2
-			})}
-		</div>
-	` : Template(args)}
-`;
-
 export const Default = {{ pascalCase name }}Group.bind({});
 Default.args = {};
+
+export const WithForcedColors = {{ pascalCase name }}Group.bind({});
+WithForcedColors.tags = ["vrt-only"];
+WithForcedColors.parameters = {
+	chromatic: { forcedColors: "active" },
+};


### PR DESCRIPTION
## Fixes for Storybook instance

- Bring back testing preview global toggle to toolbar after it was accidentally removed in a previous release
- Chromatic disable snapshot syntax corrected in multiple stories
- Update when token assets are loaded to correct snapshot inconsistencies
- Add the vrt-only flag to ForcedColors stories to prevent them from being included in the local Storybook view
- Fixes to the Coach Indicator story

## How and where has this been tested?

### Validation steps

- [x] Regression testing

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
