### PR TITLE
fix(field-group): addresses regressions in field groups.

### DIFF
--- a/components/fieldgroup/stories/fieldgroup.stories.js
+++ b/components/fieldgroup/stories/fieldgroup.stories.js
@@ -67,7 +67,7 @@ export default {
 		inputType: "radio",
 		labelPosition: "top",
 		layout: "vertical",
-		label: "Field Group Label",
+		label: "Field group label",
 		helpText: "Select an option.",
 		items: [
 			{

--- a/components/fieldgroup/stories/fieldgroup.stories.js
+++ b/components/fieldgroup/stories/fieldgroup.stories.js
@@ -1,7 +1,6 @@
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isInvalid, isReadOnly, isRequired } from "@spectrum-css/preview/types";
 import { default as RadioSettings } from "@spectrum-css/radio/stories/radio.stories.js";
-import { Template as Radio } from "@spectrum-css/radio/stories/template.js";
 import metadata from "../metadata/metadata.json";
 import packageJson from "../package.json";
 import { FieldGroupSet } from "./fieldgroup.test.js";
@@ -65,24 +64,21 @@ export default {
 		layout: "vertical",
 		label: "Select one of the following options:",
 		items: [
-			(passthroughs, context) => Radio({
-				...passthroughs,
+			{
 				id: "apple",
 				label: "Apples are best",
 				customClasses: ["spectrum-FieldGroup-item"],
-			}, context),
-			(passthroughs, context) => Radio({
-				...passthroughs,
+			},
+			{
 				id: "banana",
 				label: "Bananas forever",
 				customClasses: ["spectrum-FieldGroup-item"],
-			}, context),
-			(passthroughs, context) => Radio({
-				...passthroughs,
+			},
+			{
 				id: "pear",
 				label: "Pears or bust",
 				customClasses: ["spectrum-FieldGroup-item"],
-			}, context),
+			}
 		],
 		isInvalid: false,
 		isRequired: false,

--- a/components/fieldgroup/stories/fieldgroup.stories.js
+++ b/components/fieldgroup/stories/fieldgroup.stories.js
@@ -20,6 +20,10 @@ export default {
 	title: "Field group",
 	component: "FieldGroup",
 	argTypes: {
+		label: {
+			name: "Label",
+			type: { name: "string" },
+		},
 		inputType: {
 			name: "Input type",
 			type: { name: "string" },
@@ -62,7 +66,8 @@ export default {
 		inputType: "radio",
 		labelPosition: "top",
 		layout: "vertical",
-		label: "Select one of the following options:",
+		label: "Field Group Label",
+		helpText: "Select an option.",
 		items: [
 			{
 				id: "apple",

--- a/components/fieldgroup/stories/fieldgroup.stories.js
+++ b/components/fieldgroup/stories/fieldgroup.stories.js
@@ -22,6 +22,7 @@ export default {
 	argTypes: {
 		label: {
 			name: "Label",
+			description: "The label for the field group component.",
 			type: { name: "string" },
 		},
 		inputType: {

--- a/components/fieldgroup/stories/template.js
+++ b/components/fieldgroup/stories/template.js
@@ -57,20 +57,21 @@ export const Template = (
 			>
 				${inputType === "radio" ?
 					items.map((item) =>
-					Radio({
-					...item,
-					isReadOnly,
-					isRequired,
-					name: "field-group-example",
-					customClasses: [`${rootClass}-item`],
-					}, context))
-					: items.map((item) =>
-					CheckBox({
-					...item,
-					isReadOnly,
-					isRequired,
-					customClasses: [`${rootClass}-item`],
-				}, context))}
+						Radio({
+							...item,
+							isReadOnly,
+							isRequired,
+							name: "field-group-example",
+							customClasses: [`${rootClass}-item`],
+						}, context))
+						: items.map((item) =>
+						CheckBox({
+							...item,
+							isReadOnly,
+							isRequired,
+							customClasses: [`${rootClass}-item`],
+						}, context)
+				)}
 				${when(helpText, () =>
 					HelpText(
 						{

--- a/components/fieldgroup/stories/template.js
+++ b/components/fieldgroup/stories/template.js
@@ -44,6 +44,7 @@ export const Template = (
 					{
 						size: "m",
 						label,
+						isRequired,
 						alignment: labelPosition === "side" ? "right" : "top",
 					},
 					context,
@@ -59,6 +60,7 @@ export const Template = (
 					Radio({
 					...item,
 					isReadOnly,
+					isRequired,
 					name: "field-group-example",
 					customClasses: [`${rootClass}-item`],
 					}, context))
@@ -66,6 +68,7 @@ export const Template = (
 					CheckBox({
 					...item,
 					isReadOnly,
+					isRequired,
 					customClasses: [`${rootClass}-item`],
 				}, context))}
 				${when(helpText, () =>

--- a/components/fieldgroup/stories/template.js
+++ b/components/fieldgroup/stories/template.js
@@ -1,6 +1,7 @@
+import { Template as CheckBox } from "@spectrum-css/checkbox/stories/template.js";
 import { Template as FieldLabel } from "@spectrum-css/fieldlabel/stories/template.js";
 import { Template as HelpText } from "@spectrum-css/helptext/stories/template.js";
-import { renderContent } from "@spectrum-css/preview/decorators";
+import { Template as Radio } from "@spectrum-css/radio/stories/template.js";
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
@@ -53,7 +54,20 @@ export const Template = (
 					[`${rootClass}InputLayout`]: true,
 				})}
 			>
-				${renderContent(items, { args: { isReadOnly, isRequired }, context })}
+				${inputType === "radio" ?
+					items.map((item) =>
+					Radio({
+					...item,
+					isReadOnly,
+					name: "field-group-example",
+					customClasses: [`${rootClass}-item`],
+					}, context))
+					: items.map((item) =>
+					CheckBox({
+					...item,
+					isReadOnly,
+					customClasses: [`${rootClass}-item`],
+				}, context))}
 				${when(helpText, () =>
 					HelpText(
 						{


### PR DESCRIPTION
## Description

Addresses regressions in field groups.
- [x] Adds helper to return correct input types in `args.items`
- [x] Adds appropriate inputs to their respective stories
- [x] Updates labels to match legacy docs page
- [x] Restores helper text/labels
- [x] Adds req'd asterisks, parenthetical and label modifications to relevant stories

## How and where has this been tested?

Verified locally in storybook and by referencing [legacy docs page](https://pr-2827--spectrum-css.netlify.app/preview/?path=/docs/components-field-group--docs).

### Validation steps

1. Fetch branch and run locally or access the Storybook URL for the PR.
2. Navigate to the field group component.
3. Verify that the rendered field groups align with the [legacy docs page](https://pr-2827--spectrum-css.netlify.app/preview/?path=/docs/components-field-group--docs).

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

4. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

![Screenshot 2024-10-10 at 8 43 44 AM](https://github.com/user-attachments/assets/cf5f96ba-f2b5-49f8-becb-2bb49d227590)

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
