### PR TITLE
fix(icon): remove legacy ie overflow css causing ios clipping issues

### DIFF
--- a/.changeset/lucky-dots-live.md
+++ b/.changeset/lucky-dots-live.md
@@ -1,0 +1,6 @@
+---
+"@spectrum-css/icon": patch
+---
+
+Removes legacy normalization CSS for Icon SVGs that changed the overflow property. This is to fix a reported issue with clipping in iOS mobile for Express and Safari for MacOS.
+The original CSS declaration was for Internet Explorer 9/10/11 and could be removed because IE 11 is not supported.

--- a/components/icon/icons.css
+++ b/components/icon/icons.css
@@ -26,11 +26,6 @@
 	/* Fill should match the current text color. */
 	fill: currentColor;
 
-	/* Hide the SVG overflow in IE. */
-	&:not(:root) {
-		overflow: hidden;
-	}
-
 	/* Don't catch clicks or hover, otherwise they may not escape the SVG. */
 	pointer-events: none;
 }


### PR DESCRIPTION
## Description

It was reported that this normalize CSS for IE 9/10/11, which Spectrum Web Components converts to the selector `:host(:not(:root))`, was leading to "clipping on iOS mobile (for Express) as well as on Safari on MacOS". An Express-specific hotfix was already put in to override this overflow declaration.

This is safe to remove as the project does not support IE 11.

**Reference:** 
The original `necolas/normalize.css` has this normalization labeled as "Correct overflow not hidden in IE 9/10/11."

CSS-700

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

@marissahuysentruyt 
- [x] Icon stories render correctly (recommendation: also check in Safari and Edge)
- [x] There are no VRT changes

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] ✨ This pull request is ready to merge. ✨
