### PR TITLE
docs(tooltip): docs site to storybook

### DIFF
--- a/components/tooltip/stories/template.js
+++ b/components/tooltip/stories/template.js
@@ -1,8 +1,10 @@
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
+import { Container } from "@spectrum-css/preview/decorators";
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { styleMap } from "lit/directives/style-map.js";
 import { when } from "lit/directives/when.js";
+import { capitalize } from "lodash-es";
 
 import "../index.css";
 
@@ -68,4 +70,99 @@ export const Template = ({
 			})}></span>
 		</span>
 	`;
+};
+
+const placements = [
+	"top",
+	"top-left",
+	"top-right",
+	"top-start",
+	"top-end",
+	"bottom",
+	"bottom-left",
+	"bottom-right",
+	"bottom-start",
+	"bottom-end",
+	"right",
+	"right-bottom",
+	"right-top",
+	"left",
+	"left-bottom",
+	"left-top",
+	"start",
+	"start-top",
+	"start-bottom",
+	"end",
+	"end-top",
+	"end-bottom",
+];
+
+export const TooltipShowOnHover = (args, context) => {
+	const placementHeadings = ["top", "bottom", "right", "left", "start", "end"];
+	return Container({
+		withBorder: false,
+		content: placementHeadings.map((heading) => html`
+			${Container({
+				heading,
+				content: html`
+					<div style="display: flex; flex-wrap: wrap;">
+						${placements.map((placement) => 
+								when(placement.startsWith(heading), () => html`
+									<span class="u-tooltip-showOnHover" style="margin: 15px 50px; cursor: default;">
+										${capitalize(placement.replace(/-/g, " "))}
+										${Template({
+											...args,
+											context,
+											placement,
+										})}
+									</span>
+								`)
+						)}
+					</div>
+				`
+			})}
+			`)
+	});
+};
+
+export const TooltipPlacementGroup = (args, context) => Container({
+	withBorder: false,
+	content: placements.map((placement) => html`
+		${Container({
+			heading: capitalize(placement.replace(/-/g, " ")),
+			content: html`
+				${Template({
+					...args,
+					context,
+					placement,
+				})}
+			`
+		})}
+	`)
+});
+
+// these variants no longer exist in s2
+export const SemanticVariantGroup = (args, context) => {
+	const variants = [
+		"neutral",
+		"info",
+		"positive",
+		"negative",
+	];
+
+	return Container({
+		withBorder: false,
+		content: variants.map((variant) => html`
+			${Container({
+				heading: capitalize(variant.replace(/-/g, " ")),
+				content: html`
+					${Template({
+						...args,
+						context,
+						variant,
+					})}
+				`
+			})}
+		`)
+	});
 };

--- a/components/tooltip/stories/tooltip.stories.js
+++ b/components/tooltip/stories/tooltip.stories.js
@@ -1,10 +1,11 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isFocused, isOpen } from "@spectrum-css/preview/types";
 import pkgJson from "../package.json";
+import { SemanticVariantGroup, TooltipPlacementGroup, TooltipShowOnHover } from "./template.js";
 import { PlacementVariants } from "./tooltip.test.js";
 
 /**
- * Tooltips show contextual help or information about specific components when a user hovers or focuses on them.
+ * A tooltip shows contextual help or information about specific components when a user hovers or focuses on it.
  */
 export default {
 	title: "Tooltip",
@@ -31,7 +32,7 @@ export default {
 		},
 		placement: {
 			name: "Placement",
-			description: "The placement of the tooltip relative to the source. Note that placements that start with Left/Right do not change with text direction, but Start/End placements do.",
+			description: "The placement of the tooltip relative to the source. Note that placements that start with left/right do not change with text direction, but start/end placements do.",
 			type: { name: "string" },
 			table: {
 				type: { summary: "string" },
@@ -94,6 +95,52 @@ export default {
 
 export const Default = PlacementVariants.bind({});
 Default.args = {};
+
+// ********* DOCS ONLY ********* //
+/**
+ * A tooltip is positioned in relation to its target. There are 22 available positions. Ten of those positions use
+ * logical properties, containing the words "start" or "end", and will change side if text direction is changed.
+ *
+ * Position classes use the following naming convention: the first term is the tooltip's position and the second term
+ * is its source's position. For example, for the position and modifier class `--top-left`, the tooltip is positioned
+ * at the top and the source is to the left. The default placement value if none is specified is at the top.
+ */
+export const Placement = TooltipPlacementGroup.bind({});
+Placement.tags = ["!dev"];
+Placement.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+/**
+ * A tooltip that shows on hover using CSS only. Note that this approach does not support text wrapping. Also, note
+ * that these tooltips will likely not work on touch-enabled devices without additional client-side scripting.
+ */
+export const ShowOnHover = TooltipShowOnHover.bind({});
+ShowOnHover.tags = ["!dev"];
+ShowOnHover.args = {
+	label: "Tooltip",
+	isOpen: false,
+};
+ShowOnHover.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+/**
+ * By default, tooltips are the neutral variant. This is the most common variant because most tooltips are used to only
+ * disclose additional information, without conveying a semantic meaning. The neutral variant never includes an icon.
+ * 
+ * Tooltips also come in other semantic variants: informative (blue), positive (green), and negative (red). These use
+ * [semantic colors](https://spectrum.adobe.com/page/color-system/#Color-semantics) to communicate the meaning.
+ * 
+ * These semantic variants include an icon to supplement the messaging. These icons are predefined and can not be
+ * customized. Unless it's being used to provide context about the exact same icon, a semantic tooltip should always
+ * show an icon. Doing this is essential for helping users with color vision deficiency to discern the message tone.
+ */
+export const SemanticVariants = SemanticVariantGroup.bind({});
+SemanticVariants.tags = ["!dev"];
+SemanticVariants.parameters = {
+	chromatic: { disableSnapshot: true },
+};
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = PlacementVariants.bind({});


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

Makes updates to the Tooltip Docs page in Storybook to incorporate [Docs Site examples](https://opensource.adobe.com/spectrum-css/tooltip.html).

Note that in S2 all semantic variants will be removed (all variants aside from neutral). These semantic variants have been added in as a story of their own for easier removal later.

This is a docs-only PR, no changeset is necessary.

CSS-945

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
- [x] The Tooltip Storybook Docs page contains all the relevant information from the [Docs site](https://opensource.adobe.com/spectrum-css/tooltip.html)
- [x] Grammar, organization, and spacing of the content on the Tooltip Docs page is accurate/makes sense

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
