### PR TITLE
docs(fieldlabel/form): migrates docs to storybook

### DIFF
--- a/components/fieldlabel/stories/fieldlabel.stories.js
+++ b/components/fieldlabel/stories/fieldlabel.stories.js
@@ -1,7 +1,9 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isRequired, size } from "@spectrum-css/preview/types";
+import { Sizes } from "@spectrum-css/preview/decorators";
 import pkgJson from "../package.json";
 import { FieldLabelGroup } from "./fieldlabel.test.js";
+import { Template } from "./template.js";
 
 /**
  * The field label component is used along with inputs to display a label for that input.
@@ -39,15 +41,91 @@ export default {
 		alignment: "left",
 		isDisabled: false,
 		isRequired: false,
+		label: "Label",
 	},
 	parameters: {
 		packageJson: pkgJson,
 	},
 };
 
+/**
+ * By default, a field label has left-aligned text, and is a medium size. For field label text, use a short, catch-all description (1-3 words) of the information that a user needs to provide.
+ * 
+ * The default position of a field label is above an input, but it can alternatively be positioned to the side. Visit the [form component](/docs/components-form--docs) to see examples of the field label with an input.
+ 
+ */
 export const Default = FieldLabelGroup.bind({});
-Default.args = {
+Default.args = {};
+
+// ********* DOCS ONLY ********* //
+/**
+ * Field labels come in four different sizes: small, medium, large, and extra-large. The medium size is the default and most frequently used option with medium-sized inputs. Use the other sizes sparingly; they should be used to create a hierarchy of importance within the page. 
+ * 
+ * Both small and medium field labels have the same font size, but different paddings when used as side labels.
+ */
+export const Sizing = (args, context) => Sizes({
+	Template,
+	withBorder: false,
+	withHeading: false,
+	...args,
+}, context);
+Sizing.tags = ["!dev"];
+Sizing.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+/**
+ * To render right-aligned field label text, apply the `.spectrum-FieldLabel--right` class to the field label.
+ * 
+ */
+export const RightAligned = Template.bind({});
+RightAligned.args = {
 	label: "Label",
+	alignment: "right",
+	customStyles: {
+		width: "72px",
+	},
+};
+RightAligned.tags = ["!dev"];
+RightAligned.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+RightAligned.storyName = "Right-aligned";
+
+/**
+ * Field labels for required inputs can be marked with an asterisk at the end of the label. Optional inputs would then be understood to not have the asterisk. If using the asterisk icon, do not leave any space between the label text and the start of the `<svg>` element in the markup. Extra space should not be added in addition to the inline margin.
+ */
+export const Required = Template.bind({});
+Required.args = {
+	isRequired: true,
+};
+Required.tags = ["!dev"];
+Required.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+/**
+ * When the field label is too long for the available horizontal space, it wraps to form another line.
+ */
+export const WrappingAndRequired = Template.bind({});
+WrappingAndRequired.args = {
+	label: "Label example with longer text that will wrap to the next line. And with an asterisk that marks it as required.",
+	isRequired: true,
+	customStyles: { width: "200px" },
+};
+WrappingAndRequired.tags = ["!dev"];
+WrappingAndRequired.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+WrappingAndRequired.storyName = "Wrapping and required";
+
+export const Disabled = Template.bind({});
+Disabled.args = {
+	isDisabled: true,
+};
+Disabled.tags = ["!dev"];
+Disabled.parameters = {
+	chromatic: { disableSnapshot: true },
 };
 
 // ********* VRT ONLY ********* //

--- a/components/fieldlabel/stories/fieldlabel.stories.js
+++ b/components/fieldlabel/stories/fieldlabel.stories.js
@@ -94,6 +94,8 @@ RightAligned.storyName = "Right-aligned";
 
 /**
  * Field labels for required inputs can be marked with an asterisk at the end of the label. Optional inputs would then be understood to not have the asterisk. If using the asterisk icon, do not leave any space between the label text and the start of the `<svg>` element in the markup. Extra space should not be added in addition to the inline margin.
+ * 
+ * The field label for a required field can display either the text “(required)”, or an asterisk.
  */
 export const Required = Template.bind({});
 Required.args = {

--- a/components/fieldlabel/stories/fieldlabel.test.js
+++ b/components/fieldlabel/stories/fieldlabel.test.js
@@ -5,11 +5,7 @@ export const FieldLabelGroup = Variants({
 	Template,
 	testData: [
 		{
-			testHeading: "Default"
-		},
-		{
-			testHeading: "Right alignment",
-			alignment: "right",
+			testHeading: "Default",
 			customStyles: { width: "200px" },
 		},
 		{
@@ -20,7 +16,7 @@ export const FieldLabelGroup = Variants({
 		{
 			testHeading: "Wrapped",
 			withStates: false,
-			label: "Label example with longer text that will wrap to the next line. And with an asterisk that marks it as required.",
+			label: "Label example with longer text that will wrap to the next line. Sometimes there is an asterisk that marks it as required.",
 			customStyles: { width: "200px" },
 		},
 	],

--- a/components/fieldlabel/stories/fieldlabel.test.js
+++ b/components/fieldlabel/stories/fieldlabel.test.js
@@ -15,7 +15,6 @@ export const FieldLabelGroup = Variants({
 		},
 		{
 			testHeading: "Wrapped",
-			withStates: false,
 			label: "Label example with longer text that will wrap to the next line. Sometimes there is an asterisk that marks it as required.",
 			customStyles: { width: "200px" },
 		},
@@ -23,6 +22,7 @@ export const FieldLabelGroup = Variants({
 	stateData: [
 		{
 			testHeading: "Disabled",
+			ignore: ["Wrapped"],
 			isDisabled: true,
 			customStyles: { width: "200px" },
 		},

--- a/components/fieldlabel/stories/form.stories.js
+++ b/components/fieldlabel/stories/form.stories.js
@@ -42,6 +42,66 @@ export default {
 	args: {
 		rootClass: "spectrum-Form",
 		labelPosition: "top",
+		items: [
+			{
+				label: "Company title",
+				id: "form-example-company",
+				content: [
+					(passthroughs, context) => TextField({
+						...passthroughs,
+						multiline: true,
+						name: "field",
+					}, context),
+				],
+			}, {
+				label: "Email address",
+				id: "form-example-email",
+				content: [
+					(passthroughs, context) => TextField({
+						...passthroughs,
+						type: "email",
+						name: "email",
+					}, context),
+				],
+			}, {
+				label: "Country",
+				id: "form-example-country",
+				content: [
+					(passthroughs, context) => Picker({
+						...passthroughs,
+						placeholder: "Select a country",
+						name: "country",
+					}, context),
+				],
+			}, {
+				label: "Interest",
+				id: "form-example-interests",
+				content: [
+					(passthroughs, context) => Fieldgroup({
+						layout: "horizontal",
+						items: [
+							Checkbox({
+								...passthroughs,
+								label: "Kittens",
+								customClasses: ["spectrum-FieldGroup-item"],
+							}, context),
+							Checkbox({
+								...passthroughs,
+								label: "Puppies",
+								customClasses: ["spectrum-FieldGroup-item"],
+							}, context),]
+					}),
+				],
+			},{
+				label: "Age",
+				id: "form-example-amount",
+				content: [
+					(passthroughs, context) => Stepper({
+						...passthroughs,
+					}, context),
+				]
+			}
+		],
 	},
 	parameters: {
 		packageJson: pkgJson,
@@ -52,68 +112,7 @@ export default {
  * A stacked layout with the labels above the form fields. The class `.spectrum-Form--labelPosition` is applied to the form itself. You do not need to apply a specific class to the field label because `.spectrum-FieldLabel--left` is applied to each to each [field label](/docs/components-field-label--docs) by default.
  */
 export const Default = FormGroup.bind({});
-Default.args = {
-	items: [
-		{
-			label: "Company title",
-			id: "form-example-company",
-			content: [
-				(passthroughs, context) => TextField({
-					...passthroughs,
-					multiline: true,
-					name: "field",
-				}, context),
-			],
-		}, {
-			label: "Email address",
-			id: "form-example-email",
-			content: [
-				(passthroughs, context) => TextField({
-					...passthroughs,
-					type: "email",
-					name: "email",
-				}, context),
-			],
-		}, {
-			label: "Country",
-			id: "form-example-country",
-			content: [
-				(passthroughs, context) => Picker({
-					...passthroughs,
-					placeholder: "Select a country",
-					name: "country",
-				}, context),
-			],
-		}, {
-			label: "Interest",
-			id: "form-example-interests",
-			content: [
-				(passthroughs, context) => Fieldgroup({
-					layout: "horizontal",
-					items: [
-						Checkbox({
-							...passthroughs,
-							label: "Kittens",
-							customClasses: ["spectrum-FieldGroup-item"],
-						}, context),
-						Checkbox({
-							...passthroughs,
-							label: "Puppies",
-							customClasses: ["spectrum-FieldGroup-item"],
-						}, context),]
-				}),
-			],
-		},{
-			label: "Age",
-			id: "form-example-amount",
-			content: [
-				(passthroughs, context) => Stepper({
-					...passthroughs,
-				}, context),
-			]
-		}
-	],
-};
+Default.args = {};
 
 /**
  *  A two column layout with left-aligned label text.

--- a/components/fieldlabel/stories/form.stories.js
+++ b/components/fieldlabel/stories/form.stories.js
@@ -1,36 +1,56 @@
+import { Template as Checkbox } from "@spectrum-css/checkbox/stories/template.js";
+import { Template as Fieldgroup } from "@spectrum-css/fieldgroup/stories/template.js";
 import { Template as Picker } from "@spectrum-css/picker/stories/template.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { Template as Stepper } from "@spectrum-css/stepper/stories/template.js";
 import { Template as TextField } from "@spectrum-css/textfield/stories/template.js";
+import { Template } from "./form.template.js";
 import pkgJson from "../package.json";
 import { FormGroup } from "./form.test.js";
 
 /**
- * The form component is used for aligning multiple inputs and field groups within a form.
+ * The form component is used for aligning multiple inputs and field groups within a form. It provides structure and spacing for your form fields.
  */
 export default {
 	title: "Form",
 	component: "Form",
 	argTypes: {
-		labelsAbove: {
-			name: "Labels above",
-			type: { name: "boolean" },
+		labelPosition: {
+			name: "Label position",
+			description: "Position of the field label in relation to the input.",
+			type: { name: "string" },
 			table: {
-				type: { summary: "boolean" },
+				type: { summary: "string" },
 				category: "Component",
 			},
-			control: "boolean",
+			control: "select",
+			options: ["top", "side"],
 		},
+		fieldLabelAlignment: {
+			name: "Field label alignment",
+			type: { name: "string" },
+			table: {
+				type: { summary: "string" },
+				category: "Component",
+			},
+			control: "select",
+			options: ["left", "right"],
+			if: { arg: "labelPosition", eq: "side" },
+		},
+		items: { table: { disable: true } },
 	},
 	args: {
 		rootClass: "spectrum-Form",
-		labelsAbove: false,
+		labelPosition: "top",
 	},
 	parameters: {
 		packageJson: pkgJson,
 	},
 };
 
+/**
+ * A stacked layout with the labels above the form fields. The class `.spectrum-Form--labelPosition` is applied to the form itself. You do not need to apply a specific class to the field label because `.spectrum-FieldLabel--left` is applied to each to each [field label](/docs/components-field-label--docs) by default.
+ */
 export const Default = FormGroup.bind({});
 Default.args = {
 	items: [
@@ -65,7 +85,26 @@ Default.args = {
 				}, context),
 			],
 		}, {
-			label: "Amount",
+			label: "Interest",
+			id: "form-example-interests",
+			content: [
+				(passthroughs, context) => Fieldgroup({
+					layout: "horizontal",
+					items: [
+						Checkbox({
+							...passthroughs,
+							label: "Kittens",
+							customClasses: ["spectrum-FieldGroup-item"],
+						}, context),
+						Checkbox({
+							...passthroughs,
+							label: "Puppies",
+							customClasses: ["spectrum-FieldGroup-item"],
+						}, context),]
+				}),
+			],
+		},{
+			label: "Age",
 			id: "form-example-amount",
 			content: [
 				(passthroughs, context) => Stepper({
@@ -75,6 +114,35 @@ Default.args = {
 		}
 	],
 };
+
+/**
+ *  A two column layout with left-aligned label text.
+ */
+export const LeftAlignedSideLabels = Template.bind({});
+LeftAlignedSideLabels.args = {
+	...Default.args,
+	labelPosition: "side",
+};
+LeftAlignedSideLabels.tags = ["!dev"];
+LeftAlignedSideLabels.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+LeftAlignedSideLabels.storyName = "Left-aligned side labels";
+
+/**
+ *  A two column layout with right-aligned label text. `.spectrum-FieldLabel--right` is applied to each to each [field label](/docs/components-field-label--docs).
+ */
+export const RightAlignedSideLabels = Template.bind({});
+RightAlignedSideLabels.args = {
+	...Default.args,
+	labelPosition: "side",
+	fieldLabelAlignment: "right",
+};
+RightAlignedSideLabels.tags = ["!dev"];
+RightAlignedSideLabels.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+RightAlignedSideLabels.storyName = "Right-aligned side labels";
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = FormGroup.bind({});

--- a/components/fieldlabel/stories/form.template.js
+++ b/components/fieldlabel/stories/form.template.js
@@ -11,7 +11,8 @@ import "../index.css";
 
 export const Template = ({
 	rootClass = "spectrum-Form",
-	labelsAbove = false,
+	labelPosition = "top",
+	fieldLabelAlignment = "left",
 	customClasses = [],
 	customStyles = {},
 	id = getRandomId("form"),
@@ -20,7 +21,7 @@ export const Template = ({
     <form
         class=${classMap({
             [rootClass]: true,
-            [`${rootClass}--labelsAbove`]: labelsAbove,
+            [`${rootClass}--labelsAbove`]: labelPosition === "top",
             ...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
         })}
         id=${ifDefined(id)}
@@ -36,7 +37,7 @@ export const Template = ({
                     ${when(label, () => FieldLabel({
                         label,
                         forInput: item.id,
-                        alignment: labelsAbove ? undefined : "left",
+                        alignment: labelPosition === "side" ? fieldLabelAlignment : undefined,
                     }, context))}
                     <div class=${classMap({
                         [`${rootClass}-itemField`]: true,

--- a/components/fieldlabel/stories/form.test.js
+++ b/components/fieldlabel/stories/form.test.js
@@ -4,10 +4,17 @@ import { Template } from "./form.template";
 export const FormGroup = Variants({
 	Template,
 	testData: [
-		{},
 		{
-			testHeading: "Labels above",
-			labelsAbove: true,
+			testHeading: "Default",
+		},
+		{
+			testHeading: "Side labels with left-aligned text",
+			labelPosition: "side",
+		},
+		{
+			testHeading: "Side labels with right-aligned text",
+			labelPosition: "side",
+			fieldLabelAlignment: "right",
 		}
 	],
 });


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

This continues the effort to migrate documentation from the CSS static docs site into Storybook, with a focus on `fieldlabel` and `form`. 
- In each component's case, missing stories and corresponding documentation were added, along with any relevant S2 features from https://github.com/adobe/spectrum-css/pull/2569.
- Test coverage was expanded for `form`, and "cleaned up" for `fieldlabel`.
- `form` also now has a `fieldLabelAlignment` control, to better showcase left- or right-aligned field labels.

_This PR has no CSS changes, so no changeset is needed._

### Jira/Specs
[CSS-932](https://jira.corp.adobe.com/browse/CSS-932)

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

- [x]  Pull down the branch to run locally or use [the deploy preview](https://pr-3165--spectrum-css.netlify.app/preview/?path=/docs/components-field-label--docs)
- [x] Verify all stories and documentation from [the static docs site](https://opensource.adobe.com/spectrum-css/fieldlabel.html) are represented on the [Storybook field label docs page](https://pr-3165--spectrum-css.netlify.app/preview/?path=/docs/components-field-label--docs)
- [x] Verify [the Chromatic testing grid](https://pr-3165--spectrum-css.netlify.app/preview/?path=/story/components-field-label--default&globals=testingPreview:!true) for field label also captures all variants
- [x] Verify all stories and documentation from [the static docs site](https://opensource.adobe.com/spectrum-css/form.html) are represented on the [Storybook form docs page](https://pr-3165--spectrum-css.netlify.app/preview/?path=/docs/components-form--docs)
- [x] Verify [the Chromatic testing grid](https://pr-3165--spectrum-css.netlify.app/preview/?path=/story/components-form--default&globals=testingPreview:!true) for form covers all new variants
- [x] The newly added documentation has been proofread and makes sense.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
