### PR TITLE
fix(treeview, tabs, combobox): migrate --mods to index.css

### DIFF
--- a/.changeset/fuzzy-brooms-jam.md
+++ b/.changeset/fuzzy-brooms-jam.md
@@ -1,0 +1,7 @@
+---
+"@spectrum-css/combobox": minor
+"@spectrum-css/treeview": minor
+"@spectrum-css/tabs": minor
+---
+
+[CSS-890]: adjusts --mods to be applied inside of index.css

--- a/.changeset/fuzzy-jokes-begin.md
+++ b/.changeset/fuzzy-jokes-begin.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/tokens": patch
+---
+
+define undefined rgb tokens

--- a/components/combobox/index.css
+++ b/components/combobox/index.css
@@ -246,9 +246,13 @@
 
 /* QUIET VARIATION (no visible background) */
 .spectrum-Combobox--quiet {
+	--spectrum-combobox-button-inline-offset: calc((var(--mod-combobox-block-size, var(--spectrum-combobox-block-size)) / 2) - (var(--mod-combobox-icon-size, var(--spectrum-combobox-icon-size)) / 2));
+
 	/* Settings for nested Picker Button component. */
 	--mod-picker-button-background-color-quiet: transparent;
 	--mod-picker-button-border-color-quiet: transparent;
+	
+	--mod-picker-button-border-color: var(--mod-picker-button-border-color-quiet);
 
 	border-radius: 0;
 

--- a/components/combobox/themes/spectrum-two.css
+++ b/components/combobox/themes/spectrum-two.css
@@ -52,47 +52,6 @@
 		--spectrum-combobox-border-color-invalid-focus: var(--spectrum-negative-border-color-focus);
 		--spectrum-combobox-border-color-invalid-focus-hover: var(--spectrum-negative-border-color-focus-hover);
 		--spectrum-combobox-border-color-invalid-key-focus: var(--spectrum-negative-border-color-key-focus);
-
-		/* Settings for nested Textfield component. */
-		--mod-textfield-focus-indicator-gap: var(--mod-combobox-focus-indicator-gap, var(--spectrum-combobox-focus-indicator-gap));
-		--mod-textfield-focus-indicator-width: var(--mod-combobox-focus-indicator-thickness, var(--spectrum-combobox-focus-indicator-thickness));
-		--mod-textfield-focus-indicator-color: var(--mod-combobox-focus-indicator-color, var(--spectrum-combobox-focus-indicator-color));
-
-		--mod-textfield-background-color: var(--mod-combobox-background-color-default);
-		--mod-textfield-background-color-disabled: var(--mod-combobox-background-color-disabled);
-
-		--mod-textfield-font-family: var(--mod-combobox-font-family);
-		--mod-textfield-font-weight: var(--mod-combobox-font-weight);
-
-		--mod-textfield-text-color-default: var(--mod-combobox-font-color-default);
-		--mod-textfield-text-color-hover: var(--mod-combobox-font-color-hover);
-		--mod-textfield-text-color-focus: var(--mod-combobox-font-color-focus);
-		--mod-textfield-text-color-focus-hover: var(--mod-combobox-font-color-focus-hover);
-		--mod-textfield-text-color-keyboard-focus: var(--mod-combobox-font-color-key-focus);
-		--mod-textfield-text-color-disabled: var(--mod-combobox-font-color-disabled);
-
-		--mod-textfield-border-width: var(--mod-combobox-border-width, var(--spectrum-combobox-border-width));
-		--mod-textfield-border-color: var(--mod-combobox-border-color-default, var(--spectrum-combobox-border-color-default));
-		--mod-textfield-border-color-disabled: var(--mod-combobox-border-color-disabled);
-		--mod-textfield-border-color-focus: var(--mod-combobox-border-color-focus, var(--spectrum-combobox-border-color-focus));
-		--mod-textfield-border-color-focus-hover: var(--mod-combobox-border-color-focus-hover, var(--spectrum-combobox-border-color-focus-hover));
-		--mod-textfield-border-color-hover: var(--mod-combobox-border-color-hover, var(--spectrum-combobox-border-color-hover));
-		--mod-textfield-border-color-keyboard-focus: var(--mod-combobox-border-color-key-focus, var(--spectrum-combobox-border-color-key-focus));
-
-		--mod-textfield-border-color-invalid-default: var(--mod-combobox-border-color-invalid-default, var(--spectrum-combobox-border-color-invalid-default));
-		--mod-textfield-border-color-invalid-hover: var(--mod-combobox-border-color-invalid-hover, var(--spectrum-combobox-border-color-invalid-hover));
-		--mod-textfield-border-color-invalid-focus: var(--mod-combobox-border-color-invalid-focus, var(--spectrum-combobox-border-color-invalid-focus));
-		--mod-textfield-border-color-invalid-focus-hover: var(--mod-combobox-border-color-invalid-focus-hover, var(--spectrum-combobox-border-color-invalid-focus-hover));
-		--mod-textfield-border-color-invalid-keyboard-focus: var(--mod-combobox-border-color-invalid-key-focus, var(--spectrum-combobox-border-color-invalid-key-focus));
-
-		--mod-textfield-icon-color-invalid: var(--mod-combobox-alert-icon-color);
-
-		/* Settings for nested Picker Button component. */
-		--mod-picker-button-border-width: var(--mod-combobox-border-width, var(--spectrum-combobox-border-width));
-		--mod-picker-button-border-color: var(--mod-combobox-border-color-default, var(--spectrum-combobox-border-color-default));
-		--mod-picker-button-background-color: var(--mod-combobox-background-color-default);
-		--mod-picker-button-background-color-disabled: var(--mod-combobox-background-color-disabled);
-		--mod-picker-button-font-color-disabled: var(--mod-combobox-font-color-disabled);
 	}
 
 	.spectrum-Combobox--sizeS {
@@ -160,7 +119,6 @@
 		--spectrum-combobox-spacing-inline-icon-to-button: var(--spectrum-combo-box-visual-to-field-button-quiet);
 		--spectrum-combobox-spacing-inline-start-edge-to-text: var(--spectrum-field-edge-to-text-quiet);
 		--spectrum-combobox-spacing-label-to-combobox: var(--spectrum-field-label-to-component-quiet-medium);
-		--spectrum-combobox-button-inline-offset: calc((var(--mod-combobox-block-size, var(--spectrum-combobox-block-size)) / 2) - (var(--mod-combobox-icon-size, var(--spectrum-combobox-icon-size)) / 2));
 
 		&.spectrum-Combobox--sizeS {
 			--spectrum-combobox-spacing-label-to-combobox: var(--spectrum-field-label-to-component-quiet-small);
@@ -177,11 +135,5 @@
 		&.spectrum-Combobox--sizeXL {
 			--spectrum-combobox-spacing-label-to-combobox: var(--spectrum-field-label-to-component-quiet-extra-large);
 		}
-
-		/* Settings for nested Picker Button component. */
-		--mod-picker-button-background-color-quiet: transparent;
-		--mod-picker-button-border-color-quiet: transparent;
-
-		--mod-picker-button-border-color: var(--mod-picker-button-border-color-quiet);
 	}
 }

