### PR TITLE
docs(slider,stepper,steplist): docs from static site to storybook 

### DIFF
--- a/components/slider/CHANGELOG.md
+++ b/components/slider/CHANGELOG.md
@@ -206,6 +206,20 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 - **slider:**focus state matches spec, supports forced-colors ([#2217](https://github.com/adobe/spectrum-css/issues/2217))([7b9c31b](https://github.com/adobe/spectrum-css/commit/7b9c31b))
 
+### Migration Guide
+
+#### Indicating focus
+
+Focus must be bubbled up to the parent so descendants siblings can be styled.
+
+Thus, implementations should add the following class to the `.spectrum-Slider` parent class in the following situations:
+
+- `.is-disabled` - when the slider is disabled
+
+Implementations should also bubble the following class to the `.spectrum-Slider-controls` parent class in the following situations:
+
+- `.is-focused` - when the handle input is focused with the mouse or keyboard
+
 <a name="4.1.14"></a>
 
 ## 4.1.14
@@ -519,6 +533,12 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 🗓 2023-05-18 • 📝 [Commits](https://github.com/adobe/spectrum-css/compare/@spectrum-css/slider@3.1.25...@spectrum-css/slider@4.0.0)
 
 - feat(slider, fieldlabel)!: tokens migration & min-height size adjustments (#1696) ([37724f1](https://github.com/adobe/spectrum-css/commit/37724f1)), closes [#1696](https://github.com/adobe/spectrum-css/issues/1696)
+
+### Migration Guide
+
+#### Three Handles is included in the `range` variant
+
+When using a slider with three handles, classify it as a `range` variant to apply correct styling
 
 ### 🛑 BREAKING CHANGES
 
@@ -970,6 +990,21 @@ Additionally, this adds some `min-height` custom properties and adjusts the `min
 
 - ramp slider ([#829](https://github.com/adobe/spectrum-css/issues/829)) ([#923](https://github.com/adobe/spectrum-css/issues/923)) ([c539411](https://github.com/adobe/spectrum-css/commit/c539411)), closes [#850](https://github.com/adobe/spectrum-css/issues/850)
 - wip fix more components ([b74dbb8](https://github.com/adobe/spectrum-css/commit/b74dbb8))
+
+### Migration Guide
+
+#### Dial is now a separate component
+
+Dial has been moved to the [Dial](dial.html) component.
+
+#### Color slider is now a separate component
+
+-Color slider has been moved to the [Color Slider](colorslider.html) component.
+-Replace class names starting with `.spectrum-Slider` with `.spectrum-ColorSlider`.
+
+#### Use class `is-dragged` instead of `u-isGrabbing`
+
+On `spectrum-Slider-handle` when dragging, use `is-dragged` instead of `u-isGrabbing`.
 
 ### 🛑 BREAKING CHANGES
 

--- a/components/slider/stories/slider.stories.js
+++ b/components/slider/stories/slider.stories.js
@@ -1,4 +1,5 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
+import { Sizes } from "@spectrum-css/preview/decorators";
 import { isFocused } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
 import { SliderGroup } from "./slider.test.js";
@@ -6,6 +7,17 @@ import { Template } from "./template.js";
 
 /**
  * A slider allows users to quickly select a value within a range. They should be used when the upper and lower bounds to the range are invariable.
+ * 
+ * ## Indicating focus
+ * Focus must be bubbled up to the parent so its descendants can be styled.
+ *
+ * Thus, implementations should add the following class to the `.spectrum-Slider` parent class in the following situations:
+ *
+ * - `.is-disabled`: when the slider is disabled
+ * 
+ * Implementations should also bubble the following class to the `.spectrum-Slider-controls` parent class in the following situations:
+
+ * - `.is-focused`: when the handle input is focused with the mouse or keyboard
  */
 export default {
 	title: "Slider",
@@ -97,6 +109,17 @@ export default {
 			control: "boolean",
 			if: { arg: "variant", neq: "ramp" },
 		},
+		showTickLabels: {
+			name: "Show associated tick labels",
+			description: "Displays the values at each step of the slider",
+			type: { name: "boolean" },
+			table: {
+				type: { summary: "boolean" },
+				category: "Component",
+			},
+			control: "boolean",
+			if: { arg: "showTicks", truthy: true },
+		},
 		isDisabled: {
 			name: "Disabled",
 			type: { name: "boolean" },
@@ -117,6 +140,7 @@ export default {
 		isDisabled: false,
 		isFocused: false,
 		showTicks: false,
+		showTickLabels: false,
 		labelPosition: "top",
 		label: "Slider label",
 		size: "m",
@@ -136,10 +160,45 @@ export default {
 	},
 };
 
+/**
+ * Sliders should always have a label. In rare cases where context is sufficient and an accessibility expert has reviewed the design, the label could be undefined. Top labels are the default and are recommended because they work better with long copy, localization, and responsive layouts.
+ */
 export const Default = SliderGroup.bind({});
 Default.args = {};
 
 // ********* DOCS ONLY ********* //
+/**
+ * If a slider's label is undefined, it should still include an aria-label in HTML (depending on the context, “aria-label” or “aria-labelledby”).
+ */
+export const WithoutLabel = Template.bind({});
+WithoutLabel.args = { 
+	label: "",
+};
+WithoutLabel.tags = ["!dev"];
+WithoutLabel.storyName = "Without label";
+WithoutLabel.parameters = {
+	chromatic: {
+		disableSnapshot: true,
+	},
+};
+
+export const Sizing = (args, context) => Sizes({
+	Template,
+	withBorder: false,
+	withHeading: false,
+	...args,
+}, context);
+Sizing.args = Default.args;
+Sizing.tags = ["!dev"];
+Sizing.parameters = {
+	chromatic: {
+		disableSnapshot: true,
+	},
+};
+
+/**
+ * The track of the slider can have a fill. By default, the fill originates from the left side of the track.
+ */
 export const Filled = Template.bind({});
 Filled.args = {
 	...Default.args,
@@ -152,6 +211,9 @@ Filled.parameters = {
 	},
 };
 
+/**
+ * With fill and offset. If the value represents an offset, the fill start can be set to represent the point of origin. This allows the slider fill to start from inside the track.
+ */
 export const FilledOffset = Template.bind({});
 FilledOffset.args = {
 	...Default.args,
@@ -177,6 +239,9 @@ Ramp.parameters = {
 	},
 };
 
+/**
+ * A range slider with two handles.
+ */
 export const Range = Template.bind({});
 Range.args = {
 	...Default.args,
@@ -189,10 +254,12 @@ Range.parameters = {
 	},
 };
 
+/**
+ * Spectrum tick slider.
+ */
 export const Tick = Template.bind({});
 Tick.args = {
 	...Default.args,
-	label: undefined,
 	showTicks: true,
 };
 Tick.tags = ["!dev"];
@@ -201,6 +268,23 @@ Tick.parameters = {
 		disableSnapshot: true,
 	},
 };
+
+/**
+ * Spectrum tick slider with tick labels.
+ */
+export const TickWithLabels = Template.bind({});
+TickWithLabels.args = {
+	...Default.args,
+	showTicks: true,
+	showTickLabels: true,
+};
+TickWithLabels.tags = ["!dev"];
+TickWithLabels.parameters = {
+	chromatic: {
+		disableSnapshot: true,
+	},
+};
+TickWithLabels.storyName = "Tick with labels";
 
 export const Disabled = Template.bind({});
 Disabled.args = {
@@ -214,18 +298,21 @@ Disabled.parameters = {
 	},
 };
 
-export const WithFocus = Template.bind({});
-WithFocus.args = {
+export const Focused = Template.bind({});
+Focused.args = {
 	...Default.args,
 	isFocused: true,
 };
-WithFocus.tags = ["!dev"];
-WithFocus.parameters = {
+Focused.tags = ["!dev"];
+Focused.parameters = {
 	chromatic: {
 		disableSnapshot: true,
 	},
 };
 
+/**
+ * A gradient can be added to the track of any slider to give more meaning to the range of values. Tracks with a gradient can also have a fill. A gradient track should not be used for choosing a precise color; use a [color slider](/docs/components-color-slider--docs), [color area](/docs/components-color-area--docs), or [color wheel](/docs/components-color-wheel--docs) instead.
+ */
 export const Gradient = Template.bind({});
 Gradient.args = {
 	...Default.args,
@@ -244,17 +331,21 @@ Gradient.parameters = {
 	},
 };
 
-export const SideLabel = Template.bind({});
-SideLabel.args = {
+/**
+ * Labels can be placed either on top or on the side. Side labels are most useful when vertical space is limited.
+ */
+export const WithSideLabel = Template.bind({});
+WithSideLabel.args = {
 	...Default.args,
 	labelPosition: "side",
 };
-SideLabel.tags = ["!dev"];
-SideLabel.parameters = {
+WithSideLabel.tags = ["!dev"];
+WithSideLabel.parameters = {
 	chromatic: {
 		disableSnapshot: true,
 	},
 };
+WithSideLabel.storyName = "With side label";
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = SliderGroup.bind({});
@@ -262,6 +353,6 @@ WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",
-		modes: disableDefaultModes
+		modes: disableDefaultModes,
 	},
 };

--- a/components/slider/stories/slider.test.js
+++ b/components/slider/stories/slider.test.js
@@ -8,6 +8,10 @@ export const SliderGroup = Variants({
 			testHeading: "Default",
 		},
 		{
+			testHeading: "Without label",
+			label: undefined,
+		},
+		{
 			testHeading: "Filled",
 			variant: "filled",
 		},
@@ -26,8 +30,12 @@ export const SliderGroup = Variants({
 		},
 		{
 			testHeading: "Tick",
-			label: undefined,
 			showTicks: true,
+		},
+		{
+			testHeading: "Tick with labels",
+			showTicks: true,
+			showTickLabels: true,
 		},
 		{
 			testHeading: "Side label",

--- a/components/slider/stories/template.js
+++ b/components/slider/stories/template.js
@@ -20,6 +20,7 @@ export const Template = ({
 	labelPosition,
 	fillColor = "rgb(213, 213, 213)",
 	showTicks = false,
+	showTickLabels = false,
 	isDisabled = false,
 	isFocused = false,
 	customClasses = [],
@@ -68,7 +69,9 @@ export const Template = ({
 		for (let i = from; i <= to; i += step) {
 			ticks.push(html`
 				<div class="${rootClass}-tick">
-					<div class="${rootClass}-tickLabel">${i}</div>
+					<div class="${rootClass}-tickLabel">
+						${when(showTickLabels, () => html`${i}`, undefined)}
+					</div>
 				</div>
 			`);
 		}

--- a/components/steplist/stories/steplist.stories.js
+++ b/components/steplist/stories/steplist.stories.js
@@ -1,9 +1,12 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { version } from "../package.json";
 import { SteplistGroup } from "./steplist.test.js";
+import { DocsSteplistGroup } from "./template";
 
 /**
  * A steplist can communicate the progress of a task or workflow. It can help users understand where they are in a process and what they need to do next.
+ * 
+ * All variants of steplist can be static or interactive.
  */
 export default {
 	title: "Steplist",
@@ -76,6 +79,43 @@ export default {
 
 export const Default = SteplistGroup.bind({});
 Default.args = {};
+Default.tags = ["!autodocs"];
+
+/**
+ * A steplist with labels.
+ */
+export const Standard = DocsSteplistGroup.bind({});
+Standard.tags = ["!dev"];
+Standard.storyName = "Default";
+Standard.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+/**
+ * A steplist without labels. This variant does not have visible labels or tooltips.
+ */
+export const Small = DocsSteplistGroup.bind({});
+Small.args = {
+	isSmall: true,
+};
+Small.tags = ["!dev"];
+Small.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+/**
+ * A steplist with tooltips.
+ */
+export const WithTooltip = DocsSteplistGroup.bind({});
+WithTooltip.args = {
+	...Default.args,
+	withTooltip: true,
+};
+WithTooltip.tags = ["!dev"];
+WithTooltip.storyName = "With tooltip";
+WithTooltip.parameters = {
+	chromatic: { disableSnapshot: true },
+};
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = SteplistGroup.bind({});

--- a/components/steplist/stories/steplist.test.js
+++ b/components/steplist/stories/steplist.test.js
@@ -9,15 +9,15 @@ export const SteplistGroup = Variants({
 		},
 		{
 			testHeading: "Small",
-			isSmall: false,
+			isSmall: true,
 		},
 		{
 			testHeading: "Interactive",
-			isInteractive: false,
+			isInteractive: true,
 		},
 		{
 			testHeading: "With tooltip",
-			withTooltip: false,
+			withTooltip: true,
 		},
 	],
 });

--- a/components/steplist/stories/template.js
+++ b/components/steplist/stories/template.js
@@ -1,4 +1,4 @@
-import { getRandomId } from "@spectrum-css/preview/decorators";
+import { getRandomId, Container } from "@spectrum-css/preview/decorators";
 import { Template as Tooltip } from "@spectrum-css/tooltip/stories/template.js";
 import { html, nothing } from "lit";
 import { classMap } from "lit/directives/class-map.js";
@@ -108,3 +108,21 @@ export const Template = ({
 		</div>
 	`;
 };
+
+/* Shows both the static and interactive variants in one grouping. */
+export const DocsSteplistGroup = (args, context) => Container({
+	direction: "column",
+	withBorder: false,
+	content: html`
+		${Container({
+			withBorder: false,
+			heading: "Static",
+			content: Template(args, context),
+		})}
+		${Container({
+			withBorder: false,
+			heading: "Interactive",
+			content: Template({...args, isInteractive: true} ,context),
+		})}
+	`
+});

--- a/components/stepper/CHANGELOG.md
+++ b/components/stepper/CHANGELOG.md
@@ -194,11 +194,15 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 \*feat(stepper)!: stepper migrate tokens (#1960)([3a4c217](https://github.com/adobe/spectrum-css/commit/3a4c217)), closes[#1960](https://github.com/adobe/spectrum-css/issues/1960)
 
-    	###
-    	🛑 BREAKING CHANGES
+### Migration Guide
 
-    		*
-    		migrates Stepper to use `@adobe/spectrum-tokens`
+#### Use InFieldButton instead of FieldButton
+
+Stepper now uses InFieldButtons instead of FieldButtons for the up/down buttons.
+
+### 🛑 BREAKING CHANGES
+
+- migrates Stepper to use `@adobe/spectrum-tokens`
 
 Additionally:
 
@@ -1309,6 +1313,20 @@ ellipsis at medium size, instead of 3. Was a matter of 1 or 2 pixels.
 ### ✨ Features
 
 - make Stepper use new Textfield markup ([724d09a](https://github.com/adobe/spectrum-css/commit/724d09a))
+
+### Migration Guide
+
+#### Indicating validity, focus, and disable
+
+Validity and focus must be bubbled up to the parent so descendants siblings can be styled.
+
+Thus, implementations must add the following classes in the following situations:
+
+- .spectrum-Stepper.is-focused - when the input or button is focused with the mouse
+- .spectrum-Stepper.is-keyboardFocused - when the input or button is focused with the keyboard
+- .spectrum-Stepper.is-valid - when the input has an explicit valid state
+- .spectrum-Stepper.is-invalid - when the input has an explicit invalid state
+- .spectrum-Stepper.is-disabled - when the component is disabled. Note that the Textfield must have .is-disabled, and the <input> and <buttons> must have the [disabled] property.
 
 ### 🛑 BREAKING CHANGES
 

--- a/components/stepper/stories/stepper.stories.js
+++ b/components/stepper/stories/stepper.stories.js
@@ -1,8 +1,9 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isFocused, isInvalid } from "@spectrum-css/preview/types";
+import { Sizes } from "@spectrum-css/preview/decorators";
 import { version } from "../package.json";
 import { StepperGroup } from "./stepper.test.js";
-import { Template } from "./template.js";
+import { Template, DisabledVariantsGroup, AllDefaultVariantsGroup } from "./template";
 
 /**
  * A stepper can be used to increment or decrement a value by a specified amount via an up/down button. An input field displays the current value.
@@ -77,6 +78,51 @@ export default {
 
 export const Default = StepperGroup.bind({});
 Default.args = {};
+Default.tags = ["!autodocs"];
+
+export const Sizing = (args, context) => Sizes({
+	Template,
+	withBorder: false,
+	withHeading: false,
+	...args,
+}, context);
+Sizing.args = {};
+Sizing.tags = ["!dev"];
+Sizing.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+/**
+ * Steppers come in four different sizes: small, medium, large, and extra-large. The medium size is the default and most frequently used option. Use the other sizes sparingly; they should be used to create a hierarchy of importance within the page.
+ */
+export const DefaultStates = AllDefaultVariantsGroup.bind({});
+DefaultStates.args = {};
+DefaultStates.tags = ["!dev"];
+DefaultStates.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+DefaultStates.storyName = "Default";
+
+export const Disabled = DisabledVariantsGroup.bind({});
+Disabled.args = {
+	isDisabled: true,
+};
+Disabled.tags = ["!dev"];
+Disabled.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+Disabled.storyName = "Disabled";
+
+export const QuietStates = AllDefaultVariantsGroup.bind({});
+QuietStates.args = {
+	isQuiet: true,
+};
+QuietStates.tags = ["!dev"];
+QuietStates.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+QuietStates.storyName = "Quiet";
+
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = StepperGroup.bind({});
@@ -89,6 +135,9 @@ WithForcedColors.parameters = {
 };
 
 // ********* DOCS ONLY ********* //
+/**
+ * Optional stepper buttons would appear to the side of the field. Regardless of if a stepper has these buttons or not, is should always accommodate arrow key shortcuts to increase or decrease the number.
+ */
 export const HideStepper = Template.bind({});
 HideStepper.tags = ["!dev"];
 HideStepper.args = {
@@ -99,3 +148,4 @@ HideStepper.parameters = {
 		disableSnapshot: true,
 	},
 };
+HideStepper.storyName = "Hide stepper";

--- a/components/stepper/stories/template.js
+++ b/components/stepper/stories/template.js
@@ -1,5 +1,5 @@
 import { Template as InfieldButton } from "@spectrum-css/infieldbutton/stories/template.js";
-import { getRandomId } from "@spectrum-css/preview/decorators";
+import { getRandomId, Container } from "@spectrum-css/preview/decorators";
 import { Template as Textfield } from "@spectrum-css/textfield/stories/template.js";
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
@@ -94,3 +94,81 @@ export const Template = ({
 		</div>
 	`;
 };
+
+/* Shows all of the stepper states in one grouping. */
+export const AllDefaultVariantsGroup = (args, context) => Container({
+	withBorder: false,
+	content: html`
+		${Container({
+			withBorder: false,
+			containerStyles: {
+				"gap": "8px",
+			},
+			heading: "Default",
+			content: Template(args, context)
+		})}
+		${Container({
+			withBorder: false,
+			containerStyles: {
+				"gap": "8px",
+			},
+			heading: "Invalid",
+			content: Template({...args, isInvalid: true}, context)
+		})}
+		${Container({
+			withBorder: false,
+			containerStyles: {
+				"gap": "8px",
+			},
+			heading: "Focused",
+			content: Template({...args, isFocused: true}, context)
+		})}
+		${Container({
+			withBorder: false,
+			containerStyles: {
+				"gap": "8px",
+			},
+			heading: "Invalid, focused",
+			content: Template({...args, isInvalid: true, isFocused: true}, context)
+		})}
+		${Container({
+			withBorder: false,
+			containerStyles: {
+				"gap": "8px",
+			},
+			heading: "Keyboard focused",
+			content: Template({...args, isKeyboardFocused: true}, context)
+		})}
+		${Container({
+			withBorder: false,
+			containerStyles: {
+				"gap": "8px",
+			},
+			heading: "Invalid, keyboard focused",
+			content: Template({...args, isInvalid: true, isKeyboardFocused: true}, context)
+		})}
+	`
+});
+
+/* Shows the disabled variants of the default and quiet stories one grouping. */
+export const DisabledVariantsGroup = (args, context) => Container({
+	withBorder: false,
+	content: html`
+		${Container({
+			withBorder: false,
+			containerStyles: {
+				"gap": "8px",
+			},
+			heading: "Default",
+			content: Template(args, context)
+		})}
+		${Container({
+			withBorder: false,
+			containerStyles: {
+				"gap": "8px",
+			},
+			heading: "Quiet",
+			content: Template({...args, isQuiet: true}, context)
+		})}
+	`
+});


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

This PR continues migrating documentation from the static docs site into Storybook. The focus is on `slider`, `stepper`, and `steplist`. All variants of the components should now be displayed on the Storybook `Docs` page. All components have `autodocs` and/or `!dev` stories now. Some of the migration notes for `slider` and `stepper` have been added to the corresponding `changelog`s.

[Jira](https://jira.corp.adobe.com/browse/CSS-793)

No MDX pages were added for any components.

### Note
Initially, this work was supposed to include splitview, and a potential bug in the template regarding the focused story was uncovered. However, fixing that would require a CSS change (adding a class or pseudo-class), so a subsequent Jira ticket will be created to follow up on that.

**This PR doesn't need a changeset since it's docs-only.**

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

- [x] The [slider storybook docs](https://pr-2900--spectrum-css.netlify.app/preview/?path=/docs/components-slider--docs) include all necessary info when compared to the [corresponding docs site page](https://opensource.adobe.com/spectrum-css/slider.html)
- [ ] ~Double check the [splitview storybook docs](https://pr-2900--spectrum-css.netlify.app/preview/?path=/docs/components-split-view--docs) include all necessary info when compared to the [corresponding docs site page](https://opensource.adobe.com/spectrum-css/splitview.html). (_see note above about the "horizontally focused" bug_).~
- [x] The [steplist button storybook docs](https://pr-2900--spectrum-css.netlify.app/preview/?path=/docs/components-steplist--docs) include all necessary info when compared to the [corresponding docs site page](https://opensource.adobe.com/spectrum-css/steplist.html)
- [x] The [stepper storybook docs](https://pr-2900--spectrum-css.netlify.app/preview/?path=/docs/components-stepper--docs) include all necessary info when compared to the [corresponding docs site page](https://opensource.adobe.com/spectrum-css/stepper.html)
- [ ] Ensure the Chromatic testing view for each component captures all new variants.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
