### PR TITLE
chore(storybook): update fixed port to 8080

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -56,7 +56,6 @@ export default {
 
 		return mergeConfig(config, {
 			publicDir: "../assets",
-			port: 8080,
 			build: {
 				sourcemap: configType === "DEVELOPMENT",
 				manifest: true,

--- a/.storybook/project.json
+++ b/.storybook/project.json
@@ -87,7 +87,7 @@
 				{ "env": "WATCH_MODE" }
 			],
 			"options": {
-				"commands": ["WATCH_MODE=true storybook dev --config-dir ."],
+				"commands": ["WATCH_MODE=true storybook dev --port 8080 --config-dir ."],
 				"cwd": "{projectRoot}"
 			}
 		},


### PR DESCRIPTION
## Description

This PR fixes the port to 8080 to make rebuilds easier to navigate.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [x] Kick off Storybook with: `yarn start` and expect to see the localhost opened at port 8080
## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] ✨ This pull request is ready to merge. ✨
