### PR TITLE
docs: add links to figma assets part 1

### DIFF
--- a/components/accordion/stories/accordion.stories.js
+++ b/components/accordion/stories/accordion.stories.js
@@ -58,7 +58,7 @@ export default {
 		chromatic: { disableSnapshot: true },
 		design: {
 			type: "figma",
-			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=39469-6827&t=HYBJ4Hj6Rc5c83Rp-4",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=39469-5419",
 		},
 		packageJson: pkgJson,
 	},

--- a/components/accordion/stories/accordion.stories.js
+++ b/components/accordion/stories/accordion.stories.js
@@ -56,6 +56,10 @@ export default {
 			handles: ["click .spectrum-Accordion-item"],
 		},
 		chromatic: { disableSnapshot: true },
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=39469-6827&t=HYBJ4Hj6Rc5c83Rp-4",
+		},
 		packageJson: pkgJson,
 	},
 	tags: ["!autodocs"],

--- a/components/actionbar/stories/actionbar.stories.js
+++ b/components/actionbar/stories/actionbar.stories.js
@@ -64,7 +64,7 @@ export default {
 		// Getting the Figma link: https://help.figma.com/hc/en-us/articles/360045003494-Storybook-and-Figma
 		design: {
 			type: "figma",
-			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=28379-3165&node-type=frame&t=Kcz7zeePp3PeRusJ-11",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=28379-300",
 		},
 		packageJson: pkgJson,
 	},

--- a/components/actionbar/stories/actionbar.stories.js
+++ b/components/actionbar/stories/actionbar.stories.js
@@ -64,7 +64,7 @@ export default {
 		// Getting the Figma link: https://help.figma.com/hc/en-us/articles/360045003494-Storybook-and-Figma
 		design: {
 			type: "figma",
-			url: "https://www.figma.com/file/MPtRIVRzPp2VHiEplwXL2X/S-%2F-Manual?node-id=465%3A3127&t=xbooxCWItOFgG2xM-1",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=28379-3165&node-type=frame&t=Kcz7zeePp3PeRusJ-11",
 		},
 		packageJson: pkgJson,
 	},

--- a/components/actionbutton/stories/actionbutton.stories.js
+++ b/components/actionbutton/stories/actionbutton.stories.js
@@ -85,7 +85,7 @@ export default {
 		},
 		design: {
 			type: "figma",
-			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=702-2904&node-type=frame&t=Kcz7zeePp3PeRusJ-11",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=702-2877",
 		},
 		packageJson: pkgJson,
 		docs: {

--- a/components/actionbutton/stories/actionbutton.stories.js
+++ b/components/actionbutton/stories/actionbutton.stories.js
@@ -83,6 +83,10 @@ export default {
 		actions: {
 			handles: ["click .spectrum-ActionButton:not([disabled])"],
 		},
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=702-2904&node-type=frame&t=Kcz7zeePp3PeRusJ-11",
+		},
 		packageJson: pkgJson,
 		docs: {
 			story: {

--- a/components/actiongroup/stories/actiongroup.stories.js
+++ b/components/actiongroup/stories/actiongroup.stories.js
@@ -60,6 +60,10 @@ export default {
 				...(ActionButton?.parameters?.actions?.handles ?? []),
 			],
 		},
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=19083-1940&node-type=frame&t=Kcz7zeePp3PeRusJ-11",
+		},
 		packageJson: pkgJson,
 	},
 };

--- a/components/actiongroup/stories/actiongroup.stories.js
+++ b/components/actiongroup/stories/actiongroup.stories.js
@@ -62,7 +62,7 @@ export default {
 		},
 		design: {
 			type: "figma",
-			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=19083-1940&node-type=frame&t=Kcz7zeePp3PeRusJ-11",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=19083-360",
 		},
 		packageJson: pkgJson,
 	},

--- a/components/alertbanner/stories/alertbanner.stories.js
+++ b/components/alertbanner/stories/alertbanner.stories.js
@@ -68,6 +68,10 @@ export default {
 		actions: {
 			handles: ["click .spectrum-AlertBanner button"],
 		},
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=15963-1181&node-type=frame&t=Kcz7zeePp3PeRusJ-11",
+		},
 		packageJson: pkgJson,
 	},
 };

