### PR TITLE
chore(dropindicator): update storybook prop to use length instead of size

### DIFF
--- a/components/dropindicator/stories/dropindicator.stories.js
+++ b/components/dropindicator/stories/dropindicator.stories.js
@@ -20,7 +20,7 @@ export default {
 			options: ["horizontal", "vertical"],
 			control: "select",
 		},
-		size: {
+		length: {
 			name: "Size",
 			description:
 				"Size of the drop indicator, requires a unit be provided; i.e., 200px or 100%.",
@@ -35,7 +35,7 @@ export default {
 	args: {
 		rootClass: "spectrum-DropIndicator",
 		direction: "vertical",
-		size: "300px",
+		length: "300px",
 	},
 	parameters: {
 		packageJson: pkgJson,
@@ -50,7 +50,7 @@ Default.tags = ["!autodocs"];
 export const DefaultGroup = DocsDropIndicatorGroup.bind({});
 DefaultGroup.storyName = "Default";
 DefaultGroup.tags = ["!dev"];
-DefaultGroup.parameters = { 
+DefaultGroup.parameters = {
 	chromatic: { disableSnapshot: true }
 };
 

--- a/components/dropindicator/stories/template.js
+++ b/components/dropindicator/stories/template.js
@@ -10,7 +10,7 @@ export const Template = ({
 	customClasses = [],
 	customStyles = {},
 	direction = "vertical",
-	size = "300px",
+	length = "300px",
 } = {}) => {
 	return html`
 		<div
@@ -20,8 +20,8 @@ export const Template = ({
 				...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
 			})}
 			style=${ifDefined(styleMap({
-				"block-size": direction == "vertical" ? size : undefined,
-				"inline-size": direction == "horizontal" ? size : undefined,
+				"block-size": direction == "vertical" ? length : undefined,
+				"inline-size": direction == "horizontal" ? length : undefined,
 				...customStyles,
 			}))}
 		></div>
@@ -35,9 +35,7 @@ export const DocsDropIndicatorGroup = (args, context) => html`
 		"gap": "16px",
 		"justify-content": "space-evenly",
 	})}>
-	${Template({
-			...args,
-		}, context)}
+	${Template(args, context)}
 		${Template({
 			...args,
 			direction: "horizontal",


### PR DESCRIPTION
## Description

Update the dropindicator argTypes to use the key `length` instead of `size` so that the testing grid doesn't try to render the sizing table.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [ ] Expect to see no console errors about ArgGrid for drop indicator

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
