### PR TITLE
fix(contextual-help): added help-content-spacing definition

### DIFF
--- a/.changeset/silent-news-applaud.md
+++ b/.changeset/silent-news-applaud.md
@@ -3,4 +3,4 @@
 "@spectrum-css/tokens": minor
 ---
 
-added help-content-spacing definition
+added contextual-help-content-spacing custom property definition

--- a/.changeset/silent-news-applaud.md
+++ b/.changeset/silent-news-applaud.md
@@ -1,0 +1,6 @@
+---
+"@spectrum-css/contextualhelp": minor
+"@spectrum-css/tokens": minor
+---
+
+added help-content-spacing definition

--- a/components/contextualhelp/metadata/metadata.json
+++ b/components/contextualhelp/metadata/metadata.json
@@ -32,11 +32,13 @@
   "global": [
     "--spectrum-body-color",
     "--spectrum-heading-color",
+    "--spectrum-spacing-100",
     "--spectrum-spacing-300",
     "--spectrum-spacing-400"
   ],
   "system-theme": [
     "--system-contextual-help-body-color",
+    "--system-contextual-help-content-spacing",
     "--system-contextual-help-heading-color",
     "--system-contextual-help-heading-size",
     "--system-contextual-help-link-spacing",

--- a/components/contextualhelp/themes/spectrum-two.css
+++ b/components/contextualhelp/themes/spectrum-two.css
@@ -15,6 +15,7 @@
 	.spectrum-ContextualHelp {
 		/* Layout Variables */
 		--spectrum-contextual-help-padding: var(--spectrum-spacing-400);
+		--spectrum-contextual-help-content-spacing: var(--spectrum-spacing-100);
 		--spectrum-contextual-help-link-spacing: var(--spectrum-spacing-300);
 
 		/* Typography Variables */

--- a/tokens/dist/css/components/bridge/contextualhelp.css
+++ b/tokens/dist/css/components/bridge/contextualhelp.css
@@ -13,6 +13,7 @@
 
 .spectrum.spectrum--express {
 	--spectrum-contextual-help-padding: var(--system-contextual-help-padding);
+	--spectrum-contextual-help-content-spacing: var(--system-contextual-help-content-spacing);
 	--spectrum-contextual-help-link-spacing: var(--system-contextual-help-link-spacing);
 	--spectrum-contextual-help-heading-size: var(--system-contextual-help-heading-size);
 	--spectrum-contextual-help-heading-color: var(--system-contextual-help-heading-color);

--- a/tokens/dist/css/components/bridge/index.css
+++ b/tokens/dist/css/components/bridge/index.css
@@ -626,6 +626,7 @@
 	--spectrum-combobox-spacing-inline-start-edge-to-text: var(--system-combobox-quiet-spacing-inline-start-edge-to-text);
 	--spectrum-combobox-spacing-inline-end-edge-to-text: var(--system-combobox-size-xl-spacing-inline-end-edge-to-text);
 	--spectrum-contextual-help-padding: var(--system-contextual-help-padding);
+	--spectrum-contextual-help-content-spacing: var(--system-contextual-help-content-spacing);
 	--spectrum-contextual-help-link-spacing: var(--system-contextual-help-link-spacing);
 	--spectrum-contextual-help-heading-size: var(--system-contextual-help-heading-size);
 	--spectrum-contextual-help-heading-color: var(--system-contextual-help-heading-color);

--- a/tokens/dist/css/components/express/contextualhelp.css
+++ b/tokens/dist/css/components/express/contextualhelp.css
@@ -13,6 +13,7 @@
 
 .spectrum.spectrum--express {
 	--system-contextual-help-padding: var(--spectrum-spacing-400);
+	--system-contextual-help-content-spacing: var(--spectrum-spacing-100);
 	--system-contextual-help-link-spacing: var(--spectrum-spacing-300);
 	--system-contextual-help-heading-size: var(--spectrum-contextual-help-title-size);
 	--system-contextual-help-heading-color: var(--spectrum-heading-color);

--- a/tokens/dist/css/components/express/index.css
+++ b/tokens/dist/css/components/express/index.css
@@ -1396,6 +1396,7 @@
 	--system-combobox-quiet-size-l-spacing-label-to: var(--spectrum-field-label-to-component-quiet-large);
 	--system-combobox-quiet-size-xl-spacing-label-to: var(--spectrum-field-label-to-component-quiet-extra-large);
 	--system-contextual-help-padding: var(--spectrum-spacing-400);
+	--system-contextual-help-content-spacing: var(--spectrum-spacing-100);
 	--system-contextual-help-link-spacing: var(--spectrum-spacing-300);
 	--system-contextual-help-heading-size: var(--spectrum-contextual-help-title-size);
 	--system-contextual-help-heading-color: var(--spectrum-heading-color);

--- a/tokens/dist/css/components/spectrum-two/contextualhelp.css
+++ b/tokens/dist/css/components/spectrum-two/contextualhelp.css
@@ -13,6 +13,7 @@
 
 .spectrum {
 	--system-contextual-help-padding: var(--spectrum-spacing-400);
+	--system-contextual-help-content-spacing: var(--spectrum-spacing-100);
 	--system-contextual-help-link-spacing: var(--spectrum-spacing-300);
 	--system-contextual-help-heading-size: var(--spectrum-contextual-help-title-size);
 	--system-contextual-help-heading-color: var(--spectrum-heading-color);

--- a/tokens/dist/css/components/spectrum/contextualhelp.css
+++ b/tokens/dist/css/components/spectrum/contextualhelp.css
@@ -13,6 +13,7 @@
 
 .spectrum.spectrum--legacy {
 	--system-contextual-help-padding: var(--spectrum-spacing-400);
+	--system-contextual-help-content-spacing: var(--spectrum-spacing-100);
 	--system-contextual-help-link-spacing: var(--spectrum-spacing-300);
 	--system-contextual-help-heading-size: var(--spectrum-contextual-help-title-size);
 	--system-contextual-help-heading-color: var(--spectrum-heading-color);

--- a/tokens/dist/css/components/spectrum/index.css
+++ b/tokens/dist/css/components/spectrum/index.css
@@ -1396,6 +1396,7 @@
 	--system-combobox-quiet-size-l-spacing-label-to: var(--spectrum-field-label-to-component-quiet-large);
 	--system-combobox-quiet-size-xl-spacing-label-to: var(--spectrum-field-label-to-component-quiet-extra-large);
 	--system-contextual-help-padding: var(--spectrum-spacing-400);
+	--system-contextual-help-content-spacing: var(--spectrum-spacing-100);
 	--system-contextual-help-link-spacing: var(--spectrum-spacing-300);
 	--system-contextual-help-heading-size: var(--spectrum-contextual-help-title-size);
 	--system-contextual-help-heading-color: var(--spectrum-heading-color);


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

This PR addes the `--spectrum-contextual-help-content-spacing` definition to the theme file.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

 - [ ] No expected changes to `metadata.json`

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

Previously:


## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
