### PR TITLE
chore(storybook): add env variable for local testing

### DIFF
--- a/.storybook/package.json
+++ b/.storybook/package.json
@@ -25,7 +25,7 @@
 	},
 	"module": "main.js",
 	"scripts": {
-		"build": "storybook build --config-dir . --output-dir ./storybook-static"
+		"build": "cross-env NODE_ENV=development storybook build --config-dir . --output-dir ./storybook-static"
 	},
 	"dependencies": {
 		"@adobe/spectrum-css-workflow-icons": "^1.5.4",

--- a/.storybook/project.json
+++ b/.storybook/project.json
@@ -110,7 +110,8 @@
 			"inputs": [
 				"tools",
 				{ "externalDependencies": ["chromatic", "storybook"] },
-				{ "env": "CHROMATIC_PROJECT_TOKEN" }
+				{ "env": "CHROMATIC_PROJECT_TOKEN" },
+				{ "env": "NODE_ENV" }
 			],
 			"options": {
 				"commands": [


### PR DESCRIPTION
## Description

When triggering a chromatic build locally, the `yarn test` command was building using `NODE_ENV=production` instead of the expected `NODE_ENV=development`. This caused the CSS to be generated without the `is-` prefixed classes we use to quickly validate states such as focus or hover.

This PR adds the `NODE_ENV` definition to the storybook build command in the `.storybook/package.json` so that local test commands generate the expected CSS output.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [ ] `yarn test`: Expect the locally kicked off testing to pass VRT

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] ✨ This pull request is ready to merge. ✨
