### PR TITLE
feat: add component meta links to docblocks

### DIFF
--- a/.storybook/blocks/component-details.jsx
+++ b/.storybook/blocks/component-details.jsx
@@ -1,5 +1,5 @@
-import React from "react";
 import { useOf } from '@storybook/blocks';
+import React from "react";
 import "./component-details.css";
 
 /**
@@ -15,11 +15,44 @@ import "./component-details.css";
 const ComponentDetails = () => {
 	const storyMeta = useOf('meta');
 	const versionNumber = storyMeta?.csfFile?.meta?.parameters?.componentVersion ?? "Unavailable";
+  
+  const packageName = storyMeta?.csfFile?.meta?.parameters?.componentPkgName ?? undefined;
+  const packageLink = (packageName && typeof packageName !== "undefined") ? `https://npmjs.com/${packageName}` : false;
+  
+  const packageGitHubName = packageLink ? packageName.split('/').pop() : undefined;
+  const packageGitHubLink = (packageGitHubName && typeof packageGitHubName !== "undefined") ? `https://github.com/adobe/spectrum-css/tree/main/components/${packageGitHubName}` : false;
+
+  const componentGuidelinesName = storyMeta?.csfFile?.meta?.parameters?.componentGuidelinesName ?? undefined;
+  const componentGuidelinesLink = (componentGuidelinesName && typeof componentGuidelinesName !== "undefined") ? `https://spectrum.adobe.com/page/${componentGuidelinesName}` : false;
 
 	return (
 		<dl className="spectrum-storybook-component-details">
 			<dt>Current version:</dt>
 			<dd>{versionNumber}</dd>
+
+      {
+        packageLink && 
+        <>
+          <dt>npm link:</dt>
+          <dd><a href={packageLink} rel="noopener">{packageLink}</a></dd>
+        </>
+      }
+
+      {
+        packageGitHubLink && 
+        <>
+          <dt>view repository:</dt>
+          <dd><a href={packageGitHubLink} rel="noopener">{packageGitHubLink}</a></dd>
+        </>
+      }
+
+      {
+        componentGuidelinesLink && 
+        <>
+          <dt>view guidelines:</dt>
+          <dd><a href={componentGuidelinesLink} rel="noopener">{componentGuidelinesLink}</a></dd>
+        </>
+      }
 
 			{ storyMeta?.csfFile?.meta?.parameters?.status?.type == "deprecated" 
 				?	<>

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -111,6 +111,8 @@ export const parameters = {
 		},
 	},
 	componentVersion: undefined,
+	componentPkgName: undefined,
+	componentGuidelinesName: undefined,
 };
 
 export const decorators = [

--- a/components/actionbutton/stories/actionbutton.stories.js
+++ b/components/actionbutton/stories/actionbutton.stories.js
@@ -1,7 +1,7 @@
 import { default as IconStories } from "@spectrum-css/icon/stories/icon.stories.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isFocused, isHovered, isSelected } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import { name, version } from "../package.json";
 import { ActionButtonGroup, ActionButtons } from "./template";
 
 /**
@@ -116,6 +116,8 @@ export default {
 			handles: ["click .spectrum-ActionButton:not([disabled])"],
 		},
 		componentVersion: version,
+		componentPkgName: name,
+		componentGuidelinesName: "action-button",
 	},
 };
 


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

Adds more component metadata to storybook doc blocks, thus replicating the buttons we include on our existing docs site.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [ ] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