--- a/components/tabs/index.css
+++ b/components/tabs/index.css
@@ -26,6 +26,14 @@
 	vertical-align: top;
 
 	background: linear-gradient(to var(--mod-tabs-list-background-direction, var(--spectrum-tabs-list-background-direction)), var(--highcontrast-tabs-divider-background-color, var(--mod-tabs-divider-background-color, var(--spectrum-tabs-divider-background-color))) 0 var(--mod-tabs-divider-size, var(--spectrum-tabs-divider-size)), transparent var(--mod-tabs-divider-size, var(--spectrum-tabs-divider-size)));
+
+	&.spectrum-Tabs--emphasized {
+		--mod-tabs-color-selected: var(--mod-tabs-color-selected-emphasized, var(--spectrum-tabs-color-selected));
+		--mod-tabs-color-hover: var(--mod-tabs-color-hover-emphasized, var(--spectrum-tabs-color-hover));
+		--mod-tabs-color-key-focus: var(--mod-tabs-color-key-focus-emphasized, var(--spectrum-tabs-color-key-focus));
+
+		--mod-tabs-selection-indicator-color: var(--mod-tabs-selection-indicator-color-emphasized, var(--spectrum-tabs-selection-indicator-color));
+	}
 }
 
 .spectrum-Tabs-item {
@@ -177,6 +185,10 @@
 	}
 }
 
