### PR TITLE
chore(contextualhelp): docs page fix

### DIFF
--- a/components/contextualhelp/stories/contextualhelp.mdx
+++ b/components/contextualhelp/stories/contextualhelp.mdx
@@ -1,4 +1,11 @@
-import { Canvas, ArgTypes, Meta, Description, Title } from "@storybook/blocks";
+import {
+  Canvas,
+  ArgTypes,
+  Meta,
+  Description,
+  Title,
+  Subtitle,
+} from "@storybook/blocks";
 import { ComponentDetails, TaggedReleases } from "@spectrum-css/preview/blocks";
 
 import * as ContextualHelpStories from "./contextualhelp.stories";

--- a/components/contextualhelp/stories/contextualhelp.mdx
+++ b/components/contextualhelp/stories/contextualhelp.mdx
@@ -1,10 +1,14 @@
 import { Canvas, ArgTypes, Meta, Description, Title } from "@storybook/blocks";
+import { ComponentDetails, TaggedReleases } from "@spectrum-css/preview/blocks";
 
 import * as ContextualHelpStories from "./contextualhelp.stories";
 
 <Meta of={ContextualHelpStories} title="Docs" />
 
 <Title of={ContextualHelpStories} />
+<Subtitle of={ContextualHelpStories} />
+<ComponentDetails />
+
 <Description of={ContextualHelpStories} />
 
 ## Info icon variants

--- a/components/datepicker/stories/datepicker.mdx
+++ b/components/datepicker/stories/datepicker.mdx
@@ -1,10 +1,14 @@
 import { Canvas, ArgTypes, Meta, Description, Title } from "@storybook/blocks";
+import { ComponentDetails, TaggedReleases } from "@spectrum-css/preview/blocks";
 
 import * as DatePickerStories from "./datepicker.stories";
 
 <Meta of={DatePickerStories} title="Docs" />
 
 <Title of={DatePickerStories} />
+<Subtitle of={DatePickerStories} />
+<ComponentDetails />
+
 <Description of={DatePickerStories} />
 
 ## Usage notes

--- a/components/datepicker/stories/datepicker.mdx
+++ b/components/datepicker/stories/datepicker.mdx
@@ -1,4 +1,11 @@
-import { Canvas, ArgTypes, Meta, Description, Title } from "@storybook/blocks";
+import {
+  Canvas,
+  ArgTypes,
+  Meta,
+  Description,
+  Title,
+  Subtitle,
+} from "@storybook/blocks";
 import { ComponentDetails, TaggedReleases } from "@spectrum-css/preview/blocks";
 
 import * as DatePickerStories from "./datepicker.stories";


### PR DESCRIPTION
## Description

The TaggedRelease and ComponentDetails doc blocks were missing or not imported for the Contextual Help page. This PR adds those in.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

@marissahuysentruyt 
- [x] Expect to see no loading error when opening the [Contextual help doc page](https://pr-3136--spectrum-css.netlify.app/preview/?path=/docs/components-contextual-help--docs).
- [x] Expect to see no loading error when opening the [Date picker doc page](https://pr-3136--spectrum-css.netlify.app/preview/?path=/docs/components-date-picker--docs).

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] ✨ This pull request is ready to merge. ✨
