### PR TITLE
chore(storybook): organize icon loader into tooling

### DIFF
--- a/.storybook/decorators/icon-sprites.js
+++ b/.storybook/decorators/icon-sprites.js
@@ -1,0 +1,36 @@
+// Used in the icon sprite decorator to inject the sprite sheets into the document
+import workflowSprite from "@adobe/spectrum-css-workflow-icons/dist/spectrum-icons.svg?raw";
+import uiSprite from "@spectrum-css/ui-icons/dist/spectrum-css-icons.svg?raw";
+import { makeDecorator, useEffect } from "@storybook/preview-api";
+
+/**
+ * @type import('@storybook/csf').DecoratorFunction<import('@storybook/web-components').WebComponentsFramework>
+ **/
+export const withIconSpriteSheet = makeDecorator({
+	name: "withIconSpriteSheet",
+	parameterName: "spritesheet",
+	wrapper: (StoryFn, context) => {
+		const {
+            loaded = {},
+		} = context;
+
+        // Load the icons into the window object
+        if (loaded.icons) window.icons = loaded.icons;
+
+		useEffect(() => {
+            // Inject the sprite sheets into the document
+            let sprite = document.getElementById("spritesheets");
+            if (!sprite) {
+                sprite = document.createElement("div");
+                sprite.id = "spritesheets";
+                sprite.innerHTML = workflowSprite + uiSprite;
+                document.body.appendChild(sprite);
+            }
+            else {
+                sprite.innerHTML = workflowSprite + uiSprite;
+            }
+		}, []);
+
+        return StoryFn(context);
+	},
+});

--- a/.storybook/decorators/index.js
+++ b/.storybook/decorators/index.js
@@ -1,5 +1,19 @@
+/*!
+ * Copyright 2024 Adobe. All rights reserved.
+ *
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at <http://www.apache.org/licenses/LICENSE-2.0>
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
 export { withArgEvents } from "./arg-events.js";
 export { withContextWrapper } from "./context.js";
+export { withIconSpriteSheet } from "./icon-sprites.js";
 export { withLanguageWrapper } from "./language.js";
 export { withReducedMotionWrapper } from "./reduce-motion.js";
 export { withTestingPreviewWrapper } from "./testing-preview.js";

--- a/.storybook/loaders/icon-loader.js
+++ b/.storybook/loaders/icon-loader.js
@@ -1,0 +1,40 @@
+export const IconLoader = async () => ({
+	icons: {
+		workflow: {
+			medium: await import.meta.glob(
+				"/node_modules/@adobe/spectrum-css-workflow-icons/dist/18/*.svg",
+				{
+					eager: true,
+					query: "?raw",
+					import: "default",
+				}
+			),
+			large: await import.meta.glob(
+				"/node_modules/@adobe/spectrum-css-workflow-icons/dist/24/*.svg",
+				{
+					eager: true,
+					query: "?raw",
+					import: "default",
+				}
+			),
+		},
+		ui: {
+			medium: await import.meta.glob(
+				"/node_modules/@spectrum-css/ui-icons/dist/medium/*.svg",
+				{
+					eager: true,
+					query: "?raw",
+					import: "default",
+				}
+			),
+			large: await import.meta.glob(
+				"/node_modules/@spectrum-css/ui-icons/dist/large/*.svg",
+				{
+					eager: true,
+					query: "?raw",
+					import: "default",
+				}
+			),
+		},
+	},
+});

--- a/.storybook/loaders/index.js
+++ b/.storybook/loaders/index.js
@@ -1,49 +1,22 @@
+/*!
+ * Copyright 2024 Adobe. All rights reserved.
+ *
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at <http://www.apache.org/licenses/LICENSE-2.0>
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
 
 // Use the document.fonts API to check if fonts have loaded
 export const FontLoader = async () => ({
 	fonts: document.fonts ? await document.fonts.ready : true,
 });
 
-export const IconLoader = async () => ({
-	icons: {
-		workflow: {
-			medium: await import.meta.glob(
-				"/node_modules/@adobe/spectrum-css-workflow-icons/dist/18/*.svg",
-				{
-					eager: true,
-					query: "?raw",
-					import: "default",
-				}
-			),
-			large: await import.meta.glob(
-				"/node_modules/@adobe/spectrum-css-workflow-icons/dist/24/*.svg",
-				{
-					eager: true,
-					query: "?raw",
-					import: "default",
-				}
-			),
-		},
-		ui: {
-			medium: await import.meta.glob(
-				"/node_modules/@spectrum-css/ui-icons/dist/medium/*.svg",
-				{
-					eager: true,
-					query: "?raw",
-					import: "default",
-				}
-			),
-			large: await import.meta.glob(
-				"/node_modules/@spectrum-css/ui-icons/dist/large/*.svg",
-				{
-					eager: true,
-					query: "?raw",
-					import: "default",
-				}
-			),
-		},
-	},
-});
+export { IconLoader } from "./icon-loader.js";
 
 export const TokenLoader = async () => ({
 	tokens: {

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,11 +1,9 @@
-import workflowSprite from "@adobe/spectrum-css-workflow-icons/dist/spectrum-icons.svg?raw";
-import uiSprite from "@spectrum-css/ui-icons/dist/spectrum-css-icons.svg?raw";
-
 import { setConsoleOptions } from "@storybook/addon-console";
 import {
 	withActions,
 	withArgEvents,
 	withContextWrapper,
+	withIconSpriteSheet,
 	withLanguageWrapper,
 	withReducedMotionWrapper,
 	withTestingPreviewWrapper,
@@ -130,24 +128,7 @@ export const decorators = [
 	withTestingPreviewWrapper,
 	withArgEvents,
 	withActions,
-	// Attach the icons to the window object for use in the stories
-	(StoryFn, context) => {
-		if (context?.loaded?.icons) window.icons = context.loaded.icons;
-
-		// Inject the sprite sheets into the document
-		let sprite = document.getElementById("spritesheets");
-		if (!sprite) {
-			sprite = document.createElement("div");
-			sprite.id = "spritesheets";
-			sprite.innerHTML = workflowSprite + uiSprite;
-			document.body.appendChild(sprite);
-		}
-		else {
-			sprite.innerHTML = workflowSprite + uiSprite;
-		}
-
-		return StoryFn(context);
-	},
+	withIconSpriteSheet,
 ];
 
 export default {


### PR DESCRIPTION
## Description

Icon sprite loading was hardcoded into the `.storybook/preview.js` file rather than imported as part of the decorators and loaders infrastructure. This cleans that up.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author. No change to how the decorator or loaders work, just a shift in how they're imported.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] ✨ This pull request is ready to merge. ✨
