### PR TITLE
chore: husky script changes on install

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,2 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
 
 yarn commitlint --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,2 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
 
 yarn lint-staged --allow-empty --config lint-staged.config.js


### PR DESCRIPTION
## Description

When running a clean install, husky is updating our  commit message and pre commit scripts to remove the bash headers.

You can recreate this change with the following steps:

```
git clean -dfX
yarn install
```

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [ ] Validate no regressions to the pre-commit linting by attempting to commit a non-conventional commit message (i.e., `Update all the things.`).  Expect the commit to fail with a warning.
- [ ] Expect linting to run before a commit is added. Do this by checking that linting ran in the above task before the commit failed on the message.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] ✨ This pull request is ready to merge. ✨
