### PR TITLE
chore: switch postcss-rgb-mapping pkg to private

### DIFF
--- a/plugins/postcss-rgb-mapping/package.json
+++ b/plugins/postcss-rgb-mapping/package.json
@@ -1,36 +1,37 @@
 {
-  "name": "postcss-rgb-mapping",
-  "version": "2.1.0",
-  "description": "Remaps rgb(a) values to an rgb postfixed variable",
-  "license": "Apache-2.0",
-  "author": "Adobe",
-  "contributors": [
-    "Cassondra Roberts <castastrophe@users.noreply.github.com> (https://allons-y.llc)"
-  ],
-  "main": "index.js",
-  "files": [
-    "index.js"
-  ],
-  "scripts": {
-    "coverage": "c8 yarn test",
-    "prepublishOnly": "yarn test",
-    "test": "ava"
-  },
-  "dependencies": {
-    "postcss-value-parser": "^4.2.0"
-  },
-  "peerDependencies": {
-    "postcss": ">=8"
-  },
-  "devDependencies": {
-    "ava": "^6.1.3",
-    "c8": "^9.1.0",
-    "postcss": "^8.4.45"
-  },
-  "keywords": [
-    "css",
-    "rgb",
-    "plugin",
-    "postcss"
-  ]
+	"private": true,
+	"name": "postcss-rgb-mapping",
+	"version": "2.1.0",
+	"description": "Remaps rgb(a) values to an rgb postfixed variable",
+	"license": "Apache-2.0",
+	"author": "Adobe",
+	"contributors": [
+		"Cassondra Roberts <castastrophe@users.noreply.github.com> (https://allons-y.llc)"
+	],
+	"main": "index.js",
+	"files": [
+		"index.js"
+	],
+	"scripts": {
+		"coverage": "c8 yarn test",
+		"prepublishOnly": "yarn test",
+		"test": "ava"
+	},
+	"dependencies": {
+		"postcss-value-parser": "^4.2.0"
+	},
+	"peerDependencies": {
+		"postcss": ">=8"
+	},
+	"devDependencies": {
+		"ava": "^6.1.3",
+		"c8": "^9.1.0",
+		"postcss": "^8.4.45"
+	},
+	"keywords": [
+		"css",
+		"rgb",
+		"plugin",
+		"postcss"
+	]
 }


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [ ] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
