### PR TITLE
fix: update checkbox color to be emphasized even when unchecked

### DIFF
--- a/components/checkbox/index.css
+++ b/components/checkbox/index.css
@@ -288,6 +288,7 @@ governing permissions and limitations under the License.
 /* Emphasized */
 .spectrum-Checkbox--emphasized {
 	/* Checked and Indeterminate Default States */
+	.spectrum-Checkbox-input + .spectrum-Checkbox-box,
 	.spectrum-Checkbox-input:checked + .spectrum-Checkbox-box,
 	&.is-indeterminate .spectrum-Checkbox-input:checked + .spectrum-Checkbox-box,
 	&.is-indeterminate .spectrum-Checkbox-box {


### PR DESCRIPTION
## Description
updated the unchecked state of the checkbox to have the same color as the other emphasized states
rgb(2, 101, 220)

#1617 

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
  1. Open the [storybook](https://opensource.adobe.com/spectrum-css/checkbox.html#emphasized) for the checkbox component:
    - [] check that the border color for **Emphasized** is applied to the first unchecked checkbox.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->
Emphasized color
![Screenshot 2024-06-26 at 10 28 10 AM](https://github.com/adobe/spectrum-css/assets/1621537/c1f3a4e7-6198-4ab1-9866-0edef58e6b9b)
Was the same as the Standard color
![Screenshot 2024-06-26 at 10 28 21 AM](https://github.com/adobe/spectrum-css/assets/1621537/5e9594dc-8616-408d-a734-c0aba708edb8)


## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