--- a/components/alertbanner/stories/alertbanner.stories.js
+++ b/components/alertbanner/stories/alertbanner.stories.js
@@ -70,7 +70,7 @@ export default {
 		},
 		design: {
 			type: "figma",
-			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=15963-1181&node-type=frame&t=Kcz7zeePp3PeRusJ-11",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=15963-287",
 		},
 		packageJson: pkgJson,
 	},

--- a/components/alertdialog/stories/alertdialog.stories.js
+++ b/components/alertdialog/stories/alertdialog.stories.js
@@ -44,6 +44,10 @@ export default {
 		actions: {
 			handles: ["click .spectrum-AlertDialog button"],
 		},
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=21919-953&node-type=frame&t=Kcz7zeePp3PeRusJ-11",
+		},
 		docs: {
 			story: {
 				height: "300px",

--- a/components/alertdialog/stories/alertdialog.stories.js
+++ b/components/alertdialog/stories/alertdialog.stories.js
@@ -46,7 +46,7 @@ export default {
 		},
 		design: {
 			type: "figma",
-			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=21919-953&node-type=frame&t=Kcz7zeePp3PeRusJ-11",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=21917-157",
 		},
 		docs: {
 			story: {

--- a/components/avatar/stories/avatar.stories.js
+++ b/components/avatar/stories/avatar.stories.js
@@ -59,7 +59,7 @@ export default {
 	parameters: {
 		design: {
 			type: "figma",
-			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=19100-177&node-type=frame&t=Kcz7zeePp3PeRusJ-11",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=19100-131",
 		},
 		packageJson: pkgJson,
 	},

--- a/components/avatar/stories/avatar.stories.js
+++ b/components/avatar/stories/avatar.stories.js
@@ -57,6 +57,10 @@ export default {
 		altText: "Shantanu",
 	},
 	parameters: {
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=19100-177&node-type=frame&t=Kcz7zeePp3PeRusJ-11",
+		},
 		packageJson: pkgJson,
 	},
 	tags: ["!autodocs"],

--- a/components/badge/stories/badge.stories.js
+++ b/components/badge/stories/badge.stories.js
@@ -61,6 +61,10 @@ export default {
 		fixed: "none"
 	},
 	parameters: {
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=36806-7201&node-type=frame&t=Kcz7zeePp3PeRusJ-11",
+		},
 		packageJson: pkgJson,
 	},
 	tags: ["!autodocs"],

--- a/components/badge/stories/badge.stories.js
+++ b/components/badge/stories/badge.stories.js
@@ -63,7 +63,7 @@ export default {
 	parameters: {
 		design: {
 			type: "figma",
-			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=36806-7201&node-type=frame&t=Kcz7zeePp3PeRusJ-11",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=36806-6551",
 		},
 		packageJson: pkgJson,
 	},

--- a/components/breadcrumb/stories/breadcrumb.stories.js
+++ b/components/breadcrumb/stories/breadcrumb.stories.js
@@ -42,7 +42,7 @@ export default {
 	parameters: {
 		design: {
 			type: "figma",
-			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=29434-7665&node-type=frame&t=Kcz7zeePp3PeRusJ-11",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=29434-6624",
 		},
 		packageJson: pkgJson,
 	},

--- a/components/breadcrumb/stories/breadcrumb.stories.js
+++ b/components/breadcrumb/stories/breadcrumb.stories.js
@@ -40,6 +40,10 @@ export default {
 		variant: "default",
 	},
 	parameters: {
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=29434-7665&node-type=frame&t=Kcz7zeePp3PeRusJ-11",
+		},
 		packageJson: pkgJson,
 	},
 };

--- a/components/button/stories/button.stories.js
+++ b/components/button/stories/button.stories.js
@@ -86,7 +86,7 @@ export default {
 		},
 		design: {
 			type: "figma",
-			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=36713-4026&node-type=frame&t=Kcz7zeePp3PeRusJ-11",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=707-2774",
 		},
 		packageJson: pkgJson,
 	},

--- a/components/button/stories/button.stories.js
+++ b/components/button/stories/button.stories.js
@@ -84,6 +84,10 @@ export default {
 		actions: {
 			handles: ["click .spectrum-Button"],
 		},
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=36713-4026&node-type=frame&t=Kcz7zeePp3PeRusJ-11",
+		},
 		packageJson: pkgJson,
 	},
 	tags: ["!autodocs"],

--- a/components/buttongroup/stories/buttongroup.stories.js
+++ b/components/buttongroup/stories/buttongroup.stories.js
@@ -56,6 +56,10 @@ export default {
 		],
 	},
 	parameters: {
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=13663-7132&node-type=frame&t=Kcz7zeePp3PeRusJ-11",
+		},
 		packageJson: pkgJson,
 	},
 };

