### PR TITLE
fix(stepper): corrects invalid button color border to match field in windows high contrast mode

### DIFF
--- a/.changeset/clever-seas-smell.md
+++ b/.changeset/clever-seas-smell.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/stepper": minor
+---
+
+This corrects the border color for the stepper component infield buttons by setting the border color property to Highlight when the parent stepper component is invalid.

--- a/components/stepper/index.css
+++ b/components/stepper/index.css
@@ -303,11 +303,6 @@
 		--highcontrast-stepper-button-background-color-keyboard-focus: Canvas;
 		--highcontrast-stepper-focus-indicator-color: Highlight;
 
-		&.is-disabled {
-			--highcontrast-stepper-border-color: GrayText;
-			--highcontrast-stepper-buttons-border-width: var(--mod-stepper-border-width, var(--spectrum-stepper-border-width));
-		}
-
 		&.is-invalid {
 			--highcontrast-stepper-border-color: Highlight;
 			--highcontrast-stepper-border-color-hover: Highlight;
@@ -315,6 +310,12 @@
 			--highcontrast-stepper-border-color-focus-hover: Highlight;
 			--highcontrast-stepper-border-color-keyboard-focus: Highlight;
 			--highcontrast-infield-button-border-color: Highlight;
+		}
+
+		&.is-disabled {
+			--highcontrast-stepper-border-color: GrayText;
+			--highcontrast-infield-button-border-color: GrayText;
+			--highcontrast-stepper-buttons-border-width: var(--mod-stepper-border-width, var(--spectrum-stepper-border-width));
 		}
 	}
 }

--- a/components/stepper/index.css
+++ b/components/stepper/index.css
@@ -314,6 +314,7 @@
 			--highcontrast-stepper-border-color-focus: Highlight;
 			--highcontrast-stepper-border-color-focus-hover: Highlight;
 			--highcontrast-stepper-border-color-keyboard-focus: Highlight;
+			--highcontrast-infield-button-border-color: Highlight;
 		}
 	}
 }

--- a/components/stepper/metadata/metadata.json
+++ b/components/stepper/metadata/metadata.json
@@ -200,6 +200,7 @@
     "--mod-textfield-icon-spacing-inline-start-invalid"
   ],
   "high-contrast": [
+    "--highcontrast-infield-button-border-color",
     "--highcontrast-stepper-border-color",
     "--highcontrast-stepper-border-color-focus",
     "--highcontrast-stepper-border-color-focus-hover",


### PR DESCRIPTION
## Description

- This corrects the border color for the stepper component infield buttons by setting the border color property to Highlight when the parent stepper component is invalid.

## How and where has this been tested?

- Verified in assistiv labs Windows High Contrast Mode

### Validation steps

1. Run Storybook locally (or reference the link for this PR).
2. Navigate to Assistiv Labs and start a Windows High Contrast Mode VM (if running the branch locally, you'll need to enable the Assistiv Labs tunnel to access Storybook).
3. Enable Windows High Contrast Mode.
4. Navigate to the Stepper component in Storybook.
5. Verify that the stepper button border color matches the parent stepper field when the component is set to invalid.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<img width="1551" alt="Screenshot 2024-09-12 at 3 53 11 PM" src="https://github.com/user-attachments/assets/d5fc568f-e165-49f4-a79c-13c85a4b279c">

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
