### PR TITLE
docs(search): storybook doc migrations

### DIFF
--- a/components/search/stories/search.stories.js
+++ b/components/search/stories/search.stories.js
@@ -1,10 +1,15 @@
+import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isQuiet, size } from "@spectrum-css/preview/types";
 import pkgJson from "../package.json";
 import { SearchGroup } from "./search.test.js";
+import { SearchOptions, Template } from "./template.js";
 
 /**
- * This component contains a single input field with both a magnifying glass icon and a "reset" button displayed within it.
+ * A search field is used for searching and filtering items.
+ * 
+ * ## Usage Notes
+ * This component contains a single input field with both a magnifying glass icon and a clear (“reset”) button displayed within it. When making use of this component, the clear button should only be displayed when the input has a value.
  */
 export default {
 	title: "Search",
@@ -13,11 +18,34 @@ export default {
 		size: size(["s", "m", "l", "xl"]),
 		isQuiet,
 		isDisabled,
+		hasDescription: {
+			name: "Help Text",
+			description: "A search field can have help text below the field to give extra context or instruction about what a user should input. The description communicates a hint or helpful information, such as a search’s scope.",
+			type: { name: "boolean" },
+			table: {
+				type: { summary: "boolean" },
+				category: "Advanced",
+			},
+			control: "boolean",
+		},
+		description: {
+			name: "Help text (description)",
+			type: { name: "string" },
+			control: { type: "text" },
+			table: {
+				type: { summary: "string" },
+				category: "Advanced",
+			},
+			if: { arg: "hasDescription", eq: true },
+		},
 	},
 	args: {
 		rootClass: "spectrum-Search",
+		size: "m",
 		isQuiet: false,
 		isDisabled: false,
+		hasDescription: false,
+		description: "Example help text. Lorem ipsum dolor sit amet.",
 	},
 	parameters: {
 		actions: {
@@ -33,6 +61,53 @@ export default {
 
 export const Default = SearchGroup.bind({});
 Default.args = {};
+
+// ********* DOCS ONLY ********* //
+
+export const Disabled = SearchOptions.bind({});
+Disabled.args = {
+	isDisabled: true,
+};
+
+Disabled.tags = ["!dev"];
+
+/**
+ * A search field can have [help text](?path=/docs/components-help-text--docs) below the field to give extra context or instruction about what a user should input. The description communicates a hint or helpful information, such as a search’s scope.
+ * 
+ * When the help text is too long for the available horizontal space, it wraps to form another line.
+*/
+export const HelpText = SearchGroup.bind({});
+HelpText.args = {
+	hasDescription: true,
+};
+HelpText.tags = ["!dev"];
+
+/**
+ * A quiet search field can be used when searching isn’t a high priority action on the page. These search fields have no visible background, and this style works best when a clear layout makes the field easy to recognize. Too many quiet components in a small space can be hard to read.
+*/
+export const Quiet = SearchGroup.bind({});
+Quiet.args = {
+	isQuiet: true,
+};
+Quiet.tags = ["!dev"];
+
+
+/**
+ * The medium size is the default and most frequently used option. Use the other sizes sparingly; they should be used to create a hierarchy of importance within the page.
+*/
+export const Sizing = (args, context) => Sizes({
+	Template: Template,
+	withHeading: false,
+	withBorder: false,
+	...args,
+}, context);
+Sizing.args = {
+	hasDescription: true
+};
+Sizing.tags = ["!dev"];
+Sizing.parameters = {
+	chromatic: { disableSnapshot: true },
+};
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = SearchGroup.bind({});

--- a/components/search/stories/template.js
+++ b/components/search/stories/template.js
@@ -1,7 +1,10 @@
 import { Template as ClearButton } from "@spectrum-css/clearbutton/stories/template.js";
+import { Template as HelpText } from "@spectrum-css/helptext/stories/template.js";
+import { Container } from "@spectrum-css/preview/decorators";
 import { Template as TextField } from "@spectrum-css/textfield/stories/template.js";
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
+import { when } from "lit/directives/when.js";
 
 import "../index.css";
 
@@ -11,6 +14,8 @@ export const Template = ({
 	isDisabled = false,
 	isQuiet = false,
 	size,
+	hasDescription = false,
+	description,
 } = {}, context = {}) => {
 	return html`
 		<form
@@ -37,10 +42,34 @@ export const Template = ({
 				autocomplete: false,
 			}, context)}
 			${ClearButton({
-				isDisabled,
-				size,
-				customClasses: [`${rootClass}-clearButton`],
-			}, context)}
+					isDisabled,
+					size,
+					customClasses: [`${rootClass}-clearButton`],
+				}, context)}
+			${when(hasDescription, () => 
+				HelpText({
+					text: description,
+					size,
+					isDisabled
+				}, context ))}
 		</form>
 	`;
 };
+
+export const SearchOptions = ({
+	...args
+}, context = {}) => Container({
+	withBorder: false,
+	direction: "row",
+	wrapperStyles: {
+		columnGap: "12px",
+	},
+	content: html`
+		${Template({
+			...args,
+		}, context)}
+		${Template({
+			...args,
+			isQuiet: true
+		}, context)}`
+});


### PR DESCRIPTION
## Description

Added disabled, quiet, helptext docs

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [ ] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
