### PR TITLE
feat(storybook): remove custom styles on storybook-root

### DIFF
--- a/.storybook/assets/base.css
+++ b/.storybook/assets/base.css
@@ -55,12 +55,6 @@ svg:has(symbol):not(:has(use)) {
 	border-block-end: 1px solid hsla(203deg, 50%, 30%, 15%);
 }
 
-/* This is the container Chromatic uses to determine the height and width of the story */
-#storybook-root {
-	inline-size: max-content;
-	max-inline-size: 100%;
-}
-
 /* Force the modal wrapper to be contained by the frame not the viewport */
 #root-inner {
 	.spectrum-Modal-wrapper {

--- a/components/alertbanner/stories/alertbanner.stories.js
+++ b/components/alertbanner/stories/alertbanner.stories.js
@@ -78,6 +78,10 @@ export const Default = AlertBannerGroup.bind({});
 Default.tags = ["!autodocs"];
 Default.args = {
 	isOpen: true,
+	customStyles: {
+		// So it takes up the whole width in the chromatic Variants template, where it is a flex item.
+		"flex-grow": "1",
+	},
 };
 
 // ********* VRT ONLY ********* //

--- a/components/alertbanner/stories/alertbanner.test.js
+++ b/components/alertbanner/stories/alertbanner.test.js
@@ -4,6 +4,12 @@ import { Template } from "./template.js";
 export const AlertBannerGroup = Variants({
 	Template,
 	stateDirection: "column",
+	containerStyles: {
+		"inline-size": "100%",
+	},
+	wrapperStyles: {
+		"inline-size": "100%",
+	},
 	testData: [
 		{
 			testHeading: "Default (neutral)",

--- a/components/alertbanner/stories/template.js
+++ b/components/alertbanner/stories/template.js
@@ -31,10 +31,7 @@ export const Template = ({
 				[`${rootClass}--${variant}`]: typeof variant !== "undefined",
 				...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
 			})}
-			style=${styleMap({
-				"min-inline-size": "500px",
-				...customStyles,
-			})}
+			style=${styleMap(customStyles)}
 			id=${id}
 			data-testid=${ifDefined(testId)}
 		>

--- a/components/coachmark/stories/coachmark.stories.js
+++ b/components/coachmark/stories/coachmark.stories.js
@@ -48,7 +48,6 @@ export default {
 		hasImage: false,
 	},
 	parameters: {
-		layout: "padded",
 		actions: {
 			handles: [
 				...(ActionButton.parameters?.actions?.handles ?? []),


### PR DESCRIPTION
## Description

The width of the Storybook root element was being limited with inline-size: max-content, which was causing a few issues:
- min-widths on some components were no longer being tested
- some responsive grid layouts were no longer working as intended

After running a force-rebuild on the VRTs to check for differences, it looks like removing these should not be a problem.  This is likely due to the switch to the Storybook "centered" layout for most stories, which uses a flex layout for centering, which creates a less wide storybook-root. The only stories which were affected in the VRT diff were:
- **coachmark**: this was manually setting the "padded" layout, which I removed in this PR after testing that the centered layout looks fine
- **alertbanner**: this is manually setting the "padded" layout on purpose to see its `display: block` and max width behavior, that is lost with the "centered" layout, so I kept that as is. This particular snapshot will be a bit wider. I also adjusted this component's template slightly so we are no longer setting an inline `min-inline-size` that is outside of the component's actual behavior with its shipped styles. The expected VRT difference in the chromatic variants template will be slightly less wide alert banners for the non text wrapping examples.

CSS-959

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [x] Alert banner's default story now behaves like the CSS; full width up until its max-width (832px). Shrink the browser to confirm that it shrinks as well. @castastrophe (https://pr-3226--spectrum-css.netlify.app/preview/?path=/story/components-alert-banner--default)
- [x] Only [VRT changes](https://www.chromatic.com/build?appId=64762974a45b8bc5ca1705a2&number=3519) are for alert banner, as noted in the PR description

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.: https://www.chromatic.com/build?appId=64762974a45b8bc5ca1705a2&number=3519 (required running `yarn test --force-rebuild` to rebuild changes)
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] ✨ This pull request is ready to merge. ✨
