### PR TITLE
chore(storybook): update ComponentDetails to use theming & fetch data from npm

### DIFF
--- a/.storybook/blocks/ComponentDetails.jsx
+++ b/.storybook/blocks/ComponentDetails.jsx
@@ -1,40 +1,261 @@
 import { useOf } from '@storybook/blocks';
+import { ResetWrapper } from "@storybook/components";
 import { styled } from "@storybook/theming";
-import React from "react";
+import React, { useEffect, useState } from "react";
+import { Code } from "./Typography";
 import { fetchToken } from "./utilities.js";
 
-export const DList = styled.dl({
-	"display": "grid",
-	"grid-template-columns": "max-content 1fr",
-	"column-gap": 20,
-	"row-gap": 14,
-	"padding-block": "0.75rem",
-	"margin-block": "0.5rem 2.5rem",
-	"border-block": "1px solid hsla(203deg, 50%, 30%, 15%)",
-});
+export const DList = styled.dl`
+	display: grid;
+	grid-template-columns: max-content 1fr;
+	column-gap: 20px;
+	row-gap: 14px;
+	padding-block: 0.75rem;
+	margin-block: 0.5rem 2.5rem;
+	border-block: ${props => !props.skipBorder ? "1px solid hsla(203deg, 50%, 30%, 15%)" : "0"};
 
-export const DTerm = styled.dt({
-	"font-style": "normal",
-	"padding": 0,
-	"margin": 0,
-	"font-size": 14,
-});
+	& & {
+		border-block: 0px;
+		margin-block: 0;
+		padding-inline-start: 0.75rem;
+		padding-block-start: 0.25rem;
+	}
 
-export const DDefinition = styled.dd({
-	"font-style": "normal",
-	"padding": 0,
-	"margin": 0,
-	"font-size": 14,
-});
+	details > & {
+		margin-inline-start: 12px;
+	}
+`;
 
-export const StatusLight = styled.span(({ size = "m" }) => ({
-	"border-radius": "50%",
-	"height": ["l", "xl"].includes(size) ? 10 : 8,
-	"width": ["l", "xl"].includes(size) ? 10 : 8,
-	"background": fetchToken("negative-visual-color"),
-	"display": "inline-block",
-	"margin-inline-end": ["l", "xl"].includes(size) ? 10 : 8,
-}));
+export const DTerm = styled.dt`
+	font-weight: ${props => props.theme.typography.weight.bold ?? "bold"};
+	padding: 0;
+	margin: 0;
+	font-size: ${props => props.theme.typography.size.s};
+`;
+
+export const Details = styled.details`
+	cursor: pointer;
+	grid-column: 1 / 3;
+	padding: 0;
+
+	&[open] > summary::before {
+		transform: rotate(90deg);
+	}
+`;
+
+export const Summary = styled.summary`
+	display: inline-flex;
+	align-items: center;
+	font-weight: ${props => props.theme.typography.weight.bold ?? "bold"};
+	padding: 0;
+	padding-block-end: 0.75rem;
+	margin: 0;
+	font-size: ${props => props.theme.typography.size.s};
+	list-style: none;
+
+	&::-webkit-details-marker {
+		display: none;
+	}
+
+	&::before {
+		content: '';
+		width: 10px;
+		height: 10px;
+		background-image: url('data:image/svg+xml,<svg focusable="false" aria-hidden="true" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><path d="M3 9.95a.875.875 0 0 1-.615-1.498L5.88 5 2.385 1.547A.875.875 0 0 1 3.615.302L7.74 4.377a.876.876 0 0 1 0 1.246L3.615 9.698A.87.87 0 0 1 3 9.95"></path></svg>');
+		background-size: cover;
+		margin-inline-end: .75em;
+		transition: 0.2s;
+	}
+`;
+
+export const DDefinition = styled.dd`
+	font-style: normal;
+	padding: 0;
+	margin: 0;
+	font-size: ${props => props.theme.typography.size.s};
+`;
+
+export const StatusLight = styled.span(({ variant = "positive", ...props }) => `
+	border-radius: 50%;
+	vertical-align: middle;
+	/* Scale this in relation to the typography */
+	block-size: 0.6rem;
+	inline-size: 0.6rem;
+	background-color: ${fetchToken(`${variant}-visual-color`)};
+	display: inline-block;
+	line-height: 2;
+	margin-inline-end: ${["l", "xl"].includes(props.size) ? 10 : 8}px;
+	margin-block-end: 1px;
+`);
+
+const VersionDetails = ({ tag, data = {}, isDeprecated = false, skipDate = false, skipLink = false }) => {
+	let statusType = "notice";
+	let statusMessage = "Not yet available on the npm registry.";
+
+	if (isDeprecated) {
+		statusType = "negative";
+		statusMessage = "Deprecated; no longer maintained.";
+	} else if (data.date) {
+		statusType = "positive";
+		statusMessage = "Available on the npm registry.";
+	}
+
+	if (!isDeprecated && tag !== "latest") {
+		statusType = "notice";
+		statusMessage = `Available on the npm registry but not recommended for production use.`;
+	}
+
+	if (tag === "local") {
+		statusType = "negative";
+		statusMessage = `Not yet published to the npm registry.`;
+	}
+
+	return (
+		<>
+			<StatusLight variant={statusType} title={statusMessage}/>
+			{!skipLink && data.link ? <a href={data.link} rel="noopener noreferrer">{data.version}</a> : data.version}
+			{!skipDate && data.date ? ` ${data.date}` : ""}
+		</>
+	);
+};
+
+/**
+ * Process the npm data to determine the versions to display.
+ * @param {object>} storyMeta
+ * @param {object} npmData
+ * @returns
+ */
+function processReleaseData(storyMeta, npmData) {
+	console.log("Processing release data", npmData);
+	const previewURL = "https://www.npmjs.org/package/";
+
+	const packageJson = storyMeta?.csfFile?.meta?.parameters?.packageJson ?? {};
+	const ignoredTags = storyMeta?.csfFile?.meta?.parameters?.ignoredTags ?? [];
+
+	const tags = [
+		// Force "local" to be included in the list because we won't fetch it from npm
+		// but we want to show it in the list of tags
+		"local",
+		...Object.keys(npmData?.["dist-tags"] ?? {})
+	].filter(tag => !ignoredTags.includes(tag));
+
+	// Create a robust fallback stack to capture the version number
+	const fallbackVersion = packageJson?.version ?? storyMeta?.csfFile?.meta?.parameters?.componentVersion;
+
+	const mapVersions = new Map();
+	for (const tag of tags) {
+		let version = npmData?.versions?.[npmData?.["dist-tags"]?.[tag]]?.version;
+		let date = npmData?.time?.[npmData?.["dist-tags"]?.[tag]] ? "published " + new Date(npmData?.time?.[npmData?.["dist-tags"]?.[tag]]).toLocaleDateString("en-US", {
+			year: 'numeric',
+			month: 'short',
+			day: '2-digit',
+		}) : null;
+		const link = npmData?.["dist-tags"]?.[tag] ? `${previewURL}${packageJson.name}/v/${npmData?.["dist-tags"]?.[tag]}` : null;
+
+		// Prefer the version from the package.json file if this is the "local" tag
+		if (tag === "local") {
+			version = fallbackVersion;
+			date = "unpublished";
+		}
+
+		mapVersions.set(tag, {
+			version,
+			date,
+			link
+		});
+	}
+
+	const allVersions = [...mapVersions.entries()].sort(([aTag, a], [bTag, b]) => {
+		// Sort the local tag to the top, followed by the latest tag
+		// then sort the rest of the tags by date in descending order
+		if (aTag === "local") return -1;
+		if (bTag === "local") return 1;
+		if (aTag === "latest") return -1;
+		if (bTag === "latest") return 1;
+		return new Date(b.date) - new Date(a.date);
+	});
+
+	// Remove the local tag from the list if the latest tag is available and it's larger than the local tag using semver
+	if (tags.includes("local") && tags.includes("latest")) {
+		const localVersion = allVersions.find(([tag]) => tag === "local")?.[1]?.version;
+		const latestVersion = allVersions.find(([tag]) => tag === "latest")?.[1]?.version;
+		if (localVersion && latestVersion && localVersion === latestVersion) {
+			allVersions.splice(allVersions.findIndex(([tag]) => tag === "local"), 1);
+		} else if (localVersion && latestVersion && localVersion !== latestVersion) {
+			// Check if the local version is a lower semver than the latest version
+			const localSemver = localVersion.split(".");
+			const latestSemver = latestVersion.split(".");
+			const localMajor = parseInt(localSemver[0]);
+			const latestMajor = parseInt(latestSemver[0]);
+			if (localMajor < latestMajor) {
+				allVersions.splice(allVersions.findIndex(([tag, data]) => tag === "local"), 1);
+			} else if (localMajor === latestMajor) {
+				const localMinor = parseInt(localSemver[1]);
+				const latestMinor = parseInt(latestSemver[1]);
+				if (localMinor < latestMinor) {
+					allVersions.splice(allVersions.findIndex(([tag, data]) => tag === "local"), 1);
+				} else if (localMinor === latestMinor) {
+					const localPatch = parseInt(localSemver[2]);
+					const latestPatch = parseInt(latestSemver[2]);
+					if (localPatch < latestPatch) {
+						allVersions.splice(allVersions.findIndex(([tag, data]) => tag === "local"), 1);
+					}
+				}
+			}
+		}
+	}
+
+	// A boolean to determine if the local version should be shown based on if it still exists in the list of all versions
+	const showLocalVersion = allVersions.find(([tag]) => tag === "local");
+
+	return {
+		showLocalVersion,
+		allVersions,
+	};
+}
+
+function initCache(key) {
+	const [cache, setCache] = useState(JSON.parse(localStorage.getItem(key)) ?? {});
+
+	useEffect(() => {
+		localStorage.setItem(key, JSON.stringify(cache));
+	}, [key, cache]);
+
+	return [cache, setCache];
+}
+
+function fetchNpmData(packageName, setnpmData, setIsLoading) {
+	const [cache, setCache] = initCache(packageName);
+
+	// Capture the npm data for the component from the registry
+	useEffect(() => {
+		if (typeof cache === "object" && Object.keys(cache).length > 0) {
+			console.log(`Use cached npm data for ${packageName}`);
+			setnpmData(cache);
+			setIsLoading(false);
+			return;
+		}
+
+		console.log(`Fetching npm data for ${packageName}`);
+		fetch("https://registry.npmjs.org/" + packageName).then(async (response) => {
+			if (!response.ok) {
+				throw new Error(`Failed to fetch npm data for ${packageName}`);
+			}
+
+			const json = await response.json();
+
+			if (!json) {
+				throw new Error(`Failed to fetch npm data for ${packageName}`);
+			}
+
+			setnpmData(json);
+			setCache(json);
+			setIsLoading(false);
+		}).catch((error) => {
+			console.error(error?.message ?? error);
+		});
+	}, [cache, setCache, packageName, setnpmData, setIsLoading]);
+}
 
 /**
  * Displays the current version number of the component. The version is read from
@@ -48,21 +269,83 @@ export const StatusLight = styled.span(({ size = "m" }) => ({
  */
 export const ComponentDetails = () => {
 	const storyMeta = useOf('meta');
-	const versionNumber = storyMeta?.csfFile?.meta?.parameters?.componentVersion ?? "Unavailable";
+
+	const isDeprecated = storyMeta?.csfFile?.meta?.parameters?.status?.type == "deprecated";
+	const packageJson = storyMeta?.csfFile?.meta?.parameters?.packageJson ?? {};
+
+	if (!packageJson?.name) return;
+
+	const [isLoading, setIsLoading] = useState(true);
+	const [npmData, setnpmData] = useState({});
+
+	fetchNpmData(packageJson.name, setnpmData, setIsLoading);
+
+	const { showLocalVersion, allVersions } = processReleaseData(storyMeta, npmData);
 
 	return (
-		<DList className="sb-unstyled">
-			<DTerm>Current version:</DTerm>
-			<DDefinition>{versionNumber}</DDefinition>
+		<ResetWrapper>
+			{ !isLoading ?
+				<DList className="docblock-metadata sb-unstyled">
+					{ isDeprecated
+						?	<>
+								<DTermDTerm key={'status'}>Status:</DTermDTerm>
+								<DDefinition key={'status-data'}>Deprecated</DDefinition>
+							</>
+						: ""
+					}
+					{ showLocalVersion
+						?	<>
+								<DTerm>Local version:</DTerm>
+								<DDefinition><VersionDetails tag={"local"} data={allVersions && allVersions.find(([tag]) => tag === "local")?.[1]} isDeprecated={isDeprecated} /></DDefinition>
+							</>
+						: <>
+							<DTerm>Latest version:</DTerm>
+							<DDefinition><VersionDetails tag={"latest"} data={allVersions && allVersions.find(([tag]) => tag === "latest")?.[1]} isDeprecated={isDeprecated} skipLink={true} /></DDefinition>
+						</>
+					}
+				</DList>
+			: ""}
+		</ResetWrapper>
+	);
+};
 
