### PR TITLE
docs(inlinealert,link,logicbutton,miller): docs migration from static site to storybook

### DIFF
--- a/components/inlinealert/stories/inlinealert.stories.js
+++ b/components/inlinealert/stories/inlinealert.stories.js
@@ -52,7 +52,7 @@ export default {
 	},
 	args: {
 		rootClass: "spectrum-InLineAlert",
-		headerText: "in-line alert header",
+		headerText: "Neutral in-line alert header",
 		text: "This is an alert.",
 		variant: "neutral",
 		isClosable: false,

--- a/components/inlinealert/stories/inlinealert.stories.js
+++ b/components/inlinealert/stories/inlinealert.stories.js
@@ -1,6 +1,7 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { version } from "../package.json";
 import { InlineAlertGroup } from "./inlinealert.test.js";
+import { Template } from "./template";
 
 /**
  * In-line alerts display a non-modal message associated with objects in a view. These are often used in form validation, providing a place to aggregate feedback related to multiple fields.
@@ -61,8 +62,88 @@ export default {
 	},
 };
 
+/**
+ * The neutral variant is the default for in-line alerts.
+ */
 export const Default = InlineAlertGroup.bind({});
 Default.args = {};
+
+// ********* DOCS ONLY ********* //
+/**
+ * The informative variant uses the informative semantic color (blue) and has an "information" icon to help those with color vision deficiency discern the message tone. This should be used when the message needs to call extra attention, as compared to the neutral variant.
+ * 
+ * _Spectrum for Adobe Express uses a different icon. Use the SX_Info_18_S.svg icon in the Express workflow icon set._
+ */
+export const Informative = Template.bind({});
+Informative.args = {
+	variant: "info",
+	headerText: "in-line alert header",
+};
+Informative.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+Informative.tags = ["!dev"];
+
+/**
+ * A negative variant uses the negative semantic color (red) and has an "alert" icon to help those with color vision deficiency to discern the message tone. Negative variants are used to show an error or failure, or to convey something that needs to be immediately acknowledged or addressed.
+ * 
+ * _Spectrum for Adobe Express uses a different icon. Use the SX_Alert_18_S.svg icon in the Express workflow icon set._
+ */
+export const Negative = Template.bind({});
+Negative.args = {
+	variant: "negative",
+	headerText: "in-line alert header",
+};
+Negative.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+Negative.tags = ["!dev"];
+
+/**
+ * The positive variant uses the positive semantic color (green) and has a "checkmark" icon to help those with color vision deficiency discern the message tone. This variant should be used to inform someone of a successful function or result of an action they took.
+ * 
+ * _Spectrum for Adobe Express uses a different icon. Use the SX_CheckmarkCircle_18_S.svg icon in the Express workflow icon set._
+ */
+export const Positive = Template.bind({});
+Positive.args = {
+	variant: "positive",
+	headerText: "in-line alert header",
+};
+Positive.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+Positive.tags = ["!dev"];
+
+/**
+ * To warn about a situation that may need to be addressed soon, use the notice variant. It utilizes the notice semantic color (orange) and has an "alert" icon to help those with color vision deficiency to discern the message tone.
+ * 
+ * _Spectrum for Adobe Express uses a different icon. Use the SX_Alert_18_S.svg icon in the Express workflow icon set._
+ */
+export const Notice = Template.bind({});
+Notice.args = {
+	variant: "notice",
+	headerText: "in-line alert header",
+};
+Notice.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+Notice.tags = ["!dev"];
+
+/**
+ * An in-line alert with a close button in the footer. Combine this strategy with any variant.
+ * 
+ * _Spectrum for Adobe Express uses a different icon. Use the SX_Alert_18_S.svg icon in the Express workflow icon set._
+ */
+export const Closable = Template.bind({});
+Closable.args = {
+	variant: "negative",
+	isClosable: true,
+	headerText: "Incorrect payment information - error",
+};
+Closable.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+Closable.tags = ["!dev"];
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = InlineAlertGroup.bind({});
@@ -70,6 +151,6 @@ WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",
-		modes: disableDefaultModes
+		modes: disableDefaultModes,
 	},
 };

