### PR TITLE
feat(storybook): add the swc preview

### DIFF
--- a/.changeset/dull-coats-pull.md
+++ b/.changeset/dull-coats-pull.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/preview": minor
+---
+
+New feature: Add a look-through to the Spectrum Web Components Storybook project to create an easier connection between components that exist in CSS and those in SWC.

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -80,4 +80,11 @@ export default {
 		autodocs: true,
 		defaultName: "Docs",
 	},
+	refs: {
+		"web-components": {
+			title: "Spectrum web components",
+			url: "https://opensource.adobe.com/spectrum-web-components/storybook/",
+			expanded: false,
+		},
+	},
 };


### PR DESCRIPTION
## Description

Add a look-through to the Spectrum Web Components Storybook project to create an easier connection between components that exist in CSS and those in SWC.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [ ] Open storybook. Scroll down to the bottom of the side navigation. Expect to see Spectrum web components as a collapsed menu item. Expand that and expect to see the content that aligns with this link: [https://opensource.adobe.com/spectrum-web-components/storybook/](https://opensource.adobe.com/spectrum-web-components/storybook/)

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] ✨ This pull request is ready to merge. ✨
