### PR TITLE
docs(toast): migrate docs to storybook

### DIFF
--- a/components/toast/stories/template.js
+++ b/components/toast/stories/template.js
@@ -22,6 +22,7 @@ export const Template = ({
 	let iconName = "Info";
 	if (variant === "negative") iconName = "Alert";
 	if (variant === "positive") iconName = "CheckmarkCircle";
+	if (variant === "neutral") iconName = undefined;
 
 	return html`
 		<div
@@ -68,7 +69,7 @@ export const ToastWrapOptions = ({
 	...args
 }, context ) => Container({
 	withBorder: false,
-	direction: "row",
+	direction: "column",
 	wrapperStyles: {
 		columnGap: "12",
 	},
@@ -76,7 +77,61 @@ export const ToastWrapOptions = ({
 		${Template({
 			...args,
 			message: "A new version of Lightroom Classic is now available",
-			variant: "info"
+			variant: "info",
+			inlineButtonLabel: "Update"
 		}, context )}
-	`
+		${Template({
+			...args,
+			message: "A new version of Lightroom Classic is now available. Use the Update button below to start using the new version.",
+			variant: "info",
+			inlineButtonLabel: "Update"
+		}, context )}
+		${Template({
+			...args,
+			message: "A new version of Lightroom Classic is now available",
+			variant: "info",
+		}, context )}
+		${Template({
+			...args,
+			message: "An update is available",
+			variant: "info",
+			customStyles: {
+				"max-inline-size": "240px"
+			},
+		}, context )}`
+});
+
+export const ActionTemplate = ({
+	...args
+}, context ) => Container({
+	withBorder: false,
+	direction: "column",
+	wrapperStyles: {
+		columnGap: "12",
+	},
+	content: html`
+		${Template({
+			...args,
+			message: "All files archived",
+			variant: "neutral",
+			inlineButtonLabel: "Undo"
+		}, context )}
+		${Template({
+			...args,
+			message: "Analysis complete",
+			variant: "positive",
+			inlineButtonLabel: "View"
+		}, context )}
+		${Template({
+			...args,
+			message: "An update is available",
+			variant: "info",
+			inlineButtonLabel: "Update"
+		}, context )}
+		${Template({
+			...args,
+			message: "2 assets missing",
+			variant: "negative",
+			inlineButtonLabel: "Show"
+		}, context )}`
 });

--- a/components/toast/stories/template.js
+++ b/components/toast/stories/template.js
@@ -1,7 +1,7 @@
 import { Template as Button } from "@spectrum-css/button/stories/template.js";
 import { Template as CloseButton } from "@spectrum-css/closebutton/stories/template.js";
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
-import { getRandomId } from "@spectrum-css/preview/decorators";
+import { Container, getRandomId } from "@spectrum-css/preview/decorators";
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
@@ -63,3 +63,20 @@ export const Template = ({
 		</div>
 	`;
 };
+
+export const ToastWrapOptions = ({
+	...args
+}, context ) => Container({
+	withBorder: false,
+	direction: "row",
+	wrapperStyles: {
+		columnGap: "12",
+	},
+	content: html`
+		${Template({
+			...args,
+			message: "A new version of Lightroom Classic is now available",
+			variant: "info"
+		}, context )}
+	`
+});

--- a/components/toast/stories/template.js
+++ b/components/toast/stories/template.js
@@ -65,13 +65,11 @@ export const Template = ({
 	`;
 };
 
-export const ToastWrapOptions = ({
-	...args
-}, context ) => Container({
+export const ToastWrapOptions = (args, context ) => Container({
 	withBorder: false,
 	direction: "column",
 	wrapperStyles: {
-		columnGap: "12",
+		columnGap: "12px",
 	},
 	content: html`
 		${Template({
@@ -101,9 +99,7 @@ export const ToastWrapOptions = ({
 		}, context )}`
 });
 
-export const ActionTemplate = ({
-	...args
-}, context ) => Container({
+export const ActionTemplate = (args, context ) => Container({
 	withBorder: false,
 	direction: "column",
 	wrapperStyles: {

--- a/components/toast/stories/template.js
+++ b/components/toast/stories/template.js
@@ -65,7 +65,7 @@ export const Template = ({
 	`;
 };
 
-export const ToastWrapOptions = (args, context ) => Container({
+export const ToastWrapOptions = (args, context) => Container({
 	withBorder: false,
 	direction: "column",
 	wrapperStyles: {
@@ -77,18 +77,18 @@ export const ToastWrapOptions = (args, context ) => Container({
 			message: "A new version of Lightroom Classic is now available",
 			variant: "info",
 			inlineButtonLabel: "Update"
-		}, context )}
+		}, context)}
 		${Template({
 			...args,
 			message: "A new version of Lightroom Classic is now available. Use the Update button below to start using the new version.",
 			variant: "info",
 			inlineButtonLabel: "Update"
-		}, context )}
+		}, context)}
 		${Template({
 			...args,
 			message: "A new version of Lightroom Classic is now available",
 			variant: "info",
-		}, context )}
+		}, context)}
 		${Template({
 			...args,
 			message: "An update is available",
@@ -96,14 +96,14 @@ export const ToastWrapOptions = (args, context ) => Container({
 			customStyles: {
 				"max-inline-size": "240px"
 			},
-		}, context )}`
+		}, context)}`
 });
 
