### PR TITLE
chore: set lint action to review PR not just check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -82,7 +82,7 @@ jobs:
               with:
                   fail_on_error: true
                   level: error
-                  reporter: github-pr-check
+                  reporter: github-pr-review
                   filter_mode: diff_context
                 #   stylelint_input: "components/*/index.css components/*/themes/*.css"
                   stylelint_input: "${{ inputs.styles_added_files }} ${{ inputs.styles_modified_files }}"
@@ -94,7 +94,7 @@ jobs:
               with:
                   fail_on_error: true
                   level: error
-                  reporter: github-pr-check
+                  reporter: github-pr-review
                   filter_mode: diff_context
                 #   eslint_flags: "components/*/stories/*.js"
                   eslint_flags: "${{ inputs.eslint_added_files }} ${{ inputs.eslint_modified_files }}"


### PR DESCRIPTION
## Description

Update the linting action to report on errors to the PR as inline comments rather than as a boolean Pass/Fail check.

This will provide more meaningful feedback when a linting error is introduced in a pull request.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

Setup:

1. Pull down this branch locally.
2. Create a fork branch of this pull request: git checkout -b fork-validate-linting
3. Move the properties defined on line 23 down below the &:lang selectors to line 34.

<img width="692" alt="Screenshot 2024-08-23 at 11 53 52 AM" src="https://github.com/user-attachments/assets/969e0af7-4b51-416e-935a-0b8e5e59195a">

4. Commit that change to the fork branch.
5. Open a new pull request for this change with this branch as your base: `gh pr create --base chore-lint-review-action` (only works if you have the [GitHub CLI](https://cli.github.com) installed).

- [ ] Expect to see a comment show up in the diff outlining the error introduced.
- [ ] Do not expect to see any other linting warnings show up for any files not altered by the fork pull request.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
