### PR TITLE
fix(picker): prevent diacritic text cutoff

### DIFF
--- a/.changeset/nasty-moose-act.md
+++ b/.changeset/nasty-moose-act.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/picker": patch
+---
+
+Changes picker margin to padding in order to accommodate text with diacritics that may be cut off vertically.

--- a/components/picker/index.css
+++ b/components/picker/index.css
@@ -358,8 +358,8 @@
 	text-overflow: ellipsis;
 	text-align: start;
 
-	margin-block-start: var(--mod-picker-spacing-top-to-text, var(--spectrum-picker-spacing-top-to-text));
-	margin-block-end: calc(var(--mod-picker-spacing-bottom-to-text, var(--spectrum-picker-spacing-bottom-to-text)) - var(--mod-picker-border-width, var(--spectrum-picker-border-width)));
+	padding-block-start: var(--mod-picker-spacing-top-to-text, var(--spectrum-picker-spacing-top-to-text));
+	padding-block-end: calc(var(--mod-picker-spacing-bottom-to-text, var(--spectrum-picker-spacing-bottom-to-text)) - var(--mod-picker-border-width, var(--spectrum-picker-border-width)));
 
 	&.is-placeholder {
 		font-weight: var(--mod-picker-placeholder-font-weight, var(--spectrum-picker-font-weight));

--- a/components/picker/stories/picker.stories.js
+++ b/components/picker/stories/picker.stories.js
@@ -207,7 +207,7 @@ const Variants = (args) => html`
 					...args,
 					isOpen: false,
 					withSwitch: true,
-					placeholder: "Select your contry of origin",
+					placeholder: "Select your country of origin",
 					isQuiet: true,
 				})}
 		</div>
@@ -220,7 +220,7 @@ const Variants = (args) => html`
 				isQuiet: true,
 				fieldLabelStyle: {"max-width": "90px"},
 				label: "Enter country, text should wrap",
-				placeholder: "Select your contry of origin"
+				placeholder: "Select your country of origin"
 			})}
 		</div>
 	</div>


### PR DESCRIPTION
## Description

Addressing [CSS-810](https://jira.corp.adobe.com/browse/CSS-810), this fix addresses [a bug that was called out recently](https://adobedesign.slack.com/archives/CESK60MQD/p1718744842850969), similar to what was seen in Textfield for both [Spectrum CSS](https://github.com/adobe/spectrum-css/pull/2123) and [React Spectrum](https://github.com/adobe/react-spectrum/pull/4579) with text with diacritics being cut off vertically. In this case, as the affected text occurs in a `<span>` rather than an `<input>` tag, the line-height does not need an adjustment, and changing the margin to padding appears to be sufficient to allow the vertical cutoff to be displayed.

There is also a [draft PR](https://github.com/adobe/spectrum-css/pull/2913) to fix the same issue that uses the same line-height fix that is seen in textfield.

_Note: When testing with Assistiv Labs, this cutoff issue did not appear to be present (in production)--this fix has been tested in Assistiv Labs (Chrome, Firefox, Edge) and does not appear to have an impact there._

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
1. Check out the Picker in Storybook locally or in the [deploy preview](https://pr-2914--spectrum-css.netlify.app/preview/?path=/story/components-picker--default)
2. Change text to Thai:
    - In the Storybook controls, you can change the text for both "Label" and "Placeholder" to the Thai phrase that was causing an issue previously, "ทั้งหมด". You can also do this in the [deployed version of Picker](https://opensource.adobe.com/spectrum-css/preview/index.html?path=/story/components-picker--default) or from the `main` branch to see the cutoff issue.
    - If checking out Picker locally, you can alternatively cherry pick [commit](https://github.com/adobe/spectrum-css/pull/2914/commits/a1fab905fba48b9d3cf641a19160bee1b07e376a) `a1fab905fba48b9d3cf641a19160bee1b07e376a` to temporarily change the English in Picker to Thai. This was a temporary commit I'd put in the PR but reverted in order to run VRTs.
3. Confirm that the text within the Picker is not being cut off vertically. The best way to know is to compare the field label ("Label" text, which has not been experiencing cutoff) with the picker label ("Placeholder" text, which is the element experiencing cutoff), applying zoom as needed.
4. Confirm that this continues to be true for:
    - [x] all sizes of Picker
    - [x] all variants of Picker
    - [x] in more than one browser (I checked Chrome, Firefox, Edge, and Safari, all for Mac)
5. Check the [Tabs component in Storybook](https://github.com/adobe/spectrum-css/pull/2914/commits/a1fab905fba48b9d3cf641a19160bee1b07e376a):
    - [x] confirm that there do not appear to be any regressions or issues as the result of this change to Picker

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

9. If components have been modified, VRTs have been run on this branch:

- [X] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes--there is a 2px length difference in the snapshots for the Tabs component, this cannot be replicated in the browser, and I am unsure if it's an indication of significant diffs that might be visible downstream.

## Screenshots

Before:
![image](https://github.com/user-attachments/assets/265975c1-8bce-4e1e-aba7-7a0c255a6386)

After:
![image](https://github.com/user-attachments/assets/752ffd64-bf3a-4e72-ae40-068158c17f67)

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode (and AssistivLabs).
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] ✨ This pull request is ready to merge. ✨
