### PR TITLE
docs(typography): add tagged releases

### DIFF
--- a/.changeset/shiny-balloons-remember.md
+++ b/.changeset/shiny-balloons-remember.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/generator": minor
+---
+
+Update mdx template to include TaggedReleases and ComponentDetails

--- a/components/typography/stories/typography.mdx
+++ b/components/typography/stories/typography.mdx
@@ -8,7 +8,7 @@ import {
   Source,
   Story,
 } from "@storybook/blocks";
-import { ComponentDetails } from "@spectrum-css/preview/blocks";
+import { ComponentDetails, TaggedReleases } from "@spectrum-css/preview/blocks";
 
 import * as TypographyStories from "./typography.stories";
 
@@ -94,3 +94,7 @@ Spectrum typography is broken out into several separate components: [heading](#h
 
 <Description of={TypographyStories.InternationalizedCode} />
 <Canvas of={TypographyStories.InternationalizedCode} />
+
+## Tagged releases
+
+<TaggedReleases />

--- a/generator/templates/stories/{{ folderName }}.mdx.hbs
+++ b/generator/templates/stories/{{ folderName }}.mdx.hbs
@@ -1,13 +1,24 @@
-import { ArgTypes, Meta, Description, Primary, Stories, Title } from '@storybook/blocks';
+import {
+  ArgTypes,
+  Canvas,
+  Meta,
+  Description,
+  Title,
+  Subtitle,
+} from "@storybook/blocks";
+import { ComponentDetails, TaggedReleases } from "@spectrum-css/preview/blocks";
 
 import * as {{ pascalCase name }}Stories from './{{ folderName }}.stories';
 
-<Meta of={{{ pascalCase name }}Stories} title="Docs" />
+<Meta of={ {{ pascalCase name }}Stories } title="Docs" />
 
-<Title of={{{ pascalCase name }}Stories} />
-<Description of={{{ pascalCase name }}Stories} />
+<Title of={ {{ pascalCase name }}Stories } />
+<Subtitle of={ {{ pascalCase name }}Stories } />
+<ComponentDetails />
 
-<Primary of={{{ pascalCase name }}Stories} />
+<Description of={ {{ pascalCase name }}Stories } />
+
+<Stories of={ {{ pascalCase name }}Stories } />
 
 ## Properties
 
@@ -15,4 +26,6 @@ The component accepts the following inputs (properties):
 
 <ArgTypes />
 
-<Stories of={{{ pascalCase name }}Stories} includePrimary={ false } />
+## Tagged releases
+
+<TaggedReleases />


### PR DESCRIPTION
## Description

Update typography docs to include the tagged releases.

Update the generator to add the ComponentDetails and TaggedReleases doc blocks.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [x] Expect to see the tagged releases section at the bottom of the typography docs page.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
