### PR TITLE
fix(preview): use new autodocs configuration format

### DIFF
--- a/.changeset/short-sheep-sip.md
+++ b/.changeset/short-sheep-sip.md
@@ -1,0 +1,7 @@
+---
+"@spectrum-css/preview": minor
+---
+
+Updates the way that autodocs is configured, as documented in the [Storybook migration guide
+for 8.0.x to 8.1.x])(https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#mainjs-docsautodocs-is-deprecated).
+The `docs.autodocs` setting in `main.js` was deprecated and is being removed in Storybook 9.0.

--- a/.storybook/guides/develop.mdx
+++ b/.storybook/guides/develop.mdx
@@ -439,9 +439,7 @@ Default.parameters = {
 
 #### Story tags
 
-Through this project's global configuration, all stories include the `autodocs` tag by default, which causes them to appear on the component's "Docs" page. The `dev` tag, which Storybook applies by default, denotes stories that should be included in the Storybook sidebar.
-A story's [tags](https://storybook.js.org/docs/writing-stories/tags#built-in-tags) can be configured for a few different purposes. The `!` symbol is used to negate the tag:
-
+A story's [tags](https://storybook.js.org/docs/writing-stories/tags#built-in-tags) can be configured for a few different purposes. Through this project's global configuration, all stories include the `autodocs` tag by default, which causes them to appear on the component's "Docs" page. The `dev` tag, which Storybook applies by default, denotes stories that should be included in the Storybook sidebar. The `!` symbol is used to negate the tag.
 - If a story should not be shown in the sidebar:
   ```js
   Default.tags = ["!dev"];

--- a/.storybook/guides/develop.mdx
+++ b/.storybook/guides/develop.mdx
@@ -437,18 +437,23 @@ Default.parameters = {
 };
 ```
 
-If a story should not be shown in the sidebar because it is only for:
+#### Story tags
 
-- Documentation purposes, you can use the tags:
-  ```js
-  Default.tags = ["autodocs", "!dev"];
-  ```
-- Visual regression testing, you can use the following tags:
-  ```js
-  Default.tags = ["test", "!autodocs", "!dev"];
-  ```
+Through this project's global configuration, all stories include the `autodocs` tag by default, which causes them to appear on the component's "Docs" page. The `dev` tag, which Storybook applies by default, denotes stories that should be included in the Storybook sidebar.
+A story's [tags](https://storybook.js.org/docs/writing-stories/tags#built-in-tags) can be configured for a few different purposes. The `!` symbol is used to negate the tag:
 
-The `!` symbol is used to negate the tag. This is useful for filtering stories in the sidebar. The `autodocs` tag is used to denote stories that are only for documentation purposes and should not be included in the visual regression suite. The `dev` tag is used to denote stories that should be included in the storybook sidebar. The `test` tag is used to denote stories that should be included in the visual regression suite.
+- If a story should not be shown in the sidebar:
+  ```js
+  Default.tags = ["!dev"];
+  ```
+- If a story should not be shown on the component's "Docs" page:
+  ```js
+  Default.tags = ["!autodocs"];
+  ```
+- For stories that are for visual regression testing only, both tags can be used:
+  ```js
+  Default.tags = ["!autodocs", "!dev"];
+  ```
 
 ### Getting started
 

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -76,7 +76,6 @@ export default {
 		buildStoriesJson: true,
 	},
 	docs: {
-		autodocs: true,
 		defaultName: "Docs",
 	},
 	refs: {

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,24 +1,24 @@
 import { setConsoleOptions } from "@storybook/addon-console";
 import {
-	withActions,
-	withArgEvents,
-	withContextWrapper,
-	withIconSpriteSheet,
-	withLanguageWrapper,
-	withReducedMotionWrapper,
-	withTestingPreviewWrapper,
-	withTextDirectionWrapper,
+  withActions,
+  withArgEvents,
+  withContextWrapper,
+  withIconSpriteSheet,
+  withLanguageWrapper,
+  withReducedMotionWrapper,
+  withTestingPreviewWrapper,
+  withTextDirectionWrapper,
 } from "./decorators";
 import {
-	FontLoader,
-	IconLoader,
-	TokenLoader
+  FontLoader,
+  IconLoader,
+  TokenLoader
 } from "./loaders";
 import modes from "./modes";
 import DocumentationTemplate from "./templates/DocumentationTemplate.mdx";
 import {
-	argTypes,
-	globalTypes
+  argTypes,
+  globalTypes
 } from "./types";
 
 import "./assets/base.css";
@@ -86,7 +86,6 @@ export const parameters = {
 		},
 	},
 	docs: {
-		autodocs: true,
 		page: DocumentationTemplate,
 		story: {
 			inline: true,
@@ -140,4 +139,5 @@ export default {
 		IconLoader,
 		TokenLoader,
 	],
+	tags: ["autodocs"],
 };

--- a/components/accordion/stories/accordion.stories.js
+++ b/components/accordion/stories/accordion.stories.js
@@ -66,6 +66,7 @@ export default {
 		chromatic: { disableSnapshot: true },
 		componentVersion: version,
 	},
+	tags: ["!autodocs"],
 };
 
 /* Content sourced from: https://www.adobe.com/products/catalog.html#:~:text=Frequently%20asked%20questions. */

--- a/components/accordion/stories/accordion.stories.js
+++ b/components/accordion/stories/accordion.stories.js
@@ -169,7 +169,7 @@ Default.parameters = {
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Default.bind({});
 WithForcedColors.args = Default.args;
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/accordion/stories/accordion.stories.js
+++ b/components/accordion/stories/accordion.stories.js
@@ -179,14 +179,14 @@ WithForcedColors.parameters = {
 
 // ********* DOCS ONLY ********* //
 export const Compact = Template.bind({});
-Compact.tags = ["autodocs", "!dev"];
+Compact.tags = ["!dev"];
 Compact.args = {
 	items: content,
 	density: "compact",
 };
 
 export const Spacious = Template.bind({});
-Spacious.tags = ["autodocs", "!dev"];
+Spacious.tags = ["!dev"];
 Spacious.args = {
 	items: content,
 	density: "spacious",

--- a/components/actionbar/stories/actionbar.stories.js
+++ b/components/actionbar/stories/actionbar.stories.js
@@ -83,7 +83,7 @@ Default.args = {};
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Default.bind({});
 WithForcedColors.args = Default.args;
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/actionbar/stories/actionbar.stories.js
+++ b/components/actionbar/stories/actionbar.stories.js
@@ -74,6 +74,7 @@ export default {
 		},
 		componentVersion: version,
 	},
+	tags: ["!autodocs"],
 };
 
 export const Default = ActionBarGroup.bind({});

--- a/components/actionbar/stories/actionbar.stories.js
+++ b/components/actionbar/stories/actionbar.stories.js
@@ -93,7 +93,7 @@ WithForcedColors.parameters = {
 
 // ********* DOCS ONLY ********* //
 export const Emphasized = Template.bind({});
-Emphasized.tags = ["autodocs", "!dev"];
+Emphasized.tags = ["!dev"];
 Emphasized.args = {
 	isEmphasized: true,
 };

--- a/components/actionbutton/stories/actionbutton.stories.js
+++ b/components/actionbutton/stories/actionbutton.stories.js
@@ -140,7 +140,7 @@ Quiet.args = {
 
 // ********* VRT ONLY ********* //
 export const StaticBlack = Default.bind({});
-StaticBlack.tags = ["!autodocs", "!dev", "test"];
+StaticBlack.tags = ["!autodocs", "!dev"];
 StaticBlack.args = {
 	...Default.args,
 	staticColor: "black",
@@ -152,7 +152,7 @@ StaticBlack.parameters = {
 };
 
 export const StaticWhite = Default.bind({});
-StaticWhite.tags = ["!autodocs", "!dev", "test"];
+StaticWhite.tags = ["!autodocs", "!dev"];
 StaticWhite.args = {
 	...Default.args,
 	staticColor: "white",
@@ -165,7 +165,7 @@ StaticWhite.parameters = {
 
 export const WithForcedColors = Default.bind({});
 WithForcedColors.args = Default.args;
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/actionbutton/stories/actionbutton.stories.js
+++ b/components/actionbutton/stories/actionbutton.stories.js
@@ -125,14 +125,14 @@ Default.args = {
 };
 
 export const Emphasized = ActionButtons.bind({});
-Emphasized.tags = ["autodocs", "!dev"];
+Emphasized.tags = ["!dev"];
 Emphasized.args = {
 	label: "More",
 	isEmphasized: true,
 };
 
 export const Quiet = ActionButtons.bind({});
-Quiet.tags = ["autodocs", "!dev"];
+Quiet.tags = ["!dev"];
 Quiet.args = {
 	label: "More",
 	isQuiet: true,

--- a/components/actiongroup/stories/actiongroup.stories.js
+++ b/components/actiongroup/stories/actiongroup.stories.js
@@ -93,7 +93,7 @@ Default.args = {
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Default.bind({});
 WithForcedColors.args = Default.args;
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/actionmenu/stories/actionmenu.stories.js
+++ b/components/actionmenu/stories/actionmenu.stories.js
@@ -84,7 +84,7 @@ Default.args = {
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Default.bind({});
 WithForcedColors.args = Default.args;
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/alertbanner/stories/alertbanner.stories.js
+++ b/components/alertbanner/stories/alertbanner.stories.js
@@ -64,7 +64,7 @@ Default.args = {
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Default.bind({});
 WithForcedColors.args = Default.args;
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/alertdialog/stories/alertdialog.stories.js
+++ b/components/alertdialog/stories/alertdialog.stories.js
@@ -107,7 +107,7 @@ WithForcedColors.parameters = {
  * Note that an alert dialog can have a total of 3 buttons if the secondary outline button label is defined.
  */
 export const Information = Template.bind({});
-Information.tags = ["autodocs", "!dev"];
+Information.tags = ["!dev"];
 Information.args = {
 	isOpen: true,
 	variant: "information",
@@ -135,7 +135,7 @@ Information.parameters = {
  * Warning alert dialogs communicate important information to users in relation to an issue that needs to be acknowledged, but does not block the user from moving forward.
  */
 export const Warning = Template.bind({});
-Warning.tags = ["autodocs", "!dev"];
+Warning.tags = ["!dev"];
 Warning.args = {
 	isOpen: true,
 	variant: "warning",
@@ -160,7 +160,7 @@ Warning.parameters = {
  * Error alert dialogs communicate critical information about an issue that a user needs to acknowledge.
  */
 export const Error = Template.bind({});
-Error.tags = ["autodocs", "!dev"];
+Error.tags = ["!dev"];
 Error.args = {
 	isOpen: true,
 	variant: "error",
@@ -185,7 +185,7 @@ Error.parameters = {
  * Destructive alert dialogs are for when a user needs to confirm an action that will impact their data or experience in a potentially negative way, such as deleting files or contacts.
  */
 export const Destructive = Template.bind({});
-Destructive.tags = ["autodocs", "!dev"];
+Destructive.tags = ["!dev"];
 Destructive.args = {
 	isOpen: true,
 	variant: "destructive",
@@ -206,7 +206,7 @@ Destructive.parameters = {
 };
 
 export const Scroll = Template.bind({});
-Scroll.tags = ["autodocs", "!dev"];
+Scroll.tags = ["!dev"];
 Scroll.args = {
 	isOpen: true,
 	variant: "confirmation",

--- a/components/alertdialog/stories/alertdialog.stories.js
+++ b/components/alertdialog/stories/alertdialog.stories.js
@@ -92,7 +92,7 @@ Default.parameters = {
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Default.bind({});
 WithForcedColors.args = Default.args;
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/asset/stories/asset.stories.js
+++ b/components/asset/stories/asset.stories.js
@@ -36,6 +36,7 @@ export default {
 	parameters: {
 		componentVersion: version,
 	},
+	tags: ["!autodocs"],
 };
 
 export const Default = AssetGroup.bind({});

--- a/components/asset/stories/asset.stories.js
+++ b/components/asset/stories/asset.stories.js
@@ -47,7 +47,7 @@ Default.args = {
 
 // ********* DOCS ONLY ********* //
 export const File = Template.bind({});
-File.tags = ["autodocs", "!dev"];
+File.tags = ["!dev"];
 File.args = {
 	preset: "file",
 };
@@ -56,7 +56,7 @@ File.parameters = {
 };
 
 export const Folder = Template.bind({});
-Folder.tags = ["autodocs", "!dev"];
+Folder.tags = ["!dev"];
 Folder.args = {
 	preset: "folder",
 };

--- a/components/asset/stories/asset.stories.js
+++ b/components/asset/stories/asset.stories.js
@@ -67,7 +67,7 @@ Folder.parameters = {
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Default.bind({});
 WithForcedColors.args = Default.args;
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/assetcard/stories/assetcard.stories.js
+++ b/components/assetcard/stories/assetcard.stories.js
@@ -86,6 +86,7 @@ export default {
 		},
 		componentVersion: version,
 	},
+	tags: ["!autodocs"],
 };
 
 export const Default = AssetCardGroup.bind({});

--- a/components/assetcard/stories/assetcard.stories.js
+++ b/components/assetcard/stories/assetcard.stories.js
@@ -191,7 +191,7 @@ DropTarget.parameters = {
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Default.bind({});
 WithForcedColors.args = Default.args;
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/assetcard/stories/assetcard.stories.js
+++ b/components/assetcard/stories/assetcard.stories.js
@@ -103,7 +103,7 @@ Portrait.args = {
 	exampleImage: "portrait",
 	content: ["Image"],
 };
-Portrait.tags = ["autodocs", "!dev"];
+Portrait.tags = ["!dev"];
 Portrait.parameters = {
 	chromatic: { disableSnapshot: true },
 };
@@ -113,7 +113,7 @@ Landscape.args = {
 	title: "Landscape asset",
 	exampleImage: "landscape",
 };
-Landscape.tags = ["autodocs", "!dev"];
+Landscape.tags = ["!dev"];
 Landscape.parameters = {
 	chromatic: { disableSnapshot: true },
 };
@@ -123,7 +123,7 @@ Square.args = {
 	title: "Square asset",
 	exampleImage: "square",
 };
-Square.tags = ["autodocs", "!dev"];
+Square.tags = ["!dev"];
 Square.parameters = {
 	chromatic: { disableSnapshot: true },
 };
@@ -134,7 +134,7 @@ OptionalContent.args = {
 	headerContent: "39:02",
 	exampleImage: "square",
 };
-OptionalContent.tags = ["autodocs", "!dev"];
+OptionalContent.tags = ["!dev"];
 OptionalContent.parameters = {
 	chromatic: { disableSnapshot: true },
 };
@@ -146,7 +146,7 @@ HighlightSelection.args = {
 	exampleImage: "portrait",
 	isSelected: true,
 };
-HighlightSelection.tags = ["autodocs", "!dev"];
+HighlightSelection.tags = ["!dev"];
 HighlightSelection.parameters = {
 	chromatic: { disableSnapshot: true },
 };
@@ -158,7 +158,7 @@ CheckboxSelection.args = {
 	exampleImage: "portrait",
 	isSelected: true,
 };
-CheckboxSelection.tags = ["autodocs", "!dev"];
+CheckboxSelection.tags = ["!dev"];
 CheckboxSelection.parameters = {
 	chromatic: { disableSnapshot: true },
 };
@@ -170,7 +170,7 @@ OrderedSelection.args = {
 	isSelected: true,
 	exampleImage: "landscape",
 };
-OrderedSelection.tags = ["autodocs", "!dev"];
+OrderedSelection.tags = ["!dev"];
 OrderedSelection.parameters = {
 	chromatic: { disableSnapshot: true },
 };
@@ -183,7 +183,7 @@ DropTarget.args = {
 	exampleImage: "portrait",
 	isSelected: true,
 };
-DropTarget.tags = ["autodocs", "!dev"];
+DropTarget.tags = ["!dev"];
 DropTarget.parameters = {
 	chromatic: { disableSnapshot: true },
 };

--- a/components/assetlist/stories/assetlist.stories.js
+++ b/components/assetlist/stories/assetlist.stories.js
@@ -65,7 +65,7 @@ Default.args = {
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Default.bind({});
 WithForcedColors.args = Default.args;
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/avatar/stories/avatar.stories.js
+++ b/components/avatar/stories/avatar.stories.js
@@ -71,6 +71,7 @@ export default {
 	parameters: {
 		componentVersion: version,
 	},
+	tags: ["!autodocs"],
 };
 
 export const Default = AvatarGroup.bind({});

--- a/components/avatar/stories/avatar.stories.js
+++ b/components/avatar/stories/avatar.stories.js
@@ -117,7 +117,7 @@ Disabled.parameters = {
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Default.bind({});
 WithForcedColors.args = Default.args;
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/avatar/stories/avatar.stories.js
+++ b/components/avatar/stories/avatar.stories.js
@@ -82,7 +82,7 @@ Default.args = {
 
 // ********* DOCS ONLY ********* //
 export const SizeOptions = AvatarSizes.bind({});
-SizeOptions.tags = ["autodocs", "!dev"];
+SizeOptions.tags = ["!dev"];
 SizeOptions.parameters = {
 	chromatic: { disableSnapshot: true },
 };
@@ -92,7 +92,7 @@ SizeOptions.args = {
 };
 
 export const NoLink = Template.bind({});
-NoLink.tags = ["autodocs", "!dev"];
+NoLink.tags = ["!dev"];
 NoLink.args = {
 	hasLink: false,
 	image: "example-ava@2x.png",
@@ -103,7 +103,7 @@ NoLink.parameters = {
 };
 
 export const Disabled = Template.bind({});
-Disabled.tags = ["autodocs", "!dev"];
+Disabled.tags = ["!dev"];
 Disabled.args = {
 	hasLink: false,
 	isDisabled: true,

--- a/components/badge/stories/badge.stories.js
+++ b/components/badge/stories/badge.stories.js
@@ -70,6 +70,7 @@ export default {
 	parameters: {
 		componentVersion: version,
 	},
+	tags: ["!autodocs"],
 };
 
 export const Default = BadgeGroup.bind({});

--- a/components/badge/stories/badge.stories.js
+++ b/components/badge/stories/badge.stories.js
@@ -81,19 +81,19 @@ Default.args = {
 
 // ********* DOCS ONLY ********* //
 export const SemanticVariants = (args, context) => PreviewSets(semanticOptions, args, context);
-SemanticVariants.tags = ["autodocs", "!dev"];
+SemanticVariants.tags = ["!dev"];
 SemanticVariants.parameters = {
 	chromatic: { disableSnapshot: true },
 };
 
 export const NonSemanticVariants = (args, context) => PreviewSets(nonSemanticOptions, args, context);
-NonSemanticVariants.tags = ["autodocs", "!dev"];
+NonSemanticVariants.tags = ["!dev"];
 NonSemanticVariants.parameters = {
 	chromatic: { disableSnapshot: true },
 };
 
 export const FixedVariants = (args, context) => PreviewSets(fixedOptions, args, context);
-FixedVariants.tags = ["autodocs", "!dev"];
+FixedVariants.tags = ["!dev"];
 FixedVariants.parameters = {
 	chromatic: { disableSnapshot: true },
 };

--- a/components/badge/stories/badge.stories.js
+++ b/components/badge/stories/badge.stories.js
@@ -101,7 +101,7 @@ FixedVariants.parameters = {
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Default.bind({});
 WithForcedColors.args = Default.args;
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/breadcrumb/stories/breadcrumb.stories.js
+++ b/components/breadcrumb/stories/breadcrumb.stories.js
@@ -59,7 +59,7 @@ Default.args = {
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Default.bind({});
 WithForcedColors.args = Default.args;
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/button/stories/button.stories.js
+++ b/components/button/stories/button.stories.js
@@ -155,7 +155,7 @@ Default.args = {};
 
 // ********* VRT ONLY ********* //
 export const StaticWhite = Default.bind({});
-StaticWhite.tags = ["!autodocs", "!dev", "test"];
+StaticWhite.tags = ["!autodocs", "!dev"];
 StaticWhite.args = {
 	staticColor: "white",
 };
@@ -166,7 +166,7 @@ StaticWhite.parameters = {
 };
 
 export const StaticBlack = Default.bind({});
-StaticBlack.tags = ["!autodocs", "!dev", "test"];
+StaticBlack.tags = ["!autodocs", "!dev"];
 StaticBlack.args = {
 	staticColor: "black",
 };
@@ -178,7 +178,7 @@ StaticBlack.parameters = {
 
 export const WithForcedColors = Default.bind({});
 WithForcedColors.args = Default.args;
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/buttongroup/stories/buttongroup.stories.js
+++ b/components/buttongroup/stories/buttongroup.stories.js
@@ -66,7 +66,7 @@ Default.args = {
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Default.bind({});
 WithForcedColors.args = Default.args;
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/calendar/stories/calendar.stories.js
+++ b/components/calendar/stories/calendar.stories.js
@@ -155,7 +155,7 @@ Focused.parameters = {
 
 export const WithForcedColors = Default.bind({});
 WithForcedColors.args = Default.args;
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/calendar/stories/calendar.stories.js
+++ b/components/calendar/stories/calendar.stories.js
@@ -96,6 +96,7 @@ export default {
 		},
 		componentVersion: version,
 	},
+	tags: ["!autodocs"],
 };
 
 export const Default = CalendarGroup.bind({});

--- a/components/calendar/stories/calendar.stories.js
+++ b/components/calendar/stories/calendar.stories.js
@@ -111,7 +111,7 @@ export const AbbreviatedWeekdays = Template.bind({});
 AbbreviatedWeekdays.args = {
 	useDOWAbbrev: true,
 };
-AbbreviatedWeekdays.tags = ["autodocs", "!dev"];
+AbbreviatedWeekdays.tags = ["!dev"];
 AbbreviatedWeekdays.parameters = {
 	chromatic: { disableSnapshot: true },
 };
@@ -125,7 +125,7 @@ RangeSelection.args = {
 	useDOWAbbrev: true,
 	padded: true,
 };
-RangeSelection.tags = ["autodocs", "!dev"];
+RangeSelection.tags = ["!dev"];
 RangeSelection.parameters = {
 	chromatic: { disableSnapshot: true },
 };
@@ -137,13 +137,13 @@ Focused.args = {
 	year: undefined,
 	isFocused: true,
 };
-Focused.tags = ["autodocs", "!dev"];
+Focused.tags = ["!dev"];
 Focused.parameters = {
 	chromatic: { disableSnapshot: true },
 };
 
 export const Disabled = Template.bind({});
-Disabled.tags = ["autodocs", "!dev"];
+Disabled.tags = ["!dev"];
 Disabled.args = {
 	isDisabled: true
 };

--- a/components/card/stories/card.stories.js
+++ b/components/card/stories/card.stories.js
@@ -100,6 +100,7 @@ export default {
 		},
 		componentVersion: version,
 	},
+	tags: ["!autodocs"],
 };
 
 export const Default = CardGroup.bind({});

--- a/components/card/stories/card.stories.js
+++ b/components/card/stories/card.stories.js
@@ -124,7 +124,7 @@ WithForcedColors.parameters = {
 
 // ********* DOCS ONLY ********* //
 export const Selected = Default.bind({});
-Selected.tags = ["autodocs", "!dev"];
+Selected.tags = ["!dev"];
 Selected.parameters = {
 	chromatic: { disableSnapshot: true },
 };
@@ -138,7 +138,7 @@ Focused.args = {
 	title: "Card title that is longer and should wrap",
 	customStyles: { "max-inline-size": "205px"},
 };
-Focused.tags = ["autodocs", "!dev"];
+Focused.tags = ["!dev"];
 Focused.parameters = {
 	chromatic: { disableSnapshot: true },
 };
@@ -151,7 +151,7 @@ Quiet.args = {
 	description: "10/15/18",
 	isQuiet: true,
 };
-Quiet.tags = ["autodocs", "!dev"];
+Quiet.tags = ["!dev"];
 Quiet.parameters = {
 	chromatic: { disableSnapshot: true },
 };
@@ -165,13 +165,13 @@ QuietFile.args = {
 	image: undefined,
 	isQuiet: true,
 };
-QuietFile.tags = ["autodocs", "!dev"];
+QuietFile.tags = ["!dev"];
 QuietFile.parameters = {
 	chromatic: { disableSnapshot: true },
 };
 
 export const Horizontal = Template.bind({});
-Horizontal.tags = ["autodocs", "!dev"];
+Horizontal.tags = ["!dev"];
 Horizontal.parameters = {
 	chromatic: { disableSnapshot: true },
 };
@@ -190,7 +190,7 @@ NoImage.args = {
 	title: "Card title",
 	description: "Optional description that should be one or two lines",
 };
-NoImage.tags = ["autodocs", "!dev"];
+NoImage.tags = ["!dev"];
 NoImage.parameters = {
 	chromatic: { disableSnapshot: true },
 };
@@ -202,7 +202,7 @@ QuietFolder.args = {
 	description: "10/15/18",
 	isQuiet: true,
 };
-QuietFolder.tags = ["autodocs", "!dev"];
+QuietFolder.tags = ["!dev"];
 QuietFolder.parameters = {
 	chromatic: { disableSnapshot: true },
 };
@@ -216,7 +216,7 @@ QuietFocused.args = {
 	isQuiet: true,
 	isFocused: true,
 };
-QuietFocused.tags = ["autodocs", "!dev"];
+QuietFocused.tags = ["!dev"];
 QuietFocused.parameters = {
 	chromatic: { disableSnapshot: true },
 };
@@ -230,7 +230,7 @@ QuietSelected.args = {
 	isQuiet: true,
 	isSelected: true,
 };
-QuietSelected.tags = ["autodocs", "!dev"];
+QuietSelected.tags = ["!dev"];
 QuietSelected.parameters = {
 	chromatic: { disableSnapshot: true },
 };
@@ -247,7 +247,7 @@ AssetPreview.args = {
 		"width": "200px",
 	}
 };
-AssetPreview.tags = ["autodocs", "!dev"];
+AssetPreview.tags = ["!dev"];
 AssetPreview.parameters = {
 	chromatic: { disableSnapshot: true },
 };
@@ -264,7 +264,7 @@ Gallery.args = {
 		"width": "700px",
 	}
 };
-Gallery.tags = ["autodocs", "!dev"];
+Gallery.tags = ["!dev"];
 Gallery.parameters = {
 	chromatic: { disableSnapshot: true },
 };

--- a/components/card/stories/card.stories.js
+++ b/components/card/stories/card.stories.js
@@ -114,7 +114,7 @@ Default.args = {
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Default.bind({});
 WithForcedColors.args = Default.args;
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/checkbox/stories/checkbox.stories.js
+++ b/components/checkbox/stories/checkbox.stories.js
@@ -131,7 +131,7 @@ Default.args = {
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Default.bind({});
 WithForcedColors.args = Default.args;
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/clearbutton/stories/clearbutton.stories.js
+++ b/components/clearbutton/stories/clearbutton.stories.js
@@ -55,13 +55,13 @@ Default.args = {};
 
 // ********* VRT ONLY ********* //
 export const OverBackground = Template.bind({});
-OverBackground.tags = ["!autodocs", "!dev", "test"];
+OverBackground.tags = ["!autodocs", "!dev"];
 OverBackground.args = {
 	staticColor: "white",
 };
 
 export const WithForcedColors = Template.bind({});
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/closebutton/stories/closebutton.stories.js
+++ b/components/closebutton/stories/closebutton.stories.js
@@ -57,7 +57,7 @@ Default.args = {};
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Template.bind({});
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/coachindicator/stories/coachindicator.stories.js
+++ b/components/coachindicator/stories/coachindicator.stories.js
@@ -50,7 +50,7 @@ Default.parameters = {
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Default.bind({});
 WithForcedColors.args = Default.args;
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	// Sets the forced-colors media feature for a specific story.
 	chromatic: {

--- a/components/coachmark/stories/coachmark.stories.js
+++ b/components/coachmark/stories/coachmark.stories.js
@@ -83,7 +83,7 @@ WithMedia.parameters = {
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Template.bind({});
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/coachmark/stories/coachmark.stories.js
+++ b/components/coachmark/stories/coachmark.stories.js
@@ -62,6 +62,7 @@ export default {
 			modes: mobile,
 		}
 	},
+	tags: ["!autodocs"],
 };
 
 export const Default = Template.bind({});

--- a/components/colorarea/stories/colorarea.stories.js
+++ b/components/colorarea/stories/colorarea.stories.js
@@ -57,7 +57,7 @@ Disabled.parameters = {
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Template.bind({});
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/colorarea/stories/colorarea.stories.js
+++ b/components/colorarea/stories/colorarea.stories.js
@@ -33,6 +33,7 @@ export default {
 	parameters: {
 		componentVersion: version,
 	},
+	tags: ["!autodocs"],
 };
 
 export const Default = Template.bind({});

--- a/components/colorarea/stories/colorarea.stories.js
+++ b/components/colorarea/stories/colorarea.stories.js
@@ -47,7 +47,7 @@ CustomSize.args = {
 
 // ********* DOCS ONLY ********* //
 export const Disabled = Template.bind({});
-Disabled.tags = ["autodocs", "!dev"];
+Disabled.tags = ["!dev"];
 Disabled.args = {
 	isDisabled: true,
 };

--- a/components/colorhandle/stories/colorhandle.stories.js
+++ b/components/colorhandle/stories/colorhandle.stories.js
@@ -67,7 +67,7 @@ WithColorLoupe.parameters = {
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Template.bind({});
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/colorhandle/stories/colorhandle.stories.js
+++ b/components/colorhandle/stories/colorhandle.stories.js
@@ -45,7 +45,7 @@ export const Disabled = Template.bind({});
 Disabled.args = {
 	isDisabled: true,
 };
-Disabled.tags = ["autodocs", "!dev"];
+Disabled.tags = ["!dev"];
 Disabled.parameters = {
 	chromatic: { disableSnapshot: true },
 };
@@ -54,7 +54,7 @@ export const WithColorLoupe = Template.bind({});
 WithColorLoupe.args = {
 	isWithColorLoupe: true,
 };
-WithColorLoupe.tags = ["autodocs", "!dev"];
+WithColorLoupe.tags = ["!dev"];
 WithColorLoupe.parameters = {
 	chromatic: { disableSnapshot: true },
 	docs: {

--- a/components/colorhandle/stories/colorhandle.stories.js
+++ b/components/colorhandle/stories/colorhandle.stories.js
@@ -34,6 +34,7 @@ export default {
 	parameters: {
 		componentVersion: version,
 	},
+	tags: ["!autodocs"],
 };
 
 export const Default = Template.bind({});

--- a/components/colorloupe/stories/colorloupe.stories.js
+++ b/components/colorloupe/stories/colorloupe.stories.js
@@ -33,7 +33,7 @@ Default.args = {};
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Template.bind({});
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/colorloupe/stories/colorloupe.stories.js
+++ b/components/colorloupe/stories/colorloupe.stories.js
@@ -25,6 +25,7 @@ export default {
 		},
 		componentVersion: version,
 	},
+	tags: ["!autodocs"],
 };
 
 export const Default = Template.bind({});

--- a/components/colorslider/stories/colorslider.stories.js
+++ b/components/colorslider/stories/colorslider.stories.js
@@ -42,6 +42,7 @@ export default {
 	parameters: {
 		componentVersion: version,
 	},
+	tags: ["!autodocs"],
 };
 
 export const Default = ColorSliderGroup.bind({});

--- a/components/colorslider/stories/colorslider.stories.js
+++ b/components/colorslider/stories/colorslider.stories.js
@@ -67,7 +67,7 @@ export const Vertical = Default.bind({});
 Vertical.args = {
 	vertical: true,
 };
-Vertical.tags = ["autodocs", "!dev"];
+Vertical.tags = ["!dev"];
 Vertical.parameters = {
 	chromatic: { disableSnapshot: true },
 };
@@ -79,7 +79,7 @@ Alpha.args = {
 		"--spectrum-picked-color": "rgba(0, 0, 0, 1)",
 	},
 };
-Alpha.tags = ["autodocs", "!dev"];
+Alpha.tags = ["!dev"];
 Alpha.parameters = {
 	chromatic: { disableSnapshot: true },
 };
@@ -93,7 +93,7 @@ WithImage.args = {
 	},
 };
 WithImage.storyName = "Image";
-WithImage.tags = ["autodocs", "!dev"];
+WithImage.tags = ["!dev"];
 WithImage.parameters = {
 	chromatic: { disableSnapshot: true },
 };
@@ -102,7 +102,7 @@ export const Disabled = Default.bind({});
 Disabled.args = {
 	isDisabled: true,
 };
-Disabled.tags = ["autodocs", "!dev"];
+Disabled.tags = ["!dev"];
 Disabled.parameters = {
 	chromatic: { disableSnapshot: true },
 };

--- a/components/colorslider/stories/colorslider.stories.js
+++ b/components/colorslider/stories/colorslider.stories.js
@@ -54,7 +54,7 @@ Default.args = {
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Default.bind({});
 WithForcedColors.args = Default.args;
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/colorwheel/stories/colorwheel.stories.js
+++ b/components/colorwheel/stories/colorwheel.stories.js
@@ -61,7 +61,7 @@ WithColorArea.parameters = {
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Template.bind({});
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/colorwheel/stories/colorwheel.stories.js
+++ b/components/colorwheel/stories/colorwheel.stories.js
@@ -42,7 +42,7 @@ Default.args = {};
 
 // ********* DOCS ONLY ********* //
 export const Disabled = Template.bind({});
-Disabled.tags = ["autodocs", "!dev"];
+Disabled.tags = ["!dev"];
 Disabled.args = {
 	isDisabled: true,
 };
@@ -51,7 +51,7 @@ Disabled.parameters = {
 };
 
 export const WithColorArea = Template.bind({});
-WithColorArea.tags = ["autodocs", "!dev"];
+WithColorArea.tags = ["!dev"];
 WithColorArea.args = {
 	isWithColorArea: true,
 };

--- a/components/colorwheel/stories/colorwheel.stories.js
+++ b/components/colorwheel/stories/colorwheel.stories.js
@@ -34,6 +34,7 @@ export default {
 	parameters: {
 		componentVersion: version,
 	},
+	tags: ["!autodocs"],
 };
 
 export const Default = Template.bind({});

--- a/components/combobox/stories/combobox.stories.js
+++ b/components/combobox/stories/combobox.stories.js
@@ -228,7 +228,7 @@ Quiet.args = {
 // ********* DOCS ONLY ********* //
 // Standard
 export const WithLabel = Template.bind({});
-WithLabel.tags = ["autodocs", "!dev"];
+WithLabel.tags = ["!dev"];
 WithLabel.args = {
 	showFieldLabel: true,
 	fieldLabelText: "Country",
@@ -239,7 +239,7 @@ WithLabel.parameters = {
 };
 
 export const Closed = Template.bind({});
-Closed.tags = ["autodocs", "!dev"];
+Closed.tags = ["!dev"];
 Closed.args = {
 	isOpen: false,
 };
@@ -248,7 +248,7 @@ Closed.parameters = {
 };
 
 export const Invalid = Template.bind({});
-Invalid.tags = ["autodocs", "!dev"];
+Invalid.tags = ["!dev"];
 Invalid.args = {
 	isInvalid: true,
 };
@@ -257,7 +257,7 @@ Invalid.parameters = {
 };
 
 export const Loading = Template.bind({});
-Loading.tags = ["autodocs", "!dev"];
+Loading.tags = ["!dev"];
 Loading.args = {
 	isLoading: true,
 };
@@ -266,7 +266,7 @@ Loading.parameters = {
 };
 
 export const Disabled = Template.bind({});
-Disabled.tags = ["autodocs", "!dev"];
+Disabled.tags = ["!dev"];
 Disabled.args = {
 	isDisabled: true,
 };
@@ -276,7 +276,7 @@ Disabled.parameters = {
 
 // Quiet
 export const QuietWithLabel = Template.bind({});
-QuietWithLabel.tags = ["autodocs", "!dev"];
+QuietWithLabel.tags = ["!dev"];
 QuietWithLabel.args = {
 	showFieldLabel: true,
 	fieldLabelText: "Country",
@@ -287,7 +287,7 @@ QuietWithLabel.parameters = {
 };
 
 export const QuietClosed = Template.bind({});
-QuietClosed.tags = ["autodocs", "!dev"];
+QuietClosed.tags = ["!dev"];
 QuietClosed.args = {
 	isQuiet: true,
 	isOpen: false,
@@ -297,7 +297,7 @@ QuietClosed.parameters = {
 };
 
 export const QuietInvalid = Template.bind({});
-QuietInvalid.tags = ["autodocs", "!dev"];
+QuietInvalid.tags = ["!dev"];
 QuietInvalid.args = {
 	isQuiet: true,
 	isInvalid: true,
@@ -307,7 +307,7 @@ QuietInvalid.parameters = {
 };
 
 export const QuietLoading = Template.bind({});
-QuietLoading.tags = ["autodocs", "!dev"];
+QuietLoading.tags = ["!dev"];
 QuietLoading.args = {
 	isQuiet: true,
 	isLoading: true,
@@ -317,7 +317,7 @@ QuietLoading.parameters = {
 };
 
 export const QuietDisabled = Template.bind({});
-QuietDisabled.tags = ["autodocs", "!dev"];
+QuietDisabled.tags = ["!dev"];
 QuietDisabled.args = {
 	isQuiet: true,
 	isDisabled: true,

--- a/components/combobox/stories/combobox.stories.js
+++ b/components/combobox/stories/combobox.stories.js
@@ -328,7 +328,7 @@ QuietDisabled.parameters = {
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = ComboboxGroup.bind({});
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/combobox/stories/combobox.stories.js
+++ b/components/combobox/stories/combobox.stories.js
@@ -142,6 +142,7 @@ export default {
 		},
 		componentVersion: version,
 	},
+	tags: ["!autodocs"],
 };
 
 const Variants = (args, context) => html`

--- a/components/contextualhelp/stories/contextualhelp.stories.js
+++ b/components/contextualhelp/stories/contextualhelp.stories.js
@@ -119,7 +119,7 @@ TopPopover.args = {
 
 // ********* DOCS ONLY ********* //
 export const HelpDefault = Template.bind({});
-HelpDefault.tags = ["autodocs", "!dev"];
+HelpDefault.tags = ["!dev"];
 HelpDefault.args = {
 	iconName: "Help",
 };
@@ -128,7 +128,7 @@ HelpDefault.parameters = {
 };
 
 export const HelpWithLink = Template.bind({});
-HelpWithLink.tags = ["autodocs", "!dev"];
+HelpWithLink.tags = ["!dev"];
 HelpWithLink.args = {
 	link: {
 		text: "Learn about permissions",
@@ -141,7 +141,7 @@ HelpWithLink.parameters = {
 };
 
 export const HelpTopPopover = Template.bind({});
-HelpTopPopover.tags = ["autodocs", "!dev"];
+HelpTopPopover.tags = ["!dev"];
 HelpTopPopover.args = {
 	popoverPlacement: "top",
 	customStyles: { "max-inline-size": "275px" },

--- a/components/contextualhelp/stories/contextualhelp.stories.js
+++ b/components/contextualhelp/stories/contextualhelp.stories.js
@@ -156,7 +156,7 @@ HelpTopPopover.parameters = {
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Default.bind({});
 WithForcedColors.args = Default.args;
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/contextualhelp/stories/contextualhelp.stories.js
+++ b/components/contextualhelp/stories/contextualhelp.stories.js
@@ -91,6 +91,7 @@ export default {
 		},
 		componentVersion: version,
 	},
+	tags: ["!autodocs"],
 	decorators: [
 		// Add padding for VRT so drop shadows are not cut off.
 		(story) => window.isChromatic() ? html`<div style="padding: 32px; min-height: 300px;">${story()}</div>` : story(),

--- a/components/datepicker/stories/datepicker.stories.js
+++ b/components/datepicker/stories/datepicker.stories.js
@@ -138,7 +138,7 @@ Range.parameters = {
 
 // ********* DOCS ONLY ********* //
 export const QuietRange = Template.bind({});
-QuietRange.tags = ["autodocs", "!dev"];
+QuietRange.tags = ["!dev"];
 QuietRange.args = {
 	lastDay: 3,
 	isRange: true,
@@ -155,7 +155,7 @@ QuietRange.parameters = {
 };
 
 export const Invalid = Template.bind({});
-Invalid.tags = ["autodocs", "!dev"];
+Invalid.tags = ["!dev"];
 Invalid.args = {
 	isInvalid: true,
 	isOpen: false,
@@ -170,7 +170,7 @@ Invalid.parameters = {
 };
 
 export const QuietInvalid = Template.bind({});
-QuietInvalid.tags = ["autodocs", "!dev"];
+QuietInvalid.tags = ["!dev"];
 QuietInvalid.args = {
 	isInvalid: true,
 	isQuiet: true,
@@ -187,7 +187,7 @@ QuietInvalid.parameters = {
 
 
 export const ReadOnly = Template.bind({});
-ReadOnly.tags = ["autodocs", "!dev"];
+ReadOnly.tags = ["!dev"];
 ReadOnly.args = {
 	readOnly: true,
 };
@@ -201,7 +201,7 @@ ReadOnly.parameters = {
 };
 
 export const Disabled = Template.bind({});
-Disabled.tags = ["autodocs", "!dev"];
+Disabled.tags = ["!dev"];
 Disabled.args = {
 	isDisabled: true,
 };
@@ -214,7 +214,7 @@ Disabled.parameters = {
 	}
 };
 export const QuietDisabled = Template.bind({});
-QuietDisabled.tags = ["autodocs", "!dev"];
+QuietDisabled.tags = ["!dev"];
 QuietDisabled.args = {
 	isDisabled: true,
 	isQuiet: true,

--- a/components/datepicker/stories/datepicker.stories.js
+++ b/components/datepicker/stories/datepicker.stories.js
@@ -107,6 +107,7 @@ export default {
 		},
 		componentVersion: version,
 	},
+	tags: ["!autodocs"],
 	decorators: [
 		// Add padding for VRT so drop shadows are not cut off.
 		(story) => window.isChromatic() ? html`<div style="padding: 32px; min-height: 450px;">${story()}</div>` : story(),

--- a/components/datepicker/stories/datepicker.stories.js
+++ b/components/datepicker/stories/datepicker.stories.js
@@ -230,7 +230,7 @@ QuietDisabled.parameters = {
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Template.bind({});
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/dial/stories/dial.stories.js
+++ b/components/dial/stories/dial.stories.js
@@ -66,7 +66,7 @@ Default.args = {};
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Default.bind({});
 WithForcedColors.args = Default.args;
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/dialog/stories/dialog.stories.js
+++ b/components/dialog/stories/dialog.stories.js
@@ -1,5 +1,5 @@
 import { withUnderlayWrapper } from "@spectrum-css/preview/decorators";
-import modes, {disableDefaultModes, mobile } from "@spectrum-css/preview/modes";
+import modes, { disableDefaultModes, mobile } from "@spectrum-css/preview/modes";
 import { isOpen } from "@spectrum-css/preview/types";
 import { Template as Typography } from "@spectrum-css/typography/stories/template.js";
 import { version } from "../package.json";
@@ -114,7 +114,7 @@ Default.parameters = {
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Default.bind({});
 WithForcedColors.args = Default.args;
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/divider/stories/divider.stories.js
+++ b/components/divider/stories/divider.stories.js
@@ -55,7 +55,7 @@ Default.args = {};
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Template.bind({});
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/dropindicator/stories/dropindicator.stories.js
+++ b/components/dropindicator/stories/dropindicator.stories.js
@@ -51,7 +51,7 @@ Default.args = {};
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Template.bind({});
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/dropzone/stories/dropzone.stories.js
+++ b/components/dropzone/stories/dropzone.stories.js
@@ -63,7 +63,7 @@ Default.args = {
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Default.bind({});
 WithForcedColors.args = Default.args;
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/fieldgroup/stories/fieldgroup.stories.js
+++ b/components/fieldgroup/stories/fieldgroup.stories.js
@@ -111,7 +111,7 @@ WithForcedColors.parameters = {
 
 // ********* DOCS ONLY ********* //
 export const VerticalRadio = Template.bind({});
-VerticalRadio.tags = ["autodocs", "!dev"];
+VerticalRadio.tags = ["!dev"];
 VerticalRadio.args = {
 	layout: "vertical",
 	inputType: "radio",
@@ -121,7 +121,7 @@ VerticalRadio.parameters = {
 };
 
 export const VerticalCheckbox = Template.bind({});
-VerticalCheckbox.tags = ["autodocs", "!dev"];
+VerticalCheckbox.tags = ["!dev"];
 VerticalCheckbox.args = {
 	layout: "vertical",
 	inputType: "checkbox",
@@ -131,7 +131,7 @@ VerticalCheckbox.parameters = {
 };
 
 export const HorizontalRadio = Template.bind({});
-HorizontalRadio.tags = ["autodocs", "!dev"];
+HorizontalRadio.tags = ["!dev"];
 HorizontalRadio.args = {
 	layout: "horizontal",
 	inputType: "radio",
@@ -141,7 +141,7 @@ HorizontalRadio.parameters = {
 };
 
 export const HorizontalCheckbox = Template.bind({});
-HorizontalCheckbox.tags = ["autodocs", "!dev"];
+HorizontalCheckbox.tags = ["!dev"];
 HorizontalCheckbox.args = {
 	layout: "horizontal",
 	inputType: "checkbox",
@@ -151,7 +151,7 @@ HorizontalCheckbox.parameters = {
 };
 
 export const InvalidRadio = Template.bind({});
-InvalidRadio.tags = ["autodocs", "!dev"];
+InvalidRadio.tags = ["!dev"];
 InvalidRadio.args = {
 	layout: "horizontal",
 	inputType: "radio",
@@ -162,7 +162,7 @@ InvalidRadio.parameters = {
 };
 
 export const InvalidCheckbox = Template.bind({});
-InvalidCheckbox.tags = ["autodocs", "!dev"];
+InvalidCheckbox.tags = ["!dev"];
 InvalidCheckbox.args = {
 	layout: "horizontal",
 	inputType: "checkbox",
@@ -178,7 +178,7 @@ InvalidCheckbox.parameters = {
 * If required, the field group must either contain a "(required)" label or an asterisk. If an asterisk is used, help text must explain what the asterisk means.
  */
 export const Required = Template.bind({});
-Required.tags = ["autodocs", "!dev"];
+Required.tags = ["!dev"];
 Required.args = {
 	inputType: "radio",
 	fieldLabel: "Radio group label (required)"
@@ -188,7 +188,7 @@ Required.parameters = {
 };
 
 export const RequiredAsterisk = Template.bind({});
-RequiredAsterisk.tags = ["autodocs", "!dev"];
+RequiredAsterisk.tags = ["!dev"];
 RequiredAsterisk.args = {
 	fieldLabel: "Checkbox group label",
 	inputType: "checkbox",
@@ -202,7 +202,7 @@ RequiredAsterisk.parameters = {
  * Optional field groups can be denoted with text added to the end of the label "(optional)" or have no indication at all.
  */
 export const Optional = Template.bind({});
-Optional.tags = ["autodocs", "!dev"];
+Optional.tags = ["!dev"];
 Optional.args = {
 	fieldLabel: "Checkbox group label (optional)",
 	helpText: "",
@@ -216,7 +216,7 @@ Optional.parameters = {
  * The field group label has two layout options: the label can be top aligned with `spectrum-FieldGroup spectrum-FieldGroup--toplabel`, or side aligned with `spectrum-FieldGroup spectrum-FieldGroup--sidelabel`.
  */
 export const VerticalSideLabelRadio = Template.bind({});
-VerticalSideLabelRadio.tags = ["autodocs", "!dev"];
+VerticalSideLabelRadio.tags = ["!dev"];
 VerticalSideLabelRadio.args = {
 	labelPosition: "side",
 	inputType: "radio",
@@ -227,7 +227,7 @@ VerticalSideLabelRadio.parameters = {
 };
 
 export const HorizontalSideLabelRadio = Template.bind({});
-HorizontalSideLabelRadio.tags = ["autodocs", "!dev"];
+HorizontalSideLabelRadio.tags = ["!dev"];
 HorizontalSideLabelRadio.args = {
 	labelPosition: "side",
 	inputType: "radio",
@@ -238,7 +238,7 @@ HorizontalSideLabelRadio.parameters = {
 };
 
 export const VerticalSideLabelCheckbox = Template.bind({});
-VerticalSideLabelCheckbox.tags = ["autodocs", "!dev"];
+VerticalSideLabelCheckbox.tags = ["!dev"];
 VerticalSideLabelCheckbox.args = {
 	labelPosition: "side",
 	inputType: "checkbox",
@@ -249,7 +249,7 @@ VerticalSideLabelCheckbox.parameters = {
 };
 
 export const HorizontalSideLabelCheckbox = Template.bind({});
-HorizontalSideLabelCheckbox.tags = ["autodocs", "!dev"];
+HorizontalSideLabelCheckbox.tags = ["!dev"];
 HorizontalSideLabelCheckbox.args = {
 	labelPosition: "side",
 	inputType: "checkbox",
@@ -263,7 +263,7 @@ HorizontalSideLabelCheckbox.parameters = {
  * A group of read-only checkboxes that have been checked. In U.S. English, use commas to delineate items within read-only checkbox groups. In other languages, use the locale-specific formatting.
  */
 export const ReadOnly = Template.bind({});
-ReadOnly.tags = ["autodocs", "!dev"];
+ReadOnly.tags = ["!dev"];
 ReadOnly.args = {
 	isReadOnly: true,
 	inputType: "checkbox",

--- a/components/fieldgroup/stories/fieldgroup.stories.js
+++ b/components/fieldgroup/stories/fieldgroup.stories.js
@@ -100,7 +100,7 @@ Default.args = {
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Default.bind({});
 WithForcedColors.args = Default.args;
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/fieldgroup/stories/fieldgroup.stories.js
+++ b/components/fieldgroup/stories/fieldgroup.stories.js
@@ -72,6 +72,7 @@ export default {
 		},
 		componentVersion: version,
 	},
+	tags: ["!autodocs"],
 };
 
 export const Default = FieldGroupSet.bind({});

--- a/components/fieldlabel/stories/fieldlabel.stories.js
+++ b/components/fieldlabel/stories/fieldlabel.stories.js
@@ -77,7 +77,7 @@ Default.args = {
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Default.bind({});
 WithForcedColors.args = Default.args;
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/fieldlabel/stories/form.stories.js
+++ b/components/fieldlabel/stories/form.stories.js
@@ -67,7 +67,7 @@ Default.args = {
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Default.bind({});
 WithForcedColors.args = Default.args;
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/floatingactionbutton/stories/floatingactionbutton.stories.js
+++ b/components/floatingactionbutton/stories/floatingactionbutton.stories.js
@@ -51,7 +51,7 @@ Secondary.args = {
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Template.bind({});
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/helptext/stories/helptext.stories.js
+++ b/components/helptext/stories/helptext.stories.js
@@ -81,7 +81,7 @@ Default.args = {};
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Default.bind({});
 WithForcedColors.args = Default.args;
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/icon/stories/icon.stories.js
+++ b/components/icon/stories/icon.stories.js
@@ -115,7 +115,7 @@ Default.args = {};
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Variants.bind({});
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/icon/stories/icon.stories.js
+++ b/components/icon/stories/icon.stories.js
@@ -338,7 +338,7 @@ const UIDefaultTemplate = (args) => html`
  * A sampling of multiple Workflow icons.
  */
 export const WorkflowDefault = WorkflowDefaultTemplate.bind({});
-WorkflowDefault.tags = ["autodocs", "!dev"];
+WorkflowDefault.tags = ["!dev"];
 WorkflowDefault.parameters = {
 	chromatic: { disableSnapshot: true },
 };
@@ -347,7 +347,7 @@ WorkflowDefault.parameters = {
  * An example of a Workflow icon displayed at all sizes, from small to extra-large.
  */
 export const WorkflowSizing = WorkflowSizingTemplate.bind({});
-WorkflowSizing.tags = ["autodocs", "!dev"];
+WorkflowSizing.tags = ["!dev"];
 WorkflowSizing.args = {
 	setName: "workflow",
 	iconName: "Asset",
@@ -361,7 +361,7 @@ WorkflowSizing.parameters = {
  */
 export const UIDefault = UIDefaultTemplate.bind({});
 UIDefault.storyName = "UI Default";
-UIDefault.tags = ["autodocs", "!dev"];
+UIDefault.tags = ["!dev"];
 UIDefault.parameters = {
 	chromatic: { disableSnapshot: true },
 };
@@ -371,7 +371,7 @@ UIDefault.parameters = {
  */
 export const UIArrows = UIArrowsTemplate.bind({});
 UIArrows.storyName = "UI Arrows";
-UIArrows.tags = ["autodocs", "!dev"];
+UIArrows.tags = ["!dev"];
 UIArrows.parameters = {
 	chromatic: { disableSnapshot: true },
 };

--- a/components/icon/stories/icon.stories.js
+++ b/components/icon/stories/icon.stories.js
@@ -99,6 +99,7 @@ export default {
 			modes: mobile,
 		},
 	},
+	tags: ["!autodocs"],
 };
 
 const Variants = (args, context) => {

--- a/components/illustratedmessage/stories/illustratedmessage.stories.js
+++ b/components/illustratedmessage/stories/illustratedmessage.stories.js
@@ -71,7 +71,7 @@ AccentColor.args = {
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = IllustratedMessageGroup.bind({});
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/illustratedmessage/stories/illustratedmessage.stories.js
+++ b/components/illustratedmessage/stories/illustratedmessage.stories.js
@@ -58,7 +58,7 @@ Default.args = {
  * To use the accent color, the class `.spectrum-IllustratedMessage-accent` can be added to element(s) within the illustration SVG.
  */
 export const AccentColor = Template.bind({});
-AccentColor.tags = ["autodocs", "!dev"];
+AccentColor.tags = ["!dev"];
 AccentColor.args = {
 	heading: "Drag and drop your file",
 	description: [

--- a/components/infieldbutton/stories/infieldbutton.stories.js
+++ b/components/infieldbutton/stories/infieldbutton.stories.js
@@ -101,7 +101,7 @@ Disabled.args = {
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Template.bind({});
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/infieldbutton/stories/infieldbutton.stories.js
+++ b/components/infieldbutton/stories/infieldbutton.stories.js
@@ -72,7 +72,7 @@ export const Default = Template.bind({});
 Default.args = {};
 
 export const Start = Template.bind({});
-Start.tags = ["autodocs", "!dev"];
+Start.tags = ["!dev"];
 Start.args = {
 	position: "left"
 };
@@ -81,7 +81,7 @@ Start.parameters = {
 };
 
 export const End = Template.bind({});
-End.tags = ["autodocs", "!dev"];
+End.tags = ["!dev"];
 End.args = {
 	position: "right"
 };
@@ -110,7 +110,7 @@ WithForcedColors.parameters = {
 };
 
 export const Stacked = Template.bind({});
-Stacked.tags = ["autodocs", "!dev"];
+Stacked.tags = ["!dev"];
 Stacked.args = {
 	isStacked: true,
 };

--- a/components/inlinealert/stories/inlinealert.stories.js
+++ b/components/inlinealert/stories/inlinealert.stories.js
@@ -94,7 +94,7 @@ Default.args = {};
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Variants.bind({});
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/link/stories/link.stories.js
+++ b/components/link/stories/link.stories.js
@@ -78,7 +78,7 @@ Default.args = {
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Default.bind({});
 WithForcedColors.args = Default.args;
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/logicbutton/stories/logicbutton.stories.js
+++ b/components/logicbutton/stories/logicbutton.stories.js
@@ -54,7 +54,7 @@ Disabled.args = {
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Template.bind({});
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/menu/stories/menu.stories.js
+++ b/components/menu/stories/menu.stories.js
@@ -462,7 +462,7 @@ WithDividers.args = {
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = MenuItemWithVariants.bind({});
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/menu/stories/menu.stories.js
+++ b/components/menu/stories/menu.stories.js
@@ -443,7 +443,7 @@ MenuItem.args = {
 // story used in Picker component
 export const WithDividers = Template.bind({});
 WithDividers.storyName = "Standard with dividers";
-WithDividers.tags = ["autodocs", "!dev"];
+WithDividers.tags = ["!dev"];
 WithDividers.parameters = {
 	chromatic: { disableSnapshot: true },
 };

--- a/components/miller/stories/miller.stories.js
+++ b/components/miller/stories/miller.stories.js
@@ -147,7 +147,7 @@ FilesSelectable.args = {
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Template.bind({});
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/modal/stories/modal.stories.js
+++ b/components/modal/stories/modal.stories.js
@@ -52,7 +52,7 @@ Default.args = {};
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Default.bind({});
 WithForcedColors.args = Default.args;
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/opacitycheckerboard/stories/opacitycheckerboard.stories.js
+++ b/components/opacitycheckerboard/stories/opacitycheckerboard.stories.js
@@ -59,7 +59,7 @@ CheckerboardPosition.parameters = {
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Template.bind({});
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/pagination/stories/pagination.stories.js
+++ b/components/pagination/stories/pagination.stories.js
@@ -63,7 +63,7 @@ Default.args = {};
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = PaginationGroup.bind({});
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/picker/stories/picker.stories.js
+++ b/components/picker/stories/picker.stories.js
@@ -241,7 +241,7 @@ Open.args = {
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Variants.bind({});
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/pickerbutton/stories/pickerbutton.stories.js
+++ b/components/pickerbutton/stories/pickerbutton.stories.js
@@ -119,7 +119,7 @@ WithLabel.args = {
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Template.bind({});
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",
@@ -128,13 +128,13 @@ WithForcedColors.parameters = {
 };
 
 export const Disabled = Template.bind({});
-Disabled.tags = ["!autodocs", "!dev", "test"];
+Disabled.tags = ["!autodocs", "!dev"];
 Disabled.args = {
 	isDisabled: true
 };
 
 export const Quiet = Template.bind({});
-Quiet.tags = ["!autodocs", "!dev", "test"];
+Quiet.tags = ["!autodocs", "!dev"];
 Quiet.args = {
 	isQuiet: true
 };

--- a/components/popover/stories/popover.stories.js
+++ b/components/popover/stories/popover.stories.js
@@ -192,7 +192,7 @@ Nested.args = {
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Default.bind({});
 WithForcedColors.args = Default.args;
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/progressbar/stories/meter.stories.js
+++ b/components/progressbar/stories/meter.stories.js
@@ -38,7 +38,7 @@ Default.args = {
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Default.bind({});
 WithForcedColors.args = Default.args;
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/progressbar/stories/progressbar.stories.js
+++ b/components/progressbar/stories/progressbar.stories.js
@@ -78,7 +78,7 @@ Default.args = {
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Default.bind({});
 WithForcedColors.args = Default.args;
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",
@@ -87,7 +87,7 @@ WithForcedColors.parameters = {
 };
 
 export const StaticWhite = Default.bind({});
-StaticWhite.tags = ["!autodocs", "!dev", "test"];
+StaticWhite.tags = ["!autodocs", "!dev"];
 StaticWhite.args = {
 	staticColor: "white",
 	label: "Loading your fonts, images, and icons",

--- a/components/progresscircle/stories/progresscircle.stories.js
+++ b/components/progresscircle/stories/progresscircle.stories.js
@@ -68,7 +68,7 @@ Default.args = {};
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Default.bind({});
 WithForcedColors.args = Default.args;
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",
@@ -77,7 +77,7 @@ WithForcedColors.parameters = {
 };
 
 export const StaticWhite = Default.bind({});
-StaticWhite.tags = ["!autodocs", "!dev", "test"];
+StaticWhite.tags = ["!autodocs", "!dev"];
 StaticWhite.args = {
 	staticColor: "white",
 };

--- a/components/radio/stories/radio.stories.js
+++ b/components/radio/stories/radio.stories.js
@@ -129,7 +129,7 @@ Default.args = {};
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Variants.bind({});
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/rating/stories/rating.stories.js
+++ b/components/rating/stories/rating.stories.js
@@ -74,7 +74,7 @@ Default.args = {};
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Template.bind({});
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/search/stories/search.stories.js
+++ b/components/search/stories/search.stories.js
@@ -60,7 +60,7 @@ Default.args = {};
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Template.bind({});
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/sidenav/stories/sidenav.stories.js
+++ b/components/sidenav/stories/sidenav.stories.js
@@ -66,7 +66,7 @@ Default.args = {};
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Template.bind({});
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/slider/stories/slider.stories.js
+++ b/components/slider/stories/slider.stories.js
@@ -186,7 +186,7 @@ WithFocus.args = {
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = WithFocus.bind({});
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/splitview/stories/splitview.stories.js
+++ b/components/splitview/stories/splitview.stories.js
@@ -166,7 +166,7 @@ VerticalCollapsedBottom.args = {
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = HorizontallyFocused.bind({});
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/statuslight/stories/statuslight.stories.js
+++ b/components/statuslight/stories/statuslight.stories.js
@@ -92,7 +92,7 @@ Default.args = {};
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Variants.bind({});
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/steplist/stories/steplist.stories.js
+++ b/components/steplist/stories/steplist.stories.js
@@ -79,7 +79,7 @@ Default.args = {};
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Template.bind({});
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/stepper/stories/stepper.stories.js
+++ b/components/stepper/stories/stepper.stories.js
@@ -194,7 +194,7 @@ Default.args = {};
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Variants.bind({});
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/swatch/stories/swatch.stories.js
+++ b/components/swatch/stories/swatch.stories.js
@@ -68,7 +68,7 @@ Default.args = {};
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = States.bind({});
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/swatchgroup/stories/swatchgroup.stories.js
+++ b/components/swatchgroup/stories/swatchgroup.stories.js
@@ -73,7 +73,7 @@ Default.args = {};
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Template.bind({});
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/switch/stories/switch.stories.js
+++ b/components/switch/stories/switch.stories.js
@@ -72,7 +72,7 @@ Default.args = {};
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Template.bind({});
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/table/stories/table.stories.js
+++ b/components/table/stories/table.stories.js
@@ -129,7 +129,7 @@ Default.args = {};
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Template.bind({});
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/tabs/stories/tabs.stories.js
+++ b/components/tabs/stories/tabs.stories.js
@@ -163,7 +163,7 @@ Default.args = {};
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Variants.bind({});
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/tag/stories/tag.stories.js
+++ b/components/tag/stories/tag.stories.js
@@ -123,7 +123,7 @@ Default.args = {};
 // ********* VRT ONLY ********* //
 // @todo combine variants into one snapshot
 export const WithForcedColors = Template.bind({});
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/taggroup/stories/taggroup.stories.js
+++ b/components/taggroup/stories/taggroup.stories.js
@@ -115,7 +115,7 @@ OverflowItems.args = {
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Default.bind({});
 WithForcedColors.args = Default.args;
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/taggroup/stories/taggroup.stories.js
+++ b/components/taggroup/stories/taggroup.stories.js
@@ -77,7 +77,7 @@ Default.args = {
  * When horizontal space is limited in a tag group, the individual tags wrap to form another line.
  */
 export const OverflowItems = Template.bind({});
-OverflowItems.tags = ["autodocs", "!dev"];
+OverflowItems.tags = ["!dev"];
 OverflowItems.parameters = {
 	chromatic: {
 		disableSnapshot: true,

--- a/components/textfield/stories/textfield.stories.js
+++ b/components/textfield/stories/textfield.stories.js
@@ -198,7 +198,7 @@ TextArea.args = {
 // @todo should this show text field and text area in the same snapshot?
 export const WithForcedColors = Default.bind({});
 WithForcedColors.args = Default.args;
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/textfield/stories/textfield.stories.js
+++ b/components/textfield/stories/textfield.stories.js
@@ -186,7 +186,7 @@ Default.args = {
 
 // ********* DOCS ONLY ********* //
 export const TextArea = Template.bind({});
-TextArea.tags = ["autodocs", "!dev"];
+TextArea.tags = ["!dev"];
 TextArea.args = {
 	labelText: "Username",
 	multiline: true,

--- a/components/thumbnail/stories/thumbnail.stories.js
+++ b/components/thumbnail/stories/thumbnail.stories.js
@@ -142,7 +142,7 @@ WithBackground.args = {
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Template.bind({});
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/toast/stories/toast.stories.js
+++ b/components/toast/stories/toast.stories.js
@@ -74,7 +74,7 @@ Positive.args = {
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Default.bind({});
 WithForcedColors.args = Default.args;
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/tooltip/stories/tooltip.stories.js
+++ b/components/tooltip/stories/tooltip.stories.js
@@ -130,7 +130,7 @@ Default.args = {};
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Default.bind({});
 WithForcedColors.args = Default.args;
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/tray/stories/tray.stories.js
+++ b/components/tray/stories/tray.stories.js
@@ -60,7 +60,7 @@ Default.parameters = {
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Default.bind({});
 WithForcedColors.args = Default.args;
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/treeview/stories/treeview.stories.js
+++ b/components/treeview/stories/treeview.stories.js
@@ -358,7 +358,7 @@ Flat.parameters = {
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Default.bind({});
 WithForcedColors.args = Default.args;
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/treeview/stories/treeview.stories.js
+++ b/components/treeview/stories/treeview.stories.js
@@ -173,7 +173,7 @@ FoldersAndFiles.args = {
 		},
 	],
 };
-FoldersAndFiles.tags = ["autodocs", "!dev"];
+FoldersAndFiles.tags = ["!dev"];
 FoldersAndFiles.parameters = {
 	chromatic: { disableAllSnapshots: true },
 };
@@ -215,7 +215,7 @@ Thumbnails.args = {
 		},
 	],
 };
-Thumbnails.tags = ["autodocs", "!dev"];
+Thumbnails.tags = ["!dev"];
 Thumbnails.parameters = {
 	chromatic: { disableAllSnapshots: true },
 };
@@ -260,7 +260,7 @@ WithSections.args = {
 		},
 	],
 };
-WithSections.tags = ["autodocs", "!dev"];
+WithSections.tags = ["!dev"];
 WithSections.parameters = {
 	chromatic: { disableAllSnapshots: true },
 };
@@ -281,7 +281,7 @@ WithDropTarget.args = {
 		},
 	],
 };
-WithDropTarget.tags = ["autodocs", "!dev"];
+WithDropTarget.tags = ["!dev"];
 WithDropTarget.parameters = {
 	chromatic: { disableAllSnapshots: true },
 };
@@ -350,7 +350,7 @@ Flat.args = {
 		},
 	],
 };
-Flat.tags = ["autodocs", "!dev"];
+Flat.tags = ["!dev"];
 Flat.parameters = {
 	chromatic: { disableAllSnapshots: true },
 };

--- a/components/typography/stories/typography.stories.js
+++ b/components/typography/stories/typography.stories.js
@@ -99,7 +99,7 @@ Default.args = {
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Default.bind({});
 WithForcedColors.args = Default.args;
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/components/typography/stories/typography.stories.js
+++ b/components/typography/stories/typography.stories.js
@@ -112,7 +112,7 @@ Heading.args = {
 	semantics: "heading",
 	content: ["Aliquet Mauris Eu"],
 };
-Heading.tags = ["autodocs", "!dev"];
+Heading.tags = ["!dev"];
 Heading.parameters = {
 	chromatic: { disableSnapshot: true },
 };
@@ -131,7 +131,7 @@ Body.args = {
 		"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit. Sed finibus dapibus diam et sollicitudin. Phasellus in ipsum nec ante elementum congue eget in leo. Morbi eleifend justo non rutrum venenatis. Fusce cursus et lectus eu facilisis. Ut laoreet felis in magna dignissim feugiat.",
 	],
 };
-Body.tags = ["autodocs", "!dev"];
+Body.tags = ["!dev"];
 Body.parameters = {
 	chromatic: { disableSnapshot: true },
 };
@@ -152,7 +152,7 @@ Detail.args = {
 	semantics: "detail",
 	content: ["Aliquet Mauris Eu"],
 };
-Detail.tags = ["autodocs", "!dev"];
+Detail.tags = ["!dev"];
 
 export const Code = (args, context) => Sizes({ Template, ...args }, context);
 Code.argTypes = {
@@ -166,4 +166,4 @@ Code.args = {
 	semantics: "code",
 	content: ["console.log('Hello World!');"],
 };
-Code.tags = ["autodocs", "!dev"];
+Code.tags = ["!dev"];

--- a/components/underlay/stories/underlay.stories.js
+++ b/components/underlay/stories/underlay.stories.js
@@ -33,7 +33,7 @@ export default {
 };
 
 export const Default = Template.bind({});
-Default.tags = ["autodocs", "!test"];
+Default.tags = ["!test"];
 Default.args = {
 	isOpen: true,
 	content: [

--- a/components/underlay/stories/underlay.stories.js
+++ b/components/underlay/stories/underlay.stories.js
@@ -33,7 +33,6 @@ export default {
 };
 
 export const Default = Template.bind({});
-Default.tags = ["!test"];
 Default.args = {
 	isOpen: true,
 	content: [

--- a/components/well/stories/well.stories.js
+++ b/components/well/stories/well.stories.js
@@ -35,7 +35,7 @@ Default.args = {
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Default.bind({});
 WithForcedColors.args = Default.args;
-WithForcedColors.tags = ["!autodocs", "!dev", "test"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",

--- a/generator/templates/stories/{{ folderName }}.stories.js.hbs
+++ b/generator/templates/stories/{{ folderName }}.stories.js.hbs
@@ -44,7 +44,7 @@ Default.args = {};
 // ********* VRT ONLY ********* //
 export const WithForcedColors = Default.bind({});
 WithForcedColors.args = Default.args;
-WithForcedColors.tags = ["test", "!autodocs", "!dev"];
+WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",


### PR DESCRIPTION
## Description

Updates the way that autodocs is configured, as documented in the [Storybook migration guide
for 8.0.x to 8.1.x](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#mainjs-docsautodocs-is-deprecated). The `docs.autodocs` setting in `main.js` was deprecated and is being removed in Storybook 9.0.

For the stories using custom MDX files, it was necessary to add `!autodocs` to their default story. Otherwise Storybook throws a bunch of errors like the following and would not load:
> "You created a component docs page for 'Components/*', but also tagged the CSF file with 'autodocs'. This is probably a mistake."

Includes an update to the "Contributing" guide in Storybook to clarify how tags are used on stories.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [x] The "Docs" pages are still appearing for various components. Including those with autodocs and those with custom MDX files. @marissahuysentruyt (components with MDX files that were checked: actionbar, accordion, asset, assetcard @rise-erpelding : badge, calendar, card, coachmark, coloarea, colorhandle, colorloupe, colorslider, colorwheel, combobox, contextualhelp, datepicker, fieldgroup (which is broken anyway but not because of this work), and icon)
- [x] Stories with `!autodocs` continue to not appear (for example, With Forced Colors stories). @marissahuysentruyt (checked buttongroup, tabs, switch, picker) @rise-erpelding checked actionbutton, asset, badge, button, clearbutton, datepicker, icon, popover, splitview
- [x] Proofread tags section of Storybook "Contributing" docs

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
