### PR TITLE
chore(build): update component builder to use modules; suppresses stylelint notice on build

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -78,7 +78,7 @@ jobs:
 
             - name: Lint component styles
               if: ${{ inputs.styles_added_files != '' || inputs.styles_modified_files != '' }}
-              uses: reviewdog/action-stylelint@v1.18.1
+              uses: reviewdog/action-stylelint@v1.28.0
               with:
                   fail_on_error: true
                   level: error
@@ -86,10 +86,10 @@ jobs:
                   filter_mode: diff_context
                 #   stylelint_input: "components/*/index.css components/*/themes/*.css"
                   stylelint_input: "${{ inputs.styles_added_files }} ${{ inputs.styles_modified_files }}"
-                  stylelint_config: stylelint.config.js
+                  stylelint_config: stylelint.config.mjs
 
             - name: Run eslint on packages and stories
-              uses: reviewdog/action-eslint@v1.20.0
+              uses: reviewdog/action-eslint@v1.31.0
               if: ${{ inputs.eslint_added_files != '' || inputs.eslint_modified_files != '' }}
               with:
                   fail_on_error: true

--- a/.storybook/project.json
+++ b/.storybook/project.json
@@ -18,11 +18,11 @@
 		"build": {
 			"configurations": {
 				"ci": {
-					"commands": ["storybook build --config-dir ."]
+					"commands": ["cross-env NODE_OPTIONS=\"--no-warnings\" storybook build --config-dir ."]
 				},
 				"docs": {
 					"commands": [
-						"storybook build --config-dir . --output-dir ../dist/preview"
+						"cross-env NODE_OPTIONS=\"--no-warnings\" storybook build --config-dir . --output-dir ../dist/preview"
 					],
 					"outputs": ["{workspaceRoot}/dist/preview"]
 				}
@@ -32,7 +32,7 @@
 			"inputs": ["tools", { "externalDependencies": ["storybook"] }],
 			"options": {
 				"commands": [
-					"storybook build --config-dir . --output-dir ./storybook-static"
+					"cross-env NODE_OPTIONS=\"--no-warnings\" storybook build --config-dir . --output-dir ./storybook-static"
 				],
 				"cwd": "{projectRoot}"
 			},
@@ -93,7 +93,7 @@
 				{ "env": "WATCH_MODE" }
 			],
 			"options": {
-				"commands": ["WATCH_MODE=true storybook dev --port 8080 --config-dir ."],
+				"commands": ["cross-env NODE_OPTIONS=\"--no-warnings\" WATCH_MODE=true storybook dev --port 8080 --config-dir ."],
 				"cwd": "{projectRoot}"
 			}
 		},

--- a/nx.json
+++ b/nx.json
@@ -1,60 +1,42 @@
 {
 	"$schema": "./node_modules/nx/schemas/nx-schema.json",
 	"cli": {
+		"analytics": false,
+		"packageManager": "yarn",
 		"warnings": {
 			"versionMismatch": true
-		},
-		"packageManager": "yarn",
-		"analytics": false
+		}
+	},
+	"namedInputs": {
+		"core": ["{projectRoot}/*.css", "{projectRoot}/themes/*.css"],
+		"docs": ["{projectRoot}/metadata/*.yml"],
+		"eslint": ["{workspaceRoot}/.eslintrc"],
+		"prettier": ["{workspaceRoot}/.prettierrc"],
+		"scripts": ["{projectRoot}/stories/*.js"],
+		"stylelint": [
+			"{workspaceRoot}/.stylelintignore",
+			"{workspaceRoot}/stylelint.config.mjs",
+			"{workspaceRoot}/plugins/stylelint-*/index.js"
+		],
+		"tools": [
+			"{projectRoot}/*.json",
+			"{workspaceRoot}/postcss.config.mjs",
+			"{workspaceRoot}/plugins/postcss-*/index.js"
+		]
 	},
 	"pluginsConfig": {
 		"@nx/js": {
 			"analyzeSourceFiles": false
 		}
 	},
