### PR TITLE
chore(build): add additional metadata for mapping to improve map paths

### DIFF
--- a/tasks/component-builder.js
+++ b/tasks/component-builder.js
@@ -213,7 +213,11 @@ async function processCSS(content, input, output, {
 		configPath // This is the path to the directory where the postcss.config.js lives
 	);
 
-	const result = await postcss(plugins).process(content, options);
+	const result = await postcss(plugins).process(content, {
+		from: input,
+		to: output,
+		...options
+	});
 
 	if (result.error) return Promise.reject(result.error);
 


### PR DESCRIPTION
## Description

After adding `@spectrum-css/typography` imports to Storybook, we started seeing:

```
Error: An error occurred while trying to read the map file at components/typography/index.css.map
Error: ENOENT: no such file or directory, open '/Users/carobert/Projects/spectrum/spectrum-css/components/typography/dist/components/typography/index.css.map'
```

in the console which reflects an invalid path being used in the sourcemap files generated by the component-builder. This fix improves the path generated and removes the error messaging from our Storybook build.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

1. Do a clean local build (storybook symlinks to local dist); `yarn build`.
2. Kick off the storybook server: `yarn start`

- [ ] Expect to see no logging in the output related to invalid local *.css maps.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] ✨ This pull request is ready to merge. ✨
