### PR TITLE
docs: add links to figma assets part 4

### DIFF
--- a/components/popover/stories/popover.stories.js
+++ b/components/popover/stories/popover.stories.js
@@ -90,6 +90,10 @@ export default {
 				height: "200px",
 			}
 		},
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=42086-5684",
+		},
 		packageJson: pkgJson,
 	},
 };

--- a/components/progressbar/stories/progressbar.stories.js
+++ b/components/progressbar/stories/progressbar.stories.js
@@ -90,6 +90,12 @@ export default {
 		isIndeterminate: false,
 		showValueLabel: true,
 	},
+	parameters: {
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=13059-181",
+		},
+	}
 };
 
 /**

--- a/components/progresscircle/stories/progresscircle.stories.js
+++ b/components/progresscircle/stories/progresscircle.stories.js
@@ -26,6 +26,10 @@ export default {
 		staticColor: undefined,
 	},
 	parameters: {
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=13061-181",
+		},
 		packageJson: pkgJson,
 	},
 };

--- a/components/radio/stories/radio.stories.js
+++ b/components/radio/stories/radio.stories.js
@@ -53,6 +53,10 @@ export default {
 		actions: {
 			handles: ["click input[type=\"radio\"]"],
 		},
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=164-16723",
+		},
 		packageJson: pkgJson,
 	},
 };

--- a/components/rating/stories/rating.stories.js
+++ b/components/rating/stories/rating.stories.js
@@ -52,6 +52,10 @@ export default {
 		value: 3,
 	},
 	parameters: {
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=59953-195",
+		},
 		packageJson: pkgJson,
 	},
 };

--- a/components/search/stories/search.stories.js
+++ b/components/search/stories/search.stories.js
@@ -55,6 +55,10 @@ export default {
 				"click .spectrum-Search-icon",
 			],
 		},
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=13670-229",
+		},
 		packageJson: pkgJson,
 	},
 };

--- a/components/sidenav/stories/sidenav.stories.js
+++ b/components/sidenav/stories/sidenav.stories.js
@@ -62,6 +62,10 @@ export default {
 		],
 	},
 	parameters: {
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=21993-665",
+		},
 		packageJson: pkgJson,
 	},
 };
@@ -140,6 +144,10 @@ Multilevel.args = {
 	]
 };
 Multilevel.parameters = {
+	design: {
+		type: "figma",
+		url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=21993-941&node-type=frame&t=YT3sYHqnhqpnjdv9-11",
+	},
 	chromatic: { disableSnapshot: true },
 };
 
@@ -187,6 +195,10 @@ WithHeading.args = {
 	]
 };
 WithHeading.parameters = {
+	design: {
+		type: "figma",
+		url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=21993-941&node-type=frame&t=YT3sYHqnhqpnjdv9-11",
+	},
 	chromatic: { disableSnapshot: true },
 };
 

--- a/components/slider/stories/slider.stories.js
+++ b/components/slider/stories/slider.stories.js
@@ -139,6 +139,10 @@ export default {
 				"change .spectrum-Slider-input",
 			],
 		},
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=842-1056",
+		},
 		packageJson: pkgJson,
 	},
 };

--- a/components/statuslight/stories/statuslight.stories.js
+++ b/components/statuslight/stories/statuslight.stories.js
@@ -64,6 +64,10 @@ export default {
 		isDisabled: false,
 	},
 	parameters: {
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=36797-954",
+		},
 		packageJson: pkgJson,
 	},
 };

--- a/components/stepper/stories/stepper.stories.js
+++ b/components/stepper/stories/stepper.stories.js
@@ -41,6 +41,10 @@ export default {
 		hideStepper: false
 	},
 	parameters: {
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=67507-450",
+		},
 		packageJson: pkgJson,
 	},
 };

--- a/components/swatch/stories/swatch.stories.js
+++ b/components/swatch/stories/swatch.stories.js
@@ -107,6 +107,10 @@ export default {
 		isMixedValue: false,
 	},
 	parameters: {
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=57008-1092",
+		},
 		packageJson: pkgJson,
 	},
 };

--- a/components/swatchgroup/stories/swatchgroup.stories.js
+++ b/components/swatchgroup/stories/swatchgroup.stories.js
@@ -111,6 +111,10 @@ export default {
 				...(Swatch.parameters?.actions?.handles ?? []),
 			],
 		},
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=57008-1093",
+		},
 		packageJson: pkgJson,
 	},
 };


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

This PR is the fourth installment in a series that adds S2 design links to components. Now, when a user is on a story page (not a docs page), under the "Design" tab, a Figma asset should render. 

<img width="548" alt="Screenshot 2024-10-04 at 10 58 33 AM" src="https://github.com/user-attachments/assets/419dc0ea-c37d-4b37-8713-726de3ba6bbf">

Using the [S2 / Desktop Figma file](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=5634-5140&node-type=frame&t=YT3sYHqnhqpnjdv9-0), the top-level component pages are linked in an attempt to give a user (specifically a developer) context to the component they are viewing. (instructions on how to get the Figma frame links are here: [slack canvas](https://adobe.enterprise.slack.com/docs/T024FSURM/F07PTPUPMRV)

Components affected:
- popover
- progress bar
- progress circle
- radio
- rating
- search
- side nav (multi-level/withHeadings = side navigation in Figma; default = side navigation item in Figma)
- slider
- status light
- stepper (number field in Figma)
- swatch 
- swatch group

_Note: not all Spectrum CSS components have corresponding Figma designs._

### Jira/Specs

[CSS-975](https://jira.corp.adobe.com/browse/CSS-975)

#### Design pages
- [popover](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=42086-5684)
- [progress bar](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=13059-181)
- [progress circle](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=13061-181)
- [radio](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=164-16723)
- [rating](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=59953-195)
- [search](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=13670-229)
- [side nav](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=21993-665)
- [slider](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=842-1056)
- [status light](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=36797-954)
- [stepper (number field in Figma)](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=67507-450)
- [swatch](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=57008-1092) 
- [swatch group](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=57008-1093)

#### Pending Questions
- Are there any objections to how the side nav stories are linked to Figma? It sort of breaks the convention of adding a link to the top-level component page, with the multi-level and withHeadings stories linked to a different frame in the design.
- Is there any additional benefit or helpful context to linking to radio group, instead of just radio button? 

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

- [ ] Pull down the branch to run locally 
- [ ] Visit [the popover default story page](http://localhost:8080/?path=/story/components-popover--default)
- [ ] Open the `Design` tab (in the add-ons control panel)
- [ ] Verify a corresponding S2 Figma asset for the component now renders. It should say which page and which frame was rendered in the bottom left corner.

<img width="300" alt="Screenshot 2024-10-04 at 11 35 47 AM" src="https://github.com/user-attachments/assets/387f053e-2545-4c12-bc32-102c9f5c6f73">

- [ ] Repeat the steps above for each of the affected components listed
    - [ ] popover
    - [ ] progress bar
    - [ ] progress circle
    - [ ] radio
    - [ ] rating
    - [ ] search
    - [ ] multi-level and with heading side nav stories (side navigation in Figma)
    - [ ] default side nav (side navigation item in Figma)
    - [ ] slider
    - [ ] status light
    - [ ] stepper (number field in Figma)
    - [ ] swatch
    - [ ] swatch group 

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [ ] ✨ This pull request is ready to merge. ✨
