### PR TITLE
chore: fix stylelint extension error

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -86,7 +86,7 @@ jobs:
                   filter_mode: diff_context
                 #   stylelint_input: "components/*/index.css components/*/themes/*.css"
                   stylelint_input: "${{ inputs.styles_added_files }} ${{ inputs.styles_modified_files }}"
-                  stylelint_config: stylelint.config.mjs
+                  stylelint_config: stylelint.config.js
 
             - name: Run eslint on packages and stories
               uses: reviewdog/action-eslint@v1.31.0

--- a/nx.json
+++ b/nx.json
@@ -15,7 +15,7 @@
 		"scripts": ["{projectRoot}/stories/*.js"],
 		"stylelint": [
 			"{workspaceRoot}/.stylelintignore",
-			"{workspaceRoot}/stylelint.config.mjs",
+			"{workspaceRoot}/stylelint.config.js",
 			"{workspaceRoot}/plugins/stylelint-*/index.js"
 		],
 		"tools": [


### PR DESCRIPTION
## Description

A hanging `stylelint.config.mjs` was left over in nx.json and the lint workflow from when I attempted to support mixed ESM and CJS in the monorepo for the stylelint migration to v16.  This removes those and ensures they are pointing to the `stylelint.config.js` file.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [ ] Inject a linting error into any `component/*/index.css` file. Use the `--no-verify` flag to commit it to the branch. Expect to see a linting error thrown for that file successfully with no error messages in the log such as: `Error: ENOENT: no such file or directory, open '/home/runner/work/spectrum-css/spectrum-css/stylelint.config.mjs'.`

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [n/a] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
