### PR TITLE
fix(card)!: change cover photo background color and include mod

### DIFF
--- a/.changeset/little-dodos-peel.md
+++ b/.changeset/little-dodos-peel.md
@@ -1,0 +1,7 @@
+---
+"@spectrum-css/card": major
+---
+
+BREAKING CHANGE: The card component's default variant now uses the same grey background color behind the cover photo that is used behind the image for the quiet variant. This background was only visible when the image did not take up the entire space. The intended background color of `--spectrum-background-base-color` for non-quiet variants was confirmed by the design team.
+
+This also provides the existing mod custom property `--mod-card-preview-background-color` for customizing this area behind the image for the default variant.

--- a/components/card/index.css
+++ b/components/card/index.css
@@ -227,7 +227,8 @@
 
 	background-size: cover;
 	background-position: center center;
-	background-color: var(--mod-card-background-color, var(--spectrum-card-background-color));
+
+	background-color: var(--mod-card-preview-background-color, var(--spectrum-card-preview-background-color));
 	border-block-end-color: var(--mod-card-border-color, var(--spectrum-card-border-color));
 }
 


### PR DESCRIPTION
## Description

Updates the background color behind the default variant's cover photo to match the design spec and adds a mod property so it can be customized.

1. BREAKING CHANGE: The default variant's cover photo now uses the same grey background color as the preview area for the quiet variant, which is visible when the image does not take up the entire space. This intended background color for non-quiet `--spectrum-background-base-color` was confirmed by the design team.

   Spectrum CSS currently always uses `background-size: cover` on a background image for this variant, but SWC uses an actual image with `object-fit`, so the use case of an image that did not fill the whole area was not present or testable on the CSS side. I created a followup Jira issue CSS-878 for getting this markup more in sync and adding it to VRTs.

2. This provides the existing mod `--mod-card-preview-background-color` for the area behind the image in the default variant. Which is the same mod already used for the area behind the image in the existing quiet variant. This resolves an issue reported in Slack about needing to customize this background color behind the cover photo (`.spectrum-Card-coverPhoto`).

### Screenshots

Before:
<img width="365" alt="Screenshot 2024-08-09 at 3 39 08 PM" src="https://github.com/user-attachments/assets/1dbad69a-8eb6-4d77-9313-6f9bb7463075">

After:
<img width="371" alt="Screenshot 2024-08-09 at 3 37 03 PM" src="https://github.com/user-attachments/assets/76c51bfd-64d3-404b-8969-9bc88a5ff24d">

S1 design spec for quiet. This same background is what should apply to the default variant, as confirmed by design.
![Screenshot 2024-08-08 at 3 36 18 PM](https://github.com/user-attachments/assets/3b4e6d9e-bb2e-4400-8284-9d1c87a74b0d)

And [the existing guidelines](https://spectrum.adobe.com/page/cards/#Preview-aspect-ratio) had an image with this use case including the darker background.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [x] Set `--mod-card-preview-background-color: red` in the inspector on `.spectrum-Card-coverPhoto` (Default card story) and turning off the background image, should show red in the background of the preview image area only:
![Screenshot 2024-07-30 at 1 13 56 PM](https://github.com/user-attachments/assets/6758f3a8-a640-40ed-9b2f-51c8df3e2ad6)
- [x] There are no regressions in VRT
- [x] Set `background-size: contain; background-repeat: no-repeat;` in the inspector on `.spectrum-Card-coverPhoto`. The grey background should appear as it does in the "After" screenshot above.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
