### PR TITLE
chore(typography): add fallback sizes for testing

### DIFF
--- a/components/typography/stories/template.js
+++ b/components/typography/stories/template.js
@@ -38,9 +38,28 @@ export const Template = (args = {}, context = {}) => {
 			return Template({ ...args, ...c }, context);
 		}
 
-		// body doesn't come in xxs, but if paired with an xxs heading, use xs (the closest size to xxs)
-		if (semantics === "body" && size === "xxs") {
-			size = "xs";
+		switch(size) {
+			case "xxs":
+				// Neither code nor body support xxs, but if paired with an xxs heading, use xs (the closest size to xxs)
+				if (["body", "code"].includes(semantics)) {
+					size = "xs";
+				}
+				break;
+			case "xs":
+				if (["detail"].includes(semantics)) {
+					size = "s";
+				}
+				break;
+			case "xxl":
+				if (["detail", "code"].includes(semantics)) {
+					size = "xl";
+				}
+				break;
+			case "xxxl":
+				if (["detail", "code"].includes(semantics)) {
+					size = "xl";
+				}
+				break;
 		}
 
 		if (typeof semantics === "undefined") {


### PR DESCRIPTION
## Description

In the Typography storybook, allow typography elements to gracefully fallback to the next closest size when an invalid size is provided.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

Visit the [typography storybook page here](https://pr-3198--spectrum-css.netlify.app/preview/?path=/story/components-typography--default):

- [X] @pfulton At the extra-extra-small size, expect the spectrum-Body and spectrum-Code snippets to use the `sizeXS` class.
- [X] @pfulton At the extra-small size, expect the spectrum-Detail snippet to use the `sizeS` class.
- [X] @pfulton At the extra-extra-large size, expect the spectrum-Detail and spectrum-Code snippets to use the `sizeXL` class.
- [X] @pfulton At the extra-extra-extra-large size, expect the spectrum-Detail and spectrum-Code snippets to use the `sizeXL` class.
- [x] Expect to see updates to VRT baselines for typography sizing.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] ✨ This pull request is ready to merge. ✨
