### PR TITLE
chore(dialog): z-index for dialog docs

### DIFF
--- a/components/dialog/metadata/dialog.yml
+++ b/components/dialog/metadata/dialog.yml
@@ -71,8 +71,8 @@ examples:
     markup: |
       <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--outline spectrum-Button--staticWhite spectrum-CSSExample-overlayShowButton" onclick="openDialog(this.nextElementSibling)"><span class="spectrum-Button-label">Open Dismissible Dialog</span></button>
 
-      <div class="spectrum-Modal-wrapper spectrum-CSSExample-dialog">
-        <div class="spectrum-Modal is-open" data-testid="modal">
+      <div class="spectrum-Modal-wrapper spectrum-CSSExample-modal">
+        <div class="spectrum-Modal" data-testid="modal">
           <section class="spectrum-Dialog spectrum-Dialog--medium spectrum-Dialog--dismissable" role="dialog" tabindex="-1" aria-modal="true">
             <div class="spectrum-Dialog-grid">
               <h1 class="spectrum-Dialog-heading">Disclaimer</h1>
@@ -98,8 +98,8 @@ examples:
     markup: |
       <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--outline spectrum-Button--staticWhite spectrum-CSSExample-overlayShowButton" onclick="openDialog(this.nextElementSibling)"><span class="spectrum-Button-label">Open No Divider Dialog</span></button>
 
-      <div class="spectrum-Modal-wrapper spectrum-CSSExample-dialog">
-        <div class="spectrum-Modal is-open" data-testid="modal">
+      <div class="spectrum-Modal-wrapper spectrum-CSSExample-modal">
+        <div class="spectrum-Modal" data-testid="modal">
           <section class="spectrum-Dialog spectrum-Dialog--medium spectrum-Dialog--dismissable spectrum-Dialog--noDivider" role="dialog" tabindex="-1" aria-modal="true">
             <div class="spectrum-Dialog-grid">
               <h1 class="spectrum-Dialog-heading">Disclaimer</h1>
@@ -123,8 +123,8 @@ examples:
     demoClassName: spectrum-CSSExample-example--overlay
     markup: |
       <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--outline spectrum-Button--staticWhite spectrum-CSSExample-overlayShowButton" onclick="openDialog(this.nextElementSibling)"><span class="spectrum-Button-label">Open Hero Dialog</span></button>
-      <div class="spectrum-Modal-wrapper spectrum-CSSExample-dialog">
-        <div class="spectrum-Modal is-open" data-testid="modal">
+      <div class="spectrum-Modal-wrapper spectrum-CSSExample-modal">
+        <div class="spectrum-Modal" data-testid="modal">
           <section class="spectrum-Dialog spectrum-Dialog--medium spectrum-Dialog--dismissable spectrum-Dialog--noDivider" role="dialog" tabindex="-1" aria-modal="true">
             <div class="spectrum-Dialog-grid">
               <div class="spectrum-Dialog-hero" style="background-image: url(img/example-card-portrait.jpg)"></div>
@@ -148,7 +148,7 @@ examples:
     demoClassName: spectrum-CSSExample-example--overlay
     markup: |
       <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--outline spectrum-Button--staticWhite spectrum-CSSExample-overlayShowButton" onclick="openDialog(this.nextElementSibling)"><span class="spectrum-Button-label">Open Scrolling Dialog</span></button>
-      <div class="spectrum-Modal-wrapper">
+      <div class="spectrum-Modal-wrapper spectrum-CSSExample-modal">
         <div class="spectrum-Modal" data-testid="modal">
           <section class="spectrum-Dialog spectrum-Dialog--large" role="alertdialog" tabindex="-1" aria-modal="true">
             <div class="spectrum-Dialog-grid">
@@ -205,9 +205,9 @@ examples:
     demoClassName: spectrum-CSSExample-example--overlay
     markup: |
       <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--outline spectrum-Button--staticWhite spectrum-CSSExample-overlayShowButton" onclick="openDialog(this.nextElementSibling)"><span class="spectrum-Button-label">Open Fullscreen Dialog</span></button>