--- a/components/buttongroup/stories/buttongroup.stories.js
+++ b/components/buttongroup/stories/buttongroup.stories.js
@@ -58,7 +58,7 @@ export default {
 	parameters: {
 		design: {
 			type: "figma",
-			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=13663-7132&node-type=frame&t=Kcz7zeePp3PeRusJ-11",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=13663-6530",
 		},
 		packageJson: pkgJson,
 	},


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->
This PR is the first in a series that adds S2 design links to components. Now, when a user is on a story page (not a docs page), under the "Design" tab, a Figma asset should render. 

<img width="548" alt="Screenshot 2024-10-04 at 10 58 33 AM" src="https://github.com/user-attachments/assets/419dc0ea-c37d-4b37-8713-726de3ba6bbf">

Using the [S2 / Desktop Figma file](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=5634-5140&node-type=frame&t=YT3sYHqnhqpnjdv9-0), specific frames were selected in an attempt to give a user (specifically a developer) context to the component they are viewing. (instructions on how to get the Figma frame links are here: [slack canvas](https://adobe.enterprise.slack.com/docs/T024FSURM/F07PTPUPMRV)

Most designs are geared towards the default for a component, like linking to the `M`/medium grouping of the component and its states, or the frame selection with the most options for a user to see (like accordion item, with its multiple states, densities and variants).

Components affected:
- accordion
- action bar
- action button
- action group
- alert banner
- alert dialog
- avatar
- badge
- breadcrumbs
- button
- button group

_Note: not all Spectrum CSS components have corresponding Figma designs._

### Jira/Specs

[CSS-972](https://jira.corp.adobe.com/browse/CSS-972)

#### Design pages
- [accordion](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=39469-5419)
- [action bar](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=28379-300)
- [action button](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=702-2877)
- [action group](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=19083-360)
- [alert banner](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=15963-287)
- [alert dialog](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=21917-157)
- [avatar](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=19100-131)
- [badge](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=36806-6551)
- [breadcrumbs](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=29434-6624)
- [button](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=707-2774)
- [button group](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=13663-6530)

### Pending Questions

Would we rather link to the entire component Figma page...
<img width="1053" alt="Screenshot 2024-10-03 at 4 43 27 PM" src="https://github.com/user-attachments/assets/342d86c5-babe-4750-9a82-0688d06c15ba">

...instead of a just a particular frame? 
<img width="1139" alt="Screenshot 2024-10-03 at 4 50 01 PM" src="https://github.com/user-attachments/assets/ab5aa744-6228-45dc-b3e8-b4a86e6f3a81">

The full page gives a user the most context and is the most understandable, particularly when the pages have additional labels/columns that aren't part of the frame selection, as can be seen with the button group frame. Does that pose any security issues if the Figma page can be seen on the open source site, since people typically have to request access to the Figma files?

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

- [x] Pull down the branch to run locally @rise-erpelding 
- [x] Visit [the accordion default story page](http://localhost:8080/?path=/story/components-accordion--default)
- [x] Open the `Design` tab (in the add-ons control panel)
- [x] Verify a corresponding S2 Figma asset for the component now renders. It should say which page and which frame was rendered in the bottom left corner.

<img width="300" alt="Screenshot 2024-10-04 at 11 35 47 AM" src="https://github.com/user-attachments/assets/387f053e-2545-4c12-bc32-102c9f5c6f73">

- [ ] Repeat the steps above for each of the affected components listed
    - [x] accordion
    - [x] action bar
    - [x] action button
    - [x] action group
    - [x] alert banner
    - [x] alert dialog
    - [x] avatar
    - [x] badge
    - [x] breadcrumbs
    - [x] button
    - [x] button group

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [ ] ✨ This pull request is ready to merge. ✨
