### PR TITLE
docs(meter): let meter use its rootclass in storybook

### DIFF
--- a/components/progressbar/stories/meter.stories.js
+++ b/components/progressbar/stories/meter.stories.js
@@ -36,6 +36,7 @@ export default {
 	},
 	args: {
 		...ProgressBar.args,
+		rootClass: "spectrum-Meter",
 		size: "l",
 		label: "Storage space",
 	},

--- a/components/progressbar/stories/meter.template.js
+++ b/components/progressbar/stories/meter.template.js
@@ -1,6 +1,7 @@
 import { Container } from "@spectrum-css/preview/decorators";
-import { Template as ProgressBar } from "./template.js";
 import { html } from "lit";
+import { capitalize } from "lodash-es";
+import { Template as ProgressBar } from "./template.js";
 
 import "../index.css";
 
@@ -8,15 +9,24 @@ export const Template = ({
 	customClasses = [],
 	fill,
 	size = "s",
+	rootClass = "spectrum-Meter",
+	staticColor,
 	...item
 } = {}, context = {}) => ProgressBar({
 	customClasses: [
-		...customClasses,
-		"spectrum-Meter",
-		typeof size !== "undefined" ? `spectrum-Meter--size${size.toUpperCase()}` : null,
+		rootClass,
+		typeof size !== "undefined" ? `${rootClass}--size${size.toUpperCase()}` : null,
 		typeof fill !== "undefined" ? `is-${fill}` : null,
+		/*
+		 * The `spectrum-Meter--staticWhite` class is not present in the Meter CSS, as it makes use of
+		 * `spectrum-ProgressBar--staticWhite`, but having this allows for simpler detection of static
+		 * colors when looking at the element using its `rootClass` in our decorators.
+		 */
+		typeof staticColor !== "undefined" ? `${rootClass}--static${capitalize(staticColor)}` : null,
+		...customClasses,
 	].filter(Boolean),
 	size,
+	staticColor,
 	...item,
 }, context);
 


### PR DESCRIPTION
## Description

An update to the meter component storybook templates to help with simplifying the comparison between `rootClass` values in #3129. The Meter component was the only component using a `rootClass` arg value that is not unique and its own (previously it was using `spectrum-ProgressBar`).

### Details

Meter's Storybook template was using the `rootClass` for progress bar, rather than its own `rootClass`. It was set up this way because of the way the two components are housed together, and meter primarily just uses ProgressBar, with some added classes.

This value not being unique made it difficult to compare and match up the value of `rootClass` in the `package.json` `spectrum` data to the actual `rootClass` defined in the story files default args.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [ ] Meter still displays correctly
- [ ] The static color background color option still works in meter; the class `spectrum-Meter--staticWhite` gets applied to the component root and the teal background still appears. 

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] ✨ This pull request is ready to merge. ✨