--- a/components/inlinealert/stories/inlinealert.stories.js
+++ b/components/inlinealert/stories/inlinealert.stories.js
@@ -77,7 +77,7 @@ Default.args = {};
 export const Informative = Template.bind({});
 Informative.args = {
 	variant: "info",
-	headerText: "in-line alert header",
+	headerText: "Info in-line alert header",
 };
 Informative.parameters = {
 	chromatic: { disableSnapshot: true },
@@ -92,7 +92,7 @@ Informative.tags = ["!dev"];
 export const Negative = Template.bind({});
 Negative.args = {
 	variant: "negative",
-	headerText: "in-line alert header",
+	headerText: "Negative in-line alert header",
 };
 Negative.parameters = {
 	chromatic: { disableSnapshot: true },
@@ -107,7 +107,7 @@ Negative.tags = ["!dev"];
 export const Positive = Template.bind({});
 Positive.args = {
 	variant: "positive",
-	headerText: "in-line alert header",
+	headerText: "Positive in-line alert header",
 };
 Positive.parameters = {
 	chromatic: { disableSnapshot: true },
@@ -122,7 +122,7 @@ Positive.tags = ["!dev"];
 export const Notice = Template.bind({});
 Notice.args = {
 	variant: "notice",
-	headerText: "in-line alert header",
+	headerText: "Notice in-line alert header",
 };
 Notice.parameters = {
 	chromatic: { disableSnapshot: true },

--- a/components/inlinealert/stories/inlinealert.test.js
+++ b/components/inlinealert/stories/inlinealert.test.js
@@ -8,6 +8,7 @@ export const InlineAlertGroup = Variants({
 		...["neutral", "info", "positive", "notice", "negative"].map((variant) => ({
 			testHeading: capitalize(variant),
 			variant,
+			headerText: `${variant.charAt(0).toUpperCase() + variant.slice(1)} inline-alert header`
 		})),
 		{
 			testHeading: "Truncation",

--- a/components/inlinealert/stories/inlinealert.test.js
+++ b/components/inlinealert/stories/inlinealert.test.js
@@ -8,7 +8,7 @@ export const InlineAlertGroup = Variants({
 		...["neutral", "info", "positive", "notice", "negative"].map((variant) => ({
 			testHeading: capitalize(variant),
 			variant,
-			headerText: `${variant.charAt(0).toUpperCase() + variant.slice(1)} inline-alert header`
+			headerText: `${variant.charAt(0).toUpperCase() + variant.slice(1)} in-line alert header`
 		})),
 		{
 			testHeading: "Truncation",

--- a/components/inlinealert/stories/template.js
+++ b/components/inlinealert/stories/template.js
@@ -3,7 +3,6 @@ import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 import { html, nothing } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { styleMap } from "lit/directives/style-map.js";
-import { when } from "lit/directives/when.js";
 
 import "../index.css";
 
@@ -63,9 +62,7 @@ export const Template = ({
 
 		>
 			<div class="${rootClass}-header">
-				${when(headerText, () => 
-					headerText.charAt(0).toUpperCase() + headerText.slice(1)
-				)}
+				${headerText}
 				${iconMarkup}
 			</div>
 			<div class="${rootClass}-content">${text}</div>

--- a/components/inlinealert/stories/template.js
+++ b/components/inlinealert/stories/template.js
@@ -3,6 +3,7 @@ import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 import { html, nothing } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { styleMap } from "lit/directives/style-map.js";
+import { when } from "lit/directives/when.js";
 
 import "../index.css";
 
@@ -62,7 +63,9 @@ export const Template = ({
 
 		>
 			<div class="${rootClass}-header">
-				${variant.charAt(0).toUpperCase() + variant.slice(1)} ${headerText}
+				${when(headerText, () => 
+					headerText.charAt(0).toUpperCase() + headerText.slice(1)
+				)}
 				${iconMarkup}
 			</div>
 			<div class="${rootClass}-content">${text}</div>

--- a/components/link/CHANGELOG.md
+++ b/components/link/CHANGELOG.md
@@ -1034,6 +1034,12 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 - link component updates ([#650](https://github.com/adobe/spectrum-css/issues/650)) ([4ff38d3](https://github.com/adobe/spectrum-css/commit/4ff38d3)), closes [#703](https://github.com/adobe/spectrum-css/issues/703)
 
+### Migration Guide
+
+#### Subtle variant
+
+Subtle variant was removed. Please use Quiet.
+
 ### 🛑 BREAKING CHANGES
 
 - .is-disabled is no longer supported

--- a/components/link/stories/link.stories.js
+++ b/components/link/stories/link.stories.js
@@ -2,9 +2,10 @@ import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isActive, isFocused, isHovered } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
 import { LinkGroup } from "./link.test.js";
+import { TemplateWithFillerText } from "./template";
 
 /**
- * A link allow users to navigate to a different location. They can be presented in-line inside a paragraph or as a standalone text.
+ * A link allows users to navigate to a different location. They can be presented in-line inside a paragraph or as standalone text.
  */
 export default {
 	title: "Link",
@@ -17,7 +18,7 @@ export default {
 				type: { summary: "string" },
 				category: "Content",
 			},
-			control: "url",
+			control: "text",
 		},
 		text: {
 			name: "Text",
@@ -35,7 +36,7 @@ export default {
 				type: { summary: "string" },
 				category: "Component",
 			},
-			options: ["secondary"],
+			options: ["default/primary", "secondary"],
 			control: "select",
 		},
 		isHovered,
@@ -73,6 +74,7 @@ export default {
 	args: {
 		rootClass: "spectrum-Link",
 		isQuiet: false,
+		variant: "primary",
 		isHovered: false,
 		isActive: false,
 		isFocused: false,
@@ -91,6 +93,120 @@ Default.args = {
 	url: "https://www.adobe.com",
 	text: "Learn more about Adobe",
 };
+Default.tags = ["!autodocs"];
+
+// ********* DOCS ONLY ********* //
+/**
+ * The primary link is the default variant and is blue. This should be used to call attention to the link and for when the blue color won’t feel too overwhelming in the experience.
+ */
+export const Primary = TemplateWithFillerText.bind({});
+Primary.args = {
+	...Default.args,
+	text: "link using spectrum-Link"
+};
+Primary.tags = ["!dev"];
+Primary.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+/**
+ * The secondary variant is the same gray color as the paragraph text. Its subdued appearance is optimal for when the primary variant is too overwhelming, such as in blocks of text with several references linked throughout.
+ */
+export const Secondary = TemplateWithFillerText.bind({});
+Secondary.args = {
+	variant: "secondary",
+	text: "link using spectrum-Link--secondary",
+};
+Secondary.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+Secondary.tags = ["!dev"];
+
+/**
+ * All links can have a quiet style, without an underline. This style should only be used when the placement and context of the link is explicit enough that a visible underline isn’t necessary.
+ */
+export const QuietPrimary = TemplateWithFillerText.bind({});
+QuietPrimary.storyName = "Primary (quiet)";
+QuietPrimary.args = {
+	isQuiet: true,
+	text: "link using spectrum-Link--quiet",
+};
+QuietPrimary.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+QuietPrimary.tags = ["!dev"];
+
+export const QuietSecondary = TemplateWithFillerText.bind({});
+QuietSecondary.storyName = "Secondary (quiet)";
+QuietSecondary.args = {
+	isQuiet: true,
+	variant: "secondary",
+	text: "link using spectrum-Link--quiet and spectrum-Link--secondary",
+};
+QuietSecondary.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+QuietSecondary.tags = ["!dev"];
+
+/**
+ * Use static white on dark color or image backgrounds, regardless of color theme. Make sure that the background and the link color meet the minimum color contrast ratio.
+ */
+export const StaticWhite = Default.bind({});
+StaticWhite.storyName = "Static white";
+StaticWhite.args = {
+	staticColor: "white",
+	text: "Link using spectrum-Link--staticWhite",
+};
+StaticWhite.tags = ["!dev"];
+StaticWhite.parameters = {
+	chromatic: {
+		modes: disableDefaultModes,
+	},
+};
+
+/**
+ * Use static black on light color or image backgrounds, regardless of color theme. Make sure that the background and the link color meet the minimum color contrast ratio.
+ */
+export const StaticBlack = Default.bind({});
+StaticBlack.storyName = "Static black";
+StaticBlack.args = {
+	staticColor: "black",
+	text: "Link using spectrum-Link--staticBlack",
+};
+StaticBlack.tags = ["!dev"];
+StaticBlack.parameters = {
+	chromatic: {
+		modes: disableDefaultModes,
+	},
+};
+
+export const QuietStaticWhite = Default.bind({});
+QuietStaticWhite.storyName = "Static white (quiet)";
+QuietStaticWhite.args = {
+	isQuiet: true,
+	staticColor: "white",
+	text: "Link using spectrum-Link--staticWhite and spectrum-Link--quiet",
+};
+QuietStaticWhite.tags = ["!dev"];
+QuietStaticWhite.parameters = {
+	chromatic: {
+		modes: disableDefaultModes,
+	},
+};
+
+export const QuietStaticBlack = Default.bind({});
+QuietStaticBlack.storyName = "Static black (quiet)";
+QuietStaticBlack.args = {
+	isQuiet: true,
+	staticColor: "black",
+	text: "Link using spectrum-Link--staticBlack and spectrum-Link--quiet",
+};
+QuietStaticBlack.tags = ["!dev"];
+QuietStaticBlack.parameters = {
+	chromatic: {
+		modes: disableDefaultModes,
+	},
+};
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = LinkGroup.bind({});
@@ -99,6 +215,6 @@ WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",
-		modes: disableDefaultModes
+		modes: disableDefaultModes,
 	},
 };

--- a/components/link/stories/link.stories.js
+++ b/components/link/stories/link.stories.js
@@ -31,7 +31,7 @@ export default {
 		},
 		variant: {
 			name: "Variant",
-			defaultValue: "Primary",
+			defaultValue: "primary",
 			type: { name: "string" },
 			table: {
 				type: { summary: "string" },

--- a/components/link/stories/link.stories.js
+++ b/components/link/stories/link.stories.js
@@ -31,12 +31,14 @@ export default {
 		},
 		variant: {
 			name: "Variant",
+			defaultValue: "Primary",
 			type: { name: "string" },
 			table: {
 				type: { summary: "string" },
 				category: "Component",
+				defaultValue: { summary: "Primary" },
 			},
-			options: ["default/primary", "secondary"],
+			options: ["primary", "secondary"],
 			control: "select",
 		},
 		isHovered,

--- a/components/link/stories/template.js
+++ b/components/link/stories/template.js
@@ -39,3 +39,11 @@ export const Template = ({
 		${text}
 	</a>
 `;
+
+export const TemplateWithFillerText = (args, context) => html`
+	<div>
+		Hello, this is a
+		${Template({...args, context})}
+		. This is just filler text, but if you keep reading maybe something good will happen.
+	</div>
+`;

--- a/components/logicbutton/stories/logicbutton.stories.js
+++ b/components/logicbutton/stories/logicbutton.stories.js
@@ -1,7 +1,7 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { version } from "../package.json";
 import { LogicButtonGroup } from "./logicbutton.test.js";
-import { Template } from "./template.js";
+import { Template, VariantGroup } from "./template.js";
 
 /**
  * A logic button displays an operator within a boolean logic sequence.
@@ -36,10 +36,13 @@ export default {
 		isDisabled: false,
 	},
 	parameters: {
-		componentVersion: version,
+		componentVersion: version,	
 	},
 };
 
+/**
+ * The default logic button is the And variant.
+ */
 export const Default = LogicButtonGroup.bind({});
 Default.args = {};
 
@@ -47,16 +50,16 @@ Default.args = {};
 export const Or = Template.bind({});
 Or.tags = ["!dev"];
 Or.args = {
-	variant: "or"
+	variant: "or",
 };
 Or.parameters = {
 	chromatic: { disableSnapshot: true }
 };
 
-export const Disabled = Template.bind({});
+export const Disabled = VariantGroup.bind({});
 Disabled.tags = ["!dev"];
 Disabled.args = {
-	isDisabled: true
+	isDisabled: true,
 };
 Disabled.parameters = {
 	chromatic: { disableSnapshot: true }
@@ -68,6 +71,6 @@ WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",
-		modes: disableDefaultModes
+		modes: disableDefaultModes,
 	},
 };

--- a/components/logicbutton/stories/template.js
+++ b/components/logicbutton/stories/template.js
@@ -24,3 +24,11 @@ export const Template = ({
 			: undefined}
 	</button>
 `;
+
+export const VariantGroup = (args, context) => html`
+	${Template({...args}, context)}
+	${Template({
+		...args,
+		variant: "or",
+	}, context)}
+`;

--- a/components/miller/stories/miller.stories.js
+++ b/components/miller/stories/miller.stories.js
@@ -90,7 +90,6 @@ BranchesSelectable.args = {};
  * Miller columns that only allow files to be selected.
  */
 export const FilesSelectable = Template.bind({});
-FilesSelectable.tags = ["!dev"];
 FilesSelectable.args = {
 	columns: [
 		{

--- a/components/miller/stories/miller.stories.js
+++ b/components/miller/stories/miller.stories.js
@@ -80,9 +80,15 @@ export default {
 	},
 };
 
+/**
+ * Miller columns that allow both files and folders to be selected.
+ */
 export const BranchesSelectable = MillerGroup.bind({});
 BranchesSelectable.args = {};
 
+/**
+ * Miller columns that only allow files to be selected.
+ */
 export const FilesSelectable = Template.bind({});
 FilesSelectable.tags = ["!dev"];
 FilesSelectable.args = {


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->
This PR continues migrating documentation from the docs site into Storybook. The focus is on `inlinealert`, `link`, `logicbutton` and `miller`. All variants of the component should now be displayed on the Storybook `Docs` page. Additionally, Chromatic coverage was added to `inlinealert`, `link`, and `logicbutton`.

- `inlinealert`: new stories and enhanced chromatic coverage
- `link`: new stories and added chromatic coverage
- `logicbutton`: enhanced chromatic coverage
- `miller`: new story descriptions

**This PR doesn't need a changeset since it's docs only.**

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->
- [x] The [inline alert docs page]() matches all content found on the [docs site](https://opensource.adobe.com/spectrum-css/inlinealert.html)
- [x] Using [the chromatic preview](https://pr-2884--spectrum-css.netlify.app/preview/?path=/docs/components-in-line-alert--docs&globals=testingPreview:!true) should display all variants of the inline alert in the default/neutral story.
- [x] The [link docs page]() matches all content found on the [docs site](https://opensource.adobe.com/spectrum-css/link.html)
- [x] Using [the chromatic preview](https://pr-2884--spectrum-css.netlify.app/preview/?path=/docs/components-link--docs) should display all variants of the link in the default story.
- [x] The [logic button docs page]() matches all content found on the [docs site](https://opensource.adobe.com/spectrum-css/logicbutton.html)
- [x] Using [the chromatic preview](https://pr-2884--spectrum-css.netlify.app/preview/?path=/docs/components-logic-button--docs) should display all variants of the logic button.
- [x] The [miller columns docs page]() matches all content found on the [docs site](https://opensource.adobe.com/spectrum-css/miller.html)
- [ ] Ensure the Chromatic testing view for each component captures all new variants.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