+.spectrum-Tabs--vertical {
+	--mod-tabs-list-background-direction: var(--mod-tabs-list-background-direction-vertical, right);
+}
+
 .spectrum-Tabs--vertical,
 .spectrum-Tabs--vertical-right {
 	display: inline-flex;
@@ -214,8 +226,46 @@
 }
 
 .spectrum-Tabs--vertical-right {
+	--mod-tabs-list-background-direction: var(--mod-tabs-list-background-direction-vertical-right, left);
+
 	.spectrum-Tabs-selectionIndicator {
 		inset-inline: auto 0;
+	}
+}
+
+.spectrum-Tabs--vertical:dir(rtl) {
+	--mod-tabs-list-background-direction: var(--mod-tabs-list-background-direction-vertical, left);
+}
+
+.spectrum-Tabs--vertical-right:dir(rtl) {
+	--mod-tabs-list-background-direction: var(--mod-tabs-list-background-direction-vertical, right);
+}
+
+.spectrum-Tabs.spectrum-Tabs--compact {
+	--spectrum-tabs-item-height: var(--mod-tabs-item-height-compact, var(--spectrum-tab-item-compact-height-medium));
+	--spectrum-tabs-top-to-text: var(--mod-tabs-top-to-text-compact, var(--spectrum-tab-item-top-to-text-compact-medium));
+	--spectrum-tabs-bottom-to-text: var(--mod-tabs-bottom-to-text-compact, var(--spectrum-tab-item-top-to-text-compact-medium));
+	--spectrum-tabs-top-to-icon: var(--mod-tabs-top-to-icon-compact, var(--spectrum-tab-item-top-to-workflow-icon-compact-medium));
+
+	&.spectrum-Tabs--sizeS {
+		--spectrum-tabs-item-height: var(--mod-tabs-item-height-compact, var(--spectrum-tab-item-compact-height-small));
+		--spectrum-tabs-top-to-text: var(--mod-tabs-top-to-text-compact, var(--spectrum-tab-item-top-to-text-compact-small));
+		--spectrum-tabs-bottom-to-text: var(--mod-tabs-bottom-to-text-compact, var(--spectrum-tab-item-top-to-text-compact-small));
+		--spectrum-tabs-top-to-icon: var(--mod-tabs-top-to-icon-compact, var(--spectrum-tab-item-top-to-workflow-icon-compact-small));
+	}
+
+	&.spectrum-Tabs--sizeL {
+		--spectrum-tabs-item-height: var(--mod-tabs-item-height-compact, var(--spectrum-tab-item-compact-height-large));
+		--spectrum-tabs-top-to-text: var(--mod-tabs-top-to-text-compact, var(--spectrum-tab-item-top-to-text-compact-large));
+		--spectrum-tabs-bottom-to-text: var(--mod-tabs-bottom-to-text-compact, var(--spectrum-tab-item-top-to-text-compact-large));
+		--spectrum-tabs-top-to-icon: var(--mod-tabs-top-to-icon-compact, var(--spectrum-tab-item-top-to-workflow-icon-compact-large));
+	}
+
+	&.spectrum-Tabs--sizeXL {
+		--spectrum-tabs-item-height: var(--mod-tabs-item-height-compact, var(--spectrum-tab-item-compact-height-extra-large));
+		--spectrum-tabs-top-to-text: var(--mod-tabs-top-to-text-compact, var(--spectrum-tab-item-top-to-text-compact-extra-large));
+		--spectrum-tabs-bottom-to-text: var(--mod-tabs-bottom-to-text-compact, var(--spectrum-tab-item-top-to-text-compact-extra-large));
+		--spectrum-tabs-top-to-icon: var(--mod-tabs-top-to-icon-compact, var(--spectrum-tab-item-top-to-workflow-icon-compact-extra-large));
 	}
 }
 

