### PR TITLE
fix(calendar): addresses issue where text that was not selected was illegible in high contrast mode

### DIFF
--- a/.changeset/lemon-tools-look.md
+++ b/.changeset/lemon-tools-look.md
@@ -2,4 +2,4 @@
 "@spectrum-css/calendar": minor
 ---
 
-Makes text in the calendar in high contrast mode that is not in a selected cell visible again by removing redundant color property and allowing it to be set by the adjusted variable values.
+Makes text in the calendar in high contrast mode that is not in a selected cell visible again by removing redundant color property and allowing it to be set by the adjusted variable values (--highcontrast-calendar-day-today-text-\*).

--- a/.changeset/lemon-tools-look.md
+++ b/.changeset/lemon-tools-look.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/calendar": minor
+---
+
+Makes text in the calendar in high contrast mode that is not in a selected cell visible again by removing redundant color property and allowing it to be set by the adjusted variable values.

--- a/components/calendar/index.css
+++ b/components/calendar/index.css
@@ -416,9 +416,6 @@
 	}
 
 	.spectrum-Calendar-date {
-		color: CanvasText;
-		forced-color-adjust: none;
-
 		--highcontrast-calendar-day-background-color-cap-selected: Highlight;
 		--highcontrast-calendar-day-background-color-down: ButtonFace;
 		--highcontrast-calendar-day-background-color-hover: Transparent;
@@ -438,6 +435,8 @@
 		--highcontrast-calendar-day-today-border-color: ButtonText;
 		--highcontrast-calendar-day-today-text-color-disabled: GrayText;
 		--highcontrast-calendar-day-today-text-color: ButtonText;
+
+		forced-color-adjust: none;
 
 		&.is-range-selection {
 			&.is-today {


### PR DESCRIPTION
## Description

- Makes text in the calendar in high contrast mode that is not in a selected cell visible again by removing redundant color property and allowing it to be set by the adjusted variable values.

## How and where has this been tested?

Verified in Assistiv Labs high contrast mode-enabled Windows VM.

### Validation steps

1. Run Storybook locally (or reference the link for this PR).
2. Navigate to Assistiv Labs and start a Windows High Contrast Mode VM (if running the branch locally, you'll need to enable the Assistiv Labs tunnel to access Storybook).
3. Enable Windows High Contrast Mode.
4. Navigate to the Calendar component in Storybook.
5. Verify that the selected and hover states behave as expected and that the text that is neither selected nor focused is visible.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<img width="1082" alt="Screenshot 2024-09-13 at 4 11 19 PM" src="https://github.com/user-attachments/assets/7d12a0e2-a474-442e-ac6c-b084b7447320">

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
