### PR TITLE
fix(card -> action button): corrects the size and alignment of the card action button

### DIFF
--- a/.changeset/selfish-readers-wave.md
+++ b/.changeset/selfish-readers-wave.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/card": minor
+---
+
+Corrects the issue with the action button in the card by removing the flex property and definition that caused the action button to fill the available space; additionally, justify-content has been set to space-between on the card header to properly horizontally align the action button relative to the card title (at either edge).

--- a/components/card/index.css
+++ b/components/card/index.css
@@ -311,10 +311,10 @@
 .spectrum-Card-header {
 	display: flex;
 	align-items: center;
+	justify-content: space-between;
 }
 
 .spectrum-Card-actionButton {
-	flex: 1;
 	align-self: center;
 	display: flex;
 	justify-content: flex-end;


### PR DESCRIPTION
## Description

- [x] adds `justify-content: space-between` to `.spectrum-Card-header`
- [x] removes `flex: 1` from `.spectrum-Card-actionButton`

This prevents `.spectrum-Card-actionButton` from spilling the available space in the header and aligns the title and action button at the opposite edges of the container.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

1. Open the Storybook URL for the PR (or run against the branch locally).
2. Navigate to the card component.
3. Set **Card actions** to `true`
4. Hover over the action button to verify the proper card dimensions.

<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

5. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<img width="365" alt="Screenshot 2024-09-04 at 4 37 05 PM" src="https://github.com/user-attachments/assets/1d7b5d0f-6ad3-41e1-87b2-5234481ac400">

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
