### PR TITLE
test: always run Chromatic against main

### DIFF
--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -1,6 +1,9 @@
 name: Visual regression testing
 
 on:
+    push:
+      branches:
+        - main
     workflow_dispatch:
     workflow_call:
         inputs:


### PR DESCRIPTION
Updates our GitHub Action for VRT to always run on pushes to `main`, as suggested in the Chromatic docs:
https://www.chromatic.com/docs/github-actions/#maintain-a-clean-main-branch

> A clean main branch is a development best practice and highly recommended for Chromatic. This means testing your main branch to ensure builds are passing. It’s important to note that baselines will not persist through branching and merging unless you test your main branch.

> If the builds result from direct commits to main, you must accept changes to keep the main branch clean. If they’re merged from feature-branches, you must ensure those branches are passing before you merge into main.

<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
Unfortunately, I think we'll only know upon merging this into `main`.

<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [X] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [X] ✨ This pull request is ready to merge. ✨
