### PR TITLE
docs: add links to figma assets part 5

### DIFF
--- a/components/switch/stories/switch.stories.js
+++ b/components/switch/stories/switch.stories.js
@@ -37,7 +37,13 @@ export default {
 		label: "Switch label",
 		size: "m",
 	},
-	packageJson: pkgJson,
+	parameters: {
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=164-16761",
+		},
+		packageJson: pkgJson,
+	}
 };
 
 export const Default = SwitchGroup.bind({});

--- a/components/table/stories/table.stories.js
+++ b/components/table/stories/table.stories.js
@@ -110,6 +110,10 @@ export default {
 		],
 	},
 	parameters: {
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=54024-574",
+		},
 		packageJson: pkgJson,
 	},
 };

--- a/components/tabs/stories/tabs.stories.js
+++ b/components/tabs/stories/tabs.stories.js
@@ -112,6 +112,10 @@ export default {
 		actions: {
 			handles: [".spectrum-Tabs-item"],
 		},
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=48979-4695",
+		},
 		packageJson: pkgJson,
 	},
 };

--- a/components/tag/stories/tag.stories.js
+++ b/components/tag/stories/tag.stories.js
@@ -93,6 +93,10 @@ export default {
 		actions: {
 			handles: [],
 		},
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=715-2687",
+		},
 		packageJson: pkgJson,
 	},
 };

--- a/components/taggroup/stories/taggroup.stories.js
+++ b/components/taggroup/stories/taggroup.stories.js
@@ -54,6 +54,10 @@ export default {
 				...(TagStories.parameters.actions.handles ?? [])
 			],
 		},
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=45924-645",
+		},
 		packageJson: pkgJson,
 	},
 };

--- a/components/textfield/stories/textfield.stories.js
+++ b/components/textfield/stories/textfield.stories.js
@@ -116,6 +116,10 @@ export default {
 				"focusout .spectrum-Textfield"
 			],
 		},
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=717-2629",
+		},
 		packageJson: pkgJson,
 	},
 };

--- a/components/thumbnail/stories/thumbnail.stories.js
+++ b/components/thumbnail/stories/thumbnail.stories.js
@@ -87,6 +87,10 @@ export default {
 		actions: {
 			handles: [],
 		},
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=29951-634",
+		},
 		packageJson: pkgJson,
 	},
 };

--- a/components/toast/stories/toast.stories.js
+++ b/components/toast/stories/toast.stories.js
@@ -40,6 +40,10 @@ export default {
 		actions: {
 			handles: ["click .spectrum-Toast button"],
 		},
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=2666-4482",
+		},
 		packageJson: pkgJson,
 	},
 };

--- a/components/tooltip/stories/tooltip.stories.js
+++ b/components/tooltip/stories/tooltip.stories.js
@@ -89,6 +89,10 @@ export default {
 		label: "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
 	},
 	parameters: {
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=2591-4482",
+		},
 		packageJson: pkgJson,
 	},
 };

--- a/components/treeview/stories/treeview.stories.js
+++ b/components/treeview/stories/treeview.stories.js
@@ -36,6 +36,10 @@ export default {
 		actions: {
 			handles: ["click .spectrum-TreeView-itemLink"],
 		},
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=64762-1960",
+		},
 		packageJson: pkgJson,
 	},
 };

--- a/components/typography/stories/typography.stories.js
+++ b/components/typography/stories/typography.stories.js
@@ -77,6 +77,10 @@ export default {
 		semantics: "body",
 	},
 	parameters: {
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=1-3",
+		},
 		packageJson: pkgJson,
 	},
 };


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->
This PR is the final installment in a series that adds S2 design links to components. Now, when a user is on a story page (not a docs page), under the "Design" tab, a Figma asset should render. 

<img width="548" alt="Screenshot 2024-10-04 at 10 58 33 AM" src="https://github.com/user-attachments/assets/419dc0ea-c37d-4b37-8713-726de3ba6bbf">

Using the [S2 / Desktop Figma file](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=5634-5140&node-type=frame&t=YT3sYHqnhqpnjdv9-0), the top-level component pages are linked in an attempt to give a user (specifically a developer) context to the component they are viewing. (instructions on how to get the Figma frame links are here: [slack canvas](https://adobe.enterprise.slack.com/docs/T024FSURM/F07PTPUPMRV)

Components affected:
- switch
- table
- tabs
- tag
- tag group
- text field
- thumbnail
- toast
- tooltip
- tree view
- typography (in the Foundations section)

_Note: not all Spectrum CSS components have corresponding Figma designs._

### Jira/Specs

[CSS-976](https://jira.corp.adobe.com/browse/CSS-976)

#### Design pages
- [switch](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=164-16761)
- [table](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=54024-574)
- [tabs](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=48979-4695)
- [tag](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=715-2687)
- [tag group](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=45924-645)
- [text field](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=717-2629)
- [thumbnail](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=29951-634)
- [toast](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=2666-4482)
- [tooltip](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=2591-4482)
- [tree view](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=64762-1960)
- [typography](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=1-3)

#### Pending Question
This may be another argument _for_ splitting text area and text field into "separate" components like meter & progress bar. If they were separated, we could link to [the text area Figma file](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=725-2579).

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

- [ ] Pull down the branch to run locally 
- [ ] Visit [the switch default story page](http://localhost:8080/?path=/story/components-switch--default)
- [ ] Open the `Design` tab (in the add-ons control panel)
- [ ] Verify a corresponding S2 Figma asset for the component now renders. It should say which page and which frame was rendered in the bottom left corner.

<img width="300" alt="Screenshot 2024-10-04 at 11 35 47 AM" src="https://github.com/user-attachments/assets/387f053e-2545-4c12-bc32-102c9f5c6f73">

- [ ] Repeat the steps above for each of the affected components listed
    - [ ] switch
    - [ ] table
    - [ ] tabs
    - [ ] tag
    - [ ] tag group
    - [ ] text field
    - [ ] thumbnail
    - [ ] toast
    - [ ] tooltip
    - [ ] tree view
    - [ ] typography

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [ ] ✨ This pull request is ready to merge. ✨
