### PR TITLE
ci: be selective about running VRT on main

### DIFF
--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -4,8 +4,8 @@ on:
     push:
       branches:
         - main
-        - !changeset-release/**
-        - !dependabot/**
+        - "!changeset-release/**"
+        - "!dependabot/**"
 
     workflow_dispatch:
     workflow_call:

--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
     vrt:
-        if: ${{ github.event.push.ref != 'refs/heads/changeset-release' ||  github.event.push.ref != 'refs/heads/dependabot'}}
+        if: ${{ !contains(github.event.push.ref, 'changeset-release') &&  !contains(github.event.push.ref, 'dependabot') }}
         name: Chromatic
         runs-on: ubuntu-latest
         timeout-minutes: 20

--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -4,6 +4,9 @@ on:
     push:
       branches:
         - main
+        - !changeset-release/**
+        - !dependabot/**
+
     workflow_dispatch:
     workflow_call:
         inputs:
@@ -23,12 +26,12 @@ permissions:
 
 jobs:
     vrt:
+        if: ${{ github.event.push.ref != 'refs/heads/changeset-release' ||  github.event.push.ref != 'refs/heads/dependabot'}}
         name: Chromatic
         runs-on: ubuntu-latest
         timeout-minutes: 20
         outputs:
-            storybook-url: ${{ steps.chromatic.outputs.storybookUrl != 'undefined' && steps.chromatic.outputs.storybookUrl || '' }}
-
+          storybook-url: ${{ steps.chromatic.outputs.storybookUrl != 'undefined' && steps.chromatic.outputs.storybookUrl || '' }}
         steps:
             - name: Check out code
               uses: actions/checkout@v4


### PR DESCRIPTION
Specifies that certain branch names should be excluded from triggering Chromatic when they're merged into `main`

<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

Attempts to be selective about when a merge to `main` triggers a Chromatic run. The first bit of code here should prevent Chromatic from being run on any Dependabot or Changesets-created branches.

The second bit of code checks to see if the branch being merged into `main` is a Dependabot or Changesets-related branch, and stops the Chromatic action if the merge has come from one of those two types of branches.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [ ] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
