### PR TITLE
docs: add links to figma assets part 2

### DIFF
--- a/components/checkbox/stories/checkbox.stories.js
+++ b/components/checkbox/stories/checkbox.stories.js
@@ -50,6 +50,10 @@ export default {
 		actions: {
 			handles: ["click input[type=\"checkbox\"]"],
 		},
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=164-16685",
+		},
 		packageJson: pkgJson,
 	},
 };

--- a/components/closebutton/stories/closebutton.stories.js
+++ b/components/closebutton/stories/closebutton.stories.js
@@ -45,6 +45,10 @@ export default {
 		actions: {
 			handles: ["click .spectrum-CloseButton"],
 		},
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=13601-149",
+		},
 		packageJson: pkgJson,
 	},
 };

--- a/components/coachindicator/stories/coachindicator.stories.js
+++ b/components/coachindicator/stories/coachindicator.stories.js
@@ -31,6 +31,10 @@ export default {
 		variant: "default",
 	},
 	parameters: {
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=48600-896",
+		},
 		packageJson: pkgJson,
 	},
 };

--- a/components/coachmark/stories/coachmark.stories.js
+++ b/components/coachmark/stories/coachmark.stories.js
@@ -54,6 +54,10 @@ export default {
 				...(Menu.parameters?.actions?.handles ?? []),
 			],
 		},
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=37804-254",
+		},
 		packageJson: pkgJson,
 		docs: {
 			story: {

--- a/components/colorarea/stories/colorarea.stories.js
+++ b/components/colorarea/stories/colorarea.stories.js
@@ -40,6 +40,10 @@ export default {
 		selectedColor: "rgba(255, 0, 0, 1)",
 	},
 	parameters: {
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=36734-2573",
+		},
 		packageJson: pkgJson,
 	},
 	tags: ["!autodocs"],

--- a/components/colorhandle/stories/colorhandle.stories.js
+++ b/components/colorhandle/stories/colorhandle.stories.js
@@ -45,6 +45,10 @@ export default {
 		}
 	},
 	parameters: {
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=13065-162",
+		},
 		packageJson: pkgJson,
 	},
 	tags: ["!autodocs"],

--- a/components/colorslider/stories/colorslider.stories.js
+++ b/components/colorslider/stories/colorslider.stories.js
@@ -49,6 +49,10 @@ export default {
 		selectedColor: "rgba(255, 0, 0, 1)",
 	},
 	parameters: {
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=36740-137",
+		},
 		packageJson: pkgJson,
 	},
 	tags: ["!autodocs"],

--- a/components/colorwheel/stories/colorwheel.stories.js
+++ b/components/colorwheel/stories/colorwheel.stories.js
@@ -41,6 +41,10 @@ export default {
 		selectedColor: "rgba(255, 0, 0, 50%)",
 	},
 	parameters: {
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=20606-73",
+		},
 		packageJson: pkgJson,
 	},
 	tags: ["!autodocs"],

--- a/components/combobox/stories/combobox.stories.js
+++ b/components/combobox/stories/combobox.stories.js
@@ -66,6 +66,10 @@ export default {
 		testId: "combobox",
 	},
 	parameters: {
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=727-2550",
+		},
 		packageJson: pkgJson,
 	},
 };

--- a/components/contextualhelp/stories/contextualhelp.stories.js
+++ b/components/contextualhelp/stories/contextualhelp.stories.js
@@ -92,6 +92,10 @@ export default {
 				...(ActionButtonStories?.parameters?.actions?.handles ?? [])
 			],
 		},
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=49480-1934",
+		},
 		packageJson: pkgJson,
 		docs: {
 			story: {


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

This PR is the second in a series that adds S2 design links to components. Now, when a user is on a story page (not a docs page), under the "Design" tab, a Figma asset should render. 

<img width="548" alt="Screenshot 2024-10-04 at 10 58 33 AM" src="https://github.com/user-attachments/assets/419dc0ea-c37d-4b37-8713-726de3ba6bbf">

Using the [S2 / Desktop Figma file](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=5634-5140&node-type=frame&t=YT3sYHqnhqpnjdv9-0), the top-level component pages are linked in an attempt to give a user (specifically a developer) context to the component they are viewing. (instructions on how to get the Figma frame links are here: [slack canvas](https://adobe.enterprise.slack.com/docs/T024FSURM/F07PTPUPMRV)

Components affected:
- checkbox (do we want the designs to link to the single checkbox, or checkbox group?)
- close button
- coach indicator
- coach mark
- colar area
- color handle
- color slider
- color wheel
- combobox
- contextual help

_Note: not all Spectrum CSS components have corresponding Figma designs._

### Jira/Specs

[CSS-973](https://jira.corp.adobe.com/browse/CSS-973)

#### Design pages

- [checkbox](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=164-16685)
- [close button](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=13601-149)
- [coach indicator](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=48600-896)
- [coach mark](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=37804-254)
- [colar area](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=36734-2573)
- [color handle](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=13065-162)
- [color slider](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=36740-137)
- [color wheel](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=20606-73)
- [combobox](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=727-2550)
- [contextual help](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=49480-1934)

### Pending Questions

Do we want the designs to link to the single checkbox, or checkbox group? 

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

- [ ] Pull down the branch to run locally 
- [ ] Visit [the checkbox default story page](http://localhost:8080/?path=/story/components-checkbox--default)
- [ ] Open the `Design` tab (in the add-ons control panel)
- [ ] Verify a corresponding S2 Figma asset for the component now renders. It should say which page and which frame was rendered in the bottom left corner.

<img width="300" alt="Screenshot 2024-10-04 at 11 35 47 AM" src="https://github.com/user-attachments/assets/387f053e-2545-4c12-bc32-102c9f5c6f73">

- [ ] Repeat the steps above for each of the affected components listed
    - [ ] checkbox
    - [ ] close button
    - [ ] coach indicator
    - [ ] coach mark
    - [ ] colar area
    - [ ] color handle
    - [ ] color slider
    - [ ] color wheel
    - [ ] combobox
    - [ ] contextual help

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [ ] ✨ This pull request is ready to merge. ✨
