### PR TITLE
fix: blank field group docs and read-only radio alignment

### DIFF
--- a/.changeset/three-months-provide.md
+++ b/.changeset/three-months-provide.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/radio": minor
+---
+
+Fixes an issue with the alignment of a read-only radio's label element within field group and flex layouts.

--- a/components/fieldgroup/stories/fieldgroup.stories.js
+++ b/components/fieldgroup/stories/fieldgroup.stories.js
@@ -62,6 +62,27 @@ export default {
 		inputType: "radio",
 		labelPosition: "top",
 		layout: "vertical",
+		label: "Select one of the following options:",
+		items: [
+			(passthroughs, context) => Radio({
+				...passthroughs,
+				id: "apple",
+				label: "Apples are best",
+				customClasses: ["spectrum-FieldGroup-item"],
+			}, context),
+			(passthroughs, context) => Radio({
+				...passthroughs,
+				id: "banana",
+				label: "Bananas forever",
+				customClasses: ["spectrum-FieldGroup-item"],
+			}, context),
+			(passthroughs, context) => Radio({
+				...passthroughs,
+				id: "pear",
+				label: "Pears or bust",
+				customClasses: ["spectrum-FieldGroup-item"],
+			}, context),
+		],
 		isInvalid: false,
 		isRequired: false,
 		isReadOnly: false,
@@ -78,29 +99,7 @@ export default {
 };
 
 export const Default = FieldGroupSet.bind({});
-Default.args = {
-	label: "Select one of the following options:",
-	items: [
-		(passthroughs, context) => Radio({
-			...passthroughs,
-			id: "apple",
-			label: "Apples are best",
-			customClasses: ["spectrum-FieldGroup-item"],
-		}, context),
-		(passthroughs, context) => Radio({
-			...passthroughs,
-			id: "banana",
-			label: "Bananas forever",
-			customClasses: ["spectrum-FieldGroup-item"],
-		}, context),
-		(passthroughs, context) => Radio({
-			...passthroughs,
-			id: "pear",
-			label: "Pears or bust",
-			customClasses: ["spectrum-FieldGroup-item"],
-		}, context),
-	],
-};
+Default.args = {};
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = FieldGroupSet.bind({});

--- a/components/radio/index.css
+++ b/components/radio/index.css
@@ -253,10 +253,10 @@
 		}
 
 		.spectrum-Radio-label,
-    /* ensure disabled readonly has normal text color */
-    & .spectrum-Radio-input:disabled ~ .spectrum-Radio-label,
-    & .spectrum-Radio-input:checked:disabled ~ .spectrum-Radio-label {
-			margin-inline-start: auto;
+		/* ensure disabled readonly has normal text color */
+		& .spectrum-Radio-input:disabled ~ .spectrum-Radio-label,
+		& .spectrum-Radio-input:checked:disabled ~ .spectrum-Radio-label {
+			margin-inline-start: 0;
 			color: var(--highcontrast-radio-neutral-content-color, var(--mod-radio-neutral-content-color, var(--spectrum-radio-neutral-content-color)));
 		}
 	}


### PR DESCRIPTION
## Description

Includes two small fixes:

1. The field group "Docs" page was blank. It was missing the default arg value for `items` in its Template, causing nothing to render within the field group markup.
2. The read-only radios on the field group Docs page were displaying on the completely wrong side. This issue also existed on the Chromatic template for radio. This was because of `margin-inline-start` being set to `auto` instead of `0` for read-only. In a flex container, `auto` on the margin of a flex item will automatically extend its specified margin to occupy the extra space.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [x] Stories on the field group "Docs" page in Storybook are now appearing @marissahuysentruyt 
- [x] Read-only radios in field group are no longer aligned to the right. Fix is visible in VRT changes for field group. @marissahuysentruyt 

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

**Read-only bug. Previous behavior:**
![Screenshot 2024-09-24 at 4 26 20 PM](https://github.com/user-attachments/assets/d3623f79-cb3a-4b1d-81c8-f3506beaf5cd)

![Screenshot 2024-09-24 at 4 25 33 PM](https://github.com/user-attachments/assets/160b6af0-ded4-4b2b-ba0b-d5275c8838ca)

**Fixed behavior:**
![Screenshot 2024-09-24 at 4 45 58 PM](https://github.com/user-attachments/assets/66a83c6e-a084-41df-9105-96950309e866)

![Screenshot 2024-09-24 at 4 47 28 PM](https://github.com/user-attachments/assets/3afc4f5c-25fb-4747-9a78-a4ab98ecd514)


## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [ ] ✨ This pull request is ready to merge. ✨
