### PR TITLE
docs: add links to figma assets part 3

### DIFF
--- a/components/dialog/stories/dialog.stories.js
+++ b/components/dialog/stories/dialog.stories.js
@@ -119,6 +119,10 @@ export default {
 				height: "500px",
 			},
 		},
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=839-1128",
+		},
 		packageJson: pkgJson,
 	},
 	decorators: [
@@ -235,6 +239,10 @@ WithScroll.parameters = {
 export const Fullscreen = DialogFullscreen.bind({});
 Fullscreen.parameters = {
 	chromatic: { disableSnapshot: true },
+	design: {
+		type: "figma",
+		url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=61935-5399",
+	},
 };
 Fullscreen.args = {
 	...Default.args,
@@ -247,6 +255,10 @@ Fullscreen.args = {
 export const FullscreenTakeover = DialogFullscreenTakeover.bind({});
 FullscreenTakeover.parameters = {
 	chromatic: { disableSnapshot: true },
+	design: {
+		type: "figma",
+		url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=61935-5399",
+	},
 };
 FullscreenTakeover.args = {
 	...Default.args,

--- a/components/divider/stories/divider.stories.js
+++ b/components/divider/stories/divider.stories.js
@@ -33,6 +33,10 @@ export default {
 		minDimensionValues: true,
 	},
 	parameters: {
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=13642-334",
+		},
 		packageJson: pkgJson,
 	},
 };

--- a/components/dropzone/stories/dropzone.stories.js
+++ b/components/dropzone/stories/dropzone.stories.js
@@ -34,6 +34,10 @@ export default {
 		isFilled: false,
 	},
 	parameters: {
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=13049-185",
+		},
 		packageJson: pkgJson,
 	},
 };

--- a/components/fieldlabel/stories/fieldlabel.stories.js
+++ b/components/fieldlabel/stories/fieldlabel.stories.js
@@ -44,6 +44,10 @@ export default {
 		label: "Label",
 	},
 	parameters: {
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=16090-95",
+		},
 		packageJson: pkgJson,
 	},
 };

--- a/components/helptext/stories/helptext.stories.js
+++ b/components/helptext/stories/helptext.stories.js
@@ -56,6 +56,10 @@ export default {
 		size: "m",
 	},
 	parameters: {
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=13653-196",
+		},
 		packageJson: pkgJson,
 	},
 };

--- a/components/illustratedmessage/stories/illustratedmessage.stories.js
+++ b/components/illustratedmessage/stories/illustratedmessage.stories.js
@@ -43,6 +43,10 @@ export default {
 		useAccentColor: false,
 	},
 	parameters: {
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=20032-601",
+		},
 		packageJson: pkgJson,
 	},
 };

--- a/components/inlinealert/stories/inlinealert.stories.js
+++ b/components/inlinealert/stories/inlinealert.stories.js
@@ -58,6 +58,10 @@ export default {
 		isClosable: false,
 	},
 	parameters: {
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=2659-4482",
+		},
 		packageJson: pkgJson,
 	},
 };

--- a/components/link/stories/link.stories.js
+++ b/components/link/stories/link.stories.js
@@ -69,6 +69,10 @@ export default {
 		actions: {
 			handles: ["click .spectrum-Link"],
 		},
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=18850-110",
+		},
 		packageJson: pkgJson,
 	},
 };

--- a/components/menu/stories/menu.stories.js
+++ b/components/menu/stories/menu.stories.js
@@ -81,6 +81,10 @@ export default {
 				height: "300px"
 			}
 		},
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=37252-553",
+		},
 		packageJson: pkgJson,
 	},
 };
@@ -317,6 +321,12 @@ MenuItem.args = {
 	isHovered: false,
 	isSelected: false,
 	hasActions: false,
+};
+MenuItem.parameters = {
+	design: {
+		type: "figma",
+		url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=37252-2242&node-type=frame&t=Kcz7zeePp3PeRusJ-11",
+	},
 };
 
 /**

--- a/components/picker/stories/picker.stories.js
+++ b/components/picker/stories/picker.stories.js
@@ -83,6 +83,10 @@ export default {
 				height: "400px"
 			}
 		},
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=739-1453",
+		},
 		packageJson: pkgJson,
 	},
 };

--- a/components/progressbar/stories/meter.stories.js
+++ b/components/progressbar/stories/meter.stories.js
@@ -39,6 +39,10 @@ export default {
 		label: "Storage space",
 	},
 	parameters: {
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=33840-90",
+		},
 		packageJson: pkgJson,
 	},
 };


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->
This PR is the third in a series that adds S2 design links to components. Now, when a user is on a story page (not a docs page), under the "Design" tab, a Figma asset should render. 

<img width="548" alt="Screenshot 2024-10-04 at 10 58 33 AM" src="https://github.com/user-attachments/assets/419dc0ea-c37d-4b37-8713-726de3ba6bbf">

Using the [S2 / Desktop Figma file](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=5634-5140&node-type=frame&t=YT3sYHqnhqpnjdv9-0), the top-level component pages are linked in an attempt to give a user (specifically a developer) context to the component they are viewing. (instructions on how to get the Figma frame links are here: [slack canvas](https://adobe.enterprise.slack.com/docs/T024FSURM/F07PTPUPMRV)

Components affected:
- standard/default dialog
- takeover dialog
- divider
- drop zone
- field label
- help text
- illustrated message
- inline alert
- link
- menu (menu group in Figma = default menu; menu item in Figma = menu item story/variant)
- meter
- picker

_Note: not all Spectrum CSS components have corresponding Figma designs._

### Jira/Specs

[CSS-974](https://jira.corp.adobe.com/browse/CSS-974)

#### Design pages
- [standard dialog](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=839-1128)
- [takeover dialog](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=61935-5399)
- [divider](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=13642-334)
- [drop zone](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=13049-185)
- [field label](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=16090-95)
- [help text](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=13653-196)
- [illustrated message](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=20032-601)
- [inline alert](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=2659-4482)
- [link](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=18850-110)
- [menu](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=37252-553)
- [menu item](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=37252-2242&node-type=frame&t=Kcz7zeePp3PeRusJ-11)
- [meter](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=33840-90)
- [picker](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=739-1453)

### Pending Questions

- Are there any objections to how the dialog stories and menu stories are linked to Figma? Menu sort of breaks the convention of adding a link to the top-level component page, with `Menu item` linked to a certain frame in the design.
- Is there any icon Figma file we could link to? 

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

- [ ] Pull down the branch to run locally 
- [ ] Visit [the dialog default story page](http://localhost:8080/?path=/story/components-dialog--default)
- [ ] Open the `Design` tab (in the add-ons control panel)
- [ ] Verify a corresponding S2 Figma asset for the component now renders. It should say which page and which frame was rendered in the bottom left corner.

<img width="300" alt="Screenshot 2024-10-04 at 11 35 47 AM" src="https://github.com/user-attachments/assets/387f053e-2545-4c12-bc32-102c9f5c6f73">

- [ ] Repeat the steps above for each of the affected components listed
    - [ ] default dialog (called standard dialog in Figma
    - [ ] fullscreen dialog (a variant of takeover dialog in Figma)
    - [ ] fullscreen takeover dialog (a variant of takeover dialog in Figma)
    - [ ] divider
    - [ ] drop zone
    - [ ] field label
    - [ ] help text
    - [ ] illustrated message
    - [ ] inline alert
    - [ ] link
    - [ ] default menu (called menu group in Figma)
    - [ ] menu item (called menu item in Figma)
    - [ ] meter
    - [ ] picker


### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [ ] ✨ This pull request is ready to merge. ✨
