### PR TITLE
feat(storybook): modifiers table added to docs

### DIFF
--- a/.storybook/blocks/PropertiesTable.jsx
+++ b/.storybook/blocks/PropertiesTable.jsx
@@ -1,0 +1,66 @@
+import "@spectrum-css/table";
+
+import { DocsContext, useOf } from "@storybook/blocks";
+import { ResetWrapper } from "@storybook/components";
+import { NAVIGATE_URL } from "@storybook/core-events";
+import { styled } from "@storybook/theming";
+import React, { useContext } from 'react';
+import { Body, Code, LinkableHeading } from "./Typography.jsx";
+
+export const Table = styled.table`
+	--mod-table-cursor-row-default: auto;
+	padding-block: 10px;
+`;
+
+/**
+ * Displays the modifiable custom properties for a component based on the metadata provided in the story.
+ * The story metadata object is imported from the "metadata.json" file in the component's directory.
+ *
+ * If the metadata object does not contain a "modifiers" array, this component will not render.
+ *
+ * Usage of this doc block within MDX template(s):
+ *  <PropertiesTable />
+ */
+export const PropertiesTable = () => {
+	const context = useContext(DocsContext);
+	const storyMeta = useOf("meta");
+
+	const packageJson = storyMeta?.csfFile?.meta?.parameters?.packageJson ?? {};
+	const metadata = storyMeta?.csfFile?.meta?.parameters?.metadata ?? {};
+
+	if (!packageJson?.name) return;
+	if (!metadata?.modifiers || !metadata?.modifiers.length) return;
+
+	return (
+		<ResetWrapper>
+			<LinkableHeading id="modifiable-properties" size="m">
+				<a aria-hidden="true" href="#modifiable-properties" tabIndex="-1" target="_self" onClick={() => {
+					context.channel.emit(NAVIGATE_URL, "#modifiable-properties");
+				}}></a>
+				Modifiable custom properties
+			</LinkableHeading>
+			<Body>
+				These are empty CSS custom property hooks available in this component
+				that enable one-off customizations specific to a product implementation.
+			</Body>
+			<Table className="docblock-properties-table sb-unstyled spectrum-Table spectrum-Table--sizeL spectrum-Table--compact">
+				<thead className="spectrum-Table-head">
+					<tr>
+						<th className="spectrum-Table-headCell">Property</th>
+					</tr>
+				</thead>
+				<tbody className="spectrum-Table-body">
+					{metadata?.modifiers.map((propertyName) => (
+						<tr key={propertyName} className="spectrum-Table-row">
+							<td className="spectrum-Table-cell">
+								<Code backgroundColor={"transparent"} size="s">
+									{propertyName}
+								</Code>
+							</td>
+						</tr>
+					))}
+				</tbody>
+			</Table>
+		</ResetWrapper>
+	);
+};

--- a/.storybook/blocks/Typography.jsx
+++ b/.storybook/blocks/Typography.jsx
@@ -1,64 +1,90 @@
 import { styled } from "@storybook/theming";
 import { fetchToken } from "./utilities";
 
-export const Heading = styled.div(({
-    theme,
-    size = "m",
-}) => {
-    const fontSize = size === "s" ? 300 : size === "l" ? 700 : size === "xl" ? 900 : 500;
-    return {
-        fontFamily: theme.typography.fontFamily,
-        fontWeight: theme.typography.weight.bold,
-        color: "inherit",
-        fontSize: fetchToken(`font-size-${fontSize}`, 22),
+export const Heading = styled.h3`
+    font-family: ${({ theme }) => theme.typography.fontFamily};
+    font-weight: ${({ theme }) => theme.typography.weight.bold};
+    color: inherit;
+    font-size: ${({ size }) => fetchToken(`font-size-${size === "s" ? 300 : size === "l" ? 700 : size === "xl" ? 900 : 500}`, 22)};
+    -webkit-font-smoothing: antialiased;
 
-        '> strong': {
-            fontWeight: 900, // @todo: this uses "black" which isn't valid CSS
-        },
+    > strong {
+        font-weight: 900;
+    }
 
-        '> em': {
-            fontStyle: fetchToken("heading-sans-serif-emphasized-font-style", "italic"),
-        }
-    };
-});
+    > em {
+        font-style: ${() => fetchToken(
+            "heading-sans-serif-emphasized-font-style",
+            "italic",
+        )};
+    }
+`;
 
-export const Body = styled.div(({
-    theme,
-    size = "m",
-    scale = "desktop",
-    ...props
-}) => {
-    const fontSize = size === "s" ? 100 : size === "l" ? 300 : size === "xl" ? 400 : 200;
-    return {
-        fontFamily: theme.typography.fontFamily,
-        fontWeight: "normal",
-        color: "inherit",
-        fontSize: fetchToken(`font-size-${fontSize}`, 16),
-        '> strong': {
-            fontWeight: 900, // @todo: this uses "black" which isn't valid CSS
-        },
-        '> em': {
-            fontStyle: fetchToken("body-sans-serif-emphasized-font-style", "italic"),
-        },
-        ...props
-    };
-});
+export const Body = styled.div(
+	({ theme, size = "m", scale = "desktop", ...props }) => {
+		const fontSize =
+			size === "s" ? 100 : size === "l" ? 300 : size === "xl" ? 400 : 200;
+		return {
+			fontFamily: theme.typography.fontFamily,
+			fontWeight: "normal",
+			color: "inherit",
+			fontSize: fetchToken(`font-size-${fontSize}`, 16),
+			"> strong": {
+				fontWeight: 900, // @todo: this uses "black" which isn't valid CSS
+			},
+			"> em": {
+				fontStyle: fetchToken(
+					"body-sans-serif-emphasized-font-style",
+					"italic",
+				),
+			},
+			...props,
+		};
+	},
+);
 
-export const Code = styled.div(({
-    theme,
-    size = "m",
-    scale = "desktop",
-    ...props
-}) => {
-    return {
-        fontFamily: theme.typography.fonts.mono,
-        fontStyle: fetchToken("code-font-style", "normal"),
-        fontWeight: fetchToken("code-font-weight", "400"),
-        color: fetchToken("code-color", "inherit"),
-        fontSize: fetchToken(`code-size-${size}`, 22),
-        backgroundColor: fetchToken("gray-200"),
-        padding: "0.125em 0.25em",
-        borderRadius: "0.125em",
-        ...props
-    };
-});
+export const Code = styled.div(
+	({ theme, size = "m", scale = "desktop", ...props }) => {
+		return {
+			fontFamily: theme.typography.fonts.mono,
+			fontStyle: fetchToken("code-font-style", "normal"),
+			fontWeight: fetchToken("code-font-weight", "400"),
+			color: fetchToken("code-color", "inherit"),
+			fontSize: fetchToken(`code-size-${size}`, 22),
+			backgroundColor: props => props.backgroundColor ?? fetchToken("gray-200"),
+			padding: "0.125em 0.25em",
+			borderRadius: "0.125em",
+			...props,
+		};
+	},
+);
+
+export const LinkableHeading = styled(Heading)`
+    margin: 20px 0 8px;
+    padding: 0;
+    cursor: text;
+    position: relative;
+    padding-bottom: 4px;
+    border-bottom: 1px solid hsla(203, 50%, 30%, 0.15);
+
+    a {
+        float: left;
+        line-height: inherit;
+        padding-right: 10px;
+        margin-left: -24px;
+        color: inherit;
+    }
+
+    a::after {
+        display: inline-block;
+        content: "";
+        visibility: hidden;
+        background: url('data:image/svg+xml;charset=UTF-8,%3Csvg%20width%3D%2214%22%20height%3D%2214%22%20viewBox%3D%220%200%2014%2014%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M11.841%202.159a2.25%202.25%200%2000-3.182%200l-2.5%202.5a2.25%202.25%200%20000%203.182.5.5%200%2001-.707.707%203.25%203.25%200%20010-4.596l2.5-2.5a3.25%203.25%200%20014.596%204.596l-2.063%202.063a4.27%204.27%200%2000-.094-1.32l1.45-1.45a2.25%202.25%200%20000-3.182z%22%20fill%3D%22currentColor%22%3E%3C%2Fpath%3E%3Cpath%20d%3D%22M3.61%207.21c-.1-.434-.132-.88-.095-1.321L1.452%207.952a3.25%203.25%200%20104.596%204.596l2.5-2.5a3.25%203.25%200%20000-4.596.5.5%200%2000-.707.707%202.25%202.25%200%20010%203.182l-2.5%202.5A2.25%202.25%200%20112.159%208.66l1.45-1.45z%22%20fill%3D%22currentColor%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E');
+        block-size: 14px;
+        inline-size: 14px;
+    }
+
+    &:hover a::after {
+        visibility: visible;
+    }
+`;

--- a/.storybook/blocks/index.js
+++ b/.storybook/blocks/index.js
@@ -13,5 +13,6 @@
 
 export * from "./ColorPalette.jsx";
 export * from "./ComponentDetails.jsx";
+export * from "./PropertiesTable.jsx";
 export * from "./ThemeContainer.jsx";
 export * from "./Typography.jsx";

--- a/.storybook/deprecated/cyclebutton/cyclebutton.stories.js
+++ b/.storybook/deprecated/cyclebutton/cyclebutton.stories.js
@@ -1,6 +1,6 @@
 import { default as ActionButtonStories } from "@spectrum-css/actionbutton/stories/actionbutton.stories.js";
 import { Template as ActionButton } from "@spectrum-css/actionbutton/stories/template.js";
-import pkgJson from "@spectrum-css/cyclebutton/package.json";
+import packageJson from "@spectrum-css/cyclebutton/package.json";
 import { default as IconStories } from "@spectrum-css/icon/stories/icon.stories.js";
 import { html } from "lit";
 
@@ -45,7 +45,7 @@ export default {
 		status: {
 			type: "deprecated"
 		},
-		packageJson: pkgJson,
+		packageJson,
 	},
 };
 

--- a/.storybook/deprecated/quickaction/quickaction.stories.js
+++ b/.storybook/deprecated/quickaction/quickaction.stories.js
@@ -1,4 +1,4 @@
-import pkgJson from "@spectrum-css/quickaction/package.json";
+import packageJson from "@spectrum-css/quickaction/package.json";
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
@@ -72,7 +72,7 @@ export default {
 		status: {
 			type: "deprecated"
 		},
-		packageJson: pkgJson,
+		packageJson,
 	},
 };
 

--- a/.storybook/deprecated/searchwithin/searchwithin.stories.js
+++ b/.storybook/deprecated/searchwithin/searchwithin.stories.js
@@ -1,4 +1,4 @@
-import pkgJson from "@spectrum-css/searchwithin/package.json";
+import packageJson from "@spectrum-css/searchwithin/package.json";
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
@@ -143,7 +143,7 @@ export default {
 		status: {
 			type: "deprecated"
 		},
-		packageJson: pkgJson,
+		packageJson,
 	},
 };
 

--- a/.storybook/deprecated/splitbutton/splitbutton.stories.js
+++ b/.storybook/deprecated/splitbutton/splitbutton.stories.js
@@ -1,4 +1,4 @@
-import pkgJson from "@spectrum-css/splitbutton/package.json";
+import packageJson from "@spectrum-css/splitbutton/package.json";
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 
@@ -64,7 +64,7 @@ export default {
 		status: {
 			type: "deprecated"
 		},
-		packageJson: pkgJson,
+		packageJson,
 	},
 };
 

--- a/.storybook/package.json
+++ b/.storybook/package.json
@@ -29,6 +29,7 @@
 	},
 	"dependencies": {
 		"@adobe/spectrum-css-workflow-icons": "^1.5.4",
+		"@spectrum-css/table": "workspace:^",
 		"@spectrum-css/tokens": "workspace:^",
 		"@spectrum-css/typography": "workspace:^",
 		"@spectrum-css/ui-icons": "workspace:^"

--- a/.storybook/project.json
+++ b/.storybook/project.json
@@ -27,7 +27,7 @@
 					"outputs": ["{workspaceRoot}/dist/preview"]
 				}
 			},
