### PR TITLE
fix(ComponentDetails): apply sb-unstyled className to correct version number misalignment

### DIFF
--- a/.changeset/seven-ways-search.md
+++ b/.changeset/seven-ways-search.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/preview": minor
+---
+
+Applies the sb-unstyled className to fix the version number alignment on Storybook docs pages.

--- a/.storybook/blocks/ComponentDetails.jsx
+++ b/.storybook/blocks/ComponentDetails.jsx
@@ -51,7 +51,7 @@ export const ComponentDetails = () => {
 	const versionNumber = storyMeta?.csfFile?.meta?.parameters?.componentVersion ?? "Unavailable";
 
 	return (
-		<DList>
+		<DList className="sb-unstyled">
 			<DTerm>Current version:</DTerm>
 			<DDefinition>{versionNumber}</DDefinition>
 


### PR DESCRIPTION
## Description

- [x] applies `className="sb-unstyled"` to the parent `DList` node to correct the version number misalignment.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

1. Access Storybook (by fetching and running the branch or via the preview generated by this pull request).
2. Open any component and navigate to docs page.
3. Verify version number alignment.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

4. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

![Screenshot 2024-09-03 at 6 55 29 AM](https://github.com/user-attachments/assets/4f0d1c91-5df5-4111-9217-0245b9defecc)

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