-	"namedInputs": {
-		"core": ["{projectRoot}/*.css", "{projectRoot}/themes/*.css"],
-		"scripts": ["{projectRoot}/stories/*.js"],
-		"docs": ["{projectRoot}/metadata/*.yml"],
-		"stylelint": [
-			"{workspaceRoot}/.stylelintignore",
-			"{workspaceRoot}/stylelint.config.js",
-			"{workspaceRoot}/plugins/stylelint-*/index.js"
-		],
-		"eslint": ["{workspaceRoot}/.eslintrc"],
-		"prettier": ["{workspaceRoot}/.prettierrc"],
-		"tools": [
-			"{projectRoot}/*.json",
-			"{workspaceRoot}/postcss.config.js",
-			"{workspaceRoot}/plugins/postcss-*/index.js"
-		]
-	},
 	"targetDefaults": {
-		"clean": {
-			"cache": true,
-			"inputs": [
-				"{projectRoot}/dist/*.{css,json}",
-				"{projectRoot}/dist/**/*.{css,json}",
-				"{projectRoot}/dist/*.map",
-				"{projectRoot}/dist/**/*.map",
-				{ "externalDependencies": ["rimraf"] }
-			],
-			"outputs": [],
-			"executor": "nx:run-commands",
-			"options": {
-				"commands": [
-					"rimraf {projectRoot}/dist",
-					"test -d {projectRoot}/dist && echo \"Error: dist directory could not be removed\" && exit 1 || exit 0"
-				],
-				"parallel": false
-			}
-		},
 		"build": {
 			"cache": true,
 			"dependsOn": [
 				"^build",
 				"clean"
 			],
+			"executor": "nx:run-commands",
 			"inputs": [
 				"core",
 				"tools",
@@ -62,23 +44,42 @@
 				{ "externalDependencies": ["postcss"] },
 				{ "env": "NODE_ENV" }
 			],
+			"options": {
+				"commands": [
+					"node --no-warnings -e 'require(\"./tasks/component-builder.js\").default()'"
+				]
+			},
 			"outputs": [
 				"{projectRoot}/dist/*.{css,json}",
 				"{projectRoot}/dist/themes/*.css",
 				"{projectRoot}/dist/*.map",
 				"{projectRoot}/dist/themes/*.css.map",
 				"{projectRoot}/metadata/mods.md"
-			],
+			]
+		},
+		"clean": {
+			"cache": true,
 			"executor": "nx:run-commands",
+			"inputs": [
+				"{projectRoot}/dist/*.{css,json}",
+				"{projectRoot}/dist/**/*.{css,json}",
+				"{projectRoot}/dist/*.map",
+				"{projectRoot}/dist/**/*.map",
+				{ "externalDependencies": ["rimraf"] }
+			],
 			"options": {
 				"commands": [
-					"node -e 'require(\"./tasks/component-builder.js\").default()'"
-				]
-			}
+					"rimraf {projectRoot}/dist",
+					"test -d {projectRoot}/dist && echo \"Error: dist directory could not be removed\" && exit 1 || exit 0"
+				],
+				"parallel": false
+			},
+			"outputs": []
 		},
 		"compare": {
 			"cache": true,
 			"dependsOn": ["build"],
+			"executor": "nx:run-commands",
 			"inputs": [
 				"{workspaceRoot}/tasks/compare-compiled-output.js",
 				{ "dependentTasksOutputFiles": "dist/*.css", "transitive": true },
@@ -98,34 +99,16 @@
 				},
 				{ "env": "NODE_ENV" }
 			],
