### PR TITLE
docs(dial,dialog,divider,dropindicator): Migrate docs to storybook pt7

### DIFF
--- a/components/dial/stories/dial.stories.js
+++ b/components/dial/stories/dial.stories.js
@@ -1,4 +1,5 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
+import { isFocused } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
 import { DialGroup } from "./dial.test.js";
 import { Template } from "./template.js";
@@ -28,15 +29,7 @@ export default {
 			},
 			control: "text",
 		},
-		isFocusVisible: {
-			name: "Focused",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
+		isFocusVisible: isFocused,
 		isDragged: {
 			name: "Dragged",
 			type: { name: "boolean" },

--- a/components/dial/stories/dial.stories.js
+++ b/components/dial/stories/dial.stories.js
@@ -1,7 +1,7 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import { isFocused } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
 import { DialGroup } from "./dial.test.js";
+import { Template } from "./template.js";
 
 /**
  * A dial is an input control used for selecting a value within a range, similar to a slider. It's often used in audio and video mixing and editing applications, where horizontal space is limited.
@@ -28,7 +28,15 @@ export default {
 			},
 			control: "text",
 		},
-		isFocused,
+		isFocusVisible: {
+			name: "Focused",
+			type: { name: "boolean" },
+			table: {
+				type: { summary: "boolean" },
+				category: "State",
+			},
+			control: "boolean",
+		},
 		isDragged: {
 			name: "Dragged",
 			type: { name: "boolean" },
@@ -51,7 +59,7 @@ export default {
 	args: {
 		rootClass: "spectrum-Dial",
 		size: "m",
-		isFocused: false,
+		isFocusVisible: false,
 		isDragged: false,
 		isDisabled: false,
 	},
@@ -62,6 +70,33 @@ export default {
 
 export const Default = DialGroup.bind();
 Default.args = {};
+
+export const Small = Template.bind();
+Small.args = {
+	size: "s",
+};
+Small.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+Small.tags = ["!dev"];
+
+export const WithLabel = Template.bind();
+WithLabel.args = {
+	label: "Volume",
+};
+WithLabel.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+WithLabel.tags = ["!dev"];
+
+export const Disabled = Template.bind();
+Disabled.args = {
+	isDisabled: true,
+};
+Disabled.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+Disabled.tags = ["!dev"];
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = DialGroup.bind({});

--- a/components/dial/stories/dial.test.js
+++ b/components/dial/stories/dial.test.js
@@ -15,15 +15,15 @@ export const DialGroup = Variants({
 	],
 	stateData: [
 		{
-			heading: "Disabled",
+			testHeading: "Disabled",
 			isDisabled: true,
 		},
 		{
-			heading: "Focused",
-			isFocused: true,
+			testHeading: "Focused",
+			isFocusVisible: true,
 		},
 		{
-			heading: "Dragged",
+			testHeading: "Dragged",
 			isDragged: true,
 		},
 	],

--- a/components/dial/stories/template.js
+++ b/components/dial/stories/template.js
@@ -10,7 +10,7 @@ export const Template = ({
 	rootClass = "spectrum-Dial",
 	size = "m",
 	label,
-	isFocused = false,
+	isFocusVisible = false,
 	isDragged = false,
 	isDisabled = false,
 	min = 0,
@@ -38,58 +38,58 @@ export const Template = ({
         if (isDisabled) return;
         if (!document.body.classList.contains("u-isGrabbing")) return;
 
-        const dial = e.target.closest(".spectrum-Dial");
-        const handle = dial.querySelector(".spectrum-Dial-handle");
-        const input = dial.querySelector("input");
-        const min = -45;
-        const max = 225;
-        const dialOffsetLeft = dial.offsetLeft + dial.offsetParent.offsetLeft;
-        var x = Math.max(Math.min(e.x - dialOffsetLeft, dial.offsetWidth), 0);
-        var percent = (x / dial.offsetWidth) * 100;
-        var deg = percent * 0.01 * (max - min) + min;
-        handle.style.transform = "rotate(" + deg + "deg" + ")";
-        input.value = Math.round(
-          percent * 0.01 * (input.max - input.min) + input.min
-        );
-      }}
-    >
-      ${when(
-        label,
-        () => html`<div class="${rootClass}-labelContainer">
-          <label id="dialLabel" class="${rootClass}-label" for="labeledDial"
-            >${label}</label
-          >
-          <div
-            class="${rootClass}-value"
-            role="textbox"
-            aria-readonly="true"
-            aria-labelledby="dialLabel"
-          >
-            ${min}
-          </div>
-        </div>`
-      )}
-      <div class="${rootClass}-controls">
-        <div
-          class="${rootClass}-handle ${isDragged ? "is-dragged" : ""} ${isFocused
-            ? "is-focused"
-            : ""}"
-          tabindex="0"
-        >
-          <input
-            type="range"
-            class="${rootClass}-input"
-            min="${min}"
-            max="${max}"
-            value="${min}"
-            @change=${(e) => {
-              const value = e.target.value;
-              const label = document.getElementById("dialLabel");
-              label.nextSibling.textContent = value;
-            }}
-          />
-        </div>
-      </div>
-    </div>
-  `;
+				const dial = e.target.closest(".spectrum-Dial");
+				const handle = dial.querySelector(".spectrum-Dial-handle");
+				const input = dial.querySelector("input");
+				const min = -45;
+				const max = 225;
+				const dialOffsetLeft = dial.offsetLeft + dial.offsetParent.offsetLeft;
+				var x = Math.max(Math.min(e.x - dialOffsetLeft, dial.offsetWidth), 0);
+				var percent = (x / dial.offsetWidth) * 100;
+				var deg = percent * 0.01 * (max - min) + min;
+				handle.style.transform = "rotate(" + deg + "deg" + ")";
+				input.value = Math.round(
+					percent * 0.01 * (input.max - input.min) + input.min
+				);
+			}}
+		>
+			${when(
+				label,
+				() => html`<div class="${rootClass}-labelContainer">
+					<label id="dialLabel" class="${rootClass}-label" for="labeledDial"
+						>${label}</label
+					>
+					<div
+						class="${rootClass}-value"
+						role="textbox"
+						aria-readonly="true"
+						aria-labelledby="dialLabel"
+					>
+						${min}
+					</div>
+				</div>`
+			)}
+			<div class="${rootClass}-controls">
+				<div
+					class="${rootClass}-handle
+					${isDragged ? "is-dragged": ""}
+					${isFocusVisible ? "is-focus-visible": ""}"
+					tabindex="0"
+				>
+					<input
+						type="range"
+						class="${rootClass}-input"
+						min="${min}"
+						max="${max}"
+						value="${min}"
+						@change=${(e) => {
+							const value = e.target.value;
+							const label = document.getElementById("dialLabel");
+							label.nextSibling.textContent = value;
+						}}
+					/>
+				</div>
+			</div>
+		</div>
+	`;
 };

--- a/components/dialog/stories/dialog.stories.js
+++ b/components/dialog/stories/dialog.stories.js
@@ -3,47 +3,71 @@ import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isOpen } from "@spectrum-css/preview/types";
 import { Template as Typography } from "@spectrum-css/typography/stories/template.js";
 import { version } from "../package.json";
+// import { DialogGroup } from "./dialog.test.js";
 import { DialogFullscreen, DialogFullscreenTakeover, DialogGroup } from "./dialog.test.js";
+import { Template } from "./template";
 
 /**
  * A dialog displays important information that users need to acknowledge. They appear over the interface and block further interactions.
+ * 
+ * The alert variants that were previously a part of Dialog were moved to their own component, [Alert Dialog](/docs/components-alert-dialog--docs).
  */
 export default {
 	title: "Dialog",
 	component: "Dialog",
 	argTypes: {
-		heading: { table: { disable: true } },
+		dialogHeading: {
+			name: "Heading",
+			type: { name: "string" },
+			table: {
+				type: { summary: "string" },
+				category: "Content",
+			},
+			control: { type: "text" },
+		},
 		content: { table: { disable: true } },
-		footer: { table: { disable: true } },
 		hasFooter: {
 			name: "Has footer",
 			type: { name: "boolean" },
 			table: {
 				type: { summary: "boolean" },
-				category: "Component",
+				category: "Content",
 			},
 			control: "boolean",
 		},
-		isDismissable: {
-			name: "Dismissable",
+		footer: { table: { disable: true } },
+		size: {
+			name: "Size",
+			type: { name: "string", required: true },
+			table: {
+				type: { summary: "string" },
+				category: "Component",
+			},
+			options: ["small", "medium", "large"],
+			control: "select",
+		},
+		layout: {
+			name: "Layout",
+			type: { name: "string" },
+			table: {
+				type: { summary: "string" },
+				category: "Component",
+			},
+			options: ["default", "fullscreen", "fullscreenTakeover"],
+			control: "select",
+		},
+		isDismissible: {
+			name: "Dismissible",
 			type: { name: "boolean" },
 			table: {
 				type: { summary: "boolean" },
 				category: "Component",
 			},
 			control: "boolean",
+			if: { arg: "layout", eq: "default" },
 		},
-		isFullScreen: {
-			name: "Fullscreen",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "Component",
-			},
-			control: "boolean",
-		},
-		isFullScreenTakeover: {
-			name: "Fullscreen takeover",
+		hasDivider: {
+			name: "Divider",
 			type: { name: "boolean" },
 			table: {
 				type: { summary: "boolean" },
@@ -61,15 +85,37 @@ export default {
 			control: "boolean",
 		},
 		isOpen,
+		hasHeroImage: {
+			name: "Has hero image",
+			type: { name: "boolean" },
+			table: {
+				type: { summary: "boolean" },
+				category: "Content",
+			},
+			control: "boolean",
+			if: { arg: "layout", eq: "default" },
+		},
+		heroImageUrl: {
+			name: "Hero Image",
+			type: { name: "string" },
+			table: {
+				type: { summary: "string" },
+				category: "Content",
+			},
+			control: { type: "file", accept: ".svg,.png,.jpg,.jpeg,.webc" },
+			if: { arg: "hasHeroImage", truthy: true },
+		},
 	},
 	args: {
 		rootClass: "spectrum-Dialog",
 		hasFooter: true,
-		isDismissable: true,
-		isFullScreen: false,
-		isFullScreenTakeover: false,
+		isDismissible: false,
+		hasDivider: true,
 		isOpen: true,
 		showModal: true,
+		size: "medium",
+		hasHeroImage: false,
+		layout: "default",
 	},
 	parameters: {
 		actions: {
@@ -88,30 +134,172 @@ export default {
 	],
 };
 
+// the "TallerViewport" modes are accommodating the underlay, which is position: fixed,
+// and Chromatic's treatment of position:fixed elements. By increasing the viewport height,
+// it doesn't look like the background color just stops without wrapping the
+// entire container of templates.
+// const defaultModesWithTallerViewport = Object.keys(modes).reduce((acc, key) => {
+// 	acc[key] = { 
+// 		...modes[key],
+// 		viewport: {
+// 			height: "5300px",
+// 		}
+// 	};
+// 	return acc;
+// }, {});
+
+// const mobileModeWithTallerViewport = Object.keys(mobile).reduce((acc, key) => {
+// 	acc[key] = { 
+// 		...mobile[key],
+// 		viewport: {
+// 			height: "5600px",
+// 		}
+// 	};
+// 	return acc;
+// }, {});
+
+const ExampleContent = Typography({
+	semantics: "body",
+	size: "m",
+	content: [
+		"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Auctor augue mauris augue neque gravida. Libero volutpat sed ornare arcu. Quisque egestas diam in arcu cursus euismod quis viverra. Posuere ac ut consequat semper viverra nam libero justo laoreet. Enim ut tellus elementum sagittis vitae et leo duis ut. Neque laoreet suspendisse interdum consectetur libero id faucibus nisl. Diam volutpat commodo sed egestas egestas. Dolor magna eget est lorem ipsum dolor. Vitae suscipit tellus mauris a diam maecenas sed. Turpis in eu mi bibendum neque egestas congue. Rhoncus est pellentesque elit ullamcorper dignissim cras lobortis."
+	]
+});
+
+/**
+ * The default size for dialog is medium.
+ */
 export const Default = DialogGroup.bind({});
-Default.tags = ["dev"];
 Default.args = {
-	heading: "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
+	dialogHeading: "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
 	content: [
 		(passthroughs, context) => Typography({
 			semantics: "body",
 			size: "m",
-			content: [
-				"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Auctor augue mauris augue neque gravida. Libero volutpat sed ornare arcu. Quisque egestas diam in arcu cursus euismod quis viverra. Posuere ac ut consequat semper viverra nam libero justo laoreet. Enim ut tellus elementum sagittis vitae et leo duis ut. Neque laoreet suspendisse interdum consectetur libero id faucibus nisl. Diam volutpat commodo sed egestas egestas. Dolor magna eget est lorem ipsum dolor. Vitae suscipit tellus mauris a diam maecenas sed. Turpis in eu mi bibendum neque egestas congue. Rhoncus est pellentesque elit ullamcorper dignissim cras lobortis."
-			],
+			content: ExampleContent,
 			...passthroughs,
 		}, context),
 	],
 };
+// Default.parameters = {
+// 	chromatic: {
+// 		modes: {
+// 			...defaultModesWithTallerViewport,
+// 			...mobileModeWithTallerViewport }
+// 	},
+// };
 
+// ********* DOCS ONLY ********* //
+export const DefaultSmall = Template.bind({});
+DefaultSmall.tags = ["!dev"];
+DefaultSmall.storyName = "Dialog - small",
+DefaultSmall.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+DefaultSmall.args = {
+	...Default.args,
+	size: "small",
+};
+
+export const DefaultLarge = Template.bind({});
+DefaultLarge.tags = ["!dev"];
+DefaultLarge.storyName = "Dialog - large",
+DefaultLarge.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+DefaultLarge.args = {
+	...Default.args,
+	size: "large",
+};
+
+/**
+ * A dialog that can be dismissed without taking an action. Dismissible dialogs should never have buttons.
+ */
+export const Dismissible = Template.bind({});
+Dismissible.tags = ["!dev"];
+Dismissible.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+Dismissible.args = {
+	...Default.args,
+	isDismissible: true,
+};
+
+/**
+ * Dialogs can forgo the divider if they have content that spans the entire width of the dialog.
+ */
+export const NoDivider = Template.bind({});
+NoDivider.tags = ["!dev"];
+NoDivider.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+NoDivider.args = {
+	...Default.args,
+	isDismissible: true,
+	hasDivider: false,
+};
+
+/**
+ * Dialogs can have a hero or cover image header.
+ */
+export const WithHero = Template.bind({});
+WithHero.tags = ["!dev"];
+WithHero.parameters = {
+	docs: {
+		story: {
+			height: "650px",
+		},
+	},
+	chromatic: { disableSnapshot: true },
+};
+WithHero.args = {
+	...Default.args,
+	isDismissible: true,
+	hasHeroImage: true,
+	heroImageUrl: "example-card-portrait.png",
+};
+
+/**
+ * The content inside the body area can scroll when necessary.
+ */
+export const WithScroll = Template.bind({});
+WithScroll.args = {
+	...Default.args,
+	customStyles: {
+		"max-block-size": "400px",
+	}
+};
+WithScroll.tags = ["!dev"];
+WithScroll.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+/**
+ * A fullscreen dialog will automatically fill almost all of the available screen space. A margin is included around the outside of the dialog.
+ */
 export const Fullscreen = DialogFullscreen.bind({});
-Fullscreen.tags = ["!autodocs", "dev"];
-Fullscreen.args = Default.args;
+// export const Fullscreen = Template.bind({});
+Fullscreen.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+Fullscreen.args = {
+	...Default.args,
+	layout: "fullscreen",
+};
 
+/**
+ * A fullscreen takeover dialog will fill all of the available screen space.
+ */
 export const FullscreenTakeover = DialogFullscreenTakeover.bind({});
-FullscreenTakeover.tags = ["!autodocs", "dev"];
-FullscreenTakeover.args = Default.args;
-
+// export const FullscreenTakeover = Template.bind({});
+FullscreenTakeover.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+FullscreenTakeover.args = {
+	...Default.args,
+	layout: "fullscreenTakeover",
+	content: [ExampleContent, ExampleContent, ExampleContent, ExampleContent],
+};
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = DialogGroup.bind({});

--- a/components/dialog/stories/dialog.stories.js
+++ b/components/dialog/stories/dialog.stories.js
@@ -86,25 +86,16 @@ export default {
 			control: "boolean",
 		},
 		isOpen,
-		hasHeroImage: {
-			name: "Has hero image",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "Content",
-			},
-			control: "boolean",
-			if: { arg: "layout", eq: "default" },
-		},
 		heroImageUrl: {
 			name: "Hero Image",
 			type: { name: "string" },
+			description: "Adds a cover image to the header of a dialog.",
 			table: {
 				type: { summary: "string" },
 				category: "Content",
 			},
 			control: { type: "file", accept: ".svg,.png,.jpg,.jpeg,.webc" },
-			if: { arg: "hasHeroImage", truthy: true },
+			if: { arg: "layout", eq: "default" },
 		},
 	},
 	args: {
@@ -115,7 +106,6 @@ export default {
 		isOpen: true,
 		showModal: true,
 		size: "medium",
-		hasHeroImage: false,
 		layout: "default",
 	},
 	parameters: {

--- a/components/dialog/stories/dialog.stories.js
+++ b/components/dialog/stories/dialog.stories.js
@@ -48,9 +48,11 @@ export default {
 		layout: {
 			name: "Layout",
 			type: { name: "string" },
+			defaultValue: "Default",
 			table: {
 				type: { summary: "string" },
 				category: "Component",
+				defaultValue: { summary: "Default" },
 			},
 			options: ["default", "fullscreen", "fullscreenTakeover"],
 			control: "select",

--- a/components/dialog/stories/dialog.stories.js
+++ b/components/dialog/stories/dialog.stories.js
@@ -246,7 +246,6 @@ WithScroll.parameters = {
  * A fullscreen dialog will automatically fill almost all of the available screen space. A margin is included around the outside of the dialog.
  */
 export const Fullscreen = DialogFullscreen.bind({});
-// export const Fullscreen = Template.bind({});
 Fullscreen.parameters = {
 	chromatic: { disableSnapshot: true },
 };
@@ -259,7 +258,6 @@ Fullscreen.args = {
  * A fullscreen takeover dialog will fill all of the available screen space.
  */
 export const FullscreenTakeover = DialogFullscreenTakeover.bind({});
-// export const FullscreenTakeover = Template.bind({});
 FullscreenTakeover.parameters = {
 	chromatic: { disableSnapshot: true },
 };

--- a/components/dialog/stories/dialog.stories.js
+++ b/components/dialog/stories/dialog.stories.js
@@ -16,7 +16,7 @@ export default {
 	title: "Dialog",
 	component: "Dialog",
 	argTypes: {
-		dialogHeading: {
+		heading: {
 			name: "Heading",
 			type: { name: "string" },
 			table: {
@@ -171,7 +171,7 @@ const ExampleContent = Typography({
  */
 export const Default = DialogGroup.bind({});
 Default.args = {
-	dialogHeading: "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
+	heading: "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
 	content: [
 		(passthroughs, context) => Typography({
 			semantics: "body",

--- a/components/dialog/stories/dialog.stories.js
+++ b/components/dialog/stories/dialog.stories.js
@@ -3,7 +3,6 @@ import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isOpen } from "@spectrum-css/preview/types";
 import { Template as Typography } from "@spectrum-css/typography/stories/template.js";
 import { version } from "../package.json";
-// import { DialogGroup } from "./dialog.test.js";
 import { DialogFullscreen, DialogFullscreenTakeover, DialogGroup } from "./dialog.test.js";
 import { Template } from "./template";
 
@@ -134,30 +133,6 @@ export default {
 	],
 };
 
-// the "TallerViewport" modes are accommodating the underlay, which is position: fixed,
-// and Chromatic's treatment of position:fixed elements. By increasing the viewport height,
-// it doesn't look like the background color just stops without wrapping the
-// entire container of templates.
-// const defaultModesWithTallerViewport = Object.keys(modes).reduce((acc, key) => {
-// 	acc[key] = { 
-// 		...modes[key],
-// 		viewport: {
-// 			height: "5300px",
-// 		}
-// 	};
-// 	return acc;
-// }, {});
-
-// const mobileModeWithTallerViewport = Object.keys(mobile).reduce((acc, key) => {
-// 	acc[key] = { 
-// 		...mobile[key],
-// 		viewport: {
-// 			height: "5600px",
-// 		}
-// 	};
-// 	return acc;
-// }, {});
-
 const ExampleContent = Typography({
 	semantics: "body",
 	size: "m",
@@ -181,13 +156,6 @@ Default.args = {
 		}, context),
 	],
 };
-// Default.parameters = {
-// 	chromatic: {
-// 		modes: {
-// 			...defaultModesWithTallerViewport,
-// 			...mobileModeWithTallerViewport }
-// 	},
-// };
 
 // ********* DOCS ONLY ********* //
 export const DefaultSmall = Template.bind({});

--- a/components/dialog/stories/dialog.test.js
+++ b/components/dialog/stories/dialog.test.js
@@ -30,6 +30,7 @@ export const DialogGroup = Variants({
 		{
 			testHeading: "Dismissible",
 			isDismissible: true,
+			hasFooter: false,
 			wrapperStyles: {
 				"background-color": "var(--spectrum-gray-50)"
 			},
@@ -42,9 +43,44 @@ export const DialogGroup = Variants({
 			},
 		},
 		{
-			testHeading: "No divider",
+			testHeading: "With hero/cover image, dismissible",
+			hasHeroImage: true,
 			isDismissible: true,
+			hasFooter: false,
+			wrapperStyles: {
+				"background-color": "var(--spectrum-gray-50)"
+			},
+		},
+		{
+			testHeading: "No divider",
 			hasDivider: false,
+			wrapperStyles: {
+				"background-color": "var(--spectrum-gray-50)"
+			},
+		},
+		{
+			testHeading: "No divider, dismissible",
+			hasDivider: false,
+			isDismissible: true,
+			hasFooter: false,
+			wrapperStyles: {
+				"background-color": "var(--spectrum-gray-50)"
+			},
+		},
+		{
+			testHeading: "With hero/cover image, no divider",
+			hasDivider: false,
+			hasHeroImage: true,
+			wrapperStyles: {
+				"background-color": "var(--spectrum-gray-50)"
+			},
+		},
+		{
+			testHeading: "With hero/cover image, no divider, dismissible",
+			hasDivider: false,
+			isDismissible: true,
+			hasFooter: false,
+			hasHeroImage: true,
 			wrapperStyles: {
 				"background-color": "var(--spectrum-gray-50)"
 			},

--- a/components/dialog/stories/dialog.test.js
+++ b/components/dialog/stories/dialog.test.js
@@ -2,18 +2,46 @@ import { Variants } from "@spectrum-css/preview/decorators";
 import { Template } from "./template.js";
 
 export const DialogGroup = Variants({
-	Template,
+	Template: (args, context) => (
+		/*
+		 * This template forces each test case to showModal: false, and give a background 
+		 * color to the dialog grid container when isChromatic() is true.
+		 * This should ensure that the Sizes within the Variants() template to display correctly.
+		 */
+		window.isChromatic() ?
+			Template({
+				...args,
+				showModal: false,
+				customStyles: {
+					"background-color": "var(--spectrum-gray-100)",
+				},
+			}, context)
+			: Template(args, context)
+	),
 	testData: [
 		{
-			showModal: false,
 			wrapperStyles: {
 				"background-color": "var(--spectrum-gray-50)"
 			},
 		},
 		{
-			testHeading: "Not dismissable",
-			isDismissable: false,
-			showModal: false,
+			testHeading: "Dismissible",
+			isDismissible: true,
+			wrapperStyles: {
+				"background-color": "var(--spectrum-gray-50)"
+			},
+		},
+		{
+			testHeading: "With hero/cover image",
+			hasHeroImage: true,
+			wrapperStyles: {
+				"background-color": "var(--spectrum-gray-50)"
+			},
+		},
+		{
+			testHeading: "No divider",
+			isDismissible: true,
+			hasDivider: false,
 			wrapperStyles: {
 				"background-color": "var(--spectrum-gray-50)"
 			},
@@ -23,12 +51,13 @@ export const DialogGroup = Variants({
 
 export const DialogFullscreen = Variants({
 	Template,
+	withSizes: false,
 	testData: [
 		{
 			showModal: false,
-			isFullScreen: true,
+			layout: "fullscreen",
 			wrapperStyles: {
-				"background-color": "var(--spectrum-gray-100)"
+				"background-color": "var(--spectrum-gray-50)"
 			},
 		},
 	],
@@ -36,13 +65,15 @@ export const DialogFullscreen = Variants({
 
 export const DialogFullscreenTakeover = Variants({
 	Template,
+	withSizes: false,
 	testData: [
 		{
 			showModal: false,
-			isFullScreenTakeover: true,
+			layout: "fullscreenTakeover",
 			wrapperStyles: {
-				"background-color": "var(--spectrum-gray-100)"
+				"background-color": "var(--spectrum-gray-50)"
 			},
 		},
 	],
 });
+

--- a/components/dialog/stories/dialog.test.js
+++ b/components/dialog/stories/dialog.test.js
@@ -12,6 +12,9 @@ export const DialogGroup = Variants({
 			Template({
 				...args,
 				showModal: false,
+
+				// TODO: remove this heading arg when the "Sizing" heading is no longer overwritten by it.
+				heading: "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
 				customStyles: {
 					"background-color": "var(--spectrum-gray-100)",
 				},

--- a/components/dialog/stories/dialog.test.js
+++ b/components/dialog/stories/dialog.test.js
@@ -8,18 +8,18 @@ export const DialogGroup = Variants({
 		 * color to the dialog grid container when isChromatic() is true.
 		 * This should ensure that the Sizes within the Variants() template to display correctly.
 		 */
-		window.isChromatic() ?
-			Template({
-				...args,
-				showModal: false,
 
-				// TODO: remove this heading arg when the "Sizing" heading is no longer overwritten by it.
-				heading: "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
-				customStyles: {
-					"background-color": "var(--spectrum-gray-100)",
-				},
-			}, context)
-			: Template(args, context)
+		Template({
+			...args,
+			showModal: window.isChromatic() ? false : args.showModal,
+			// TODO: The dialog's heading arg is getting passed as the "Sizing" heading arg (instead of the 
+			// TODO: word "Sizing"). We should be able to remove this arg once that no longers happens.
+			heading: window.isChromatic() ? "Lorem ipsum dolor sit amet, consectetur adipiscing elit" : args.heading,
+			customStyles: {
+				...(args.customStyles ?? {}),
+				"background-color": window.isChromatic() ? "var(--spectrum-gray-100)" : undefined,
+			},
+		}, context)
 	),
 	testData: [
 		{
@@ -37,14 +37,14 @@ export const DialogGroup = Variants({
 		},
 		{
 			testHeading: "With hero/cover image",
-			hasHeroImage: true,
+			heroImageUrl: "example-card-portrait.png",
 			wrapperStyles: {
 				"background-color": "var(--spectrum-gray-50)"
 			},
 		},
 		{
 			testHeading: "With hero/cover image, dismissible",
-			hasHeroImage: true,
+			heroImageUrl: "example-card-portrait.png",
 			isDismissible: true,
 			hasFooter: false,
 			wrapperStyles: {
@@ -70,7 +70,7 @@ export const DialogGroup = Variants({
 		{
 			testHeading: "With hero/cover image, no divider",
 			hasDivider: false,
-			hasHeroImage: true,
+			heroImageUrl: "example-card-portrait.png",
 			wrapperStyles: {
 				"background-color": "var(--spectrum-gray-50)"
 			},
@@ -80,7 +80,7 @@ export const DialogGroup = Variants({
 			hasDivider: false,
 			isDismissible: true,
 			hasFooter: false,
-			hasHeroImage: true,
+			heroImageUrl: "example-card-portrait.png",
 			wrapperStyles: {
 				"background-color": "var(--spectrum-gray-50)"
 			},

--- a/components/dialog/stories/template.js
+++ b/components/dialog/stories/template.js
@@ -25,7 +25,6 @@ export const Template = ({
 	id = getRandomId("dialog"),
 	size = "medium",
 	layout,
-	hasHeroImage = false,
 	heroImageUrl,
 	customStyles = {},
 } = {}, context = {}) => {
@@ -36,8 +35,8 @@ export const Template = ({
 		<div
 			class=${classMap({
 				[rootClass]: true,
-				[`${rootClass}--dismissable`]: isDismissible && (layout !== "fullscreen" || layout !== "fullscreenTakeover"),
-				[`${rootClass}--${layout}`]: typeof layout !== "undefined" && layout !== "default",
+				[`${rootClass}--dismissable`]: isDismissible && ["fullscreen", "fullscreenTakeover"].every(l => layout !== l),
+				[`${rootClass}--${layout}`]: typeof layout !== "undefined",
 				[`${rootClass}--${size}`]: typeof size !== "undefined", 
 				[`${rootClass}--noDivider`]: !hasDivider,
 				...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
@@ -49,11 +48,11 @@ export const Template = ({
 			style=${ifDefined(styleMap(customStyles))}
 		>
 			<div class="${rootClass}-grid">
-				${when(hasHeroImage, () =>
+				${when(typeof heroImageUrl !== "undefined", () =>
 					html`
 						<div 
 							class="spectrum-Dialog-hero"
-							style="background-image:url(${heroImageUrl ?  heroImageUrl : "example-card-portrait.png"})">
+							style="background-image:url(${heroImageUrl})">
 						</div>
 					`
 				)}

--- a/components/dialog/stories/template.js
+++ b/components/dialog/stories/template.js
@@ -18,7 +18,7 @@ export const Template = ({
 	isOpen = true,
 	showModal = false,
 	hasFooter = false,
-	dialogHeading,
+	heading,
 	content = [],
 	footer = [],
 	customClasses = [],
@@ -57,8 +57,8 @@ export const Template = ({
 						</div>
 					`
 				)}
-				${when(dialogHeading, () => html`
-					<h1 class="${rootClass}-heading">${dialogHeading}</h1>
+				${when(heading, () => html`
+					<h1 class="${rootClass}-heading">${heading}</h1>
 				`)}
 				${when(hasDivider, () =>
 					Divider({

--- a/components/divider/stories/divider.stories.js
+++ b/components/divider/stories/divider.stories.js
@@ -41,11 +41,13 @@ export default {
 			control: "boolean",
 		},
 		tag: { table: { disable: true } },
+		minDimensionValues: {table: { disable: true }},
 	},
 	args: {
 		rootClass: "spectrum-Divider",
-		size: "m",
+		size: "s",
 		vertical: false,
+		minDimensionValues: true,
 	},
 	parameters: {
 		componentVersion: version,
@@ -53,25 +55,35 @@ export default {
 };
 
 /**
- * The default size for divider is medium.
+ * By default, dividers are horizontal and should be used for separating content vertically. The small divider is the default size. 
  */
 export const Default = DividerGroup.bind({});
 Default.args = {};
 
 // ********* DOCS ONLY ********* //
+/**
+ * To divide similar components such as table rows, action button groups, and components within a panel, use the default, small divider.
+ *
+ * The medium divider is used for dividing subsections on a page, or to separate different groupings of components such as panels, rails, etc.
+ *
+ * Only use the large divider for page titles or section titles.
+ */
 export const Sizing = (args, context) => Sizes({
 	Template,
 	withHeading: false,
 	withBorder: false,
 	...args,
 }, context);
+Sizing.args = {
+	minDimensionValues: true,
+};
 Sizing.tags = ["!dev"];
 Sizing.parameters = {
 	chromatic: { disableSnapshot: true },
 };
 
 /**
- * When a vertical divider is used inside of a flex container, use `align-self: stretch; block-size: auto;` on the divider.
+ * The vertical divider is used to separate content horizontally. When a vertical divider is used inside of a flex container, use `align-self: stretch; block-size: 100%;` on the divider.
  */
 export const VerticalSizing = (args, context) => Sizes({
 	Template,
@@ -83,18 +95,13 @@ VerticalSizing.storyName = "Vertical";
 VerticalSizing.tags = ["!dev"];
 VerticalSizing.args = {
 	vertical: true,
+	minDimensionValues: true,
 };
 VerticalSizing.parameters = {
 	chromatic: { disableSnapshot: true },
 };
 
-export const StaticWhiteGroup = (args, context) => Sizes({
-	Template,
-	withHeading: false,
-	withBorder: false,
-	...args,
-}, context);
-
+export const StaticWhiteGroup = Default.bind({});
 StaticWhiteGroup.storyName = "Static white";
 StaticWhiteGroup.tags = ["!dev"];
 StaticWhiteGroup.args = {
@@ -106,12 +113,7 @@ StaticWhiteGroup.parameters = {
 	},
 };
 
-export const StaticBlackGroup = (args, context) => Sizes({
-	Template,
-	withHeading: false,
-	withBorder: false,
-	...args,
-}, context);
+export const StaticBlackGroup = Default.bind({});
 StaticBlackGroup.storyName = "Static black";
 StaticBlackGroup.tags = ["!dev"];
 StaticBlackGroup.args = {

--- a/components/divider/stories/divider.stories.js
+++ b/components/divider/stories/divider.stories.js
@@ -73,18 +73,18 @@ Sizing.parameters = {
 /**
  * When a vertical divider is used inside of a flex container, use `align-self: stretch; block-size: auto;` on the divider.
  */
-export const VerticalGroup = (args, context) => Sizes({
+export const VerticalSizing = (args, context) => Sizes({
 	Template,
 	withHeading: false,
 	withBorder: false,
 	...args,
 }, context);
-VerticalGroup.storyName = "Vertical";
-VerticalGroup.tags = ["!dev"];
-VerticalGroup.args = {
+VerticalSizing.storyName = "Vertical";
+VerticalSizing.tags = ["!dev"];
+VerticalSizing.args = {
 	vertical: true,
 };
-VerticalGroup.parameters = {
+VerticalSizing.parameters = {
 	chromatic: { disableSnapshot: true },
 };
 

--- a/components/divider/stories/divider.stories.js
+++ b/components/divider/stories/divider.stories.js
@@ -1,6 +1,7 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { version } from "../package.json";
 import { DividerGroup } from "./divider.test.js";
+import { SizingGroup } from "./template.js";
 
 /**
  * Dividers bring clarity to a layout by grouping and dividing content that exists in close proximity. It can also be used to establish rhythm and hierarchy.
@@ -44,17 +45,61 @@ export default {
 		rootClass: "spectrum-Divider",
 		size: "m",
 		vertical: false,
-		customStyles: {
-			"min-inline-size": "200px",
-		},
 	},
 	parameters: {
 		componentVersion: version,
 	},
 };
 
+/**
+ * The default size for divider is medium.
+ */
 export const Default = DividerGroup.bind({});
 Default.args = {};
+
+// ********* DOCS ONLY ********* //
+export const Sizing = SizingGroup.bind({});
+Sizing.tags = ["!dev"];
+Sizing.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+/**
+ * When a vertical divider is used inside of a flex container, use `align-self: stretch; block-size: auto;` on the divider.
+ */
+export const VerticalGroup = SizingGroup.bind({});
+VerticalGroup.storyName = "Vertical";
+VerticalGroup.tags = ["!dev"];
+VerticalGroup.args = {
+	vertical: true,
+};
+VerticalGroup.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+export const StaticWhiteGroup = SizingGroup.bind({});
+StaticWhiteGroup.storyName = "Static white";
+StaticWhiteGroup.tags = ["!dev"];
+StaticWhiteGroup.args = {
+	staticColor: "white",
+};
+StaticWhiteGroup.parameters = {
+	chromatic: {
+		modes: disableDefaultModes,
+	},
+};
+
+export const StaticBlackGroup = SizingGroup.bind({});
+StaticBlackGroup.storyName = "Static black";
+StaticBlackGroup.tags = ["!dev"];
+StaticBlackGroup.args = {
+	staticColor: "black",
+};
+StaticBlackGroup.parameters = {
+	chromatic: {
+		modes: disableDefaultModes,
+	},
+};
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = DividerGroup.bind({});

--- a/components/divider/stories/divider.stories.js
+++ b/components/divider/stories/divider.stories.js
@@ -1,7 +1,8 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
+import { Sizes } from "@spectrum-css/preview/decorators";
 import { version } from "../package.json";
 import { DividerGroup } from "./divider.test.js";
-import { SizingGroup } from "./template.js";
+import { Template } from "./template.js";
 
 /**
  * Dividers bring clarity to a layout by grouping and dividing content that exists in close proximity. It can also be used to establish rhythm and hierarchy.
@@ -58,7 +59,12 @@ export const Default = DividerGroup.bind({});
 Default.args = {};
 
 // ********* DOCS ONLY ********* //
-export const Sizing = SizingGroup.bind({});
+export const Sizing = (args, context) => Sizes({
+	Template,
+	withHeading: false,
+	withBorder: false,
+	...args,
+}, context);
 Sizing.tags = ["!dev"];
 Sizing.parameters = {
 	chromatic: { disableSnapshot: true },
@@ -67,7 +73,12 @@ Sizing.parameters = {
 /**
  * When a vertical divider is used inside of a flex container, use `align-self: stretch; block-size: auto;` on the divider.
  */
-export const VerticalGroup = SizingGroup.bind({});
+export const VerticalGroup = (args, context) => Sizes({
+	Template,
+	withHeading: false,
+	withBorder: false,
+	...args,
+}, context);
 VerticalGroup.storyName = "Vertical";
 VerticalGroup.tags = ["!dev"];
 VerticalGroup.args = {
@@ -77,7 +88,13 @@ VerticalGroup.parameters = {
 	chromatic: { disableSnapshot: true },
 };
 
-export const StaticWhiteGroup = SizingGroup.bind({});
+export const StaticWhiteGroup = (args, context) => Sizes({
+	Template,
+	withHeading: false,
+	withBorder: false,
+	...args,
+}, context);
+
 StaticWhiteGroup.storyName = "Static white";
 StaticWhiteGroup.tags = ["!dev"];
 StaticWhiteGroup.args = {
@@ -89,7 +106,12 @@ StaticWhiteGroup.parameters = {
 	},
 };
 
-export const StaticBlackGroup = SizingGroup.bind({});
+export const StaticBlackGroup = (args, context) => Sizes({
+	Template,
+	withHeading: false,
+	withBorder: false,
+	...args,
+}, context);
 StaticBlackGroup.storyName = "Static black";
 StaticBlackGroup.tags = ["!dev"];
 StaticBlackGroup.args = {

--- a/components/divider/stories/divider.test.js
+++ b/components/divider/stories/divider.test.js
@@ -8,14 +8,18 @@ export const DividerGroup = Variants({
 		{
 			testHeading: "Default",
 			vertical: false,
+			minDimensionValues: true,
 		},
 		{
 			testHeading: "Non-HR",
 			tag: "div",
+			vertical: false,
+			minDimensionValues: true,
 		},
 		{
 			testHeading: "Vertical",
 			vertical: true,
+			minDimensionValues: true,
 		}
 	],
 });

--- a/components/divider/stories/divider.test.js
+++ b/components/divider/stories/divider.test.js
@@ -8,23 +8,14 @@ export const DividerGroup = Variants({
 		{
 			testHeading: "Default",
 			vertical: false,
-			customStyles: {
-				"min-inline-size": "200px",
-			},
 		},
 		{
 			testHeading: "Non-HR",
 			tag: "div",
-			customStyles: {
-				"min-inline-size": "200px",
-			},
 		},
 		{
 			testHeading: "Vertical",
 			vertical: true,
-			customStyles: {
-				"min-block-size": "100px",
-			},
 		}
 	],
 });

--- a/components/divider/stories/template.js
+++ b/components/divider/stories/template.js
@@ -28,7 +28,7 @@ export const Template = ({
 				"min-block-size": vertical == true ? "20px" : undefined,
 				"block-size": vertical ? "auto" : undefined,
 				"min-inline-size": !vertical ? "200px" : "var(--spectrum-divider-thickness)",
-				"inline-size": !vertical ? "100%" : undefined,
+				"inline-size": !vertical ? "auto" : undefined,
 				"align-self": vertical == true ? "stretch" : undefined,
 				...customStyles,
 			})}
@@ -49,7 +49,7 @@ export const Template = ({
 			"min-block-size": vertical == true ? "20px" : undefined,
 			"block-size": vertical == true ? "auto" : undefined,
 			"min-inline-size": !vertical ? "200px" : "var(--spectrum-divider-thickness)",
-			"inline-size": !vertical ? "100%" : undefined,
+			"inline-size": !vertical ? "auto" : undefined,
 			"align-self": vertical == true ? "stretch" : undefined,
 			...customStyles,
 		})}

--- a/components/divider/stories/template.js
+++ b/components/divider/stories/template.js
@@ -1,4 +1,3 @@
-import { Template as Typography } from "@spectrum-css/typography/stories/template.js";
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { styleMap } from "lit/directives/style-map.js";
@@ -56,42 +55,4 @@ export const Template = ({
 		})}
 		role="separator"
 	></div>`;
-};
-
-export const SizingGroup = (args, context) => {
-	// Color for heading that shows the name of the size. Adjustments for static white and black backgrounds,
-	// which don't change with the color context.
-	let headingColor = "var(--spectrum-seafoam-900)";
-	if (context?.args?.staticColor == "white") { headingColor = "rgb(255, 255, 255)"; }
-	if (context?.args?.staticColor == "black") { headingColor = "rgb(0, 0, 0)"; }
-
-	return html`
-		${["s", "m", "l"].map((size) => html`
-			<div style=${styleMap({
-				"display": "flex",
-				"gap": "16px",
-				"flex-direction": "column",
-				"align-items": "flex-start",
-				})}
-			>
-				${Typography({
-					semantics: "heading",
-					size: "xs",
-					content: [{
-						s: "Small",
-						m: "Medium (default)",
-						l: "Large",
-					}[size]],
-					customClasses: ["chromatic-ignore"],
-					customStyles: {
-						"white-space": "nowrap",
-						"--mod-heading-font-color": headingColor,
-					},
-				})}
-				${Template({
-						...args,
-						size,
-				}, context)}
-		`)}
-	`;
 };

--- a/components/divider/stories/template.js
+++ b/components/divider/stories/template.js
@@ -1,3 +1,4 @@
+import { Template as Typography } from "@spectrum-css/typography/stories/template.js";
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { styleMap } from "lit/directives/style-map.js";
@@ -25,7 +26,9 @@ export const Template = ({
 				...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
 			})}
 			style=${styleMap({
+				"min-block-size": vertical == true ? "20px" : undefined,
 				"block-size": vertical ? "auto" : undefined,
+				"min-inline-size": !vertical ? "200px" : "var(--spectrum-divider-thickness)",
 				"inline-size": !vertical ? "100%" : undefined,
 				"align-self": vertical == true ? "stretch" : undefined,
 				...customStyles,
@@ -44,11 +47,51 @@ export const Template = ({
 			...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
 		})}
 		style=${styleMap({
-			"min-height": vertical == true ? "20px" : undefined,
-			height: vertical == true ? "auto" : undefined,
+			"min-block-size": vertical == true ? "20px" : undefined,
+			"block-size": vertical == true ? "auto" : undefined,
+			"min-inline-size": !vertical ? "200px" : "var(--spectrum-divider-thickness)",
+			"inline-size": !vertical ? "100%" : undefined,
 			"align-self": vertical == true ? "stretch" : undefined,
 			...customStyles,
 		})}
 		role="separator"
 	></div>`;
+};
+
+export const SizingGroup = (args, context) => {
+	// Color for heading that shows the name of the size. Adjustments for static white and black backgrounds,
+	// which don't change with the color context.
+	let headingColor = "var(--spectrum-seafoam-900)";
+	if (context?.args?.staticColor == "white") { headingColor = "rgb(255, 255, 255)"; }
+	if (context?.args?.staticColor == "black") { headingColor = "rgb(0, 0, 0)"; }
+
+	return html`
+		${["s", "m", "l"].map((size) => html`
+			<div style=${styleMap({
+				"display": "flex",
+				"gap": "16px",
+				"flex-direction": "column",
+				"align-items": "flex-start",
+				})}
+			>
+				${Typography({
+					semantics: "heading",
+					size: "xs",
+					content: [{
+						s: "Small",
+						m: "Medium (default)",
+						l: "Large",
+					}[size]],
+					customClasses: ["chromatic-ignore"],
+					customStyles: {
+						"white-space": "nowrap",
+						"--mod-heading-font-color": headingColor,
+					},
+				})}
+				${Template({
+						...args,
+						size,
+				}, context)}
+		`)}
+	`;
 };

--- a/components/divider/stories/template.js
+++ b/components/divider/stories/template.js
@@ -11,6 +11,7 @@ export const Template = ({
 	tag = "hr",
 	staticColor,
 	vertical = false,
+	minDimensionValues,
 	customClasses = [],
 	customStyles = {},
 } = {}) => {
@@ -25,11 +26,8 @@ export const Template = ({
 				...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
 			})}
 			style=${styleMap({
-				"min-block-size": vertical == true ? "20px" : undefined,
-				"block-size": vertical ? "auto" : undefined,
-				"min-inline-size": !vertical ? "200px" : "var(--spectrum-divider-thickness)",
-				"inline-size": !vertical ? "auto" : undefined,
-				"align-self": vertical == true ? "stretch" : undefined,
+				"min-inline-size": minDimensionValues && !vertical ? "200px": undefined,
+				"min-block-size": minDimensionValues && vertical ? "20px": undefined,
 				...customStyles,
 			})}
 			role="separator"
@@ -46,11 +44,8 @@ export const Template = ({
 			...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
 		})}
 		style=${styleMap({
-			"min-block-size": vertical == true ? "20px" : undefined,
-			"block-size": vertical == true ? "auto" : undefined,
-			"min-inline-size": !vertical ? "200px" : "var(--spectrum-divider-thickness)",
-			"inline-size": !vertical ? "auto" : undefined,
-			"align-self": vertical == true ? "stretch" : undefined,
+			"min-inline-size": minDimensionValues && !vertical ? "200px": undefined,
+			"min-block-size": minDimensionValues && vertical ? "20px": undefined,
 			...customStyles,
 		})}
 		role="separator"

--- a/components/dropindicator/stories/dropindicator.stories.js
+++ b/components/dropindicator/stories/dropindicator.stories.js
@@ -1,6 +1,7 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { version } from "../package.json";
 import { DropIndicatorGroup } from "./dropindicator.test.js";
+import { DocsDropIndicatorGroup } from "./template";
 
 /**
  * The drop indicator component is used to show the insertion position into a list or table.
@@ -43,6 +44,15 @@ export default {
 
 export const Default = DropIndicatorGroup.bind({});
 Default.args = {};
+Default.tags = ["!autodocs"];
+
+// ********* DOCS ONLY ********* //
+export const DefaultGroup = DocsDropIndicatorGroup.bind({});
+DefaultGroup.storyName = "Default";
+DefaultGroup.tags = ["!dev"];
+DefaultGroup.parameters = { 
+	chromatic: { disableSnapshot: true }
+};
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = DropIndicatorGroup.bind({});
@@ -50,6 +60,6 @@ WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",
-		modes: disableDefaultModes
+		modes: disableDefaultModes,
 	},
 };

--- a/components/dropindicator/stories/template.js
+++ b/components/dropindicator/stories/template.js
@@ -27,3 +27,20 @@ export const Template = ({
 		></div>
 	`;
 };
+
+export const DocsDropIndicatorGroup = (args, context) => html`
+	<div style=${styleMap({
+		"display": "flex",
+		"align-items": "center",
+		"gap": "16px",
+		"justify-content": "space-evenly",
+	})}>
+	${Template({
+			...args,
+		}, context)}
+		${Template({
+			...args,
+			direction: "horizontal",
+		}, context)}
+	</div>
+`;

--- a/components/tray/stories/tray.stories.js
+++ b/components/tray/stories/tray.stories.js
@@ -56,7 +56,7 @@ Default.args = {
 			...passthroughs,
 			heading: "New messages",
 			content: ["You have 5 new messages!"],
-			isDismissable: false,
+			isDismissible: false,
 		}, context)
 	],
 };

--- a/components/tray/stories/tray.test.js
+++ b/components/tray/stories/tray.test.js
@@ -11,7 +11,7 @@ export const TrayGroup = Variants({
 					...passthroughs,
 					heading: "You have new messages waiting in your inbox",
 					content: ["You have 5 new messages! This notification is extra long so it wraps to the next line"],
-					isDismissable: true,
+					isDismissible: true,
 				}, context)
 			],
 		},


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

This PR continues migrating documentation from the static docs site into Storybook. The focus is on `dial`, `dialog` (standard dialog), `divider` and `dropindicator`. All variants of the components should now be displayed on the Storybook `Docs` page.

- `dial`: ~~new MDX docs page~~ new stories
- `dialog`: !!new MDX docs page~~ new stories and controls (plus an additional note regarding alert dialog)
- `divider`: ~~new MDX docs page~~ new stories
- `dropindicator`: ~~new MDX docs page~~ 

**This PR doesn't need a changeset since it's docs-only.**

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

- [x] The [dial storybook docs](https://pr-2833--spectrum-css.netlify.app/preview/?path=/docs/components-dial--docs) include all necessary info when compared to the [corresponding docs site page](https://opensource.adobe.com/spectrum-css/dial.html)
- [x] The [dialog storybook docs](https://pr-2833--spectrum-css.netlify.app/preview/?path=/docs/components-dialog--docs) include all necessary info when compared to the [corresponding docs site page](https://opensource.adobe.com/spectrum-css/dialog.html)
- [x] The [divider button storybook docs](https://pr-2833--spectrum-css.netlify.app/preview/?path=/docs/components-divider--docs) include all necessary info when compared to the [corresponding docs site page](https://opensource.adobe.com/spectrum-css/divider.html)
- [x] The [drop indicator storybook docs](https://pr-2833--spectrum-css.netlify.app/preview/?path=/docs/components-drop-indicator--docs) include all necessary info when compared to the [corresponding docs site page](https://opensource.adobe.com/spectrum-css/dropindicator.html)
- [ ] Ensure the Chromatic testing view for each component captures all new variants.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
