### PR TITLE
fix: static white meter story and corrected fill colors

### DIFF
--- a/.changeset/lucky-jeans-happen.md
+++ b/.changeset/lucky-jeans-happen.md
@@ -1,0 +1,6 @@
+---
+"@spectrum-css/progressbar": patch
+---
+
+- Enforces the correct static white progress bar fill color when meter is using both the `spectrum-ProgressBar--staticWhite` class and one of the `is-positive`, `is-negative`, or `is-notice` classes.
+- Adds a static white story to meter.

--- a/components/progressbar/index.css
+++ b/components/progressbar/index.css
@@ -223,7 +223,7 @@
 }
 
 /* Static White */
-.spectrum-ProgressBar--staticWhite {
+.spectrum-ProgressBar.spectrum-ProgressBar--staticWhite {
 	.spectrum-ProgressBar-fill {
 		color: var(--mod-progressbar-label-and-value-white, var(--spectrum-progressbar-label-and-value-white));
 		background-color: var(--mod-progressbar-fill-color-white, var(--spectrum-progressbar-fill-color-white));

--- a/components/progressbar/stories/meter.stories.js
+++ b/components/progressbar/stories/meter.stories.js
@@ -45,3 +45,16 @@ WithForcedColors.parameters = {
 		modes: disableDefaultModes
 	},
 };
+
+export const StaticWhite = Default.bind({});
+StaticWhite.tags = ["!autodocs", "!dev", "test"];
+StaticWhite.args = {
+	staticColor: "white",
+	label: "Loading your fonts, images, and icons",
+	value: 50,
+};
+StaticWhite.parameters = {
+	chromatic: {
+		modes: disableDefaultModes
+	},
+};

--- a/components/progressbar/stories/meter.stories.js
+++ b/components/progressbar/stories/meter.stories.js
@@ -47,7 +47,7 @@ WithForcedColors.parameters = {
 };
 
 export const StaticWhite = Default.bind({});
-StaticWhite.tags = ["!autodocs", "!dev", "test"];
+StaticWhite.tags = ["!autodocs", "!dev"];
 StaticWhite.args = {
 	staticColor: "white",
 	label: "Loading your fonts, images, and icons",


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->
Because meter just extends the `ProgressBar.args`, `staticWhite` shows in the meter controls in Storybook. During the work in #2929, we noticed that the positive, negative and notice fill colors for meter do not respond as expected when looking at a `staticWhite` story. When `staticWhite` was turned on, the positive, negative and notice colors remained the same, while the default story (and all of the progress bar stories) have reinforced, white fill colors.

🚫 
![Screenshot 2024-07-29 at 10 49 39 AM](https://github.com/user-attachments/assets/5d65291f-ee5d-4983-9ffe-9c5b7a4d3aa5)

After checking with design (Nadeen), it was confirmed all stories should have the same fill colors as the default story when `staticWhite` is toggled on: 
> if the component is in the static option - all the elements take on white (field label, value and fill of the progress bar) and transparent white for the progress bar track.

✅ 
<img width="224" alt="Screenshot 2024-08-06 at 1 03 24 PM" src="https://github.com/user-attachments/assets/047bb751-89a7-4821-80b8-bb6d7b84e384">

This PR adds the static white story to meter to increase Chromatic coverage, and adds CSS to enforce the static white design specs.

[CSS-872](https://jira.corp.adobe.com/browse/CSS-872)

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

#### Meter
- [x] Check with design on behavior of positive, negative, notice stories for meter @marissahuysentruyt 
- [ ] Visit the [meter default story](https://pr-2965--spectrum-css.netlify.app/preview/?path=/story/components-meter--default)
- [ ] In the controls, turn on the static white styles
- [ ] Verify the default story's progress bar fill color changes from blue to white
- [ ] Turn the Chromatic preview on and verify all stories behave the same, with any fill colors changing to white (`--spectrum-progressbar-fill-color-white`), and track colors turning to transparent white (`--spectrum-progressbar-track-color-white`)
- [ ] Reset the component (to turn off the static white styles) and choose a fill color from the controls
- [ ] Verify the default and large stories' progress bars turn to the appropriate colors (positive=green; negative=red; notice=orange)
- [ ] Turn the static white controls on once more and verify the static white styles are applied (all progress bars should be white)
- [ ] Inspect `spectrum-ProgressBar` (the parent element)
- [ ] Verify that your chosen fill color has added the appropriate class to parent element for the default and large stories (postive=`is-positive`; negative=`is-negative`; notice=`is-notice`), and also has the additional `spectrum-ProgressBar--staticWhite` class)

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