-			"outputs": ["{workspaceRoot}/.diff-output"],
-			"executor": "nx:run-commands",
 			"options": {
 				"commands": [
-					"node ./tasks/compare-compiled-output.js $NX_TASK_TARGET_PROJECT"
+					"node --no-warnings ./tasks/compare-compiled-output.js $NX_TASK_TARGET_PROJECT"
 				]
-			}
-		},
-		"lint": {
-			"cache": true,
-			"inputs": [
-				"core",
-				"scripts",
-				"stylelint",
-				"eslint",
-				"prettier",
-				{ "externalDependencies": ["stylelint", "eslint", "prettier"] }
-			],
-			"executor": "nx:run-commands",
-			"options": {
-				"commands": [
-					"stylelint --cache --allow-empty-input --report-descriptionless-disables --report-invalid-scope-disables --report-needless-disables {projectRoot}/*.css {projectRoot}/**/*.css --ignore-pattern {projectRoot}/dist",
-					"eslint --cache --no-error-on-unmatched-pattern --report-unused-disable-directives {projectRoot}/*.{js,json} {projectRoot}/**/*.{js,json} --ignore-pattern {projectRoot}/dist || exit 0"
-				]
-			}
+			},
+			"outputs": ["{workspaceRoot}/.diff-output"]
 		},
 		"format": {
 			"cache": true,
+			"executor": "nx:run-commands",
 			"inputs": [
 				"core",
 				"scripts",
@@ -134,7 +117,6 @@
 				"prettier",
 				{ "externalDependencies": ["stylelint", "eslint", "prettier"] }
 			],
-			"executor": "nx:run-commands",
 			"options": {
 				"commands": [
 					"prettier --write --cache --log-level error --ignore-unknown --no-error-on-unmatched-pattern {projectRoot}/*.css {projectRoot}/**/*.css && stylelint --fix --cache --allow-empty-input {projectRoot}/*.css {projectRoot}/**/*.css",
@@ -143,41 +125,59 @@
 				]
 			}
 		},
+		"lint": {
+			"cache": true,
+			"executor": "nx:run-commands",
+			"inputs": [
+				"core",
+				"scripts",
+				"stylelint",
+				"eslint",
+				"prettier",
+				{ "externalDependencies": ["stylelint", "eslint", "prettier"] }
+			],
+			"options": {
+				"commands": [
+					"stylelint --cache --allow-empty-input --report-descriptionless-disables --report-invalid-scope-disables --report-needless-disables {projectRoot}/*.css {projectRoot}/**/*.css --ignore-pattern {projectRoot}/dist",
+					"eslint --cache --no-error-on-unmatched-pattern --report-unused-disable-directives {projectRoot}/*.{js,json} {projectRoot}/**/*.{js,json} --ignore-pattern {projectRoot}/dist || exit 0"
+				]
+			}
+		},
 		"test": {
 			"cache": true,
-			"inputs": ["scripts", "tools", { "externalDependencies": ["chromatic"] }],
-			"executor": "nx:run-commands",
-			"options": {
-				"cwd": ".storybook",
-				"commands": [
-					"chromatic --only-changed --build-script-name build --junit-report"
-				]
-			},
 			"configurations": {
-				"scope": {
-					"commands": [
-						"chromatic --build-script-name build --junit-report --only-story-names"
-					]
-				},
 				"plugins": {
+					"commands": ["ava test.js"],
+					"cwd": "{projectRoot}",
 					"inputs": [
 						"{projectRoot}/index.js",
 						"{projectRoot}/test.js",
 						"{projectRoot}/expected/*.css",
 						"{projectRoot}/fixtures/*.css"
-					],
-					"cwd": "{projectRoot}",
-					"commands": ["ava test.js"]
+					]
+				},
+				"scope": {
+					"commands": [
+						"chromatic --build-script-name build --junit-report --only-story-names"
+					]
 				}
+			},
+			"executor": "nx:run-commands",
+			"inputs": ["scripts", "tools", { "externalDependencies": ["chromatic"] }],
+			"options": {
+				"commands": [
+					"chromatic --only-changed --build-script-name build --junit-report"
+				],
+				"cwd": ".storybook"
 			}
 		},
 		"validate": {
+			"executor": "nx:run-commands",
 			"inputs": [
 				"{workspaceRoot}/schemas/documentation.schema.json",
 				"docs",
 				{ "externalDependencies": ["pajv"] }
 			],
-			"executor": "nx:run-commands",
 			"options": {
 				"commands": [
 					"test -e {projectRoot}/metadata && pajv validate -s ./schemas/documentation.schema.json -d \"{projectRoot}/metadata/*.yml\" || exit 0"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"clean:docs": "rimraf dist",
 		"clean:preview": "nx clean storybook",
 		"cleaner": "nx run-many --target clean --projects",
-		"compare": "cross-env NODE_ENV=production node ./tasks/compare-compiled-output.js",
+		"compare": "cross-env NODE_ENV=production node --no-warnings ./tasks/compare-compiled-output.js",
 		"dev": "cross-env NODE_ENV=production nx run storybook:build:docs && nx start docs",
 		"format": "yarn formatter tag:component",
 		"formatter": "nx run-many --target format --projects",

--- a/site/project.json
+++ b/site/project.json
@@ -13,6 +13,23 @@
 		]
 	},
 	"targets": {
+		"build": {
+			"cache": false,
+			"dependsOn": [
+				"^build",
+				{
+					"projects": "tag:component",
+					"target": "build"
+				},
+				"clean"
+			],
+			"inputs": ["core", "tools"],
+			"options": {
+				"commands": ["node --no-warnings -e \"require('./tasks').builder()\""],
+				"cwd": "{projectRoot}"
+			},
+			"outputs": ["{workspaceRoot}/dist"]
+		},
 		"clean": {
 			"inputs": [
 				"{workspaceRoot}/dist",
@@ -25,33 +42,16 @@
 				]
 			}
 		},
-		"build": {
-			"cache": false,
-			"dependsOn": [
-				"^build",
-				{
-					"target": "build",
-					"projects": "tag:component"
-				},
-				"clean"
-			],
-			"inputs": ["core", "tools"],
-			"outputs": ["{workspaceRoot}/dist"],
-			"options": {
-				"cwd": "{projectRoot}",
-				"commands": ["node -e \"require('./tasks').builder()\""]
-			}
-		},
 		"start": {
 			"cache": false,
 			"dependsOn": ["build"],
-			"inputs": ["core", "tools"],
-			"outputs": ["{workspaceRoot}/dist"],
 			"executor": "nx:run-commands",
+			"inputs": ["core", "tools"],
 			"options": {
-				"cwd": "{projectRoot}",
-				"commands": ["node -e \"require('./tasks').server()\""]
-			}
+				"commands": ["node --no-warnings -e \"require('./tasks').server()\""],
+				"cwd": "{projectRoot}"
+			},
+			"outputs": ["{workspaceRoot}/dist"]
 		}
 	}
 }