--- a/components/tabs/themes/spectrum-two.css
+++ b/components/tabs/themes/spectrum-two.css
@@ -102,55 +102,11 @@
 		}
 
 		&.spectrum-Tabs--emphasized {
-			--spectrum-tabs-color-selected: var(--mod-tabs-color-selected-emphasized, var(--spectrum-accent-content-color-default));
-			--spectrum-tabs-color-hover: var(--mod-tabs-color-hover-emphasized, var(--spectrum-accent-content-color-hover));
-			--spectrum-tabs-color-key-focus: var(--mod-tabs-color-key-focus-emphasized, var(--spectrum-accent-content-color-key-focus));
+			--spectrum-tabs-color-selected: var(--spectrum-accent-content-color-default);
+			--spectrum-tabs-color-hover: var(--spectrum-accent-content-color-hover);
+			--spectrum-tabs-color-key-focus: var(--spectrum-accent-content-color-key-focus);
 
-			--spectrum-tabs-selection-indicator-color: var(--mod-tabs-selection-indicator-color-emphasized, var(--spectrum-accent-content-color-default));
-		}
-	}
-
-	.spectrum-Tabs--vertical {
-		--spectrum-tabs-list-background-direction: var(--mod-tabs-list-background-direction-vertical, right);
-	}
-
-	.spectrum-Tabs--vertical-right {
-		--spectrum-tabs-list-background-direction: var(--mod-tabs-list-background-direction-vertical-right, left);
-	}
-
-	.spectrum-Tabs--vertical:dir(rtl) {
-		--spectrum-tabs-list-background-direction: var(--mod-tabs-list-background-direction-vertical, left);
-	}
-
-	.spectrum-Tabs--vertical-right:dir(rtl) {
-		--spectrum-tabs-list-background-direction: var(--mod-tabs-list-background-direction-vertical, right);
-	}
-
-	.spectrum-Tabs.spectrum-Tabs--compact {
-		--spectrum-tabs-item-height: var(--mod-tabs-item-height-compact, var(--spectrum-tab-item-compact-height-medium));
-		--spectrum-tabs-top-to-text: var(--mod-tabs-top-to-text-compact, var(--spectrum-tab-item-top-to-text-compact-medium));
-		--spectrum-tabs-bottom-to-text: var(--mod-tabs-bottom-to-text-compact, var(--spectrum-tab-item-top-to-text-compact-medium));
-		--spectrum-tabs-top-to-icon: var(--mod-tabs-top-to-icon-compact, var(--spectrum-tab-item-top-to-workflow-icon-compact-medium));
-
-		&.spectrum-Tabs--sizeS {
-			--spectrum-tabs-item-height: var(--mod-tabs-item-height-compact, var(--spectrum-tab-item-compact-height-small));
-			--spectrum-tabs-top-to-text: var(--mod-tabs-top-to-text-compact, var(--spectrum-tab-item-top-to-text-compact-small));
-			--spectrum-tabs-bottom-to-text: var(--mod-tabs-bottom-to-text-compact, var(--spectrum-tab-item-top-to-text-compact-small));
-			--spectrum-tabs-top-to-icon: var(--mod-tabs-top-to-icon-compact, var(--spectrum-tab-item-top-to-workflow-icon-compact-small));
-		}
-
-		&.spectrum-Tabs--sizeL {
-			--spectrum-tabs-item-height: var(--mod-tabs-item-height-compact, var(--spectrum-tab-item-compact-height-large));
-			--spectrum-tabs-top-to-text: var(--mod-tabs-top-to-text-compact, var(--spectrum-tab-item-top-to-text-compact-large));
-			--spectrum-tabs-bottom-to-text: var(--mod-tabs-bottom-to-text-compact, var(--spectrum-tab-item-top-to-text-compact-large));
-			--spectrum-tabs-top-to-icon: var(--mod-tabs-top-to-icon-compact, var(--spectrum-tab-item-top-to-workflow-icon-compact-large));
-		}
-
-		&.spectrum-Tabs--sizeXL {
-			--spectrum-tabs-item-height: var(--mod-tabs-item-height-compact, var(--spectrum-tab-item-compact-height-extra-large));
-			--spectrum-tabs-top-to-text: var(--mod-tabs-top-to-text-compact, var(--spectrum-tab-item-top-to-text-compact-extra-large));
-			--spectrum-tabs-bottom-to-text: var(--mod-tabs-bottom-to-text-compact, var(--spectrum-tab-item-top-to-text-compact-extra-large));
-			--spectrum-tabs-top-to-icon: var(--mod-tabs-top-to-icon-compact, var(--spectrum-tab-item-top-to-workflow-icon-compact-extra-large));
+			--spectrum-tabs-selection-indicator-color: var(--spectrum-accent-content-color-default);
 		}
 	}
 }

