### PR TITLE
docs(textfield,textarea): migrating docs to storybook

### DIFF
--- a/components/textfield/stories/template.js
+++ b/components/textfield/stories/template.js
@@ -1,6 +1,7 @@
 import { Template as FieldLabel } from "@spectrum-css/fieldlabel/stories/template.js";
+import { Template as HelpText } from "@spectrum-css/helptext/stories/template.js";
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
-import { getRandomId } from "@spectrum-css/preview/decorators";
+import { Container, getRandomId } from "@spectrum-css/preview/decorators";
 import { Template as ProgressCircle } from "@spectrum-css/progresscircle/stories/template.js";
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
@@ -72,11 +73,13 @@ export const Template = ({
 	displayLabel = false,
 	labelPosition = "top",
 	labelText,
+	characterCount,
 	iconName,
 	iconSet,
 	pattern,
 	placeholder,
 	name,
+	helpText = "",
 	id = getRandomId("textfield"),
 	value = "",
 	type = "text",
@@ -134,6 +137,8 @@ export const Template = ({
 			size,
 			label: labelText,
 		}, context))}
+		${when(typeof characterCount !== "undefined", () => html`
+			<span class="${rootClass}-characterCount">${characterCount}</span>`)}
 		${when(iconName, () => Icon({
 			size,
 			iconName,
@@ -183,6 +188,90 @@ export const Template = ({
 			size: "s",
 			customClasses: customProgressCircleClasses,
 		}, context))}
+		${when(helpText, () =>
+				HelpText({
+					text: helpText,
+					variant: isInvalid ? "negative" : "neutral",
+					size,
+					hideIcon: true,
+					isDisabled
+				}, context ))}
 	</div>
 	`;
 };
+
+export const HelpTextOptions = (args, context) => Container({
+	direction: "column",
+	withBorder: false,
+	withHeading: false,
+	content: html`
+		${Container({
+			withBorder: false,
+			heading: "Description",
+			content: Template({...args, isRequired: true, labelText: "Username", value: "lisawilson24", helpText: "Username must be at least 8 characters."}, context),
+		})}
+		${Container({
+			withBorder: false,
+			heading: "Error message",
+			content: Template({...args, isRequired: true, labelText: "Email address", value: "abc@adobe.com", helpText: "Enter your email address", isInvalid: true }, context),
+		})}
+	`
+});
+
+export const TextFieldOptions = (args, context) => Container({
+	direction: "row",
+	withBorder: false,
+	wrapperStyles: {
+		rowGap: "12px",
+	},
+	content: html`
+		${Container({
+			withBorder: false,
+			containerStyles: {
+				"gap": "8px",
+			},
+			heading: "Default",
+			content: Template({...args, context})
+		})}
+		${Container({
+			withBorder: false,
+			containerStyles: {
+				"gap": "8px",
+			},
+			heading: "Invalid",
+			content: Template({...args, isInvalid: true}, context)
+		})}
+		${Container({
+			withBorder: false,
+			containerStyles: {
+				"gap": "8px",
+			},
+			heading: "Focused",
+			content: Template({...args, isFocused: true}, context)
+		})}
+		${Container({
+			withBorder: false,
+			containerStyles: {
+				"gap": "8px",
+			},
+			heading: "Invalid, focused",
+			content: Template({...args, isInvalid: true, isFocused: true}, context)
+		})}
+		${Container({
+			withBorder: false,
+			containerStyles: {
+				"gap": "8px",
+			},
+			heading: "Keyboard-focused",
+			content: Template({...args, isKeyboardFocused: true}, context)
+		})}
+		${Container({
+			withBorder: false,
+			containerStyles: {
+				"gap": "8px",
+			},
+			heading: "Invalid, keyboard-focused",
+			content: Template({...args, isInvalid: true, isKeyboardFocused: true}, context)
+		})}
+	`
+});

--- a/components/textfield/stories/textarea.stories.js
+++ b/components/textfield/stories/textarea.stories.js
@@ -1,0 +1,155 @@
+import { Sizes } from "@spectrum-css/preview/decorators";
+import { disableDefaultModes } from "@spectrum-css/preview/modes";
+import metadata from "../metadata/metadata.json";
+import packageJson from "../package.json";
+import { HelpTextOptionsTextArea, Template, TextAreaOptions } from "./textarea.template.js";
+import { TextAreaGroup } from "./textarea.test.js";
+import { default as Textfield } from "./textfield.stories.js";
+
+/**
+ * A text area is multi-line text field using the `<textarea>` element that lets a user input a longer amount of text than a standard text field. It can include all of the standard validation options supported by the text field component.
+*/
+
+export default {
+	title: "Text area",
+	component: "TextArea",
+	argTypes: {
+		...Textfield.argTypes
+	},
+	args: {
+		...Textfield.args,
+		labelText: "Comments"
+	},
+	parameters: {
+		packageJson,
+		metadata,
+	}
+};
+
+export const Default = TextAreaGroup.bind({});
+Default.args = {};
+Default.tags = ["!autodocs"];
+
+// ********* DOCS ONLY ********* //
+
+export const Standard = TextAreaOptions.bind({});
+Standard.tags = ["!dev"];
+Standard.storyName = "Default";
+Standard.parameters = {
+	chromatic: { disableSnapshot: true }
+};
+
+export const CharacterCount = Template.bind({});
+CharacterCount.tags = ["!dev"];
+CharacterCount.args = {
+	hasCharacterCount: true,
+	characterCount: 50,
+	value: "Duis mollit ut laboris est labore sunt ipsum. Proident nostrud in ea reprehenderit proident nostrud. Anim ut est anim ex amet."
+};
+CharacterCount.parameters = {
+	chromatic: { disableSnapshot: true }
+};
+
+/**
+ * A text area in a disabled state shows that an input field exists, but is not available in that circumstance. This can be used to maintain layout continuity and communicate that a field may become available later.
+*/
+export const Disabled = Template.bind({});
+Disabled.tags = ["!dev"];
+Disabled.args = {
+	isDisabled: true
+};
+Disabled.parameters = {
+	chromatic: { disableSnapshot: true }
+};
+
+/**
+ * A text area can have [help text](/docs/components-help-text--docs) below the field to give extra context or instruction about what a user should input in the field. The help text area has two options: a description and an error message. The description communicates a hint or helpful information, such as specific requirements for correctly filling out the field. The error message communicates an error for when the field requirements aren’t met, prompting a user to adjust what they had originally input.
+ *
+ * Instead of placeholder text, use the help text description to convey requirements or to show any formatting examples that would help user comprehension. Putting instructions for how to complete an input, requirements, or any other essential information into placeholder text is not accessible.
+*/
+export const HelpText = HelpTextOptionsTextArea.bind({});
+HelpText.tags = ["!dev"];
+HelpText.parameters = {
+	chromatic: { disableSnapshot: true }
+};
+
+export const Quiet = TextAreaOptions.bind({});
+Quiet.tags = ["!dev"];
+Quiet.args = {
+	isQuiet: true,
+};
+Quiet.parameters = {
+	chromatic: { disableSnapshot: true }
+};
+
+/**
+ * Text area has a read-only option for when content in the disabled state still needs to be shown. This allows for content to be copied, but not interacted with or changed.
+*/
+export const Readonly = Template.bind({});
+Readonly.tags = ["!dev"];
+Readonly.args = {
+	isReadOnly: true,
+	value: "Adipisicing dolor quis ad non ad ipsum irure ullamco."
+};
+Readonly.parameters = {
+	chromatic: { disableSnapshot: true }
+};
+Readonly.storyName = "Read-only";
+
+/**
+ * Side labels are most useful when vertical space is limited.
+*/
+export const SideLabel = Template.bind({});
+SideLabel.tags = ["!dev"];
+SideLabel.args = {
+	labelPosition: "side",
+	value: "Qui nulla cupidatat do ex laborum ipsum et culpa reprehenderit dolore.",
+	displayCounter: true,
+	characterCount: 50,
+	helpText: "Example help text. Lorem ipsum dolor sit amet."
+};
+SideLabel.parameters = {
+	chromatic: { disableSnapshot: true }
+};
+
+
+/**
+ * Text area can display a validation icon when the text entry is expected to conform to a specific format (e.g., email address, credit card number, password creation requirements, etc.). The icon appears as soon as a user types a valid entry in the field.
+*/
+export const Validation = Template.bind({});
+Validation.tags = ["!dev"];
+Validation.args = {
+	isValid: true
+};
+Validation.parameters = {
+	chromatic: { disableSnapshot: true }
+};
+Validation.storyName = "Validation icon";
+
+
+export const Sizing = (args, context) => Sizes({
+	Template: Template,
+	withHeading: false,
+	withBorder: false,
+	...args,
+}, context);
+Sizing.args = {
+	helpText: "Example help text. Lorem ipsum dolor sit amet.",
+	hasCharacterCount: true
+};
+Sizing.tags = ["!dev"];
+Sizing.parameters = {
+	chromatic: { disableSnapshot: true }
+};
+
+// ********* VRT ONLY ********* //
+// @todo should this show text field and text area in the same snapshot?
+export const WithForcedColors = TextAreaGroup.bind({});
+WithForcedColors.args = Default.args;
+WithForcedColors.tags = ["!autodocs", "!dev"];
+WithForcedColors.parameters = {
+	chromatic: {
+		forcedColors: "active",
+		modes: disableDefaultModes
+	},
+};

--- a/components/textfield/stories/textarea.template.js
+++ b/components/textfield/stories/textarea.template.js
@@ -1,0 +1,96 @@
+import { Container } from "@spectrum-css/preview/decorators";
+import { html } from "lit";
+import { Template as Textfield } from "./template";
+
+export const Template = ({
+	customClasses = [],
+	rootClass = "spectrum-Textfield",
+	size = "m",
+	multiline = true,
+	...item
+} = {}, context = {}) => Textfield({
+	customClasses: [
+		rootClass,
+		typeof size !== "undefined" ? `${rootClass}--size${size.toUpperCase()}` : null,
+		...customClasses
+	],
+	size,
+	multiline,
+	...item
+}, context );
+
+export const HelpTextOptionsTextArea = (args, context) => Container({
+	direction: "column",
+	withBorder: false,
+	withHeading: false,
+	content: html`
+		${Container({
+			withBorder: false,
+			heading: "Description",
+			content: Template({...args, isRequired: true, labelText: "Interests", value: "", helpText: "Describe the interests you'd like to explore through our tutorials."}, context),
+		})}
+		${Container({
+			withBorder: false,
+			heading: "Error message",
+			content: Template({...args, isRequired: true, labelText: "Interests", value: "", helpText: "Enter at least one interest.", isInvalid: true }, context),
+		})}
+	`
+});
+
+export const TextAreaOptions = (args, context) => Container({
+	direction: "row",
+	withBorder: false,
+	wrapperStyles: {
+		rowGap: "12px",
+	},
+	content: html`
+		${Container({
+			withBorder: false,
+			containerStyles: {
+				"gap": "8px",
+			},
+			heading: "Default",
+			content: Template({...args, context})
+		})}
+		${Container({
+			withBorder: false,
+			containerStyles: {
+				"gap": "8px",
+			},
+			heading: "Invalid",
+			content: Template({...args, isInvalid: true}, context)
+		})}
+		${Container({
+			withBorder: false,
+			containerStyles: {
+				"gap": "8px",
+			},
+			heading: "Focused",
+			content: Template({...args, isFocused: true}, context)
+		})}
+		${Container({
+			withBorder: false,
+			containerStyles: {
+				"gap": "8px",
+			},
+			heading: "Invalid, focused",
+			content: Template({...args, isInvalid: true, isFocused: true}, context)
+		})}
+		${Container({
+			withBorder: false,
+			containerStyles: {
+				"gap": "8px",
+			},
+			heading: "Keyboard-focused",
+			content: Template({...args, isKeyboardFocused: true}, context)
+		})}
+		${Container({
+			withBorder: false,
+			containerStyles: {
+				"gap": "8px",
+			},
+			heading: "Invalid, keyboard-focused",
+			content: Template({...args, isInvalid: true, isKeyboardFocused: true}, context)
+		})}
+	`
+});

--- a/components/textfield/stories/textarea.test.js
+++ b/components/textfield/stories/textarea.test.js
@@ -1,42 +1,36 @@
 import { Variants } from "@spectrum-css/preview/decorators";
-import { Template } from "./template.js";
+import { Template } from "./textarea.template";
 
-export const TextFieldGroup = Variants({
+export const TextAreaGroup = Variants({
 	Template,
 	testData: [{
 	},
 	{
-		testHeading: "With field label",
+		testHeading: "Text area with value",
 		displayLabel: true,
-		value: "UsernameWiderThanInput@ReallyLongEmail.com"
-	},
-	{
+		value: "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.",
+	},{
 		testHeading: "With side label",
 		displayLabel: true,
 		labelPosition: "side",
-		value: "UsernameWiderThanInput@ReallyLongEmail.com"
-	},
-	{
-		testHeading: "With value",
-		displayLabel: true,
-		value: "UsernameWiderThanInput@ReallyLongEmail.com"
+		value: "Sit ad magna pariatur id et qui ex non voluptate."
 	},{
 		testHeading: "With help text",
 		displayLabel: true,
-		value: "UsernameWiderThanInput@ReallyLongEmail.com",
+		value: "Exercitation ad magna aliqua officia adipisicing ullamco.",
 		helpText: "Example help text. Ullamco laborum."
 	},{
 		testHeading: "Quiet",
-		value: "UsernameWiderThanInput@ReallyLongEmail.com",
+		value: "Ullamco id consequat adipisicing veniam sunt ut cupidatat do ullamco.",
 		isQuiet: true
 	},{
 		testHeading: "Quiet, with side label",
-		value: "UsernameWiderThanInput@ReallyLongEmail.com",
+		value: "Sunt Lorem consequat quis sunt tempor aliqua ipsum ut.",
 		labelPosition: "side",
 		isQuiet: true
-	},{
+	}, {
 		testHeading: "Character count",
-		value: "UsernameWiderThanInput@ReallyLongEmail.com",
+		value: "Sunt Lorem consequat quis sunt tempor aliqua ipsum ut.",
 		hasCharacterCount: true,
 		characterCount: 50
 	}],

--- a/components/textfield/stories/textfield.stories.js
+++ b/components/textfield/stories/textfield.stories.js
@@ -1,12 +1,16 @@
+import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isFocused, isInvalid, isKeyboardFocused, isLoading, isQuiet, isReadOnly, isRequired, isValid, size } from "@spectrum-css/preview/types";
 import metadata from "../metadata/metadata.json";
 import packageJson from "../package.json";
-import { Template } from "./template.js";
+import { HelpTextOptions, Template, TextFieldOptions } from "./template.js";
 import { TextFieldGroup } from "./textfield.test.js";
 
 /**
  * Text fields are text boxes that allow users to input custom text entries with a keyboard. Various decorations can be displayed around the field to communicate the entry requirements.
+ *
+ * ## Usage Notes
+ * A single-line text field using the `<input>` element.
  */
 export default {
 	title: "Text field",
@@ -41,7 +45,7 @@ export default {
 			type: { name: "text" },
 			table: {
 				type: { summary: "text" },
-				category: "Component",
+				category: "Content",
 			},
 			control: "text",
 			if: { arg: "displayLabel", truthy: true },
@@ -54,15 +58,7 @@ export default {
 		isKeyboardFocused,
 		size: size(["s", "m", "l", "xl"]),
 		isQuiet,
-		multiline: {
-			name: "Multiline",
-			type: { name: "boolean" },
-			table: {
-				type: { summary: "boolean" },
-				category: "Component",
-			},
-			control: "boolean",
-		},
+		multiline: { table: { disable: true } },
 		grows: {
 			name: "Grows",
 			type: { name: "boolean" },
@@ -80,16 +76,36 @@ export default {
 		isRequired,
 		isReadOnly,
 		isLoading,
-		pattern: {
-			name: "Pattern",
+		pattern: { table: { disable: true } },
+		value: { table: { disable: true } },
+		helpText: {
+			name: "Help text (description)",
 			type: { name: "string" },
+			control: { type: "text" },
 			table: {
 				type: { summary: "string" },
+				category: "Content",
+			},
+		},
+		hasCharacterCount: {
+			name: "Has character count",
+			type: { name: "boolean" },
+			table: {
+				type: { summary: "boolean" },
 				category: "Component",
 			},
-			control: "text",
+			control: "boolean",
 		},
-		value: { table: { disable: true } },
+		characterCount: {
+			name: "Character counter",
+			type: { name: "number" },
+			table: {
+				type: { summary: "number" },
+				category: "Component",
+			},
+			control: { type: "number" },
+			if: { arg: "hasCharacterCount", eq: true },
+		}
 	},
 	args: {
 		rootClass: "spectrum-Textfield",
@@ -101,13 +117,16 @@ export default {
 		isFocused: false,
 		isKeyboardFocused: false,
 		isLoading: false,
-		displayLabel: false,
+		displayLabel: true,
+		hasCharacterCount: false,
+		characterCount: 50,
 		labelPosition: "top",
+		labelText: "Username",
 		size: "m",
-		multiline: false,
 		grows: false,
 		isQuiet: false,
 		value: "",
+		helpText: ""
 	},
 	parameters: {
 		actions: {
@@ -122,23 +141,130 @@ export default {
 	},
 };
 
+/**
+ * Text fields should always have a label. In rare cases where context is sufficient and an accessibility expert has reviewed the design, the label could be undefined. These text fields without a visible label should still include an aria-label in HTML (depending on the context, “aria-label” or “aria-labelledby”).
+*/
+
 export const Default = TextFieldGroup.bind({});
-Default.args = {
-	labelText: "Username",
-};
+Default.tags = ["!autodocs"];
+Default.args = {};
 
 // ********* DOCS ONLY ********* //
-export const TextArea = Template.bind({});
-TextArea.tags = ["!dev"];
-TextArea.args = {
-	labelText: "Username",
-	multiline: true,
-	grows: true,
-	value: "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.",
+
+export const Standard = TextFieldOptions.bind({});
+Standard.tags = ["!dev"];
+Standard.storyName = "Default";
+Standard.parameters = {
+	chromatic: { disableSnapshot: true }
 };
-TextArea.parameters = {
-	chromatic: { disableSnapshot: true },
+
+/**
+ * Text fields can display a character count indicator when the length of the text entry needs to be kept under a predefined value. Character count indicators can be used in conjunction with other indicators (validation icon, “optional” or “required” indicators) when necessary.
+*/
+export const CharacterCount = Template.bind({});
+CharacterCount.tags = ["!dev"];
+CharacterCount.args = {
+	hasCharacterCount: true,
+	characterCount: 24,
+	value: "lisawilson23"
 };
+CharacterCount.parameters = {
+	chromatic: { disableSnapshot: true }
+};
+
+/**
+ * A text field in a disabled state shows that an input field exists, but is not available in that circumstance. This can be used to maintain layout continuity and communicate that a field may become available later.
+*/
+export const Disabled = Template.bind({});
+Disabled.tags = ["!dev"];
+Disabled.args = {
+	isDisabled: true
+};
+Disabled.parameters = {
+	chromatic: { disableSnapshot: true }
+};
+
+/**
+ * A text field can have [help text](/docs/components-help-text--docs) below the field to give extra context or instruction about what a user should input in the field. The help text area has two options: a description and an error message. The description communicates a hint or helpful information, such as specific requirements for correctly filling out the field. The error message communicates an error for when the field requirements aren’t met, prompting a user to adjust what they had originally input.
+ *
+ * Instead of placeholder text, use the help text description to convey requirements or to show any formatting examples that would help user comprehension. Putting instructions for how to complete an input, requirements, or any other essential information into placeholder text is not accessible.
+*/
+export const HelpText = HelpTextOptions.bind({});
+HelpText.tags = ["!dev"];
+HelpText.parameters = {
+	chromatic: { disableSnapshot: true }
+};
+
+/**
+ * Quiet text fields can have no visible background. This style works best when a clear layout (vertical stack, table, grid) makes it easy to parse. Too many quiet components in a small space can be hard to read.
+*/
+export const Quiet = TextFieldOptions.bind({});
+Quiet.tags = ["!dev"];
+Quiet.args = {
+	isQuiet: true,
+	value: ""
+};
+Quiet.parameters = {
+	chromatic: { disableSnapshot: true }
+};
+
+/**
+ * Text fields have a read-only option for when content in the disabled state still needs to be shown. This allows for content to be copied, but not interacted with or changed.
+*/
+export const Readonly = Template.bind({});
+Readonly.tags = ["!dev"];
+Readonly.args = {
+	isReadOnly: true,
+	value: "lisawilson24"
+};
+Readonly.parameters = {
+	chromatic: { disableSnapshot: true }
+};
+Readonly.storyName = "Read-only";
+
+/**
+ * Side labels are most useful when vertical space is limited.
+*/
+export const SideLabel = Template.bind({});
+SideLabel.tags = ["!dev"];
+SideLabel.args = {
+	labelPosition: "side",
+	hasCharacterCount: true,
+	characterCount: 50,
+	helpText: "Example help text. Lorem ipsum dolor sit amet."
+};
+SideLabel.parameters = {
+	chromatic: { disableSnapshot: true }
+};
+
+export const Sizing = (args, context) => Sizes({
+	Template: Template,
+	withHeading: false,
+	withBorder: false,
+	...args,
+}, context);
+Sizing.args = {
+	helpText: "Example help text. Lorem ipsum dolor sit amet.",
+	hasCharacterCount: true
+};
+Sizing.tags = ["!dev"];
+Sizing.parameters = {
+	chromatic: { disableSnapshot: true }
+};
+
+/**
+ * Text fields can display a validation icon when the text entry is expected to conform to a specific format (e.g., email address, credit card number, password creation requirements, etc.). The icon appears as soon as a user types a valid entry in the field.
+*/
+export const Validation = Template.bind({});
+Validation.tags = ["!dev"];
+Validation.args = {
+	isValid: true,
+};
+Validation.parameters = {
+	chromatic: { disableSnapshot: true }
+};
+Validation.storyName = "Validation icon";
+
 
 // ********* VRT ONLY ********* //
 // @todo should this show text field and text area in the same snapshot?


### PR DESCRIPTION
## Description

Migrating docs for Textfield and Textarea. 

- Textarea Storybook coverage has been added 
- Helptext component is now a part of the Textfield Template

### Validation steps

Textarea/Textfield docs:
- [x] Textarea docs and test are added in `textfield` stories folder
- [x] Disabled, Side Label, Character Count, Help Text, Validation and Error stories are available
- [x] Help text text control is available / `inValid` state example is included
- [x] Textarea testing preview mode is available


### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