-			{ storyMeta?.csfFile?.meta?.parameters?.status?.type == "deprecated"
-				?	<>
-						<DTerm>Component status:</DTerm>
-						<DDefinition><StatusLight/>Deprecated</DDefinition>
-					</>
+/**
+ * Displays the tagged releases of the component. The tagged releases are read from npm.
+ *
+ * Usage of this doc block within MDX template(s):
+ *  <TaggedReleases />
+ */
+export const TaggedReleases = () => {
+	const storyMeta = useOf('meta');
+
+	const isDeprecated = storyMeta?.csfFile?.meta?.parameters?.status?.type == "deprecated";
+	const packageJson = storyMeta?.csfFile?.meta?.parameters?.packageJson ?? {};
+
+	const [isLoading, setIsLoading] = useState(true);
+	const [npmData, setnpmData] = useState({});
+
+	fetchNpmData(packageJson.name, setnpmData, setIsLoading);
+
+	const { allVersions } = processReleaseData(storyMeta, npmData);
+
+	return (
+		<ResetWrapper>
+			{ !isLoading ?
+				<DList skipBorder={true} className="docblock-releases sb-unstyled">
+					{ allVersions.filter(([tag]) => tag !== "local").map(([tag, data], idx) => (
+						<>
+							<DTerm>
+								<Code style={{ display: "inline-block" }}>{tag}</Code>
+							</DTerm>
+							<DDefinition>
+								<VersionDetails tag={tag} data={data} isDeprecated={isDeprecated} />
+							</DDefinition>
+						</>
+					))}
+				</DList>
 				: ""
 			}
-		</DList>
+		</ResetWrapper>
 	);
 };
 

--- a/.storybook/blocks/Typography.jsx
+++ b/.storybook/blocks/Typography.jsx
@@ -43,3 +43,22 @@ export const Body = styled.div(({
         ...props
     };
 });
+
+export const Code = styled.div(({
+    theme,
+    size = "m",
+    scale = "desktop",
+    ...props
+}) => {
+    return {
+        fontFamily: theme.typography.fonts.mono,
+        fontStyle: fetchToken("code-font-style", "normal"),
+        fontWeight: fetchToken("code-font-weight", "400"),
+        color: fetchToken("code-color", "inherit"),
+        fontSize: fetchToken(`code-size-${size}`, 22),
+        backgroundColor: fetchToken("gray-200"),
+        padding: "0.125em 0.25em",
+        borderRadius: "0.125em",
+        ...props
+    };
+});

--- a/.storybook/blocks/utilities.js
+++ b/.storybook/blocks/utilities.js
@@ -55,10 +55,10 @@ export function fetchToken(key, fallback = undefined, { color, scale } = {}) {
 	const theme = useTheme() ?? {};
 
     // If the color or scale is not provided, use the theme values or a fallback
-    if (!color && theme.color) color = theme.color;
+    if (typeof color !== "string" && typeof theme.color == "string") color = theme.color;
     else if (!color) color = "light";
 
-    if (!scale && theme.scale) scale = theme.scale;
+    if (typeof scale !== "string" && typeof theme.scale == "string") scale = theme.scale;
     else if (!scale) scale = "medium";
 
     // Create a platform context based on the scale (platform used in the token data)

--- a/.storybook/deprecated/cyclebutton/cyclebutton.stories.js
+++ b/.storybook/deprecated/cyclebutton/cyclebutton.stories.js
@@ -1,5 +1,6 @@
 import { default as ActionButtonStories } from "@spectrum-css/actionbutton/stories/actionbutton.stories.js";
 import { Template as ActionButton } from "@spectrum-css/actionbutton/stories/template.js";
+import pkgJson from "@spectrum-css/cyclebutton/package.json";
 import { default as IconStories } from "@spectrum-css/icon/stories/icon.stories.js";
 import { html } from "lit";
 
@@ -44,7 +45,7 @@ export default {
 		status: {
 			type: "deprecated"
 		},
-		componentVersion: "3.1.3",
+		packageJson: pkgJson,
 	},
 };
 

--- a/.storybook/deprecated/quickaction/quickaction.stories.js
+++ b/.storybook/deprecated/quickaction/quickaction.stories.js
@@ -1,3 +1,4 @@
+import pkgJson from "@spectrum-css/quickaction/package.json";
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
@@ -68,7 +69,7 @@ export default {
 		status: {
 			type: "deprecated"
 		},
-		componentVersion: "3.1.1",
+		packageJson: pkgJson,
 	},
 };
 

--- a/.storybook/deprecated/searchwithin/searchwithin.stories.js
+++ b/.storybook/deprecated/searchwithin/searchwithin.stories.js
@@ -1,3 +1,4 @@
+import pkgJson from "@spectrum-css/searchwithin/package.json";
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
@@ -142,7 +143,7 @@ export default {
 		status: {
 			type: "deprecated"
 		},
-		componentVersion: "5.1.3",
+		packageJson: pkgJson,
 	},
 };
 

--- a/.storybook/deprecated/splitbutton/splitbutton.stories.js
+++ b/.storybook/deprecated/splitbutton/splitbutton.stories.js
@@ -1,3 +1,4 @@
+import pkgJson from "@spectrum-css/splitbutton/package.json";
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 
@@ -63,7 +64,7 @@ export default {
 		status: {
 			type: "deprecated"
 		},
-		componentVersion: "8.1.2",
+		packageJson: pkgJson,
 	},
 };
 

--- a/.storybook/package.json
+++ b/.storybook/package.json
@@ -57,6 +57,7 @@
 		"chromatic": "^11.4.1",
 		"lit": "^3.2.0",
 		"lodash-es": "^4.17.21",
+		"npm-registry-fetch": "^17.0.1",
 		"postcss": "^8.4.41",
 		"prettier": "^3.2.5",
 		"react": "^18.3.1",

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -107,7 +107,10 @@ const parameters = {
 			},
 		},
 	},
