### PR TITLE
fix(avatar): remove outline and reduce redundancy

### DIFF
--- a/.changeset/ninety-peas-approve.md
+++ b/.changeset/ninety-peas-approve.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/avatar": minor
+---
+
+Updates the avatar link styles to reduce redundancy and properly remove the border that was displayed in high contrast mode.

--- a/components/avatar/index.css
+++ b/components/avatar/index.css
@@ -120,9 +120,7 @@
 }
 
 .spectrum-Avatar-link {
-	outline: none;
-	outline-color: transparent;
-	outline-style: solid;
+	outline: 0;
 }
 
 .spectrum-Avatar-image {


### PR DESCRIPTION
## Description

- Updates the avatar link styles to reduce redundancy and properly remove the border that was displayed in high contrast mode.

## How and where has this been tested?

- Verified in assistiv labs Windows High Contrast Mode

### Validation steps

1. Run Storybook locally (or reference the link for this PR).
2. Navigate to Assistiv Labs and start a Windows High Contrast Mode VM (if running the branch locally, you'll need to enable the Assistiv Labs tunnel to access Storybook).
3. Enable Windows High Contrast Mode.
4. Navigate to the Avatar component in Storybook.
5. Verify that the square yellow outline no longer renders around the avatar component.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<img width="941" alt="Screenshot 2024-09-12 at 1 11 52 PM" src="https://github.com/user-attachments/assets/54fbce37-e80e-404a-b61d-a8809125e3d5">

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
