### PR TITLE
chore(storybook): leverage shared types in all existing stories

### DIFF
--- a/.storybook/types/index.js
+++ b/.storybook/types/index.js
@@ -15,4 +15,5 @@ import argTypes from "./args.js";
 import globalTypes from "./global.js";
 
 export * from "./states.js";
+export * from "./variants.js";
 export { argTypes, globalTypes };

--- a/.storybook/types/states.js
+++ b/.storybook/types/states.js
@@ -89,6 +89,16 @@ export const isLoading = {
 	control: "boolean",
 };
 
+export const isIndeterminate = {
+	name: "Indeterminate",
+	type: { name: "boolean" },
+	table: {
+		type: { summary: "boolean" },
+		category: "State",
+	},
+	control: "boolean",
+};
+
 export const isDisabled = {
 	name: "Disabled",
 	type: { name: "boolean" },
@@ -124,7 +134,7 @@ export const isReadOnly = {
 	type: { name: "boolean" },
 	table: {
 		type: { summary: "boolean" },
-		category: "Advanced",
+		category: "State",
 	},
 	control: "boolean",
 };
@@ -137,4 +147,14 @@ export const isChecked = {
 		category: "State",
 	},
 	control: { type: "boolean" },
+};
+
+export const isPending = {
+	name: "Pending",
+	type: { name: "boolean" },
+	table: {
+		type: { summary: "boolean" },
+		category: "State",
+	},
+	control: "boolean",
 };

--- a/.storybook/types/variants.js
+++ b/.storybook/types/variants.js
@@ -1,0 +1,69 @@
+/**
+ *
+ * @param {("xxs"|"xs"|"s"|"m"|"l"|"xl"|"xxl"|number)[]} options
+ * @returns
+ */
+export const size = (
+	options = ["s", "m", "l", "xl"],
+	hasLabels = true,
+) => ({
+	name: "Size",
+	type: { name: "string", required: true },
+	table: {
+		type: { summary: "string" },
+		category: "Component",
+	},
+	options,
+	control: {
+		type: "select",
+		labels: hasLabels ? {
+			xxs: "Extra-extra-small",
+			xs: "Extra-small",
+			s: "Small",
+			m: "Medium",
+			l: "Large",
+			xl: "Extra-large",
+			xxl: "Extra-extra-large",
+			xxxl: "Extra-extra-extra-large",
+		} : undefined,
+	},
+});
+
+export const isEmphasized = {
+	name: "Emphasized styling",
+	type: { name: "boolean" },
+	table: {
+		type: { summary: "boolean" },
+		category: "Component",
+	},
+	control: { type: "boolean" },
+};
+
+export const isQuiet = {
+	name: "Quiet styling",
+	type: { name: "boolean" },
+	table: {
+		type: { summary: "boolean" },
+		category: "Component",
+	},
+	control: { type: "boolean" },
+};
+
+export const staticColor = {
+	name: "Static color",
+	description:
+        "Used when component is layered over a background or visual contrary to the general theme.",
+	type: { name: "string" },
+	table: {
+		type: { summary: "string" },
+		category: "Advanced",
+	},
+	options: ["white", "black"],
+	control: {
+		type: "select",
+		labels: {
+			white: "Over dark background",
+			black: "Over light background",
+		},
+	},
+};

--- a/components/accordion/stories/accordion.stories.js
+++ b/components/accordion/stories/accordion.stories.js
@@ -1,5 +1,6 @@
 import { Template as Link } from "@spectrum-css/link/stories/template.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
+import { size } from "@spectrum-css/preview/types";
 import { Template as Typography } from "@spectrum-css/typography/stories/template.js";
 import { version } from "../package.json";
 import { AccordionGroup } from "./accordion.test.js";