-			"dependsOn": ["clean", "^build"],
+			"dependsOn": ["clean", "^build", { "target": "report", "tag": "component" }],
 			"executor": "nx:run-commands",
 			"inputs": ["tools", { "externalDependencies": ["storybook"] }],
 			"options": {
@@ -85,7 +85,7 @@
 		},
 		"start": {
 			"cache": true,
-			"dependsOn": ["^build"],
+			"dependsOn": [{ "target": "report", "projects": "tag:component" }, "^build"],
 			"executor": "nx:run-commands",
 			"inputs": [
 				"tools",

--- a/.storybook/templates/DocumentationTemplate.mdx
+++ b/.storybook/templates/DocumentationTemplate.mdx
@@ -9,7 +9,7 @@ import {
   ArgTypes,
   Stories,
 } from "@storybook/blocks";
-import { ComponentDetails, TaggedReleases } from "../blocks";
+import { ComponentDetails, TaggedReleases, PropertiesTable } from "../blocks";
 
 {/* 👇 The isTemplate property is required to tell Storybook that this is a template */}
 
@@ -28,6 +28,8 @@ import { ComponentDetails, TaggedReleases } from "../blocks";
 The component accepts the following inputs (properties):
 
 <ArgTypes />
+
+<PropertiesTable />
 
 ## Tagged releases
 

--- a/components/accordion/stories/accordion.mdx
+++ b/components/accordion/stories/accordion.mdx
@@ -6,7 +6,11 @@ import {
   Title,
   Subtitle,
 } from "@storybook/blocks";
-import { ComponentDetails, TaggedReleases } from "@spectrum-css/preview/blocks";
+import {
+  ComponentDetails,
+  TaggedReleases,
+  PropertiesTable,
+} from "@spectrum-css/preview/blocks";
 import * as AccordionStories from "./accordion.stories";
 
 <Meta of={AccordionStories} title="Docs" />
@@ -38,6 +42,8 @@ Accordion has three density options and requires that you specify one of the den
 The component accepts the following inputs (properties):
 
 <ArgTypes />
+
+<PropertiesTable />
 
 ## Tagged releases
 

--- a/components/accordion/stories/accordion.stories.js
+++ b/components/accordion/stories/accordion.stories.js
@@ -2,7 +2,8 @@ import { Template as Link } from "@spectrum-css/link/stories/template.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { size } from "@spectrum-css/preview/types";
 import { Template as Typography } from "@spectrum-css/typography/stories/template.js";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { AccordionGroup } from "./accordion.test.js";
 import { Template } from "./template.js";
 
@@ -56,7 +57,8 @@ export default {
 			handles: ["click .spectrum-Accordion-item"],
 		},
 		chromatic: { disableSnapshot: true },
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 	tags: ["!autodocs"],
 };

--- a/components/actionbar/stories/actionbar.mdx
+++ b/components/actionbar/stories/actionbar.mdx
@@ -6,7 +6,11 @@ import {
   Title,
   Subtitle,
 } from "@storybook/blocks";
-import { ComponentDetails, TaggedReleases } from "@spectrum-css/preview/blocks";
+import {
+  ComponentDetails,
+  TaggedReleases,
+  PropertiesTable,
+} from "@spectrum-css/preview/blocks";
 import * as ActionBarStories from "./actionbar.stories";
 
 <Meta of={ActionBarStories} title="Docs" />
@@ -40,6 +44,8 @@ Action bar requires Popover, which is nested within Action bar. Action bar backg
 The component accepts the following inputs (properties):
 
 <ArgTypes />
+
+<PropertiesTable />
 
 ## Tagged releases
 

--- a/components/actionbar/stories/actionbar.stories.js
+++ b/components/actionbar/stories/actionbar.stories.js
@@ -3,7 +3,8 @@ import { default as CloseButton } from "@spectrum-css/closebutton/stories/closeb
 import { default as Popover } from "@spectrum-css/popover/stories/popover.stories.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isEmphasized, isOpen } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { ActionBarGroup } from "./actionbar.test.js";
 import { Template } from "./template.js";
 
@@ -66,7 +67,8 @@ export default {
 			type: "figma",
 			url: "https://www.figma.com/file/MPtRIVRzPp2VHiEplwXL2X/S-%2F-Manual?node-id=465%3A3127&t=xbooxCWItOFgG2xM-1",
 		},
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 	tags: ["!autodocs"],
 };