--- a/components/treeview/index.css
+++ b/components/treeview/index.css
@@ -301,9 +301,20 @@
 }
 
 /* ***** VARIANTS ***** */
+.spectrum-TreeView--quiet {
+	--spectrum-treeview-item-background-color-selected: var(--highcontrast-treeview-item-background-color-selected, var(--mod-treeview-item-background-color-quiet-selected, var(--spectrum-treeview-item-background-color-quiet-selected)));
+	--mod-treeview-item-border-color-selected: var(--highcontrast-treeview-item-border-color-selected, var(--mod-treeview-item-border-color-selected-quiet, var(--spectrum-treeview-item-border-color-quiet-selected)));
+}
+
 .spectrum-TreeView--thumbnail {
+	--mod-treeview-item-min-block-size: var(--mod-treeview-item-min-block-size-thumbnail, calc(var(--spectrum-treeview-item-min-block-size) + var(--spectrum-treeview-item-min-block-size-thumbnail-offset)));
+
 	.spectrum-TreeView-itemThumbnail {
 		flex-shrink: 0;
 		margin-inline-end: var(--mod-treeview-item-icon-gap, var(--spectrum-treeview-item-icon-gap));
 	}
+}
+
+.spectrum-TreeView--detached {
+	--spectrum-treeview-item-border-radius: var(--mod-treeview-item-border-radius-detached, var(--spectrum-corner-radius-100));
 }

--- a/components/treeview/themes/spectrum-two.css
+++ b/components/treeview/themes/spectrum-two.css
@@ -106,16 +106,7 @@
 		--spectrum-treeview-item-min-block-size-thumbnail-offset: 0px;
 	}
 
-	.spectrum-TreeView--quiet {
-		--spectrum-treeview-item-background-color-selected: var(--highcontrast-treeview-item-background-color-selected, var(--mod-treeview-item-background-color-quiet-selected, var(--spectrum-treeview-item-background-color-quiet-selected)));
-		--spectrum-treeview-item-border-color-selected: var(--highcontrast-treeview-item-border-color-selected, var(--mod-treeview-item-border-color-selected-quiet, transparent));
-	}
-
-	.spectrum-TreeView--thumbnail {
-		--spectrum-treeview-item-min-block-size: var(--mod-treeview-item-min-block-size-thumbnail, calc(var(--spectrum-treeview-item-min-block-size) + var(--spectrum-treeview-item-min-block-size-thumbnail-offset)));
-	}
-
 	.spectrum-TreeView--detached {
-		--spectrum-treeview-item-border-radius: var(--mod-treeview-item-border-radius-detached, var(--spectrum-corner-radius-100));
+		--spectrum-treeview-item-border-radius: var(--spectrum-corner-radius-100);
 	}
 }

