### PR TITLE
docs: clarify usage of very low opacity on some inputs

### DIFF
--- a/components/checkbox/index.css
+++ b/components/checkbox/index.css
@@ -399,6 +399,10 @@
 	}
 }
 
+/**
+ * The input is visually hidden (with opacity), and remains accessible using assistive tech.
+ * It is still sized and positioned where it would naturally be present so that touch users can find it with haptics.
+ */
 .spectrum-Checkbox-input {
 	color: var(--mod-checkbox-control-color-default, var(--spectrum-checkbox-control-color-default));
 
@@ -423,6 +427,7 @@
 	inline-size: 100%;
 	block-size: 100%;
 
+	/* @todo Look into replacing with opacity 0. The tiny opacity value appears to be a workaround for a ChromeVox legacy bug (circa 2018). */
 	opacity: 0.0001;
 	z-index: 1;
 

--- a/components/dial/index.css
+++ b/components/dial/index.css
@@ -227,12 +227,17 @@
 	}
 }
 
+/**
+ * The input is visually hidden (with opacity), and remains accessible using assistive tech.
+ * It is still sized and positioned where it would naturally be present so that touch users can find it with haptics.
+ */
 .spectrum-Dial-input {
 	/*  Remove the margin for input in Firefox and Safari. */
 	margin: 0;
 	padding: 0;
 	position: absolute;
 	overflow: hidden;
+	/* @todo Look into replacing with opacity 0. The tiny opacity value appears to be a workaround for a ChromeVox legacy bug (circa 2018). */
 	opacity: 0.000001;
 	cursor: default;
 	appearance: none;

--- a/components/slider/index.css
+++ b/components/slider/index.css
@@ -363,6 +363,10 @@
 	}
 }
 
+/**
+ * The input is visually hidden (with opacity), and remains accessible using assistive tech.
+ * It is still sized and positioned where it would naturally be present so that touch users can find it with haptics.
+ */
 .spectrum-Slider-input {
 	/*  Remove the margin for input in Firefox and Safari. */
 	margin: 0;
@@ -375,6 +379,7 @@
 	inset-block-start: var(--mod-slider-input-top-size, var(--spectrum-slider-input-top-size));
 	inset-inline-start: var(--mod-slider-input-left, var(--spectrum-slider-input-left));
 	overflow: hidden;
+	/* @todo Look into replacing with opacity 0. The tiny opacity value appears to be a workaround for a ChromeVox legacy bug (circa 2018). */
 	opacity: 0.000001; /* stylelint-disable-line number-max-precision */
 	cursor: default;
 	appearance: none;


### PR DESCRIPTION
## Description

Adds some comments to clarify existing CSS that uses a low opacity (0.0001 and 0.000001) for visually hidden inputs. And explains why they are hidden this way with sizing and positioning for touch users, instead of using a screenreader only (.sr-only) technique.

**Reference info:**
- [Inclusively Hiding & Styling Checkboxes and Radio Buttons: Hiding the checkboxes inclusively](https://www.sarasoueidan.com/blog/inclusively-hiding-and-styling-checkboxes-and-radio-buttons/#:~:text=navigating%20by%20touch.-,Hiding%20the%20checkboxes%20inclusively,-Touch%20interface%20screen) (2020)  - Why this technique appears to be used and why a visually-hidden or sr-only class would not be an improvement over the current way that these inputs are hidden.
- [Inclusive Considerations When Restyling Form Controls](https://24ways.org/2018/inclusive-considerations-when-restyling-form-controls/) (2018) - Source code that referenced the ChromeVox issue as being the reason that a very small but not zero opacity is used. This issue is also mentioned in a few old tangential GitHub issues and on StackOverflow. I wasn't able to find any other reasoning for why this technique would be used, as `opacity: 0` elements are included in the accessibility tree.

At some point in the future we may want to look at dropping the very low opacity in favor of `opacity: 0`. I cannot find any official change log available that references exactly when the ChromeVox issue was fixed.

CSS-814

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [ ] Validate that explanation and wording are correct 

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
