### PR TITLE
docs(closebutton): migrate docs to storybook and add missing control

### DIFF
--- a/components/closebutton/metadata/closebutton.yml
+++ b/components/closebutton/metadata/closebutton.yml
@@ -1,4 +1,5 @@
 name: Close button
+SpectrumSiteSlug: https://spectrum.adobe.com/page/close-button/
 status: Verified
 description: |
   A button used to close or dismiss components.

--- a/components/closebutton/stories/closebutton.stories.js
+++ b/components/closebutton/stories/closebutton.stories.js
@@ -1,10 +1,13 @@
+import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isFocused, isHovered, isKeyboardFocused, size, staticColor } from "@spectrum-css/preview/types";
 import pkgJson from "../package.json";
 import { CloseButtonGroup } from "./closebutton.test.js";
+import { CloseButtonExample, Template } from "./template.js";
 
 /**
- * A button used to close or dismiss components.
+ * Close button is used to close or dismiss its parent component. It is used inside of other components such
+ * as [toast](?path=/docs/components-toast--docs) and [action bar](?path=/docs/components-action-bar--docs).
  */
 export default {
 	title: "Close button",
@@ -16,11 +19,24 @@ export default {
 		isHovered,
 		isFocused,
 		isKeyboardFocused,
+		iconSize: {
+			name: "Icon size",
+			description: "Adjusts which cross icon size is displayed per component size.",
+			type: { name: "string" },
+			table: {
+				type: { summary: "string" },
+				category: "Component",
+				defaultValue: { summary: "regular" },
+			},
+			options: ["regular", "large"],
+			control: "select",
+		},
 	},
 	args: {
 		rootClass: "spectrum-CloseButton",
 		size: "m",
 		isDisabled: false,
+		iconSize: "regular",
 		isHovered: false,
 		isFocused: false,
 		isKeyboardFocused: false,
@@ -36,6 +52,29 @@ export default {
 export const Default = CloseButtonGroup.bind({});
 Default.args = {};
 
+/**
+ * Close button provides a "large" icon size option, for displaying a larger cross icon for each component size.
+ * When using this option, the following UI icons should be used:
+ * 
+ * | Close button class name         | UI icon class name          |
+ * | ------------------------------- | --------------------------- |
+ * | `.spectrum-CloseButton--sizeS`  | `.spectrum-UIIcon-Cross200` |
+ * | `.spectrum-CloseButton--sizeM`  | `.spectrum-UIIcon-Cross300` |
+ * | `.spectrum-CloseButton--sizeL`  | `.spectrum-UIIcon-Cross400` |
+ * | `.spectrum-CloseButton--sizeXL` | `.spectrum-UIIcon-Cross500` |
+ */
+export const SizingLargeIcons = (args, context) => Sizes({
+	Template: Template,
+	withHeading: false,
+	withBorder: false,
+	...args,
+}, context);
+SizingLargeIcons.storyName = "Sizing, large icon size";
+SizingLargeIcons.args = {
+	iconSize: "large",
+};
+SizingLargeIcons.tags = ["!dev"];
+
 // ********* VRT ONLY ********* //
 export const WithForcedColors = CloseButtonGroup.bind({});
 WithForcedColors.tags = ["!autodocs", "!dev"];
@@ -45,3 +84,56 @@ WithForcedColors.parameters = {
 		modes: disableDefaultModes
 	},
 };
+
+// ********* DOCS ONLY ********* //
+
+/**
+* Close buttons come in four different sizes: small, medium, large, and extra-large. By default ("regular" icon size), the cross icon
+* within the close button should use the following UI icons for each component size:
+* 
+* | Close button class name         | UI icon class name          |
+* | ------------------------------- | --------------------------- |
+* | `.spectrum-CloseButton--sizeS`  | `.spectrum-UIIcon-Cross75`  |
+* | `.spectrum-CloseButton--sizeM`  | `.spectrum-UIIcon-Cross100` |
+* | `.spectrum-CloseButton--sizeL`  | `.spectrum-UIIcon-Cross200` |
+* | `.spectrum-CloseButton--sizeXL` | `.spectrum-UIIcon-Cross300` |
+ */
+export const Sizing = (args, context) => Sizes({
+	Template: Template,
+	withHeading: false,
+	withBorder: false,
+	...args,
+}, context);
+Sizing.args = {};
+Sizing.tags = ["!dev"];
+Sizing.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+export const Disabled = Template.bind({});
+Disabled.args = {
+	isDisabled: true,
+};
+Disabled.tags = ["!dev"];
+Disabled.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+export const StaticWhite = CloseButtonExample.bind({});
+StaticWhite.args = {
+	staticColor: "white",
+};
+StaticWhite.tags = ["!dev"];
+StaticWhite.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+export const StaticBlack = CloseButtonExample.bind({});
+StaticBlack.args = {
+	staticColor: "black",
+};
+StaticBlack.tags = ["!dev"];
+StaticBlack.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+

--- a/components/closebutton/stories/template.js
+++ b/components/closebutton/stories/template.js
@@ -1,5 +1,5 @@
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
-import { getRandomId } from "@spectrum-css/preview/decorators";
+import { Container, getRandomId } from "@spectrum-css/preview/decorators";
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
@@ -10,6 +10,7 @@ import "../index.css";
 export const Template = ({
 	rootClass = "spectrum-CloseButton",
 	size = "m",
+	iconSize = "regular",
 	label = "Close",
 	staticColor,
 	isDisabled = false,
@@ -40,9 +41,64 @@ export const Template = ({
 		>
 			${Icon({
 				size,
-				iconName: "Cross",
+				iconName: getCloseButtonIconName(size, iconSize),
 				customClasses: [`${rootClass}-UIIcon`],
 			}, context)}
 		</button>
 	`;
 };
+
+/**
+ * Get the cross UI icon name (including sizing scale number), as defined by the design spec.
+ */
+const getCloseButtonIconName = (size = "m", iconSize = "regular", iconName = "Cross") => {
+	// When using the "large" icon size option, the set of icons changes.
+	if (iconSize == "large") {
+		switch (size) {
+			case "s":
+				return `${iconName}200`;
+			case "l":
+				return `${iconName}400`;
+			case "xl":
+				return `${iconName}500`;
+			default:
+				return `${iconName}300`;
+		}
+	}
+	// Default, "regular" icon size.
+	switch (size) {
+		case "s":
+			return `${iconName}75`;
+		case "l":
+			return `${iconName}200`;
+		case "xl":
+			return `${iconName}300`;
+		default:
+			return `${iconName}100`;
+	}
+};
+
+/**
+ * Example template that includes both the default and disabled close button 
+ * for some of the Docs only stories.
+ */
+export const CloseButtonExample = (args, context) => Container({
+	withBorder: false,
+	content: html`
+		${Container({
+			withBorder: false,
+			direction: "column",
+			heading: "Default",
+			content: Template(args, context),
+		})}
+		${Container({
+			withBorder: false,
+			direction: "column",
+			heading: "Disabled",
+			content: Template({
+				...args,
+				isDisabled: true,
+			}, context),
+		})}
+	`,
+});


### PR DESCRIPTION
## Description

Migrates the **close button** documentation and examples from the docs site to Storybook. Some docs specific stories were added, and descriptions adjusted for clarity.

This adds a missing control for the "icon size" option that was documented on the [docs site](https://opensource.adobe.com/spectrum-css/closebutton.html) and [guidelines](https://spectrum.adobe.com/page/close-button/#Icon-size), and updates the template to render the correct cross UI icon sizes. The "large" icon size story is also included in the VRTs, so this option at each component size is covered.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [ ] Relevant close button documentation from the [docs site](https://opensource.adobe.com/spectrum-css/closebutton.html) now exists in [its Storybook "Docs" page](https://pr-3077--spectrum-css.netlify.app/preview/?path=/docs/components-close-button--docs).
- [ ] Proofread documentation.
- [ ] "Icon size" control is functioning and docs surrounding it are clear.
- [ ] The "large" icon size option at each t-shirt size is represented in VRTs.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.
  - Expected VRT change: new story for icon size "large"; accepted in Chromatic.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
