### PR TITLE
docs(statuslight): docs to storybook migration

### DIFF
--- a/components/statuslight/CHANGELOG.md
+++ b/components/statuslight/CHANGELOG.md
@@ -1030,6 +1030,12 @@ Co-authored-by: Patrick Fulton <pfulton@adobe.com>
 
 - implement t-shirt sizing for Status Light, closes [#686](https://github.com/adobe/spectrum-css/issues/686) ([0a20b52](https://github.com/adobe/spectrum-css/commit/0a20b52))
 
+### Migration Guide
+
+#### T-shirt sizing
+
+Status Light now supports t-shirt sizing and requires that you specify the size by adding a `.spectrum-StatusLight--size*` class.
+
 <a name="3.0.0-beta.4"></a>
 
 ## 3.0.0-beta.4

--- a/components/statuslight/stories/statuslight.stories.js
+++ b/components/statuslight/stories/statuslight.stories.js
@@ -1,5 +1,5 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import { size } from "@spectrum-css/preview/types";
+import { isDisabled, size } from "@spectrum-css/preview/types";
 import { Sizes } from "@spectrum-css/preview/decorators";
 import pkgJson from "../package.json";
 import { StatusLightGroup } from "./statuslight.test.js";
@@ -22,6 +22,7 @@ export default {
 			},
 			control: { type: "text" },
 		},
