### PR TITLE
fix(breadcrumb): center breadcrumb itemLink

### DIFF
--- a/.changeset/gold-spies-learn.md
+++ b/.changeset/gold-spies-learn.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/breadcrumb": patch
+---
+
+Aligns breadcrumb item text node to center of container. This should ensure the text and separator icon are center-aligned.

--- a/components/breadcrumb/index.css
+++ b/components/breadcrumb/index.css
@@ -176,6 +176,8 @@
 	display: inline-flex;
 	white-space: nowrap;
 
+	align-items: center;
+
 	font-family: var(--mod-breadcrumbs-font-family, var(--spectrum-breadcrumbs-font-family));
 	font-size: var(--mod-breadcrumbs-font-size, var(--spectrum-breadcrumbs-font-size));
 	font-weight: var(--mod-breadcrumbs-font-weight, var(--spectrum-breadcrumbs-font-weight));


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

During the [SWC implementation of breadcrumbs](https://github.com/adobe/spectrum-web-components/pull/4578), it was noticed that [there might be some misalignment of the breadcrumb items](https://adobedesign.slack.com/archives/CS22GNRU2/p1721217941481189?thread_ts=1720625760.158419&cid=CS22GNRU2), specifically for large/mobile scale: 

https://github.com/user-attachments/assets/33dc71fb-2f5a-4fee-8985-538457d914ac

In the video above, when breadcrumbs is toggled to the mobile scale, the margin around the separator icon increases from 19px to 25px. That margin causes the `spectrum-Breadcrumbs-item` element to increase in height in comparison to the last breadcrumb item, which has `display: none` set on its corresponding separator icon. You can see in the screenshots below that the last breadcrumb item is shorter in height without the additional margin increase from the icon:

<img width="407" alt="Screenshot 2024-08-01 at 9 11 07 AM" src="https://github.com/user-attachments/assets/a91b5956-5a8b-4ef7-bf45-ef0aa76463bf">
<img width="435" alt="Screenshot 2024-08-01 at 9 11 24 AM" src="https://github.com/user-attachments/assets/fbf2d204-5d31-47f1-9024-95d69c86627a">

Because of the increase in height, as well as the margins placed on the `spectrum-Breadcrumbs-itemLink` element, you can see that element increases in height, filling any remaining space. Although the `spectrum-Breadcrumbs` parent element has `align-items: center`, that was only affecting the `spectrum-Breadcrumbs-item` element, and not the `spectrum-Breadcrumbs-itemLink` element that houses the text node. As the item link element grows, you can see the visual misalignment of text to the separator icon because the text node was not centered in the item link element. This also leads to the first few breadcrumbs' text to look misaligned to the last breadcrumb text:

<img width="328" alt="Screenshot 2024-08-01 at 9 16 54 AM" src="https://github.com/user-attachments/assets/3c01d71b-1054-4f58-8c09-60be11f2aa2b">
<img width="268" alt="Screenshot 2024-08-01 at 9 16 29 AM" src="https://github.com/user-attachments/assets/a62a78b7-a9e9-49da-8088-0a2b7a1865c8">

Adding `align-self: center` to `spectrum-Breadcrumbs-itemLink` resolves the height increase and corresponding text node misalignment. Additionally, `align-self: center` was added to the `spectrum-ActionButton` in use cases where an icon is used.

before:
<img width="179" alt="Screenshot 2024-08-01 at 9 27 24 AM" src="https://github.com/user-attachments/assets/78e99feb-1e07-48b3-9d0d-dd18115248c6">

after: 
<img width="191" alt="Screenshot 2024-08-01 at 9 27 46 AM" src="https://github.com/user-attachments/assets/ec588761-7d88-407f-802d-31f08ed62846">

The example below is from the Spectrum CSS Storybook, toggling between desktop and mobile scale: 

https://github.com/user-attachments/assets/aaa3105b-14bd-454c-80bf-20cc86203b72

This example below uses the preview URL from the SWC breadcrumb PR, adding `align-self: center` in the inspector, and toggling it on and off:

https://github.com/user-attachments/assets/055f48a9-c6bd-4b3c-a498-c30819726601

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

- Visit the [breadcrumbs default story page](https://pr-2961--spectrum-css.netlify.app/preview/?path=/story/components-breadcrumbs--default)
- Toggle the scale to "large" for mobile viewing, and turn on both the border and measurement tools

<img width="381" alt="Screenshot 2024-08-02 at 10 16 12 AM" src="https://github.com/user-attachments/assets/b07f1008-7beb-42a1-b9f0-880d34c343db">

- Inspect one of the `spectrum-Breadcrumbs-itemLink` elements. 
- Toggle the `align-self: center` in the inspector. You should see the borders of the item link elements change, and the text within them move up, away from the center line of the container

<img width="216" alt="Screenshot 2024-08-02 at 10 12 16 AM" src="https://github.com/user-attachments/assets/7af08529-9bf5-4877-a596-54b083c24993">

- With `align-self: center` turned off, measure the heights of `spectrum-Breadcrumbs-itemLink`. You should see a height difference with the first two items, in comparison to the last item/current breadcrumb. The first two items will be taller
- Turn on `align-self: center` in the inspector, and remeasure all breadcrumb item links. All should be the same height now
- In the Storybook controls, change the variant to compact or multiline. Repeat the process of checking that `align-self: center` better aligns the text nodes to the separator icons, and keeps the height of `spectrum-Breadcrumbs-itemLink` the same across all breadcrumb items (note that the final breadcrumb item in the multi-line variant _should_ have a different height)

#### Additional validation
- Pull down the branch and run locally
- In `breadcrumbs/breadcrumbs.stories.js`, add the following to ` Default.args.items` (add this before the last item): 
```
  {
    iconName: "FolderOpen",
    isDisabled: true,
  },
```
- Visit [the breadcrumbs default page](http://localhost:8080/?path=/story/components-breadcrumbs--default&globals=scale:large;measureEnabled:!true;outline:!true) (with the large scale, borders on, and measurement on)
- Back in the browser, you should now have additional breadcrumb with a disabled action button and folder icon
- Inspect the action button and toggle the `align-self: center` property. You should see the same behavior as with the text nodes, where `align-self: center` turned on ensures the action button is centered with the separator, and that property turned off leaves the action button unaligned.


### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
