### PR TITLE
docs(underlay): migrate docs to storybook

### DIFF
--- a/components/underlay/stories/underlay.stories.js
+++ b/components/underlay/stories/underlay.stories.js
@@ -1,11 +1,11 @@
-import { Default as DialogStory } from "@spectrum-css/dialog/stories/dialog.stories.js";
-import { Template as Dialog } from "@spectrum-css/dialog/stories/template.js";
+import { Default as ModalStory } from "@spectrum-css/modal/stories/modal.stories.js";
+import { Template as Modal } from "@spectrum-css/modal/stories/template.js";
 import { isOpen } from "@spectrum-css/preview/types";
 import pkgJson from "../package.json";
 import { Template } from "./template.js";
 
 /**
- * An underlay component is used with modal and dialog. It lays over the rest of the page to deliver a blocking layer between the two contexts.
+ * An underlay component is used with [modal](?path=/docs/components-modal--docs) and [dialog](?path=/docs/components-dialog--docs). It lays over the rest of the page to deliver a blocking layer between the two contexts.
  */
 export default {
 	title: "Underlay",
@@ -32,14 +32,43 @@ export default {
 	}
 };
 
+/**
+ * An underlay by itself is not very useful. It is typically used in conjunction with a [dialog](?path=/docs/components-dialog--docs) or [modal](?path=/docs/components-modal--docs).
+ */
 export const Default = Template.bind({});
 Default.args = {
 	isOpen: true,
+};
+
+// ********* DOCS ONLY ********* //
+
+/**
+ * An underlay can be used to block the rest of the page when a [modal](?path=/docs/components-modal--docs) is open.
+ */
+export const WithModal = Template.bind({});
+WithModal.storyName = "Underlay with a modal";
+WithModal.parameters = {
+	docs: {
+		story: {
+			height: "400px",
+			width: "800px"
+		},
+	},
+};
+WithModal.args = {
+	...Default.args,
 	content: [
-		(passthrough) => Dialog({
-			...DialogStory.args,
+		(passthrough, context) => Modal({
 			...passthrough,
-			showModal: true,
-		})
+			...ModalStory.args,
+			rootClass: "spectrum-Modal",
+			isOpen: true,
+			variant: "responsive",
+			customStyles: {
+				// Without this, the content sits right up against the edge of the modal
+				padding: "20px",
+			},
+			showUnderlay: false,
+		}, context),
 	],
 };


### PR DESCRIPTION
## Description

No documentation currently exists on the site for the underlay styles so this PR adds a very light-weight set of notes on the proper usage of the underlay, similar to those found on the [SWC docs site](https://opensource.adobe.com/spectrum-web-components/components/underlay/).

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

On the Underlay Storybook docs page, expect to see:

- [x] One example with a solo underlay element and no dialog or modal.
- [x] One example with a modal over the underlay element.
- [x] No changes to the existing VRT suite.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