-	componentVersion: undefined,
+	// Set an empty object to avoid the "undefined" value in the ComponentDetails doc block
+	packageJson: {},
+	// A list of published npm tags that should not appear in the ComponentDetails doc block
+	ignoredTags: ["beta", "next"],
 };
 
 export default {

--- a/.storybook/templates/DocumentationTemplate.mdx
+++ b/.storybook/templates/DocumentationTemplate.mdx
@@ -9,7 +9,7 @@ import {
   ArgTypes,
   Stories,
 } from "@storybook/blocks";
-import { ComponentDetails } from "../blocks";
+import { ComponentDetails, TaggedReleases } from "../blocks";
 
 {/* 👇 The isTemplate property is required to tell Storybook that this is a template */}
 
@@ -28,3 +28,7 @@ import { ComponentDetails } from "../blocks";
 The component accepts the following inputs (properties):
 
 <ArgTypes />
+
+## Tagged releases
+
+<TaggedReleases />

--- a/components/accordion/stories/accordion.mdx
+++ b/components/accordion/stories/accordion.mdx
@@ -1,12 +1,12 @@
 import {
-	Canvas,
-	ArgTypes,
-	Meta,
-	Description,
-	Title,
-	Subtitle,
+  Canvas,
+  ArgTypes,
+  Meta,
+  Description,
+  Title,
+  Subtitle,
 } from "@storybook/blocks";
-import { ComponentDetails } from "@spectrum-css/preview/blocks";
+import { ComponentDetails, TaggedReleases } from "@spectrum-css/preview/blocks";
 import * as AccordionStories from "./accordion.stories";
 
 <Meta of={AccordionStories} title="Docs" />
@@ -35,4 +35,10 @@ Accordion has three density options and requires that you specify one of the den
 
 ## Properties
 
+The component accepts the following inputs (properties):
+
 <ArgTypes />
+
+## Tagged releases
+
+<TaggedReleases />

--- a/components/accordion/stories/accordion.stories.js
+++ b/components/accordion/stories/accordion.stories.js
@@ -2,7 +2,7 @@ import { Template as Link } from "@spectrum-css/link/stories/template.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { size } from "@spectrum-css/preview/types";
 import { Template as Typography } from "@spectrum-css/typography/stories/template.js";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { AccordionGroup } from "./accordion.test.js";
 import { Template } from "./template.js";
 
@@ -56,7 +56,7 @@ export default {
 			handles: ["click .spectrum-Accordion-item"],
 		},
 		chromatic: { disableSnapshot: true },
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 	tags: ["!autodocs"],
 };

--- a/components/actionbar/stories/actionbar.mdx
+++ b/components/actionbar/stories/actionbar.mdx
@@ -1,12 +1,12 @@
 import {
-	Canvas,
-	ArgTypes,
-	Meta,
-	Description,
-	Title,
-	Subtitle,
+  Canvas,
+  ArgTypes,
+  Meta,
+  Description,
+  Title,
+  Subtitle,
 } from "@storybook/blocks";
-import { ComponentDetails } from "@spectrum-css/preview/blocks";
+import { ComponentDetails, TaggedReleases } from "@spectrum-css/preview/blocks";
 import * as ActionBarStories from "./actionbar.stories";
 
 <Meta of={ActionBarStories} title="Docs" />
@@ -40,3 +40,7 @@ Action bar requires Popover, which is nested within Action bar. Action bar backg
 The component accepts the following inputs (properties):
 
 <ArgTypes />
+
+## Tagged releases
+
+<TaggedReleases />

--- a/components/actionbar/stories/actionbar.stories.js
+++ b/components/actionbar/stories/actionbar.stories.js
@@ -3,7 +3,7 @@ import { default as CloseButton } from "@spectrum-css/closebutton/stories/closeb
 import { default as Popover } from "@spectrum-css/popover/stories/popover.stories.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isEmphasized, isOpen } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { ActionBarGroup } from "./actionbar.test.js";
 import { Template } from "./template.js";
 
@@ -66,7 +66,7 @@ export default {
 			type: "figma",
 			url: "https://www.figma.com/file/MPtRIVRzPp2VHiEplwXL2X/S-%2F-Manual?node-id=465%3A3127&t=xbooxCWItOFgG2xM-1",
 		},
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 	tags: ["!autodocs"],
 };

--- a/components/actionbutton/stories/actionbutton.stories.js
+++ b/components/actionbutton/stories/actionbutton.stories.js
@@ -1,7 +1,7 @@
 import { default as IconStories } from "@spectrum-css/icon/stories/icon.stories.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isActive, isDisabled, isEmphasized, isFocused, isHovered, isQuiet, isSelected, size, staticColor } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { ActionButtonGroup, ActionButtons } from "./actionbutton.test.js";
 
 /**
@@ -72,7 +72,7 @@ export default {
 		actions: {
 			handles: ["click .spectrum-ActionButton:not([disabled])"],
 		},
-		componentVersion: version,
+		packageJson: pkgJson,
 		docs: {
 			story: {
 				height: "auto",

--- a/components/actiongroup/stories/actiongroup.stories.js
+++ b/components/actiongroup/stories/actiongroup.stories.js
@@ -1,8 +1,9 @@
 import { default as ActionButton } from "@spectrum-css/actionbutton/stories/actionbutton.stories.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { size } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { ActionGroups } from "./actiongroup.test.js";
+
 /**
  * The action group component is a collection of action buttons.
  */
