### PR TITLE
docs(button): increase coverage of outline variants

### DIFF
--- a/components/button/stories/button.test.js
+++ b/components/button/stories/button.test.js
@@ -39,9 +39,11 @@ export const ButtonGroups = Variants({
 			testHeading: capitalize(variant),
 			variant,
 		})),
-		...["fill", "outline"].map((treatment) => ({
-			testHeading: capitalize(treatment),
-			treatment,
+		// Note: In Spectrum 2, outline buttons are no longer available in accent and negative options.
+		...["accent", "negative", "primary", "secondary"].map((variant) => ({
+			testHeading: capitalize(variant) + " - outline",
+			variant,
+			treatment: "outline",
 		})),
 		{
 			testHeading: "Text wrapping with workflow icon",
@@ -49,8 +51,7 @@ export const ButtonGroups = Variants({
 				"max-inline-size": "480px",
 			},
 			iconName: "Edit",
-			label:
-        "An example of text overflow behavior within the button component. When the button text is too long for the horizontal space available, it wraps to form another line.",
+			label: "An example of text overflow behavior within the button component. When the button text is too long for the horizontal space available, it wraps to form another line.",
 			withStates: false,
 			Template,
 		},
@@ -61,8 +62,7 @@ export const ButtonGroups = Variants({
 			},
 			// Uses a UI icon that is smaller than workflow sizing, to test alignment:
 			iconName: "Cross100",
-			label:
-        "An example of text overflow behavior within the button component. When the button text is too long for the horizontal space available, it wraps to form another line.",
+			label: "An example of text overflow behavior within the button component. When the button text is too long for the horizontal space available, it wraps to form another line.",
 			withStates: false,
 			Template,
 		},
@@ -73,8 +73,7 @@ export const ButtonGroups = Variants({
 			},
 			// UI icon that is larger than workflow sizing:
 			iconName: "ArrowDown600",
-			label:
-        "An example of text overflow behavior within the button component. When the button text is too long for the horizontal space available, it wraps to form another line.",
+			label: "An example of text overflow behavior within the button component. When the button text is too long for the horizontal space available, it wraps to form another line.",
 			withStates: false,
 			Template,
 		},


### PR DESCRIPTION
## Description

Some of the button component's outline variants were not covered in the VRTs. This PR adds additional coverage of these combinations:
- outline + primary
- outline + secondary
- outline + negative

It also removes the "Fill" test as it was a duplicate of the existing "Accent" test where the default treatment is already "fill".

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [ ] All outline variants are now covered in the Chromatic template of the Default button story (turn on "Show testing preview")
- [ ] "Fill" test is removed and is covered by the existing "Accent" test.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

![Screenshot 2024-09-18 at 11 03 51 AM](https://github.com/user-attachments/assets/59cf3f96-80b0-47f0-a482-276affba468a)

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
