### PR TITLE
feat: add new mod variable to set the popover max block size

### DIFF
--- a/components/popover/index.css
+++ b/components/popover/index.css
@@ -73,6 +73,8 @@
 	background-color: var(--mod-popover-background-color, var(--spectrum-popover-background-color));
 	filter: var(--mod-popover-filter, var(--spectrum-popover-filter));
 
+	max-block-size: var(--mod-popover-max-block-size);
+
 	/* has tip triangle */
 	&.spectrum-Popover--withTip {
 		.spectrum-Popover-tip {

--- a/components/popover/metadata/metadata.json
+++ b/components/popover/metadata/metadata.json
@@ -107,6 +107,7 @@
     "--mod-popover-content-area-spacing-vertical",
     "--mod-popover-corner-radius",
     "--mod-popover-filter",
+    "--mod-popover-max-block-size",
     "--mod-popover-pointer-edge-spacing",
     "--mod-popover-pointer-height",
     "--mod-popover-pointer-width",

--- a/components/popover/metadata/mods.md
+++ b/components/popover/metadata/mods.md
@@ -9,6 +9,7 @@
 | `--mod-popover-content-area-spacing-vertical` |
 | `--mod-popover-corner-radius`                 |
 | `--mod-popover-filter`                        |
+| `--mod-popover-max-block-size`                |
 | `--mod-popover-pointer-edge-spacing`          |
 | `--mod-popover-pointer-height`                |
 | `--mod-popover-pointer-width`                 |


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [ ] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
