### PR TITLE
chore(card): import Divider and remove static hr from card story

### DIFF
--- a/components/card/stories/template.js
+++ b/components/card/stories/template.js
@@ -1,6 +1,7 @@
 import { Template as ActionButton } from "@spectrum-css/actionbutton/stories/template.js";
 import { Template as Asset } from "@spectrum-css/asset/stories/template.js";
 import { Template as Checkbox } from "@spectrum-css/checkbox/stories/template.js";
+import { Template as Divider } from "@spectrum-css/divider/stories/template.js";
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 import { getRandomId } from "@spectrum-css/preview/decorators";
 import { Template as QuickAction } from "@spectrum-css/quickaction/stories/template.js";
@@ -96,7 +97,10 @@ export const Template = ({
               class=${classMap({ [`${rootClass}-coverPhoto`]: true })}
               style=${styleMap({ "background-image": `url(${image})` })}
             ></div>
-            <hr class="spectrum-Divider spectrum-Divider--sizeS spectrum-Card-divider">
+            ${Divider({
+              size: "s",
+              customClasses: [`${rootClass}-divider`],
+            }, context)}
           `
         )
       )}


### PR DESCRIPTION
## Description

- [x] removes static `hr` from card story and replaces said `hr` with `Divider` import

## How and where has this been tested?

- [x] Locally, in storybook

### Validation steps

1. Fetch the branch and run Storybook locally, or reference the URL associated with the PR.
2. Navigate to the card component and verify the border renders under the image.
3. Inspect the border and verify `.spectrum-Divider` styles are applied.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

4. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<img width="1066" alt="Screenshot 2024-09-10 at 8 41 06 AM" src="https://github.com/user-attachments/assets/f5f1c592-7de0-4a6f-9a66-b004b20203f3">

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
