### PR TITLE
fix(storybook): some inline stories in docs cutting off

### DIFF
--- a/.storybook/assets/base.css
+++ b/.storybook/assets/base.css
@@ -34,7 +34,7 @@ svg:has(symbol):not(:has(use)) {
 	display: none;
 }
 
-/* set back to default h2 styles */
+/* Make sure heading provided by <Stories/> doc block uses styles consistent with the default H2. */
 #variants {
 	font-size: 24px;
 	margin-block-end: 8px;
@@ -44,4 +44,10 @@ svg:has(symbol):not(:has(use)) {
 	letter-spacing: normal;
 	text-transform: none;
 	border-block-end: 1px solid hsla(203deg, 50%, 30%, 15%);
+}
+
+.sb-story {
+	/* Prevent inline stories in the Docs from cutting off content (which is different than the regular
+	story view), due to Storybook's inline style that sets overflow: auto */
+	overflow: visible !important;
 }


### PR DESCRIPTION
## Description

Adds some CSS to Storybook to adjust inline stories on the Docs pages. This stops them from cutting off content, by adjusting the overflow property. This was affecting components such as in-field button, color loupe, etc.

The display difference between regular stories and inline stories is because [Storybook sets an inline style with `overflow: auto` in its InlineStory function](https://github.com/storybookjs/storybook/blob/535f7b9ba3849719e10e4b577f78660b77cdcaec/code/ui/blocks/src/components/Story.tsx#L80C63-L80C74). This appears to be originally added in Storybook 6.1 to help fixed elements from leaking out; that does not appear to be an issue with our fixed elements after this fix (is it possibly not an issue anymore in Storybook due to other changes?).

CSS-816

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [x] The following components are not cut off on their Docs pages:
  - Action bar
  - Color area
  - Color handle (previously was cutting off 3/4 of the circle)
  - Color loupe
  - Color slider
  - Dial
  - Drop indicator
  - Floating action button
  - In-field button
  - Tooltip
- [x] Components with `position: fixed` still display the same in Docs and their story: action bar, alert dialog, modal, tray, underlay

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [ ] ✨ This pull request is ready to merge. ✨
