### PR TITLE
chore: fix logic in file-diff github action

### DIFF
--- a/.github/actions/file-diff/index.js
+++ b/.github/actions/file-diff/index.js
@@ -138,13 +138,9 @@ async function run() {
 					 *
 					 * Else: report that there is no change
 					 */
-					if (
-						(existsSync(join(basePath, filePath, name)) && !existsSync(join(headPath, filePath, name)))
-					) {
+					if (isRemoved(headMainSize, baseMainSize)) {
 						data.push("🚨 deleted, moved, or renamed");
-					} else if (
-						(existsSync(join(headPath, filePath, name)) && !existsSync(join(basePath, filePath, name)))
-					) {
+					} else if (isNew(headMainSize, baseMainSize)) {
 						data.push("🎉 new");
 					} else if (
 						((Math.abs(difference(headMainSize, baseMainSize))) / 1000) >= 0.001


### PR DESCRIPTION
## Description

File diff GitHub Action has a small logic error when determining if a package has been removed or added. This PR fixes that logic error.

- Updates logic to the existing `isRemoved` and `isNew` functions which are being used elsewhere for the same determination

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [x] The S2 foundations branch is using this update and the [Diff table](https://github.com/adobe/spectrum-css/pull/2786#issuecomment-2129806824) is correct now

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] ✨ This pull request is ready to merge. ✨
