### PR TITLE
docs(icon): fix ui icons not displaying in storybook

### DIFF
--- a/components/icon/stories/template.js
+++ b/components/icon/stories/template.js
@@ -88,7 +88,8 @@ const fetchIconDetails = ({
  * @param {string} props.rootClass
  * @param {"xs"|"s"|"m"|"l"|"xl"|"xxl"} props.size
  * @param {"ui"|"workflow"} props.setName
- * @param {string} props.iconName - Icon name with or without the icon scale number appended. Names with the scale (e.g. 75, 100) will replace it based upon the value of 'size'.
+ * @param {string} props.iconName Icon name; could be from either icon set.
+ * @param {string} props.uiIconName Icon name selected from the UI icon set. When defined, takes precedence over iconName when setName == "ui".
  * @param {string} props.fill
  * @param {string} props.id
  * @param {string[]} props.customClasses
@@ -99,6 +100,7 @@ export const Template = ({
 	size = "m",
 	setName,
 	iconName,
+	uiIconName,
 	fill,
 	id = getRandomId("icon"),
 	customClasses = [],
@@ -134,6 +136,11 @@ export const Template = ({
 		if (!uiIconSizes && details.uiIconSizes) {
 			uiIconSizes = details.uiIconSizes;
 		}
+	}
+
+	// UI icons are selected from a different control.
+	if (setName === "ui" && uiIconName) {
+		iconName = uiIconName;
 	}
 
 	if (!iconName) {


### PR DESCRIPTION
## Description

Fixes the issue with UI icons [not displaying in Storybook for the Default story](https://spectrum-css.netlify.app/preview/?path=/story/components-icon--default&args=setName:ui;uiIconName:Asterisk75). The Template was not making use of `uiIconName`, which is a separate control/arg when the setName is UI. The console was displaying our error message "Icon: Could not render a result because no icon name was provided to the icon template.".

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

 - [x] UI icons are appearing in Storybook when selecting a setName of UI and choosing an icon
 - [x] Workflow icons are still appearing, and both types of icons render correctly when switching back and forth between the different sets and icon names using the Storybook controls
 - [x] No VRT changes

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] ✨ This pull request is ready to merge. ✨