+		isDisabled,
 		variant: {
 			name: "Variant",
 			description: "Changes the color of the status dot. The variant list includes both semantic and non-semantic options.",
@@ -60,6 +61,7 @@ export default {
 		size: "m",
 		label: "Status",
 		variant: "info",
+		isDisabled: false,
 	},
 	parameters: {
 		packageJson: pkgJson,
@@ -114,6 +116,15 @@ NonSemanticColors.parameters = {
 	chromatic: { disabledSnapshot: true },
 };
 NonSemanticColors.storyName = "Non-semantic colors";
+
+export const Disabled = Template.bind({});
+Disabled.args = {
+	isDisabled: true,
+};
+Disabled.tags = ["!dev"];
+Disabled.parameters = {
+	chromatic: { disabledSnapshot: true },
+};
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = StatusLightGroup.bind({});

--- a/components/statuslight/stories/statuslight.stories.js
+++ b/components/statuslight/stories/statuslight.stories.js
@@ -87,7 +87,7 @@ export const Sizing = (args, context) => Sizes({
 }, context);
 Sizing.tags = ["!dev"];
 Sizing.parameters = {
-	chromatic: { disabledSnapshot: true },
+	chromatic: { disableSnapshot: true },
 };
 
 /**
@@ -103,7 +103,7 @@ Sizing.parameters = {
 export const SemanticColors = SemanticGroup.bind({});
 SemanticColors.tags = ["!dev"];
 SemanticColors.parameters = {
-	chromatic: { disabledSnapshot: true },
+	chromatic: { disableSnapshot: true },
 };
 SemanticColors.storyName = "Semantic colors";
 
@@ -113,7 +113,7 @@ SemanticColors.storyName = "Semantic colors";
 export const NonSemanticColors = NonsemanticGroup.bind({});
 NonSemanticColors.tags = ["!dev"];
 NonSemanticColors.parameters = {
-	chromatic: { disabledSnapshot: true },
+	chromatic: { disableSnapshot: true },
 };
 NonSemanticColors.storyName = "Non-semantic colors";
 
@@ -123,7 +123,7 @@ Disabled.args = {
 };
 Disabled.tags = ["!dev"];
 Disabled.parameters = {
-	chromatic: { disabledSnapshot: true },
+	chromatic: { disableSnapshot: true },
 };
 
 // ********* VRT ONLY ********* //

--- a/components/statuslight/stories/statuslight.stories.js
+++ b/components/statuslight/stories/statuslight.stories.js
@@ -1,8 +1,13 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { size } from "@spectrum-css/preview/types";
+import { Sizes } from "@spectrum-css/preview/decorators";
 import pkgJson from "../package.json";
 import { StatusLightGroup } from "./statuslight.test.js";
+import { Template, SemanticGroup, NonsemanticGroup } from "./template.js";
 
+/**
+ * Status lights describe the condition of an entity. They can be used to convey semantic meaning, such as statuses and categories.
+ */
 export default {
 	title: "Status light",
 	component: "Statuslight",
@@ -19,6 +24,7 @@ export default {
 		},
 		variant: {
 			name: "Variant",
+			description: "Changes the color of the status dot. The variant list includes both semantic and non-semantic options.",
 			type: { name: "string", required: true },
 			table: {
 				type: { summary: "string" },
@@ -60,8 +66,54 @@ export default {
 	},
 };
 
+/**
+ * Status lights should always include a label with text that clearly communicates the kind of status being shown. Color alone is not enough to communicate the status. Do not change the text color to match the dot.
+ * 
+ * When the text is too long for the horizontal space available, it wraps to form another line.
+ */
 export const Default = StatusLightGroup.bind({});
 Default.args = {};
+
+/**
+ * Status lights come in four different sizes: small, medium, large, and extra-large. The medium size is the default and most frequently used option. Use the other sizes sparingly; they should be used to create a hierarchy of importance within the page.
+ */
+export const Sizing = (args, context) => Sizes({
+	Template,
+	withBorder: false,
+	withHeading: false,
+	...args,
+}, context);
+Sizing.tags = ["!dev"];
+Sizing.parameters = {
+	chromatic: { disabledSnapshot: true },
+};
+
+/**
+ * When status lights have a semantic meaning, they use semantic colors. Use these variants for the following statuses:
+ * - Informative (active, in use, live, published)
+ * - Neutral (archived, deleted, paused, draft, not started, ended)
+ * - Positive (approved, complete, success, new, purchased, licensed)
+ * - Notice (needs approval, pending, scheduled, syncing, indexing, processing)
+ * - Negative (error, alert, rejected, failed)
+ * 
+ * Semantic status lights should never be used for color coding categories or labels, and vice versa.
+ */
+export const SemanticColors = SemanticGroup.bind({});
+SemanticColors.tags = ["!dev"];
+SemanticColors.parameters = {
+	chromatic: { disabledSnapshot: true },
+};
+SemanticColors.storyName = "Semantic colors";
+
+/**
+ * When status lights are used to color code categories and labels that are commonly found in data visualization, they use label colors. The ideal usage for these is when there are 8 or fewer categories or labels being color coded.
+ */
+export const NonSemanticColors = NonsemanticGroup.bind({});
+NonSemanticColors.tags = ["!dev"];
+NonSemanticColors.parameters = {
+	chromatic: { disabledSnapshot: true },
+};
+NonSemanticColors.storyName = "Non-semantic colors";
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = StatusLightGroup.bind({});

--- a/components/statuslight/stories/statuslight.test.js
+++ b/components/statuslight/stories/statuslight.test.js
@@ -16,7 +16,13 @@ export const StatusLightGroup = Variants({
 		{
 			testHeading: "Truncation",
 			label: "Status light label that is long and wraps to the next line",
-			customStyles: {"max-width": "150px"}
+			customStyles: {"max-width": "150px"},
 		}
 	],
+	stateData: [
+		{
+			testHeading: "Disabled",
+			isDisabled: true,
+		}
+	]
 });

--- a/components/statuslight/stories/template.js
+++ b/components/statuslight/stories/template.js
@@ -1,3 +1,4 @@
+import { Container } from "@spectrum-css/preview/decorators";
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { styleMap } from "lit/directives/style-map.js";
@@ -23,3 +24,38 @@ export const Template = ({
 		${label}
 	</div>
 `;
+
+// TODO: the accent variant will be removed in S2.
+export const SemanticGroup = (args, context) => Container({
+	withBorder: false,
+	direction: "column",
+	content: html`${[
+		"accent",
+		"neutral",
+		"info",
+		"negative",
+		"notice",
+		"positive"].map(variant => Template({...args, variant: variant, label: `${variant.charAt(0).toUpperCase() + variant.slice(1)} status` }, context))
+	}`
+});
+
+export const NonsemanticGroup = (args, context) => Container({
+	withBorder: false,
+	direction: "column",
+	content: html`${[
+		"gray",
+		"red",
+		"orange",
+		"yellow",
+		"chartreuse",
+		"celery",
+		"green",
+		"seafoam",
+		"cyan",
+		"blue",
+		"indigo",
+		"purple",
+		"fuchsia",
+		"magenta",].map(variant => Template({...args, variant: variant, label: `${variant.charAt(0).toUpperCase() + variant.slice(1)}`}, context))
+	}`
+});

--- a/components/statuslight/stories/template.js
+++ b/components/statuslight/stories/template.js
@@ -10,6 +10,7 @@ export const Template = ({
 	size = "m",
 	variant = "info",
 	label,
+	isDisabled,
 	customStyles = {},
 } = {}) => html`
 	<div
@@ -18,6 +19,7 @@ export const Template = ({
 			[`${rootClass}--size${size?.toUpperCase()}`]:
 				typeof size !== "undefined",
 			[`${rootClass}--${variant}`]: typeof variant !== "undefined",
+			"is-disabled": isDisabled,
 		})}
 		style=${styleMap(customStyles)}
 	>


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

This PR continues migrating documentation from the static docs site to Storybook, with a focus on the status light component. When possible, documentation and/or stories were brought over from the [S2 status light migration](https://github.com/adobe/spectrum-css/pull/2818).

- Added the migration notes to the `CHANGELOG`
- Added component description and some control descriptions
- Added documentation around variant usage
- Added sizing, semantic and non-semantic stories to showcase all variants of status light

### Jira/Specs
[CSS-939](https://jira.corp.adobe.com/browse/CSS-939)

_This PR has no CSS changes, so no changeset is needed._

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

- [ ]  Pull down the branch to run locally or use [the deploy preview](https://pr-3152--spectrum-css.netlify.app/preview/?path=/docs/components-status-light--docs).
- [ ] Verify all info from [the static docs site](https://opensource.adobe.com/spectrum-css/statuslight.html) is represented on [the storybook docs page](https://pr-3152--spectrum-css.netlify.app/preview/?path=/docs/components-status-light--docs)
- [ ] Visit the [default status light story](https://pr-3152--spectrum-css.netlify.app/preview/?path=/story/components-status-light--default) and [view the testing grid](https://pr-3152--spectrum-css.netlify.app/preview/?path=/story/components-status-light--default&globals=testingPreview:!true)
- [ ] Ensure all status light variants are represented in the testing grid. 

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
