### PR TITLE
fix(breadcrumb): disabled behaviors and styles

### DIFF
--- a/.changeset/modern-ladybugs-wash.md
+++ b/.changeset/modern-ladybugs-wash.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/breadcrumb": patch
+---
+
+Ensures disabled breadrumb items behave as expected. They are conditionally left out of tab order depending on their `isDisabled` value. Uses [aria-disabled="true"] and applies `is-disabled` class to `.spectrum-Breadcrumb-itemLink`.

--- a/components/breadcrumb/index.css
+++ b/components/breadcrumb/index.css
@@ -269,7 +269,8 @@ governing permissions and limitations under the License.
 	margin-block-start: var(--mod-breadcrumbs-text-spacing-block-start, var(--spectrum-breadcrumbs-text-spacing-block-start));
 	margin-block-end: var(--mod-breadcrumbs-text-spacing-block-end, var(--spectrum-breadcrumbs-text-spacing-block-end));
 
-	&.is-disabled {
+	&.is-disabled,
+	&[aria-disabled="true"] {
 		color: var(--highcontrast-breadcrumbs-text-color-disabled, var(--mod-breadcrumbs-text-color-disabled, var(--spectrum-breadcrumbs-text-color-disabled)));
 	}
 

--- a/components/breadcrumb/stories/template.js
+++ b/components/breadcrumb/stories/template.js
@@ -1,7 +1,7 @@
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { when } from "lit/directives/when.js";
-
+import { ifDefined } from "lit/directives/if-defined.js";
 import { Template as ActionButton } from "@spectrum-css/actionbutton/stories/template.js";
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 
@@ -28,7 +28,6 @@ export const Template = ({
 				return html` <li
 					class=${classMap({
 						[`${rootClass}-item`]: true,
-						"is-disabled": isDisabled,
 						"is-dragged": isDragged && item.isDragged,
 					})}
 				>
@@ -48,9 +47,13 @@ export const Template = ({
 								idx !== arr.length - 1,
 								() =>
 									html`<div
-										class="${rootClass}-itemLink"
+										class=${classMap({
+											[`${rootClass}-itemLink`]: true,
+											"is-disabled": isDisabled,
+										})}
+										aria-disabled=${ifDefined(isDisabled ? "true" : undefined)}
 										role="link"
-										tabindex="0"
+										tabindex=${ifDefined(!isDisabled ? "0" : undefined)}
 									>
 										${label}
 									</div>`,


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

Disabled breadcrumbs (except for action buttons) in storybook still had pointer events, hover and focus styles. There was no indication that a text-based breadcrumb was disabled. This was partially because the `tabindex` was being set to `0`, which then was adding specific styles. Additionally, the `is-disabled` class was not being added to the proper `.spectrum-Breadcrumb-itemLink` element. This PR should address these a11y concerns and disabled bugs.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

@jawinn 
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->
- [x] Verify that the disabled breadcrumb on the [breadcrumb storybook page](https://pr-2886--spectrum-css.netlify.app/preview/?path=/docs/components-breadcrumbs--docs) has no hover/focus styles, and no pointer events. Additionally, the breadcrumb item should be left out of the tab order
- [x] Verify that the parent `.spectrum-Breadcrumbs-item` does not have the `is-disabled` class
- [x] With the project running locally, (`yarn start`), find the breadcrumb storybook docs or default page
- [x] In `breadcrumb/stories/breadcrumb.stories.js`, add an additional disabled breadcrumb item (or feel free to experiment with ones already there). In the browser inspector, verify the following:
    - [x] when `isDisabled: false`, the `tabindex` of your `.spectrum-Breadcrumbs-itemLink` breadcrumb is `0`. It should be focusable, clickable, and have a hover state. The `is-disabled` class should not be applied at this point and there should not be a `disabled` attribute
    - [x] when `isDisabled: true`, the `tabindex` should not be defined on that element. It should not be focusable, clickable, or have a hover state. The `is-disabled` class and `aria-disabled="true"` attribute should be added to `.spectrum-Breadcrumbs-itemLink`

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
