### PR TITLE
fix: remove abstractions from build process for grid and keyframe

### DIFF
--- a/.changeset/thin-jeans-wink.md
+++ b/.changeset/thin-jeans-wink.md
@@ -4,7 +4,6 @@
 "@spectrum-css/menu": patch
 "@spectrum-css/progressbar": patch
 "@spectrum-css/progresscircle": patch
-"@spectrum-css/swatch": patch
 ---
 
 Updated CSSNano plugin to toggle reduceIdent off to prevent invalid abstractions from breaking named grid templates.

--- a/.changeset/thin-jeans-wink.md
+++ b/.changeset/thin-jeans-wink.md
@@ -1,0 +1,10 @@
+---
+"@spectrum-css/coachindicator": patch
+"@spectrum-css/dialog": patch
+"@spectrum-css/menu": patch
+"@spectrum-css/progressbar": patch
+"@spectrum-css/progresscircle": patch
+"@spectrum-css/swatch": patch
+---
+
+Updated CSSNano plugin to toggle reduceIdent off to prevent invalid abstractions from breaking named grid templates.

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -134,6 +134,7 @@ module.exports = ({
 					"cssnano-preset-advanced",
 					{
 						colormin: false,
+						reduceIdents: false,
 						discardComments: {
 							removeAllButFirst: true,
 						},


### PR DESCRIPTION
## Description

Set [`reduceIdents`](https://www.npmjs.com/package/postcss-reduce-idents) to false for cssnano minification as the grid-template-area and keyframe magnifications were causing mismatches in the resulting code.

## How and where has this been tested?

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

The pages render correctly, are accessible, and are responsive.
- [x] [coachindicator](https://pr-2842--spectrum-css.netlify.app/coachindicator)
- [x] [dialog](https://pr-2842--spectrum-css.netlify.app/dialog)
- [x] [menu](https://pr-2842--spectrum-css.netlify.app/menu)
- [x] [progressbar](https://pr-2842--spectrum-css.netlify.app/progressbar)
- [x] [progresscircle](https://pr-2842--spectrum-css.netlify.app/progresscircle)

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
