### PR TITLE
docs(dropzone,fieldgroup,floatingactionbutton,illustratedmessage,infieldbutton): site docs to Storybook

### DIFF
--- a/.storybook/DocumentationTemplate.mdx
+++ b/.storybook/DocumentationTemplate.mdx
@@ -6,7 +6,7 @@ import {
 	Subtitle,
 	Description,
 	Primary,
-	Controls,
+	ArgTypes,
 	Stories,
 } from "@storybook/blocks";
 
@@ -18,12 +18,10 @@ import {
 <Subtitle />
 <Description />
 
-<Primary />
+<Stories title="Variants" />
 
 ## Properties
 
 The component accepts the following inputs (properties):
 
-<Controls />
-
-<Stories includePrimary={false} />
+<ArgTypes />

--- a/.storybook/assets/base.css
+++ b/.storybook/assets/base.css
@@ -33,3 +33,15 @@ body {
 svg:has(symbol):not(:has(use)) {
 	display: none;
 }
+
+/* set back to default h2 styles */
+#variants {
+	font-size: 24px;
+	margin-bottom: 8px;
+	color: rgb(46, 52, 56);
+	font-weight: bold;
+	line-height: normal;
+	letter-spacing: normal;
+	text-transform: none;
+	border-bottom: 1px solid hsla(203, 50%, 30%, 0.15)
+}

--- a/components/dropzone/stories/dropzone.stories.js
+++ b/components/dropzone/stories/dropzone.stories.js
@@ -5,7 +5,7 @@ import { Template } from "./template";
 import { Template as Link } from "@spectrum-css/link/stories/template.js";
 
 /**
- * A drop zone is an area on the screen into a which an object can be dragged and dropped to accomplish a task. For example, a drop zone might be used in an upload workflow to enable the user to simply drop a file from their operating system into the drop zone, which is a more efficient and intuitive action, rather than utilize the standard "Choose file" dialog.
+ * A drop zone is an area on the screen into a which an object can be dragged and dropped to accomplish a task. It's a common interaction in uploading and file management workflows. For example, a drop zone might be used in an upload workflow to enable the user to simply drop a file from their operating system into the drop zone, which is a more efficient and intuitive action, rather than utilizing the standard "Choose file" dialog.
  */
 export default {
 	title: "Drop zone",
@@ -30,6 +30,7 @@ export default {
 			control: "boolean",
 			if: { arg: "isDragged", truthy: true },
 		},
+		reducedMotion: { table: { disable: true } },
 	},
 	args: {
 		rootClass: "spectrum-DropZone",
@@ -70,4 +71,5 @@ export const FilledAndDragged = Template.bind({});
 FilledAndDragged.args = {
 	isDragged: true,
 	isFilled: true,
+	customStyles: {"height": "200px", "background-image":"url(example-card-portrait.png)"},
 };

--- a/components/dropzone/stories/template.js
+++ b/components/dropzone/stories/template.js
@@ -1,9 +1,11 @@
-import { Template as ActionButton } from "@spectrum-css/actionbutton/stories/template.js";
-import { AccentColor as IllustratedMessageStory } from "@spectrum-css/illustratedmessage/stories/illustratedmessage.stories.js";
-import { Template as IllustratedMessage } from "@spectrum-css/illustratedmessage/stories/template.js";
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
+import { styleMap } from "lit/directives/style-map.js";
+
+import { Template as ActionButton } from "@spectrum-css/actionbutton/stories/template.js";
+import { AccentColor as IllustratedMessageStory } from "@spectrum-css/illustratedmessage/stories/illustratedmessage.stories.js";
+import { Template as IllustratedMessage } from "@spectrum-css/illustratedmessage/stories/template.js";
 
 import "../index.css";
 
@@ -15,6 +17,7 @@ export const Template = ({
 	customHeading,
 	customDescription,
 	customLabel,
+	customStyles = {},
 	id,
 	...globals
 }, context) => html`
@@ -28,7 +31,7 @@ export const Template = ({
 		id=${ifDefined(id)}
 		role="region"
 		tabindex="0"
-		style="width: 300px;"
+		style=${ifDefined(styleMap(customStyles))}
 	>
 		${IllustratedMessage({
 			...globals,

--- a/components/fieldgroup/stories/fieldgroup.mdx
+++ b/components/fieldgroup/stories/fieldgroup.mdx
@@ -1,0 +1,79 @@
+import { ArgTypes, Canvas, Meta, Description, Title } from '@storybook/blocks';
+
+import * as FieldGroupStories from './fieldgroup.stories';
+
+<Meta of={FieldGroupStories} title="Docs" />
+
+<Title of={FieldGroupStories} />
+<Description of={FieldGroupStories} />
+
+## Variants
+
+### Vertical
+
+A vertical group of fields:
+
+#### Vertical Radio
+<Canvas of={FieldGroupStories.VerticalRadio} />
+
+#### Vertical Checkbox
+<Canvas of={FieldGroupStories.VerticalCheckbox} />
+
+### Horizontal
+
+A horizontal group of fields:
+
+#### Horizontal Radio
+<Canvas of={FieldGroupStories.HorizontalRadio} />
+
+#### Horizontal Checkbox
+<Canvas of={FieldGroupStories.HorizontalCheckbox} />
+
+### Invalid
+
+An invalid group of fields:
+
+#### Invalid Radio
+<Canvas of={FieldGroupStories.InvalidRadio} />
+
+#### Invalid Checkbox
+<Canvas of={FieldGroupStories.InvalidCheckbox} />
+
+### Required or optional
+<Description of={FieldGroupStories.Required} />
+<Description of={FieldGroupStories.Optional} />
+
+#### Required
+<Canvas of={FieldGroupStories.Required} />
+
+#### Required Asterisk
+<Canvas of={FieldGroupStories.RequiredAsterisk} />
+
+#### Optional
+<Canvas of={FieldGroupStories.Optional} />
+
+
+### Side label position
+<Description of={FieldGroupStories.VerticalSideLabelRadio} />
+
+#### Side Label Vertical Radio
+<Canvas of={FieldGroupStories.VerticalSideLabelRadio} />
+
+#### Side Label Horizontal Radio
+<Canvas of={FieldGroupStories.HorizontalSideLabelRadio} />
+
+#### Side Label Vertical Checkbox
+<Canvas of={FieldGroupStories.VerticalSideLabelCheckbox} />
+
+#### Side Label Horizontal Checkbox
+<Canvas of={FieldGroupStories.HorizontalSideLabelCheckbox} />
+
+
+### Read-only checkboxes
+<Description of={FieldGroupStories.ReadOnly} />
+
+<Canvas of={FieldGroupStories.ReadOnly} />
+
+### Properties
+
+<ArgTypes />

--- a/components/fieldgroup/stories/fieldgroup.stories.js
+++ b/components/fieldgroup/stories/fieldgroup.stories.js
@@ -2,10 +2,30 @@ import { Template } from "./template";
 
 import { default as Radio } from "@spectrum-css/radio/stories/radio.stories.js";
 
+/**
+ * A field group is a group of fields, usually radios (also known as a radio group) or checkboxes
+ * (also known as a checkbox group). A field group is composed of a field label, a group of radio
+ * inputs or checkboxes, and an optional help text component. The field label within the field group
+ * can be used to mark a field group as optional or required. The field group items other than the
+ * label must be wrapped in a nested `div` with `.spectrum-FieldGroupInputLayout` to control their
+ * layout separately from the label. Help text may or may not appear below a field group and is
+ * necessary when denoting invalid checkbox fields, invalid radio button fields, and required 
+ * fields. Invalid radio buttons and checkboxes are signified by negative help text.
+ */
 export default {
 	title: "Field group",
 	component: "FieldGroup",
 	argTypes: {
+		inputType: {
+			name: "Input type",
+			type: { name: "string" },
+			table: {
+				type: { summary: "string" },
+				category: "Component",
+			},
+			options: ["checkbox", "radio"],
+			control: "select",
+		},
 		layout: {
 			name: "Layout",
 			type: { name: "string", required: true },
@@ -35,12 +55,32 @@ export default {
 			},
 			control: "boolean",
 		},
+		items: { table: { disable: true } },
+		fieldLabel: { table: { disable: true } },
+		helpText: { table: { disable: true } },
+		isRequired: { table: { disable: true } },
+		isReadOnly: { table: { disable: true } },
 	},
 	args: {
 		rootClass: "spectrum-FieldGroup",
 		layout: "vertical",
+		inputType: "radio",
 		labelPosition: "top",
 		isInvalid: false,
+		isRequired: false,
+		items: [
+			{
+				id: "1",
+				label: "Kittens",
+			},
+			{
+				id: "2",
+				label: "Puppies",
+				isChecked: true,
+			},
+		],
+		fieldLabel: "Field Group Label",
+		helpText: "Select an option.",
 	},
 	parameters: {
 		actions: {
@@ -51,34 +91,166 @@ export default {
 	},
 };
 
-export const Vertical = Template.bind({});
-Vertical.args = {
+export const Default = Template.bind({});
+
+export const VerticalRadio = Template.bind({});
+VerticalRadio.tags = ["docs-only"];
+VerticalRadio.args = {
 	layout: "vertical",
-	isInvalid: true,
-	items: [
-		{
-			id: "1",
-			label: "Radio 1",
-		},
-		{
-			id: "2",
-			label: "Radio 2",
-		},
-	],
+	inputType: "radio",
+};
+VerticalRadio.parameters = {
+	chromatic: { disableSnapshot: true },
 };
 
-export const Horizontal = Template.bind({});
-Horizontal.args = {
+export const VerticalCheckbox = Template.bind({});
+VerticalCheckbox.tags = ["docs-only"];
+VerticalCheckbox.args = {
+	layout: "vertical",
+	inputType: "checkbox",
+};
+VerticalCheckbox.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+export const HorizontalRadio = Template.bind({});
+HorizontalRadio.tags = ["docs-only"];
+HorizontalRadio.args = {
 	layout: "horizontal",
+	inputType: "radio",
+};
+HorizontalRadio.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+export const HorizontalCheckbox = Template.bind({});
+HorizontalCheckbox.tags = ["docs-only"];
+HorizontalCheckbox.args = {
+	layout: "horizontal",
+	inputType: "checkbox",
+};
+HorizontalCheckbox.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+export const InvalidRadio = Template.bind({});
+InvalidRadio.tags = ["docs-only"];
+InvalidRadio.args = {
+	layout: "horizontal",
+	inputType: "radio",
 	isInvalid: true,
-	items: [
-		{
-			id: "1",
-			label: "Radio 1",
-		},
-		{
-			id: "2",
-			label: "Radio 2",
-		},
-	],
+};
+InvalidRadio.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+export const InvalidCheckbox = Template.bind({});
+InvalidCheckbox.tags = ["docs-only"];
+InvalidCheckbox.args = {
+	layout: "horizontal",
+	inputType: "checkbox",
+	isInvalid: true,
+};
+InvalidCheckbox.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+/**
+ * Field groups can be marked as optional or required, depending on the situation.
+ * 
+* If required, the field group must either contain a "(required)" label or an asterisk. If an asterisk is used, help text must explain what the asterisk means.
+ */
+export const Required = Template.bind({});
+Required.tags = ["docs-only"];
+Required.args = {
+	inputType: "radio",
+	fieldLabel: "Radio group label (required)"
+};
+Required.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+export const RequiredAsterisk = Template.bind({});
+RequiredAsterisk.tags = ["docs-only"];
+RequiredAsterisk.args = {
+	fieldLabel: "Checkbox group label",
+	inputType: "checkbox",
+	isRequired: true,
+};
+RequiredAsterisk.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+/**
+ * Optional field groups can be denoted with text added to the end of the label "(optional)" or have no indication at all.
+ */
+export const Optional = Template.bind({});
+Optional.tags = ["docs-only"];
+Optional.args = {
+	fieldLabel: "Checkbox group label (optional)",
+	helpText: "",
+	inputType: "checkbox",
+};
+Optional.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+/**
+ * The field group label has two layout options: the label can be top aligned with `spectrum-FieldGroup spectrum-FieldGroup--toplabel`, or side aligned with `spectrum-FieldGroup spectrum-FieldGroup--sidelabel`.
+ */
+export const VerticalSideLabelRadio = Template.bind({});
+VerticalSideLabelRadio.tags = ["docs-only"];
+VerticalSideLabelRadio.args = {
+	labelPosition: "side",
+	inputType: "radio",
+	layout: "vertical",
+};
+VerticalSideLabelRadio.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+export const HorizontalSideLabelRadio = Template.bind({});
+HorizontalSideLabelRadio.tags = ["docs-only"];
+HorizontalSideLabelRadio.args = {
+	labelPosition: "side",
+	inputType: "radio",
+	layout: "horizontal",
+};
+HorizontalSideLabelRadio.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+export const VerticalSideLabelCheckbox = Template.bind({});
+VerticalSideLabelCheckbox.tags = ["docs-only"];
+VerticalSideLabelCheckbox.args = {
+	labelPosition: "side",
+	inputType: "checkbox",
+	layout: "vertical",
+};
+VerticalSideLabelCheckbox.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+export const HorizontalSideLabelCheckbox = Template.bind({});
+HorizontalSideLabelCheckbox.tags = ["docs-only"];
+HorizontalSideLabelCheckbox.args = {
+	labelPosition: "side",
+	inputType: "checkbox",
+	layout: "horizontal",
+};
+HorizontalSideLabelCheckbox.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+/**
+ * A group of read-only checkboxes that have been checked. In U.S. English, use commas to delineate items within read-only checkbox groups. In other languages, use the locale-specific formatting.
+ */
+export const ReadOnly = Template.bind({});
+ReadOnly.tags = ["docs-only"];
+ReadOnly.args = {
+	isReadOnly: true,
+	inputType: "checkbox",
+};
+ReadOnly.parameters = {
+	chromatic: { disableSnapshot: true },
 };

--- a/components/fieldgroup/stories/template.js
+++ b/components/fieldgroup/stories/template.js
@@ -1,8 +1,8 @@
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
-import { repeat } from "lit/directives/repeat.js";
 
+import { Template as Checkbox } from "@spectrum-css/checkbox/stories/template.js";
 import { Template as FieldLabel } from "@spectrum-css/fieldlabel/stories/template.js";
 import { Template as HelpText } from "@spectrum-css/helptext/stories/template.js";
 import { Template as Radio } from "@spectrum-css/radio/stories/template.js";
@@ -12,10 +12,15 @@ import "../index.css";
 export const Template = ({
 	rootClass = "spectrum-FieldGroup",
 	customClasses = [],
-	layout,
+	layout = "vertical",
 	labelPosition,
+	inputType = "radio",
 	isInvalid,
+	isReadOnly = false,
+	isRequired = false,
 	items,
+	fieldLabel,
+	helpText,
 	...globals
 }, context) => html`
 	<div
@@ -30,27 +35,30 @@ export const Template = ({
 	>
 		${FieldLabel({
 			...globals,
+			isRequired,
 			size: "m",
-			label: "Field Group Label",
+			label: fieldLabel,
 			alignment: labelPosition === "side" ? "right" : "top",
 		}, context)}
-
 		<div class="${rootClass}InputLayout">
-			${repeat(
-				items,
-				(item) => item.id,
-				(item) => {
-					return Radio({
+			${inputType === "radio" ? items.map((item) =>
+					Radio({
 						...globals,
 						...item,
+						isReadOnly,
+						name: "field-group-example",
 						customClasses: [`${rootClass}-item`],
-					}, context);
-				}
-			)}
+					}, context)) : items.map((item) =>
+					Checkbox({
+					...globals,
+					...item,
+					isReadOnly,
+					customClasses: [`${rootClass}-item`],
+					}, context))}
 			${HelpText({
 				...globals,
 				size: "m",
-				text: "Select an option",
+				text: helpText,
 				variant: isInvalid ? "negative" : "neutral",
 			}, context)}
 		</div>

--- a/components/floatingactionbutton/stories/floatingactionbutton.stories.js
+++ b/components/floatingactionbutton/stories/floatingactionbutton.stories.js
@@ -4,6 +4,8 @@ import { default as IconStories } from "@spectrum-css/icon/stories/icon.stories.
 
 /**
  * The floating action button component is used to give users a more prominent button for high frequency actions.
+ *
+ * When using floating action button in dark themes, the `background-layer-color-2` will often show up on the base color `gray-50` or `gray-75` or on content, images, etc.
  */
 export default {
 	title: "Floating action button",
@@ -25,6 +27,7 @@ export default {
 			...(IconStories?.argTypes?.iconName ?? {}),
 			if: false,
 		},
+		reducedMotion: { table: { disable: true } },
 	},
 	args: {
 		rootClass: "spectrum-FloatingActionButton",
@@ -34,6 +37,7 @@ export default {
 };
 
 export const Default = Template.bind({});
+Default.storyName = "Default (Primary)";
 Default.args = {};
 
 export const Secondary = Template.bind({});

--- a/components/illustratedmessage/stories/illustratedmessage.stories.js
+++ b/components/illustratedmessage/stories/illustratedmessage.stories.js
@@ -5,7 +5,7 @@ import { Template as Link } from "@spectrum-css/link/stories/template.js";
 import { Template } from "./template";
 
 /**
- * The illustrated message component is used for status and errors. It is also used for calls-to-action, such as within the drop zone component.
+ * The Illustrated Message displays an illustration along with a heading and description. Optionally, part of the illustration can use an accent color. It can be used for status and errors, or as a call to action. For example, the Drop Zone component makes use of Illustrated Message as an area to drag and drop files.
  */
 export default {
 	title: "Illustrated message",
@@ -36,6 +36,7 @@ export default {
 				disable: true,
 			},
 		},
+		reducedMotion: { table: { disable: true } },
 	},
 	args: {
 		rootClass: "spectrum-IllustratedMessage",
@@ -67,7 +68,7 @@ export const Default = (args) => html`
 `;
 
 /**
- * An accent color class can be used on elements of the illustration SVG.
+ * To use the accent color, the class `.spectrum-IllustratedMessage-accent` can be added to element(s) within the illustration SVG.
  */
 export const AccentColor = Template.bind({});
 AccentColor.args = {

--- a/components/infieldbutton/stories/infieldbutton.stories.js
+++ b/components/infieldbutton/stories/infieldbutton.stories.js
@@ -51,6 +51,7 @@ export default {
 			},
 			control: "boolean"
 		},
+		isStacked: { table: { disable: true } },
 	},
 	args: {
 		rootClass: "spectrum-InfieldButton",
@@ -58,16 +59,30 @@ export default {
 		position: "left",
 		iconName: "Add",
 		isQuiet: false,
-		isDisabled: false
+		isDisabled: false,
+		isStacked: false,
 	},
 };
 
 export const Default = Template.bind({});
 Default.args = {};
 
-export const Right = Template.bind({});
-Right.args = {
+export const Start = Template.bind({});
+Start.tags = ["docs-only"];
+Start.args = {
+	position: "left"
+};
+Start.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+export const End = Template.bind({});
+End.tags = ["docs-only"];
+End.args = {
 	position: "right"
+};
+End.parameters = {
+	chromatic: { disableSnapshot: true },
 };
 
 export const Quiet = Template.bind({});
@@ -78,4 +93,13 @@ Quiet.args = {
 export const Disabled = Template.bind({});
 Disabled.args = {
 	isDisabled: true
+};
+
+export const Stacked = Template.bind({});
+Stacked.tags = ["docs-only"];
+Stacked.args = {
+	isStacked: true,
+};
+Stacked.parameters = {
+	chromatic: { disableSnapshot: true },
 };

--- a/components/infieldbutton/stories/template.js
+++ b/components/infieldbutton/stories/template.js
@@ -14,10 +14,60 @@ export const Template = ({
 	iconName = "Add",
 	isDisabled,
 	isInvalid,
+	isStacked,
 	tabIndex = 0,
 	...globals
 }, context) => {
-	return html`
+	return isStacked ? html`
+    <button
+      class=${classMap({
+        [rootClass]: true,
+        [`${rootClass}--size${size?.toUpperCase()}`]: typeof size !== "undefined",
+        [`${rootClass}--top`]: typeof position !== "undefined",
+        [`${rootClass}--quiet`]: isQuiet,
+        "is-invalid": isInvalid,
+        ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
+      })}
+      ?disabled=${isDisabled}
+      aria-haspopup="listbox"
+      type="button"
+      tabIndex=${tabIndex}
+      aria-label="add"
+    >
+      <div class="${rootClass}-fill">
+        ${Icon({
+          ...globals,
+          size,
+          iconName: "ChevronUp75",
+          customClasses: [`${rootClass}-icon`],
+        })}
+      </div>
+    </button>
+    <button
+      class=${classMap({
+        [rootClass]: true,
+        [`${rootClass}--size${size?.toUpperCase()}`]: typeof size !== "undefined",
+        [`${rootClass}--bottom`]: typeof position !== "undefined",
+        [`${rootClass}--quiet`]: isQuiet,
+        "is-invalid": isInvalid,
+        ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
+      })}
+      ?disabled=${isDisabled}
+      aria-haspopup="listbox"
+      type="button"
+      tabIndex=${tabIndex}
+      aria-label="add"
+    >
+      <div class="${rootClass}-fill">
+        ${Icon({
+          ...globals,
+          size,
+          iconName: "ChevronDown75",
+          customClasses: [`${rootClass}-icon`],
+        })}
+      </div>
+    </button>
+  ` : html`
     <button
       class=${classMap({
         [rootClass]: true,

--- a/components/radio/stories/template.js
+++ b/components/radio/stories/template.js
@@ -3,6 +3,8 @@ import { classMap } from "lit/directives/class-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { styleMap } from "lit/directives/style-map.js";
 
+import { useArgs } from "@storybook/preview-api";
+
 import "../index.css";
 
 export const Template = ({
@@ -18,6 +20,8 @@ export const Template = ({
 	customClasses = [],
 	customStyles = {},
 }) => {
+	const [, updateArgs] = useArgs();
+
 	return html`
 		<div
 			class=${classMap({
@@ -39,6 +43,10 @@ export const Template = ({
 				readOnly=${isReadOnly ? "readonly" : ""}
 				?checked=${isChecked}
 				?disabled=${isDisabled}
+				@change=${() => {
+					if (isDisabled) return;
+					updateArgs({ isChecked: !isChecked });
+				}}
 			/>
 			<span class="${rootClass}-button ${rootClass}-button--sizeS"></span>
 			<label class="${rootClass}-label ${rootClass}-label--sizeS" for="radio-0"


### PR DESCRIPTION
## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

This continues the migration work to move the documentation from the deprecated docs site to Storybook, covering components drop zone, field group, floating action button, illustrated message, and infield button. Variants shown on the docs site for these components have been added to Storybook if they did not already exist.

An MDX page was only created if the existing documentation template could not support displaying information in a manner consistent with the docs site. In this PR, the only component that received an MDX page was field group, because its variants encompass both checkbox groups and radio groups and organizing these stories to be displayed side-by-side felt more logical.

Since we anticipate that some components will use their own MDX docs page and others will use the existing documentation template, the documentation template was updated to make the formatting look more consistent with what is seen on the MDX page.

### Component-specific changes
- Drop zone: The `FilledAndDragged` story was updated to be able to receive custom styles, which were used to add a background image to the component as it's seen on the docs site.
- Field group: The docs site demonstrates both radio inputs and checkboxes, but Storybook was only demonstrating radio inputs. Checkboxes have now been added to the template with an arg/control to switch between these two field group types. I did some follow-up work to confirm that what I was copying from the docs site was accurate, and in the process, added a few pieces of information from the internal docs site. Some information about the invalid state was also updated (see comments).
- Floating action button - This required only minor additions to the description. I also renamed the Default story to "Default (Primary)" to make more sense alongside the "Secondary" variant.
- Illustrated message - Additional information was added to supplement the current descriptions in the JSDoc comments.

This PR is docs-only and does not require a changeset.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
- [ ] [Documentation template ](https://github.com/adobe/spectrum-css/pull/2827/files#diff-569b9b80de2456e5a082d20cc1f491ee06aff354c1d5d930cdfedf2d4193c576)- the changes here make sense and bring visual parity between MDX docs pages and pages using the template
- [ ] [Drop zone](https://pr-2827--spectrum-css.netlify.app/preview/?path=/docs/components-drop-zone--docs) - includes all necessary information compared to the [docs site](https://opensource.adobe.com/spectrum-css/dropzone.html)
- [ ] [Field group](https://pr-2827--spectrum-css.netlify.app/preview/?path=/docs/components-field-group--docs) - includes all necessary information compared to the [docs site](https://opensource.adobe.com/spectrum-css/fieldgroup.html)
- [ ] [Floating action button](https://pr-2827--spectrum-css.netlify.app/preview/?path=/docs/components-floating-action-button--docs) - includes all necessary information compared to the [docs site](https://opensource.adobe.com/spectrum-css/floatingactionbutton.html)
- [ ] [Illustrated message](https://pr-2827--spectrum-css.netlify.app/preview/?path=/docs/components-illustrated-message--docs) - includes all necessary information compared to the [docs site](https://opensource.adobe.com/spectrum-css/illustratedmessage.html)
- [ ] [Infield button](https://pr-2827--spectrum-css.netlify.app/preview/?path=/docs/components-in-field-button--docs) - includes all necessary information compared to the [docs site](https://opensource.adobe.com/spectrum-css/infieldbutton.html)

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots
This PR should bring visual parity to MDX and non-MDX docs pages:

Drop Zone Storybook Entry (No MDX file added)
![image](https://github.com/adobe/spectrum-css/assets/54716846/6d84ab07-123e-42d7-af2e-4c3139d2192a)

Field Group Storybook Entry (MDX file added)
![image](https://github.com/adobe/spectrum-css/assets/54716846/4473ab9a-70e6-4b30-b764-d4fc8d7b6629)

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