--- a/tokens/custom/dark-vars.css
+++ b/tokens/custom/dark-vars.css
@@ -69,6 +69,8 @@
 
 	--spectrum-swatch-border-color: rgba(255, 255, 255, 51%);
 
+	--spectrum-blue-800-rgb: 69, 110, 254;
 	--spectrum-blue-900-rgb: 86, 129, 255;
 	--spectrum-gray-800-rgb: 219, 219, 219;
+	--spectrum-gray-900-rgb: 242, 242, 242;
 }

--- a/tokens/custom/light-vars.css
+++ b/tokens/custom/light-vars.css
@@ -69,5 +69,7 @@
 	--spectrum-swatch-border-color: rgba(0, 0, 0, 51%);
 
 	--spectrum-blue-800-rgb: 75, 117, 255;
+	--spectrum-blue-900-rgb: 59, 99, 251;
 	--spectrum-gray-800-rgb: 41, 41, 41;
+	--spectrum-gray-900-rgb: 19, 19, 19;
 }

--- a/tokens/dist/css/dark-vars.css
+++ b/tokens/dist/css/dark-vars.css
@@ -440,6 +440,8 @@
 
 	--spectrum-swatch-border-color:rgba(255, 255, 255, 0.51);
 
+	--spectrum-blue-800-rgb:69, 110, 254;
 	--spectrum-blue-900-rgb:86, 129, 255;
 	--spectrum-gray-800-rgb:219, 219, 219;
+	--spectrum-gray-900-rgb:242, 242, 242;
 }

--- a/tokens/dist/css/light-vars.css
+++ b/tokens/dist/css/light-vars.css
@@ -441,5 +441,7 @@
 	--spectrum-swatch-border-color:rgba(0, 0, 0, 0.51);
 
 	--spectrum-blue-800-rgb:75, 117, 255;
+	--spectrum-blue-900-rgb:59, 99, 251;
 	--spectrum-gray-800-rgb:41, 41, 41;
+	--spectrum-gray-900-rgb:19, 19, 19;
 }

--- a/tokens/dist/index.css
+++ b/tokens/dist/index.css
@@ -440,8 +440,10 @@
 
 	--spectrum-swatch-border-color: rgba(255, 255, 255, 0.51);
 
+	--spectrum-blue-800-rgb: 69, 110, 254;
 	--spectrum-blue-900-rgb: 86, 129, 255;
 	--spectrum-gray-800-rgb: 219, 219, 219;
+	--spectrum-gray-900-rgb: 242, 242, 242;
 }
 .spectrum {
 	--spectrum-focus-indicator-color: var(--spectrum-blue-800);
@@ -2159,7 +2161,9 @@
 	--spectrum-swatch-border-color: rgba(0, 0, 0, 0.51);
 
 	--spectrum-blue-800-rgb: 75, 117, 255;
+	--spectrum-blue-900-rgb: 59, 99, 251;
 	--spectrum-gray-800-rgb: 41, 41, 41;
+	--spectrum-gray-900-rgb: 19, 19, 19;
 }
 .spectrum--medium {
 	--spectrum-workflow-icon-size-50: 14px;


### PR DESCRIPTION
## Description
- Migrates `--mod` variables in `themes/` to `index.css` for treeview, tabs, combobox
- Defines undefined rgb variables for treeview

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
 - [x] No --mod prefixed properties exist in the themes/*.css files for treeview, tabs, and combobox
 - [x] Mods were moved to index.css and when applied, should still work the same as before
 - [x] No expected changes to `metadata.json`
 - [x] Treeview selected items should now have a background color for default variant and quiet variant (treeview does not appear to be used in SWC, which is likely why this wasn't fixed earlier)

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [ ] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
