### PR TITLE
feat(swatch): add support for lightBorder

### DIFF
--- a/.changeset/pretty-socks-notice.md
+++ b/.changeset/pretty-socks-notice.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/swatch": minor
+---
+
+Reimplements support for the `spectrum-Swatch--lightBorder` class for swatches specifically in a swatch group.

--- a/components/swatch/index.css
+++ b/components/swatch/index.css
@@ -40,12 +40,14 @@
 	/* Light theme placeholder tokens */
 	.spectrum--light & {
 		--spectrum-swatch-border-color: rgba(0, 0, 0, 51%);
+		--spectrum-swatch-border-color-light: rgba(0, 0, 0, 20%);
 	}
 
 	/* Dark and Darkest theme placeholder tokens */
 	.spectrum--dark &,
 	.spectrum--darkest & {
 		--spectrum-swatch-border-color: rgba(255, 255, 255, 51%);
+		--spectrum-swatch-border-color-light: rgba(255, 255, 255, 20%);
 	}
 }
 
@@ -279,6 +281,14 @@
 
 			/* Undefined variable allows custom stylesheet or JS to pass the value to this element */
 			background-color: var(--spectrum-picked-color, transparent);
+		}
+	}
+}
+
+.spectrum-Swatch--lightBorder {
+	.spectrum-Swatch-fill {
+		&::before {
+			box-shadow: inset 0 0 0 var(--mod-swatch-border-thickness, var(--spectrum-swatch-border-thickness)) var(--highcontrast-swatch-border-color-light, var(--mod-swatch-border-color-light, var(--spectrum-swatch-border-color-light)));
 		}
 	}
 }

--- a/components/swatch/metadata/mods.md
+++ b/components/swatch/metadata/mods.md
@@ -2,6 +2,7 @@
 | -------------------------------------------- |
 | `--mod-animation-duration-100`               |
 | `--mod-swatch-border-color`                  |
+| `--mod-swatch-border-color-light`            |
 | `--mod-swatch-border-color-selected`         |
 | `--mod-swatch-border-radius`                 |
 | `--mod-swatch-border-thickness`              |


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

During the documentation migration work in #2925, it was noticed that the "light border" variant didn't have corresponding CSS. After some digging, I found that we did support it at one point, but it may have accidentally gotten deleted. When reading the Slack messages linked in #1501, it sounds like a light border variant should have been supported, but I believe that was one of the "open questions" related to that PR. This PR re-implements the modifier class `.spectrum-Swatch--lightBorder` based on a new conversation with design.

I restarted this conversation with Miruna and got clarification from her:

me: 
...I've been migrating a bunch of documentation from our [static site](https://opensource.adobe.com/spectrum-css/swatch.html) to storybook. I saw on the static site there was a "light border" variant that we don't currently support, and also found on the [Spectrum guidance page ](https://spectrum.corp.adobe.com/page/swatch-group/#Border-only-for-low-contrast-swatches) that there should be a border around a swatch with low contrast to its background. Right now, we don't have any CSS for this. I was just going to add it during my docs migration, but wanted to double check first that we still should be supporting this, or if I just found outdated info.

Miruna: 
> ...yes the border with low contrast (20% opacity) should be applied to Swatch only when they are in a Swatch group. This helps with comparing colors in a Swatch group better than the 42% opacity border that is applied to the single swatch...I think for Spectrum 1 the border was applied individually by product teams cause it was depending on the color of the Swatch ( it was not applied to all colors in a Swatch group, but dont quote me on that tho lol). But we decided that for S2 we are gonna be more restrictive with this and give the guidance to have a border for single swatch or swatch group cause its an important spectrum component so there should be a design POV in place

me: For the lightBorder, do the values change at all between light/dark modes?

Miruna: 
> it just stays linked to gray-1000 20% for both

This PR does not address any S2 design recommendations, but does set up CSS support for swatches to have a light border. Further implementation of `--lightBorder` should be seen in #2925 after this PR is merged. 

[Jira ticket](https://jira.corp.adobe.com/browse/CSS-855)

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

- [x] Double check with design that lightBorder should be supported, and the value does not change between light and dark modes @marissahuysentruyt
- [x] Visit [the swatch docs page](https://pr-2954--spectrum-css.netlify.app/preview/?path=/docs/components-swatch--docs)
- [x] Inspect the swatch and find `.spectrum-Swatch`. Verify the swatch has its default border (`rgba(0, 0, 0, 0.51)`) in light mode.
- [x] Toggle the light and dark modes in the toolbar switcher. The default border should change based on the color mode as before. (`rgba(255, 255, 255, 0.51)` is for dark/darkest mode)
- [x] Add the `.spectrum-Swatch--lightBorder` class to the element. Verify the border has changed to `rgba(0, 0, 0, 0.2)`. 
- [x] Toggle light and dark modes in the toolbar switcher. The `spectrum-Swatch--lightBorder` class should  mimic the border behavior from before, but now uses `--spectrum-Swatch-border-color-light` that has a 20% opacity (instead of 51%). You may have to re-add the `--lightBorder` class each time you change color modes. 😩

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
