### PR TITLE
fix: chromatic testing preview refresh issue and docs exception

### DIFF
--- a/.storybook/decorators/testing-preview.js
+++ b/.storybook/decorators/testing-preview.js
@@ -23,7 +23,7 @@ export const withTestingPreviewWrapper = makeDecorator({
 		// Add a boolean to the context that indicates whether the Chromatic view is enabled.
 		context.args.isChromaticView = isChromaticViewEnabled(testingPreview, viewMode === "docs");
 
-		// Backwards compatability with existing use of this custom function.
+		// Backwards compatibility with existing use of this custom function.
 		// @todo This can be removed from window after changing everywhere it is accessed to use args.isChromaticView instead.
 		window.isChromatic = () => context.args.isChromaticView;
 

--- a/components/actionbutton/stories/template.js
+++ b/components/actionbutton/stories/template.js
@@ -117,7 +117,7 @@ const ActionButtons = (args) => html` <div
 		label: "Truncate this long content",
 		iconName: undefined,
 		customStyles: {
-			display: window.isChromatic() ? undefined : "none",
+			display: args?.isChromaticView ? undefined : "none",
 			maxInlineSize: "100px"
 		},
 	})}
@@ -125,7 +125,7 @@ const ActionButtons = (args) => html` <div
 		...args,
 		label: "Truncate this long content",
 		customStyles: {
-			display: window.isChromatic() ? undefined : "none",
+			display: args?.isChromaticView ? undefined : "none",
 			maxInlineSize: "100px"
 		},
 	})}
@@ -253,7 +253,7 @@ export const Variants = (args) => html`
 		}
 	</style>
 	<div style=${styleMap({
-		"display": window.isChromatic() ? "flex" : "none",
+		"display": args?.isChromaticView ? "flex" : "none",
 		"flex-direction": "column",
 		"align-items": "flex-start",
 		"gap": "16px",
@@ -327,7 +327,7 @@ export const Variants = (args) => html`
 		</div>
 	</div>
 	<div style=${styleMap({
-		display: window.isChromatic() ? "none" : undefined,
+		display: args?.isChromaticView ? "none" : undefined,
 	})}>
 		${ActionButtons(args)}
 	</div>

--- a/components/pagination/stories/template.js
+++ b/components/pagination/stories/template.js
@@ -108,12 +108,12 @@ export const Template = ({
 export const PaginationGroup = (args, context) => {
 	return html`
 		<div style=${styleMap({
-			"display": window.isChromatic() ? "none" : undefined,
+			"display": args?.isChromaticView ? "none" : undefined,
 		})}>
 			${Template(args, context)}
 		</div>
 		<div style=${styleMap({
-			"display": window.isChromatic() ? "flex" : "none",
+			"display": args?.isChromaticView ? "flex" : "none",
 			"flex-direction": "column",
 			"gap": "32px",
 		})}>


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

### Storybook: fixes the refresh issue with the chromatic testing preview toolbar item, and excludes Chromatic-only templates from the autodocs
    
Previously when the Chromatic "view testing preview" toolbar item was used, the story would not refresh and display the correct templates until the browser was hard refreshed.
    
This appears to be partly because the custom window.isChromatic function was not working with the dynamic global values (globals.testingPreview).
    
This update makes sure that when the decorator is run, it's working with the current value of `globals.testingPreview`. It also passes through a boolean `isChromaticView` to the story args, which should remove the need to use the window object. 

The `window.isChromatic()` function is left in for the time being for backwards compatibility and consideration of current migrations, but can be refactored away (noted in a `@todo` comment). For this PR I updated **Action button** and **Pagination** as an example of this. I could go through and modify all usage of `window.isChromatic()` as part of this PR if desired; I limited the scope of this in order to get feedback on this first.
    
✨ The function also now excludes Chromatic-only templates from the Docs / autodocs pages by adding a check against `context.viewMode`.

CSS-832

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [x] Toolbar item in Storybook to view the Chromatic templates ("Show testing preview" and "Default mode") will now refresh the story when it is used. Without a browser refresh. @marissahuysentruyt 
- [x] Chromatic-only templates are not appearing on the docs / autodocs pages (whether "show testing preview" is active or inactive). @marissahuysentruyt 
- [x] Chromatic-only and regular templates are working correctly for Action button and Pagination (which now access `args.isChromaticView`) @marissahuysentruyt 
- [x] Chromatic-only and regular templates are working correctly for other components. Please go through and test a bunch of other components. @marissahuysentruyt  (tested: `accordion`, `picker`, `statuslight`, `coachindicator`, `tray`, `progresscircle`, `menu`, `illustratedmessage`)
- [ ] VRT is working normally. There are no VRT changes from this PR.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
