### PR TITLE
build: commons reporting bug fix

### DIFF
--- a/components/commons/project.json
+++ b/components/commons/project.json
@@ -14,7 +14,9 @@
 		},
 		"format": {},
 		"lint": {},
-		"report": {},
+		"report": {
+			"executor": "nx:noop"
+		},
 		"test": {
 			"executor": "nx:noop"
 		},


### PR DESCRIPTION
## Description

When running `yarn reporter commons`, an error was being thrown. This resolves that error by switching commons report task to a no-op. This aligns with how we run build and test on the commons package.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [ ] Expect `yarn build` to throw no errors
- [ ] Expect `yarn reporter commons` to throw no errors

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] ✨ This pull request is ready to merge. ✨