@@ -59,7 +60,7 @@ export default {
 				...(ActionButton?.parameters?.actions?.handles ?? []),
 			],
 		},
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/actionmenu/stories/actionmenu.stories.js
+++ b/components/actionmenu/stories/actionmenu.stories.js
@@ -4,7 +4,7 @@ import { default as Menu } from "@spectrum-css/menu/stories/menu.stories.js";
 import { default as Popover } from "@spectrum-css/popover/stories/popover.stories.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isOpen } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { ActionMenuGroup } from "./actionmenu.test.js";
 
 /**
@@ -48,7 +48,7 @@ export default {
 				...(Menu.parameters?.actions?.handles ?? []),
 			],
 		},
-		componentVersion: version,
+		packageJson: pkgJson,
 		docs: {
 			story: {
 				height: "200px",

--- a/components/alertbanner/stories/alertbanner.stories.js
+++ b/components/alertbanner/stories/alertbanner.stories.js
@@ -1,6 +1,6 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isOpen } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { AlertBannerGroup } from "./alertbanner.test.js";
 
 /**
@@ -50,7 +50,7 @@ export default {
 		actions: {
 			handles: ["click .spectrum-AlertBanner button"],
 		},
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/alertdialog/stories/alertdialog.stories.js
+++ b/components/alertdialog/stories/alertdialog.stories.js
@@ -1,7 +1,7 @@
 import { withUnderlayWrapper } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isOpen } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { AlertDialogGroup } from "./alertdialog.test.js";
 import { Template } from "./template.js";
 
@@ -48,7 +48,7 @@ export default {
 				height: "300px",
 			}
 		},
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 	decorators: [
 		withUnderlayWrapper,

--- a/components/asset/stories/asset.mdx
+++ b/components/asset/stories/asset.mdx
@@ -1,12 +1,12 @@
 import {
-	ArgTypes,
-	Canvas,
-	Meta,
-	Description,
-	Title,
-	Subtitle,
+  ArgTypes,
+  Canvas,
+  Meta,
+  Description,
+  Title,
+  Subtitle,
 } from "@storybook/blocks";
-import { ComponentDetails } from "@spectrum-css/preview/blocks";
+import { ComponentDetails, TaggedReleases } from "@spectrum-css/preview/blocks";
 import * as AssetStories from "./asset.stories";
 
 <Meta of={AssetStories} title="Docs" />
@@ -33,4 +33,10 @@ import * as AssetStories from "./asset.stories";
 
 ## Properties
 
+The component accepts the following inputs (properties):
+
 <ArgTypes />
+
+## Tagged releases
+
+<TaggedReleases />

--- a/components/asset/stories/asset.stories.js
+++ b/components/asset/stories/asset.stories.js
@@ -1,5 +1,5 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { AssetGroup } from "./asset.test.js";
 import { Template } from "./template.js";
 
@@ -35,7 +35,7 @@ export default {
 		rootClass: "spectrum-Asset",
 	},
 	parameters: {
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 	tags: ["!autodocs"],
 };

--- a/components/assetcard/stories/assetcard.mdx
+++ b/components/assetcard/stories/assetcard.mdx
@@ -1,12 +1,12 @@
 import {
-	ArgTypes,
-	Canvas,
-	Meta,
-	Description,
-	Title,
-	Subtitle,
+  ArgTypes,
+  Canvas,
+  Meta,
+  Description,
+  Title,
+  Subtitle,
 } from "@storybook/blocks";
-import { ComponentDetails } from "@spectrum-css/preview/blocks";
+import { ComponentDetails, TaggedReleases } from "@spectrum-css/preview/blocks";
 import * as AssetCardStories from "./assetcard.stories";
 
 <Meta of={AssetCardStories} title="Docs" />
@@ -51,4 +51,10 @@ import * as AssetCardStories from "./assetcard.stories";
 
 ## Properties
 
+The component accepts the following inputs (properties):
+
 <ArgTypes />
+
+## Tagged releases
+
+<TaggedReleases />

--- a/components/assetcard/stories/assetcard.stories.js
+++ b/components/assetcard/stories/assetcard.stories.js
@@ -1,7 +1,7 @@
 import { default as Checkbox } from "@spectrum-css/checkbox/stories/checkbox.stories.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isFocused, isSelected } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { AssetCardGroup } from "./assetcard.test.js";
 import { Template } from "./template.js";
 
@@ -85,7 +85,7 @@ export default {
 		actions: {
 			handles: [...(Checkbox.parameters?.actions?.handles ?? [])],
 		},
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 	tags: ["!autodocs"],
 };

--- a/components/assetlist/stories/assetlist.stories.js
+++ b/components/assetlist/stories/assetlist.stories.js
@@ -1,6 +1,6 @@
 import { default as Checkbox } from "@spectrum-css/checkbox/stories/checkbox.stories.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { AssetListGroup } from "./assetlist.test.js";
 
 /**
@@ -19,7 +19,7 @@ export default {
 		actions: {
 			handles: [...(Checkbox.parameters?.actions?.handles ?? [])],
 		},
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/avatar/stories/avatar.mdx
+++ b/components/avatar/stories/avatar.mdx
@@ -1,12 +1,12 @@
 import {
-	ArgTypes,
-	Canvas,
-	Meta,
-	Description,
-	Title,
-	Subtitle,
+  ArgTypes,
+  Canvas,
+  Meta,
+  Description,
+  Title,
+  Subtitle,
 } from "@storybook/blocks";
-import { ComponentDetails } from "@spectrum-css/preview/blocks";
+import { ComponentDetails, TaggedReleases } from "@spectrum-css/preview/blocks";
 import * as AvatarStories from "./avatar.stories";
 
 <Meta of={AvatarStories} title="Docs" />
@@ -49,4 +49,10 @@ When disabled, the avatar should only be used without a link.
 
 ## Properties
 
+The component accepts the following inputs (properties):
+
 <ArgTypes />
+
+## Tagged releases
+
+<TaggedReleases />

--- a/components/avatar/stories/avatar.stories.js
+++ b/components/avatar/stories/avatar.stories.js
@@ -1,7 +1,7 @@
 import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, size } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { AvatarGroup } from "./avatar.test.js";
 import { Template } from "./template.js";
 
@@ -57,7 +57,7 @@ export default {
 		altText: "Shantanu",
 	},
 	parameters: {
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 	tags: ["!autodocs"],
 };

--- a/components/badge/stories/badge.mdx
+++ b/components/badge/stories/badge.mdx
@@ -1,12 +1,12 @@
 import {
-	ArgTypes,
-	Canvas,
-	Meta,
-	Description,
-	Title,
-	Subtitle,
+  ArgTypes,
+  Canvas,
+  Meta,
+  Description,
+  Title,
+  Subtitle,
 } from "@storybook/blocks";
-import { ComponentDetails } from "@spectrum-css/preview/blocks";
+import { ComponentDetails, TaggedReleases } from "@spectrum-css/preview/blocks";
 
 import * as BadgeStories from "./badge.stories";
 
@@ -40,4 +40,10 @@ The border radius is 0 along the fixed edge of the component. The actual compone
 
 ## Properties
 
+The component accepts the following inputs (properties):
+
 <ArgTypes />
+
+## Tagged releases
+
+<TaggedReleases />

--- a/components/badge/stories/badge.stories.js
+++ b/components/badge/stories/badge.stories.js
@@ -1,7 +1,7 @@
 import { default as IconStories } from "@spectrum-css/icon/stories/icon.stories.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { size } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { BadgeGroup } from "./badge.test.js";
 import { PreviewSets } from "./template.js";
 
@@ -61,7 +61,7 @@ export default {
 		fixed: "none"
 	},
 	parameters: {
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 	tags: ["!autodocs"],
 };

--- a/components/breadcrumb/stories/breadcrumb.stories.js
+++ b/components/breadcrumb/stories/breadcrumb.stories.js
@@ -1,6 +1,6 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDragged } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { BreadcrumbGroup } from "./breadcrumb.test.js";
 import { Template } from "./template";
 
@@ -40,7 +40,7 @@ export default {
 		variant: "default",
 	},
 	parameters: {
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/button/stories/button.stories.js
+++ b/components/button/stories/button.stories.js
@@ -1,7 +1,7 @@
 import { default as IconStories } from "@spectrum-css/icon/stories/icon.stories.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isActive, isDisabled, isFocused, isHovered, isPending, size, staticColor } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { ButtonGroups } from "./button.test.js";
 
 /**
@@ -73,7 +73,7 @@ export default {
 		actions: {
 			handles: ["click .spectrum-Button"],
 		},
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/buttongroup/stories/buttongroup.stories.js
+++ b/components/buttongroup/stories/buttongroup.stories.js
@@ -1,7 +1,7 @@
 import { default as Icon } from "@spectrum-css/icon/stories/icon.stories.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { size } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { ButtonGroup } from "./buttongroup.test.js";
 
 /**
@@ -38,7 +38,7 @@ export default {
 		vertical: false,
 	},
 	parameters: {
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/calendar/stories/calendar.mdx
+++ b/components/calendar/stories/calendar.mdx
@@ -1,12 +1,12 @@
 import {
-	ArgTypes,
-	Canvas,
-	Meta,
-	Description,
-	Title,
-	Subtitle,
+  ArgTypes,
+  Canvas,
+  Meta,
+  Description,
+  Title,
+  Subtitle,
 } from "@storybook/blocks";
-import { ComponentDetails } from "@spectrum-css/preview/blocks";
+import { ComponentDetails, TaggedReleases } from "@spectrum-css/preview/blocks";
 
 import * as CalendarStories from "./calendar.stories";
 
@@ -45,4 +45,10 @@ For calendars with a selected range:
 
 ## Properties
 
+The component accepts the following inputs (properties):
+
 <ArgTypes />
+
+## Tagged releases
+
+<TaggedReleases />

--- a/components/calendar/stories/calendar.stories.js
+++ b/components/calendar/stories/calendar.stories.js
@@ -1,7 +1,7 @@
 import ActionButtonStories from "@spectrum-css/actionbutton/stories/actionbutton.stories.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isFocused } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { CalendarGroup } from "./calendar.test.js";
 import { Template } from "./template.js";
 
@@ -95,7 +95,7 @@ export default {
 				...(ActionButtonStories.parameters.actions.handles ?? [])
 			],
 		},
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 	tags: ["!autodocs"],
 };

--- a/components/card/stories/card.mdx
+++ b/components/card/stories/card.mdx
@@ -1,12 +1,12 @@
 import {
-	ArgTypes,
-	Canvas,
-	Meta,
-	Description,
-	Title,
-	Subtitle,
+  ArgTypes,
+  Canvas,
+  Meta,
+  Description,
+  Title,
+  Subtitle,
 } from "@storybook/blocks";
-import { ComponentDetails } from "@spectrum-css/preview/blocks";
+import { ComponentDetails, TaggedReleases } from "@spectrum-css/preview/blocks";
 
 import * as CardStories from "./card.stories";
 
@@ -72,4 +72,10 @@ A gallery card for an image.
 
 ## Properties
 
+The component accepts the following inputs (properties):
+
 <ArgTypes />
+
+## Tagged releases
+
+<TaggedReleases />

--- a/components/card/stories/card.stories.js
+++ b/components/card/stories/card.stories.js
@@ -2,7 +2,7 @@ import { default as ActionButton } from "@spectrum-css/actionbutton/stories/acti
 import { default as Checkbox } from "@spectrum-css/checkbox/stories/checkbox.stories.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isFocused, isQuiet, isSelected } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { CardGroup } from "./card.test.js";
 import { Template } from "./template.js";
 
@@ -91,7 +91,7 @@ export default {
 				...(Checkbox.parameters?.actions?.handles ?? []),
 			],
 		},
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 	tags: ["!autodocs"],
 };

--- a/components/checkbox/stories/checkbox.stories.js
+++ b/components/checkbox/stories/checkbox.stories.js
@@ -1,7 +1,7 @@
 import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isChecked, isDisabled, isEmphasized, isIndeterminate, isInvalid, isReadOnly, size } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { DocsCheckboxGroup, AllVariantsCheckboxGroup, } from "./template";
 import { CheckboxGroup } from "./checkbox.test.js";
 
@@ -50,7 +50,7 @@ export default {
 		actions: {
 			handles: ["click input[type=\"checkbox\"]"],
 		},
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/clearbutton/stories/clearbutton.stories.js
+++ b/components/clearbutton/stories/clearbutton.stories.js
@@ -1,7 +1,7 @@
 import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isQuiet, size, staticColor } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { ClearButtonGroup } from "./clearbutton.test.js";
 import { Template } from "./template";
 
@@ -58,7 +58,7 @@ export default {
 		isQuiet: false,
 	},
 	parameters: {
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/closebutton/stories/closebutton.stories.js
+++ b/components/closebutton/stories/closebutton.stories.js
@@ -1,6 +1,6 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, size, staticColor } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { CloseButtonGroup } from "./closebutton.test.js";
 
 /**
@@ -23,7 +23,7 @@ export default {
 		actions: {
 			handles: ["click .spectrum-CloseButton"],
 		},
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/coachindicator/stories/coachindicator.stories.js
+++ b/components/coachindicator/stories/coachindicator.stories.js
@@ -1,6 +1,6 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isQuiet } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { CoachIndicatorGroup } from "./coachindicator.test.js";
 import { AllVariantsCoachIndicatorGroup } from "./template";
 
@@ -31,7 +31,7 @@ export default {
 		variant: "default",
 	},
 	parameters: {
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/coachmark/stories/coachmark.mdx
+++ b/components/coachmark/stories/coachmark.mdx
@@ -1,12 +1,12 @@
 import {
-	ArgTypes,
-	Canvas,
-	Meta,
-	Description,
-	Title,
-	Subtitle,
+  ArgTypes,
+  Canvas,
+  Meta,
+  Description,
+  Title,
+  Subtitle,
 } from "@storybook/blocks";
-import { ComponentDetails } from "@spectrum-css/preview/blocks";
+import { ComponentDetails, TaggedReleases } from "@spectrum-css/preview/blocks";
 
 import * as CoachmarkStories from "./coachmark.stories";
 
@@ -28,4 +28,10 @@ import * as CoachmarkStories from "./coachmark.stories";
 
 ## Properties
 
+The component accepts the following inputs (properties):
+
 <ArgTypes />
+
+## Tagged releases
+
+<TaggedReleases />

--- a/components/coachmark/stories/coachmark.stories.js
+++ b/components/coachmark/stories/coachmark.stories.js
@@ -1,7 +1,7 @@
 import { default as ActionButton } from "@spectrum-css/actionbutton/stories/actionbutton.stories.js";
 import { default as Menu } from "@spectrum-css/menu/stories/menu.stories.js";
 import { disableDefaultModes, mobile } from "@spectrum-css/preview/modes";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { CoachMarkGroup } from "./coachmark.test.js";
 import { Template } from "./template.js";
 
@@ -53,7 +53,7 @@ export default {
 				...(Menu.parameters?.actions?.handles ?? []),
 			],
 		},
-		componentVersion: version,
+		packageJson: pkgJson,
 		chromatic: {
 			modes: mobile,
 		},

--- a/components/colorarea/stories/colorarea.mdx
+++ b/components/colorarea/stories/colorarea.mdx
@@ -1,12 +1,12 @@
 import {
-	ArgTypes,
-	Canvas,
-	Meta,
-	Description,
-	Title,
-	Subtitle,
+  ArgTypes,
+  Canvas,
+  Meta,
+  Description,
+  Title,
+  Subtitle,
 } from "@storybook/blocks";
-import { ComponentDetails } from "@spectrum-css/preview/blocks";
+import { ComponentDetails, TaggedReleases } from "@spectrum-css/preview/blocks";
 
 import * as ColorAreaStories from "./colorarea.stories";
 
@@ -32,4 +32,10 @@ import * as ColorAreaStories from "./colorarea.stories";
 
 ## Properties
 
+The component accepts the following inputs (properties):
+
 <ArgTypes />
+
+## Tagged releases
+
+<TaggedReleases />

--- a/components/colorarea/stories/colorarea.stories.js
+++ b/components/colorarea/stories/colorarea.stories.js
@@ -1,6 +1,6 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isFocused } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { ColorAreaGroup } from "./colorarea.test.js";
 import { Template } from "./template.js";
 
@@ -40,7 +40,7 @@ export default {
 		selectedColor: "rgba(255, 0, 0, 1)",
 	},
 	parameters: {
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 	tags: ["!autodocs"],
 };

--- a/components/colorhandle/stories/colorhandle.mdx
+++ b/components/colorhandle/stories/colorhandle.mdx
@@ -1,12 +1,12 @@
 import {
-	ArgTypes,
-	Canvas,
-	Meta,
-	Description,
-	Title,
-	Subtitle,
+  ArgTypes,
+  Canvas,
+  Meta,
+  Description,
+  Title,
+  Subtitle,
 } from "@storybook/blocks";
-import { ComponentDetails } from "@spectrum-css/preview/blocks";
+import { ComponentDetails, TaggedReleases } from "@spectrum-css/preview/blocks";
 
 import * as ColorHandleStories from "./colorhandle.stories";
 
@@ -36,4 +36,10 @@ Nest the color loupe component within the color handle markup and apply `.is-ope
 
 ## Properties
 
+The component accepts the following inputs (properties):
+
 <ArgTypes />
+
+## Tagged releases
+
+<TaggedReleases />

--- a/components/colorhandle/stories/colorhandle.stories.js
+++ b/components/colorhandle/stories/colorhandle.stories.js
@@ -1,6 +1,6 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isFocused } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { ColorHandleGroup } from "./colorhandle.test.js";
 import { Template } from "./template.js";
 
@@ -45,7 +45,7 @@ export default {
 		}
 	},
 	parameters: {
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 	tags: ["!autodocs"],
 };

--- a/components/colorloupe/stories/colorloupe.mdx
+++ b/components/colorloupe/stories/colorloupe.mdx
@@ -1,12 +1,12 @@
 import {
-	ArgTypes,
-	Canvas,
-	Meta,
-	Description,
-	Title,
-	Subtitle,
+  ArgTypes,
+  Canvas,
+  Meta,
+  Description,
+  Title,
+  Subtitle,
 } from "@storybook/blocks";
-import { ComponentDetails } from "@spectrum-css/preview/blocks";
+import { ComponentDetails, TaggedReleases } from "@spectrum-css/preview/blocks";
 
 import * as ColorLoupeStories from "./colorloupe.stories";
 
@@ -30,4 +30,10 @@ import * as ColorLoupeStories from "./colorloupe.stories";
 
 ## Properties
 
+The component accepts the following inputs (properties):
+
 <ArgTypes />
+
+## Tagged releases
+
+<TaggedReleases />

--- a/components/colorloupe/stories/colorloupe.stories.js
+++ b/components/colorloupe/stories/colorloupe.stories.js
@@ -1,6 +1,6 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isOpen } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { ColorLoupeGroup } from "./colorloupe.test.js";
 
 /**
@@ -31,12 +31,12 @@ export default {
 		}
 	},
 	parameters: {
-		componentVersion: version,
 		docs: {
 			story: {
 				height: "100px"
 			}
 		},
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/colorslider/stories/colorslider.mdx
+++ b/components/colorslider/stories/colorslider.mdx
@@ -1,12 +1,12 @@
 import {
-	ArgTypes,
-	Canvas,
-	Meta,
-	Description,
-	Title,
-	Subtitle,
+  ArgTypes,
+  Canvas,
+  Meta,
+  Description,
+  Title,
+  Subtitle,
 } from "@storybook/blocks";
-import { ComponentDetails } from "@spectrum-css/preview/blocks";
+import { ComponentDetails, TaggedReleases } from "@spectrum-css/preview/blocks";
 
 import * as ColorSliderStories from "./colorslider.stories";
 
@@ -49,4 +49,10 @@ import * as ColorSliderStories from "./colorslider.stories";
 
 ## Properties
 
+The component accepts the following inputs (properties):
+
 <ArgTypes />
+
+## Tagged releases
+
+<TaggedReleases />

--- a/components/colorslider/stories/colorslider.stories.js
+++ b/components/colorslider/stories/colorslider.stories.js
@@ -1,6 +1,6 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isFocused } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { ColorSliderGroup } from "./colorslider.test.js";
 import { Template } from "./template.js";
 
@@ -49,7 +49,7 @@ export default {
 		selectedColor: "rgba(255, 0, 0, 1)",
 	},
 	parameters: {
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 	tags: ["!autodocs"],
 };

--- a/components/colorwheel/stories/colorwheel.mdx
+++ b/components/colorwheel/stories/colorwheel.mdx
@@ -1,12 +1,12 @@
 import {
-	ArgTypes,
-	Canvas,
-	Meta,
-	Description,
-	Title,
-	Subtitle,
+  ArgTypes,
+  Canvas,
+  Meta,
+  Description,
+  Title,
+  Subtitle,
 } from "@storybook/blocks";
-import { ComponentDetails } from "@spectrum-css/preview/blocks";
+import { ComponentDetails, TaggedReleases } from "@spectrum-css/preview/blocks";
 
 import * as ColorWheelStories from "./colorwheel.stories";
 
@@ -44,4 +44,10 @@ Usage notes:
 
 ## Properties
 
+The component accepts the following inputs (properties):
+
 <ArgTypes />
+
+## Tagged releases
+
+<TaggedReleases />

--- a/components/colorwheel/stories/colorwheel.stories.js
+++ b/components/colorwheel/stories/colorwheel.stories.js
@@ -1,6 +1,6 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isFocused } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { ColorWheelGroup } from "./colorwheel.test.js";
 import { Template } from "./template.js";
 
@@ -41,7 +41,7 @@ export default {
 		selectedColor: "rgba(255, 0, 0, 50%)",
 	},
 	parameters: {
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 	tags: ["!autodocs"],
 };

--- a/components/combobox/stories/combobox.mdx
+++ b/components/combobox/stories/combobox.mdx
@@ -1,12 +1,12 @@
 import {
-	Canvas,
-	ArgTypes,
-	Meta,
-	Description,
-	Title,
-	Subtitle,
+  Canvas,
+  ArgTypes,
+  Meta,
+  Description,
+  Title,
+  Subtitle,
 } from "@storybook/blocks";
-import { ComponentDetails } from "@spectrum-css/preview/blocks";
+import { ComponentDetails, TaggedReleases } from "@spectrum-css/preview/blocks";
 import * as ComboboxStories from "./combobox.stories";
 
 <Meta of={ComboboxStories} title="Docs" />
@@ -92,4 +92,10 @@ Validity and focus must be bubbled up to the parent so descendants siblings can 
 
 ## Properties
 
+The component accepts the following inputs (properties):
+
 <ArgTypes />
+
+## Tagged releases
+
+<TaggedReleases />

--- a/components/combobox/stories/combobox.stories.js
+++ b/components/combobox/stories/combobox.stories.js
@@ -1,7 +1,7 @@
 import { Template as Menu } from "@spectrum-css/menu/stories/template.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isFocused, isInvalid, isKeyboardFocused, isLoading, isOpen, isQuiet, size } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { ComboBoxGroup } from "./combobox.test.js";
 import { Template } from "./template.js";
 
@@ -66,7 +66,7 @@ export default {
 		testId: "combobox",
 	},
 	parameters: {
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/contextualhelp/stories/contextualhelp.mdx
+++ b/components/contextualhelp/stories/contextualhelp.mdx
@@ -37,4 +37,10 @@ import * as ContextualHelpStories from "./contextualhelp.stories";
 
 ## Properties
 
+The component accepts the following inputs (properties):
+
 <ArgTypes />
+
+## Tagged releases
+
+<TaggedReleases />

--- a/components/contextualhelp/stories/contextualhelp.stories.js
+++ b/components/contextualhelp/stories/contextualhelp.stories.js
@@ -1,6 +1,6 @@
 import { default as ActionButtonStories } from "@spectrum-css/actionbutton/stories/actionbutton.stories.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { ContextualHelpGroup } from "./contextualhelp.test.js";
 import { Template } from "./template.js";
 
@@ -90,7 +90,7 @@ export default {
 				...(ActionButtonStories?.parameters?.actions?.handles ?? [])
 			],
 		},
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 	tags: ["!autodocs"],
 };

--- a/components/datepicker/stories/datepicker.mdx
+++ b/components/datepicker/stories/datepicker.mdx
@@ -60,4 +60,10 @@ Read-only displays the same for standard and quiet variants.
 
 ## Properties
 
+The component accepts the following inputs (properties):
+
 <ArgTypes />
+
+## Tagged releases
+
+<TaggedReleases />

--- a/components/datepicker/stories/datepicker.stories.js
+++ b/components/datepicker/stories/datepicker.stories.js
@@ -1,7 +1,7 @@
 import { default as CalendarStories } from "@spectrum-css/calendar/stories/calendar.stories.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isInvalid, isOpen, isQuiet, isReadOnly, isRequired, isValid } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { DatePickerGroup } from "./datepicker.test.js";
 import { Template } from "./template.js";
 
@@ -68,12 +68,12 @@ export default {
 				...(CalendarStories.parameters.actions.handles ?? [])
 			],
 		},
-		componentVersion: version,
 		docs: {
 			story: {
 				height: "50px"
 			}
 		},
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/dial/stories/dial.stories.js
+++ b/components/dial/stories/dial.stories.js
@@ -1,6 +1,6 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isDragged, isFocused, size } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { DialGroup } from "./dial.test.js";
 import { Template } from "./template.js";
 
@@ -32,7 +32,7 @@ export default {
 		isDisabled: false,
 	},
 	parameters: {
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/dialog/stories/dialog.stories.js
+++ b/components/dialog/stories/dialog.stories.js
@@ -2,7 +2,7 @@ import { withUnderlayWrapper } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isOpen } from "@spectrum-css/preview/types";
 import { Template as Typography } from "@spectrum-css/typography/stories/template.js";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { DialogFullscreen, DialogFullscreenTakeover, DialogGroup } from "./dialog.test.js";
 import { Template } from "./template";
 
@@ -118,7 +118,7 @@ export default {
 				height: "500px",
 			},
 		},
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 	decorators: [
 		withUnderlayWrapper,

--- a/components/divider/stories/divider.stories.js
+++ b/components/divider/stories/divider.stories.js
@@ -1,7 +1,7 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { size, staticColor } from "@spectrum-css/preview/types";
 import { Sizes } from "@spectrum-css/preview/decorators";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { DividerGroup } from "./divider.test.js";
 import { Template } from "./template.js";
 
@@ -33,7 +33,7 @@ export default {
 		minDimensionValues: true,
 	},
 	parameters: {
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/dropindicator/stories/dropindicator.stories.js
+++ b/components/dropindicator/stories/dropindicator.stories.js
@@ -1,5 +1,5 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { DropIndicatorGroup } from "./dropindicator.test.js";
 import { DocsDropIndicatorGroup } from "./template";
 
@@ -38,7 +38,7 @@ export default {
 		size: "300px",
 	},
 	parameters: {
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/dropzone/stories/dropzone.stories.js
+++ b/components/dropzone/stories/dropzone.stories.js
@@ -4,7 +4,7 @@ import { Template as Link } from "@spectrum-css/link/stories/template.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDragged } from "@spectrum-css/preview/types";
 import { html } from "lit";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { DropzoneGroup } from "./dropzone.test.js";
 
 /**
@@ -34,7 +34,7 @@ export default {
 		isFilled: false,
 	},
 	parameters: {
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/fieldgroup/stories/fieldgroup.mdx
+++ b/components/fieldgroup/stories/fieldgroup.mdx
@@ -1,12 +1,12 @@
 import {
-	ArgTypes,
-	Canvas,
-	Meta,
-	Description,
-	Title,
-	Subtitle,
+  ArgTypes,
+  Canvas,
+  Meta,
+  Description,
+  Title,
+  Subtitle,
 } from "@storybook/blocks";
-import { ComponentDetails } from "@spectrum-css/preview/blocks";
+import { ComponentDetails, TaggedReleases } from "@spectrum-css/preview/blocks";
 
 import * as FieldGroupStories from "./fieldgroup.stories";
 
@@ -99,6 +99,12 @@ An invalid group of fields:
 
 <Canvas of={FieldGroupStories.ReadOnly} />
 
-### Properties
+## Properties
+
+The component accepts the following inputs (properties):
 
 <ArgTypes />
+
+## Tagged releases
+
+<TaggedReleases />

--- a/components/fieldgroup/stories/fieldgroup.stories.js
+++ b/components/fieldgroup/stories/fieldgroup.stories.js
@@ -2,7 +2,7 @@ import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isInvalid, isReadOnly, isRequired } from "@spectrum-css/preview/types";
 import { default as RadioSettings } from "@spectrum-css/radio/stories/radio.stories.js";
 import { Template as Radio } from "@spectrum-css/radio/stories/template.js";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { FieldGroupSet } from "./fieldgroup.test.js";
 import { Template } from "./template.js";
 
@@ -72,7 +72,7 @@ export default {
 				...(RadioSettings.parameters?.actions?.handles ?? [])
 			],
 		},
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 	tags: ["!autodocs"],
 };

--- a/components/fieldlabel/stories/fieldlabel.stories.js
+++ b/components/fieldlabel/stories/fieldlabel.stories.js
@@ -1,6 +1,6 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isRequired, size } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { FieldLabelGroup } from "./fieldlabel.test.js";
 
 /**
@@ -41,7 +41,7 @@ export default {
 		isRequired: false,
 	},
 	parameters: {
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/fieldlabel/stories/form.stories.js
+++ b/components/fieldlabel/stories/form.stories.js
@@ -2,7 +2,7 @@ import { Template as Picker } from "@spectrum-css/picker/stories/template.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { Template as Stepper } from "@spectrum-css/stepper/stories/template.js";
 import { Template as TextField } from "@spectrum-css/textfield/stories/template.js";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { FormGroup } from "./form.test.js";
 
 /**
@@ -27,7 +27,7 @@ export default {
 		labelsAbove: false,
 	},
 	parameters: {
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/floatingactionbutton/stories/floatingactionbutton.stories.js
+++ b/components/floatingactionbutton/stories/floatingactionbutton.stories.js
@@ -1,7 +1,7 @@
 import { default as IconStories } from "@spectrum-css/icon/stories/icon.stories.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isActive, isFocused, isHovered } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { FloatingActionButtonGroup } from "./floatingactionbutton.test.js";
 import { Template } from "./template.js";
 
@@ -44,7 +44,7 @@ export default {
 		isActive: false,
 	},
 	parameters: {
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/helptext/stories/helptext.stories.js
+++ b/components/helptext/stories/helptext.stories.js
@@ -1,6 +1,6 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, size } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { HelpTextGroup } from "./helptext.test.js";
 
 /**
@@ -54,7 +54,7 @@ export default {
 		size: "m",
 	},
 	parameters: {
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/icon/stories/icon.mdx
+++ b/components/icon/stories/icon.mdx
@@ -1,10 +1,13 @@
 import { Canvas, ArgTypes, Meta, Description, Title } from "@storybook/blocks";
+import { ComponentDetails, TaggedReleases } from "@spectrum-css/preview/blocks";
 
 import * as IconStories from "./icon.stories";
 
 <Meta of={IconStories} title="Docs" />
 
 <Title of={IconStories} />
+<ComponentDetails />
+
 <Description of={IconStories} />
 
 ## Icon sets
@@ -66,4 +69,10 @@ The workflow icon SVGs are within a separate respository, which is also publishe
 
 ## Properties
 
+The component accepts the following inputs (properties):
+
 <ArgTypes />
+
+## Tagged releases
+
+<TaggedReleases />

--- a/components/icon/stories/icon.stories.js
+++ b/components/icon/stories/icon.stories.js
@@ -3,7 +3,7 @@ import { size } from "@spectrum-css/preview/types";
 import { Template as Typography } from "@spectrum-css/typography/stories/template.js";
 import { html } from "lit";
 import { styleMap } from "lit/directives/style-map.js";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { IconGroup } from "./icon.test.js";
 import { Template } from "./template.js";
 import { uiIconSizes, uiIconsWithDirections, workflowIcons } from "./utilities.js";
@@ -88,7 +88,7 @@ export default {
 		useRef: true,
 	},
 	parameters: {
-		componentVersion: version,
+		packageJson: pkgJson,
 		chromatic: {
 			modes: mobile,
 		},

--- a/components/illustratedmessage/stories/illustratedmessage.stories.js
+++ b/components/illustratedmessage/stories/illustratedmessage.stories.js
@@ -1,7 +1,7 @@
 import { Template as Link } from "@spectrum-css/link/stories/template.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { html } from "lit";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { IllustratedMessageGroup } from "./illustratedmessage.test.js";
 import { Template } from "./template.js";
 
@@ -43,7 +43,7 @@ export default {
 		useAccentColor: false,
 	},
 	parameters: {
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/infieldbutton/stories/infieldbutton.stories.js
+++ b/components/infieldbutton/stories/infieldbutton.stories.js
@@ -1,7 +1,7 @@
 import { default as IconStories } from "@spectrum-css/icon/stories/icon.stories.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isActive, isDisabled, isFocused, isHovered, isQuiet, size } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { InfieldButtonGroup } from "./infieldbutton.test.js";
 import { Template } from "./template.js";
 
@@ -47,7 +47,7 @@ export default {
 		isStacked: false,
 	},
 	parameters: {
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/inlinealert/stories/inlinealert.stories.js
+++ b/components/inlinealert/stories/inlinealert.stories.js
@@ -1,5 +1,5 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { InlineAlertGroup } from "./inlinealert.test.js";
 import { Template } from "./template";
 
@@ -58,7 +58,7 @@ export default {
 		isClosable: false,
 	},
 	parameters: {
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/link/stories/link.stories.js
+++ b/components/link/stories/link.stories.js
@@ -1,6 +1,6 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isActive, isFocused, isHovered, isQuiet, staticColor } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { LinkGroup } from "./link.test.js";
 import { TemplateWithFillerText } from "./template";
 
@@ -69,7 +69,7 @@ export default {
 		actions: {
 			handles: ["click .spectrum-Link"],
 		},
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/logicbutton/stories/logicbutton.stories.js
+++ b/components/logicbutton/stories/logicbutton.stories.js
@@ -1,6 +1,6 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { LogicButtonGroup } from "./logicbutton.test.js";
 import { Template, VariantGroup } from "./template.js";
 
@@ -29,7 +29,7 @@ export default {
 		isDisabled: false,
 	},
 	parameters: {
-		componentVersion: version,	
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/menu/stories/menu.stories.js
+++ b/components/menu/stories/menu.stories.js
@@ -1,7 +1,7 @@
 import { default as IconStories } from "@spectrum-css/icon/stories/icon.stories.js";
 import { disableDefaultModes, viewports } from "@spectrum-css/preview/modes";
 import { isActive, isDisabled, isFocused, isHovered, isOpen, isSelected, size } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { MenuItemGroup, MenuTraySubmenu, MenuWithVariants } from "./menu.test.js";
 import { Template } from "./template.js";
 
@@ -180,12 +180,12 @@ export default {
 		actions: {
 			handles: ["click .spectrum-Menu-item"],
 		},
-		componentVersion: version,
 		docs: {
 			story: {
 				height: "300px"
 			}
 		},
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/miller/stories/miller.stories.js
+++ b/components/miller/stories/miller.stories.js
@@ -1,5 +1,5 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { MillerGroup } from "./miller.test.js";
 import { Template } from "./template.js";
 
@@ -76,7 +76,7 @@ export default {
 		],
 	},
 	parameters: {
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/modal/stories/modal.stories.js
+++ b/components/modal/stories/modal.stories.js
@@ -2,7 +2,7 @@ import { withUnderlayWrapper } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isOpen } from "@spectrum-css/preview/types";
 import { Template as Typography } from "@spectrum-css/typography/stories/template.js";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { ModalGroup } from "./modal.test.js";
 
 /**
@@ -48,7 +48,7 @@ export default {
 				width: "800px"
 			},
 		},
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 	decorators: [
 		withUnderlayWrapper,

--- a/components/opacitycheckerboard/stories/opacitycheckerboard.stories.js
+++ b/components/opacitycheckerboard/stories/opacitycheckerboard.stories.js
@@ -1,5 +1,5 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { OpacityCheckboardGroup } from "./opacitycheckerboard.test.js";
 import { Template } from "./template.js";
 
@@ -29,7 +29,7 @@ export default {
 		}
 	},
 	parameters: {
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/pagination/stories/pagination.stories.js
+++ b/components/pagination/stories/pagination.stories.js
@@ -1,7 +1,7 @@
 import { default as ActionButton } from "@spectrum-css/actionbutton/stories/actionbutton.stories";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { size } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { PaginationGroup } from "./pagination.test.js";
 import { Template } from "./template";
 
@@ -67,7 +67,7 @@ export default {
 				...(ActionButton.parameters?.actions?.handles ?? [])
 			],
 		},
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/picker/stories/picker.stories.js
+++ b/components/picker/stories/picker.stories.js
@@ -1,7 +1,7 @@
 import { WithDividers as MenuStories } from "@spectrum-css/menu/stories/menu.stories.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isInvalid, isKeyboardFocused, isLoading, isOpen, isQuiet, size } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { PickerGroup } from "./picker.test.js";
 
 /**
@@ -78,12 +78,12 @@ export default {
 		],
 	},
 	parameters: {
-		componentVersion: version,
 		docs: {
 			story: {
 				height: "400px"
 			}
 		},
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/pickerbutton/stories/pickerbutton.stories.js
+++ b/components/pickerbutton/stories/pickerbutton.stories.js
@@ -2,7 +2,7 @@ import { default as Icon } from "@spectrum-css/icon/stories/icon.stories.js";
 import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isFocused, isOpen, isQuiet, size } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { PickerGroup } from "./pickerbutton.test.js";
 import { CustomIconTemplate, Template } from "./template";
 
@@ -84,7 +84,7 @@ export default {
 		position: "right",
 	},
 	parameters: {
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/popover/stories/popover.stories.js
+++ b/components/popover/stories/popover.stories.js
@@ -2,7 +2,7 @@ import { Template as ActionButton } from "@spectrum-css/actionbutton/stories/tem
 import { Template as Menu } from "@spectrum-css/menu/stories/template.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isOpen } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { PopoverGroup } from "./popover.test.js";
 import { Template } from "./template.js";
 
@@ -75,7 +75,7 @@ export default {
 	},
 	parameters: {
 		layout: "centered",
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/progressbar/stories/meter.stories.js
+++ b/components/progressbar/stories/meter.stories.js
@@ -1,5 +1,5 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { MeterGroup } from "./meter.test.js";
 import { default as ProgressBar } from "./progressbar.stories";
 
@@ -24,7 +24,7 @@ export default {
 	},
 	args: ProgressBar.args,
 	parameters: {
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/progresscircle/stories/progresscircle.stories.js
+++ b/components/progresscircle/stories/progresscircle.stories.js
@@ -1,6 +1,6 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isIndeterminate, size, staticColor } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { ProgressCircleGroup } from "./progresscircle.test.js";
 
 /**
@@ -24,7 +24,7 @@ export default {
 		staticColor: undefined,
 	},
 	parameters: {
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/radio/stories/radio.stories.js
+++ b/components/radio/stories/radio.stories.js
@@ -1,6 +1,6 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isChecked, isDisabled, isEmphasized, isReadOnly, size } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { RadioGroup } from "./radio.test.js";
 
 /**
@@ -48,7 +48,7 @@ export default {
 			handles: ["click input[type=\"radio\"]"],
 
 		},
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/rating/stories/rating.stories.js
+++ b/components/rating/stories/rating.stories.js
@@ -1,6 +1,6 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isEmphasized, isFocused, isReadOnly } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { RatingGroup } from "./rating.test.js";
 import { Template } from "./template.js";
 
@@ -42,7 +42,7 @@ export default {
 		value: 3,
 	},
 	parameters: {
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/search/stories/search.stories.js
+++ b/components/search/stories/search.stories.js
@@ -1,6 +1,6 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isQuiet, size } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { SearchGroup } from "./search.test.js";
 
 /**
@@ -27,7 +27,7 @@ export default {
 				"click .spectrum-Search-icon",
 			],
 		},
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/sidenav/stories/sidenav.stories.js
+++ b/components/sidenav/stories/sidenav.stories.js
@@ -1,5 +1,5 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { SideNavGroup } from "./sidenav.test.js";
 import { Template } from "./template.js";
 
@@ -58,7 +58,7 @@ export default {
 		],
 	},
 	parameters: {
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/slider/stories/slider.stories.js
+++ b/components/slider/stories/slider.stories.js
@@ -1,7 +1,7 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { Sizes } from "@spectrum-css/preview/decorators";
 import { isDisabled, isFocused, size } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { SliderGroup } from "./slider.test.js";
 import { Template } from "./template.js";
 
@@ -139,7 +139,7 @@ export default {
 				"change .spectrum-Slider-input",
 			],
 		},
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/splitview/stories/splitview.stories.js
+++ b/components/splitview/stories/splitview.stories.js
@@ -1,6 +1,6 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isFocused } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { SplitViewGroup } from "./splitview.test.js";
 import { Template } from "./template.js";
 
@@ -78,7 +78,7 @@ export default {
 		panelStyles: ["width: 304px;", "flex: 1;"],
 	},
 	parameters: {
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/statuslight/stories/statuslight.stories.js
+++ b/components/statuslight/stories/statuslight.stories.js
@@ -1,6 +1,6 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { size } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { StatusLightGroup } from "./statuslight.test.js";
 
 export default {
@@ -56,7 +56,7 @@ export default {
 		variant: "info",
 	},
 	parameters: {
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/steplist/stories/steplist.stories.js
+++ b/components/steplist/stories/steplist.stories.js
@@ -1,5 +1,5 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { SteplistGroup } from "./steplist.test.js";
 import { DocsSteplistGroup } from "./template";
 
@@ -73,7 +73,7 @@ export default {
 		],
 	},
 	parameters: {
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/stepper/stories/stepper.stories.js
+++ b/components/stepper/stories/stepper.stories.js
@@ -1,7 +1,7 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isFocused, isInvalid, isKeyboardFocused, isQuiet, size } from "@spectrum-css/preview/types";
 import { Sizes } from "@spectrum-css/preview/decorators";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { StepperGroup } from "./stepper.test.js";
 import { Template, DisabledVariantsGroup, AllDefaultVariantsGroup } from "./template";
 
@@ -39,7 +39,7 @@ export default {
 		hideStepper: false
 	},
 	parameters: {
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/swatch/stories/swatch.stories.js
+++ b/components/swatch/stories/swatch.stories.js
@@ -1,6 +1,6 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isSelected, size } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { SwatchGroup } from "./swatch.test.js";
 
 /**
@@ -42,7 +42,7 @@ export default {
 		swatchColor: "rgb(174, 216, 230)"
 	},
 	parameters: {
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/swatchgroup/stories/swatchgroup.stories.js
+++ b/components/swatchgroup/stories/swatchgroup.stories.js
@@ -1,6 +1,6 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { default as Swatch } from "@spectrum-css/swatch/stories/swatch.stories.js";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { SwatchGroup } from "./swatchgroup.test.js";
 
 /**
@@ -64,7 +64,7 @@ export default {
 				...(Swatch.parameters?.actions?.handles ?? []),
 			],
 		},
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/switch/stories/switch.stories.js
+++ b/components/switch/stories/switch.stories.js
@@ -1,6 +1,6 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isChecked, isDisabled, isEmphasized, size } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { SwitchGroup } from "./switch.test.js";
 import { Template } from "./template.js";
 
@@ -33,7 +33,7 @@ export default {
 		label: "Switch label",
 		size: "m",
 	},
-	componentVersion: version,
+	packageJson: pkgJson,
 };
 
 export const Default = SwitchGroup.bind({});

--- a/components/table/stories/table.stories.js
+++ b/components/table/stories/table.stories.js
@@ -1,6 +1,6 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isEmphasized, isQuiet, size } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { TableGroup } from "./table.test.js";
 import { Template } from "./template.js";
 
@@ -98,7 +98,7 @@ export default {
 		],
 	},
 	parameters: {
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/tabs/stories/tabs.stories.js
+++ b/components/tabs/stories/tabs.stories.js
@@ -1,6 +1,6 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isEmphasized, isQuiet, size } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { TabsGroups } from "./tabs.test.js";
 import { Template } from "./template.js";
 
@@ -77,7 +77,7 @@ export default {
 		actions: {
 			handles: [".spectrum-Tabs-item"],
 		},
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/tag/stories/tag.stories.js
+++ b/components/tag/stories/tag.stories.js
@@ -1,7 +1,7 @@
 import { default as IconStories } from "@spectrum-css/icon/stories/icon.stories.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isEmphasized, isInvalid, isSelected, size } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { TagGroups } from "./tag.test.js";
 import { Template } from "./template.js";
 
@@ -92,7 +92,7 @@ export default {
 		actions: {
 			handles: [],
 		},
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/taggroup/stories/taggroup.stories.js
+++ b/components/taggroup/stories/taggroup.stories.js
@@ -1,6 +1,6 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { default as TagStories } from "@spectrum-css/tag/stories/tag.stories.js";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { TagGroups } from "./taggroup.test.js";
 import { Template } from "./template.js";
 
@@ -54,7 +54,7 @@ export default {
 				...(TagStories.parameters.actions.handles ?? [])
 			],
 		},
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/textfield/stories/textfield.stories.js
+++ b/components/textfield/stories/textfield.stories.js
@@ -1,6 +1,6 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isFocused, isInvalid, isKeyboardFocused, isLoading, isQuiet, isReadOnly, isRequired, isValid, size } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { Template } from "./template.js";
 import { TextFieldGroup } from "./textfield.test.js";
 
@@ -116,7 +116,7 @@ export default {
 				"focusout .spectrum-Textfield"
 			],
 		},
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/thumbnail/stories/thumbnail.stories.js
+++ b/components/thumbnail/stories/thumbnail.stories.js
@@ -1,7 +1,7 @@
 import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isFocused, isSelected, size } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { Template } from "./template.js";
 import { ThumbnailGroup } from "./thumbnail.test.js";
 
@@ -87,7 +87,7 @@ export default {
 		actions: {
 			handles: [],
 		},
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/toast/stories/toast.stories.js
+++ b/components/toast/stories/toast.stories.js
@@ -1,5 +1,5 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { Template } from "./template.js";
 import { ToastGroup } from "./toast.test.js";
 
@@ -40,7 +40,7 @@ export default {
 		actions: {
 			handles: ["click .spectrum-Toast button"],
 		},
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/tooltip/stories/tooltip.stories.js
+++ b/components/tooltip/stories/tooltip.stories.js
@@ -1,6 +1,6 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isFocused, isOpen } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { PlacementVariants } from "./tooltip.test.js";
 
 /**
@@ -88,7 +88,7 @@ export default {
 		label: "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
 	},
 	parameters: {
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/tray/stories/tray.stories.js
+++ b/components/tray/stories/tray.stories.js
@@ -1,7 +1,7 @@
 import { Template as Dialog } from "@spectrum-css/dialog/stories/template.js";
 import { disableDefaultModes, viewports } from "@spectrum-css/preview/modes";
 import { isOpen } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { TrayGroup } from "./tray.test.js";
 
 /**
@@ -41,7 +41,7 @@ export default {
 				},
 			},
 		},
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/treeview/stories/treeview.stories.js
+++ b/components/treeview/stories/treeview.stories.js
@@ -1,7 +1,7 @@
 import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isQuiet, size } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { Template } from "./template.js";
 import { TreeViewGroup } from "./treeview.test.js";
 
@@ -28,7 +28,7 @@ export default {
 		actions: {
 			handles: ["click .spectrum-TreeView-itemLink"],
 		},
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/typography/stories/typography.stories.js
+++ b/components/typography/stories/typography.stories.js
@@ -1,7 +1,7 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { size } from "@spectrum-css/preview/types";
 import { html } from "lit";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { Template } from "./template.js";
 import { TypographyGroup } from "./typography.test.js";
 
@@ -65,7 +65,7 @@ export default {
 		semantics: "body",
 	},
 	parameters: {
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/components/underlay/stories/underlay.stories.js
+++ b/components/underlay/stories/underlay.stories.js
@@ -1,7 +1,7 @@
 import { Default as DialogStory } from "@spectrum-css/dialog/stories/dialog.stories.js";
 import { Template as Dialog } from "@spectrum-css/dialog/stories/template.js";
 import { isOpen } from "@spectrum-css/preview/types";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { Template } from "./template.js";
 
 /**
@@ -28,7 +28,7 @@ export default {
 			},
 		},
 		chromatic: { disableSnapshot: true },
-		componentVersion: version,
+		packageJson: pkgJson,
 	}
 };
 

--- a/components/well/stories/well.stories.js
+++ b/components/well/stories/well.stories.js
@@ -1,7 +1,7 @@
 import { Template as Link } from "@spectrum-css/link/stories/template.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { Template as Typography } from "@spectrum-css/typography/stories/template.js";
-import { version } from "../package.json";
+import pkgJson from "../package.json";
 import { WellGroup } from "./well.test.js";
 
 /**
@@ -20,7 +20,7 @@ export default {
 		actions: {
 			handles: [],
 		},
-		componentVersion: version,
+		packageJson: pkgJson,
 	},
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5282,6 +5282,7 @@ __metadata:
     chromatic: "npm:^11.4.1"
     lit: "npm:^3.2.0"
     lodash-es: "npm:^4.17.21"
+    npm-registry-fetch: "npm:^17.0.1"
     postcss: "npm:^8.4.41"
     prettier: "npm:^3.2.5"
     react: "npm:^18.3.1"


### PR DESCRIPTION
## Description

This PR builds off the color docs PR and adds theming support to the existing ComponentDetails block.  It also updates the block to fetch data from npm the way the current site does.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [x] On any [component docs page](https://pr-2987--spectrum-css.netlify.app/preview/?path=/docs/components-accordion--docs) below the heading, expect to see a section like this:
<img width="826" alt="Screenshot 2024-08-29 at 4 00 04 PM" src="https://github.com/user-attachments/assets/d71b5694-27f4-4bf6-94f2-7af7e2f4531a">

- [x] At the bottom of the page, after the properties, expect to see the tagged releases for this component: 
<img width="822" alt="Screenshot 2024-08-29 at 4 00 59 PM" src="https://github.com/user-attachments/assets/a85c9c33-b268-4fdf-9f9d-68cf9640ecec">

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