@@ -13,16 +14,7 @@ export default {
 	component: "Accordion",
 	argTypes: {
 		items: { table: { disable: true } },
-		size: {
-			name: "Size",
-			type: { name: "string", required: true },
-			table: {
-				type: { summary: "string" },
-				category: "Component",
-			},
-			options: ["s", "m", "l", "xl"],
-			control: "select",
-		},
+		size: size(["s", "m", "l", "xl"]),
 		disableAll: {
 			name: "Disable all items",
 			type: { name: "boolean" },

--- a/components/actionbar/stories/actionbar.stories.js
+++ b/components/actionbar/stories/actionbar.stories.js
@@ -2,7 +2,7 @@ import { default as ActionButton } from "@spectrum-css/actionbutton/stories/acti
 import { default as CloseButton } from "@spectrum-css/closebutton/stories/closebutton.stories.js";
 import { default as Popover } from "@spectrum-css/popover/stories/popover.stories.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import { isOpen } from "@spectrum-css/preview/types";
+import { isEmphasized, isOpen } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
 import { ActionBarGroup } from "./actionbar.test.js";
 import { Template } from "./template.js";
@@ -15,15 +15,7 @@ export default {
 	component: "ActionBar",
 	argTypes: {
 		isOpen,
-		isEmphasized: {
-			name: "Emphasized styling",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "Component",
-			},
-			control: "boolean",
-		},
+		isEmphasized,
 		isSticky: {
 			name: "Sticky",
 			type: { name: "boolean" },

--- a/components/actionbutton/stories/actionbutton.stories.js
+++ b/components/actionbutton/stories/actionbutton.stories.js
@@ -1,6 +1,6 @@
 import { default as IconStories } from "@spectrum-css/icon/stories/icon.stories.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import { isDisabled, isFocused, isHovered, isSelected } from "@spectrum-css/preview/types";
+import { isActive, isDisabled, isEmphasized, isFocused, isHovered, isQuiet, isSelected, size, staticColor } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
 import { ActionButtonGroup, ActionButtons } from "./actionbutton.test.js";
 
@@ -11,16 +11,7 @@ export default {
 	title: "Action button",
 	component: "ActionButton",
 	argTypes: {
-		size: {
-			name: "Size",
-			type: { name: "string", required: true },
-			table: {
-				type: { summary: "string" },
-				category: "Component",
-			},
-			options: ["xs", "s", "m", "l", "xl"],
-			control: "select",
-		},
+		size: size(["xs", "s", "m", "l", "xl"]),
 		iconName: {
 			...(IconStories?.argTypes?.iconName ?? {}),
 			if: false,
@@ -34,38 +25,13 @@ export default {
 			},
 			control: { type: "text" },
 		},
-		isQuiet: {
-			name: "Quiet styling",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "Component",
-			},
-			control: "boolean",
-		},
-		isEmphasized: {
-			name: "Emphasized styling",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "Component",
-			},
-			control: "boolean",
-			if: { arg: "isSelected", truthy: true }
-		},
+		isQuiet,
+		isEmphasized,
 		isDisabled,
 		isSelected,
 		isHovered,
 		isFocused,
-		isActive: {
-			name: "Active",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
+		isActive,
 		hideLabel: {
 			name: "Hide label",
 			type: { name: "boolean" },
@@ -86,16 +52,7 @@ export default {
 			control: "select",
 			options: ["true", "menu", "listbox", "tree", "grid", "dialog", "false"],
 		},
-		staticColor: {
-			name: "Static color",
-			type: { name: "string" },
-			table: {
-				type: { summary: "string" },
-				category: "Advanced",
-			},
-			options: ["white", "black"],
-			control: "select",
-		},
+		staticColor,
 	},
 	args: {
 		rootClass: "spectrum-ActionButton",
@@ -116,6 +73,11 @@ export default {
 			handles: ["click .spectrum-ActionButton:not([disabled])"],
 		},
 		componentVersion: version,
+		docs: {
+			story: {
+				height: "auto",
+			},
+		}
 	},
 };
 

--- a/components/actionbutton/stories/template.js
+++ b/components/actionbutton/stories/template.js
@@ -93,7 +93,11 @@ export const Template = ({
 			role=${ifDefined(role)}
 			style=${styleMap(customStyles)}
 			?disabled=${isDisabled}
-			@click=${onclick}
+			@click=${onclick ?? function() {
+				updateArgs({
+					isSelected: !isSelected
+				});
+			}}
 			@focusin=${function() {
 				updateArgs({ isFocused: true });
 			}}

--- a/components/actiongroup/stories/actiongroup.stories.js
+++ b/components/actiongroup/stories/actiongroup.stories.js
@@ -1,5 +1,6 @@
 import { default as ActionButton } from "@spectrum-css/actionbutton/stories/actionbutton.stories.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
+import { size } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
 import { ActionGroups } from "./actiongroup.test.js";
 /**
@@ -13,16 +14,7 @@ export default {
 		areEmphasized: ActionButton.argTypes.isEmphasized,
 		staticColor: ActionButton.argTypes.staticColor,
 		content: { table: { disable: true } },
-		size: {
-			name: "Size",
-			type: { name: "string", required: true },
-			table: {
-				type: { summary: "string" },
-				category: "Component",
-			},
-			options: ["xs", "s", "m", "l", "xl"],
-			control: "select",
-		},
+		size: size(["xs", "s", "m", "l", "xl"]),
 		vertical: {
 			name: "Vertical layout",
 			type: { name: "boolean" },

--- a/components/actiongroup/stories/template.js
+++ b/components/actiongroup/stories/template.js
@@ -3,6 +3,7 @@ import { renderContent } from "@spectrum-css/preview/decorators";
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { styleMap } from "lit/directives/style-map.js";
+import { capitalize } from "lodash-es";
 
 import "../index.css";
 
@@ -29,6 +30,8 @@ export const Template = ({
 				[`${rootClass}--vertical`]: vertical,
 				[`${rootClass}--compact`]: compact,
 				[`${rootClass}--justified`]: justified,
+				[`${rootClass}--static${capitalize(staticColor)}`]:
+					typeof staticColor !== "undefined",
 				...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
 			})}
 			style=${styleMap(customStyles)}

--- a/components/avatar/stories/avatar.stories.js
+++ b/components/avatar/stories/avatar.stories.js
@@ -1,5 +1,6 @@
 import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
+import { isDisabled, size } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
 import { AvatarGroup } from "./avatar.test.js";
 import { Template } from "./template.js";
@@ -16,16 +17,7 @@ export default {
 	title: "Avatar",
 	component: "Avatar",
 	argTypes: {
-		size: {
-			name: "Size",
-			type: { name: "string", required: true },
-			table: {
-				type: { summary: "string" },
-				category: "Component",
-			},
-			options: ["50", "75", "100", "200", "300", "400", "500", "600", "700"],
-			control: "select",
-		},
+		size: size([50, 75, 100, 200, 300, 400, 500, 600, 700], false),
 		image: {
 			name: "Image",
 			type: { name: "string" },
@@ -54,15 +46,7 @@ export default {
 			control: "boolean",
 			if: { arg: "isDisabled", truthy: false },
 		},
-		isDisabled: {
-			name: "Disabled",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
+		isDisabled,
 	},
 	args: {
 		rootClass: "spectrum-Avatar",

--- a/components/avatar/stories/template.js
+++ b/components/avatar/stories/template.js
@@ -12,7 +12,7 @@ export const Template = ({
 	altText,
 	isDisabled = false,
 	isFocused = false,
-	size = "700",
+	size = 700,
 	hasLink,
 	id = getRandomId("avatar"),
 	customClasses = [],

--- a/components/badge/stories/badge.stories.js
+++ b/components/badge/stories/badge.stories.js
@@ -1,5 +1,6 @@
 import { default as IconStories } from "@spectrum-css/icon/stories/icon.stories.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
+import { size } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
 import { BadgeGroup } from "./badge.test.js";
 import { PreviewSets } from "./template.js";
@@ -18,16 +19,7 @@ export default {
 	title: "Badge",
 	component: "Badge",
 	argTypes: {
-		size: {
-			name: "Size",
-			type: { name: "string", required: true },
-			table: {
-				type: { summary: "string" },
-				category: "Component",
-			},
-			options: ["s", "m", "l", "xl"],
-			control: "select",
-		},
+		size: size(["s", "m", "l", "xl"]),
 		label: {
 			name: "Label",
 			type: { name: "string" },

--- a/components/breadcrumb/stories/breadcrumb.stories.js
+++ b/components/breadcrumb/stories/breadcrumb.stories.js
@@ -1,4 +1,5 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
+import { isDragged } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
 import { BreadcrumbGroup } from "./breadcrumb.test.js";
 import { Template } from "./template";
@@ -31,15 +32,7 @@ export default {
 			options: ["default", "compact", "multiline"],
 			control: "select",
 		},
-		isDragged: {
-			name: "Dragged",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean"
-		},
+		isDragged,
 	},
 	args: {
 		rootClass: "spectrum-Breadcrumbs",

--- a/components/button/stories/button.stories.js
+++ b/components/button/stories/button.stories.js
@@ -1,6 +1,6 @@
 import { default as IconStories } from "@spectrum-css/icon/stories/icon.stories.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import { isDisabled, isFocused } from "@spectrum-css/preview/types";
+import { isActive, isDisabled, isFocused, isHovered, isPending, size, staticColor } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
 import { ButtonGroups } from "./button.test.js";
 
@@ -11,16 +11,7 @@ export default {
 	title: "Button",
 	component: "Button",
 	argTypes: {
-		size: {
-			name: "Size",
-			type: { name: "string", required: true },
-			table: {
-				type: { summary: "string" },
-				category: "Component",
-			},
-			options: ["s", "m", "l", "xl"],
-			control: "select",
-		},
+		size: size(["s", "m", "l", "xl"]),
 		label: {
 			name: "Label",
 			type: { name: "string" },
@@ -60,46 +51,11 @@ export default {
 			control: "inline-radio",
 		},
 		isDisabled,
-		isHovered: {
-			name: "Hovered",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
+		isHovered,
 		isFocused,
-		isActive: {
-			name: "Active",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
-		isPending: {
-			name: "Pending",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
-		staticColor: {
-			name: "Static color",
-			description:
-				"Variants that can be used when a button needs to be placed on top of a colored background or a visual.",
-			type: { name: "string" },
-			table: {
-				type: { summary: "string" },
-				category: "Advanced",
-			},
-			options: ["white", "black"],
-			control: "select",
-		},
+		isActive,
+		isPending,
+		staticColor,
 	},
 	args: {
 		rootClass: "spectrum-Button",

--- a/components/buttongroup/stories/buttongroup.stories.js
+++ b/components/buttongroup/stories/buttongroup.stories.js
@@ -1,5 +1,6 @@
 import { default as Icon } from "@spectrum-css/icon/stories/icon.stories.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
+import { size } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
 import { ButtonGroup } from "./buttongroup.test.js";
 
@@ -10,16 +11,7 @@ export default {
 	title: "Button group",
 	component: "ButtonGroup",
 	argTypes: {
-		size: {
-			name: "Size",
-			type: { name: "string", required: true },
-			table: {
-				type: { summary: "string" },
-				category: "Component",
-			},
-			options: ["s", "m", "l", "xl"],
-			control: "select",
-		},
+		size: size(["s", "m", "l", "xl"]),
 		vertical: {
 			name: "Vertical layout",
 			type: { name: "boolean" },

--- a/components/calendar/stories/calendar.stories.js
+++ b/components/calendar/stories/calendar.stories.js
@@ -58,7 +58,7 @@ export default {
 			control: "number",
 		},
 		isDisabled,
-		padded: {
+		isPadded: {
 			name: "Padded",
 			type: { name: "boolean" },
 			table: {
@@ -83,7 +83,7 @@ export default {
 	},
 	args: {
 		rootClass: "spectrum-Calendar",
-		padded: false,
+		isPadded: false,
 		isDisabled: false,
 		isFocused: false,
 		useDOWAbbrev: false,
@@ -124,7 +124,7 @@ RangeSelection.args = {
 	year: 2023,
 	lastDay: new Date(2023, 6, 7),
 	useDOWAbbrev: true,
-	padded: true,
+	isPadded: true,
 };
 RangeSelection.tags = ["!dev"];
 RangeSelection.parameters = {

--- a/components/calendar/stories/template.js
+++ b/components/calendar/stories/template.js
@@ -15,7 +15,7 @@ export const Template = ({
 	selectedDay,
 	lastDay,
 	year,
-	padded,
+	isPadded,
 	isDisabled = false,
 	isFocused = false,
 	useDOWAbbrev = false,
@@ -256,7 +256,7 @@ export const Template = ({
 		<div
 			class=${classMap({
 				[rootClass]: true,
-				[`${rootClass}--padded`]: padded,
+				[`${rootClass}--padded`]: isPadded,
 				...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
 			})}
 			style=${styleMap({

--- a/components/card/stories/card.stories.js
+++ b/components/card/stories/card.stories.js
@@ -1,7 +1,7 @@
 import { default as ActionButton } from "@spectrum-css/actionbutton/stories/actionbutton.stories.js";
 import { default as Checkbox } from "@spectrum-css/checkbox/stories/checkbox.stories.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import { isFocused, isSelected } from "@spectrum-css/preview/types";
+import { isFocused, isQuiet, isSelected } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
 import { CardGroup } from "./card.test.js";
 import { Template } from "./template.js";
@@ -22,15 +22,7 @@ export default {
 			},
 			control: { type: "file", accept: ".svg,.png,.jpg,.jpeg,.webc" },
 		},
-		isQuiet: {
-			name: "Quiet styling",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "Component",
-			},
-			control: "boolean",
-		},
+		isQuiet,
 		isSelected,
 		isFocused,
 		hasActions: {

--- a/components/checkbox/stories/checkbox.stories.js
+++ b/components/checkbox/stories/checkbox.stories.js
@@ -1,6 +1,6 @@
 import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import { isInvalid } from "@spectrum-css/preview/types";
+import { isChecked, isDisabled, isEmphasized, isIndeterminate, isInvalid, isReadOnly, size } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
 import { DocsCheckboxGroup, AllVariantsCheckboxGroup, } from "./template";
 import { CheckboxGroup } from "./checkbox.test.js";
@@ -18,16 +18,7 @@ export default {
 	title: "Checkbox",
 	component: "Checkbox",
 	argTypes: {
-		size: {
-			name: "Size",
-			type: { name: "string", required: true },
-			table: {
-				type: { summary: "string" },
-				category: "Component",
-			},
-			options: ["s", "m", "l", "xl"],
-			control: "select",
-		},
+		size: size(["s", "m", "l", "xl"]),
 		label: {
 			name: "Label",
 			type: { name: "string" },
@@ -37,52 +28,12 @@ export default {
 			},
 			control: { type: "text" },
 		},
-		isEmphasized: {
-			name: "Emphasized styling",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "Component",
-			},
-			control: { type: "boolean" },
-		},
+		isEmphasized,
 		isInvalid,
-		isDisabled: {
-			name: "Disabled",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
-		isChecked: {
-			name: "Checked",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: { type: "boolean" },
-		},
-		isIndeterminate: {
-			name: "Checkbox indeterminate",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
-		isReadOnly: {
-			name: "Read only",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
+		isDisabled,
+		isChecked,
+		isIndeterminate,
+		isReadOnly,
 	},
 	args: {
 		rootClass: "spectrum-Checkbox",

--- a/components/clearbutton/stories/clearbutton.stories.js
+++ b/components/clearbutton/stories/clearbutton.stories.js
@@ -1,12 +1,13 @@
 import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
+import { isDisabled, isQuiet, size, staticColor } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
 import { ClearButtonGroup } from "./clearbutton.test.js";
 import { Template } from "./template";
 
 /**
  * The clear button component is an in-field button used in search and tags.
- * 
+ *
  * ## Usage Notes
 
 	Use the correct cross icon size that corresponds to the t-shirt size you require for the clear button.
@@ -42,44 +43,12 @@ export default {
 	title: "Clear button",
 	component: "ClearButton",
 	argTypes: {
-		size: {
-			name: "Size",
-			type: { name: "string", required: true },
-			table: {
-				type: { summary: "string" },
-				category: "Component",
-			},
-			options: ["s", "m", "l", "xl"],
-			control: "select",
-		},
-		isDisabled: {
-			name: "Disabled",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
-		isQuiet: {
-			name: "Quiet styling",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "Component",
-			},
-			control: "boolean",
-		},
+		size: size(["s", "m", "l", "xl"]),
+		isDisabled,
+		isQuiet,
 		staticColor: {
-			name: "Static color",
-			type: { name: "string" },
-			table: {
-				disable: true,
-				type: { summary: "string" },
-				category: "Advanced",
-			},
+			...staticColor,
 			options: ["white"],
-			control: "select",
 		},
 	},
 	args: {

--- a/components/closebutton/stories/closebutton.stories.js
+++ b/components/closebutton/stories/closebutton.stories.js
@@ -1,4 +1,5 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
+import { isDisabled, size, staticColor } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
 import { CloseButtonGroup } from "./closebutton.test.js";
 
@@ -9,35 +10,9 @@ export default {
 	title: "Close button",
 	component: "CloseButton",
 	argTypes: {
-		size: {
-			name: "Size",
-			type: { name: "string", required: true },
-			table: {
-				type: { summary: "string" },
-				category: "Component",
-			},
-			options: ["s", "m", "l", "xl"],
-			control: "select",
-		},
-		staticColor: {
-			name: "Static color",
-			type: { name: "string" },
-			table: {
-				type: { summary: "string" },
-				category: "Advanced",
-			},
-			options: ["white", "black"],
-			control: "select",
-		},
-		isDisabled: {
-			name: "Disabled",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
+		size: size(["s", "m", "l", "xl"]),
+		staticColor,
+		isDisabled,
 	},
 	args: {
 		rootClass: "spectrum-CloseButton",

--- a/components/closebutton/stories/template.js
+++ b/components/closebutton/stories/template.js
@@ -3,7 +3,7 @@ import { getRandomId } from "@spectrum-css/preview/decorators";
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
-import { capitalize, lowerCase, upperCase } from "lodash-es";
+import { capitalize, upperCase } from "lodash-es";
 
 import "../index.css";
 
@@ -22,7 +22,7 @@ export const Template = ({
 			class=${classMap({
 				[rootClass]: true,
 				[`${rootClass}--size${upperCase(size)}`]: typeof size !== "undefined",
-				[`${rootClass}--static${capitalize(lowerCase(staticColor))}`]:
+				[`${rootClass}--static${capitalize(staticColor)}`]:
 					typeof staticColor !== "undefined",
 				...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
 			})}

--- a/components/coachindicator/stories/coachindicator.stories.js
+++ b/components/coachindicator/stories/coachindicator.stories.js
@@ -1,4 +1,5 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
+import { isQuiet } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
 import { CoachIndicatorGroup } from "./coachindicator.test.js";
 import { AllVariantsCoachIndicatorGroup } from "./template";
@@ -12,15 +13,7 @@ export default {
 	title: "Coach indicator",
 	component: "CoachIndicator",
 	argTypes: {
-		isQuiet: {
-			name: "Quiet styling",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "Component",
-			},
-			control: "boolean",
-		},
+		isQuiet,
 		variant: {
 			name: "Variant",
 			type: { name: "string" },

--- a/components/combobox/stories/combobox.stories.js
+++ b/components/combobox/stories/combobox.stories.js
@@ -1,6 +1,6 @@
 import { Template as Menu } from "@spectrum-css/menu/stories/template.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import { isFocused, isInvalid, isOpen } from "@spectrum-css/preview/types";
+import { isDisabled, isFocused, isInvalid, isKeyboardFocused, isLoading, isOpen, isQuiet, size } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
 import { ComboBoxGroup } from "./combobox.test.js";
 import { Template } from "./template.js";
@@ -12,55 +12,14 @@ export default {
 	title: "Combobox",
 	component: "Combobox",
 	argTypes: {
-		size: {
-			name: "Size",
-			type: { name: "string", required: true },
-			table: {
-				type: { summary: "string" },
-				category: "Component",
-			},
-			options: ["s", "m", "l", "xl"],
-			control: "select",
-		},
+		size: size(["s", "m", "l", "xl"]),
 		isOpen,
-		isQuiet: {
-			name: "Quiet styling",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "Component",
-			},
-			control: "boolean",
-		},
+		isQuiet,
 		isInvalid,
 		isFocused,
-		isKeyboardFocused: {
-			name: "Keyboard Focused",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
-		isLoading: {
-			name: "Loading",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
-		isDisabled: {
-			name: "Disabled",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
+		isKeyboardFocused,
+		isLoading,
+		isDisabled,
 		showFieldLabel: {
 			name: "Show field label",
 			type: { name: "boolean" },

--- a/components/datepicker/stories/datepicker.stories.js
+++ b/components/datepicker/stories/datepicker.stories.js
@@ -1,6 +1,6 @@
 import { default as CalendarStories } from "@spectrum-css/calendar/stories/calendar.stories.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import { isInvalid, isOpen, isValid } from "@spectrum-css/preview/types";
+import { isDisabled, isInvalid, isOpen, isQuiet, isReadOnly, isRequired, isValid } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
 import { DatePickerGroup } from "./datepicker.test.js";
 import { Template } from "./template.js";
@@ -21,15 +21,7 @@ export default {
 			return { ...acc, [key]: { table: { disable: true } } };
 		}, {}),
 		isOpen,
-		isQuiet: {
-			name: "Quiet styling",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "Component",
-			},
-			control: "boolean",
-		},
+		isQuiet,
 		isValid: {
 			...isValid,
 			if: { arg: "isInvalid", truthy: false },
@@ -48,33 +40,9 @@ export default {
 			...isInvalid,
 			if: { arg: "isValid", truthy: false },
 		},
-		isDisabled: {
-			name: "Disabled",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
-		isRequired: {
-			name: "Required",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
-		readOnly: {
-			name: "Read only",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
+		isDisabled,
+		isRequired,
+		isReadOnly,
 		content: { table: { disable: true } },
 		isRange: { table: {disable: true} },
 	},
@@ -88,7 +56,7 @@ export default {
 		isValid: false,
 		isDisabled: false,
 		isRequired: false,
-		readOnly: false,
+		isReadOnly: false,
 		month: "March",
 		selectedDay: 1,
 		year: 2023,
@@ -181,7 +149,7 @@ QuietInvalid.parameters = {
 export const ReadOnly = Template.bind({});
 ReadOnly.tags = ["!dev"];
 ReadOnly.args = {
-	readOnly: true,
+	isReadOnly: true,
 };
 ReadOnly.parameters = {
 	chromatic: { disableSnapshot: true },

--- a/components/datepicker/stories/template.js
+++ b/components/datepicker/stories/template.js
@@ -22,7 +22,7 @@ export const DatePicker = ({
 	isDateTimeRange = false,
 	isDisabled = false,
 	isRequired = false,
-	readOnly = false,
+	isReadOnly = false,
 	selectedDay,
 	lastDay,
 } = {}, context = {}) => {
@@ -47,7 +47,7 @@ export const DatePicker = ({
 			id=${ifDefined(id)}
 			aria-disabled=${isDisabled ? "true" : "false"}
 			aria-invalid=${ifDefined(isInvalid && !isDisabled ? "false" : undefined)}
-			aria-readonly=${ifDefined(readOnly ? "true" : "false")}
+			aria-readonly=${ifDefined(isReadOnly ? "true" : "false")}
 			aria-required=${ifDefined(isRequired ? "true" : "false")}
 			aria-haspopup="dialog"
 		>
@@ -55,7 +55,7 @@ export const DatePicker = ({
 				size: "m",
 				isQuiet,
 				isDisabled,
-				isReadOnly: readOnly,
+				isReadOnly,
 				isInvalid: !isRange ? isInvalid : undefined,
 				customClasses: [`${rootClass}-textfield`],
 				customInputClasses: isRange ? [`${rootClass}-input`, `${rootClass}-startField`] : [`${rootClass}-input`],
@@ -73,7 +73,7 @@ export const DatePicker = ({
 				isQuiet,
 				isDisabled,
 				isInvalid,
-				isReadOnly: readOnly,
+				isReadOnly,
 				customClasses: [`${rootClass}-textfield`],
 				customInputClasses: [`${rootClass}-input`, `${rootClass}-endField`],
 				placeholder: "Choose a date",
@@ -88,7 +88,7 @@ export const DatePicker = ({
 				iconType: "workflow",
 				iconName: "Calendar",
 				isQuiet,
-				customStyles: readOnly ? { "display": "none" } : undefined,
+				customStyles: isReadOnly ? { "display": "none" } : undefined,
 				// @todo this is not added to the button on the website; need to make sure it's not a bug
 				// isOpen,
 				isInvalid,
@@ -106,12 +106,12 @@ export const Template = ({
 	isOpen = true,
 	isQuiet = false,
 	isDisabled = false,
-	readOnly = false,
+	isReadOnly = false,
 	...args
 } = {}, context = {}) => {
 	return html`
 		${Popover({
-			isOpen: isOpen && !isDisabled && !readOnly,
+			isOpen: isOpen && !isDisabled && !isReadOnly,
 			withTip: false,
 			position: "bottom-start",
 			isQuiet,
@@ -120,7 +120,7 @@ export const Template = ({
 				isOpen,
 				isQuiet,
 				isDisabled,
-				readOnly,
+				isReadOnly,
 				...args,
 			}, context),
 			content: [

--- a/components/dial/stories/dial.stories.js
+++ b/components/dial/stories/dial.stories.js
@@ -1,5 +1,5 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import { isFocused } from "@spectrum-css/preview/types";
+import { isDisabled, isDragged, isFocused, size } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
 import { DialGroup } from "./dial.test.js";
 import { Template } from "./template.js";
@@ -11,16 +11,7 @@ export default {
 	title: "Dial",
 	component: "Dial",
 	argTypes: {
-		size: {
-			name: "Size",
-			type: { name: "string", required: true },
-			table: {
-				type: { summary: "string" },
-				category: "Component",
-			},
-			options: ["s", "m"],
-			control: "select",
-		},
+		size: size(["s", "m"]),
 		label: {
 			name: "Label",
 			table: {
@@ -30,24 +21,8 @@ export default {
 			control: "text",
 		},
 		isFocusVisible: isFocused,
-		isDragged: {
-			name: "Dragged",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
-		isDisabled: {
-			name: "Disabled",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
+		isDragged,
+		isDisabled,
 	},
 	args: {
 		rootClass: "spectrum-Dial",

--- a/components/divider/stories/divider.stories.js
+++ b/components/divider/stories/divider.stories.js
@@ -1,4 +1,5 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
+import { size, staticColor } from "@spectrum-css/preview/types";
 import { Sizes } from "@spectrum-css/preview/decorators";
 import { version } from "../package.json";
 import { DividerGroup } from "./divider.test.js";
@@ -11,26 +12,8 @@ export default {
 	title: "Divider",
 	component: "Divider",
 	argTypes: {
-		size: {
-			name: "Size",
-			type: { name: "string", required: true },
-			table: {
-				type: { summary: "string" },
-				category: "Component",
-			},
-			options: ["s", "m", "l"],
-			control: "select",
-		},
-		staticColor: {
-			name: "Static color",
-			type: { name: "string" },
-			table: {
-				type: { summary: "string" },
-				category: "Advanced",
-			},
-			options: ["white", "black"],
-			control: "select",
-		},
+		size: size(["s", "m", "l"]),
+		staticColor,
 		vertical: {
 			name: "Vertical",
 			type: { name: "boolean" },

--- a/components/divider/stories/template.js
+++ b/components/divider/stories/template.js
@@ -1,7 +1,7 @@
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { styleMap } from "lit/directives/style-map.js";
-import { capitalize, lowerCase, upperCase } from "lodash-es";
+import { capitalize, upperCase } from "lodash-es";
 
 import "../index.css";
 
@@ -21,7 +21,7 @@ export const Template = ({
 				[rootClass]: true,
 				[`${rootClass}--size${upperCase(size)}`]: typeof size !== "undefined",
 				[`${rootClass}--vertical`]: vertical === true,
-				[`${rootClass}--static${capitalize(lowerCase(staticColor))}`]:
+				[`${rootClass}--static${capitalize(staticColor)}`]:
 					typeof staticColor !== "undefined",
 				...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
 			})}
@@ -39,7 +39,7 @@ export const Template = ({
 			[rootClass]: true,
 			[`${rootClass}--size${size?.toUpperCase()}`]: typeof size !== "undefined",
 			[`${rootClass}--vertical`]: vertical === true,
-			[`${rootClass}--static${capitalize(lowerCase(staticColor))}`]:
+			[`${rootClass}--static${capitalize(staticColor)}`]:
 				typeof staticColor !== "undefined",
 			...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
 		})}

--- a/components/dropzone/stories/dropzone.stories.js
+++ b/components/dropzone/stories/dropzone.stories.js
@@ -2,6 +2,7 @@ import { default as ActionButton } from "@spectrum-css/actionbutton/stories/acti
 import { default as IllustratedMessage } from "@spectrum-css/illustratedmessage/stories/illustratedmessage.stories.js";
 import { Template as Link } from "@spectrum-css/link/stories/template.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
+import { isDragged } from "@spectrum-css/preview/types";
 import { html } from "lit";
 import { version } from "../package.json";
 import { DropzoneGroup } from "./dropzone.test.js";
@@ -13,15 +14,7 @@ export default {
 	title: "Drop zone",
 	component: "DropZone",
 	argTypes: {
-		isDragged: {
-			name: "Dragged",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
+		isDragged,
 		isFilled: {
 			name: "Filled",
 			type: { name: "boolean" },

--- a/components/fieldgroup/stories/fieldgroup.stories.js
+++ b/components/fieldgroup/stories/fieldgroup.stories.js
@@ -1,5 +1,5 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import { isInvalid } from "@spectrum-css/preview/types";
+import { isInvalid, isReadOnly, isRequired } from "@spectrum-css/preview/types";
 import { default as RadioSettings } from "@spectrum-css/radio/stories/radio.stories.js";
 import { Template as Radio } from "@spectrum-css/radio/stories/template.js";
 import { version } from "../package.json";
@@ -54,8 +54,8 @@ export default {
 		items: { table: { disable: true } },
 		fieldLabel: { table: { disable: true } },
 		helpText: { table: { disable: true } },
-		isRequired: { table: { disable: true } },
-		isReadOnly: { table: { disable: true } },
+		isRequired,
+		isReadOnly,
 	},
 	args: {
 		rootClass: "spectrum-FieldGroup",
@@ -64,6 +64,7 @@ export default {
 		layout: "vertical",
 		isInvalid: false,
 		isRequired: false,
+		isReadOnly: false,
 	},
 	parameters: {
 		actions: {

--- a/components/fieldlabel/stories/fieldlabel.stories.js
+++ b/components/fieldlabel/stories/fieldlabel.stories.js
@@ -1,4 +1,5 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
+import { isDisabled, isRequired, size } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
 import { FieldLabelGroup } from "./fieldlabel.test.js";
 
@@ -9,16 +10,7 @@ export default {
 	title: "Field label",
 	component: "FieldLabel",
 	argTypes: {
-		size: {
-			name: "Size",
-			type: { name: "string", required: true },
-			table: {
-				type: { summary: "string" },
-				category: "Component",
-			},
-			options: ["s", "m", "l", "xl"],
-			control: "select",
-		},
+		size: size(["s", "m", "l", "xl"]),
 		label: {
 			name: "Label",
 			type: { name: "string" },
@@ -38,24 +30,8 @@ export default {
 			options: ["left", "right"],
 			control: "select",
 		},
-		isDisabled: {
-			name: "Disabled",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
-		isRequired: {
-			name: "Required",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
+		isDisabled,
+		isRequired,
 	},
 	args: {
 		rootClass: "spectrum-FieldLabel",

--- a/components/helptext/stories/helptext.stories.js
+++ b/components/helptext/stories/helptext.stories.js
@@ -1,4 +1,5 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
+import { isDisabled, size } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
 import { HelpTextGroup } from "./helptext.test.js";
 
@@ -29,16 +30,7 @@ export default {
 			options: ["neutral", "negative"],
 			control: "inline-radio",
 		},
-		size: {
-			name: "Size",
-			type: { name: "string", required: true },
-			table: {
-				type: { summary: "string" },
-				category: "Component",
-			},
-			options: ["s", "m", "l", "xl"],
-			control: "select",
-		},
+		size: size(["s", "m", "l", "xl"]),
 		hideIcon: {
 			name: "Hide icon",
 			type: { name: "boolean" },
@@ -51,16 +43,7 @@ export default {
 			control: "boolean",
 			if: { arg: "variant", eq: "negative" },
 		},
-		isDisabled: {
-			name: "Disabled",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-
-			},
-			control: "boolean",
-		},
+		isDisabled,
 	},
 	args: {
 		rootClass: "spectrum-HelpText",

--- a/components/icon/stories/icon.stories.js
+++ b/components/icon/stories/icon.stories.js
@@ -1,4 +1,5 @@
 import { disableDefaultModes, mobile } from "@spectrum-css/preview/modes";
+import { size } from "@spectrum-css/preview/types";
 import { Template as Typography } from "@spectrum-css/typography/stories/template.js";
 import { html } from "lit";
 import { styleMap } from "lit/directives/style-map.js";
@@ -31,14 +32,7 @@ export default {
 	component: "Icon",
 	argTypes: {
 		size: {
-			name: "Workflow Icon Size",
-			type: { name: "string", required: true },
-			table: {
-				type: { summary: "string" },
-				category: "Component",
-			},
-			options: ["xs", "s", "m", "l", "xl", "xxl"],
-			control: "select",
+			...size(["xs", "s", "m", "l", "xl", "xxl"]),
 			if: { arg: "setName", eq: "workflow" },
 		},
 		setName: {

--- a/components/infieldbutton/stories/infieldbutton.stories.js
+++ b/components/infieldbutton/stories/infieldbutton.stories.js
@@ -1,6 +1,6 @@
 import { default as IconStories } from "@spectrum-css/icon/stories/icon.stories.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import { isActive, isDisabled, isFocused, isHovered } from "@spectrum-css/preview/types";
+import { isActive, isDisabled, isFocused, isHovered, isQuiet, size } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
 import { InfieldButtonGroup } from "./infieldbutton.test.js";
 import { Template } from "./template.js";
@@ -12,25 +12,8 @@ export default {
 	title: "In-field button",
 	component: "InFieldButton",
 	argTypes: {
-		size: {
-			name: "Size",
-			type: { name: "string", required: true },
-			table: {
-				type: { summary: "string" },
-				category: "Component",
-			},
-			options: ["s", "m", "l", "xl"],
-			control: "select"
-		},
-		isQuiet: {
-			name: "Quiet",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "Component",
-			},
-			control: "boolean"
-		},
+		size: size(["s", "m", "l", "xl"]),
+		isQuiet,
 		position: {
 			name: "Position",
 			type: { name: "string", required: true },

--- a/components/link/stories/link.stories.js
+++ b/components/link/stories/link.stories.js
@@ -1,5 +1,5 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import { isActive, isFocused, isHovered } from "@spectrum-css/preview/types";
+import { isActive, isFocused, isHovered, isQuiet, staticColor } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
 import { LinkGroup } from "./link.test.js";
 import { TemplateWithFillerText } from "./template";
@@ -53,25 +53,8 @@ export default {
 			},
 			control: "boolean",
 		},
-		staticColor: {
-			name: "Static color",
-			type: { name: "string" },
-			table: {
-				type: { summary: "string" },
-				category: "Advanced",
-			},
-			options: ["white", "black"],
-			control: "select",
-		},
-		isQuiet: {
-			name: "Quiet styling",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "Component",
-			},
-			control: "boolean",
-		},
+		staticColor,
+		isQuiet,
 	},
 	args: {
 		rootClass: "spectrum-Link",

--- a/components/link/stories/template.js
+++ b/components/link/stories/template.js
@@ -2,7 +2,7 @@ import { getRandomId } from "@spectrum-css/preview/decorators";
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
-import { capitalize, lowerCase } from "lodash-es";
+import { capitalize } from "lodash-es";
 
 import "../index.css";
 
@@ -25,7 +25,7 @@ export const Template = ({
 			[rootClass]: true,
 			[`${rootClass}--quiet`]: isQuiet,
 			[`${rootClass}--${variant}`]: typeof variant !== "undefined",
-			[`${rootClass}--static${capitalize(lowerCase(staticColor))}`]:
+			[`${rootClass}--static${capitalize(staticColor)}`]:
 				typeof staticColor !== "undefined",
 			"is-hover": isHovered,
 			"is-active": isActive,

--- a/components/logicbutton/stories/logicbutton.stories.js
+++ b/components/logicbutton/stories/logicbutton.stories.js
@@ -1,4 +1,5 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
+import { isDisabled } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
 import { LogicButtonGroup } from "./logicbutton.test.js";
 import { Template, VariantGroup } from "./template.js";
@@ -20,15 +21,7 @@ export default {
 			options: ["and", "or"],
 			control: "inline-radio",
 		},
-		isDisabled: {
-			name: "Disabled",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
+		isDisabled,
 	},
 	args: {
 		rootClass: "spectrum-LogicButton",

--- a/components/menu/stories/menu.stories.js
+++ b/components/menu/stories/menu.stories.js
@@ -1,6 +1,6 @@
 import { default as IconStories } from "@spectrum-css/icon/stories/icon.stories.js";
 import { disableDefaultModes, viewports } from "@spectrum-css/preview/modes";
-import { isActive, isDisabled, isFocused, isHovered, isOpen, isSelected } from "@spectrum-css/preview/types";
+import { isActive, isDisabled, isFocused, isHovered, isOpen, isSelected, size } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
 import { MenuItemGroup, MenuTraySubmenu, MenuWithVariants } from "./menu.test.js";
 import { Template } from "./template.js";
@@ -23,16 +23,7 @@ export default {
 			options: ["none", "single", "multiple"],
 			control: "select",
 		},
-		size: {
-			name: "Size",
-			type: { name: "string", required: true },
-			table: {
-				type: { summary: "string" },
-				category: "Component",
-			},
-			options: ["s", "m", "l", "xl"],
-			control: "select",
-		},
+		size: size(["s", "m", "l", "xl"]),
 		shouldTruncate: {
 			name: "Truncate menu item label",
 			type: { name: "boolean" },
@@ -312,7 +303,6 @@ Collapsible.argTypes = {
 	hasDividers: { table: { disable: true } },
 	isTraySubmenu: { table: { disable: true } },
 };
-
 Collapsible.parameters = {
 	chromatic: { disableSnapshot: true },
 };

--- a/components/pagination/stories/pagination.stories.js
+++ b/components/pagination/stories/pagination.stories.js
@@ -1,5 +1,6 @@
 import { default as ActionButton } from "@spectrum-css/actionbutton/stories/actionbutton.stories";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
+import { size } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
 import { PaginationGroup } from "./pagination.test.js";
 import { Template } from "./template";
@@ -11,16 +12,7 @@ export default {
 	title: "Pagination",
 	component: "Pagination",
 	argTypes: {
-		size: {
-			name: "Size",
-			type: { name: "string", required: true },
-			table: {
-				type: { summary: "string" },
-				category: "Component",
-			},
-			options: ["s", "m", "l", "xl"],
-			control: "select",
-		},
+		size: size(["s", "m", "l", "xl"]),
 		variant: {
 			name: "Variant",
 			type: { name: "string" },

--- a/components/picker/stories/picker.stories.js
+++ b/components/picker/stories/picker.stories.js
@@ -1,6 +1,6 @@
 import { WithDividers as MenuStories } from "@spectrum-css/menu/stories/menu.stories.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import { isInvalid, isOpen } from "@spectrum-css/preview/types";
+import { isDisabled, isInvalid, isKeyboardFocused, isLoading, isOpen, isQuiet, size } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
 import { PickerGroup } from "./picker.test.js";
 
@@ -11,16 +11,7 @@ export default {
 	title: "Picker",
 	component: "Picker",
 	argTypes: {
-		size: {
-			name: "Size",
-			type: { name: "string", required: true },
-			table: {
-				type: { summary: "string" },
-				category: "Component",
-			},
-			options: ["s", "m", "l", "xl"],
-			control: "select",
-		},
+		size: size(["s", "m", "l", "xl"]),
 		label: {
 			name: "Label",
 			type: { name: "string" },
@@ -59,43 +50,11 @@ export default {
 			},
 			control: { type: "text" },
 		},
-		isQuiet: {
-			name: "Quiet styling",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "Component",
-			},
-			control: "boolean",
-		},
+		isQuiet,
 		isOpen,
-		isKeyboardFocused: {
-			name: "Keyboard focused",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
-		isDisabled: {
-			name: "Disabled",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
-		isLoading: {
-			name: "Loading",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
+		isKeyboardFocused,
+		isDisabled,
+		isLoading,
 		isInvalid,
 		content: { table: { disable: true } },
 	},

--- a/components/pickerbutton/stories/pickerbutton.stories.js
+++ b/components/pickerbutton/stories/pickerbutton.stories.js
@@ -1,7 +1,7 @@
 import { default as Icon } from "@spectrum-css/icon/stories/icon.stories.js";
 import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import { isFocused, isOpen } from "@spectrum-css/preview/types";
+import { isDisabled, isFocused, isOpen, isQuiet, size } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
 import { PickerGroup } from "./pickerbutton.test.js";
 import { CustomIconTemplate, Template } from "./template";
@@ -13,16 +13,7 @@ export default {
 	title: "Picker button",
 	component: "PickerButton",
 	argTypes: {
-		size: {
-			name: "Size",
-			type: { name: "string", required: true },
-			table: {
-				type: { summary: "string" },
-				category: "Component",
-			},
-			options: ["s", "m", "l", "xl"],
-			control: "select",
-		},
+		size: size(["s", "m", "l", "xl"]),
 		iconType: {
 			name: "Icon",
 			type: { name: "string", required: false },
@@ -60,24 +51,8 @@ export default {
 			},
 			control: "boolean",
 		},
-		isQuiet: {
-			name: "Quiet styling",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "Component",
-			},
-			control: "boolean",
-		},
-		isDisabled: {
-			name: "Disabled",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
+		isQuiet,
+		isDisabled,
 		isFocused: {
 			...isFocused,
 			if: { arg: "isDisabled", truthy: false }

--- a/components/progressbar/stories/progressbar.stories.js
+++ b/components/progressbar/stories/progressbar.stories.js
@@ -1,4 +1,5 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
+import { isIndeterminate, size, staticColor } from "@spectrum-css/preview/types";
 import { ProgressBarGroup } from "./progressbar.test.js";
 
 /**
@@ -9,25 +10,8 @@ export default {
 	component: "ProgressBar",
 	argTypes: {
 		customWidth: { table: { disable: true } },
-		size: {
-			name: "Size",
-			type: { name: "string", required: true },
-			table: {
-				type: { summary: "string" },
-				category: "Component",
-			},
-			options: ["s", "m", "l", "xl"],
-			control: "select",
-		},
-		isIndeterminate: {
-			name: "Indeterminate state",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
+		size: size(["s", "m", "l", "xl"]),
+		isIndeterminate,
 		labelPosition: {
 			name: "Label position",
 			type: { name: "string" },
@@ -60,14 +44,8 @@ export default {
 		trackFill: { table: { disable: true }},
 		progressBarFill: { table: { disable: true }},
 		staticColor: {
-			name: "Static color",
-			type: { name: "string" },
-			table: {
-				type: { summary: "string" },
-				category: "Advanced",
-			},
+			...staticColor,
 			options: ["white"],
-			control: "select",
 		},
 	},
 	args: {

--- a/components/progressbar/stories/template.js
+++ b/components/progressbar/stories/template.js
@@ -3,7 +3,7 @@ import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { styleMap } from "lit/directives/style-map.js";
-import { capitalize, lowerCase } from "lodash-es";
+import { capitalize } from "lodash-es";
 
 import "../index.css";
 
@@ -26,7 +26,7 @@ export const Template = ({
 				[rootClass]: true,
 				[`${rootClass}--size${size?.toUpperCase()}`]: typeof size !== "undefined",
 				[`${rootClass}--${labelPosition}Label`]: typeof labelPosition !== "undefined",
-				[`${rootClass}--static${capitalize(lowerCase(staticColor))}`]: typeof staticColor !== "undefined",
+				[`${rootClass}--static${capitalize(staticColor)}`]: typeof staticColor !== "undefined",
 				[`${rootClass}--indeterminate`]: isIndeterminate,
 				...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
 			})}

--- a/components/progresscircle/stories/progresscircle.stories.js
+++ b/components/progresscircle/stories/progresscircle.stories.js
@@ -1,4 +1,5 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
+import { isIndeterminate, size, staticColor } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
 import { ProgressCircleGroup } from "./progresscircle.test.js";
 
@@ -9,35 +10,11 @@ export default {
 	title: "Progress circle",
 	component: "ProgressCircle",
 	argTypes: {
-		size: {
-			name: "Size",
-			type: { name: "string", required: true },
-			table: {
-				type: { summary: "string" },
-				category: "Component",
-			},
-			options: ["s", "m", "l"],
-			control: "select",
-		},
-		isIndeterminate: {
-			name: "Indeterminate",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
+		size: size(["s", "m", "l"]),
+		isIndeterminate,
 		staticColor: {
-			name: "Static color",
-			type: { name: "string" },
-			table: {
-				disable: true,
-				type: { summary: "string" },
-				category: "Advanced",
-			},
+			...staticColor,
 			options: ["white"],
-			control: "select",
 		},
 	},
 	args: {

--- a/components/radio/stories/radio.stories.js
+++ b/components/radio/stories/radio.stories.js
@@ -1,4 +1,5 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
+import { isChecked, isDisabled, isEmphasized, isReadOnly, size } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
 import { RadioGroup } from "./radio.test.js";
 
@@ -9,16 +10,7 @@ export default {
 	title: "Radio",
 	component: "Radio",
 	argTypes: {
-		size: {
-			name: "Size",
-			type: { name: "string", required: true },
-			table: {
-				type: { summary: "string" },
-				category: "Component",
-			},
-			options: ["s", "m", "l", "xl"],
-			control: "select",
-		},
+		size: size(["s", "m", "l", "xl"]),
 		label: {
 			name: "Label",
 			type: { name: "string" },
@@ -37,42 +29,10 @@ export default {
 			},
 			control: { type: "text" },
 		},
-		isEmphasized: {
-			name: "Emphasized styling",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: { type: "boolean" },
-		},
-		isChecked: {
-			name: "Radio selected",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: { type: "boolean" },
-		},
-		isDisabled: {
-			name: "Disabled",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
-		isReadOnly: {
-			name: "Read Only",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
+		isEmphasized,
+		isChecked,
+		isDisabled,
+		isReadOnly,
 	},
 	args: {
 		rootClass: "spectrum-Radio",

--- a/components/rating/stories/rating.stories.js
+++ b/components/rating/stories/rating.stories.js
@@ -1,5 +1,5 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import { isFocused } from "@spectrum-css/preview/types";
+import { isDisabled, isEmphasized, isFocused, isReadOnly } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
 import { RatingGroup } from "./rating.test.js";
 import { Template } from "./template.js";
@@ -11,34 +11,10 @@ export default {
 	title: "Rating",
 	component: "Rating",
 	argTypes: {
-		isEmphasized: {
-			name: "Emphasized styling",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "Component",
-			},
-			control: "boolean",
-		},
+		isEmphasized,
 		isFocused,
-		isDisabled: {
-			name: "Disabled",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
-		isReadOnly: {
-			name: "Read only",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "Component",
-			},
-			control: "boolean",
-		},
+		isDisabled,
+		isReadOnly,
 		max: {
 			name: "Maximum value",
 			type: { name: "number" },

--- a/components/search/stories/search.stories.js
+++ b/components/search/stories/search.stories.js
@@ -1,4 +1,5 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
+import { isDisabled, isQuiet, size } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
 import { SearchGroup } from "./search.test.js";
 
@@ -9,34 +10,9 @@ export default {
 	title: "Search",
 	component: "Search",
 	argTypes: {
-		size: {
-			name: "Size",
-			type: { name: "string", required: true },
-			table: {
-				type: { summary: "string" },
-				category: "Component",
-			},
-			options: ["s", "m", "l", "xl"],
-			control: "select",
-		},
-		isQuiet: {
-			name: "Quiet styling",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "Component",
-			},
-			control: "boolean",
-		},
-		isDisabled: {
-			name: "Disabled",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
+		size: size(["s", "m", "l", "xl"]),
+		isQuiet,
+		isDisabled,
 	},
 	args: {
 		rootClass: "spectrum-Search",

--- a/components/slider/stories/slider.stories.js
+++ b/components/slider/stories/slider.stories.js
@@ -1,6 +1,6 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { Sizes } from "@spectrum-css/preview/decorators";
-import { isFocused } from "@spectrum-css/preview/types";
+import { isDisabled, isFocused, size } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
 import { SliderGroup } from "./slider.test.js";
 import { Template } from "./template.js";
@@ -23,16 +23,7 @@ export default {
 	title: "Slider",
 	component: "Slider",
 	argTypes: {
-		size: {
-			name: "Size",
-			type: { name: "string", required: true },
-			table: {
-				type: { summary: "string" },
-				category: "Component",
-			},
-			options: ["s", "m", "l", "xl"],
-			control: "select",
-		},
+		size: size(["s", "m", "l", "xl"]),
 		label: {
 			name: "Label",
 			type: { name: "string" },
@@ -120,15 +111,7 @@ export default {
 			control: "boolean",
 			if: { arg: "showTicks", truthy: true },
 		},
-		isDisabled: {
-			name: "Disabled",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
+		isDisabled,
 		isFocused: {
 			...isFocused,
 			if: { arg: "isDisabled", truthy: false },

--- a/components/statuslight/stories/statuslight.stories.js
+++ b/components/statuslight/stories/statuslight.stories.js
@@ -1,4 +1,5 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
+import { size } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
 import { StatusLightGroup } from "./statuslight.test.js";
 
@@ -6,16 +7,7 @@ export default {
 	title: "Status light",
 	component: "Statuslight",
 	argTypes: {
-		size: {
-			name: "Size",
-			type: { name: "string", required: true },
-			table: {
-				type: { summary: "string" },
-				category: "Component",
-			},
-			options: ["s", "m", "l", "xl"],
-			control: "select",
-		},
+		size: size(["s", "m", "l", "xl"]),
 		label: {
 			name: "Label",
 			type: { name: "string" },

--- a/components/stepper/stories/stepper.stories.js
+++ b/components/stepper/stories/stepper.stories.js
@@ -1,5 +1,5 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import { isFocused, isInvalid } from "@spectrum-css/preview/types";
+import { isDisabled, isFocused, isInvalid, isKeyboardFocused, isQuiet, size } from "@spectrum-css/preview/types";
 import { Sizes } from "@spectrum-css/preview/decorators";
 import { version } from "../package.json";
 import { StepperGroup } from "./stepper.test.js";
@@ -12,25 +12,8 @@ export default {
 	title: "Stepper",
 	component: "Stepper",
 	argTypes: {
-		size: {
-			name: "Size",
-			type: { name: "string", required: true },
-			table: {
-				type: { summary: "string" },
-				category: "Component",
-			},
-			options: ["s", "m", "l", "xl"],
-			control: "select"
-		},
-		isQuiet: {
-			name: "Quiet",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "Component",
-			},
-			control: "boolean",
-		},
+		size: size(["s", "m", "l", "xl"]),
+		isQuiet,
 		hideStepper: {
 			name: "Hide stepper",
 			type: { name: "boolean" },
@@ -40,26 +23,10 @@ export default {
 			},
 			control: "boolean",
 		},
-		isDisabled: {
-			name: "Disabled",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
+		isDisabled,
 		isInvalid,
 		isFocused,
-		isKeyboardFocused: {
-			name: "Keyboard focused",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
+		isKeyboardFocused,
 	},
 	args: {
 		rootClass: "spectrum-Stepper",

--- a/components/swatch/stories/swatch.stories.js
+++ b/components/swatch/stories/swatch.stories.js
@@ -1,5 +1,5 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import { isSelected } from "@spectrum-css/preview/types";
+import { isDisabled, isSelected, size } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
 import { SwatchGroup } from "./swatch.test.js";
 
@@ -10,16 +10,7 @@ export default {
 	title: "Swatch",
 	component: "Swatch",
 	argTypes: {
-		size: {
-			name: "Size",
-			type: { name: "string", required: true },
-			table: {
-				type: { summary: "string" },
-				category: "Component",
-			},
-			options: ["xs", "s", "m", "l",],
-			control: "select",
-		},
+		size: size(["xs", "s", "m", "l"]),
 		swatchColor: {
 			name: "Color",
 			type: { name: "string", required: true },
@@ -39,15 +30,7 @@ export default {
 			options: ["none", "regular", "full"],
 			control: "select",
 		},
-		isDisabled: {
-			name: "Disabled",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
+		isDisabled,
 		isSelected,
 	},
 	args: {

--- a/components/switch/stories/switch.stories.js
+++ b/components/switch/stories/switch.stories.js
@@ -1,4 +1,5 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
+import { isChecked, isDisabled, isEmphasized, size } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
 import { SwitchGroup } from "./switch.test.js";
 import { Template } from "./template.js";
@@ -10,43 +11,10 @@ export default {
 	title: "Switch",
 	component: "Switch",
 	argTypes: {
-		size: {
-			name: "Size",
-			type: { name: "string", required: true },
-			table: {
-				type: { summary: "string" },
-				category: "Component",
-			},
-			options: ["s", "m", "l", "xl"],
-			control: "select",
-		},
-		isEmphasized: {
-			name: "Emphasized",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
-		isDisabled: {
-			name: "Disabled",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
-		isChecked: {
-			name: "Checked",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
+		size: size(["s", "m", "l", "xl"]),
+		isEmphasized,
+		isDisabled,
+		isChecked,
 		label: {
 			name: "Label",
 			type: { name: "string" },

--- a/components/table/stories/table.stories.js
+++ b/components/table/stories/table.stories.js
@@ -1,4 +1,5 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
+import { isEmphasized, isQuiet, size } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
 import { TableGroup } from "./table.test.js";
 import { Template } from "./template.js";
@@ -10,15 +11,7 @@ export default {
 	title: "Table",
 	component: "Table",
 	argTypes: {
-		size: {
-			name: "Size",
-			table: {
-				type: { summary: "string" },
-				category: "Component",
-			},
-			options: ["s", "m", "l", "xl"],
-			control: "select",
-		},
+		size: size(["s", "m", "l", "xl"]),
 		density: {
 			name: "Density",
 			table: {
@@ -28,24 +21,8 @@ export default {
 			options: ["standard", "compact", "spacious"],
 			control: "select",
 		},
-		isQuiet: {
-			name: "Quiet styling",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "Component",
-			},
-			control: "boolean",
-		},
-		isEmphasized: {
-			name: "Emphasized",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "Component",
-			},
-			control: "boolean",
-		},
+		isQuiet,
+		isEmphasized,
 		useDivs: {
 			name: "Use Divs for Markup",
 			description:
@@ -80,7 +57,7 @@ export default {
 			control: "boolean",
 		},
 		isDropTarget: {
-			name: "Dropzone (Drop Target)",
+			name: "Dropzone (Drop target)",
 			type: { name: "boolean" },
 			table: {
 				type: { summary: "boolean" },

--- a/components/tabs/stories/tabs.stories.js
+++ b/components/tabs/stories/tabs.stories.js
@@ -1,4 +1,5 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
+import { isEmphasized, isQuiet, size } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
 import { TabsGroups } from "./tabs.test.js";
 import { Template } from "./template.js";
@@ -11,16 +12,7 @@ export default {
 	component: "Tabs",
 	argTypes: {
 		content: { table: { disable: true } },
-		size: {
-			name: "Size",
-			type: { name: "string", required: true },
-			table: {
-				type: { summary: "string" },
-				category: "Component",
-			},
-			options: ["s", "m", "l", "xl"],
-			control: "select",
-		},
+		size: size(["s", "m", "l", "xl"]),
 		orientation: {
 			name: "Orientation",
 			type: { name: "string", required: true },
@@ -33,24 +25,8 @@ export default {
 			control: "select",
 			default: "horizontal",
 		},
-		isQuiet: {
-			name: "Quiet",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
-		isEmphasized: {
-			name: "Emphasized",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
+		isQuiet,
+		isEmphasized,
 		isCompact: {
 			name: "Compact",
 			type: { name: "boolean" },

--- a/components/tag/stories/tag.stories.js
+++ b/components/tag/stories/tag.stories.js
@@ -1,6 +1,6 @@
 import { default as IconStories } from "@spectrum-css/icon/stories/icon.stories.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import { isInvalid, isSelected } from "@spectrum-css/preview/types";
+import { isDisabled, isEmphasized, isInvalid, isSelected, size } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
 import { TagGroups } from "./tag.test.js";
 import { Template } from "./template.js";
@@ -12,15 +12,7 @@ export default {
 	title: "Tag",
 	component: "Tag",
 	argTypes: {
-		size: {
-			name: "Size",
-			table: {
-				type: { summary: "string" },
-				category: "Component",
-			},
-			options: ["s", "m", "l"],
-			control: "select",
-		},
+		size: size(["s", "m", "l"]),
 		hasIcon: {
 			name: "Has icon",
 			type: { name: "boolean" },
@@ -65,25 +57,11 @@ export default {
 			control: { type: "text" },
 		},
 		isEmphasized: {
-			name: "Emphasized styling",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "Component",
-			},
-			control: "boolean",
+			...isEmphasized,
 			if: { arg: "isInvalid", truthy: false },
 		},
 		isInvalid,
-		isDisabled: {
-			name: "Disabled",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
+		isDisabled,
 		isSelected,
 		hasClearButton: {
 			name: "Clear button",

--- a/components/textfield/stories/textfield.stories.js
+++ b/components/textfield/stories/textfield.stories.js
@@ -1,5 +1,5 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import { isFocused, isInvalid, isValid } from "@spectrum-css/preview/types";
+import { isDisabled, isFocused, isInvalid, isKeyboardFocused, isLoading, isQuiet, isReadOnly, isRequired, isValid, size } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
 import { Template } from "./template.js";
 import { TextFieldGroup } from "./textfield.test.js";
@@ -50,34 +50,9 @@ export default {
 			if: { arg: "isValid", truthy: false },
 		},
 		isFocused,
-		isKeyboardFocused: {
-			name: "Keyboard focused",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
-		size: {
-			name: "Size",
-			type: { name: "string", required: true },
-			table: {
-				type: { summary: "string" },
-				category: "Component",
-			},
-			options: ["s", "m", "l", "xl"],
-			control: "select",
-		},
-		isQuiet: {
-			name: "Quiet styling",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "Component",
-			},
-			control: "boolean",
-		},
+		isKeyboardFocused,
+		size: size(["s", "m", "l", "xl"]),
+		isQuiet,
 		multiline: {
 			name: "Multiline",
 			type: { name: "boolean" },
@@ -100,43 +75,10 @@ export default {
 		iconName: {
 			table: { disable: true },
 		},
-		isDisabled: {
-			name: "Disabled",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
-		isRequired: {
-			name: "Required",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "Component",
-			},
-			control: "boolean",
-		},
-		isReadOnly: {
-			name: "Read only",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "Component",
-			},
-			control: "boolean",
-		},
-		isLoading: {
-			name: "Loading",
-			type: { name: "boolean" },
-			table: {
-				disable: true,
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
+		isDisabled,
+		isRequired,
+		isReadOnly,
+		isLoading,
 		pattern: {
 			name: "Pattern",
 			type: { name: "string" },
@@ -146,9 +88,7 @@ export default {
 			},
 			control: "text",
 		},
-		value: {
-			table: { disable: true },
-		},
+		value: { table: { disable: true } },
 	},
 	args: {
 		rootClass: "spectrum-Textfield",

--- a/components/thumbnail/stories/template.js
+++ b/components/thumbnail/stories/template.js
@@ -10,7 +10,7 @@ import "../index.css";
 
 export const Template = ({
 	rootClass = "spectrum-Thumbnail",
-	size = "500",
+	size = 500,
 	imageURL,
 	svg,
 	altText,

--- a/components/thumbnail/stories/thumbnail.stories.js
+++ b/components/thumbnail/stories/thumbnail.stories.js
@@ -1,6 +1,6 @@
 import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import { isFocused, isSelected } from "@spectrum-css/preview/types";
+import { isDisabled, isFocused, isSelected, size } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
 import { Template } from "./template.js";
 import { ThumbnailGroup } from "./thumbnail.test.js";
@@ -13,29 +13,7 @@ export default {
 	component: "Thumbnail",
 	argTypes: {
 		reduceMotion: { table: { disable: true } },
-		size: {
-			name: "Size",
-			type: { name: "string", required: true },
-			table: {
-				type: { summary: "string" },
-				category: "Component",
-			},
-			options: [
-				"50",
-				"75",
-				"100",
-				"200",
-				"300",
-				"400",
-				"500",
-				"600",
-				"700",
-				"800",
-				"900",
-				"1000",
-			],
-			control: "select",
-		},
+		size: size([50, 75, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000], false),
 		imageURL: {
 			name: "Image URL",
 			type: { name: "string" },
@@ -87,15 +65,7 @@ export default {
 			},
 			control: "boolean",
 		},
-		isDisabled: {
-			name: "Disabled",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "State",
-			},
-			control: "boolean",
-		},
+		isDisabled,
 		isSelected: {
 			...isSelected,
 			if: { arg: "isLayer" },
@@ -104,7 +74,7 @@ export default {
 	},
 	args: {
 		rootClass: "spectrum-Thumbnail",
-		size: "1000",
+		size: 1000,
 		isCover: false,
 		isLayer: false,
 		isDisabled: false,

--- a/components/treeview/stories/treeview.stories.js
+++ b/components/treeview/stories/treeview.stories.js
@@ -1,5 +1,6 @@
 import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
+import { isQuiet, size } from "@spectrum-css/preview/types";
 import { version } from "../package.json";
 import { Template } from "./template.js";
 import { TreeViewGroup } from "./treeview.test.js";
@@ -15,25 +16,8 @@ export default {
 	argTypes: {
 		items: { table: { disable: true } },
 		variant: { table: { disable: true } },
-		size: {
-			name: "Size",
-			type: { name: "string", required: true },
-			table: {
-				type: { summary: "string" },
-				category: "Component",
-			},
-			options: ["s", "m", "l", "xl"],
-			control: "select",
-		},
-		isQuiet: {
-			name: "Quiet",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "Component",
-			},
-			control: "boolean",
-		},
+		size: size(["s", "m", "l", "xl"]),
+		isQuiet,
 	},
 	args: {
 		rootClass: "spectrum-TreeView",

--- a/components/typography/stories/template.js
+++ b/components/typography/stories/template.js
@@ -11,7 +11,7 @@ import "../index.css";
 export const Template = (args = {}, context = {}) => {
 	let {
 		rootClass = "spectrum-Typography",
-		semantics = "body",
+		semantics,
 		size = "m",
 		variant,
 		weight,

--- a/components/typography/stories/typography.stories.js
+++ b/components/typography/stories/typography.stories.js
@@ -1,4 +1,5 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
+import { size } from "@spectrum-css/preview/types";
 import { html } from "lit";
 import { version } from "../package.json";
 import { Template } from "./template.js";
@@ -22,16 +23,7 @@ export default {
 			options: ["heading", "body", "detail", "code"],
 			control: "inline-radio",
 		},
-		size: {
-			name: "Size",
-			type: { name: "string" },
-			table: {
-				type: { summary: "string" },
-				category: "Component",
-			},
-			options: ["xxs", "xs", "s", "m", "l", "xl", "xxl", "xxxl"],
-			control: "select",
-		},
+		size: size(["xxs", "xs", "s", "m", "l", "xl", "xxl", "xxxl"]),
 		weight: {
 			name: "Weight",
 			type: { name: "string" },
@@ -136,11 +128,7 @@ Heading.parameters = {
 export const Body = Template.bind({});
 Body.tags = ["!dev"];
 Body.argTypes = {
-	size: {
-		name: "Size",
-		options: ["xs", "s", "m", "l", "xl", "xxl", "xxxl"],
-		table: { disable: true },
-	},
+	size: size(["xs", "s", "m", "l", "xl", "xxl", "xxxl"]),
 };
 Body.args = {
 	semantics: "body",
@@ -154,11 +142,7 @@ Body.parameters = {
 
 export const Detail = Template.bind({});
 Detail.argTypes = {
-	size: {
-		name: "Size",
-		options: ["s", "m", "l", "xl"],
-		table: { disable: true },
-	},
+	size: size(["s", "m", "l", "xl"]),
 	weight: {
 		options: ["light"],
 		if: { arg: "semantics", eq: "detail"},
@@ -176,11 +160,7 @@ Detail.parameters = {
 export const Code = Template.bind({});
 Code.tags = ["!dev"];
 Code.argTypes = {
-	size: {
-		name: "Size",
-		options: ["xs", "s", "m", "l", "xl"],
-		table: { disable: true },
-	},
+	size: size(["xs", "s", "m", "l", "xl"]),
 };
 Code.args = {
 	semantics: "code",


### PR DESCRIPTION
## Description

This PR updates existing stories to leverage the shared types provided by the Storybook package. This also adds a new types file `variants.js` for a set of shared global variants (i.e., sizing, quiet, emphasized).

Expect updated sizing drop-down to include full-text labels:

<img width="479" alt="Screenshot 2024-08-06 at 9 25 20 PM" src="https://github.com/user-attachments/assets/972bd503-13d7-405e-9e8a-b82a553e6775">

This PR also ran `eslint --fix` on the `.storybook` js assets to allow for whitespace and quotation mark corrections to be applied.


## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

@marissahuysentruyt 
Expect to see no regressions in knob functionality:
- [x] accordion: size
- [x] actionbar: emphasized
- [x] actionbutton: size, quiet, emphasized, active, static color
- [x] actiongroup: size
- [x] avatar: size, disabled
- [x] badge: size
- [x] breadcrumb: dragged
- [x] button: size, hovered, active, pending, static color
- [x] buttongroup: size
- [x] calendar: padded renamed to isPadded (b/c it's a boolean variable)
- [x] card: quiet
- [x] checkbox: size, emphasized, disabled, checked, indeterminate, read-only
- [x] clearbutton: size, disabled, static color (should still show only white)
- [x] closebutton: size, static color, disabled
- [x] coach indicator: quiet
- [x] combobox: size, quiet, keyboard focused, loading, disabled
- [x] date picker: quiet, disabled, required, read-only
- [x] dial: size, dragged, disabled
- [x] divider: size, static color
- [x] drop zone: dragged
- [x] fieldgroup: required, read only
- [x] fieldlabel: size, disabled, required
- [x] helptext: size, disabled
- [x] icon: size
- [x] infield button: size, quiet, disabled
- [x] link: static color, quiet
- [x] logic button: disabled
- [x] menu: size, disabled, selected
- [x] pagination: size
- [x] picker: size, quiet, keyboard-focused, disabled, loading
- [x] picker button: size, quiet, disabled
- [x] progressbar: size, static color
- [x] progress circle: size, indeterminate, static color
- [x] radio: size, emphasized, checked, disabled, read-only
- [x] rating: emphasized, disabled, read-only
- [x] search: size, quiet, disabled
- [x] slider: size, disabled
- [x] status light: size
- [x] stepper: size, quiet, disabled, keyboard focused
- [x] swatch: size, disabled
- [x] switch: size, emphasized, disabled, checked
- [x] table: size, quiet, emphasized
- [x] tabs: size, quiet, emphasized
- [x] tag: size, emphasized, disabled
- [x] textfield: disabled, keyboard-focused, size, quiet, required, read-only, loading
- [x] thumbnail: size, disabled
- [x] treeview: size, quiet
- [x] typography: size

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] ✨ This pull request is ready to merge. ✨
