### PR TITLE
chore(storybook): support static color settings in testing grid

### DIFF
--- a/.storybook/assets/base.css
+++ b/.storybook/assets/base.css
@@ -40,7 +40,6 @@ svg:has(symbol):not(:has(use)) {
 
 /* --- DOCS STYLES --- */
 .docs-story > *:first-child {
-	background-color: var(--spectrum-background-layer-1-color);
 	overflow: hidden;
 }
 

--- a/.storybook/decorators/helpers.js
+++ b/.storybook/decorators/helpers.js
@@ -50,22 +50,28 @@ export function fetchStyleContainer(id, container) {
  * @type (id: string, isDocs: boolean = false) => HTMLElement[]
  * @description Fetches the style container for the given ID or creates a new one
  **/
-export function fetchContainers(id, isDocs = false) {
-    if (!id) return [];
-    const { document } = global;
+export function fetchContainers(id, isDocs = false, isTesting = false) {
+	if (!id) return [];
+	const { document } = global;
 
-    let containers = [document.body];
+	let containers = [];
 
-    // Storybook IDs used to target the container element for the docs pages
-    const roots = [
-        ...document.querySelectorAll(`#story--${id}`),
-        ...document.querySelectorAll(`#story--${id}--primary`)
-    ];
+	// Storybook IDs used to target the container element for the docs pages
+	const roots = [
+		...document.querySelectorAll(`#story--${id}`),
+		...document.querySelectorAll(`#story--${id}--primary`)
+	];
 
-    // viewMode is either "docs" or "story"
-    if (isDocs && roots.length > 0) {
-        containers = roots.map(root => root.closest(".docs-story") ?? root);
-    }
+	// viewMode is either "docs" or "story"
+	if (isDocs && roots.length > 0) {
+		containers = roots.map(root => root.closest(".docs-story") ?? root);
+	}
+	else if (isTesting) {
+		// Only capture the top-level container for testing previews
+		containers.push(...document.querySelectorAll("[data-inner-container]"));
+	}
 
-    return containers;
+	if (containers.length === 0) containers = [document.body];
+
+	return containers;
 }

--- a/.storybook/decorators/utilities.js
+++ b/.storybook/decorators/utilities.js
@@ -209,6 +209,8 @@ export const ArgGrid = ({
 	withWrapperBorder = true,
 	...args
 } = {}, context = {}) => {
+	const isDocs = context.viewMode === "docs";
+
 	if (typeof argKey === "undefined") {
 		console.warn("ArgGrid: argKey is required to render the grid.");
 		return nothing;
@@ -228,6 +230,11 @@ export const ArgGrid = ({
 	if (typeof options === "undefined" || !options.length) {
 		console.warn(`ArgGrid: No options found for ${argKey}.`);
 		return nothing;
+	}
+
+	// If no heading and this is a docs view, skip the border
+	if (!heading && isDocs) {
+		withWrapperBorder = false;
 	}
 
 	return Container({
@@ -323,17 +330,26 @@ export const Variants = ({
 		TestTemplate = Template;
 	}
 
+	const staticColor = {
+		black: "var(--spectrum-docs-static-black-background-color)",
+		white: "var(--spectrum-docs-static-white-background-color)",
+	};
+
 	return (args, context) => {
 		// Fetch any docs configurations from the context to use for VRT
-		const { parameters = {} } = context;
+		const { argTypes = {}, parameters = {} } = context;
 
 		const height = parameters?.docs?.story?.height;
 		const width = parameters?.docs?.story?.width;
+
+		// Check if the staticColor property exists in this story
+		const hasStaticColor = Object.keys(argTypes).includes("staticColor");
 
 		return html`
 			<!-- Simple, clean template preview for non-testing grid views -->
 			<div
 				style=${styleMap({
+					backgroundColor: hasStaticColor && staticColor[args.staticColor],
 					"padding": "12px",
 					"min-block-size": typeof height === "number" ? `${height}px` : height,
 					"min-inline-size": typeof width === "number" ? `${width}px` : width,
@@ -347,6 +363,7 @@ export const Variants = ({
 
 			<!-- Start testing grid markup -->
 			<div
+				data-testing-preview
 				style=${styleMap({
 					"padding": "24px",
 					"display": window.isChromatic() ? "flex" : "none",
@@ -391,7 +408,14 @@ export const Variants = ({
 							testHeading = "Default";
 						}
 
+						// Check if the staticColor property is being used in this story
+						let backgroundColor;
+						if (hasStaticColor && data.staticColor) {
+							backgroundColor = staticColor[data.staticColor];
+						}
+
 						const combinedStyles = {
+							backgroundColor,
 							...wrapperStyles,
 							...testWrapperStyles,
 						};
@@ -405,7 +429,7 @@ export const Variants = ({
 								...containerStyles,
 							},
 							// if the test has multiple states, pass the wrapper styles to that container, otherwise use it here
-							wrapperStyles: withStates ? {} : combinedStyles,
+							wrapperStyles: withStates ? { backgroundColor } : combinedStyles,
 							content: html`
 								${when(withStates, () =>
 									States({

--- a/components/actionbutton/stories/actionbutton.stories.js
+++ b/components/actionbutton/stories/actionbutton.stories.js
@@ -237,30 +237,6 @@ Sizing.parameters = {
 
 
 // ********* VRT ONLY ********* //
-export const StaticBlack = ActionButtonGroup.bind({});
-StaticBlack.tags = ["!autodocs", "!dev"];
-StaticBlack.args = {
-	...Default.args,
-	staticColor: "black",
-};
-StaticBlack.parameters = {
-	chromatic: {
-		modes: disableDefaultModes
-	},
-};
-
-export const StaticWhite = ActionButtonGroup.bind({});
-StaticWhite.tags = ["!autodocs", "!dev"];
-StaticWhite.args = {
-	...Default.args,
-	staticColor: "white",
-};
-StaticWhite.parameters = {
-	chromatic: {
-		modes: disableDefaultModes
-	},
-};
-
 export const WithForcedColors = ActionButtonGroup.bind({});
 WithForcedColors.args = Default.args;
 WithForcedColors.tags = ["!autodocs", "!dev"];

--- a/components/actionbutton/stories/actionbutton.test.js
+++ b/components/actionbutton/stories/actionbutton.test.js
@@ -4,24 +4,27 @@ import { Template } from "./template.js";
 
 export const ActionButtons = (args, context) => {
 	return html`
-		${Template(args, context)}
-		${Template({
-			...args,
-		}, context)}
-		${Template({
-			...args,
-			hideLabel: true,
-		}, context)}
-		${Template({
-			...args,
-			hasPopup: "true",
-			hideLabel: true,
-		}, context)}
-		${Template({
-			...args,
-			iconName: undefined,
-			hasPopup: "true",
-		}, context)}
+		<div style="display: flex; column-gap: 13px; row-gap: 24px;">
+			${Template(args, context)}
+			${Template({
+				...args,
+				iconName: undefined,
+			}, context)}
+			${Template({
+				...args,
+				hideLabel: true,
+			}, context)}
+			${Template({
+				...args,
+				hasPopup: "true",
+				hideLabel: true,
+			}, context)}
+			${Template({
+				...args,
+				iconName: undefined,
+				hasPopup: "true",
+			}, context)}
+		</div>
 	`;
 };
 
@@ -63,6 +66,14 @@ export const ActionButtonGroup = Variants({
 				maxInlineSize: "100px"
 			},
 			withStates: false,
+		},
+		{
+			testHeading: "Static black",
+			staticColor: "black",
+		},
+		{
+			testHeading: "Static white",
+			staticColor: "white",
 		},
 	],
 	stateData: [{

--- a/components/actionbutton/stories/template.js
+++ b/components/actionbutton/stories/template.js
@@ -129,9 +129,7 @@ export const Template = ({
 	`;
 };
 
-export const ActionButtonsWithIconOptions = ({
-	...args
-}, context ) => Container({
+export const ActionButtonsWithIconOptions = (args, context) => Container({
 	withBorder: false,
 	direction: "row",
 	wrapperStyles: {
@@ -141,46 +139,46 @@ export const ActionButtonsWithIconOptions = ({
 		${Template({
 			...args,
 			iconName: undefined,
-		}, context )}
+		}, context)}
 		${Template({
 			...args,
-		}, context )}
+		}, context)}
 		${Template({
 			...args,
 			hideLabel: true,
-		}, context )}
-	${Template({
+		}, context)}
+		${Template({
 			...args,
 			hideLabel: true,
 			hasPopup: "true",
-		}, context )}
-	${Template({
+		}, context)}
+		${Template({
 			...args,
 			iconName: undefined,
 			hasPopup: "true",
-		}, context )}`
+		}, context)}
+	`
 });
 
-export const IconOnlyOption = ({
-	...args
-}, context ) => Container({
+export const IconOnlyOption = (args, context) => Container({
 	withBorder: false,
 	direction: "row",
 	wrapperStyles: {
 		columnGap: "12px",
 	},
 	content: html`
-	${Template({
+		${Template({
 			...args,
 			hideLabel: true,
 			hasPopup: "true",
-		}, context )}
-	${Template({
+		}, context)}
+		${Template({
 			...args,
 			hideLabel: true,
 			isQuiet: true,
 			hasPopup: "true",
-		}, context )}`
+		}, context)}
+	`
 });
 
 export const TreatmentTemplate = (args, context) => Container({
@@ -190,11 +188,11 @@ export const TreatmentTemplate = (args, context) => Container({
 		rowGap: "12px",
 	},
 	content: html`${[
-		{ isSelected: false, isDisabled: false, heading: "Default" }, 
+		{ isSelected: false, isDisabled: false, heading: "Default" },
 		{ isSelected: true, isDisabled: false, heading: "Selected" },
 		{ isSelected: false, isDisabled: true, heading: "Disabled" },
 		{ isSelected: true, isDisabled: true, heading: "Selected + disabled" }
-	].map(({ isSelected, isDisabled, heading }) => Container({ 
+	].map(({ isSelected, isDisabled, heading }) => Container({
 		withBorder: false,
 		heading: heading,
 		content: ActionButtonsWithIconOptions({

--- a/components/actiongroup/stories/actiongroup.test.js
+++ b/components/actiongroup/stories/actiongroup.test.js
@@ -122,6 +122,14 @@ export const ActionGroups = Variants({
 				},
 			]
 		},
+		{
+			testHeading: "Static black",
+			staticColor: "black",
+		},
+		{
+			testHeading: "Static white",
+			staticColor: "white",
+		},
 	],
 	stateData: [
 		{

--- a/components/badge/stories/badge.test.js
+++ b/components/badge/stories/badge.test.js
@@ -5,9 +5,11 @@ import { Template } from "./template.js";
 
 const Badges = (args, context) => {
 	return html`
-		${Template(args, context)}
-		${Template({ ...args, iconName: undefined }, context)}
-		${Template({ ...args, label: undefined }, context)}
+		<div style="display: flex; column-gap: 13px; row-gap: 24px;">
+			${Template(args, context)}
+			${Template({ ...args, iconName: undefined }, context)}
+			${Template({ ...args, label: undefined }, context)}
+		</div>
 	`;
 };
 

--- a/components/button/stories/button.stories.js
+++ b/components/button/stories/button.stories.js
@@ -93,28 +93,6 @@ export const Default = ButtonGroups.bind({});
 Default.args = {};
 
 // ********* VRT ONLY ********* //
-export const StaticWhite = ButtonGroups.bind({});
-StaticWhite.tags = ["!autodocs", "!dev"];
-StaticWhite.args = {
-	staticColor: "white",
-};
-StaticWhite.parameters = {
-	chromatic: {
-		modes: disableDefaultModes
-	},
-};
-
-export const StaticBlack = ButtonGroups.bind({});
-StaticBlack.tags = ["!autodocs", "!dev"];
-StaticBlack.args = {
-	staticColor: "black",
-};
-StaticBlack.parameters = {
-	chromatic: {
-		modes: disableDefaultModes
-	},
-};
-
 export const WithForcedColors = ButtonGroups.bind({});
 WithForcedColors.args = Default.args;
 WithForcedColors.tags = ["!autodocs", "!dev"];
@@ -267,7 +245,7 @@ Pending.parameters = {
 };
 
 /**
- * A button in a disabled state shows that an action exists, but is not available in that circumstance. 
+ * A button in a disabled state shows that an action exists, but is not available in that circumstance.
  * This state can be used to maintain layout continuity and to communicate that an action may become
  * available later.
  */
@@ -282,7 +260,7 @@ Disabled.parameters = {
 };
 
 /**
- * When the button text is too long for the horizontal space available, it wraps to form another line. 
+ * When the button text is too long for the horizontal space available, it wraps to form another line.
  * When there is no icon present, the text is aligned center. When there is an icon present, the text is
  * aligned `start` (left with a writing direction of left-to-right) and the icon remains vertically aligned
  * at the top.

--- a/components/button/stories/button.test.js
+++ b/components/button/stories/button.test.js
@@ -8,30 +8,23 @@ import { Template } from "./template.js";
  * Used as the base template for the stories.
  */
 const CustomButton = ({ iconName, iconSet, ...args }, context) => html`
-  ${Template(
-	{
-		...args,
-		iconName: undefined,
-	},
-	context
-  )}
-  ${Template(
-	{
-		...args,
-		iconName: iconName ?? "Edit",
-		iconSet: iconSet ?? "workflow",
-	},
-	context
-  )}
-  ${Template(
-	{
-		...args,
-		hideLabel: true,
-		iconName: iconName ?? "Edit",
-		iconSet: iconSet ?? "workflow",
-	},
-	context
-  )}
+	<div style="display: flex; column-gap: 13px; row-gap: 24px;">
+		${Template({
+			...args,
+			iconName: undefined,
+		}, context)}
+		${Template({
+			...args,
+			iconName: iconName ?? "Edit",
+			iconSet: iconSet ?? "workflow",
+		}, context)}
+		${Template({
+			...args,
+			hideLabel: true,
+			iconName: iconName ?? "Edit",
+			iconSet: iconSet ?? "workflow",
+		}, context)}
+	</div>
 `;
 
 export const ButtonGroups = Variants({
@@ -47,6 +40,14 @@ export const ButtonGroups = Variants({
 			variant,
 			treatment: "outline",
 		})),
+		{
+			testHeading: "Static black",
+			staticColor: "black",
+		},
+		{
+			testHeading: "Static white",
+			staticColor: "white",
+		},
 		{
 			testHeading: "Text wrapping with workflow icon",
 			customStyles: {
@@ -125,6 +126,7 @@ export const ButtonGroups = Variants({
 		{
 			testHeading: "Pending",
 			isPending: true,
+			ignore: ["Static black"],
 		},
 	],
 	sizeDirection: "row",

--- a/components/clearbutton/stories/clearbutton.stories.js
+++ b/components/clearbutton/stories/clearbutton.stories.js
@@ -108,9 +108,7 @@ OverBackground.args = {
 	staticColor: "white",
 };
 OverBackground.parameters = {
-	chromatic: {
-		modes: disableDefaultModes
-	},
+	chromatic: { disableSnapshot: true },
 };
 
 // ********* VRT ONLY ********* //

--- a/components/clearbutton/stories/clearbutton.test.js
+++ b/components/clearbutton/stories/clearbutton.test.js
@@ -13,6 +13,10 @@ export const ClearButtonGroup = Variants({
 			testHeading: "Quiet",
 			isQuiet: true,
 		},
+		{
+			testHeading: "Static white",
+			staticColor: "white",
+		},
 	],
 	stateData: [
 		{

--- a/components/clearbutton/stories/template.js
+++ b/components/clearbutton/stories/template.js
@@ -21,10 +21,14 @@ export const Template = ({
 		type="reset"
 		class=${classMap({
 			[rootClass]: true,
-			[`${rootClass}--size${size?.toUpperCase()}`]:
-				typeof size !== "undefined",
+			[`${rootClass}--size${size?.toUpperCase()}`]: typeof size !== "undefined",
 			[`${rootClass}--quiet`]: isQuiet,
 			[`${rootClass}--overBackground`]: staticColor === "white",
+			/**
+			 * There aren't styles for `--staticWhite` in clear button (yet)
+			 * but this makes it easier to support in the testing grid
+			 */
+			[`${rootClass}--staticWhite`]: staticColor === "white",
 			"is-disabled": isDisabled,
 			...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
 		})}

--- a/components/closebutton/stories/closebutton.test.js
+++ b/components/closebutton/stories/closebutton.test.js
@@ -9,6 +9,14 @@ export const CloseButtonGroup = Variants({
 		{
 			testHeading: "Default",
 		},
+		{
+			testHeading: "Static black",
+			staticColor: "black",
+		},
+		{
+			testHeading: "Static white",
+			staticColor: "white",
+		},
 	],
 	stateData: [
 		{

--- a/components/divider/stories/divider.stories.js
+++ b/components/divider/stories/divider.stories.js
@@ -1,6 +1,6 @@
+import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { size, staticColor } from "@spectrum-css/preview/types";
-import { Sizes } from "@spectrum-css/preview/decorators";
 import pkgJson from "../package.json";
 import { DividerGroup } from "./divider.test.js";
 import { Template } from "./template.js";
@@ -38,7 +38,7 @@ export default {
 };
 
 /**
- * By default, dividers are horizontal and should be used for separating content vertically. The small divider is the default size. 
+ * By default, dividers are horizontal and should be used for separating content vertically. The small divider is the default size.
  */
 export const Default = DividerGroup.bind({});
 Default.args = {};
@@ -91,9 +91,7 @@ StaticWhiteGroup.args = {
 	staticColor: "white",
 };
 StaticWhiteGroup.parameters = {
-	chromatic: {
-		modes: disableDefaultModes,
-	},
+	chromatic: { disableSnapshot: true },
 };
 
 export const StaticBlackGroup = Default.bind({});
@@ -103,9 +101,7 @@ StaticBlackGroup.args = {
 	staticColor: "black",
 };
 StaticBlackGroup.parameters = {
-	chromatic: {
-		modes: disableDefaultModes,
-	},
+	chromatic: { disableSnapshot: true },
 };
 
 // ********* VRT ONLY ********* //

--- a/components/divider/stories/divider.test.js
+++ b/components/divider/stories/divider.test.js
@@ -3,7 +3,6 @@ import { Template } from "./template.js";
 
 export const DividerGroup = Variants({
 	Template,
-	skipBorders: true,
 	testData: [
 		{
 			testHeading: "Default",
@@ -20,6 +19,14 @@ export const DividerGroup = Variants({
 			testHeading: "Vertical",
 			vertical: true,
 			minDimensionValues: true,
-		}
+		},
+		{
+			testHeading: "Static black",
+			staticColor: "black",
+		},
+		{
+			testHeading: "Static white",
+			staticColor: "white",
+		},
 	],
 });

--- a/components/link/stories/link.stories.js
+++ b/components/link/stories/link.stories.js
@@ -144,9 +144,7 @@ StaticWhite.args = {
 };
 StaticWhite.tags = ["!dev"];
 StaticWhite.parameters = {
-	chromatic: {
-		modes: disableDefaultModes,
-	},
+	chromatic: { disableSnapshot: true },
 };
 
 /**
@@ -160,9 +158,7 @@ StaticBlack.args = {
 };
 StaticBlack.tags = ["!dev"];
 StaticBlack.parameters = {
-	chromatic: {
-		modes: disableDefaultModes,
-	},
+	chromatic: { disableSnapshot: true },
 };
 
 export const QuietStaticWhite = Default.bind({});
@@ -174,9 +170,7 @@ QuietStaticWhite.args = {
 };
 QuietStaticWhite.tags = ["!dev"];
 QuietStaticWhite.parameters = {
-	chromatic: {
-		modes: disableDefaultModes,
-	},
+	chromatic: { disableSnapshot: true },
 };
 
 export const QuietStaticBlack = Default.bind({});
@@ -188,9 +182,7 @@ QuietStaticBlack.args = {
 };
 QuietStaticBlack.tags = ["!dev"];
 QuietStaticBlack.parameters = {
-	chromatic: {
-		modes: disableDefaultModes,
-	},
+	chromatic: { disableSnapshot: true },
 };
 
 // ********* VRT ONLY ********* //

--- a/components/link/stories/link.test.js
+++ b/components/link/stories/link.test.js
@@ -20,6 +20,24 @@ export const LinkGroup = Variants({
 			isQuiet: true,
 			variant: "secondary",
 		},
+		{
+			testHeading: "Static black",
+			staticColor: "black",
+		},
+		{
+			testHeading: "Static black (quiet)",
+			staticColor: "black",
+			isQuiet: true,
+		},
+		{
+			testHeading: "Static white",
+			staticColor: "white",
+		},
+		{
+			testHeading: "Static white (quiet)",
+			staticColor: "white",
+			isQuiet: true,
+		},
 	],
 	stateData: [
 		{

--- a/components/progressbar/stories/meter.stories.js
+++ b/components/progressbar/stories/meter.stories.js
@@ -98,16 +98,3 @@ WithForcedColors.parameters = {
 		modes: disableDefaultModes
 	},
 };
-
-export const StaticWhite = Default.bind({});
-StaticWhite.tags = ["!autodocs", "!dev"];
-StaticWhite.args = {
-	staticColor: "white",
-	label: "Loading your fonts, images, and icons",
-	value: 50,
-};
-StaticWhite.parameters = {
-	chromatic: {
-		modes: disableDefaultModes
-	},
-};

--- a/components/progressbar/stories/meter.test.js
+++ b/components/progressbar/stories/meter.test.js
@@ -3,7 +3,6 @@ import { Template } from "./meter.template.js";
 
 export const MeterGroup = Variants({
 	Template,
-	skipBorders: true,
 	testData: [
 		{
 			testHeading: "Default",
@@ -33,9 +32,13 @@ export const MeterGroup = Variants({
 		linear-gradient for any --mod-*-{fill} properties, set those custom properties in CSS.
 		*/
 		{
-			testHeading: "Gradient support", 
+			testHeading: "Gradient support",
 			trackFill: "linear-gradient(to right, hotpink, orange)",
 			progressBarFill: "linear-gradient(to left, teal, purple)",
-		}
+		},
+		{
+			testHeading: "Static white",
+			staticColor: "white",
+		},
 	],
 });

--- a/components/progressbar/stories/progressbar.stories.js
+++ b/components/progressbar/stories/progressbar.stories.js
@@ -1,15 +1,15 @@
-import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { Sizes } from "@spectrum-css/preview/decorators";
+import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isIndeterminate, size, staticColor } from "@spectrum-css/preview/types";
 import { ProgressBarGroup } from "./progressbar.test.js";
 import { IndeterminateGroup, Template } from "./template.js";
 
 /**
  * The progress bar component shows the progression of a system operation such as downloading, uploading, processing, etc. in a visual way.
- * 
+ *
  * ## Values
  * The value is the progress of a system operation (e.g., downloading, uploading, processing) within the progress bar’s range, from the min value to max value. By default, the min value starts at 0 and the max value is set to 100. These values are not applicable when a progress bar is indeterminate.
- * 
+ *
  * Progress bars can have a value label at the end of the track that gives detailed information about the progress (e.g. "60%" or "2 of 8"). This value label works alongside the label and should not be displayed if the label itself is not displayed. It should also not be displayed if the progress is indeterminate. Similar to the label, the value label is always placed above the track.
  */
 export default {
@@ -94,7 +94,7 @@ export default {
 
 /**
  * By default, progress bars are determinate and have a blue fill that shows the progress. This component should have a label at the start of the track that gives context about the operation being performed. In rare cases where context is sufficient and an accessibility expert has reviewed the design, the label could be undefined. These progress bars should still include an “aria-label” or “aria-labelledby” in HTML, depending on the context. The label is always placed above the track.
- * 
+ *
  * When the label is too long for the available horizontal space, it wraps to form another line. The value is always shown in full and never wraps or truncates.
  */
 export const Default = ProgressBarGroup.bind({});
@@ -109,7 +109,7 @@ export const Sizing = (args, context) => Sizes({
 	Template,
 	withBorder: false,
 	withHeading: false,
-	...args, 
+	...args,
 }, context);
 Sizing.args = Default.args;
 Sizing.tags = ["!dev"];
@@ -181,9 +181,7 @@ StaticWhite.args = {
 	value: 50,
 };
 StaticWhite.parameters = {
-	chromatic: {
-		modes: disableDefaultModes
-	},
+	chromatic: { disableSnapshot: true },
 };
 
 // ********* VRT ONLY ********* //

--- a/components/progressbar/stories/progressbar.test.js
+++ b/components/progressbar/stories/progressbar.test.js
@@ -32,6 +32,10 @@ export const ProgressBarGroup = Variants({
 			trackFill: "linear-gradient(to right, hotpink, orange)",
 			progressBarFill: "linear-gradient(to left, teal, purple)",
 		},
+		{
+			testHeading: "Static white",
+			staticColor: "white",
+		},
 	],
 	stateData: [
 		{

--- a/components/progresscircle/stories/progresscircle.stories.js
+++ b/components/progresscircle/stories/progresscircle.stories.js
@@ -44,18 +44,6 @@ WithForcedColors.parameters = {
 	},
 };
 
-export const StaticWhite = ProgressCircleGroup.bind({});
-StaticWhite.tags = ["!autodocs", "!dev"];
-StaticWhite.storyName = "Static white";
-StaticWhite.args = {
-	staticColor: "white",
-};
-StaticWhite.parameters = {
-	chromatic: {
-		modes: disableDefaultModes,
-	},
-};
-
 // ********* DOCS ONLY ********* //
 
 export const Sizing = (args, context) => Sizes({

--- a/components/progresscircle/stories/progresscircle.test.js
+++ b/components/progresscircle/stories/progresscircle.test.js
@@ -7,6 +7,10 @@ export const ProgressCircleGroup = Variants({
 		{
 			testHeading: "Default",
 		},
+		{
+			testHeading: "Static white",
+			staticColor: "white",
+		},
 	],
 	stateData: [
 		{


### PR DESCRIPTION
## Description

This update adds support for static colors in the testing grids saving us from having to run static white/static black snapshots separately. I accomplished this by updating which containers are returned by the fetchContainers function based on if the document is in a testing state or not.

Updated tests:

- ActionButton: Remove separate static black & static white tests; add both to the testing grid.
- ActionGroup: Add static black & static white to the test grid.
- Button: Remove separate static black & static white tests; add both to the testing grid.
- ClearButton: Remove OverBackground test; add static white to testing grid.
- CloseButton: Add static black & static white to testing grid.
- Divider: Remove static white and static black from separate snapshots; add to testing grid.
- Link: Remove static white and static black and static white + quiet and static black + quiet from separate snapshots; add to testing grid.
- ProgressBar: Remove static white from test; add to testing grid.
- Meter: Remove static white from test; add to testing grid (remove the skipBorders flag).
- ProgressCircle: Remove static white from test; add to testing grid.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [ ] On the [action button story](https://64762974a45b8bc5ca1705a2-kbpzmrxpgp.chromatic.com/?path=/story/components-action-button--default&args=staticColor:white), expect to see a dark teal background with a grouping of white outlined buttons
- [ ] In the [action button testing grid](https://64762974a45b8bc5ca1705a2-kbpzmrxpgp.chromatic.com/?path=/story/components-action-button--default&globals=testingPreview:!true), expect to see a light teal and dark teal box containing the static white and static black variant tests: 

<img width="766" alt="Screenshot 2024-09-27 at 6 31 41 PM" src="https://github.com/user-attachments/assets/75d137d3-1fd7-4beb-b140-934107335345">

- [x] Review the [changeset](https://www.chromatic.com/review?appId=64762974a45b8bc5ca1705a2&number=22&type=unlinked&view=changes) for this PR to validate other additions to the snapshots

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
