### PR TITLE
fix(slider ramp): correct handle and ramp vertical alignment

### DIFF
--- a/.changeset/rude-rivers-crash.md
+++ b/.changeset/rude-rivers-crash.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/slider": minor
+---
+
+This applies a flex layout to the spectrum slider controls to consistently align the enclosed handle and ramp, while also removing the margins that might otherwise interfere with alignment. This aims to resolve the issues with the calc-based approach that exhibited variations in vertical alignment.

--- a/components/slider/index.css
+++ b/components/slider/index.css
@@ -152,6 +152,11 @@
 	position: relative;
 	z-index: auto;
 
+	&:not(:has(.spectrum-Slider-ticks)) {
+		display: flex;
+		align-items: center;
+	}
+
 	/* These calculations prevent the track from spilling outside of the control */
 	inline-size: calc(100% - calc(var(--mod-slider-controls-margin, var(--spectrum-slider-controls-margin))) * 2);
 	margin-inline-start: var(--mod-slider-controls-margin, var(--spectrum-slider-controls-margin));

--- a/components/slider/index.css
+++ b/components/slider/index.css
@@ -116,6 +116,10 @@
 	min-inline-size: var(--mod-slider-min-size, var(--spectrum-slider-min-size));
 
 	user-select: none;
+
+	&:not(.spectrum-Slider--sideLabel) .spectrum-Slider-labelContainer + .spectrum-Slider-controls:has(.spectrum-Slider-ramp) {
+		margin-block-start: calc(var(--mod-slider-ramp-track-height, var(--spectrum-slider-ramp-track-height)) / 2);
+	}
 }
 
 .spectrum-Slider--sideLabel {
@@ -416,6 +420,7 @@
 	&:lang(ko) {
 		line-height: var(--mod-slider-cjk-line-height, var(--spectrum-slider-cjk-line-height));
 	}
+
 }
 
 .spectrum-Slider-label {

--- a/components/slider/index.css
+++ b/components/slider/index.css
@@ -289,7 +289,6 @@
 }
 
 .spectrum-Slider-ramp {
-	margin-block-start: calc(var(--mod-slider-ramp-track-height, var(--spectrum-slider-ramp-track-height)) / 2);
 	block-size: var(--mod-slider-ramp-track-height, var(--spectrum-slider-ramp-track-height));
 
 	position: absolute;

--- a/components/slider/metadata/metadata.json
+++ b/components/slider/metadata/metadata.json
@@ -90,6 +90,7 @@
     ".spectrum-Slider:not(.is-disabled, .spectrum-Slider--filled, .spectrum-Slider--range) .spectrum-Slider-controls:focus-within",
     ".spectrum-Slider:not(.is-disabled, .spectrum-Slider--filled, .spectrum-Slider--range) .spectrum-Slider-controls:hover",
     ".spectrum-Slider:not(.is-disabled, .spectrum-Slider--filled, .spectrum-Slider--range).js-focus-within .spectrum-Slider-controls[focus-within]",
+    ".spectrum-Slider:not(.spectrum-Slider--sideLabel) .spectrum-Slider-labelContainer + .spectrum-Slider-controls:has(.spectrum-Slider-ramp)",
     "[dir=\"rtl\"] .spectrum-Slider",
     "[dir=\"rtl\"] .spectrum-Slider .spectrum-Slider-handle:before"
   ],

--- a/components/slider/metadata/metadata.json
+++ b/components/slider/metadata/metadata.json
@@ -27,6 +27,7 @@
     ".spectrum-Slider--tick .spectrum-Slider-handle",
     ".spectrum-Slider--tick .spectrum-Slider-tickLabel",
     ".spectrum-Slider-controls",
+    ".spectrum-Slider-controls:not(:has(.spectrum-Slider-ticks))",
     ".spectrum-Slider-fill",
     ".spectrum-Slider-fill--right",
     ".spectrum-Slider-fill:before",


### PR DESCRIPTION
## Description

This applies a flex layout to the spectrum slider controls to consistently align the enclosed handle and ramp, while also removing the margins that might otherwise interfere with alignment. This aims to resolve the issues with the calc-based approach that exhibited variations in vertical alignment.

## How and where has this been tested?

Checked locally in Storybook.

### Validation steps

1. Pull down the branch and run Storybook locally or access the Storybook URL for the PR.
2. Open the Slider component and select `Default`.
3. Verify that the handle is vertically aligned over the track.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

4. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<img width="951" alt="Screenshot 2024-09-30 at 3 56 14 PM" src="https://github.com/user-attachments/assets/b4379153-b213-43fd-9a38-409d5361663e">

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
