### PR TITLE
docs(taggroup, thumbnail, tray, treeview, well): docs site to storybook

### DIFF
--- a/components/taggroup/CHANGELOG.md
+++ b/components/taggroup/CHANGELOG.md
@@ -1087,3 +1087,17 @@ CSS-500
 ### ✨ Features
 
 - move to individually versioned packages with Lerna ([#265](https://github.com/adobe/spectrum-css/issues/265)) ([cb7fd4b](https://github.com/adobe/spectrum-css/commit/cb7fd4b)), closes [#231](https://github.com/adobe/spectrum-css/issues/231) [#214](https://github.com/adobe/spectrum-css/issues/214) [#229](https://github.com/adobe/spectrum-css/issues/229) [#240](https://github.com/adobe/spectrum-css/issues/240) [#239](https://github.com/adobe/spectrum-css/issues/239) [#161](https://github.com/adobe/spectrum-css/issues/161) [#242](https://github.com/adobe/spectrum-css/issues/242) [#246](https://github.com/adobe/spectrum-css/issues/246) [#219](https://github.com/adobe/spectrum-css/issues/219) [#235](https://github.com/adobe/spectrum-css/issues/235) [#189](https://github.com/adobe/spectrum-css/issues/189) [#248](https://github.com/adobe/spectrum-css/issues/248) [#232](https://github.com/adobe/spectrum-css/issues/232) [#248](https://github.com/adobe/spectrum-css/issues/248) [#218](https://github.com/adobe/spectrum-css/issues/218) [#237](https://github.com/adobe/spectrum-css/issues/237) [#255](https://github.com/adobe/spectrum-css/issues/255) [#256](https://github.com/adobe/spectrum-css/issues/256) [#258](https://github.com/adobe/spectrum-css/issues/258) [#257](https://github.com/adobe/spectrum-css/issues/257) [#259](https://github.com/adobe/spectrum-css/issues/259)
+
+### Migration guide
+
+- **Div wrapper is required for avatar**
+
+  ```
+  <div class="spectrum-Avatar spectrum-Avatar--size50">
+  		<img class="spectrum-Avatar-image" src="img/example-ava.jpg" alt="Avatar">
+  </div>
+  ```
+
+- **Icon size changed to small**
+
+  If you use an icon `spectrum-Tag-itemIcon` along with a tag, please replace `.spectrum-Icon--sizeXS` with `.spectrum-Icon--sizeS`.

--- a/components/taggroup/stories/taggroup.stories.js
+++ b/components/taggroup/stories/taggroup.stories.js
@@ -27,7 +27,6 @@ export default {
 			table: {
 				type: { summary: "string" },
 				category: "Content",
-				disable: true,
 			},
 			control: { type: "text" },
 		},
@@ -76,7 +75,7 @@ Default.args = {
 
 // ********* DOCS ONLY ********* //
 /**
- * A tag group can contain removable tags when the context is for editing, or non-removable tags when tags are read-only, but removable and non-removable tags cannot be combined within the tag group.
+ * A tag group can contain removable tags when the context is for editing or non-removable tags when tags are read-only. Removable and non-removable tags cannot be combined within the tag group.
  */
 export const Removable = Template.bind({});
 Removable.tags = ["!dev"];
@@ -105,15 +104,12 @@ Removable.args = {
 		},
 		{
 			label: "Tag 5",
-			isInvalid: true,
 		},
 		{
 			label: "Tag 6",
-			isEmphasized: true,
 		},
 		{
 			label: "Tag 7",
-			isDisabled: true,
 		},
 	],
 };

--- a/components/taggroup/stories/taggroup.stories.js
+++ b/components/taggroup/stories/taggroup.stories.js
@@ -79,7 +79,7 @@ Default.args = {
  * A tag group can contain removable tags when the context is for editing, or non-removable tags when tags are read-only, but removable and non-removable tags cannot be combined within the tag group.
  */
 export const Removable = Template.bind({});
-Removable.tags = ["autodocs", "!dev"];
+Removable.tags = ["!dev"];
 Removable.parameters = {
 	chromatic: {
 		disableSnapshot: true,

--- a/components/taggroup/stories/taggroup.stories.js
+++ b/components/taggroup/stories/taggroup.stories.js
@@ -6,7 +6,9 @@ import { TagGroups, Template } from "./template";
 const ignoreProps = ["rootClass", "hasClearButton", "label"];
 
 /**
- * A group of tags.
+ * A group of [tags](?path=/docs/components-tag--docs). Tags allow users to categorize content. They can represent keywords or people, and are grouped to describe an item or a search request.
+ *
+ * When horizontal space is limited in a tag group, the individual tags wrap to form another line.
  */
 export default {
 	title: "Tag group",
@@ -74,16 +76,16 @@ Default.args = {
 
 // ********* DOCS ONLY ********* //
 /**
- * When horizontal space is limited in a tag group, the individual tags wrap to form another line.
+ * A tag group can contain removable tags when the context is for editing, or non-removable tags when tags are read-only, but removable and non-removable tags cannot be combined within the tag group.
  */
-export const OverflowItems = Template.bind({});
-OverflowItems.tags = ["!dev"];
-OverflowItems.parameters = {
+export const Removable = Template.bind({});
+Removable.tags = ["autodocs", "!dev"];
+Removable.parameters = {
 	chromatic: {
 		disableSnapshot: true,
 	},
 };
-OverflowItems.args = {
+Removable.args = {
 	isRemovable: true,
 	isEmphasized: false,
 	customStyles: {"max-width": "300px"},
@@ -99,15 +101,19 @@ OverflowItems.args = {
 		},
 		{
 			label: "Tag 4",
+			avatarUrl: "example-ava.png",
 		},
 		{
 			label: "Tag 5",
+			isInvalid: true,
 		},
 		{
 			label: "Tag 6",
+			isEmphasized: true,
 		},
 		{
 			label: "Tag 7",
+			isDisabled: true,
 		},
 	],
 };

--- a/components/taggroup/stories/template.js
+++ b/components/taggroup/stories/template.js
@@ -15,6 +15,7 @@ export const Template = ({
 	customClasses = [],
 	customStyles = {},
 	size = "m",
+	...args
 }, context) => html`
 	<div
 		class=${classMap({
@@ -27,6 +28,7 @@ export const Template = ({
 	>
 		${items.map((i) => Tag({
 			...i,
+			...args,
 			size,
 			hasClearButton: isRemovable,
 			customClasses: [`${rootClass}-item`],

--- a/components/thumbnail/CHANGELOG.md
+++ b/components/thumbnail/CHANGELOG.md
@@ -1032,3 +1032,17 @@ show space above and below, fill horizontally
 - docs: add migration guide
 
 Co-authored-by: Jian Liao <jianliao@adobe.com>
+
+### Migration guide
+
+- **Thumbnail sizing**
+
+  Thumbnail sizes are specified by appending a number to the size class: `.spectrum-Thumbnail--size*`. Sizes scale expotentially and are based on the Spectrum type scale. These range from size-50 to size-1000.
+
+- **Image cover**
+
+  Thumbnail now offers a way to control the content inside a child `img` tag by adding a modifier `spectrum-Thumbnail--cover` class in addition to the `spectrum-Thumbnail` class.
+
+- **Remove focus-ring class**
+
+  Adds variant for when thumbnails are used in layer management (such as the Compact or Detail Layers panels). When used this way the thumbnail is given a thick blue border when selected.

--- a/components/thumbnail/stories/template.js
+++ b/components/thumbnail/stories/template.js
@@ -1,4 +1,5 @@
 import { Template as OpacityCheckerboard } from "@spectrum-css/opacitycheckerboard/stories/template.js";
+import { Template as Typography } from "@spectrum-css/typography/stories/template.js";
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
@@ -122,6 +123,41 @@ export const Template = ({
 				customClasses: isLayer ? [`${rootClass}-layer-inner`] : !backgroundColor ? [`${rootClass}-image-wrapper`] : [],
 				content: image ? [image] : [],
 			}, context)}
+		</div>
+	`;
+};
+
+export const SizingGroup = (args, context) => {
+	const sizeOptions = context?.argTypes?.size?.options ?? [];
+	if (!sizeOptions.length) {
+		return html`<div>No size options</div>`;
+	}
+
+	return html`
+		<div
+			style=${styleMap({
+				"display": "flex",
+				"gap": "16px",
+			})}
+		>
+			${sizeOptions.map((size) => (html`
+				<div
+					style=${styleMap({
+						"display": "flex",
+						"gap": "16px",
+						"flex-direction": "column",
+						"align-items": "center",
+					})}
+				>
+					${Template({...args, size})}
+					${Typography({
+						semantics: "heading",
+						size: "xs",
+						content: [size],
+						customClasses: ["chromatic-ignore"],
+					})}
+				</div>
+			`))}
 		</div>
 	`;
 };

--- a/components/thumbnail/stories/thumbnail.stories.js
+++ b/components/thumbnail/stories/thumbnail.stories.js
@@ -157,7 +157,7 @@ WithForcedColors.parameters = {
 
 // ********* DOCS ONLY ********* //
 export const Focused = Template.bind({});
-Focused.tags = ["autodocs", "!dev"];
+Focused.tags = ["!dev"];
 Focused.args = {
 	imageURL: "example-ava.png",
 	altText: "Shantanu",
@@ -173,7 +173,7 @@ Focused.parameters = {
  * Thumbnail should only be displayed as disabled if the entire component is also disabled.
  */
 export const Disabled = Template.bind({});
-Disabled.tags = ["autodocs", "!dev"];
+Disabled.tags = ["!dev"];
 Disabled.args = {
 	imageURL: "example-ava.png",
 	altText: "Shantanu",
@@ -189,7 +189,7 @@ Disabled.parameters = {
  * Thumbnail sizes scale exponentially, based on the Spectrum type scale, ranging from size-50 to size-1000.
  */
 export const Sizing = SizingGroup.bind({});
-Sizing.tags = ["autodocs", "!dev"];
+Sizing.tags = ["!dev"];
 Sizing.parameters = {
 	chromatic: {
 		disableSnapshot: true,
@@ -201,7 +201,7 @@ Sizing.parameters = {
  */
 export const Cover = Template.bind({});
 Cover.storyName = "Image Fit (Cover)";
-Cover.tags = ["autodocs", "!dev"];
+Cover.tags = ["!dev"];
 Cover.args = {
 	imageURL: "example-card-landscape.png",
 	altText: "Landscape with mountains and lake",
@@ -218,7 +218,7 @@ Cover.parameters = {
  */
 export const Portrait = Template.bind({});
 Portrait.storyName = "Image Fit (Portrait)";
-Portrait.tags = ["autodocs", "!dev"];
+Portrait.tags = ["!dev"];
 Portrait.args = {
 	imageURL: "example-card-portrait.png",
 	altText: "Cityscape with lights",
@@ -234,7 +234,7 @@ Portrait.parameters = {
  */
 export const Landscape = Template.bind({});
 Landscape.storyName = "Image Fit (Landscape)";
-Landscape.tags = ["autodocs", "!dev"];
+Landscape.tags = ["!dev"];
 Landscape.args = {
 	imageURL: "example-card-landscape.png",
 	altText: "Landscape with mountains and lake",
@@ -250,7 +250,7 @@ Landscape.parameters = {
  */
 export const SelectedLayer = Template.bind({});
 SelectedLayer.storyName = "Layer (Selected)";
-SelectedLayer.tags = ["autodocs", "!dev"];
+SelectedLayer.tags = ["!dev"];
 SelectedLayer.args = {
 	imageURL: "flowers.png",
 	altText: "Flowers",

--- a/components/thumbnail/stories/thumbnail.stories.js
+++ b/components/thumbnail/stories/thumbnail.stories.js
@@ -1,7 +1,7 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isFocused, isSelected } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
-import { Template } from "./template";
+import { SizingGroup, Template } from "./template";
 
 /**
  * A thumbnail is used to display a preview of an image, layer, or effect.
@@ -50,12 +50,6 @@ export default {
 			table: {
 				type: { summary: "string" },
 				category: "Content",
-			/* The `isSelected` property in the tree view component is used to indicate whether a specific item
-			in the tree view is currently selected or not. When `isSelected` is set to `true` for an item, it
-			visually highlights that item as selected, providing a visual cue to the user that it is the
-			currently active or focused item in the tree view. This property helps improve user experience by
-			making it easier for users to identify which item they are interacting with within the tree view
-			structure. */
 			},
 			control: "text",
 		},
@@ -127,14 +121,25 @@ export default {
 
 // @todo combine variants into one snapshot
 export const Default = Template.bind({});
-Default.args = {};
+Default.args = {
+	imageURL: "example-ava.png",
+	altText: "Shantanu",
+};
 
+/**
+ * The layer variant is used in layer management (such as the Compact or Detail Layers panels).
+ */
 export const Layer = Template.bind({});
 Layer.args = {
 	isLayer: true,
 	isSelected: false,
+	imageURL: "flowers.png",
+	altText: "Flowers",
 };
 
+/**
+ * Thumbnail supports transparent images with a background (color or image) behind them.
+ */
 export const WithBackground = Template.bind({});
 WithBackground.args = {
 	backgroundColor: "orange",
@@ -147,5 +152,113 @@ WithForcedColors.parameters = {
 	chromatic: {
 		forcedColors: "active",
 		modes: disableDefaultModes
+	},
+};
+
+// ********* DOCS ONLY ********* //
+export const Focused = Template.bind({});
+Focused.tags = ["autodocs", "!dev"];
+Focused.args = {
+	imageURL: "example-ava.png",
+	altText: "Shantanu",
+	isFocused: true,
+};
+Focused.parameters = {
+	chromatic: {
+		disableSnapshot: true,
+	},
+};
+
+/**
+ * Thumbnail should only be displayed as disabled if the entire component is also disabled.
+ */
+export const Disabled = Template.bind({});
+Disabled.tags = ["autodocs", "!dev"];
+Disabled.args = {
+	imageURL: "example-ava.png",
+	altText: "Shantanu",
+	isDisabled: true,
+};
+Disabled.parameters = {
+	chromatic: {
+		disableSnapshot: true,
+	},
+};
+
+/**
+ * Thumbnail sizes scale exponentially, based on the Spectrum type scale, ranging from size-50 to size-1000.
+ */
+export const Sizing = SizingGroup.bind({});
+Sizing.tags = ["autodocs", "!dev"];
+Sizing.parameters = {
+	chromatic: {
+		disableSnapshot: true,
+	},
+};
+
+/**
+ * The cover variant allows images to maintain their aspect ratio while filling the entire content box.
+ */
+export const Cover = Template.bind({});
+Cover.storyName = "Image Fit (Cover)";
+Cover.tags = ["autodocs", "!dev"];
+Cover.args = {
+	imageURL: "example-card-landscape.png",
+	altText: "Landscape with mountains and lake",
+	isCover: true,
+};
+Cover.parameters = {
+	chromatic: {
+		disableSnapshot: true,
+	},
+};
+
+/**
+ * Portrait images will fill vertically and have space on either side.
+ */
+export const Portrait = Template.bind({});
+Portrait.storyName = "Image Fit (Portrait)";
+Portrait.tags = ["autodocs", "!dev"];
+Portrait.args = {
+	imageURL: "example-card-portrait.png",
+	altText: "Cityscape with lights",
+};
+Portrait.parameters = {
+	chromatic: {
+		disableSnapshot: true,
+	},
+};
+
+/**
+ * Landscape images will fill horizontally and have space above and below.
+ */
+export const Landscape = Template.bind({});
+Landscape.storyName = "Image Fit (Landscape)";
+Landscape.tags = ["autodocs", "!dev"];
+Landscape.args = {
+	imageURL: "example-card-landscape.png",
+	altText: "Landscape with mountains and lake",
+};
+Landscape.parameters = {
+	chromatic: {
+		disableSnapshot: true,
+	},
+};
+
+/**
+ * When used in layer management, the thumbnail is given a thick blue border to indicate its selection.
+ */
+export const SelectedLayer = Template.bind({});
+SelectedLayer.storyName = "Layer (Selected)";
+SelectedLayer.tags = ["autodocs", "!dev"];
+SelectedLayer.args = {
+	imageURL: "flowers.png",
+	altText: "Flowers",
+	isLayer: true,
+	isSelected: true,
+};
+SelectedLayer.parameters = {
+	chromatic: {
+		disableSnapshot: true,
 	},
 };

--- a/components/tray/stories/tray.stories.js
+++ b/components/tray/stories/tray.stories.js
@@ -4,7 +4,7 @@ import { version } from "../package.json";
 import { TrayGroup } from "./template";
 
 /**
- * Tray dialogs are typically used to portray information on mobile device or smaller screens.
+ * A tray is typically used to display transient content (menus, options, additional actions, etc.) on mobile devices or smaller screens, exposing types of content that may be too overwhelming for [popovers](?path=/docs/components-popover--docs).
  */
 export default {
 	title: "Tray",
@@ -31,9 +31,12 @@ export default {
 			delay: 2000,
 		},
 		componentVersion: version,
-	}
+	},
 };
 
+/**
+ * The tray displays differently depending on the orientation of the viewport, using the `orientation` CSS media feature. In portrait orientation, a Tray is displayed at the bottom of the screen and takes up the full width of the view. In landscape orientation, it keeps its portrait width, is centered horizontally, and has rounded upper corners.
+ */
 export const Default = TrayGroup.bind({});
 Default.args = {
 	isOpen: true,

--- a/components/treeview/CHANGELOG.md
+++ b/components/treeview/CHANGELOG.md
@@ -1018,3 +1018,28 @@ Co-authored-by: Jian Liao <jianliao@adobe.com>
 ### ✨ Features
 
 - move to individually versioned packages with Lerna ([#265](https://github.com/adobe/spectrum-css/issues/265)) ([cb7fd4b](https://github.com/adobe/spectrum-css/commit/cb7fd4b)), closes [#231](https://github.com/adobe/spectrum-css/issues/231) [#214](https://github.com/adobe/spectrum-css/issues/214) [#229](https://github.com/adobe/spectrum-css/issues/229) [#240](https://github.com/adobe/spectrum-css/issues/240) [#239](https://github.com/adobe/spectrum-css/issues/239) [#161](https://github.com/adobe/spectrum-css/issues/161) [#242](https://github.com/adobe/spectrum-css/issues/242) [#246](https://github.com/adobe/spectrum-css/issues/246) [#219](https://github.com/adobe/spectrum-css/issues/219) [#235](https://github.com/adobe/spectrum-css/issues/235) [#189](https://github.com/adobe/spectrum-css/issues/189) [#248](https://github.com/adobe/spectrum-css/issues/248) [#232](https://github.com/adobe/spectrum-css/issues/232) [#248](https://github.com/adobe/spectrum-css/issues/248) [#218](https://github.com/adobe/spectrum-css/issues/218) [#237](https://github.com/adobe/spectrum-css/issues/237) [#255](https://github.com/adobe/spectrum-css/issues/255) [#256](https://github.com/adobe/spectrum-css/issues/256) [#258](https://github.com/adobe/spectrum-css/issues/258) [#257](https://github.com/adobe/spectrum-css/issues/257) [#259](https://github.com/adobe/spectrum-css/issues/259)
+
+### Migration guide
+
+- **Additional classes**
+
+  - `.spectrum-TreeView-label` is now required to wrap labels to enable truncation behavior
+  - `.spectrum-Treeview-icon` is now required on all non-indicator icons
+
+- **Renamed classes**
+
+  - `.spectrum-TreeView-standalone` renamed to `.spectrum-TreeView-detached`
+  - `.spectrum-TreeView-indicator` renamed to `.spectrum-TreeView-itemIndicator`
+  - `.spectrum-TreeView-icon` renamed to `.spectrum-TreeView-itemIcon`
+
+- **Moved classes**
+
+  - `.is-drop-target` and `.is-selected` must be placed on the `.spectrum-TreeView-item` element
+
+- **Workflow icon size**
+
+  Please replace `.spectrum-Icon--sizeS` with `.spectrum-Icon--sizeM`.
+
+- **Revised sections markup**
+
+  The markup for sections has changed so that the heading is now a child of an `li` instead of the `ul`, to ensure valid markup. An additional class `.spectrum-TreeView-section` has been added for the first level `li` elements that contain the section heading and its child tree view.

--- a/components/treeview/stories/template.js
+++ b/components/treeview/stories/template.js
@@ -1,6 +1,7 @@
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 import { Variants } from "@spectrum-css/preview/decorators";
 import { Template as Thumbnail } from "@spectrum-css/thumbnail/stories/template.js";
+import { Template as Typography } from "@spectrum-css/typography/stories/template.js";
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { repeat } from "lit/directives/repeat.js";
@@ -409,3 +410,37 @@ export const TreeViewGroup = Variants({
 	],
 	sizeDirection: "row",
 });
+
+export const SizingGroup = (args, context) => {
+	const sizeOptions = context?.argTypes?.size?.options ?? [];
+	if (!sizeOptions.length) {
+		return html`<div>No size options</div>`;
+	}
+	return html`
+		<div
+			style=${styleMap({
+				"display": "flex",
+				"gap": "32px",
+			})}
+		>
+			${sizeOptions.map((size) => (html`
+				<div
+					style=${styleMap({
+						"display": "flex",
+						"gap": "16px",
+						"flex-direction": "column",
+						"align-items": "center",
+					})}
+				>
+				${Typography({
+					semantics: "heading",
+					size: "xs",
+					content: [size],
+					customClasses: ["chromatic-ignore"],
+				})}
+				${Template({...args, size})}
+				</div>
+			`))}
+		</div>
+	`;
+};

--- a/components/treeview/stories/treeview.stories.js
+++ b/components/treeview/stories/treeview.stories.js
@@ -1,9 +1,11 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { version } from "../package.json";
-import { Template, TreeViewGroup } from "./template";
+import { SizingGroup, Template, TreeViewGroup } from "./template";
 
 /**
- * The typical usage of a treeview involves nesting a .spectrum-Treeview element within the .spectrum-TreeView-item parent element.
+ * The typical usage of a treeview involves nesting a `.spectrum-Treeview element` within the `.spectrum-TreeView-item` parent element.
+ *
+ * The visibility of child treeviews is controlled by adding `.is-open` to the `.spectrum-TreeView-item` of the parent element.
  */
 export default {
 	title: "Tree view",
@@ -44,6 +46,9 @@ export default {
 	},
 };
 
+/**
+ * By default, treeviews span the entire width of their parent container and are used within panels.
+ */
 export const Default = TreeViewGroup.bind({});
 Default.args = {
 	items: [
@@ -51,7 +56,6 @@ Default.args = {
 			id: "label1",
 			label: "Label 1",
 			link: "#",
-			isSelected: true,
 		},
 		{
 			id: "group1",
@@ -63,7 +67,6 @@ Default.args = {
 					id: "label2",
 					label: "Label 2",
 					link: "#",
-					isDisabled: true,
 				},
 				{
 					id: "label3",
@@ -106,6 +109,154 @@ Default.args = {
 };
 
 // ********* DOCS ONLY ********* //
+export const Sizing = SizingGroup.bind({});
+Sizing.args = Default.args;
+Sizing.tags = ["autodocs", "!dev"];
+Sizing.parameters = {
+	chromatic: { disableAllSnapshots: true },
+};
+
+
+/**
+ * A tree view with a selected item.
+ */
+export const Selected = Default.bind({});
+Selected.tags = ["autodocs", "!dev"];
+Selected.args = {
+	items: [
+		{
+			id: "layer1",
+			label: "Layer 1",
+			link: "#",
+		},
+		{
+			id: "layer2",
+			label: "Layer 2",
+			link: "#",
+			isSelected: true,
+		},
+	]
+};
+Selected.parameters = {
+	chromatic: { disableAllSnapshots: true },
+};
+
+/**
+ * A tree view with quiet selection.
+ */
+export const Quiet = Default.bind({});
+Quiet.storyName = "Selected (Quiet)";
+Quiet.tags = ["autodocs", "!dev"];
+Quiet.args = {
+	...Selected.args,
+	isQuiet: true,
+};
+Quiet.parameters = {
+	chromatic: { disableAllSnapshots: true },
+};
+
+/**
+ * Detached tree views are meant to be used outside of a panel. Items in detached tree views have rounded corners.
+ */
+export const Detached = Default.bind({});
+Detached.tags = ["autodocs", "!dev"];
+Detached.args = {
+	...Selected.args,
+	variant: "detached",
+};
+Detached.parameters = {
+	chromatic: { disableAllSnapshots: true },
+};
+
+/**
+ * A detached, quiet tree view.
+ */
+export const DetachedQuiet = Default.bind({});
+DetachedQuiet.storyName = "Detached (Quiet)";
+DetachedQuiet.tags = ["autodocs", "!dev"];
+DetachedQuiet.args = {
+	...Selected.args,
+	variant: "detached",
+	isQuiet: true,
+};
+DetachedQuiet.parameters = {
+	chromatic: { disableAllSnapshots: true },
+};
+
+/**
+ * In this example, the Label 2 and Group 2 are disabled.
+ */
+export const Disabled = Template.bind({});
+Disabled.tags = ["autodocs", "!dev"];
+Disabled.args = {
+	items: [
+		{
+			id: "label1",
+			label: "Label 1",
+			link: "#",
+			isSelected: true,
+		},
+		{
+			id: "group1",
+			label: "Group 1",
+			link: "#",
+			isOpen: true,
+			items: [
+				{
+					id: "label2",
+					label: "Label 2",
+					link: "#",
+					isDisabled: true,
+				},
+				{
+					id: "label3",
+					label: "Label 3",
+					link: "#",
+				},
+			],
+		},
+		{
+			id: "group2",
+			label: "Group 2",
+			isDisabled: true,
+			link: "#",
+			items: [
+				{
+					id: "label3",
+					label: "Label 3",
+					link: "#",
+				},
+				{
+					id: "group3",
+					label: "Group 3",
+					link: "#",
+					items: [
+						{
+							id: "label4",
+							label: "Label 4",
+							link: "#",
+						},
+						{
+							id: "group4",
+							label: "Group 4 (Empty)",
+							link: "#",
+							items: [],
+						},
+					],
+				},
+			],
+		},
+	],
+};
+Disabled.parameters = {
+	chromatic: { disableAllSnapshots: true },
+};
+
+/**
+ * Icons can be used to add clarification about tree view items. These help to signify content types, which creates easier reference and context within the hierarchy.
+ *
+ * In this example, a nested tree view with folder and file icons is shown. 
+ */
 export const FoldersAndFiles = Template.bind({});
 FoldersAndFiles.args = {
 	items: [
@@ -120,7 +271,6 @@ FoldersAndFiles.args = {
 			label: "Group 1",
 			link: "#",
 			isOpen: true,
-			isSelected: true,
 			icon: "Folder",
 			items: [
 				{
@@ -178,6 +328,10 @@ FoldersAndFiles.parameters = {
 	chromatic: { disableAllSnapshots: true },
 };
 
+
+/**
+ * Use thumbnails when a user needs to have a preview of the content contained in a tree view item. For its primary use within layer panels, the first example uses the layer variant of thumbnail. The second example uses the default thumbnail.
+ */
 export const Thumbnails = Template.bind({});
 Thumbnails.args = {
 	variant: "thumbnail",
@@ -220,8 +374,22 @@ Thumbnails.parameters = {
 	chromatic: { disableAllSnapshots: true },
 };
 
-export const WithSections = Template.bind({});
-WithSections.args = {
+/**
+ * A quiet tree view with thumbnails using the layer variant. When using the quiet variant, less visual emphasis is given to the selected tree view item.
+ */
+export const ThumbnailsQuiet = Template.bind({});
+ThumbnailsQuiet.storyName = "Thumbnails (Quiet)";
+ThumbnailsQuiet.tags = ["autodocs", "!dev"];
+ThumbnailsQuiet.args = {
+	...Thumbnails.args,
+	isQuiet: true,
+};
+ThumbnailsQuiet.parameters = {
+	chromatic: { disableAllSnapshots: true },
+};
+
+export const Sections = Template.bind({});
+Sections.args = {
 	items: [
 		{
 			type: "heading",
@@ -260,13 +428,17 @@ WithSections.args = {
 		},
 	],
 };
-WithSections.tags = ["!dev"];
-WithSections.parameters = {
+Sections.tags = ["autodocs", "!dev"];
+Sections.parameters = {
 	chromatic: { disableAllSnapshots: true },
 };
 
-export const WithDropTarget = Template.bind({});
-WithDropTarget.args = {
+
+/**
+ * A tree view with an item consisting of a drop target. The `.is-drop-target` class is added to the drop target item.
+ */
+export const DropTarget = Template.bind({});
+DropTarget.args = {
 	items: [
 		{
 			id: "label2",
@@ -281,20 +453,25 @@ WithDropTarget.args = {
 		},
 	],
 };
-WithDropTarget.tags = ["!dev"];
-WithDropTarget.parameters = {
+DropTarget.tags = ["autodocs", "!dev"];
+DropTarget.parameters = {
 	chromatic: { disableAllSnapshots: true },
 };
 
+/**
+ * A tree view drawn without nesting, suitable for infinite scrolling. With this version of the treeview, you must manage the visibility of "child items" manually based on the open state of the "parent item." The level of visual indentation is handled by a numbered `indent` variant class.
+ */
 export const Flat = Template.bind({});
 Flat.storyName = "Flat Markup";
 Flat.args = {
+	customStyles: {
+		"width": "500px",
+	},
 	items: [
 		{
 			id: "label1",
 			label: "Label 1. This example has longer text. Per the guidelines, long text will truncate with an ellipsis, and the full text should be available in a tooltip.",
 			link: "#",
-			isSelected: true,
 		},
 		{
 			id: "group1",
@@ -307,7 +484,6 @@ Flat.args = {
 			id: "label2",
 			label: "Label 2",
 			link: "#",
-			isDisabled: true,
 			customClasses: ["spectrum-TreeView-item--indent1"],
 		},
 		{

--- a/components/treeview/stories/treeview.stories.js
+++ b/components/treeview/stories/treeview.stories.js
@@ -253,12 +253,90 @@ Disabled.parameters = {
 };
 
 /**
+ * A tree view drawn without nesting, suitable for infinite scrolling. With this version of the treeview, you must manage the visibility of "child items" manually based on the open state of the "parent item." The level of visual indentation is handled by a numbered `indent` variant class.
+ *
+ * This example sets a maximum width of 500px (`max-inline-size`) in order to demonstrate how longer text truncates.
+ */
+export const Flat = Template.bind({});
+Flat.storyName = "Flat Markup";
+Flat.args = {
+	customStyles: {
+		"max-inline-size": "500px",
+	},
+	items: [
+		{
+			id: "label1",
+			label: "Label 1. This example has longer text. Per the guidelines, long text will truncate with an ellipsis, and the full text should be available in a tooltip.",
+			link: "#",
+		},
+		{
+			id: "group1",
+			label: "Group 1",
+			link: "#",
+			isOpen: true,
+			items: [],
+		},
+		{
+			id: "label2",
+			label: "Label 2",
+			link: "#",
+			customClasses: ["spectrum-TreeView-item--indent1"],
+		},
+		{
+			id: "label3",
+			label: "Label 3",
+			link: "#",
+			customClasses: ["spectrum-TreeView-item--indent1"],
+		},
+		{
+			id: "label4",
+			label: "Label 4",
+			link: "#",
+		},
+		{
+			id: "group2",
+			label: "Group 2",
+			link: "#",
+			isOpen: true,
+			items: [],
+		},
+		{
+			id: "label5",
+			label: "Label 5",
+			link: "#",
+			customClasses: ["spectrum-TreeView-item--indent1"],
+		},
+		{
+			id: "group3",
+			label: "Group 3",
+			link: "#",
+			isOpen: true,
+			items: [],
+			customClasses: ["spectrum-TreeView-item--indent1"],
+		},
+		{
+			id: "label6",
+			label: "Label 6",
+			link: "#",
+			customClasses: ["spectrum-TreeView-item--indent2"],
+		},
+	],
+};
+Flat.tags = ["!dev"];
+Flat.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+/**
  * Icons can be used to add clarification about tree view items. These help to signify content types, which creates easier reference and context within the hierarchy.
  *
- * In this example, a nested tree view with folder and file icons is shown. 
+ * In this example, a nested tree view with folder and file icons is shown. This example also sets a maximum width of 500px (`max-inline-size`) in order to demonstrate how longer text truncates.
  */
 export const FoldersAndFiles = Template.bind({});
 FoldersAndFiles.args = {
+	customStyles: {
+		"max-inline-size": "500px",
+	},
 	items: [
 		{
 			id: "label1",
@@ -455,79 +533,6 @@ DropTarget.args = {
 };
 DropTarget.tags = ["!dev"];
 DropTarget.parameters = {
-	chromatic: { disableSnapshot: true },
-};
-
-/**
- * A tree view drawn without nesting, suitable for infinite scrolling. With this version of the treeview, you must manage the visibility of "child items" manually based on the open state of the "parent item." The level of visual indentation is handled by a numbered `indent` variant class.
- */
-export const Flat = Template.bind({});
-Flat.storyName = "Flat Markup";
-Flat.args = {
-	customStyles: {
-		"width": "500px",
-	},
-	items: [
-		{
-			id: "label1",
-			label: "Label 1. This example has longer text. Per the guidelines, long text will truncate with an ellipsis, and the full text should be available in a tooltip.",
-			link: "#",
-		},
-		{
-			id: "group1",
-			label: "Group 1",
-			link: "#",
-			isOpen: true,
-			items: [],
-		},
-		{
-			id: "label2",
-			label: "Label 2",
-			link: "#",
-			customClasses: ["spectrum-TreeView-item--indent1"],
-		},
-		{
-			id: "label3",
-			label: "Label 3",
-			link: "#",
-			customClasses: ["spectrum-TreeView-item--indent1"],
-		},
-		{
-			id: "label4",
-			label: "Label 4",
-			link: "#",
-		},
-		{
-			id: "group2",
-			label: "Group 2",
-			link: "#",
-			isOpen: true,
-			items: [],
-		},
-		{
-			id: "label5",
-			label: "Label 5",
-			link: "#",
-			customClasses: ["spectrum-TreeView-item--indent1"],
-		},
-		{
-			id: "group3",
-			label: "Group 3",
-			link: "#",
-			isOpen: true,
-			items: [],
-			customClasses: ["spectrum-TreeView-item--indent1"],
-		},
-		{
-			id: "label6",
-			label: "Label 6",
-			link: "#",
-			customClasses: ["spectrum-TreeView-item--indent2"],
-		},
-	],
-};
-Flat.tags = ["!dev"];
-Flat.parameters = {
 	chromatic: { disableSnapshot: true },
 };
 

--- a/components/treeview/stories/treeview.stories.js
+++ b/components/treeview/stories/treeview.stories.js
@@ -111,7 +111,7 @@ Default.args = {
 // ********* DOCS ONLY ********* //
 export const Sizing = SizingGroup.bind({});
 Sizing.args = Default.args;
-Sizing.tags = ["autodocs", "!dev"];
+Sizing.tags = ["!dev"];
 Sizing.parameters = {
 	chromatic: { disableAllSnapshots: true },
 };
@@ -121,7 +121,7 @@ Sizing.parameters = {
  * A tree view with a selected item.
  */
 export const Selected = Default.bind({});
-Selected.tags = ["autodocs", "!dev"];
+Selected.tags = ["!dev"];
 Selected.args = {
 	items: [
 		{
@@ -146,7 +146,7 @@ Selected.parameters = {
  */
 export const Quiet = Default.bind({});
 Quiet.storyName = "Selected (Quiet)";
-Quiet.tags = ["autodocs", "!dev"];
+Quiet.tags = ["!dev"];
 Quiet.args = {
 	...Selected.args,
 	isQuiet: true,
@@ -159,7 +159,7 @@ Quiet.parameters = {
  * Detached tree views are meant to be used outside of a panel. Items in detached tree views have rounded corners.
  */
 export const Detached = Default.bind({});
-Detached.tags = ["autodocs", "!dev"];
+Detached.tags = ["!dev"];
 Detached.args = {
 	...Selected.args,
 	variant: "detached",
@@ -173,7 +173,7 @@ Detached.parameters = {
  */
 export const DetachedQuiet = Default.bind({});
 DetachedQuiet.storyName = "Detached (Quiet)";
-DetachedQuiet.tags = ["autodocs", "!dev"];
+DetachedQuiet.tags = ["!dev"];
 DetachedQuiet.args = {
 	...Selected.args,
 	variant: "detached",
@@ -187,7 +187,7 @@ DetachedQuiet.parameters = {
  * In this example, the Label 2 and Group 2 are disabled.
  */
 export const Disabled = Template.bind({});
-Disabled.tags = ["autodocs", "!dev"];
+Disabled.tags = ["!dev"];
 Disabled.args = {
 	items: [
 		{
@@ -379,7 +379,7 @@ Thumbnails.parameters = {
  */
 export const ThumbnailsQuiet = Template.bind({});
 ThumbnailsQuiet.storyName = "Thumbnails (Quiet)";
-ThumbnailsQuiet.tags = ["autodocs", "!dev"];
+ThumbnailsQuiet.tags = ["!dev"];
 ThumbnailsQuiet.args = {
 	...Thumbnails.args,
 	isQuiet: true,
@@ -428,7 +428,7 @@ Sections.args = {
 		},
 	],
 };
-Sections.tags = ["autodocs", "!dev"];
+Sections.tags = ["!dev"];
 Sections.parameters = {
 	chromatic: { disableAllSnapshots: true },
 };
@@ -453,7 +453,7 @@ DropTarget.args = {
 		},
 	],
 };
-DropTarget.tags = ["autodocs", "!dev"];
+DropTarget.tags = ["!dev"];
 DropTarget.parameters = {
 	chromatic: { disableAllSnapshots: true },
 };

--- a/components/treeview/stories/treeview.stories.js
+++ b/components/treeview/stories/treeview.stories.js
@@ -113,7 +113,7 @@ export const Sizing = SizingGroup.bind({});
 Sizing.args = Default.args;
 Sizing.tags = ["!dev"];
 Sizing.parameters = {
-	chromatic: { disableAllSnapshots: true },
+	chromatic: { disableSnapshot: true },
 };
 
 
@@ -138,7 +138,7 @@ Selected.args = {
 	]
 };
 Selected.parameters = {
-	chromatic: { disableAllSnapshots: true },
+	chromatic: { disableSnapshot: true },
 };
 
 /**
@@ -152,7 +152,7 @@ Quiet.args = {
 	isQuiet: true,
 };
 Quiet.parameters = {
-	chromatic: { disableAllSnapshots: true },
+	chromatic: { disableSnapshot: true },
 };
 
 /**
@@ -165,7 +165,7 @@ Detached.args = {
 	variant: "detached",
 };
 Detached.parameters = {
-	chromatic: { disableAllSnapshots: true },
+	chromatic: { disableSnapshot: true },
 };
 
 /**
@@ -180,7 +180,7 @@ DetachedQuiet.args = {
 	isQuiet: true,
 };
 DetachedQuiet.parameters = {
-	chromatic: { disableAllSnapshots: true },
+	chromatic: { disableSnapshot: true },
 };
 
 /**
@@ -249,7 +249,7 @@ Disabled.args = {
 	],
 };
 Disabled.parameters = {
-	chromatic: { disableAllSnapshots: true },
+	chromatic: { disableSnapshot: true },
 };
 
 /**
@@ -325,7 +325,7 @@ FoldersAndFiles.args = {
 };
 FoldersAndFiles.tags = ["!dev"];
 FoldersAndFiles.parameters = {
-	chromatic: { disableAllSnapshots: true },
+	chromatic: { disableSnapshot: true },
 };
 
 
@@ -371,7 +371,7 @@ Thumbnails.args = {
 };
 Thumbnails.tags = ["!dev"];
 Thumbnails.parameters = {
-	chromatic: { disableAllSnapshots: true },
+	chromatic: { disableSnapshot: true },
 };
 
 /**
@@ -385,7 +385,7 @@ ThumbnailsQuiet.args = {
 	isQuiet: true,
 };
 ThumbnailsQuiet.parameters = {
-	chromatic: { disableAllSnapshots: true },
+	chromatic: { disableSnapshot: true },
 };
 
 export const Sections = Template.bind({});
@@ -430,7 +430,7 @@ Sections.args = {
 };
 Sections.tags = ["!dev"];
 Sections.parameters = {
-	chromatic: { disableAllSnapshots: true },
+	chromatic: { disableSnapshot: true },
 };
 
 
@@ -455,7 +455,7 @@ DropTarget.args = {
 };
 DropTarget.tags = ["!dev"];
 DropTarget.parameters = {
-	chromatic: { disableAllSnapshots: true },
+	chromatic: { disableSnapshot: true },
 };
 
 /**
@@ -528,7 +528,7 @@ Flat.args = {
 };
 Flat.tags = ["!dev"];
 Flat.parameters = {
-	chromatic: { disableAllSnapshots: true },
+	chromatic: { disableSnapshot: true },
 };
 
 // ********* VRT ONLY ********* //

--- a/components/well/stories/well.stories.js
+++ b/components/well/stories/well.stories.js
@@ -5,7 +5,7 @@ import { version } from "../package.json";
 import { WellGroup } from "./template";
 
 /**
- * A well is a content container that displays non-editable content separate from other content on the screen. Often this is used to display preformatted text, such as code/markup examples on a documentation page.
+ * A well is a content container that displays non-editable content separate from other content on the screen. Often this is used to display preformatted text, such as code/markup examples on a documentation page. The well may also be labeled by an optional heading outside of the component.
  */
 export default {
 	title: "Well",


### PR DESCRIPTION
## Description
Updates Storybook to contain information from Docs site for: Tag group, Thumbnail, Tray, Treeview, Well

(Underlay and Typography are also part of this card, but Underlay does not appear to exist on the docs site and Typography will have a separate PR.)

**Tag group**:
* `Standard` variant (docs site) --> `Default` (Storybook)
* `Removable` variant (docs site) --> `Removable` (Storybook)

`OverflowItems` story changed to `Removable` to align more closely with docs site, and because `Removable` is more of a variant, whereas `OverflowItems` describes default behavior. Tag wrapping behavior is noted in Storybook rather than having its own story.

**Thumbnail**:
* `Thumbnail` variant (docs site) --> `Default` (Storybook)
* `Thumbnail (focused)` variant (docs site) --> `Focused` (Storybook)
* `Thumbnail (disabled)` variant (docs site) --> `Disabled` (Storybook)
* `Thumbnail (landscape image)` variant (docs site) --> `Image Fit (Landscape)` (Storybook)
* `Thumbnail (portrait image)` variant (docs site) --> `Image Fit (Portrait)` (Storybook)
* `Thumbnail (layer)` variant (docs site) --> `Layer` (Storybook)
* `Thumbnail (layer, selected)` variant (docs site) --> `Layer (Selected)` (Storybook)
* `Thumbnail Cover (landscape image)` variant (docs site) --> `Image Fit (Cover)` (Storybook)
* `Thumbnail (image against background)` variant (docs site) --> `With Background` (Storybook)
* `Thumbnail (sizes)` variant (docs site) --> `Sizing` (Storybook)

Updates some of the existing thumbnail images, and adds `Focused`, `Disabled`, `Sizing`, `Cover`, `Portrait`, `Landscape`, and `SelectedLayer` stories.

**Tray**:
* `Standard` (docs site) --> `Default` (Storybook)

Adds some additional context from [internal docs](https://spectrum.corp.adobe.com/page/tray/).

**Tree view**:
* `Standard` (docs site) --> `Default` (Storybook)
* `Selected` (docs site) --> `Selected` (Storybook)
* `Quiet` (docs site) --> `Selected (Quiet)` (Storybook)
* `Detached` (docs site) --> `Detached` (Storybook)
* `Detached (quiet)` (docs site) --> `Detached (Quiet)` (Storybook)
* `Folders & Files` (docs site) --> `Folders And Files` (Storybook)
* `Thumbnail` (docs site) --> `Thumbnails` (Storybook)
* `Thumbnail (quiet)` (docs site) --> `Thumbnails (Quiet)` (Storybook)
* `Disabled` (docs site) --> `Disabled` (Storybook)
* `Sections` (docs site) --> `Sections` (Storybook)
* `Drop target` (docs site) --> `Drop target` (Storybook)
* `Sizing` (docs site) --> `Sizing` (Storybook)
* `Icons` (docs site) --> `Folders And Files` (Storybook)
* `Flat` (docs site) --> `Flat markup` (Storybook)
Adjusts some stories to match markup (such as `Default`). Adds docs-only stories for `Sizing`, `Selected`, `Quiet`, `Detached`, `Detached Quiet`, `Disabled`, and `Thumbnails Quiet`. `WithSections` and `WithDropTarget` changed to `Sections` and `DropTarget` respectively.

**Well**:
* `Standard` (docs site) --> `Default` (Storybook)

[CSS-794](https://jira.corp.adobe.com/browse/CSS-794)

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

Validate:
- [x] [Tag group storybook](https://pr-2943--spectrum-css.netlify.app/preview/?path=/docs/components-tag-group--docs) contains all relevant content from [docs site](https://opensource.adobe.com/spectrum-css/taggroup.html) (see variant changes in description above):
    - [x] All relevant written content from docs site variants is in Storybook
    - [x] All relevant written content from docs site migration guide is in CHANGELOG
    - [x] All relevant markup/class names are displayed for each variant in Storybook
- [x] [Thumbnail storybook](https://pr-2943--spectrum-css.netlify.app/preview/?path=/docs/components-thumbnail--docs) contains all relevant content from [docs site](https://opensource.adobe.com/spectrum-css/thumbnail.html) (see variant changes in description above):
    - [x] All relevant written content from docs site variants is in Storybook
    - [x] All relevant written content from docs site migration guide is in CHANGELOG
    - [x] All relevant markup/class names are displayed for each variant in Storybook
- [x] [Tray storybook](https://pr-2943--spectrum-css.netlify.app/preview/?path=/docs/components-tray--docs) contains all relevant content from [docs site](https://opensource.adobe.com/spectrum-css/tray.html) (see variant changes in description above):
    - [x] All relevant written content from docs site variants is in Storybook
    - [x] All relevant markup/class names are displayed for each variant in Storybook
- [x] [Tree view storybook](https://pr-2943--spectrum-css.netlify.app/preview/?path=/docs/components-tree-view--docs) contains all relevant content from [docs site](https://opensource.adobe.com/spectrum-css/treeview.html) (see variant changes in description above):
    - [x] All relevant written content from docs site variants is in Storybook
    - [x] All relevant written content from docs site migration guide is in CHANGELOG
    - [x] All relevant markup/class names are displayed for each variant in Storybook
- [x] [Well storybook](https://pr-2943--spectrum-css.netlify.app/preview/?path=/docs/components-well--docs) contains all relevant content from [docs site](https://opensource.adobe.com/spectrum-css/well.html) (see variant changes in description above):
    - [x] All relevant written content from docs site variants is in Storybook
    - [x] All relevant markup/class names are displayed for each variant in Storybook
- [x] No new/additional stories are displayed in the sidebar

### Regression
1. The documentation pages for at least two other components are still loading, including:

    - [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

    - [ ] VRTs have been run and looked at.
    - [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.
