### PR TITLE
fix(picker): update picker display and icon flex properties to resolve layout bugs

### DIFF
--- a/.changeset/chatty-sheep-draw.md
+++ b/.changeset/chatty-sheep-draw.md
@@ -2,4 +2,4 @@
 "@spectrum-css/picker": minor
 ---
 
-Addresses issue with vertical alignment of picker text/placeholder by applying inline-flex in template rather than inline-block. Applies flex-shrink to validation icons to prevent icon from resizing when label is long enough to be truncated.
+Applies flex-shrink to validation icons to prevent icon from resizing when label is long enough to be truncated.

--- a/.changeset/chatty-sheep-draw.md
+++ b/.changeset/chatty-sheep-draw.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/picker": minor
+---
+
+Addresses issue with vertical alignment of picker text/placeholder by applying inline-flex in template rather than inline-block. Applies flex-shrink to validation icons to prevent icon from resizing when label is long enough to be truncated.

--- a/components/picker/index.css
+++ b/components/picker/index.css
@@ -397,6 +397,7 @@
 }
 
 .spectrum-Picker-validationIcon {
+	flex-shrink: 0;
 	margin-block-start: calc(var(--mod-picker-spacing-top-to-alert-icon, var(--spectrum-picker-spacing-top-to-alert-icon)) - var(--mod-picker-border-width, var(--spectrum-picker-border-width)));
 	margin-block-end: calc(var(--mod-picker-spacing-top-to-alert-icon, var(--spectrum-picker-spacing-top-to-alert-icon)) - var(--mod-picker-border-width, var(--spectrum-picker-border-width)));
 }


### PR DESCRIPTION
## Description

Addresses issue with vertical alignment of picker text/placeholder by applying inline-flex in template rather than inline-block. Applies flex-shrink to validation icons to prevent icon from resizing when label is long enough to be truncated.

CSS-977

## How and where has this been tested?

Verified locally in Storybook.

### Validation steps

1. Fetch branch and run locally or access the Storybook URL for the PR.
2. Navigate to the picker component.
3. Verify that the placeholder text is properly aligned within the picker.
4. Verify that the validation icon does not resize when a long label is supplied as an arg.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

5. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<img width="692" alt="Screenshot 2024-10-08 at 8 56 30 AM" src="https://github.com/user-attachments/assets/34108110-7003-4cbb-b7fa-c8836f417456">
<img width="1657" alt="Screenshot 2024-10-08 at 8 56 35 AM" src="https://github.com/user-attachments/assets/ab043bf2-d0b2-4da9-b423-7e8f854e2aa1">

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
