### PR TITLE
fix(slider): adds space between side positioned label and slider

### DIFF
--- a/.changeset/flat-tips-knock.md
+++ b/.changeset/flat-tips-knock.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/slider": minor
+---
+
+Corrects side label positioning by adding margin-inline-end to provide space between the label and the slider component.

--- a/components/slider/index.css
+++ b/components/slider/index.css
@@ -124,6 +124,10 @@
 
 	.spectrum-Slider-labelContainer {
 		margin-block-start: 0;
+
+		.spectrum-Slider-label { 
+			margin-inline-end: var(--mod-slider-value-side-padding-inline, var(--spectrum-slider-value-side-padding-inline));
+		}
 	}
 
 	.spectrum-Slider-labelContainer + .spectrum-Slider-controls {

--- a/components/slider/metadata/metadata.json
+++ b/components/slider/metadata/metadata.json
@@ -17,6 +17,7 @@
     ".spectrum-Slider--sideLabel .spectrum-Slider-controls",
     ".spectrum-Slider--sideLabel .spectrum-Slider-labelContainer",
     ".spectrum-Slider--sideLabel .spectrum-Slider-labelContainer + .spectrum-Slider-controls",
+    ".spectrum-Slider--sideLabel .spectrum-Slider-labelContainer .spectrum-Slider-label",
     ".spectrum-Slider--sideLabel .spectrum-Slider-value",
     ".spectrum-Slider--sizeL",
     ".spectrum-Slider--sizeS",


### PR DESCRIPTION
## Description

- Corrects side label positioning by adding margin-inline-end to provide space between the label and the slider component

## How and where has this been tested?

- Verified locally in Storybook.

### Validation steps

1. Run Storybook locally (or reference the link for this PR).
2. Navigate to the slider component
3. Set `Label position` to side.
4. Verify that there is no space between the label and the slider component.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

5. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<img width="954" alt="Screenshot 2024-09-16 at 9 41 36 AM" src="https://github.com/user-attachments/assets/878cf76e-8383-462a-a3e5-7e6fc0a05b60">
<img width="955" alt="Screenshot 2024-09-16 at 9 41 26 AM" src="https://github.com/user-attachments/assets/faa9a8b5-42b6-4d34-828c-e64f49ee4ff7">

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