--- a/tokens/project.json
+++ b/tokens/project.json
@@ -34,7 +34,7 @@
 					"cat ./dist/css/express/medium-vars.css ./dist/css/express/custom-medium-vars.css | postcss --output ./dist/css/express/medium-vars.css",
 					"cat ./dist/css/express/large-vars.css ./dist/css/express/custom-large-vars.css | postcss --output ./dist/css/express/large-vars.css",
 					"cat ./dist/css/express/global-vars.css ./dist/css/express/custom-vars.css | postcss --output ./dist/css/express/global-vars.css",
-					"node -e \"require('./tasks/token-rollup.js').default()\"",
+					"node --no-warnings -e \"require('./tasks/token-rollup.js').default()\"",
 					"find dist -type f -empty -delete",
 					"prettier --write dist/**/*.css"
 				],

--- a/ui-icons/project.json
+++ b/ui-icons/project.json
@@ -22,8 +22,8 @@
 				}
 			],
 			"options": {
-				"cwd": "{projectRoot}",
-				"commands": ["node ./index.js"]
+				"commands": ["node --no-warnings ./index.js"],
+				"cwd": "{projectRoot}"
 			},
 			"outputs": [
 				"{projectRoot}/dist/combined",


### PR DESCRIPTION
## Description

With the update of our stylelint tooling to v16, we are seeing deprecations notices in our build tasks because postcss is running stylelint in a CJS script.  This update suppresses the node warnings for the console using `--no-warnings`.

This PR also updates our linting GitHub packages to their latest versions.

A side-effect of updating the *.json files is that the linter sorted the keys.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

To ensure your run goes without referencing the build cache, start by running `nx cache`.

- [x] `yarn build --verbose`: should no longer surface warnings about CJS being deprecated for stylelint
- [x] `yarn lint --verbose`: should not surface warnings about CJS being deprecated for stylelint
- [x] `yarn build:site --verbose`: should not surface warnings about CJS being deprecated for stylelint

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] ✨ This pull request is ready to merge. ✨
