### PR TITLE
chore: corrects readOnly to isReadOnly arg

### DIFF
--- a/components/datepicker/stories/datepicker.test.js
+++ b/components/datepicker/stories/datepicker.test.js
@@ -41,7 +41,7 @@ export const DatePickerGroup = Variants({
 		},
 		{
 			testHeading: "Read-only",
-			readOnly: true,
+			isReadOnly: true,
 			wrapperStyles: {
 				"min-block-size": "30px",
 			}


### PR DESCRIPTION
the read-only datepicker should no longer display the calendar

<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

This PR corrects the spelling of an arg for the date picker component so that the appropriate styles show up, as well as clear up the Chromatic snapshot.

`readOnly` should be `isReadOnly`

Before, the date picker calendar was displayed when it shouldn't have been, and the component's read-only styles weren't rendering. It's also encroaching on the Quiet date picker's personal space.

<img width="825" alt="Screenshot 2024-10-04 at 3 24 15 PM" src="https://github.com/user-attachments/assets/0dc9f6b5-50ac-4cfe-a172-fb8e6a863a94">

After, a happy, read-only date picker:

<img width="840" alt="Screenshot 2024-10-04 at 3 23 53 PM" src="https://github.com/user-attachments/assets/bca99ad2-f178-4869-bf0b-591329a64bec">

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

- Pull down the branch locally or use [the deploy preview](https://pr-3210--spectrum-css.netlify.app/preview/?path=/docs/guides-contributing--docs)
- Visit [the date picker testing grid](https://pr-3210--spectrum-css.netlify.app/preview/?path=/story/components-date-picker--default&globals=testingPreview:!true)
- Ensure that the `read only` date picker state no longer displays the calendar component, and is highlightable text, as opposed to an editable input field (similar to the read-only story on the date picker docs page)
<img width="307" alt="Screenshot 2024-10-04 at 3 31 57 PM" src="https://github.com/user-attachments/assets/d548c316-aee8-4067-8aa1-5d10da825443">


### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [ ] ✨ This pull request is ready to merge. ✨
