### PR TITLE
fix(tokens,well): border color mapping

### DIFF
--- a/.changeset/late-wombats-begin.md
+++ b/.changeset/late-wombats-begin.md
@@ -1,0 +1,6 @@
+---
+"@spectrum-css/tokens": patch
+"@spectrum-css/well": patch
+---
+
+`--spectrum-well-border-color` was mapped to the `-rgb` postfixed value which resolves to a raw rgb number but not a valid color.

--- a/tokens/custom-spectrum/custom-light-vars.css
+++ b/tokens/custom-spectrum/custom-light-vars.css
@@ -41,7 +41,7 @@
   --spectrum-coach-indicator-ring-dark-color: var(--spectrum-gray-900);
   --spectrum-coach-indicator-ring-light-color: var(--spectrum-gray-50);
 
-  --spectrum-well-border-color: var(--spectrum-black-rgb);
+  --spectrum-well-border-color: var(--spectrum-black);
 
   --spectrum-steplist-current-marker-color-key-focus: var(--spectrum-blue-800);
 

--- a/tokens/dist/css/spectrum/light-vars.css
+++ b/tokens/dist/css/spectrum/light-vars.css
@@ -36,7 +36,7 @@
   --spectrum-coach-indicator-ring-dark-color:var(--spectrum-gray-900);
   --spectrum-coach-indicator-ring-light-color:var(--spectrum-gray-50);
 
-  --spectrum-well-border-color:var(--spectrum-black-rgb);
+  --spectrum-well-border-color:var(--spectrum-black);
 
   --spectrum-steplist-current-marker-color-key-focus:var(--spectrum-blue-800);
 

--- a/tokens/dist/index.css
+++ b/tokens/dist/index.css
@@ -3187,7 +3187,7 @@
   --spectrum-coach-indicator-ring-dark-color:var(--spectrum-gray-900);
   --spectrum-coach-indicator-ring-light-color:var(--spectrum-gray-50);
 
-  --spectrum-well-border-color:var(--spectrum-black-rgb);
+  --spectrum-well-border-color:var(--spectrum-black);
 
   --spectrum-steplist-current-marker-color-key-focus:var(--spectrum-blue-800);
 


### PR DESCRIPTION
## Description

I noticed that the `--spectrum-well-border-color` was mapped to the `-rgb` postfixed value which resolves to a raw rgb number but not a valid color. The way this property is being used, the styles expect to receive a valid color.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [ ] Expect to see the light well border color render as a valid rgb black.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] ✨ This pull request is ready to merge. ✨
