### PR TITLE
fix(toast): added overflow css to toast for long words

### DIFF
--- a/.changeset/cyan-fishes-punch.md
+++ b/.changeset/cyan-fishes-punch.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/toast": major
+---
+
+added overflow in the toast body to wrap long words

--- a/.changeset/cyan-fishes-punch.md
+++ b/.changeset/cyan-fishes-punch.md
@@ -1,5 +1,5 @@
 ---
-"@spectrum-css/toast": major
+"@spectrum-css/toast": minor
 ---
 
 added overflow in the toast body to wrap long words

--- a/components/toast/index.css
+++ b/components/toast/index.css
@@ -88,6 +88,7 @@
 
 	background-color: var(--highcontrast-toast-background-color-default, var(--mod-toast-background-color-default, var(--spectrum-toast-background-color-default)));
 	color: var(--highcontrast-toast-background-color-default, var(--mod-toast-background-color-default, var(--spectrum-toast-background-color-default)));
+	overflow-wrap: anywhere;
 }
 
 .spectrum-Toast--negative {


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description
Added `overflow-wrap:anywhere` to wrap long words in toast body

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots
Before:
<img width="1000" alt="Screenshot 2024-09-05 at 3 57 31 PM" src="https://github.com/user-attachments/assets/e5e0d70d-a1f9-41e7-8765-c262f07f0e7c">
After:
<img width="1076" alt="Screenshot 2024-09-05 at 3 57 26 PM" src="https://github.com/user-attachments/assets/4d57dc6d-825b-438d-9862-9fc65dcde8d2">

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [ ] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