-      <div class="spectrum-Modal-wrapper">
+      <div class="spectrum-Modal-wrapper spectrum-CSSExample-modal">
         <div class="spectrum-Modal spectrum-Modal--fullscreen" data-testid="modal">
-          <section class="spectrum-Dialog spectrum-Dialog--fullscreen" role="alertdialog" tabindex="-1" aria-modal="true">
+          <section class="spectrum-CSSExample-dialog spectrum-Dialog spectrum-Dialog--fullscreen" role="alertdialog" tabindex="-1" aria-modal="true">
             <div class="spectrum-Dialog-grid">
               <h1 class="spectrum-Dialog-heading spectrum-Dialog-heading--noHeader">Default Dialog - Fullscreen</h1>
               <hr class="spectrum-Divider spectrum-Divider--sizeM spectrum-Divider--horizontal spectrum-Dialog-divider">
@@ -262,9 +262,9 @@ examples:
     demoClassName: spectrum-CSSExample-example--overlay
     markup: |
       <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--outline spectrum-Button--staticWhite spectrum-CSSExample-overlayShowButton" onclick="openDialog(this.nextElementSibling)"><span class="spectrum-Button-label">Open Fullscreen Takeover Dialog</span></button>
-      <div class="spectrum-Modal-wrapper">
+      <div class="spectrum-Modal-wrapper spectrum-CSSExample-modal">
         <div class="spectrum-Modal spectrum-Modal--fullscreenTakeover" data-testid="modal">
-          <section class="spectrum-Dialog spectrum-Dialog--fullscreenTakeover" role="alertdialog" tabindex="-1" aria-modal="true">
+          <section class="spectrum-CSSExample-dialog spectrum-Dialog spectrum-Dialog--fullscreenTakeover" role="alertdialog" tabindex="-1" aria-modal="true">
             <div class="spectrum-Dialog-grid">
               <h1 class="spectrum-Dialog-heading spectrum-Dialog-heading--noHeader">Fullscreen Takeover</h1>
               <hr class="spectrum-Divider spectrum-Divider--sizeM spectrum-Divider--horizontal spectrum-Dialog-divider">

--- a/components/site/component.css
+++ b/components/site/component.css
@@ -245,6 +245,11 @@ governing permissions and limitations under the License.
 	transition: none;
 }
 
+/* Mimics the .spectrum-Modal-wrapper so the modals & dialogs are above the underlay */
+.spectrum-CSSExample-modal {
+	z-index: 2 !important;
+}
+
 .spectrum-Examples,
 .spectrum-Examples-itemGroup {
 	display: flex;


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description
Currently on the [static docs site](https://opensource.adobe.com/spectrum-css/dialog.html), the dialogs don't really function properly (the default dialog does however, work properly in [Storybook](https://opensource.adobe.com/spectrum-css/preview/?path=/docs/components-dialog--docs). If you close any open dialog variant, and try to reopen it, it is "stuck" underneath `spectrum-Underlay`. I believe this is because a `z-index: 1 !important` is overriding other `z-index: 2`s for `spectrum-Modal`. 

This PR adds a new `.spectrum-CSSExample-modal` class to mimic `.spectrum-Modal-wrapper` with a `z-index` that should position it above `.spectrum-Underlay`. It also adds/removes classes in `dialog.yml` to better implement the open/close behaviors. 

**Note:** The hero, no-divider, and dismissible dialogs are now closed on page load, as opposed to being open previously.

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

@jawinn
- [x] Pull down the branch
- [x] Run `yarn run dev` and visit [the dialog docs page](http://localhost:3000/dialog.html)
- [x] Verify the no-divider, dismissible, and hero variants are closed on page load
- [x] Test all closed dialogs on the page: 
    - opening the dialog should add the `is-open` class to `spectrum-Modal` and `spectrum-Modal-wrapper`
    - once the dialog is open, any buttons (like the close button or a button group) should be clickable/focusable
    - the z-index for `spectrum-CSSExample-modal` should be `2 !important` to ensure it remains above the `z-index: 1 !important` set on `spectrum-Underlay`.
    - closing the dialog should remove `is-open` from those same modal elements 

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
