### PR TITLE
docs(switch): docs site to storybook

### DIFF
--- a/components/switch/CHANGELOG.md
+++ b/components/switch/CHANGELOG.md
@@ -1026,6 +1026,11 @@ Also, adds t-shirt sizes
 
 🗓 2020-09-23
 
+### 🛑 BREAKING CHANGES
+
+- Toggle is now known as Switch. Replace all `.spectrum-ToggleSwitch*` classnames with `.spectrum-Switch*`.
+- Spectrum has chosen the variant previously known as `quiet` to be the default and has added an `emphasized` variant with the same styles as the previous default. If you were using the `quiet` variant, the `.spectrum-Switch--quiet` class is no longer required and can be removed. If you need a switch to look like it did before this change, add `.spectrum-Switch--emphasized`.
+
 ### 🐛 Bug fixes
 
 - resolving conflicts with main ([8cafffa](https://github.com/adobe/spectrum-css/commit/8cafffa))
@@ -1126,3 +1131,7 @@ Also, adds t-shirt sizes
 ### ✨ Features
 
 - move to individually versioned packages with Lerna ([#265](https://github.com/adobe/spectrum-css/issues/265)) ([cb7fd4b](https://github.com/adobe/spectrum-css/commit/cb7fd4b)), closes [#231](https://github.com/adobe/spectrum-css/issues/231) [#214](https://github.com/adobe/spectrum-css/issues/214) [#229](https://github.com/adobe/spectrum-css/issues/229) [#240](https://github.com/adobe/spectrum-css/issues/240) [#239](https://github.com/adobe/spectrum-css/issues/239) [#161](https://github.com/adobe/spectrum-css/issues/161) [#242](https://github.com/adobe/spectrum-css/issues/242) [#246](https://github.com/adobe/spectrum-css/issues/246) [#219](https://github.com/adobe/spectrum-css/issues/219) [#235](https://github.com/adobe/spectrum-css/issues/235) [#189](https://github.com/adobe/spectrum-css/issues/189) [#248](https://github.com/adobe/spectrum-css/issues/248) [#232](https://github.com/adobe/spectrum-css/issues/232) [#248](https://github.com/adobe/spectrum-css/issues/248) [#218](https://github.com/adobe/spectrum-css/issues/218) [#237](https://github.com/adobe/spectrum-css/issues/237) [#255](https://github.com/adobe/spectrum-css/issues/255) [#256](https://github.com/adobe/spectrum-css/issues/256) [#258](https://github.com/adobe/spectrum-css/issues/258) [#257](https://github.com/adobe/spectrum-css/issues/257) [#259](https://github.com/adobe/spectrum-css/issues/259)
+
+### 🛑 BREAKING CHANGES
+
+- A/B toggle variant has been deprecated and removed. A similar use case could be served by using Radio buttons.

--- a/components/switch/stories/switch.stories.js
+++ b/components/switch/stories/switch.stories.js
@@ -1,11 +1,12 @@
+import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isChecked, isDisabled, isEmphasized, size } from "@spectrum-css/preview/types";
 import pkgJson from "../package.json";
 import { SwitchGroup } from "./switch.test.js";
-import { Template } from "./template.js";
+import { DocsSwitchGroup, Template } from "./template.js";
 
 /**
- * A switch is used to turn an option on or off. Switches allow users to select the state of a single option at a time.
+ * A switch is used to turn an option on or off. Switches allow users to select the state of a single option at a time and are best used for communicating activation.
  */
 export default {
 	title: "Switch",
@@ -37,6 +38,7 @@ export default {
 };
 
 export const Default = SwitchGroup.bind({});
+Default.tags = ["!autodocs"];
 Default.args = {};
 
 // ********* VRT ONLY ********* //
@@ -50,31 +52,78 @@ WithForcedColors.parameters = {
 };
 
 // ********* DOCS ONLY ********* //
-export const Emphasized = Template.bind({});
-Emphasized.tags = ["!dev"];
-Emphasized.args = {
-	isEmphasized: true,
-	label: "Switch label that is so long it wraps to the next line",
-	customStyles: {"max-width": "250px"}
-};
-Emphasized.parameters = {
-	chromatic: { disableSnapshot: true }
-};
-
-export const Checked = Template.bind({});
-Checked.tags = ["!dev"];
-Checked.args = {
-	isChecked: true
-};
-Checked.parameters = {
-	chromatic: { disableSnapshot: true }
+/**
+ * Switches can either be selected or not selected. They cannot be in an indeterminate state (unlike
+ * [checkboxes](?path=/docs/components-checkbox--docs)). When a switch represents multiple values that are not
+ * identical (mixed values), the switch should appear as not selected.
+ */
+export const DocsDefault = DocsSwitchGroup.bind({});
+DocsDefault.storyName = "Default";
+DocsDefault.tags = ["!dev"];
+DocsDefault.parameters = {
+	chromatic: { disableSnapshot: true },
 };
 
-export const Disabled = Template.bind({});
+/**
+ * A switch in a disabled state shows that a selection exists, but is not available in that circumstance. This can be
+ * used to maintain layout continuity and communicate that an action may become available later.
+ */
+export const Disabled = DocsSwitchGroup.bind({});
 Disabled.tags = ["!dev"];
 Disabled.args = {
 	isDisabled: true
 };
 Disabled.parameters = {
+	chromatic: { disableSnapshot: true }
+};
+
+/**
+ * Emphasized switches are optimal for forms, settings, and other scenarios where the switches need to be noticed. Not
+ * emphasized (gray) switches are optimal for application panels where all the visual components are monochrome in
+ * order to direct focus to the canvas.
+ */
+export const Emphasized = DocsSwitchGroup.bind({});
+Emphasized.tags = ["!dev"];
+Emphasized.args = {
+	isEmphasized: true,
+};
+Emphasized.parameters = {
+	chromatic: { disableSnapshot: true }
+};
+
+/**
+ * When the label is too long for the horizontal space available, it wraps to form another line.
+ */
+export const WithLongerLabel = DocsSwitchGroup.bind({});
+WithLongerLabel.storyName = "Longer label";
+WithLongerLabel.tags = ["!dev"];
+WithLongerLabel.args = {
+	label: "Switch label that is so long it wraps to the next line",
+	customStyles: {"max-width": "250px"}
+};
+WithLongerLabel.parameters = {
+	chromatic: { disableSnapshot: true }
+};
+
+export const Sizing = (args, context) => Sizes({
+	Template,
+	...args,
+}, context);
+Sizing.tags = ["!dev"];
+Sizing.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+/**
+ * Standalone switches should be used in situations where the context is clear without an associated text label. For
+ * example, a switch located at the top of a panel next to the panel's title makes it clear that the switch will
+ * enable/disable the panel options.
+ */
+export const Standalone = DocsSwitchGroup.bind({});
+Standalone.tags = ["!dev"];
+Standalone.args = {
+	label: "",
+};
+Standalone.parameters = {
 	chromatic: { disableSnapshot: true }
 };

--- a/components/switch/stories/switch.stories.js
+++ b/components/switch/stories/switch.stories.js
@@ -15,7 +15,10 @@ export default {
 		size: size(["s", "m", "l", "xl"]),
 		isEmphasized,
 		isDisabled,
-		isChecked,
+		isChecked: {
+			...isChecked,
+			name: "Selected",
+		},
 		label: {
 			name: "Label",
 			type: { name: "string" },
@@ -107,6 +110,7 @@ WithLongerLabel.parameters = {
 
 export const Sizing = (args, context) => Sizes({
 	Template,
+	withHeading: false,
 	...args,
 }, context);
 Sizing.tags = ["!dev"];
@@ -115,9 +119,10 @@ Sizing.parameters = {
 };
 
 /**
- * Standalone switches should be used in situations where the context is clear without an associated text label. For
- * example, a switch located at the top of a panel next to the panel's title makes it clear that the switch will
- * enable/disable the panel options.
+ * Switches should always have labels. When the label is not defined, a switch becomes standalone. Standalone switches
+ * should be used in situations where the context is clear without an associated text label. For example, a switch
+ * located at the top of a panel next to the panel's title makes it clear that the switch will enable/disable the panel
+ * options.
  */
 export const Standalone = DocsSwitchGroup.bind({});
 Standalone.tags = ["!dev"];

--- a/components/switch/stories/switch.test.js
+++ b/components/switch/stories/switch.test.js
@@ -11,6 +11,12 @@ export const SwitchGroup = Variants({
 			testHeading: "Emphasized",
 			isEmphasized: true,
 		},
+		{
+			testHeading: "Wrapped",
+			label: "A longer switch label that will wrap if there is not enough space",
+			customStyles: {"max-width": "200px"},
+			withStates: false,
+		},
 	],
 	stateData: [
 		{
@@ -26,11 +32,5 @@ export const SwitchGroup = Variants({
 			isChecked: true,
 			isDisabled: true,
 		},
-		{
-			testHeading: "With longer label",
-			label: "A longer switch label that will wrap if there is not enough space",
-			customStyles: {"max-width": "200px"},
-			include: ["Default"],
-		}
 	]
 });

--- a/components/switch/stories/switch.test.js
+++ b/components/switch/stories/switch.test.js
@@ -22,9 +22,15 @@ export const SwitchGroup = Variants({
 			isChecked: true,
 		},
 		{
-			testHeading: "Checked and Disabled",
+			testHeading: "Checked and disabled",
 			isChecked: true,
 			isDisabled: true,
 		},
+		{
+			testHeading: "With longer label",
+			label: "A longer switch label that will wrap if there is not enough space",
+			customStyles: {"max-width": "200px"},
+			include: ["Default"],
+		}
 	]
 });

--- a/components/switch/stories/template.js
+++ b/components/switch/stories/template.js
@@ -1,4 +1,4 @@
-import { getRandomId } from "@spectrum-css/preview/decorators";
+import { Container, getRandomId } from "@spectrum-css/preview/decorators";
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
@@ -50,3 +50,28 @@ export const Template = ({
 		</div>
 	`;
 };
+
+export const DocsSwitchGroup = (args, context) => Container({
+	withBorder: false,
+	content: html`
+	${Container({
+		heading: "Not selected",
+		content: html`
+			${Template({
+				...args,
+				context,
+				isChecked: false,
+			})}
+		`
+	})}
+	${Container({
+		heading: "Selected",
+		content: html`
+			${Template({
+				...args,
+				context,
+				isChecked: true,
+			})}
+		`
+	})}`
+});

--- a/components/switch/stories/template.js
+++ b/components/switch/stories/template.js
@@ -56,6 +56,7 @@ export const DocsSwitchGroup = (args, context) => Container({
 	content: html`
 	${Container({
 		heading: "Not selected",
+		withBorder: false,
 		content: html`
 			${Template({
 				...args,
@@ -66,6 +67,7 @@ export const DocsSwitchGroup = (args, context) => Container({
 	})}
 	${Container({
 		heading: "Selected",
+		withBorder: false,
 		content: html`
 			${Template({
 				...args,


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description
Updates the Switch Docs page in Storybook to align more closely with [Docs site](https://opensource.adobe.com/spectrum-css/switch.html), incorporating [guidelines](https://spectrum.adobe.com/page/switch/) to add extra information.

Testing coverage was examined but no changes were made.

Docs-only, no changeset necessary.

[CSS-940](https://jira.corp.adobe.com/browse/CSS-940)

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
- [ ] The Switch storybook docs page contains all the relevant information from the [docs site](https://opensource.adobe.com/spectrum-css/switch.html)
- [ ] Grammar, capitalization, and organization of content is accurate/makes sense.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
