### PR TITLE
docs(modal,pagination,pickerbutton): site docs to storybook

### DIFF
--- a/components/modal/stories/modal.stories.js
+++ b/components/modal/stories/modal.stories.js
@@ -6,7 +6,9 @@ import { version } from "../package.json";
 import { ModalGroup } from "./modal.test.js";
 
 /**
- * A modal component is a dialog box/popup window that is displayed on top of the current page.
+ * A modal component is a dialog box/popup window that is displayed on top of the current page using `position: fixed`.
+ * This is a base component used by other components, and should not be used on its own. If you
+ * need a full-featured modal for displaying content, take a look at the [Dialog](?path=/docs/components-dialog--docs) component instead.
  */
 export default {
 	title: "Modal",
@@ -16,7 +18,7 @@ export default {
 		variant: {
 			name: "Sizing preference",
 			description:
-				"Controls how the modal fills the available space. <ul><li>\"responsive\" will fill the screen on small viewports.</li><li>\"fullscreen\" will fill almost all of the available screen space.</li><li>\"fullscreenTakeover\" will fill all of the available screen space.</li></ul>",
+				"Controls how the modal fills the available space. <ul><li>\"responsive\" will fill the screen on small viewports.</li><li>\"fullscreen\" will fill almost all of the available screen space. Includes an outer margin.</li><li>\"fullscreenTakeover\" will fill all of the available screen space.</li></ul>",
 			table: {
 				type: { summary: "string" },
 				category: "Component",
@@ -35,7 +37,8 @@ export default {
 		customStyles: {
 			// Without this, the content sits right up against the edge of the modal
 			padding: "20px",
-		}
+		},
+		showUnderlay: false,
 	},
 	parameters: {
 		layout: "fullscreen",
@@ -70,16 +73,23 @@ Default.args = {
 		}, context),
 	],
 };
+Default.parameters = {
+	docs: {
+		story: {
+			inline: false,
+		},
+	},
+};
 
 export const Fullscreen = ModalGroup.bind({});
-// Fullscreen.tags = ["!dev"];
+Fullscreen.tags = ["!dev"];
 Fullscreen.args = {
 	...Default.args,
 	variant: "fullscreen",
 };
 
 export const FullscreenTakeover = ModalGroup.bind({});
-// FullscreenTakeover.tags = ["!dev"];
+FullscreenTakeover.tags = ["!dev"];
 FullscreenTakeover.args = {
 	...Default.args,
 	variant: "fullscreenTakeover",

--- a/components/modal/stories/template.js
+++ b/components/modal/stories/template.js
@@ -6,6 +6,9 @@ import { when } from "lit/directives/when.js";
 
 import "../index.css";
 
+/**
+ * Just the modal markup.
+ */
 const Modal = ({
 	rootClass = "spectrum-Modal",
 	customClasses = [],
@@ -29,6 +32,9 @@ const Modal = ({
 	`;
 };
 
+/**
+ * The modal, optionally wrapped with .spectrum-Modal-wrapper.
+ */
 export const Template = ({
 	rootClass = "spectrum-Modal",
 	skipWrapper = false,

--- a/components/pagination/stories/pagination.stories.js
+++ b/components/pagination/stories/pagination.stories.js
@@ -2,9 +2,10 @@ import { default as ActionButton } from "@spectrum-css/actionbutton/stories/acti
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { version } from "../package.json";
 import { PaginationGroup } from "./pagination.test.js";
+import { Template } from "./template";
 
 /**
- * The pagination component displays numbered buttons or an input field to allow for navigation.
+ * The pagination component displays numbered buttons or an input field to allow for navigation. 
  */
 export default {
 	title: "Pagination",
@@ -21,7 +22,27 @@ export default {
 			control: "select",
 		},
 		variant: {
-			table: { disable: true },
+			name: "Variant",
+			type: { name: "string" },
+			table: {
+				category: "Component",
+				defaultValue: {
+					summary: "listing",
+				},
+			},
+			options: [
+				"listing",
+				"explicit",
+			],
+			control: "select",
+		},
+		items: {
+			name: "Items",
+			description: "In the \"listing\" variant, each item represents a page button and its label.",
+			table: {
+				category: "Content",
+			},
+			control: "object",
 		},
 	},
 	args: {
@@ -58,7 +79,11 @@ export default {
 	},
 };
 
+/**
+ * The default listing/page variant uses buttons for each page number. 
+ */
 export const Default = PaginationGroup.bind({});
+Default.storyName = "Default (listing)";
 Default.args = {};
 
 // ********* VRT ONLY ********* //
@@ -69,4 +94,19 @@ WithForcedColors.parameters = {
 		forcedColors: "active",
 		modes: disableDefaultModes
 	},
+};
+
+// ********* DOCS ONLY ********* //
+/**
+ * Pagination's explicit variant uses the text field component to represent the current page number,
+ * and action buttons for the previous and next navigation. It also displays text with the total
+ * number of pages.
+ */
+export const Explicit = Template.bind({});
+Explicit.tags = ["!dev"];
+Explicit.args = {
+	variant: "explicit",
+};
+Explicit.parameters = {
+	chromatic: { disableSnapshot: true },
 };

--- a/components/pagination/stories/template.js
+++ b/components/pagination/stories/template.js
@@ -13,52 +13,52 @@ export const Template = ({
 	size = "m",
 	customClasses = [],
 	variant,
-	items,
+	items
 } = {}, context = {}) => {
-	if (variant === "explicit") {
-		return html`
-			<nav
-				class=${classMap({
-					[rootClass]: true,
-					[`${rootClass}--explicit`]: true,
-					...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
-				})}
-			>
-				${ActionButton({
-					size,
-					isQuiet: true,
-					iconSet: "ui",
-					iconName: "ChevronLeft",
-					customClasses: [`${rootClass}-prevButton`],
-				}, context)}
-				${Textfield({
-					size,
-					value: "1",
-					customClasses: [`${rootClass}-textfield`],
-				}, context)}
-				<span class="${rootClass}-counter">of 89 pages</span>
-				${ActionButton({
-					size,
-					isQuiet: true,
-					iconSet: "ui",
-					iconName: "ChevronRight",
-					customClasses: [`${rootClass}-nextButton`],
-				}, context)}
-			</nav>
-		`;
-	}
-	else if (variant == "button") {
-		return SplitButton({
-			position: "left",
-			variant: "accent",
-			label: "Next",
-			iconName: "ChevronLeft100",
-			labelIconName: "ChevronRight100",
-			customFirstButtonClasses: ["spectrum-Pagination-prevButton"],
-			customLastButtonClasses: ["spectrum-Pagination-nextButton"]
-		}, context);
-	}
-	return html`
+
+	const explicitVariant = html`
+		<nav
+			class=${classMap({
+				[rootClass]: true,
+				[`${rootClass}--explicit`]: true,
+				...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
+			})}
+		>
+			${ActionButton({
+				size,
+				isQuiet: true,
+				iconSet: "ui",
+				iconName: "ChevronLeft",
+				customClasses: [`${rootClass}-prevButton`],
+			}, context)}
+			${Textfield({
+				size,
+				value: "1",
+				customClasses: [`${rootClass}-textfield`],
+			}, context)}
+			<span class="${rootClass}-counter">of 89 pages</span>
+			${ActionButton({
+				size,
+				isQuiet: true,
+				iconSet: "ui",
+				iconName: "ChevronRight",
+				customClasses: [`${rootClass}-nextButton`],
+			}, context)}
+		</nav>
+	`;
+
+	// @todo This variant should be deprecated, as it uses the deprecated SplitButton component. 
+	const buttonVariant = SplitButton({
+		position: "left",
+		variant: "accent",
+		label: "Next",
+		iconName: "ChevronLeft100",
+		labelIconName: "ChevronRight100",
+		customFirstButtonClasses: ["spectrum-Pagination-prevButton"],
+		customLastButtonClasses: ["spectrum-Pagination-nextButton"]
+	}, context);
+
+	const listingVariant = html`
 		<nav
 			class=${classMap({
 				[rootClass]: true,
@@ -98,4 +98,12 @@ export const Template = ({
 			}, context)}
 		</nav>
 	`;
+
+	if (variant === "explicit") {
+		return explicitVariant;
+	}
+	else if (variant == "button") {
+		return buttonVariant;
+	}
+	return listingVariant;
 };

--- a/components/pickerbutton/CHANGELOG.md
+++ b/components/pickerbutton/CHANGELOG.md
@@ -325,70 +325,34 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 \*feat(pickerbutton)!: migrate to use spectrum tokens (#1940)([ad6051d](https://github.com/adobe/spectrum-css/commit/ad6051d)), closes[#1940](https://github.com/adobe/spectrum-css/issues/1940)
 
-    	###
-    	🛑 BREAKING CHANGES
+### 🛑 BREAKING CHANGES
 
-    		*
-    		migrates the Picker Button component to use `@adobe/spectrum-tokens`
+#### Migrates the Picker Button component to use `@adobe/spectrum-tokens`
 
 - feat(pickerbutton)!: update to use tokens
-
-- feat(pickerbutton): updating tokens
-
 - chore(pickerbutton): move css from generated to index
-
-- feat(pickerbutton): updating with tokens
-
 - docs(pickerbutton): update docs html to correct icon sizes
-
-- refactor(pickerbutton): fixing variable names and tokens
-
-- chore(pickerbutton): update story
-
 - chore(pickerbutton): update storybook controls and template
-
 - chore(pickerbutton): adding more storybook stories for express, quiet etc
-
 - fix(pickerbutton): fixing icon color
-
-- chore(pickerbutton): reset yarn file
-
-- chore: reset yarn file
-
 - refactor(pickerbutton): fix button fill padding calculations
-
 - chore(pickerbutton): remove invalid and isKeyboardFocused variants
-
 - chore(pickerbutton): prevent focused and open when disabled
-
 - fix(pickerbutton): fix disabled hover
-
-update mods
-
 - fix(searchwithin): pass through mod for picker button border color
-
-- chore(pickerbutton): bumping up tokens release
-
 - chore(pickerbutton): update token peer dependency
-
-- fix(searchwithin): update searchwithin story to match docs site
-
-use picker instead of pickerbutton
-remove extra border
-
-- chore(pickerbutton): manual version increase for beta release
-
-- chore(pickerbutton): remove pickerbutton-generated css
-
-- fix(pickerbutton): remove icononly class and remove padding from uiicononly
-
-removes padding from uiicononly class to allow for larger icons in slots
-
+- fix(searchwithin): update searchwithin story to match docs site  
+  use picker instead of pickerbutton and remove extra border
+- fix(pickerbutton): remove icononly class and remove padding from uiicononly  
+  removes padding from uiicononly class to allow for larger icons in slots
 - fix(pickerbutton): explicitly add box-sizing border-box
-
 - fix(pickerbutton): fix icon size
 
-- chore(pickerbutton): manual version increase for beta release
+### Migration guide
+
+#### .spectrum-PickerButton-UIIcon class removed
+
+The `.spectrum-PickerButton-UIIcon` class no longer matches our naming convention. Both types of icons now use the `spectrum-PickerButton-icon` class
 
 <a name="3.0.34"></a>
 
@@ -821,6 +785,17 @@ removes padding from uiicononly class to allow for larger icons in slots
 - remove high loudness selectors from pickerbutton, apply quiet background color from inputgroup, change loudness api to quiet for infieldbutton
 - replaces `medium` loudness with `quiet`
 - refactor spectrum-PickerButton--high to use base spectrum-PickerButton styles
+
+### Migration guide
+
+#### Picker button uses the Quiet variant instead of loudness levels.
+
+The Loudness level classes, `.spectrum-PickerButton--low`, `.spectrum-PickerButton--medium`, and `.spectrum-PickerButton--high`, have been removed.
+
+- Use the base class, `.spectrum-PickerButton`, to apply the default button styles. The default styles correspond to what was previously the Loudness - High variant, which used the class `.spectrum-InfieldButton--high`.
+- Use the modifier class, `spectrum-PickerButton--quiet`, to apply the quiet variant styles. Quiet corresponds to what was previously the Loudness - Low variant, which used the class `.spectrum-InfieldButton--low` class.
+
+The Loudness - Medium variant has been removed, so there is no equivalent.
 
 <a name="1.1.22"></a>
 

--- a/components/pickerbutton/stories/pickerbutton.stories.js
+++ b/components/pickerbutton/stories/pickerbutton.stories.js
@@ -1,12 +1,13 @@
 import { default as Icon } from "@spectrum-css/icon/stories/icon.stories.js";
+import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isFocused, isOpen } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
 import { PickerGroup } from "./pickerbutton.test.js";
-import { Template } from "./template.js";
+import { CustomIconTemplate, Template } from "./template";
 
 /**
- * The picker button component is used as a dropdown trigger. See Combobox.
+ * The picker button component is used as a dropdown trigger within other components such as [combobox](?path=/docs/components-combobox--docs).
  */
 export default {
 	title: "Picker button",
@@ -51,6 +52,7 @@ export default {
 		},
 		isRounded: {
 			name: "Rounded",
+			description: "Increases the amount of rounding on the rounded corners.",
 			type: { name: "boolean" },
 			table: {
 				type: { summary: "boolean" },
@@ -82,7 +84,9 @@ export default {
 		},
 		position: {
 			name: "Position",
-			type: { name: "string" },
+			description:
+				"Denotes which side of a form field the button is displayed; this influences which corners are rounded.",
+			type: { name: "string", required: true },
 			table: {
 				type: { summary: "string" },
 				category: "Component",
@@ -100,10 +104,9 @@ export default {
 		isQuiet: false,
 		isDisabled: false,
 		isFocused: false,
-		isKeyboardFocused: false,
 		iconType: "ui",
 		iconName: "ChevronDown",
-		position: "right"
+		position: "right",
 	},
 	parameters: {
 		componentVersion: version,
@@ -139,6 +142,48 @@ Disabled.args = {
 	isDisabled: true
 };
 Disabled.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+export const Sizing = (args, context) => Sizes({
+	Template,
+	withHeading: false,
+	withBorder: false,
+	...args
+}, context);
+Sizing.tags = ["!dev"];
+Sizing.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+export const Open = Template.bind({});
+Open.tags = ["!dev"];
+Open.args = {
+	isOpen: true,
+};
+Open.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+/**
+ * This example uses a custom icon instead of the chevron UI icon.
+ */
+export const CustomIcon = CustomIconTemplate.bind({});
+CustomIcon.storyName = "With custom icon";
+CustomIcon.tags = ["!dev"];
+CustomIcon.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+/**
+ * The `spectrum-PickerButton--rounded` class increases the amount of rounding on the rounded corners.
+ */
+export const Rounded = Template.bind({});
+Rounded.tags = ["!dev"];
+Rounded.args = {
+	isRounded: true,
+};
+Rounded.parameters = {
 	chromatic: { disableSnapshot: true },
 };
 

--- a/components/pickerbutton/stories/template.js
+++ b/components/pickerbutton/stories/template.js
@@ -1,5 +1,6 @@
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 import { getRandomId } from "@spectrum-css/preview/decorators";
+import { Template as Typography } from "@spectrum-css/typography/stories/template.js";
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
@@ -70,3 +71,66 @@ export const Template = ({
 		</button>
 	`;
 };
+
+/**
+ * Displays the component with a custom icon (instead of the chevron UI icon).
+ * Two examples are shown; with a custom UI icon and a custom Workflow icon.
+ */
+export const CustomIconTemplate = (args) => html`
+	<div
+		style=${styleMap({
+			display: "flex",
+			gap: "24px",
+			flexWrap: "wrap",
+		})}
+	>
+		<div
+			style=${styleMap({
+				display: "flex",
+				gap: "16px",
+				flexDirection: "column",
+				alignItems: "center",
+				flexBasis: "80px",
+			})}
+		>
+			${Typography({
+				semantics: "detail",
+				size: "s",
+				content: ["UI icon"],
+				customStyles: {
+					"white-space": "nowrap",
+					"--mod-detail-font-color": "var(--spectrum-seafoam-900)",
+				},
+			})}
+			${Template({
+				...args,
+				iconName: "ArrowDown100",
+				iconType: "ui",
+			})}
+		</div>
+		<div
+			style=${styleMap({
+				display: "flex",
+				gap: "16px",
+				flexDirection: "column",
+				alignItems: "center",
+				flexBasis: "80px",
+			})}
+		>
+			${Typography({
+				semantics: "detail",
+				size: "s",
+				content: ["Workflow icon"],
+				customStyles: {
+					"white-space": "nowrap",
+					"--mod-detail-font-color": "var(--spectrum-seafoam-900)",
+				},
+			})}
+			${Template({
+				...args,
+				iconName: "Add",
+				iconType: "workflow",
+			})}
+		</div>
+	</div>
+`;


### PR DESCRIPTION
## Description

This continues the migration work to move the documentation from the deprecated docs site to Storybook, covering the components Modal, Pagination, and Picker button. Variants shown on the docs site for these components have been added to Storybook as new stories if they did not already exist. No custom MDX files were needed for these components.

### Component-specific changes and notes:

- Modal
  - Updates docs text and sets Docs story to `inline: false` to avoid it being cut off horizontally
- Pagination
  - Makes sure pagination variants are included in the Storybook docs. Note: the "button" style variant is represented in VRTs but not included for users as it is using the deprecated Split button component. I wasn't sure about the best way to document this as deprecated. That variant has no unique CSS and is basically just a Split button with two classes added.
- Picker button
  - Creates docs only stories to cover what is on the docs site
  - Moves old migration notes to the changelog
  - Note on the "Custom icon only" variant from the docs site: this appears to be using a workflow icon but is using the class `spectrum-PickerButton--uiicononly` that gets rid of the padding. It's unclear whether this class should be named something else that applies to both icon sets, if `spectrum-PickerButton--icononly` should use the same CSS (this currently is applied in Storybook if a workflow icon is used), if the component really should only allow UI icons, or if the wrong class was used in the example. I've included both a UI icon and a workflow icon on the Docs story in order to show that these render differently (without `spectrum-PickerButton--uiicononly` there is extra padding on the left and right).

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

@marissahuysentruyt ✅✅✅
- [Modal](https://pr-2854--spectrum-css.netlify.app/preview/?path=/docs/components-modal--docs) - includes all necessary information compared to the [docs site](https://opensource.adobe.com/spectrum-css/modal.html)
- [Pagination](https://pr-2854--spectrum-css.netlify.app/preview/?path=/docs/components-pagination--docs) - includes all necessary information compared to the [docs site 1](https://opensource.adobe.com/spectrum-css/pagination-explicit.html) [docs site 2](https://opensource.adobe.com/spectrum-css/pagination-listing.html)
- [Picker button](https://pr-2854--spectrum-css.netlify.app/preview/?path=/docs/components-picker-button--docs) - includes all necessary information compared to the [docs site](https://opensource.adobe.com/spectrum-css/pickerbutton.html)

### Regression testing

Expected VRT changes: label added to quiet Picker button.

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
