### PR TITLE
chore(card): storybook component fixes

### DIFF
--- a/components/card/stories/template.js
+++ b/components/card/stories/template.js
@@ -96,6 +96,7 @@ export const Template = ({
               class=${classMap({ [`${rootClass}-coverPhoto`]: true })}
               style=${styleMap({ "background-image": `url(${image})` })}
             ></div>
+            <hr class="spectrum-Divider spectrum-Divider--sizeS spectrum-Card-divider">
           `
         )
       )}

--- a/components/card/stories/template.js
+++ b/components/card/stories/template.js
@@ -180,7 +180,7 @@ export const Template = ({
           </div>`
       )}
       ${when(
-        footer,
+        footer && !isQuiet,
         () => html`
           <div
             class=${classMap({


### PR DESCRIPTION
## Description

- [x] restores the missing `hr` below the card image in storybook
- [x] disables the footer when `isQuiet` is true as the footer as the quiet card variation does not have the footer.

## How and where has this been tested?

Verified locally in storybook.

### Validation steps

1. Navigate to the Storybook URL for the PR (or run the branch locally)
2. Open the `card` component.
3. Zoom in below the image to verify the border is present.
4. Toggle `isQuiet` to `true` and verify that the footer is hidden.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

5. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<img width="1418" alt="Screenshot 2024-09-05 at 1 07 18 PM" src="https://github.com/user-attachments/assets/c70f1e97-6a6d-45e9-8a8c-b1e1cab7e62b">
<img width="658" alt="Screenshot 2024-09-05 at 1 11 30 PM" src="https://github.com/user-attachments/assets/b513bc6c-4333-4db9-b51f-a04c03a6a37c">

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
