### PR TITLE
chore(stepper): update vrt snapshots

### DIFF
--- a/components/stepper/stories/stepper.stories.js
+++ b/components/stepper/stories/stepper.stories.js
@@ -1,9 +1,9 @@
-import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import { isDisabled, isFocused, isInvalid, isKeyboardFocused, isQuiet, size } from "@spectrum-css/preview/types";
 import { Sizes } from "@spectrum-css/preview/decorators";
+import { disableDefaultModes } from "@spectrum-css/preview/modes";
+import { isDisabled, isFocused, isHovered, isInvalid, isKeyboardFocused, isQuiet, size } from "@spectrum-css/preview/types";
 import pkgJson from "../package.json";
 import { StepperGroup } from "./stepper.test.js";
-import { Template, DisabledVariantsGroup, AllDefaultVariantsGroup } from "./template";
+import { AllDefaultVariantsGroup, DisabledVariantsGroup, Template } from "./template";
 
 /**
  * A stepper can be used to increment or decrement a value by a specified amount via an up/down button. An input field displays the current value.
@@ -26,6 +26,7 @@ export default {
 		isDisabled,
 		isInvalid,
 		isFocused,
+		isHovered,
 		isKeyboardFocused,
 	},
 	args: {
@@ -33,6 +34,7 @@ export default {
 		size: "m",
 		isQuiet: false,
 		isFocused: false,
+		isHovered: false,
 		isKeyboardFocused: false,
 		isInvalid: false,
 		isDisabled: false,

--- a/components/stepper/stories/stepper.test.js
+++ b/components/stepper/stories/stepper.test.js
@@ -12,14 +12,27 @@ export const StepperGroup = Variants({
 			isQuiet: true,
 		},
 		{
-			testHeading: "Hide stepper",
-			hideStepper: true,
+			testHeading: "Invalid",
+			isInvalid: true,
+		},
+		{
+			testHeading: "Quiet + invalid",
+			isQuiet: true,
+			isInvalid: true,
 		},
 	],
 	stateData: [
 		{
+			testHeading: "Hide stepper",
+			hideStepper: true,
+		},
+		{
 			testHeading: "Disabled",
 			isDisabled: true,
+		},
+		{
+			testHeading: "Hovered",
+			isHovered: true,
 		},
 		{
 			testHeading: "Focused",
@@ -30,28 +43,17 @@ export const StepperGroup = Variants({
 			isKeyboardFocused: true,
 		},
 		{
-			testHeading: "Invalid",
-			isInvalid: true,
+			testHeading: "Disabled + hovered",
+			isDisabled: true,
+			isHovered: true,
 		},
 		{
-			testHeading: "Invalid + focused",
-			isInvalid: true,
-			isFocused: true,
-		},
-		{
-			testHeading: "Invalid + keyboard-focused",
-			isInvalid: true,
-			isKeyboardFocused: true,
-		},
-		{
-			testHeading: "Invalid + disabled + focused",
-			isInvalid: true,
+			testHeading: "Disabled + focused",
 			isDisabled: true,
 			isFocused: true,
 		},
 		{
-			testHeading: "Invalid + disabled + keyboard-focused",
-			isInvalid: true,
+			testHeading: "Disabled + keyboard-focused",
 			isDisabled: true,
 			isKeyboardFocused: true,
 		},

--- a/components/stepper/stories/template.js
+++ b/components/stepper/stories/template.js
@@ -1,5 +1,5 @@
 import { Template as InfieldButton } from "@spectrum-css/infieldbutton/stories/template.js";
-import { getRandomId, Container } from "@spectrum-css/preview/decorators";
+import { Container, getRandomId } from "@spectrum-css/preview/decorators";
 import { Template as Textfield } from "@spectrum-css/textfield/stories/template.js";
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
@@ -14,6 +14,7 @@ export const Template = ({
 	size = "m",
 	isQuiet = false,
 	isFocused = false,
+	isHovered = false,
 	isKeyboardFocused = false,
 	isInvalid = false,
 	isDisabled = false,
@@ -44,6 +45,7 @@ export const Template = ({
 				[`${rootClass}--size${size?.toUpperCase()}`]: typeof size !== "undefined",
 				[`${rootClass}--quiet`]: isQuiet,
 				"is-focused": isFocused,
+				"is-hover": isHovered,
 				"is-keyboardFocused": isKeyboardFocused,
 				"is-invalid": isInvalid,
 				"is-disabled": isDisabled,
@@ -120,6 +122,14 @@ export const AllDefaultVariantsGroup = (args, context) => Container({
 			containerStyles: {
 				"gap": "8px",
 			},
+			heading: "Hovered",
+			content: Template({...args, isHovered: true}, context)
+		})}
+		${Container({
+			withBorder: false,
+			containerStyles: {
+				"gap": "8px",
+			},
 			heading: "Focused",
 			content: Template({...args, isFocused: true}, context)
 		})}
@@ -136,7 +146,7 @@ export const AllDefaultVariantsGroup = (args, context) => Container({
 			containerStyles: {
 				"gap": "8px",
 			},
-			heading: "Keyboard focused",
+			heading: "Keyboard-focused",
 			content: Template({...args, isKeyboardFocused: true}, context)
 		})}
 		${Container({
@@ -144,7 +154,7 @@ export const AllDefaultVariantsGroup = (args, context) => Container({
 			containerStyles: {
 				"gap": "8px",
 			},
-			heading: "Invalid, keyboard focused",
+			heading: "Invalid, keyboard-focused",
 			content: Template({...args, isInvalid: true, isKeyboardFocused: true}, context)
 		})}
 	`


### PR DESCRIPTION
## Description

Update VRT to show "invalid" as a top-level test instead of a state because it's beneficial for us to see an "invalid" snapshot in combination with all other states (disabled, hovered, focused, etc.).

Moved "hide-stepper" to a state because it's most helpful to see it as a single snapshot for default and quiet variants.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [x] Expect visual regression tests to show a change to the testing grid for the Stepper component

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
