### PR TITLE
fix(search): addresses quiet variant clear icon positioning

### DIFF
--- a/.changeset/chatty-carrots-warn.md
+++ b/.changeset/chatty-carrots-warn.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/search": minor
+---
+
+Addresses issue where a portion of search clear button sat outside of its parent by moving the transform applied to the button to the child icon.

--- a/components/search/index.css
+++ b/components/search/index.css
@@ -224,8 +224,9 @@
 }
 
 /* Quiet Variant */
+/* stylelint-disable-next-line no-duplicate-selectors */
 .spectrum-Search--quiet {
-	.spectrum-Search-clearButton {
+	.spectrum-Search-clearButton .spectrum-ClearButton-icon {
 		transform: translateX(var(--mod-search-quiet-button-offset, var(--spectrum-search-quiet-button-offset)));
 	}
 

--- a/components/search/metadata/metadata.json
+++ b/components/search/metadata/metadata.json
@@ -7,7 +7,7 @@
     ".spectrum-Search .spectrum-Search-textfield",
     ".spectrum-Search .spectrum-Search-textfield .spectrum-Search-input",
     ".spectrum-Search--quiet",
-    ".spectrum-Search--quiet .spectrum-Search-clearButton",
+    ".spectrum-Search--quiet .spectrum-Search-clearButton .spectrum-ClearButton-icon",
     ".spectrum-Search--quiet.spectrum-Search",
     ".spectrum-Search--quiet.spectrum-Search .spectrum-Search-input",
     ".spectrum-Search--sizeL",


### PR DESCRIPTION
## Description

Addresses issue where a portion of search clear button sat outside of its parent by moving the transform applied to the button to the child icon.

This repositions the icon and the enclosing button such that the icon renders in the same place in the layout, the button doesn't move outside the bounds of the container and the clickable area to clear the input remains the same size.

**Note:** the clear icon is no longer centered within the parent _but_ addressing the overflow without re-aligning the icon would result in the icon sitting further inside the field than is the case with other variants.

CSS-914

## How and where has this been tested?

Locally in Storybook.

### Validation steps

1. Fetch branch and run locally or access the Storybook URL for the PR.
2. Navigate to the search component.
3. Enable quiet mode
4. Verify that the clear icon remains right aligned and the enclosing button does not overflow the parent container.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<img width="215" alt="Screenshot 2024-10-08 at 11 12 13 AM" src="https://github.com/user-attachments/assets/129308f7-a1eb-43c2-9f67-d4819f05a1fe">
<img width="591" alt="Screenshot 2024-10-08 at 11 12 00 AM" src="https://github.com/user-attachments/assets/6be3e73f-dfba-4482-84de-06bb579a7417">

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
