### PR TITLE
fix(treeview): display corner rounding for detached treeview

### DIFF
--- a/.changeset/loud-pandas-act.md
+++ b/.changeset/loud-pandas-act.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/treeview": minor
+---
+
+[CSS-871]: Bring back corner rounding on treeview detached variant

--- a/components/treeview/index.css
+++ b/components/treeview/index.css
@@ -289,6 +289,7 @@
 		border-style: solid;
 		border-color: transparent;
 		border-width: var(--mod-treeview-item-border-size, var(--spectrum-treeview-item-border-size)) 0;
+		border-radius: var(--mod-treeview-item-border-radius, var(--spectrum-treeview-item-border-radius));
 		background-color: transparent;
 		color: transparent;
 	}

--- a/components/treeview/stories/template.js
+++ b/components/treeview/stories/template.js
@@ -25,6 +25,7 @@ export const TreeViewItem = ({
 	iconSet,
 	thumbnail,
 	items,
+	variant,
 	customClasses = [],
 } = {}, context = {}) => {
 	if (type === "heading") {
@@ -93,14 +94,16 @@ export const TreeViewItem = ({
 						customClasses: [`${rootClass}-itemIcon`],
 					}, context)
 				)}
-				${when(thumbnail, () =>
+				${when(variant === "thumbnail", () =>
 					Thumbnail({
+						imageURL: "example-card-landscape.png",
 						...thumbnail,
 						size: size == "s"  ? "200"
 							: size == "m"  ? "200"
 							: size == "l"  ? "400"
 							: size == "xl" ? "600"
 							: "300",
+						
 						isLayer: true,
 						isSelected,
 						isDisabled,
@@ -117,6 +120,7 @@ export const TreeViewItem = ({
 				Template({
 					items: items,
 					size,
+					variant,
 					rootClass: "spectrum-TreeView",
 					customClasses: ["is-opened"],
 				}, context)
@@ -141,7 +145,7 @@ export const Template = ({
 			[rootClass]: true,
 			[`${rootClass}--size${size?.toUpperCase()}`]:
 				typeof size !== "undefined",
-			[`${rootClass}--${variant}`]: typeof variant !== "undefined",
+			[`${rootClass}--${variant}`]: typeof variant !== "undefined" && variant !== "default",
 			[`${rootClass}--quiet`]: isQuiet,
 			...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
 		})}
@@ -155,6 +159,7 @@ export const Template = ({
 			(item) => TreeViewItem({
 				...item,
 				size,
+				variant,
 			}, context),
 		)}
 	</ul>

--- a/components/treeview/stories/treeview.stories.js
+++ b/components/treeview/stories/treeview.stories.js
@@ -15,7 +15,14 @@ export default {
 	component: "TreeView",
 	argTypes: {
 		items: { table: { disable: true } },
-		variant: { table: { disable: true } },
+		variant: {
+			name: "Variant",
+			type: { name: "string" },
+			category: "Component",
+			defaultValue: { summary: "default" },
+			options: ["default", "detached", "thumbnail"],
+			control: "select",
+		},
 		size: size(["s", "m", "l", "xl"]),
 		isQuiet,
 	},
@@ -23,6 +30,7 @@ export default {
 		rootClass: "spectrum-TreeView",
 		size: "m",
 		isQuiet: false,
+		variant: "default",
 	},
 	parameters: {
 		actions: {

--- a/components/treeview/stories/treeview.test.js
+++ b/components/treeview/stories/treeview.test.js
@@ -274,6 +274,39 @@ export const TreeViewGroup = Variants({
 				},
 			],
 		}, {
+			testHeading: "Detached",
+			variant: "detached",
+			items: [
+				{
+					id: "layer1",
+					label: "Layer 1",
+					link: "#",
+				},
+				{
+					id: "layer2",
+					label: "Layer 2",
+					link: "#",
+					isSelected: true,
+				},
+			]
+		}, {
+			testHeading: "Detached Quiet",
+			variant: "detached",
+			isQuiet: true,
+			items: [
+				{
+					id: "layer1",
+					label: "Layer 1",
+					link: "#",
+				},
+				{
+					id: "layer2",
+					label: "Layer 2",
+					link: "#",
+					isSelected: true,
+				},
+			],
+		}, {
 			testHeading: "Overflow behavior",
 			items: [
 				{


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

The detached treeview variant was inadvertently removed in a refactor (#2218), this returns it to its original styling as seen before #2218, with corner rounding on items visible in the detached variant.

[CSS-871](https://jira.corp.adobe.com/browse/CSS-871)

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
- [x] Confirm that the treeview detached variant has corner rounding displayed as before, either using the [Storybook controls](https://pr-3089--spectrum-css.netlify.app/preview/?path=/story/components-tree-view--default&args=variant:detached) or viewing the Detached variant on the [Docs page](https://pr-3089--spectrum-css.netlify.app/preview/?path=/docs/components-tree-view--docs#detached) (I could not find any guidance in design files, but the [documentation](https://spectrum.adobe.com/page/tree-view/#Detached) does show this variant) @marissahuysentruyt 
- [x] Confirm that [testing preview](https://pr-3089--spectrum-css.netlify.app/preview/?path=/story/components-tree-view--default&globals=testingPreview:!true)/[VRTs](https://www.chromatic.com/build?appId=64762974a45b8bc5ca1705a2&number=2904) add coverage for detached variant @marissahuysentruyt 

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author).

## Screenshots

Before:
![image](https://github.com/user-attachments/assets/a57b8215-11d2-4256-bda5-2cb7b36e4bcc)

After:
![image](https://github.com/user-attachments/assets/e01fdb4d-515d-4366-8bab-078885fff75a)

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
