### PR TITLE
chore[actionbutton, actiongroup]: fix application of aria-labels

### DIFF
--- a/components/actionbutton/stories/actionbutton.stories.js
+++ b/components/actionbutton/stories/actionbutton.stories.js
@@ -99,26 +99,22 @@ Default.args = {};
 Default.tags = ["!autodocs"];
 
 // ********* DOCS ONLY ********* //
-
 /**
  * Action buttons should always have a label, unless they are only using an icon that is universally understood and accessible. They can have an optional icon, but it should not be used for decoration. Use an icon only when necessary and when it has a strong association with the label text.
  *
  * The label can be hidden to create an icon-only action button. If the label is hidden, an icon is required, and the label will appear in a tooltip on hover.
  */
-
 export const Standard = TreatmentTemplate.bind({});
 Standard.args = Default.args;
 Standard.tags = ["!dev"];
 Standard.parameters = {
 	chromatic: { disableSnapshot: true },
 };
-
 Standard.storyName = "Default";
 
 /**
  * The emphasized action button has a blue background for its selected state in order to provide a visual prominence. This is optimal for when the selection should call attention, such as within a tool bar.
  */
-
 export const Emphasized = TreatmentTemplate.bind({});
 Emphasized.tags = ["!dev"];
 Emphasized.args = {
@@ -133,7 +129,6 @@ Emphasized.parameters = {
 /**
  * Adding the `.spectrum-ActionButton--emphasized` class to a quiet action button can be effective in calling attention.
  */
-
 export const EmphasizedQuiet = TreatmentTemplate.bind({});
 EmphasizedQuiet.tags = ["!dev"];
 EmphasizedQuiet.args = {
@@ -150,7 +145,6 @@ EmphasizedQuiet.storyName = "Emphasized (quiet)";
 /**
  * Quiet action buttons have no visible background until they’re interacted with. This style works best when a clear layout (vertical stack, table, grid) makes it easy to parse the buttons. Too many quiet components in a small space can be hard to read.
  */
-
 export const Quiet = TreatmentTemplate.bind({});
 Quiet.tags = ["!dev"];
 Quiet.args = {
@@ -165,7 +159,6 @@ Quiet.parameters = {
 /**
  * An action button can have a hold icon (a small corner triangle). This icon indicates that holding down the action button for a short amount of time can reveal a popover menu, which can be used, for example, to switch between related actions. Because of the way padding is calculated, the hold icon must be placed before the workflow icon in the markup.
  */
-
 export const HoldIcon = IconOnlyOption.bind({});
 HoldIcon.tags = ["!dev"];
 HoldIcon.parameters = {
@@ -177,9 +170,7 @@ StaticWhiteDocs.tags = ["!dev"];
 StaticWhiteDocs.args = {
 	staticColor: "white",
 };
-
 StaticWhiteDocs.storyName = "Static white";
-
 StaticWhiteDocs.parameters = {
 	chromatic: { disableSnapshot: true },
 };
@@ -190,9 +181,7 @@ StaticWhiteQuiet.args = {
 	staticColor: "white",
 	isQuiet: true,
 };
-
 StaticWhiteQuiet.storyName = "Static white (quiet)";
-
 StaticWhiteQuiet.parameters = {
 	chromatic: { disableSnapshot: true }
 };
@@ -203,7 +192,6 @@ StaticBlackDocs.args = {
 	staticColor: "black",
 };
 StaticBlackDocs.storyName = "Static black";
-
 StaticBlackDocs.parameters = {
 	chromatic: { disableSnapshot: true },
 };
@@ -214,9 +202,7 @@ StaticBlackQuiet.args = {
 	staticColor: "black",
 	isQuiet: true,
 };
-
 StaticBlackQuiet.storyName = "Static black (quiet)";
-
 StaticBlackQuiet.parameters = {
 	chromatic: { disableSnapshot: true }
 };
@@ -224,7 +210,6 @@ StaticBlackQuiet.parameters = {
 /**
  * Action buttons come in five different sizes: extra-small, small, medium, large, and extra-large. The medium size is the default and most frequently used option. Use the other sizes sparingly; they should be used to create a hierarchy of importance within the page.
  */
-
 export const Sizing = (args, context) => Sizes({
 	Template: ActionButtonsWithIconOptions,
 	withHeading: false,
@@ -236,7 +221,6 @@ Sizing.tags = ["!dev"];
 Sizing.parameters = {
 	chromatic: { disableSnapshot:  true },
 };
-
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = ActionButtonGroup.bind({});

--- a/components/actionbutton/stories/template.js
+++ b/components/actionbutton/stories/template.js
@@ -69,7 +69,7 @@ export const Template = ({
 	const { updateArgs } = context;
 	return html`
 		<button
-			aria-label=${ifDefined(label)}
+			aria-label=${ifDefined(hideLabel ? label : undefined)}
 			aria-haspopup=${ifDefined(hasPopup && hasPopup !== "false" ? hasPopup : undefined)}
 			aria-controls=${hasPopup && hasPopup !== "false" ? popupId : undefined}
 			aria-pressed=${isSelected ? "true" : "false"}

--- a/components/actiongroup/stories/actiongroup.stories.js
+++ b/components/actiongroup/stories/actiongroup.stories.js
@@ -48,7 +48,7 @@ export default {
 			control: "boolean",
 		},
 		iconOnly: {
-			name: "Icon Only",
+			name: "Icon-only",
 			type: { name: "boolean" },
 			table: {
 				type: { summary: "boolean" },
@@ -103,17 +103,14 @@ Default.tags = ["!autodocs"];
 Default.args = {};
 
 // ********* DOCS ONLY ********* //
-
 /**
  * An action group in a disabled state shows that the action buttons within the group exist, but are not available in that circumstance. This state can be used to maintain layout continuity and to communicate that an action group may become available later.
 */
-
 export const Disabled = ActionGroups.bind({});
 Disabled.tags = ["!dev"];
 Disabled.args = {
 	areDisabled: true
 };
-
 Disabled.parameters = {
 	chromatic: { disableSnapshot: true },
 };
@@ -126,7 +123,6 @@ Emphasized.tags = ["!dev"];
 Emphasized.args = {
 	areEmphasized: true
 };
-
 Emphasized.parameters = {
 	chromatic: { disableSnapshot: true },
 };
@@ -134,11 +130,9 @@ Emphasized.parameters = {
 export const Horizontal = TreatmentTemplate.bind({});
 Horizontal.tags = ["!dev"];
 Horizontal.args = {};
-
 Horizontal.parameters = {
 	chromatic: { disableSnapshot: true },
 };
-
 Horizontal.storyName = "Default";
 
 /**
@@ -149,25 +143,22 @@ HorizontalCompact.tags = ["!dev"];
 HorizontalCompact.args = {
 	compact: true
 };
-
 HorizontalCompact.parameters = {
 	chromatic: { disableSnapshot: true },
 };
+HorizontalCompact.storyName = "Horizontal compact";
 
 /**
  * The vertical option should be reserved for when horizontal space is limited.
 */
-
 export const Vertical = TreatmentTemplate.bind({});
 Vertical.tags = ["!dev"];
 Vertical.args = {
 	vertical: true
 };
-
 Vertical.parameters = {
 	chromatic: { disableSnapshot: true },
 };
-
 
 export const VerticalCompact = TreatmentTemplate.bind({});
 VerticalCompact.tags = ["!dev"];
@@ -175,11 +166,10 @@ VerticalCompact.args = {
 	compact: true,
 	vertical: true
 };
-
 VerticalCompact.parameters = {
 	chromatic: { disableSnapshot: true },
 };
-
+VerticalCompact.storyName = "Vertical compact";
 
 export const HorizontalSizing = (args, context) => Sizes({
 	Template: ActionGroups,
@@ -192,6 +182,7 @@ HorizontalSizing.tags = ["!dev"];
 HorizontalSizing.parameters = {
 	chromatic: { disableSnapshot: true },
 };
+HorizontalSizing.storyName = "Horizontal sizing";
 
 export const VerticalSizing = (args, context) => Sizes({
 	Template: ActionGroups,
@@ -206,11 +197,11 @@ VerticalSizing.tags = ["!dev"];
 VerticalSizing.parameters = {
 	chromatic: { disableSnapshot: true },
 };
+VerticalSizing.storyName = "Vertical sizing";
 
 /**
  * When an action group is justified, it takes up the entire available container width, divided equally for each action button that is inside the group.
 */
-
 export const Justified = ActionGroups.bind({});
 Justified.tags = ["!dev"];
 Justified.args = {
@@ -219,15 +210,14 @@ Justified.args = {
 	content: [
 		{
 			iconName: "AlignTop",
-			label: "Align Top",
+			label: "Align top",
 		},
 		{
 			iconName: "AlignBottom",
-			label: "Align Bottom",
+			label: "Align bottom",
 		},
 	]
 };
-
 Justified.parameters = {
 	chromatic: { disableSnapshot: true },
 };
@@ -237,24 +227,23 @@ JustifiedIconOnly.tags = ["!dev"];
 JustifiedIconOnly.args = {
 	customStyles: {"width": "300px"},
 	justified: true,
+	iconOnly: true,
 	content: [
 		{
 			iconName: "AlignTop",
-			label: "",
+			label: "Align top",
 		},
 		{
 			iconName: "AlignBottom",
-			label: "",
+			label: "Align bottom",
 		},
 		{
 			iconName: "AlignMiddle",
-			label: "",
+			label: "Align middle",
 		},
 	]
 };
-
 JustifiedIconOnly.storyName = "Justified (icon-only)";
-
 JustifiedIconOnly.parameters = {
 	chromatic: { disableSnapshot: true },
 };
@@ -265,39 +254,35 @@ JustifiedIconOnlyCompact.args = {
 	customStyles: {"width": "300px"},
 	justified: true,
 	compact: true,
+	iconOnly: true,
 	content: [
 		{
 			iconName: "AlignTop",
-			label: "",
+			label: "Align top",
 		},
 		{
 			iconName: "AlignBottom",
-			label: "",
+			label: "Align bottom",
 		},
 		{
 			iconName: "AlignMiddle",
-			label: "",
+			label: "Align middle",
 		},
 	]
 };
-
 JustifiedIconOnlyCompact.storyName = "Justified (compact, icon-only)";
-
 JustifiedIconOnlyCompact.parameters = {
 	chromatic: { disableSnapshot: true },
 };
-
 
 /**
  * When space is limited in an action group, there are 2 options for the group's overflow behavior: wrap or collapse. By default, an action group is set to wrap, meaning that the action buttons inside the group wrap to form another line. Alternatively, an action group can be set to collapse inside a **More (...)** action button.
 */
 export const Overflow = OverflowOption.bind({});
 Overflow.tags = ["!dev"];
-
 Overflow.parameters = {
 	chromatic: { disableSnapshot: true },
 };
-
 
 // ********* VRT ONLY ********* //
 export const WithForcedColors = ActionGroups.bind({});

--- a/components/actiongroup/stories/template.js
+++ b/components/actiongroup/stories/template.js
@@ -65,70 +65,70 @@ export const OverflowOption = (context) => Container({
 	},
 	content: html`
 		${Container({
-				heading: "Wrap",
-				content: Template({
-					customStyles: { "max-inline-size": "288px" },
-					content: [
-						{
-							iconName: "Edit",
-							iconSet: "workflow",
-							label: "Edit",
-						},
-						{
-							iconName: "Copy",
-							iconSet: "workflow",
-							label: "Copy",
-						},
-						{
-							iconName: "Delete",
-							iconSet: "workflow",
-							label: "Delete",
-						},
-						{
-							iconName: "Cut",
-							iconSet: "workflow",
-							label: "Cut",
-						},
-						{
-							iconName: "Move",
-							iconSet: "workflow",
-							label: "Move",
-						},
-					]
-				})
-			}
-		)}
+			withBorder: false,
+			heading: "Wrap",
+			content: Template({
+				customStyles: { "max-inline-size": "288px" },
+				content: [
+					{
+						iconName: "Edit",
+						iconSet: "workflow",
+						label: "Edit",
+					},
+					{
+						iconName: "Copy",
+						iconSet: "workflow",
+						label: "Copy",
+					},
+					{
+						iconName: "Delete",
+						iconSet: "workflow",
+						label: "Delete",
+					},
+					{
+						iconName: "Cut",
+						iconSet: "workflow",
+						label: "Cut",
+					},
+					{
+						iconName: "Move",
+						iconSet: "workflow",
+						label: "Move",
+					},
+				]
+			}, context)
+		})}
 		${Container({
-				heading: "Collapse",
-				content: Template({
-					content: [
-						{
-							iconName: "Edit",
-							iconSet: "workflow",
-							label: "Edit",
-						},
-						{
-							iconName: "Copy",
-							iconSet: "workflow",
-							label: "Copy",
-						},
-						{
-							iconName: "Delete",
-							iconSet: "workflow",
-							label: "Delete",
-						},
-						{
-							iconName: "More",
-							label: "More options",
-							iconSet: "workflow",
-							hideLabel: true,
-						},
-					]
-				})
-			}
-		)}
+			withBorder: false,
+			heading: "Collapse",
+			content: Template({
+				content: [
+					{
+						iconName: "Edit",
+						iconSet: "workflow",
+						label: "Edit",
+					},
+					{
+						iconName: "Copy",
+						iconSet: "workflow",
+						label: "Copy",
+					},
+					{
+						iconName: "Delete",
+						iconSet: "workflow",
+						label: "Delete",
+					},
+					{
+						iconName: "More",
+						label: "More options",
+						iconSet: "workflow",
+						hideLabel: true,
+					},
+				]
+			}, context)
+		})}
 	`
-}, context );
+});
 
 export const TreatmentTemplate = (args, context) => Container({
 	withBorder: false,

--- a/components/actiongroup/stories/template.js
+++ b/components/actiongroup/stories/template.js
@@ -119,6 +119,7 @@ export const OverflowOption = (context) => Container({
 						},
 						{
 							iconName: "More",
+							label: "More options",
 							iconSet: "workflow",
 							hideLabel: true,
 						},
@@ -129,40 +130,6 @@ export const OverflowOption = (context) => Container({
 	`
 }, context );
 
-export const ActionButtonOptions = (args, context ) => Container({
-	withBorder: false,
-	direction: "row",
-	wrapperStyles: {
-		columnGap: "12px",
-	},
-	content: html`
-		${Template({
-			size: args.size || "m",
-			areQuiet: args.areQuiet || false,
-			areEmphasized: args.areEmphasized || false,
-			vertical: args.vertical || false,
-			compact: args.compact || false,
-			content: [
-				{
-					iconName: args.iconName !== undefined ? "Edit" : undefined,
-					label: args.hideLabel !== true ? "Edit" : "",
-					isQuiet: args.isQuiet
-				},
-				{
-					iconName: args.iconName !== undefined ? "Copy" : undefined,
-					label: args.hideLabel !== true ? "Copy" : "",
-					isQuiet: args.isQuiet
-				},
-				{
-					iconName: args.iconName !== undefined ? "Delete" : undefined,
-					label: args.hideLabel !== true ? "Delete" : "",
-					isSelected: true,
-					isQuiet: args.isQuiet
-				}
-			],
-		}, context )}`
-});
-
 export const TreatmentTemplate = (args, context) => Container({
 	withBorder: false,
 	direction: "row",
@@ -170,18 +137,17 @@ export const TreatmentTemplate = (args, context) => Container({
 		rowGap: "12px",
 	},
 	content: html`${[
-		{ iconName: undefined, hideLabel: false, heading: "Default" }, 
-		{ iconName: "", hideLabel: true, heading: "Icon only" },
-		{ iconName: "", hideLabel: true, isQuiet: true, heading: "Quiet, Icon only" },
-	].map(({ iconName, isQuiet, hideLabel, heading }) => Container({ 
-		withBorder: false,
-		heading: heading,
-		content: ActionButtonOptions({
-			...args,
-			hideLabel,
-			iconName,
-			isQuiet
-		})
-	}, context ))}`,
+		{ heading: "Default", },
+		{ iconOnly: true, heading: "Icon-only", },
+		{ iconOnly: true, areQuiet: true, heading: "Quiet, icon-only", },
+		].map(({ heading, areQuiet, iconOnly }) => Container({
+			withBorder: false,
+			heading: heading,
+			content: Template({
+				...args,
+				areQuiet, 
+				iconOnly,
+			}, context)}
+		))}`
 });
 


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->
All action buttons were, by default, receiving the `aria-label` attribute. When clickable elements have visible text, typically they should not receive an `aria-label` because a screen reader will read the visible text aloud. The button component was applying `aria-label`s conditionally (when a button didn't have visible text/label), so the same approach was brought to action button. Now, any action button that has "regular" label text does not receive the `aria-label`, and if an action button is icon-only, with its `hideLabel: true` arg set, an `aria-label` will be applied.

Because action buttons are used in the action group component as well, some refactoring had to be done to make sure any arguments used to create icon-only action buttons were from the action group args, as opposed to the action button args. For instance, instead of the action buttons' `label` arg getting set to empty string to render an icon-only action button within an action group like so: 
```
ActionGroup.args = {
        content: [
		{
			iconName: "AlignTop",
			label: "",
		},
		{
			iconName: "AlignBottom",
			label: "",
		},
		{
			iconName: "AlignMiddle",
			label: "",
		},
	]
}
```

...the code for action group now relies on its own `iconOnly` control to hide the action buttons' labels. 
```
ActionGroup.args = {
	iconOnly: true,
	content: [
		{
			iconName: "AlignTop",
			label: "Align top",
		},
		{
			iconName: "AlignBottom",
			label: "Align bottom",
		},
		{
			iconName: "AlignMiddle",
			label: "Align middle",
		},
	]
}
```

This should ensure that the `label` for each action button within `content` gets passed appropriately to the action button component, and set as the value for its `aria-label`. 

White space/empty lines in the story files were removed during this work, as well as some corrections made to the sentence-case of our story names on the documentation pages.

### Jira/Specs
[CSS-853](https://jira.corp.adobe.com/browse/CSS-853)
[Github issue](https://github.com/adobe/spectrum-css/issues/2853)

### Pending Questions
1. Should we go through each instance of `ActionButton` to make sure we're using label and hideLabel correctly? For instance, the breadcrumbs action button is icon-only, and has no label text or aria-label. Is that separate work from this PR? With just a quick search, card, contextual help, pagination may be other components to look into.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->
- [ ] Pull down the branch to run locally or [visit the deploy preview](https://pr-3230--spectrum-css.netlify.app/preview/?path=/docs/components-action-button--docs).
- [ ] Inspect [the action button docs page](https://pr-3230--spectrum-css.netlify.app/preview/?path=/docs/components-action-button--docs) in the browser.
- [ ] Verify that any of the action buttons that have visible label text do not have an `aria-label` attribute.
- [ ] Verify that any of the icon-only buttons (screenshot below) have an aria-label attribute that corresponds to the label text set in the controls. By default, you should see `aria-label="Edit"` for the icon-only buttons.

<img width="97" alt="Screenshot 2024-10-10 at 2 12 42 PM" src="https://github.com/user-attachments/assets/39eb99d9-5b4d-4f5c-83a1-138e0be0299c">

- [ ] Visit [the story page ](https://pr-3230--spectrum-css.netlify.app/preview/?path=/story/components-action-button--default)and change the label text via the "Label" control. Verify that your new label is set as the `aria-label` for the icon-only action buttons.

<img width="332" alt="Screenshot 2024-10-10 at 2 16 04 PM" src="https://github.com/user-attachments/assets/7bae3291-afba-4713-926e-e9e203a1fccb">

(I used "paradiddle" 🥁)
- [ ] Using a screen reader (like NVDA on AssistivLabs or VoiceOver with Safari), use the keyboard to tab focus onto the action buttons.
- [ ] Any icon-only action buttons show have their `aria-label` announced by the screenreader. You should hear something like "Edit, toggle button." You should also hear "submenu" for the action buttons with the "hold icon."
- [ ] Next [visit the action group docs page](https://pr-3230--spectrum-css.netlify.app/preview/?path=/docs/components-action-group--docs)
- [ ] In the inspector, verify that the "Default" action group has no `aria-label`s. The action button labels should be within `<span>`s.

<img width="313" alt="Screenshot 2024-10-10 at 2 56 35 PM" src="https://github.com/user-attachments/assets/163e9ee5-2326-46d5-890d-4772ef4b804b">

- [ ] Verify that the "Icon-only" and "Quiet, icon-only" have `aria-label`s set to their label text. You should see "Edit," "Copy," and "Delete."

<img width="323" alt="Screenshot 2024-10-10 at 2 57 34 PM" src="https://github.com/user-attachments/assets/265adbb9-f136-49d9-975e-5f30dbf7d4de">

- [ ] Feel free to inspect a few more of the action buttons within the action group stories. The justified stories have different label text to correspond better to their icons.
- [ ] Additionally, you can inspect [the action group within the action bar component](https://pr-3230--spectrum-css.netlify.app/preview/?path=/docs/components-action-bar--docs). Those buttons should no longer have the `aria-label` attribute since they have visible text.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] ✨ This pull request is ready to merge. ✨