-export const ActionTemplate = (args, context ) => Container({
+export const ActionTemplate = (args, context) => Container({
 	withBorder: false,
 	direction: "column",
 	wrapperStyles: {
-		columnGap: "12",
+		columnGap: "12px",
 	},
 	content: html`
 		${Template({
@@ -111,23 +111,23 @@ export const ActionTemplate = (args, context ) => Container({
 			message: "All files archived",
 			variant: "neutral",
 			inlineButtonLabel: "Undo"
-		}, context )}
+		}, context)}
 		${Template({
 			...args,
 			message: "Analysis complete",
 			variant: "positive",
 			inlineButtonLabel: "View"
-		}, context )}
+		}, context)}
 		${Template({
 			...args,
 			message: "An update is available",
 			variant: "info",
 			inlineButtonLabel: "Update"
-		}, context )}
+		}, context)}
 		${Template({
 			...args,
 			message: "2 assets missing",
 			variant: "negative",
 			inlineButtonLabel: "Show"
-		}, context )}`
+		}, context)}`
 });

--- a/components/toast/stories/toast.stories.js
+++ b/components/toast/stories/toast.stories.js
@@ -133,7 +133,7 @@ Wrapping.parameters = {
 };
 
 /**
- * A toast can have up to one action: [a static white, secondary, outline button.](?path=/docs/components-button--docs#static-white---secondary). This label should be kept concise, and it should only be used when there’s a direct action available that is related to the toast text.
+ * A toast can have up to one action: [a static white, secondary, outline button](?path=/docs/components-button--docs#static-white---secondary). This label should be kept concise, and it should only be used when there’s a direct action available that is related to the toast text.
 */
 
 export const Action = ActionTemplate.bind({});

--- a/components/toast/stories/toast.stories.js
+++ b/components/toast/stories/toast.stories.js
@@ -1,17 +1,26 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import pkgJson from "../package.json";
-import { Template } from "./template.js";
+import { ActionTemplate, Template, ToastWrapOptions } from "./template.js";
 import { ToastGroup } from "./toast.test.js";
 
 /**
  * Toasts display brief, temporary notifications. They are noticeable but do not disrupt the user experience and do not require an action to be taken.
+ * 
+ * They must include text to communicate a message. Write the text as concisely as possible while still being clear about what has happened or is happening. View the toast [content standards](https://spectrum.adobe.com/page/toast/#Content-standards) for writing guidelines.
  */
 export default {
 	title: "Toast",
 	component: "Toast",
 	argTypes: {
 		variant: {
-			table: { disable: true },
+			name: "Variant",
+			table: {
+				type: { summary: "string" },
+				defaultValue: { summary: "neutral" },
+				category: "Component",
+			},
+			control: "select",
+			options: ["neutral", "info", "negative", "positive"],
 		},
 		message: {
 			name: "Message",
@@ -44,13 +53,23 @@ export default {
 	},
 };
 
+/**
+ * The neutral toast is the default variant. It is gray and does not have an icon. This is used when the message is neutral in tone or when its semantics do not fit in any of the other variants.
+*/
+
 export const Default = ToastGroup.bind({});
 Default.args = {
 	message: "File has been archived",
 	inlineButtonLabel: "Undo",
+	variant: "neutral"
 };
 
 // ********* DOCS ONLY ********* //
+
+/**
+ * The informative toast uses the informative semantic color (blue) and has an info icon to help those with color vision deficiency discern the message tone. Similar to the accent button, this should be used when the message should call extra attention compared to the neutral variant.
+ */
+
 export const Info = Template.bind({});
 Info.tags = ["!dev"];
 Info.args = {
@@ -61,6 +80,10 @@ Info.args = {
 Info.parameters = {
 	chromatic: { disableSnapshot: true },
 };
+
+/** 
+ * The negative toast uses the negative semantic color (red) and has an alert icon to help those with color vision deficiency to discern the message tone. This is used to show an error or failure.
+*/
 
 export const Negative = Template.bind({});
 Negative.tags = ["!dev"];
@@ -73,6 +96,10 @@ Negative.parameters = {
 	chromatic: { disableSnapshot: true },
 };
 
+/**
+ * The positive toast uses the positive semantic color (green) and has a checkmark icon to help those with color vision deficiency discern the message tone. This is used to inform about a successful action or completion of a task. 
+ */
+
 export const Positive = Template.bind({});
 Positive.tags = ["!dev"];
 Positive.args = {
@@ -81,6 +108,26 @@ Positive.args = {
 	inlineButtonLabel: "Eject",
 };
 Positive.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+/**
+ * When the message text is too long for the horizontal space available, it wraps to form another line. 
+*/
+
+export const Wrapping = ToastWrapOptions.bind({});
+Wrapping.tags = ["!dev"];
+Wrapping.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+/**
+ * A toast can have up to one action: [a static white, secondary, outline button.](https://spectrum.adobe.com/page/button#Static-color) This label should be kept concise, and it should only be used when there’s a direct action available that is related to the toast text.
+*/
+
+export const Action = ActionTemplate.bind({});
+Action.tags = ["!dev"];
+Action.parameters = {
 	chromatic: { disableSnapshot: true },
 };
 

--- a/components/toast/stories/toast.stories.js
+++ b/components/toast/stories/toast.stories.js
@@ -5,8 +5,6 @@ import { ToastGroup } from "./toast.test.js";
 
 /**
  * Toasts display brief, temporary notifications. They are noticeable but do not disrupt the user experience and do not require an action to be taken.
- * 
- * They must include text to communicate a message. Write the text as concisely as possible while still being clear about what has happened or is happening. View the toast [content standards](https://spectrum.adobe.com/page/toast/#Content-standards) for writing guidelines.
  */
 export default {
 	title: "Toast",
@@ -112,6 +110,19 @@ Positive.parameters = {
 };
 
 /**
+ * They must include text to communicate a message. Write the text as concisely as possible while still being clear about what has happened or is happening.
+ * 
+ * Writing for toasts depends on the nature of the message, whether it’s communicating confirmation, information, or an error. For all kinds of toasts, keep the text to fewer than 2 lines in English, since it will become longer when localized. View the [toast content standards](https://spectrum.adobe.com/page/toast/#Content-standards) for writing guidelines.
+*/
+
+export const Text = Template.bind({});
+Text.tags = ["!dev"];
+Text.args = {
+	message: "All files archived",
+	inlineButtonLabel: ""
+};
+
+/**
  * When the message text is too long for the horizontal space available, it wraps to form another line. 
 */
 
@@ -122,7 +133,7 @@ Wrapping.parameters = {
 };
 
 /**
- * A toast can have up to one action: [a static white, secondary, outline button.](https://spectrum.adobe.com/page/button#Static-color) This label should be kept concise, and it should only be used when there’s a direct action available that is related to the toast text.
+ * A toast can have up to one action: [a static white, secondary, outline button.](?path=/docs/components-button--docs#static-white---secondary) This label should be kept concise, and it should only be used when there’s a direct action available that is related to the toast text.
 */
 
 export const Action = ActionTemplate.bind({});

--- a/components/toast/stories/toast.stories.js
+++ b/components/toast/stories/toast.stories.js
@@ -133,7 +133,7 @@ Wrapping.parameters = {
 };
 
 /**
- * A toast can have up to one action: [a static white, secondary, outline button.](?path=/docs/components-button--docs#static-white---secondary) This label should be kept concise, and it should only be used when there’s a direct action available that is related to the toast text.
+ * A toast can have up to one action: [a static white, secondary, outline button.](?path=/docs/components-button--docs#static-white---secondary). This label should be kept concise, and it should only be used when there’s a direct action available that is related to the toast text.
 */
 
 export const Action = ActionTemplate.bind({});

--- a/components/toast/stories/toast.stories.js
+++ b/components/toast/stories/toast.stories.js
@@ -5,6 +5,8 @@ import { ToastGroup } from "./toast.test.js";
 
 /**
  * Toasts display brief, temporary notifications. They are noticeable but do not disrupt the user experience and do not require an action to be taken.
+ * 
+ * They must include text to communicate a message. Write the text as concisely as possible while still being clear about what has happened or is happening. View the toast [content standards](https://spectrum.adobe.com/page/toast/#Content-standards) for writing guidelines.
  */
 export default {
 	title: "Toast",

--- a/components/toast/stories/toast.stories.js
+++ b/components/toast/stories/toast.stories.js
@@ -5,8 +5,6 @@ import { ToastGroup } from "./toast.test.js";
 
 /**
  * Toasts display brief, temporary notifications. They are noticeable but do not disrupt the user experience and do not require an action to be taken.
- * 
- * They must include text to communicate a message. Write the text as concisely as possible while still being clear about what has happened or is happening. View the toast [content standards](https://spectrum.adobe.com/page/toast/#Content-standards) for writing guidelines.
  */
 export default {
 	title: "Toast",

--- a/components/toast/stories/toast.stories.js
+++ b/components/toast/stories/toast.stories.js
@@ -110,7 +110,7 @@ Positive.parameters = {
 };
 
 /**
- * They must include text to communicate a message. Write the text as concisely as possible while still being clear about what has happened or is happening.
+ * Toasts must include text to communicate a message. Write the text as concisely as possible while still being clear about what has happened or is happening.
  * 
  * Writing for toasts depends on the nature of the message, whether it’s communicating confirmation, information, or an error. For all kinds of toasts, keep the text to fewer than 2 lines in English, since it will become longer when localized. View the [toast content standards](https://spectrum.adobe.com/page/toast/#Content-standards) for writing guidelines.
 */

--- a/components/toast/stories/toast.test.js
+++ b/components/toast/stories/toast.test.js
@@ -36,6 +36,12 @@ export const ToastGroup = Variants({
 			variant: "info",
 			message: "A new version of Lightroom Classic is now available. Use the Update button below to start using the new version.",
 			inlineButtonLabel: ""
-		}	
+		},
+		{
+			testHeading: "Short message, no required action",
+			variant: "info",
+			message: "The toast is done.",
+			inlineButtonLabel: ""
+		},
 	]
 });

--- a/components/toast/stories/toast.test.js
+++ b/components/toast/stories/toast.test.js
@@ -24,6 +24,18 @@ export const ToastGroup = Variants({
 			variant: "positive",
 			message: "Copied to clipboard",
 			inlineButtonLabel: "Eject",
-		}
+		},
+		{
+			testHeading: "Wrapping with button",
+			variant: "info",
+			message: "A new version of Lightroom Classic is now available. Use the Update button below to start using the new version.",
+			inlineButtonLabel: "Update"
+		},
+		{
+			testHeading: "Wrapping without button",
+			variant: "info",
+			message: "A new version of Lightroom Classic is now available. Use the Update button below to start using the new version.",
+			inlineButtonLabel: ""
+		}	
 	]
 });


### PR DESCRIPTION
## Description

- Added stories: Action & Wrapping
- Added descriptions for neutral, negative, and informative variants
- Added control for variants
- Added test case for wrapping story 

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [ ] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
