### PR TITLE
fix(rating): address inconsistent behavior in rating hover state

### DIFF
--- a/.changeset/spotty-penguins-sort.md
+++ b/.changeset/spotty-penguins-sort.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/rating": minor
+---
+
+Provides more granular control over the hover behavior of child stars within the rating component to prevent hovering in space adjacent to the component from highlighting all stars.

--- a/components/rating/index.css
+++ b/components/rating/index.css
@@ -98,17 +98,6 @@
 		cursor: default;
 		pointer-events: none;
 	}
-
-	/* When the entire component is hovered, show all solid icons */
-	&:hover {
-		.spectrum-Rating-starActive {
-			display: block;
-		}
-
-		.spectrum-Rating-starInactive {
-			display: none;
-		}
-	}
 }
 
 .spectrum-Rating-input {
@@ -167,6 +156,26 @@
 		.spectrum-Rating-starInactive {
 			display: block;
 		}
+	}
+
+	&:hover {
+		.spectrum-Rating-starActive {
+			display: block;
+		}
+
+		.spectrum-Rating-starInactive {
+			display: none;
+		}
+	}
+}
+
+.spectrum-Rating-icon:has(+ .spectrum-Rating-icon:hover) {
+	.spectrum-Rating-starActive {
+		display: block;
+	}
+
+	.spectrum-Rating-starInactive {
+		display: none;
 	}
 }
 


### PR DESCRIPTION
## Description

Provides more granular control over the hover behavior of child stars within the rating component to prevent hovering in space adjacent to the component from highlighting all stars.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

1. Pull down the branch and run Storybook (or access the Storybook URL for the PR).
2. Navigate to the rating component.
3. Verify that hovering near the rating does not highlight all stars; hovering over the 5th star should highlight the preceding star (as should be the case for the 4th star, 3rd and so forth).

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

4. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