--- a/components/actionbutton/stories/actionbutton.stories.js
+++ b/components/actionbutton/stories/actionbutton.stories.js
@@ -2,20 +2,21 @@ import { default as IconStories } from "@spectrum-css/icon/stories/icon.stories.
 import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isActive, isDisabled, isEmphasized, isFocused, isHovered, isQuiet, isSelected, size, staticColor } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { ActionButtonGroup } from "./actionbutton.test.js";
 import { ActionButtonsWithIconOptions, IconOnlyOption, TreatmentTemplate } from "./template.js";
 
 /**
  * The action button component represents an action a user can take.
- * 
- * ## Usage notes  
- * 
+ *
+ * ## Usage notes
+ *
  * For action buttons that only contain an icon with no label, do not include the element with the `.spectrum-ActionButton-label` class in the markup. If an icon and a label are both used, ensure that the element with the `.spectrum-ActionButton-label` class comes after the `.spectrum-Icon` element.
- * 
+ *
  * If the hold icon is used, ensure that the element with the `.spectrum-ActionButton-hold` class comes before the `.spectrum-Icon` element.
- * 
- * When using `.spectrum-ActionButton--staticWhite` or `.spectrum-ActionButton--staticBlack`, use the `--mod-actionbutton-content-color-default` custom property to set the text color when selected.  
+ *
+ * When using `.spectrum-ActionButton--staticWhite` or `.spectrum-ActionButton--staticBlack`, use the `--mod-actionbutton-content-color-default` custom property to set the text color when selected.
  */
 export default {
 	title: "Action button",
@@ -83,7 +84,8 @@ export default {
 		actions: {
 			handles: ["click .spectrum-ActionButton:not([disabled])"],
 		},
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 		docs: {
 			story: {
 				height: "auto",
@@ -227,7 +229,7 @@ export const Sizing = (args, context) => Sizes({
 	Template: ActionButtonsWithIconOptions,
 	withHeading: false,
 	withBorder: false,
-	...args,	
+	...args,
 }, context);
 Sizing.args = {};
 Sizing.tags = ["!dev"];

--- a/components/actiongroup/stories/actiongroup.stories.js
+++ b/components/actiongroup/stories/actiongroup.stories.js
@@ -2,7 +2,8 @@ import { default as ActionButton } from "@spectrum-css/actionbutton/stories/acti
 import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { size } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { ActionGroups } from "./actiongroup.test.js";
 import { OverflowOption, TreatmentTemplate } from "./template.js";
 
@@ -92,7 +93,8 @@ export default {
 				...(ActionButton?.parameters?.actions?.handles ?? []),
 			],
 		},
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 

--- a/components/actionmenu/stories/actionmenu.stories.js
+++ b/components/actionmenu/stories/actionmenu.stories.js
@@ -4,7 +4,7 @@ import { default as Menu } from "@spectrum-css/menu/stories/menu.stories.js";
 import { default as Popover } from "@spectrum-css/popover/stories/popover.stories.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isOpen } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import packageJson from "../package.json";
 import { ActionMenuGroup } from "./actionmenu.test.js";
 
 /**
@@ -48,7 +48,7 @@ export default {
 				...(Menu.parameters?.actions?.handles ?? []),
 			],
 		},
-		packageJson: pkgJson,
+		packageJson,
 		docs: {
 			story: {
 				height: "200px",

--- a/components/alertbanner/stories/alertbanner.stories.js
+++ b/components/alertbanner/stories/alertbanner.stories.js
@@ -1,6 +1,7 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isOpen } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { AlertBannerGroup } from "./alertbanner.test.js";
 import { ActionableOptionsTemplate, Template, TextOverflowTemplate } from "./template.js";
 
@@ -68,7 +69,8 @@ export default {
 		actions: {
 			handles: ["click .spectrum-AlertBanner button"],
 		},
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 

--- a/components/alertdialog/stories/alertdialog.stories.js
+++ b/components/alertdialog/stories/alertdialog.stories.js
@@ -1,7 +1,8 @@
 import { withUnderlayWrapper } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isOpen } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { AlertDialogGroup } from "./alertdialog.test.js";
 import { Template } from "./template.js";
 
@@ -49,7 +50,8 @@ export default {
 				height: "300px",
 			}
 		},
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 	decorators: [
 		withUnderlayWrapper,

--- a/components/asset/stories/asset.mdx
+++ b/components/asset/stories/asset.mdx
@@ -6,7 +6,11 @@ import {
   Title,
   Subtitle,
 } from "@storybook/blocks";
-import { ComponentDetails, TaggedReleases } from "@spectrum-css/preview/blocks";
+import {
+  ComponentDetails,
+  TaggedReleases,
+  PropertiesTable,
+} from "@spectrum-css/preview/blocks";
 import * as AssetStories from "./asset.stories";
 
 <Meta of={AssetStories} title="Docs" />
@@ -36,6 +40,8 @@ import * as AssetStories from "./asset.stories";
 The component accepts the following inputs (properties):
 
 <ArgTypes />
+
+<PropertiesTable />
 
 ## Tagged releases
 

--- a/components/asset/stories/asset.stories.js
+++ b/components/asset/stories/asset.stories.js
@@ -1,5 +1,6 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { AssetGroup } from "./asset.test.js";
 import { Template } from "./template.js";
 
@@ -35,7 +36,8 @@ export default {
 		rootClass: "spectrum-Asset",
 	},
 	parameters: {
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 	tags: ["!autodocs"],
 };

--- a/components/assetcard/stories/assetcard.mdx
+++ b/components/assetcard/stories/assetcard.mdx
@@ -6,7 +6,11 @@ import {
   Title,
   Subtitle,
 } from "@storybook/blocks";
-import { ComponentDetails, TaggedReleases } from "@spectrum-css/preview/blocks";
+import {
+  ComponentDetails,
+  TaggedReleases,
+  PropertiesTable,
+} from "@spectrum-css/preview/blocks";
 import * as AssetCardStories from "./assetcard.stories";
 
 <Meta of={AssetCardStories} title="Docs" />
@@ -54,6 +58,8 @@ import * as AssetCardStories from "./assetcard.stories";
 The component accepts the following inputs (properties):
 
 <ArgTypes />
+
+<PropertiesTable />
 
 ## Tagged releases
 

--- a/components/assetcard/stories/assetcard.stories.js
+++ b/components/assetcard/stories/assetcard.stories.js
@@ -1,7 +1,8 @@
 import { default as Checkbox } from "@spectrum-css/checkbox/stories/checkbox.stories.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isFocused, isSelected } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { AssetCardGroup } from "./assetcard.test.js";
 import { Template } from "./template.js";
 
@@ -85,7 +86,8 @@ export default {
 		actions: {
 			handles: [...(Checkbox.parameters?.actions?.handles ?? [])],
 		},
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 	tags: ["!autodocs"],
 };

--- a/components/assetlist/stories/assetlist.stories.js
+++ b/components/assetlist/stories/assetlist.stories.js
@@ -1,6 +1,7 @@
 import { default as Checkbox } from "@spectrum-css/checkbox/stories/checkbox.stories.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { AssetListGroup } from "./assetlist.test.js";
 
 /**
@@ -19,7 +20,8 @@ export default {
 		actions: {
 			handles: [...(Checkbox.parameters?.actions?.handles ?? [])],
 		},
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 

--- a/components/avatar/stories/avatar.mdx
+++ b/components/avatar/stories/avatar.mdx
@@ -6,7 +6,11 @@ import {
   Title,
   Subtitle,
 } from "@storybook/blocks";
-import { ComponentDetails, TaggedReleases } from "@spectrum-css/preview/blocks";
+import {
+  ComponentDetails,
+  TaggedReleases,
+  PropertiesTable,
+} from "@spectrum-css/preview/blocks";
 import * as AvatarStories from "./avatar.stories";
 
 <Meta of={AvatarStories} title="Docs" />
@@ -52,6 +56,8 @@ When disabled, the avatar should only be used without a link.
 The component accepts the following inputs (properties):
 
 <ArgTypes />
+
+<PropertiesTable />
 
 ## Tagged releases
 

--- a/components/avatar/stories/avatar.stories.js
+++ b/components/avatar/stories/avatar.stories.js
@@ -1,7 +1,8 @@
 import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, size } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { AvatarGroup } from "./avatar.test.js";
 import { Template } from "./template.js";
 
@@ -57,7 +58,8 @@ export default {
 		altText: "Shantanu",
 	},
 	parameters: {
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 	tags: ["!autodocs"],
 };

--- a/components/badge/stories/badge.mdx
+++ b/components/badge/stories/badge.mdx
@@ -6,7 +6,11 @@ import {
   Title,
   Subtitle,
 } from "@storybook/blocks";
-import { ComponentDetails, TaggedReleases } from "@spectrum-css/preview/blocks";
+import {
+  ComponentDetails,
+  TaggedReleases,
+  PropertiesTable,
+} from "@spectrum-css/preview/blocks";
 
 import * as BadgeStories from "./badge.stories";
 
@@ -43,6 +47,8 @@ The border radius is 0 along the fixed edge of the component. The actual compone
 The component accepts the following inputs (properties):
 
 <ArgTypes />
+
+<PropertiesTable />
 
 ## Tagged releases
 

--- a/components/badge/stories/badge.stories.js
+++ b/components/badge/stories/badge.stories.js
@@ -1,7 +1,8 @@
 import { default as IconStories } from "@spectrum-css/icon/stories/icon.stories.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { size } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { BadgeGroup } from "./badge.test.js";
 import { PreviewSets } from "./template.js";
 
@@ -63,7 +64,8 @@ export default {
 		fixed: "none"
 	},
 	parameters: {
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 	tags: ["!autodocs"],
 };

--- a/components/breadcrumb/stories/breadcrumb.stories.js
+++ b/components/breadcrumb/stories/breadcrumb.stories.js
@@ -1,17 +1,18 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDragged } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { BreadcrumbGroup } from "./breadcrumb.test.js";
-import { Template } from "./template";
+import { Template } from "./template.js";
 
 /**
  * Breadcrumbs show hierarchy and navigational context for a user's location within an app.
- * 
+ *
  * ## Nesting
  * Breadcrumbs truncate when there is not enough room to display all levels of the breadcrumb list, or as a way of managing relevance of the visible breadcrumb items in a deeply nested hierarchy. The truncation of breadcrumb items begins when either there is not enough room to display all items, or if there are 5 or more breadcrumbs to display. They are typically indicated by the truncated menu folder icon.
- * 
+ *
  * The nested variants below are non-functional. Implementations can add their own overflow menus to display all options within a breadcrumb.
- * 
+ *
  * ## Root Context
  * Some applications find that displaying the root directory is useful for user orientation. This variation keeps the root visible when other folders are truncated into a menu. For example, when users can navigate file directories on their device as well as in the cloud, exposing a root directory called “On this device” is very helpful.
  */
@@ -40,7 +41,8 @@ export default {
 		variant: "default",
 	},
 	parameters: {
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 

--- a/components/button/stories/button.mdx
+++ b/components/button/stories/button.mdx
@@ -6,7 +6,11 @@ import {
   ArgTypes,
   Canvas,
 } from "@storybook/blocks";
-import { ComponentDetails, TaggedReleases } from "@spectrum-css/preview/blocks";
+import {
+  ComponentDetails,
+  TaggedReleases,
+  PropertiesTable,
+} from "@spectrum-css/preview/blocks";
 
 import * as ButtonStories from "./button.stories";
 
@@ -107,6 +111,8 @@ option. Static color buttons do not change shades or values depending upon the c
 The component accepts the following inputs (properties):
 
 <ArgTypes of={ButtonStories} />
+
+<PropertiesTable />
 
 ## Tagged releases
 

--- a/components/button/stories/button.stories.js
+++ b/components/button/stories/button.stories.js
@@ -2,7 +2,8 @@ import { default as IconStories } from "@spectrum-css/icon/stories/icon.stories.
 import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isActive, isDisabled, isFocused, isHovered, isPending, size, staticColor } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { ButtonGroups } from "./button.test.js";
 import { ButtonsWithIconOptions, TextOverflowTemplate, TextWrapTemplate, TreatmentTemplate } from "./template.js";
 
@@ -84,7 +85,8 @@ export default {
 		actions: {
 			handles: ["click .spectrum-Button"],
 		},
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 	tags: ["!autodocs"],
 };

--- a/components/buttongroup/stories/buttongroup.stories.js
+++ b/components/buttongroup/stories/buttongroup.stories.js
@@ -1,7 +1,8 @@
 import { default as Icon } from "@spectrum-css/icon/stories/icon.stories.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { size } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { ButtonGroup } from "./buttongroup.test.js";
 
 /**
@@ -56,7 +57,8 @@ export default {
 		],
 	},
 	parameters: {
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 

--- a/components/calendar/stories/calendar.mdx
+++ b/components/calendar/stories/calendar.mdx
@@ -6,7 +6,11 @@ import {
   Title,
   Subtitle,
 } from "@storybook/blocks";
-import { ComponentDetails, TaggedReleases } from "@spectrum-css/preview/blocks";
+import {
+  ComponentDetails,
+  TaggedReleases,
+  PropertiesTable,
+} from "@spectrum-css/preview/blocks";
 
 import * as CalendarStories from "./calendar.stories";
 
@@ -48,6 +52,8 @@ For calendars with a selected range:
 The component accepts the following inputs (properties):
 
 <ArgTypes />
+
+<PropertiesTable />
 
 ## Tagged releases
 

--- a/components/calendar/stories/calendar.stories.js
+++ b/components/calendar/stories/calendar.stories.js
@@ -1,7 +1,8 @@
 import ActionButtonStories from "@spectrum-css/actionbutton/stories/actionbutton.stories.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isFocused } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { CalendarGroup } from "./calendar.test.js";
 import { Template } from "./template.js";
 
@@ -95,7 +96,8 @@ export default {
 				...(ActionButtonStories.parameters.actions.handles ?? [])
 			],
 		},
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 	tags: ["!autodocs"],
 };

--- a/components/card/stories/card.mdx
+++ b/components/card/stories/card.mdx
@@ -6,7 +6,11 @@ import {
   Title,
   Subtitle,
 } from "@storybook/blocks";
-import { ComponentDetails, TaggedReleases } from "@spectrum-css/preview/blocks";
+import {
+  ComponentDetails,
+  TaggedReleases,
+  PropertiesTable,
+} from "@spectrum-css/preview/blocks";
 
 import * as CardStories from "./card.stories";
 
@@ -75,6 +79,8 @@ A gallery card for an image.
 The component accepts the following inputs (properties):
 
 <ArgTypes />
+
+<PropertiesTable />
 
 ## Tagged releases
 

--- a/components/card/stories/card.stories.js
+++ b/components/card/stories/card.stories.js
@@ -2,7 +2,8 @@ import { default as ActionButton } from "@spectrum-css/actionbutton/stories/acti
 import { default as Checkbox } from "@spectrum-css/checkbox/stories/checkbox.stories.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isFocused, isQuiet, isSelected } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { CardGroup } from "./card.test.js";
 import { Template } from "./template.js";
 
@@ -91,7 +92,8 @@ export default {
 				...(Checkbox.parameters?.actions?.handles ?? []),
 			],
 		},
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 	tags: ["!autodocs"],
 };

--- a/components/checkbox/stories/checkbox.stories.js
+++ b/components/checkbox/stories/checkbox.stories.js
@@ -1,18 +1,19 @@
 import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isChecked, isDisabled, isEmphasized, isIndeterminate, isInvalid, isReadOnly, size } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
-import { DocsCheckboxGroup, AllVariantsCheckboxGroup, } from "./template";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { CheckboxGroup } from "./checkbox.test.js";
+import { AllVariantsCheckboxGroup, DocsCheckboxGroup, } from "./template.js";
 
 /**
  * Checkboxes allow users to select multiple items from a list of individual items, or mark one individual item as selected.
- * 
- * ## Usage notes  
- * 
- * Checkboxes should not be used on their own. They should always be used within a [field group](/docs/components-field-group--docs). Invalid checkboxes are indicated with an alert [help text](/docs/components-help-text--docs) when included in a Field group.  
- * 
- * When the label is too long for the horizontal space available, it wraps to form another line.  
+ *
+ * ## Usage notes
+ *
+ * Checkboxes should not be used on their own. They should always be used within a [field group](/docs/components-field-group--docs). Invalid checkboxes are indicated with an alert [help text](/docs/components-help-text--docs) when included in a Field group.
+ *
+ * When the label is too long for the horizontal space available, it wraps to form another line.
  */
 export default {
 	title: "Checkbox",
@@ -50,7 +51,8 @@ export default {
 		actions: {
 			handles: ["click input[type=\"checkbox\"]"],
 		},
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 

--- a/components/clearbutton/stories/clearbutton.stories.js
+++ b/components/clearbutton/stories/clearbutton.stories.js
@@ -1,9 +1,10 @@
 import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isQuiet, size, staticColor } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { ClearButtonGroup } from "./clearbutton.test.js";
-import { Template } from "./template";
+import { Template } from "./template.js";
 
 /**
  * The clear button component is an in-field button used in search and tags.
@@ -58,7 +59,8 @@ export default {
 		isQuiet: false,
 	},
 	parameters: {
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 

--- a/components/closebutton/stories/closebutton.stories.js
+++ b/components/closebutton/stories/closebutton.stories.js
@@ -1,7 +1,8 @@
 import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isFocused, isHovered, isKeyboardFocused, size, staticColor } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { CloseButtonGroup } from "./closebutton.test.js";
 import { CloseButtonExample, Template } from "./template.js";
 
@@ -45,7 +46,8 @@ export default {
 		actions: {
 			handles: ["click .spectrum-CloseButton"],
 		},
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 
@@ -55,7 +57,7 @@ Default.args = {};
 /**
  * Close button provides a "large" icon size option, for displaying a larger cross icon for each component size.
  * When using this option, the following UI icons should be used:
- * 
+ *
  * | Close button class name         | UI icon class name          |
  * | ------------------------------- | --------------------------- |
  * | `.spectrum-CloseButton--sizeS`  | `.spectrum-UIIcon-Cross200` |
@@ -90,7 +92,7 @@ WithForcedColors.parameters = {
 /**
 * Close buttons come in four different sizes: small, medium, large, and extra-large. By default ("regular" icon size), the cross icon
 * within the close button should use the following UI icons for each component size:
-* 
+*
 * | Close button class name         | UI icon class name          |
 * | ------------------------------- | --------------------------- |
 * | `.spectrum-CloseButton--sizeS`  | `.spectrum-UIIcon-Cross75`  |
@@ -136,4 +138,3 @@ StaticBlack.tags = ["!dev"];
 StaticBlack.parameters = {
 	chromatic: { disableSnapshot: true },
 };
-

--- a/components/coachindicator/stories/coachindicator.stories.js
+++ b/components/coachindicator/stories/coachindicator.stories.js
@@ -1,8 +1,9 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isQuiet } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { CoachIndicatorGroup } from "./coachindicator.test.js";
-import { AllVariantsCoachIndicatorGroup } from "./template";
+import { AllVariantsCoachIndicatorGroup } from "./template.js";
 
 /**
  * The coach indicator component can be used to bring added attention to specific parts of a page.
@@ -31,7 +32,8 @@ export default {
 		variant: "default",
 	},
 	parameters: {
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 

--- a/components/coachmark/stories/coachmark.mdx
+++ b/components/coachmark/stories/coachmark.mdx
@@ -6,7 +6,11 @@ import {
   Title,
   Subtitle,
 } from "@storybook/blocks";
-import { ComponentDetails, TaggedReleases } from "@spectrum-css/preview/blocks";
+import {
+  ComponentDetails,
+  TaggedReleases,
+  PropertiesTable,
+} from "@spectrum-css/preview/blocks";
 
 import * as CoachmarkStories from "./coachmark.stories";
 
@@ -31,6 +35,8 @@ import * as CoachmarkStories from "./coachmark.stories";
 The component accepts the following inputs (properties):
 
 <ArgTypes />
+
+<PropertiesTable />
 
 ## Tagged releases
 

--- a/components/coachmark/stories/coachmark.stories.js
+++ b/components/coachmark/stories/coachmark.stories.js
@@ -1,7 +1,8 @@
 import { default as ActionButton } from "@spectrum-css/actionbutton/stories/actionbutton.stories.js";
 import { default as Menu } from "@spectrum-css/menu/stories/menu.stories.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { CoachMarkGroup } from "./coachmark.test.js";
 import { Template } from "./template.js";
 
@@ -54,7 +55,8 @@ export default {
 				...(Menu.parameters?.actions?.handles ?? []),
 			],
 		},
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 		docs: {
 			story: {
 				height: "300px",

--- a/components/colorarea/stories/colorarea.mdx
+++ b/components/colorarea/stories/colorarea.mdx
@@ -6,7 +6,11 @@ import {
   Title,
   Subtitle,
 } from "@storybook/blocks";
-import { ComponentDetails, TaggedReleases } from "@spectrum-css/preview/blocks";
+import {
+  ComponentDetails,
+  TaggedReleases,
+  PropertiesTable,
+} from "@spectrum-css/preview/blocks";
 
 import * as ColorAreaStories from "./colorarea.stories";
 
@@ -35,6 +39,8 @@ import * as ColorAreaStories from "./colorarea.stories";
 The component accepts the following inputs (properties):
 
 <ArgTypes />
+
+<PropertiesTable />
 
 ## Tagged releases
 

--- a/components/colorarea/stories/colorarea.stories.js
+++ b/components/colorarea/stories/colorarea.stories.js
@@ -1,6 +1,7 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isFocused } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { ColorAreaGroup } from "./colorarea.test.js";
 import { Template } from "./template.js";
 
@@ -40,7 +41,8 @@ export default {
 		selectedColor: "rgba(255, 0, 0, 1)",
 	},
 	parameters: {
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 	tags: ["!autodocs"],
 };

--- a/components/colorhandle/stories/colorhandle.mdx
+++ b/components/colorhandle/stories/colorhandle.mdx
@@ -6,7 +6,11 @@ import {
   Title,
   Subtitle,
 } from "@storybook/blocks";
-import { ComponentDetails, TaggedReleases } from "@spectrum-css/preview/blocks";
+import {
+  ComponentDetails,
+  TaggedReleases,
+  PropertiesTable,
+} from "@spectrum-css/preview/blocks";
 
 import * as ColorHandleStories from "./colorhandle.stories";
 
@@ -39,6 +43,8 @@ Nest the color loupe component within the color handle markup and apply `.is-ope
 The component accepts the following inputs (properties):
 
 <ArgTypes />
+
+<PropertiesTable />
 
 ## Tagged releases
 

--- a/components/colorhandle/stories/colorhandle.stories.js
+++ b/components/colorhandle/stories/colorhandle.stories.js
@@ -1,6 +1,7 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isFocused } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { ColorHandleGroup } from "./colorhandle.test.js";
 import { Template } from "./template.js";
 
@@ -45,7 +46,8 @@ export default {
 		}
 	},
 	parameters: {
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 	tags: ["!autodocs"],
 };

--- a/components/colorloupe/stories/colorloupe.mdx
+++ b/components/colorloupe/stories/colorloupe.mdx
@@ -6,7 +6,11 @@ import {
   Title,
   Subtitle,
 } from "@storybook/blocks";
-import { ComponentDetails, TaggedReleases } from "@spectrum-css/preview/blocks";
+import {
+  ComponentDetails,
+  TaggedReleases,
+  PropertiesTable,
+} from "@spectrum-css/preview/blocks";
 
 import * as ColorLoupeStories from "./colorloupe.stories";
 
@@ -33,6 +37,8 @@ import * as ColorLoupeStories from "./colorloupe.stories";
 The component accepts the following inputs (properties):
 
 <ArgTypes />
+
+<PropertiesTable />
 
 ## Tagged releases
 

--- a/components/colorloupe/stories/colorloupe.stories.js
+++ b/components/colorloupe/stories/colorloupe.stories.js
@@ -1,6 +1,7 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isOpen } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { ColorLoupeGroup } from "./colorloupe.test.js";
 
 /**
@@ -36,7 +37,8 @@ export default {
 				height: "100px"
 			}
 		},
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 

--- a/components/colorslider/stories/colorslider.mdx
+++ b/components/colorslider/stories/colorslider.mdx
@@ -6,7 +6,11 @@ import {
   Title,
   Subtitle,
 } from "@storybook/blocks";
-import { ComponentDetails, TaggedReleases } from "@spectrum-css/preview/blocks";
+import {
+  ComponentDetails,
+  TaggedReleases,
+  PropertiesTable,
+} from "@spectrum-css/preview/blocks";
 
 import * as ColorSliderStories from "./colorslider.stories";
 
@@ -52,6 +56,8 @@ import * as ColorSliderStories from "./colorslider.stories";
 The component accepts the following inputs (properties):
 
 <ArgTypes />
+
+<PropertiesTable />
 
 ## Tagged releases
 

--- a/components/colorslider/stories/colorslider.stories.js
+++ b/components/colorslider/stories/colorslider.stories.js
@@ -1,6 +1,7 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isFocused } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { ColorSliderGroup } from "./colorslider.test.js";
 import { Template } from "./template.js";
 
@@ -49,7 +50,8 @@ export default {
 		selectedColor: "rgba(255, 0, 0, 1)",
 	},
 	parameters: {
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 	tags: ["!autodocs"],
 };

--- a/components/colorwheel/stories/colorwheel.mdx
+++ b/components/colorwheel/stories/colorwheel.mdx
@@ -6,7 +6,11 @@ import {
   Title,
   Subtitle,
 } from "@storybook/blocks";
-import { ComponentDetails, TaggedReleases } from "@spectrum-css/preview/blocks";
+import {
+  ComponentDetails,
+  TaggedReleases,
+  PropertiesTable,
+} from "@spectrum-css/preview/blocks";
 
 import * as ColorWheelStories from "./colorwheel.stories";
 
@@ -47,6 +51,8 @@ Usage notes:
 The component accepts the following inputs (properties):
 
 <ArgTypes />
+
+<PropertiesTable />
 
 ## Tagged releases
 

--- a/components/colorwheel/stories/colorwheel.stories.js
+++ b/components/colorwheel/stories/colorwheel.stories.js
@@ -1,6 +1,7 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isFocused } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { ColorWheelGroup } from "./colorwheel.test.js";
 import { Template } from "./template.js";
 
@@ -41,7 +42,8 @@ export default {
 		selectedColor: "rgba(255, 0, 0, 50%)",
 	},
 	parameters: {
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 	tags: ["!autodocs"],
 };

--- a/components/combobox/stories/combobox.stories.js
+++ b/components/combobox/stories/combobox.stories.js
@@ -1,7 +1,8 @@
 import { Template as Menu } from "@spectrum-css/menu/stories/template.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isFocused, isInvalid, isKeyboardFocused, isLoading, isOpen, isQuiet, size } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { ComboBoxGroup } from "./combobox.test.js";
 import { VariantGroup } from "./template.js";
 
@@ -131,7 +132,8 @@ export default {
 		],
 	},
 	parameters: {
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 

--- a/components/contextualhelp/stories/contextualhelp.mdx
+++ b/components/contextualhelp/stories/contextualhelp.mdx
@@ -6,7 +6,11 @@ import {
   Title,
   Subtitle,
 } from "@storybook/blocks";
-import { ComponentDetails, TaggedReleases } from "@spectrum-css/preview/blocks";
+import {
+  ComponentDetails,
+  TaggedReleases,
+  PropertiesTable,
+} from "@spectrum-css/preview/blocks";
 
 import * as ContextualHelpStories from "./contextualhelp.stories";
 
@@ -51,6 +55,8 @@ import * as ContextualHelpStories from "./contextualhelp.stories";
 The component accepts the following inputs (properties):
 
 <ArgTypes />
+
+<PropertiesTable />
 
 ## Tagged releases
 

--- a/components/contextualhelp/stories/contextualhelp.stories.js
+++ b/components/contextualhelp/stories/contextualhelp.stories.js
@@ -1,6 +1,7 @@
 import { default as ActionButtonStories } from "@spectrum-css/actionbutton/stories/actionbutton.stories.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { ContextualHelpGroup } from "./contextualhelp.test.js";
 import { Template } from "./template.js";
 
@@ -92,7 +93,8 @@ export default {
 				...(ActionButtonStories?.parameters?.actions?.handles ?? [])
 			],
 		},
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 		docs: {
 			story: {
 				height: "200px",

--- a/components/datepicker/stories/datepicker.mdx
+++ b/components/datepicker/stories/datepicker.mdx
@@ -6,7 +6,11 @@ import {
   Title,
   Subtitle,
 } from "@storybook/blocks";
-import { ComponentDetails, TaggedReleases } from "@spectrum-css/preview/blocks";
+import {
+  ComponentDetails,
+  TaggedReleases,
+  PropertiesTable,
+} from "@spectrum-css/preview/blocks";
 
 import * as DatePickerStories from "./datepicker.stories";
 
@@ -74,6 +78,8 @@ Read-only displays the same for standard and quiet variants.
 The component accepts the following inputs (properties):
 
 <ArgTypes />
+
+<PropertiesTable />
 
 ## Tagged releases
 

--- a/components/datepicker/stories/datepicker.stories.js
+++ b/components/datepicker/stories/datepicker.stories.js
@@ -1,7 +1,8 @@
 import { default as CalendarStories } from "@spectrum-css/calendar/stories/calendar.stories.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isInvalid, isOpen, isQuiet, isReadOnly, isRequired, isValid } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { DatePickerGroup } from "./datepicker.test.js";
 import { Template } from "./template.js";
 
@@ -73,7 +74,8 @@ export default {
 				height: "50px"
 			}
 		},
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 

--- a/components/dial/stories/dial.stories.js
+++ b/components/dial/stories/dial.stories.js
@@ -1,6 +1,7 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isDragged, isFocused, size } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { DialGroup } from "./dial.test.js";
 import { Template } from "./template.js";
 
@@ -32,7 +33,8 @@ export default {
 		isDisabled: false,
 	},
 	parameters: {
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 

--- a/components/dialog/stories/dialog.stories.js
+++ b/components/dialog/stories/dialog.stories.js
@@ -2,13 +2,14 @@ import { withUnderlayWrapper } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isOpen } from "@spectrum-css/preview/types";
 import { Template as Typography } from "@spectrum-css/typography/stories/template.js";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { DialogFullscreen, DialogFullscreenTakeover, DialogGroup } from "./dialog.test.js";
-import { Template } from "./template";
+import { Template } from "./template.js";
 
 /**
  * A dialog displays important information that users need to acknowledge. They appear over the interface and block further interactions.
- * 
+ *
  * The alert variants that were previously a part of Dialog were moved to their own component, [Alert Dialog](/docs/components-alert-dialog--docs).
  */
 export default {
@@ -119,7 +120,8 @@ export default {
 				height: "500px",
 			},
 		},
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 	decorators: [
 		withUnderlayWrapper,

--- a/components/divider/stories/divider.stories.js
+++ b/components/divider/stories/divider.stories.js
@@ -1,7 +1,8 @@
 import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { size, staticColor } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { DividerGroup } from "./divider.test.js";
 import { Template } from "./template.js";
 
@@ -33,7 +34,8 @@ export default {
 		minDimensionValues: true,
 	},
 	parameters: {
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 

--- a/components/dropindicator/stories/dropindicator.stories.js
+++ b/components/dropindicator/stories/dropindicator.stories.js
@@ -1,7 +1,8 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { DropIndicatorGroup } from "./dropindicator.test.js";
-import { DocsDropIndicatorGroup } from "./template";
+import { DocsDropIndicatorGroup } from "./template.js";
 
 /**
  * The drop indicator component is used to show the insertion position into a list or table.
@@ -38,7 +39,8 @@ export default {
 		length: "300px",
 	},
 	parameters: {
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 

--- a/components/dropzone/stories/dropzone.stories.js
+++ b/components/dropzone/stories/dropzone.stories.js
@@ -4,7 +4,8 @@ import { Template as Link } from "@spectrum-css/link/stories/template.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDragged } from "@spectrum-css/preview/types";
 import { html } from "lit";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { DropzoneGroup } from "./dropzone.test.js";
 
 /**
@@ -34,7 +35,8 @@ export default {
 		isFilled: false,
 	},
 	parameters: {
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 

--- a/components/fieldgroup/stories/fieldgroup.mdx
+++ b/components/fieldgroup/stories/fieldgroup.mdx
@@ -6,7 +6,11 @@ import {
   Title,
   Subtitle,
 } from "@storybook/blocks";
-import { ComponentDetails, TaggedReleases } from "@spectrum-css/preview/blocks";
+import {
+  ComponentDetails,
+  TaggedReleases,
+  PropertiesTable,
+} from "@spectrum-css/preview/blocks";
 
 import * as FieldGroupStories from "./fieldgroup.stories";
 
@@ -104,6 +108,8 @@ An invalid group of fields:
 The component accepts the following inputs (properties):
 
 <ArgTypes />
+
+<PropertiesTable />
 
 ## Tagged releases
 

--- a/components/fieldgroup/stories/fieldgroup.stories.js
+++ b/components/fieldgroup/stories/fieldgroup.stories.js
@@ -2,7 +2,8 @@ import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isInvalid, isReadOnly, isRequired } from "@spectrum-css/preview/types";
 import { default as RadioSettings } from "@spectrum-css/radio/stories/radio.stories.js";
 import { Template as Radio } from "@spectrum-css/radio/stories/template.js";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { FieldGroupSet } from "./fieldgroup.test.js";
 import { Template } from "./template.js";
 
@@ -93,7 +94,8 @@ export default {
 				...(RadioSettings.parameters?.actions?.handles ?? [])
 			],
 		},
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 	tags: ["!autodocs"],
 };

--- a/components/fieldlabel/stories/fieldlabel.stories.js
+++ b/components/fieldlabel/stories/fieldlabel.stories.js
@@ -1,7 +1,8 @@
+import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isRequired, size } from "@spectrum-css/preview/types";
-import { Sizes } from "@spectrum-css/preview/decorators";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { FieldLabelGroup } from "./fieldlabel.test.js";
 import { Template } from "./template.js";
 
@@ -44,23 +45,24 @@ export default {
 		label: "Label",
 	},
 	parameters: {
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 
 /**
  * By default, a field label has left-aligned text, and is a medium size. For field label text, use a short, catch-all description (1-3 words) of the information that a user needs to provide.
- * 
+ *
  * The default position of a field label is above an input, but it can alternatively be positioned to the side. Visit the [form component](/docs/components-form--docs) to see examples of the field label with an input.
- 
+
  */
 export const Default = FieldLabelGroup.bind({});
 Default.args = {};
 
 // ********* DOCS ONLY ********* //
 /**
- * Field labels come in four different sizes: small, medium, large, and extra-large. The medium size is the default and most frequently used option with medium-sized inputs. Use the other sizes sparingly; they should be used to create a hierarchy of importance within the page. 
- * 
+ * Field labels come in four different sizes: small, medium, large, and extra-large. The medium size is the default and most frequently used option with medium-sized inputs. Use the other sizes sparingly; they should be used to create a hierarchy of importance within the page.
+ *
  * Both small and medium field labels have the same font size, but different paddings when used as side labels.
  */
 export const Sizing = (args, context) => Sizes({
@@ -76,7 +78,7 @@ Sizing.parameters = {
 
 /**
  * To render right-aligned field label text, apply the `.spectrum-FieldLabel--right` class to the field label.
- * 
+ *
  */
 export const RightAligned = Template.bind({});
 RightAligned.args = {
@@ -94,7 +96,7 @@ RightAligned.storyName = "Right-aligned";
 
 /**
  * Field labels for required inputs can be marked with an asterisk at the end of the label. Optional inputs would then be understood to not have the asterisk. If using the asterisk icon, do not leave any space between the label text and the start of the `<svg>` element in the markup. Extra space should not be added in addition to the inline margin.
- * 
+ *
  * The field label for a required field can display either the text “(required)”, or an asterisk.
  */
 export const Required = Template.bind({});

--- a/components/fieldlabel/stories/form.stories.js
+++ b/components/fieldlabel/stories/form.stories.js
@@ -4,8 +4,9 @@ import { Template as Picker } from "@spectrum-css/picker/stories/template.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { Template as Stepper } from "@spectrum-css/stepper/stories/template.js";
 import { Template as TextField } from "@spectrum-css/textfield/stories/template.js";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { Template } from "./form.template.js";
-import pkgJson from "../package.json";
 import { FormGroup } from "./form.test.js";
 
 /**
@@ -104,7 +105,8 @@ export default {
 		],
 	},
 	parameters: {
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 

--- a/components/fieldlabel/stories/form.test.js
+++ b/components/fieldlabel/stories/form.test.js
@@ -1,5 +1,5 @@
 import { Variants } from "@spectrum-css/preview/decorators";
-import { Template } from "./form.template";
+import { Template } from "./form.template.js";
 
 export const FormGroup = Variants({
 	Template,

--- a/components/floatingactionbutton/stories/floatingactionbutton.stories.js
+++ b/components/floatingactionbutton/stories/floatingactionbutton.stories.js
@@ -1,7 +1,8 @@
 import { default as IconStories } from "@spectrum-css/icon/stories/icon.stories.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isActive, isFocused, isHovered } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { FloatingActionButtonGroup } from "./floatingactionbutton.test.js";
 import { Template } from "./template.js";
 
@@ -46,7 +47,8 @@ export default {
 		isActive: false,
 	},
 	parameters: {
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 

--- a/components/helptext/stories/helptext.stories.js
+++ b/components/helptext/stories/helptext.stories.js
@@ -1,7 +1,8 @@
 import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, size } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { HelpTextGroup } from "./helptext.test.js";
 import { NegativeTemplate, Template, VariantsTemplate } from "./template.js";
 
@@ -56,7 +57,8 @@ export default {
 		size: "m",
 	},
 	parameters: {
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 
@@ -113,10 +115,10 @@ Disabled.parameters = {
 
 /**
  * The negative variant is used to convey error messages and can have an optional icon.
- * 
- * In most cases, help text is used with a component that already displays an icon communicating an error (e.g., 
+ *
+ * In most cases, help text is used with a component that already displays an icon communicating an error (e.g.,
  * [text field](?path=/docs/components-text-field--docs),
- * [picker](?path=/docs/components-picker--docs), 
+ * [picker](?path=/docs/components-picker--docs),
  * [combo box](?path=/docs/components-combobox--docs#standard---invalid)),
  * so it’s not necessary to include another icon. In other cases, help text that is used with a component that does not display an icon
  * communicating an error (e.g., [field group](?path=/docs/components-field-group--docs#invalid)) needs to display an icon.

--- a/components/icon/stories/icon.mdx
+++ b/components/icon/stories/icon.mdx
@@ -1,5 +1,9 @@
 import { Canvas, ArgTypes, Meta, Description, Title } from "@storybook/blocks";
-import { ComponentDetails, TaggedReleases } from "@spectrum-css/preview/blocks";
+import {
+  ComponentDetails,
+  TaggedReleases,
+  PropertiesTable,
+} from "@spectrum-css/preview/blocks";
 
 import * as IconStories from "./icon.stories";
 
@@ -72,6 +76,8 @@ The workflow icon SVGs are within a separate respository, which is also publishe
 The component accepts the following inputs (properties):
 
 <ArgTypes />
+
+<PropertiesTable />
 
 ## Tagged releases
 

--- a/components/icon/stories/icon.stories.js
+++ b/components/icon/stories/icon.stories.js
@@ -3,7 +3,8 @@ import { size } from "@spectrum-css/preview/types";
 import { Template as Typography } from "@spectrum-css/typography/stories/template.js";
 import { html } from "lit";
 import { styleMap } from "lit/directives/style-map.js";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { IconGroup } from "./icon.test.js";
 import { Template } from "./template.js";
 import { uiIconSizes, uiIconsWithDirections, workflowIcons } from "./utilities.js";
@@ -88,7 +89,8 @@ export default {
 		useRef: true,
 	},
 	parameters: {
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 	tags: ["!autodocs"],
 };

--- a/components/illustratedmessage/stories/illustratedmessage.stories.js
+++ b/components/illustratedmessage/stories/illustratedmessage.stories.js
@@ -1,7 +1,8 @@
 import { Template as Link } from "@spectrum-css/link/stories/template.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { html } from "lit";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { IllustratedMessageGroup } from "./illustratedmessage.test.js";
 import { Template } from "./template.js";
 
@@ -43,7 +44,8 @@ export default {
 		useAccentColor: false,
 	},
 	parameters: {
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 

--- a/components/infieldbutton/stories/infieldbutton.stories.js
+++ b/components/infieldbutton/stories/infieldbutton.stories.js
@@ -1,7 +1,8 @@
 import { default as IconStories } from "@spectrum-css/icon/stories/icon.stories.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isActive, isDisabled, isFocused, isHovered, isQuiet, size } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { InfieldButtonGroup } from "./infieldbutton.test.js";
 import { Template } from "./template.js";
 
@@ -47,7 +48,8 @@ export default {
 		isStacked: false,
 	},
 	parameters: {
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 

--- a/components/inlinealert/stories/inlinealert.stories.js
+++ b/components/inlinealert/stories/inlinealert.stories.js
@@ -1,7 +1,8 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { InlineAlertGroup } from "./inlinealert.test.js";
-import { Template } from "./template";
+import { Template } from "./template.js";
 
 /**
  * In-line alerts display a non-modal message associated with objects in a view. These are often used in form validation, providing a place to aggregate feedback related to multiple fields.
@@ -58,7 +59,8 @@ export default {
 		isClosable: false,
 	},
 	parameters: {
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 
@@ -71,7 +73,7 @@ Default.args = {};
 // ********* DOCS ONLY ********* //
 /**
  * The informative variant uses the informative semantic color (blue) and has an "information" icon to help those with color vision deficiency discern the message tone. This should be used when the message needs to call extra attention, as compared to the neutral variant.
- * 
+ *
  * _Spectrum for Adobe Express uses a different icon. Use the SX_Info_18_S.svg icon in the Express workflow icon set._
  */
 export const Informative = Template.bind({});
@@ -86,7 +88,7 @@ Informative.tags = ["!dev"];
 
 /**
  * A negative variant uses the negative semantic color (red) and has an "alert" icon to help those with color vision deficiency to discern the message tone. Negative variants are used to show an error or failure, or to convey something that needs to be immediately acknowledged or addressed.
- * 
+ *
  * _Spectrum for Adobe Express uses a different icon. Use the SX_Alert_18_S.svg icon in the Express workflow icon set._
  */
 export const Negative = Template.bind({});
@@ -101,7 +103,7 @@ Negative.tags = ["!dev"];
 
 /**
  * The positive variant uses the positive semantic color (green) and has a "checkmark" icon to help those with color vision deficiency discern the message tone. This variant should be used to inform someone of a successful function or result of an action they took.
- * 
+ *
  * _Spectrum for Adobe Express uses a different icon. Use the SX_CheckmarkCircle_18_S.svg icon in the Express workflow icon set._
  */
 export const Positive = Template.bind({});
@@ -116,7 +118,7 @@ Positive.tags = ["!dev"];
 
 /**
  * To warn about a situation that may need to be addressed soon, use the notice variant. It utilizes the notice semantic color (orange) and has an "alert" icon to help those with color vision deficiency to discern the message tone.
- * 
+ *
  * _Spectrum for Adobe Express uses a different icon. Use the SX_Alert_18_S.svg icon in the Express workflow icon set._
  */
 export const Notice = Template.bind({});
@@ -131,7 +133,7 @@ Notice.tags = ["!dev"];
 
 /**
  * An in-line alert with a close button in the footer. Combine this strategy with any variant.
- * 
+ *
  * _Spectrum for Adobe Express uses a different icon. Use the SX_Alert_18_S.svg icon in the Express workflow icon set._
  */
 export const Closable = Template.bind({});

--- a/components/link/stories/link.stories.js
+++ b/components/link/stories/link.stories.js
@@ -1,8 +1,9 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isActive, isFocused, isHovered, isQuiet, staticColor } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { LinkGroup } from "./link.test.js";
-import { TemplateWithFillerText } from "./template";
+import { TemplateWithFillerText } from "./template.js";
 
 /**
  * A link allows users to navigate to a different location. They can be presented in-line inside a paragraph or as standalone text.
@@ -69,7 +70,8 @@ export default {
 		actions: {
 			handles: ["click .spectrum-Link"],
 		},
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 

--- a/components/logicbutton/stories/logicbutton.stories.js
+++ b/components/logicbutton/stories/logicbutton.stories.js
@@ -1,6 +1,7 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { LogicButtonGroup } from "./logicbutton.test.js";
 import { Template, VariantGroup } from "./template.js";
 
@@ -29,7 +30,8 @@ export default {
 		isDisabled: false,
 	},
 	parameters: {
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 

--- a/components/menu/stories/menu.stories.js
+++ b/components/menu/stories/menu.stories.js
@@ -2,7 +2,8 @@ import { default as IconStories } from "@spectrum-css/icon/stories/icon.stories.
 import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isActive, isDisabled, isFocused, isHovered, isSelected, size } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { MenuItemGroup, MenuTraySubmenu, MenuWithVariants } from "./menu.test.js";
 import { DisabledItemGroup, OverflowGroup, SelectionGroup, SubmenuInPopover, Template } from "./template.js";
 
@@ -81,7 +82,8 @@ export default {
 				height: "300px"
 			}
 		},
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 

--- a/components/miller/stories/miller.stories.js
+++ b/components/miller/stories/miller.stories.js
@@ -1,5 +1,6 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { MillerGroup } from "./miller.test.js";
 import { Template } from "./template.js";
 
@@ -76,7 +77,8 @@ export default {
 		],
 	},
 	parameters: {
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 

--- a/components/modal/stories/modal.stories.js
+++ b/components/modal/stories/modal.stories.js
@@ -2,7 +2,8 @@ import { withUnderlayWrapper } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isOpen } from "@spectrum-css/preview/types";
 import { Template as Typography } from "@spectrum-css/typography/stories/template.js";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { ModalGroup } from "./modal.test.js";
 
 /**
@@ -48,7 +49,8 @@ export default {
 				width: "800px"
 			},
 		},
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 	decorators: [
 		withUnderlayWrapper,

--- a/components/opacitycheckerboard/stories/opacitycheckerboard.stories.js
+++ b/components/opacitycheckerboard/stories/opacitycheckerboard.stories.js
@@ -1,5 +1,6 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { OpacityCheckboardGroup } from "./opacitycheckerboard.test.js";
 import { Template } from "./template.js";
 
@@ -29,7 +30,8 @@ export default {
 		}
 	},
 	parameters: {
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 

--- a/components/pagination/stories/pagination.stories.js
+++ b/components/pagination/stories/pagination.stories.js
@@ -1,12 +1,13 @@
 import { default as ActionButton } from "@spectrum-css/actionbutton/stories/actionbutton.stories";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { size } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { PaginationGroup } from "./pagination.test.js";
-import { Template } from "./template";
+import { Template } from "./template.js";
 
 /**
- * The pagination component displays numbered buttons or an input field to allow for navigation. 
+ * The pagination component displays numbered buttons or an input field to allow for navigation.
  */
 export default {
 	title: "Pagination",
@@ -67,12 +68,13 @@ export default {
 				...(ActionButton.parameters?.actions?.handles ?? [])
 			],
 		},
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 
 /**
- * The default listing/page variant uses buttons for each page number. 
+ * The default listing/page variant uses buttons for each page number.
  */
 export const Default = PaginationGroup.bind({});
 Default.storyName = "Default (listing)";

--- a/components/picker/stories/picker.stories.js
+++ b/components/picker/stories/picker.stories.js
@@ -2,7 +2,8 @@ import { WithDividers as MenuStories } from "@spectrum-css/menu/stories/menu.sto
 import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isActive, isDisabled, isHovered, isInvalid, isKeyboardFocused, isLoading, isOpen, isQuiet, size } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { PickerGroup } from "./picker.test.js";
 import { ClosedAndOpenTemplate, DisabledTemplate, Template } from "./template.js";
 
@@ -131,7 +132,13 @@ export default {
 		},
 	},
 	parameters: {
-		packageJson: pkgJson,
+		docs: {
+			story: {
+				height: "400px"
+			}
+		},
+		packageJson,
+		metadata,
 	},
 };
 

--- a/components/picker/stories/picker.test.js
+++ b/components/picker/stories/picker.test.js
@@ -1,5 +1,5 @@
 import { Variants } from "@spectrum-css/preview/decorators";
-import { Template } from "./template";
+import { Template } from "./template.js";
 
 export const PickerGroup = Variants({
 	Template,

--- a/components/pickerbutton/stories/pickerbutton.stories.js
+++ b/components/pickerbutton/stories/pickerbutton.stories.js
@@ -2,9 +2,10 @@ import { default as Icon } from "@spectrum-css/icon/stories/icon.stories.js";
 import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isFocused, isOpen, isQuiet, size } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { PickerGroup } from "./pickerbutton.test.js";
-import { CustomIconTemplate, Template } from "./template";
+import { CustomIconTemplate, Template } from "./template.js";
 
 /**
  * The picker button component is used as a dropdown trigger within other components such as [combobox](?path=/docs/components-combobox--docs).
@@ -84,7 +85,8 @@ export default {
 		position: "right",
 	},
 	parameters: {
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 

--- a/components/popover/stories/popover.stories.js
+++ b/components/popover/stories/popover.stories.js
@@ -5,17 +5,18 @@ import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isOpen } from "@spectrum-css/preview/types";
 import { Template as Typography } from "@spectrum-css/typography/stories/template.js";
 import { html } from "lit";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { PopoverGroup } from "./popover.test.js";
-import { FixedWidthSourceTemplate, Template, TipPlacementVariants } from "./template";
+import { FixedWidthSourceTemplate, Template, TipPlacementVariants } from "./template.js";
 
 /**
  * A popover is used to display transient content (menus, options, additional actions, etc.) and appears when clicking/tapping on a source (tools, buttons, etc.).
  * It stands out via its visual style (stroke and drop shadow) and floats on top of the rest of the interface.
- * 
+ *
  * - Popover's position and distance to its source should be handled by the implementation. Positioning in Storybook is only for demonstration purposes.
  * - When the `.is-open` class is present, popover is offset from the source by the spacing value defined in `--spectrum-popover-animation-distance`. This
- * offset is done with a CSS transform and animates with a CSS transition. 
+ * offset is done with a CSS transform and animates with a CSS transition.
  */
 export default {
 	title: "Popover",
@@ -90,14 +91,15 @@ export default {
 				height: "200px",
 			}
 		},
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 
 /**
  * By default, popovers do not have a tip. Popovers without a tip should be used when the source has a
  * visually distinct down state, in order to show the connection between the popover and its source.
- * 
+ *
  * This example uses the [menu](?path=/docs/components-menu--docs) component within the popover, and a button as the source.
  */
 export const Default = PopoverGroup.bind({});
@@ -269,7 +271,7 @@ DialogStyle.parameters = {
  * the following naming convention: the first term is the popover's position and the second term is its
  * source's position. For example, for the `spectrum-Popover--top-left` class, the popover is positioned at the top and the
  * source is to the left.
- * 
+ *
  * #### Tip SVG
  * Depending on its position, the tip uses one of two different SVGs.
  * - Top and bottom popover positions use the same SVG. The CSS handles flipping the SVG vertically.

--- a/components/progressbar/stories/meter.stories.js
+++ b/components/progressbar/stories/meter.stories.js
@@ -1,16 +1,17 @@
-import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { Sizes } from "@spectrum-css/preview/decorators";
+import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { size } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
+import { FillGroup, Template } from "./meter.template.js";
 import { MeterGroup } from "./meter.test.js";
 import { default as ProgressBar } from "./progressbar.stories";
-import { FillGroup, Template } from "./meter.template.js";
 
 /**
  * The meter component is a visual representations of a quantity or an achievement. The progress is determined by user actions, rather than system actions.
- * 
- * Meter is implemented using [the progress bar component](/docs/components-progress-bar--docs). Refer to the progress bar documentation for additional details. 
- * 
+ *
+ * Meter is implemented using [the progress bar component](/docs/components-progress-bar--docs). Refer to the progress bar documentation for additional details.
+ *
  * When determining whether or use a progress bar or meter, remember that a progress bar just indicates how long users must wait for the process to finish- their actions do not affect the progress bar. A meter indicates how much users have completed or how far they are in a continuum.
  */
 export default {
@@ -39,15 +40,16 @@ export default {
 		label: "Storage space",
 	},
 	parameters: {
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 
 /**
  * By default, meters have a blue fill and are the large sizes.
- * 
+ *
  * Meters should always have a label. In rare cases where context is sufficient and an accessibility expert has reviewed the design, the label could be undefined. These meters without a visible label should still include an “aria-label” or “aria-labelledby” in HTML, depending on the context. The label is always placed above the track.
- * 
+ *
  * When the label is too long for the available horizontal space, it wraps to form another line. The value is always shown in full and never wraps or truncates.
  */
 export const Default = MeterGroup.bind({});
@@ -72,7 +74,7 @@ Sizing.parameters = {
 
 /**
  * Meter variants can be used to represent semantic values by switching variants as the value changes, from positive, to notice, and then to negative. This kind of variant switching should be handled appropriately within the context of your product so that accurate expectations are set for users about the semantic meaning.
- * 
+ *
  * By default, the meter has a informative, blue fill to show the value. This can be used to represent a neutral or non-semantic value. The positive variant has a green fill, representing a positive semantic value. The notice variant has an orange fill, and can be used to warn users about a situation that may need to be addressed soon. The negative variant has a red fill, and can be used to warn users about a critical situation that needs their urgent attention.
 */
 export const FillColors = (args, context) => FillGroup({

--- a/components/progressbar/stories/progressbar.stories.js
+++ b/components/progressbar/stories/progressbar.stories.js
@@ -1,6 +1,8 @@
 import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isIndeterminate, size, staticColor } from "@spectrum-css/preview/types";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { ProgressBarGroup } from "./progressbar.test.js";
 import { IndeterminateGroup, Template } from "./template.js";
 
@@ -36,7 +38,6 @@ export default {
 			table: {
 				type: { summary: "string" },
 				category: "Component",
-
 				// todo: side labels are not supported according to S1 documentation, but will be in S2. Remove the disable: true once S2 is released
 				disable: true,
 			},
@@ -89,6 +90,10 @@ export default {
 		customWidth: 192,
 		isIndeterminate: false,
 		showValueLabel: true,
+	},
+	parameters: {
+		packageJson,
+		metadata,
 	},
 };
 

--- a/components/progresscircle/stories/progresscircle.stories.js
+++ b/components/progresscircle/stories/progresscircle.stories.js
@@ -1,9 +1,10 @@
 import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isIndeterminate, size, staticColor } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { ProgressCircleGroup } from "./progresscircle.test.js";
-import { Template } from "./template";
+import { Template } from "./template.js";
 
 /**
  * Progress circles show the progression of a system operation such as downloading, uploading, processing, etc. in a visual way. They can represent determinate or indeterminate progress.
@@ -26,7 +27,8 @@ export default {
 		staticColor: undefined,
 	},
 	parameters: {
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 

--- a/components/radio/stories/radio.stories.js
+++ b/components/radio/stories/radio.stories.js
@@ -1,13 +1,14 @@
 import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isChecked, isDisabled, isEmphasized, isReadOnly, size } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { RadioGroup } from "./radio.test.js";
-import { BasicGroupTemplate } from "./template";
+import { BasicGroupTemplate } from "./template.js";
 
 /**
  * Radio buttons allow users to select a single option from a list of mutually exclusive options. All possible options are exposed up front for users to compare.
- * 
+ *
  * Radio buttons should not be used on their own, they should always be used within a [field group](?path=/docs/components-field-group--docs). Invalid radio buttons are signified by including
  * [help text](?path=/docs/components-help-text--docs) in a field group. Sample usage for an [invalid radio state](?path=/docs/components-field-group--docs#invalid) is included in the field group documentation.
  */
@@ -53,7 +54,8 @@ export default {
 		actions: {
 			handles: ["click input[type=\"radio\"]"],
 		},
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 
@@ -103,7 +105,7 @@ Sizing.parameters = {
 };
 
 /**
- * The emphasized option provides a visual prominence for the selected radio button. 
+ * The emphasized option provides a visual prominence for the selected radio button.
  * It is best for forms, settings, lists or grids of assets, and other situations where a
  * radio button needs to be noticed.
  */
@@ -130,7 +132,7 @@ Disabled.parameters = {
 /**
  * A radio group has a read-only option for when it's in the disabled state but still needs to be shown.
  * This allows for content to be copied, but not interacted with or changed.
- * 
+ *
  * - Read-only radio buttons are disabled, but not all disabled radio buttons are read-only.
  * - Read-only radio buttons do not have a focus ring, but the button should be focusable.
  */

--- a/components/rating/stories/rating.stories.js
+++ b/components/rating/stories/rating.stories.js
@@ -1,12 +1,13 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isEmphasized, isFocused, isReadOnly } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { RatingGroup } from "./rating.test.js";
 import { Template } from "./template.js";
 
 /**
  * The rating component is used to display or collect a user's rating of an item as represented by a number of stars.
- * 
+ *
  * ### Usage notes
  * - All active stars have the class `is-selected` applied.
  * - The current value (the last active star) has the class `is-currentValue` applied.
@@ -52,7 +53,8 @@ export default {
 		value: 3,
 	},
 	parameters: {
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 

--- a/components/search/stories/search.stories.js
+++ b/components/search/stories/search.stories.js
@@ -1,13 +1,14 @@
 import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isQuiet, size } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { SearchGroup } from "./search.test.js";
 import { SearchOptions, Template } from "./template.js";
 
 /**
  * A search field is used for searching and filtering items.
- * 
+ *
  * ## Usage Notes
  * This component contains a single input field with both a magnifying glass icon and a clear (“reset”) button displayed within it. When making use of this component, the clear button should only be displayed when the input has a value.
  */
@@ -55,7 +56,8 @@ export default {
 				"click .spectrum-Search-icon",
 			],
 		},
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 
@@ -73,7 +75,7 @@ Disabled.tags = ["!dev"];
 
 /**
  * A search field can have [help text](?path=/docs/components-help-text--docs) below the field to give extra context or instruction about what a user should input. The description communicates a hint or helpful information, such as a search’s scope.
- * 
+ *
  * When the help text is too long for the available horizontal space, it wraps to form another line.
 */
 export const HelpText = SearchGroup.bind({});

--- a/components/sidenav/stories/sidenav.stories.js
+++ b/components/sidenav/stories/sidenav.stories.js
@@ -1,11 +1,12 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { SideNavGroup } from "./sidenav.test.js";
 import { Template } from "./template.js";
 
 /**
  * Side nav lets users navigate the entire content of a product or a section. These can be used for a single level or a multi-level navigation.
- * 
+ *
  * - A navigation item can be styled as disabled with the `is-disabled` class.
  * - A navigation item can be styled as the current or selected page with the `is-selected` class. This is accompanied by the use of the `aria-current` attribute on the anchor link.
  */
@@ -62,7 +63,8 @@ export default {
 		],
 	},
 	parameters: {
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 

--- a/components/slider/stories/slider.stories.js
+++ b/components/slider/stories/slider.stories.js
@@ -1,20 +1,21 @@
-import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { Sizes } from "@spectrum-css/preview/decorators";
+import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isFocused, size } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { SliderGroup } from "./slider.test.js";
 import { Template } from "./template.js";
 
 /**
  * A slider allows users to quickly select a value within a range. They should be used when the upper and lower bounds to the range are invariable.
- * 
+ *
  * ## Indicating focus
  * Focus must be bubbled up to the parent so its descendants can be styled.
  *
  * Thus, implementations should add the following class to the `.spectrum-Slider` parent class in the following situations:
  *
  * - `.is-disabled`: when the slider is disabled
- * 
+ *
  * Implementations should also bubble the following class to the `.spectrum-Slider-controls` parent class in the following situations:
 
  * - `.is-focused`: when the handle input is focused with the mouse or keyboard
@@ -139,7 +140,8 @@ export default {
 				"change .spectrum-Slider-input",
 			],
 		},
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 
@@ -154,7 +156,7 @@ Default.args = {};
  * If a slider's label is undefined, it should still include an aria-label in HTML (depending on the context, “aria-label” or “aria-labelledby”).
  */
 export const WithoutLabel = Template.bind({});
-WithoutLabel.args = { 
+WithoutLabel.args = {
 	label: "",
 };
 WithoutLabel.tags = ["!dev"];

--- a/components/splitview/stories/splitview.stories.js
+++ b/components/splitview/stories/splitview.stories.js
@@ -1,6 +1,7 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isFocused } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { SplitViewGroup } from "./splitview.test.js";
 import { Template } from "./template.js";
 
@@ -78,7 +79,8 @@ export default {
 		panelStyles: ["width: 304px;", "flex: 1;"],
 	},
 	parameters: {
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 

--- a/components/statuslight/stories/statuslight.stories.js
+++ b/components/statuslight/stories/statuslight.stories.js
@@ -1,9 +1,10 @@
+import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, size } from "@spectrum-css/preview/types";
-import { Sizes } from "@spectrum-css/preview/decorators";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { StatusLightGroup } from "./statuslight.test.js";
-import { Template, SemanticGroup, NonsemanticGroup } from "./template.js";
+import { NonsemanticGroup, SemanticGroup, Template } from "./template.js";
 
 /**
  * Status lights describe the condition of an entity. They can be used to convey semantic meaning, such as statuses and categories.
@@ -64,13 +65,14 @@ export default {
 		isDisabled: false,
 	},
 	parameters: {
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 
 /**
  * Status lights should always include a label with text that clearly communicates the kind of status being shown. Color alone is not enough to communicate the status. Do not change the text color to match the dot.
- * 
+ *
  * When the text is too long for the horizontal space available, it wraps to form another line.
  */
 export const Default = StatusLightGroup.bind({});
@@ -97,7 +99,7 @@ Sizing.parameters = {
  * - Positive (approved, complete, success, new, purchased, licensed)
  * - Notice (needs approval, pending, scheduled, syncing, indexing, processing)
  * - Negative (error, alert, rejected, failed)
- * 
+ *
  * Semantic status lights should never be used for color coding categories or labels, and vice versa.
  */
 export const SemanticColors = SemanticGroup.bind({});

--- a/components/steplist/stories/steplist.stories.js
+++ b/components/steplist/stories/steplist.stories.js
@@ -1,11 +1,12 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { SteplistGroup } from "./steplist.test.js";
-import { DocsSteplistGroup } from "./template";
+import { DocsSteplistGroup } from "./template.js";
 
 /**
  * A steplist can communicate the progress of a task or workflow. It can help users understand where they are in a process and what they need to do next.
- * 
+ *
  * All variants of steplist can be static or interactive.
  */
 export default {
@@ -73,7 +74,8 @@ export default {
 		],
 	},
 	parameters: {
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 

--- a/components/stepper/stories/stepper.stories.js
+++ b/components/stepper/stories/stepper.stories.js
@@ -1,9 +1,10 @@
 import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isFocused, isHovered, isInvalid, isKeyboardFocused, isQuiet, size } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { StepperGroup } from "./stepper.test.js";
-import { AllDefaultVariantsGroup, DisabledVariantsGroup, Template } from "./template";
+import { AllDefaultVariantsGroup, DisabledVariantsGroup, Template } from "./template.js";
 
 /**
  * A stepper can be used to increment or decrement a value by a specified amount via an up/down button. An input field displays the current value.
@@ -41,7 +42,8 @@ export default {
 		hideStepper: false
 	},
 	parameters: {
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 

--- a/components/swatch/stories/swatch.stories.js
+++ b/components/swatch/stories/swatch.stories.js
@@ -1,15 +1,16 @@
+import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isSelected, size } from "@spectrum-css/preview/types";
-import { Sizes } from "@spectrum-css/preview/decorators";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { SwatchGroup } from "./swatch.test.js";
-import { Template, DisabledGroup, EmptyGroup, RoundingGroup, BorderGroup, SizingGroup } from "./template";
+import { BorderGroup, DisabledGroup, EmptyGroup, RoundingGroup, SizingGroup, Template } from "./template.js";
 
 /**
  * A swatch shows a small sample of a fill--such as a color, gradient, texture, or material--that is intended to be applied to an object.
- * 
+ *
  * ## Usage notes
- * 
+ *
  * Set `--spectrum-picked-color` to customize the swatch fill background color.
  */
 export default {
@@ -107,7 +108,8 @@ export default {
 		isMixedValue: false,
 	},
 	parameters: {
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 
@@ -172,7 +174,7 @@ Selected.parameters = {
 };
 
 /**
- * By default, swatches have a border. However, when swatches are used within a swatch group, there are additional border considerations. 
+ * By default, swatches have a border. However, when swatches are used within a swatch group, there are additional border considerations.
  * - When color swatches are used in a [swatch group](?path=/docs/components-swatch-group--docs), they typically have the `.spectrum-Swatch--noBorder` class.
  * - When and only when color swatches used in a swatch group have low contrast (below 3:1 contrast with the background), those swatches will have a less prominent border compared to the swatch component when used by itself. They individually use the `.spectrum-Swatch--lightBorder` class.
  */
@@ -182,7 +184,7 @@ Border.parameters = {
 	chromatic: { disableSnapshot: true },
 };
 
-/** 
+/**
  * Swatches can also have a rectangle shape with an aspect ratio of 2:1. The square shape is the default and is used in swatch groups (e.g., a palette of colors).
  */
 export const Shape = Template.bind({});

--- a/components/swatchgroup/stories/swatchgroup.stories.js
+++ b/components/swatchgroup/stories/swatchgroup.stories.js
@@ -1,29 +1,30 @@
-import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { Sizes } from "@spectrum-css/preview/decorators";
+import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { default as Swatch } from "@spectrum-css/swatch/stories/swatch.stories.js";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { SwatchgroupGroup } from "./swatchgroup.test.js";
-import { Template, RoundingTemplate } from "./template";
+import { RoundingTemplate, Template } from "./template.js";
 
 /**
  * The swatch group component is a collection of [swatches](?path=/docs/components-swatch--docs).
- * 
+ *
  * ## Usage notes
- * 
+ *
  * ### Corner rounding in swatch groups
- * 
+ *
  * A corner rounding of “none” (`.spectrum-Swatch--roundingNone` class) should be used in a swatch group in order to help minimize the Hermann grid illusion that happens at the intersections of the white space within the group.
- * 
+ *
  * The only exception is when a swatch group only takes up a single row. In that case, use any of the rounding options.
- * 
+ *
  * ### Apply border to low-contrast swatches only
- * 
+ *
  * When swatches within a swatch group have low contrast (below 3:1 contrast with the background), they have a less prominent border compared to a single swatch component used by itself, and should have the `.spectrum-Swatch--lightBorder` class. This reduces the likelihood of the UI interfering with color perception and comparisons. Otherwise, swatches within a swatch group that meet contrast should have the `.spectrum-Swatch--noBorder` class.
- * 
+ *
  * Implementations should apply the `.spectrum-Swatch--lightBorder` to the individual swatches of a swatch group that do not meet 3:1 contrast.
- * 
+ *
  * ### Density
- * 
+ *
  * Swatch groups come in 3 densities: regular (default), compact, and spacious. Compact and spacious densities retain the same swatch size as regular density, but have less or more padding between each swatch, respectively.
  */
 export default {
@@ -111,7 +112,8 @@ export default {
 				...(Swatch.parameters?.actions?.handles ?? []),
 			],
 		},
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 
@@ -165,7 +167,7 @@ Rounding.parameters = {
 export const Sizing = (args, context) => Sizes({
 	Template,
 	withBorder: false,
-	withHeading: false, 
+	withHeading: false,
 	...args,
 }, context);
 Sizing.args = Default.args;
@@ -176,7 +178,7 @@ Sizing.parameters = {
 
 /**
  * When swatches within a swatch group have low contrast (below 3:1 contrast with the background), the `.spectrum-Swatch--lightBorder` class should be applied to those swatches only.
- * 
+ *
  * The swatch group example below contains all swatches with low contrast in light mode, therefore each has the `.spectrum-Swatch--lightBorder` class applied.
  */
 export const WithLightBorder = Template.bind({});

--- a/components/switch/stories/switch.stories.js
+++ b/components/switch/stories/switch.stories.js
@@ -1,7 +1,8 @@
 import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isChecked, isDisabled, isEmphasized, size } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { SwitchGroup } from "./switch.test.js";
 import { DocsSwitchGroup, Template } from "./template.js";
 
@@ -37,7 +38,10 @@ export default {
 		label: "Switch label",
 		size: "m",
 	},
-	packageJson: pkgJson,
+	parameters: {
+		packageJson,
+		metadata,
+	},
 };
 
 export const Default = SwitchGroup.bind({});

--- a/components/table/stories/table.stories.js
+++ b/components/table/stories/table.stories.js
@@ -1,7 +1,8 @@
+import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isEmphasized, isQuiet, size } from "@spectrum-css/preview/types";
-import { Sizes } from "@spectrum-css/preview/decorators";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { TableGroup } from "./table.test.js";
 import { Template } from "./template.js";
 
@@ -110,7 +111,8 @@ export default {
 		],
 	},
 	parameters: {
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 
@@ -341,7 +343,7 @@ SectionHeaderQuiet.parameters = {
 };
 
 /**
- * 
+ *
  * A table can be wrapped in a fixed height `div` with the `.spectrum-Table-scroller` class. This allows scrolling of the table body and makes the column headers sticky (i.e. fixed to the top on scroll).
  *
  * When using the scrollable wrapper, the column headers must have a solid background color set. This can be customized to match the parent background with the custom property `--mod-table-header-background-color-scrollable`.

--- a/components/tabs/stories/tabs.stories.js
+++ b/components/tabs/stories/tabs.stories.js
@@ -1,21 +1,22 @@
+import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isEmphasized, isQuiet, size } from "@spectrum-css/preview/types";
-import { Sizes } from "@spectrum-css/preview/decorators";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { TabsGroups } from "./tabs.test.js";
-import { Template, QuietGroup, OverflowGroup, VerticalGroup, CompactGroup } from "./template.js";
+import { CompactGroup, OverflowGroup, QuietGroup, Template, VerticalGroup } from "./template.js";
 
 /**
  * Tabs organize content into multiple sections and allow users to navigate between them. The content under the set of tabs should be related and form a coherent unit. Tabs can be either horizontal or vertical.
- * 
+ *
  * ## Usage notes
- * 
+ *
  * ### Use icons consistently
  * Icons are optional, but don’t mix the use of icons in tabs if they are utilized. Navigation controls require a clear spacial relationship to one another, and mixing the use of icons can dramatically impact the visual balance and presence for each tab item.
- * 
+ *
  * ### Setting the selected tab item
  * Only one tab item can be selected at any given time. The selected tab item is designated by the `is-selected` class. A selection indicator line is shown under or next to the selected tab item.
- * 
+ *
  */
 
 export default {
@@ -112,24 +113,25 @@ export default {
 		actions: {
 			handles: [".spectrum-Tabs-item"],
 		},
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 
 /**
  * Basic, default tab items should have a label for accessibility. If a label isn’t present, it must include an icon and becomes an icon-only tab item.
- * 
+ *
  * By default, tabs have a divider that spans across all tab items. This style works as a way to anchor them to the page. These types of tabs are best used at the top of a page, as a top-level navigation.
- * 
+ *
  * Tabs are horizontal by default and should be used when horizontal space is limited.
- * 
+ *
  */
 export const Default = TabsGroups.bind({});
 Default.args = {};
 
 // ********* DOCS ONLY ********* //
 /**
- * Vertical tabs should be used when horizontal space is more generous and when the list of sections is greater than can be presented to the user in a horizontal format. 
+ * Vertical tabs should be used when horizontal space is more generous and when the list of sections is greater than can be presented to the user in a horizontal format.
  */
 export const Vertical = VerticalGroup.bind({});
 Vertical.args = {
@@ -142,7 +144,7 @@ Vertical.parameters = {
 
 export const VerticalRight = Template.bind({});
 VerticalRight.args = {
-	...Vertical.args, 
+	...Vertical.args,
 	hasRightAlignedTabs: true,
 };
 VerticalRight.storyName = "Vertical right";
@@ -153,7 +155,7 @@ VerticalRight.parameters = {
 
 /**
  * When there are too many tabs to fit horizontally across the viewport, the tabs component can be displayed as a [quiet picker](/docs/components-picker--docs). The example below is non-functional.
- * 
+ *
  * When appropriate, alternative methods of overflowing tabs such as horizontal scrolling can be used.
  */
 export const Overflow = OverflowGroup.bind({});

--- a/components/tag/stories/tag.stories.js
+++ b/components/tag/stories/tag.stories.js
@@ -2,7 +2,8 @@ import { default as IconStories } from "@spectrum-css/icon/stories/icon.stories.
 import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isEmphasized, isInvalid, isSelected, size } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { TagGroups } from "./tag.test.js";
 import { SelectedTemplate, TagsDefaultOptions } from "./template.js";
 
@@ -93,7 +94,8 @@ export default {
 		actions: {
 			handles: [],
 		},
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 

--- a/components/taggroup/stories/taggroup.stories.js
+++ b/components/taggroup/stories/taggroup.stories.js
@@ -1,6 +1,7 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { default as TagStories } from "@spectrum-css/tag/stories/tag.stories.js";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { TagGroups } from "./taggroup.test.js";
 import { Template } from "./template.js";
 
@@ -54,7 +55,8 @@ export default {
 				...(TagStories.parameters.actions.handles ?? [])
 			],
 		},
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 

--- a/components/textfield/stories/textfield.stories.js
+++ b/components/textfield/stories/textfield.stories.js
@@ -1,6 +1,7 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isFocused, isInvalid, isKeyboardFocused, isLoading, isQuiet, isReadOnly, isRequired, isValid, size } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { Template } from "./template.js";
 import { TextFieldGroup } from "./textfield.test.js";
 
@@ -116,7 +117,8 @@ export default {
 				"focusout .spectrum-Textfield"
 			],
 		},
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 

--- a/components/thumbnail/stories/thumbnail.stories.js
+++ b/components/thumbnail/stories/thumbnail.stories.js
@@ -1,7 +1,8 @@
 import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isFocused, isSelected, size } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { Template } from "./template.js";
 import { ThumbnailGroup } from "./thumbnail.test.js";
 
@@ -87,7 +88,8 @@ export default {
 		actions: {
 			handles: [],
 		},
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 

--- a/components/toast/stories/toast.stories.js
+++ b/components/toast/stories/toast.stories.js
@@ -1,4 +1,5 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
+import metadata from "../metadata/metadata.json";
 import packageJson from "../package.json";
 import { ActionTemplate, Template, ToastWrapOptions } from "./template.js";
 import { ToastGroup } from "./toast.test.js";
@@ -48,6 +49,7 @@ export default {
 			handles: ["click .spectrum-Toast button"],
 		},
 		packageJson,
+		metadata,
 	},
 };
 

--- a/components/tooltip/stories/tooltip.stories.js
+++ b/components/tooltip/stories/tooltip.stories.js
@@ -1,6 +1,7 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isFocused, isOpen } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { SemanticVariantGroup, TooltipPlacementGroup, TooltipShowOnHover } from "./template.js";
 import { PlacementVariants } from "./tooltip.test.js";
 
@@ -89,7 +90,8 @@ export default {
 		label: "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
 	},
 	parameters: {
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 
@@ -128,10 +130,10 @@ ShowOnHover.parameters = {
 /**
  * By default, tooltips are the neutral variant. This is the most common variant because most tooltips are used to only
  * disclose additional information, without conveying a semantic meaning. The neutral variant never includes an icon.
- * 
+ *
  * Tooltips also come in other semantic variants: informative (blue), positive (green), and negative (red). These use
  * [semantic colors](https://spectrum.adobe.com/page/color-system/#Color-semantics) to communicate the meaning.
- * 
+ *
  * These semantic variants include an icon to supplement the messaging. These icons are predefined and can not be
  * customized. Unless it's being used to provide context about the exact same icon, a semantic tooltip should always
  * show an icon. Doing this is essential for helping users with color vision deficiency to discern the message tone.

--- a/components/tray/stories/tray.stories.js
+++ b/components/tray/stories/tray.stories.js
@@ -1,7 +1,8 @@
 import { Template as Dialog } from "@spectrum-css/dialog/stories/template.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isOpen } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { TrayGroup } from "./tray.test.js";
 
 /**
@@ -37,7 +38,8 @@ export default {
 		viewport: {
 			defaultViewport: "mobile2"
 		},
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 

--- a/components/treeview/stories/treeview.stories.js
+++ b/components/treeview/stories/treeview.stories.js
@@ -1,7 +1,8 @@
 import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isQuiet, size } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { Template } from "./template.js";
 import { TreeViewGroup } from "./treeview.test.js";
 
@@ -36,7 +37,8 @@ export default {
 		actions: {
 			handles: ["click .spectrum-TreeView-itemLink"],
 		},
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 

--- a/components/typography/stories/typography.mdx
+++ b/components/typography/stories/typography.mdx
@@ -8,7 +8,11 @@ import {
   Source,
   Story,
 } from "@storybook/blocks";
-import { ComponentDetails, TaggedReleases } from "@spectrum-css/preview/blocks";
+import {
+  ComponentDetails,
+  TaggedReleases,
+  PropertiesTable,
+} from "@spectrum-css/preview/blocks";
 
 import * as TypographyStories from "./typography.stories";
 
@@ -94,6 +98,14 @@ Spectrum typography is broken out into several separate components: [heading](#h
 
 <Description of={TypographyStories.InternationalizedCode} />
 <Canvas of={TypographyStories.InternationalizedCode} />
+
+## Properties
+
+The component accepts the following inputs (properties):
+
+<ArgTypes />
+
+<PropertiesTable />
 
 ## Tagged releases
 

--- a/components/typography/stories/typography.stories.js
+++ b/components/typography/stories/typography.stories.js
@@ -1,7 +1,8 @@
 import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { size } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import {
 	DocsBodyVariants,
 	DocsCodeVariants,
@@ -12,8 +13,7 @@ import {
 	DocsInternationalizedCodeVariants,
 	DocsInternationalizedDetailVariants,
 	DocsInternationalizedHeadingBodyPairing,
-	DocsInternationalizedHeadingVariants,
-	Template
+	DocsInternationalizedHeadingVariants, Template
 } from "./template.js";
 import { TypographyGroup } from "./typography.test.js";
 
@@ -77,7 +77,8 @@ export default {
 		semantics: "body",
 	},
 	parameters: {
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 
@@ -170,7 +171,7 @@ BodySizes.parameters = {
 
 /**
  * When typography elements are paired, such as with heading and body below, clear content hierarchies are shown.
- * 
+ *
  * Note that the body component is not available in XXS, but the XXS heading can be paired with the XS body as seen here.
  */
 export const HeadingBodyHierarchy = (args, context) => Sizes({
@@ -255,7 +256,7 @@ DetailVariants.parameters = {
 
 /**
  * Code is used for text that represents code.
- * 
+ *
  * Multi-line blocks of code may be wrapped with `<pre>` tags to allow block formatting.
  */
 export const CodeVariants = DocsCodeVariants.bind({});

--- a/components/underlay/stories/underlay.stories.js
+++ b/components/underlay/stories/underlay.stories.js
@@ -1,7 +1,8 @@
 import { Default as ModalStory } from "@spectrum-css/modal/stories/modal.stories.js";
 import { Template as Modal } from "@spectrum-css/modal/stories/template.js";
 import { isOpen } from "@spectrum-css/preview/types";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { Template } from "./template.js";
 
 /**
@@ -28,7 +29,8 @@ export default {
 			},
 		},
 		chromatic: { disableSnapshot: true },
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	}
 };
 

--- a/components/well/stories/well.stories.js
+++ b/components/well/stories/well.stories.js
@@ -1,7 +1,8 @@
 import { Template as Link } from "@spectrum-css/link/stories/template.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { Template as Typography } from "@spectrum-css/typography/stories/template.js";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 import { WellGroup } from "./well.test.js";
 
 /**
@@ -20,7 +21,8 @@ export default {
 		actions: {
 			handles: [],
 		},
-		packageJson: pkgJson,
+		packageJson,
+		metadata,
 	},
 };
 

--- a/generator/templates/stories/{{ folderName }}.stories.js.hbs
+++ b/generator/templates/stories/{{ folderName }}.stories.js.hbs
@@ -1,9 +1,9 @@
-import { version } from "../package.json";
 import { Template } from "./template.js";
 import { isDisabled, isSelected, isHovered, isFocused } from "@spectrum-css/preview/types";
 import { {{ pascalCase name }}Group } from "./{{ pascalCase name }}.test.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import pkgJson from "../package.json";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
 
 /**
   * {{ description }}
@@ -38,12 +38,12 @@ export default {
     actions: {
       handles: ["click .spectrum-{{ pascalCase name }}"],
     },
-    componentVersion: version,
     design: {
       type: "figma",
       url: "",
     },
-    componentVersion: pkgJson.version,
+    packageJson,
+    metadata,
   }
 };
 

--- a/nx.json
+++ b/nx.json
@@ -146,11 +146,11 @@
 			}
 		},
 		"report": {
+			"cache": true,
 			"executor": "nx:run-commands",
 			"inputs": [
 				"core",
 				"tools",
-				"!{projectRoot}/stories/*.js",
 				"{workspaceRoot}/tasks/component-report.js",
 				{ "env": "NODE_ENV" }
 			],

--- a/yarn.lock
+++ b/yarn.lock
@@ -3872,6 +3872,7 @@ __metadata:
     "@babel/core": "npm:^7.25.2"
     "@chromaui/addon-visual-tests": "npm:^1.0.0"
     "@etchteam/storybook-addon-status": "npm:^5.0.0"
+    "@spectrum-css/table": "workspace:^"
     "@spectrum-css/tokens": "workspace:^"
     "@spectrum-css/typography": "workspace:^"
     "@spectrum-css/ui-icons": "workspace:^"
@@ -4139,7 +4140,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@spectrum-css/table@workspace:components/table":
+"@spectrum-css/table@workspace:^, @spectrum-css/table@workspace:components/table":
   version: 0.0.0-use.local
   resolution: "@spectrum-css/table@workspace:components/table"
   dependencies:


### PR DESCRIPTION
## Description

This creates a custom DocBlock for our docs that displays the boilerplate text for mods on the docs site. I called this component a `PropertiesTable` with the hope that we can eventually expand this component to document all the custom properties being used by the component.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

@jawinn 

- [x] Expect to see a new section added to each component between the ArgsTable and the TaggedReleases (suggest picking 5 pages at random to validate).
- [x] Expect heading "Modifiable custom properties" show a link on hover and when the icon is selected, a direct link to that section is added to the window location.
- [x] Expect pages like actionmenu to have no custom properties table (as it has no custom properties).

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

## Screenshots

<img width="849" alt="Screenshot 2024-10-02 at 5 51 12 PM" src="https://github.com/user-attachments/assets/a8709897-3983-4323-a728-de452e20623b">

<img width="1154" alt="Screenshot 2024-10-02 at 5 51 58 PM" src="https://github.com/user-attachments/assets/10763616-033d-4c69-b402-d753f8af03b9">


## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
