### PR TITLE
chore: update vscode settings and suggestions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,20 +1,25 @@
 {
 	"recommendations": [
-		"rajdeepchandra.spectrum-design-tokens-for-vscode",
-		"gruntfuggly.todo-tree",
-		"nrwl.angular-console",
-		"esbenp.prettier-vscode",
-		"dbaeumer.vscode-eslint",
-		"vunguyentuan.vscode-postcss",
-		"mariusschulz.yarn-lock-syntax",
-		"stylelint.vscode-stylelint",
-		"joshbolduc.story-explorer",
-		"bierner.lit-html",
 		"atlassian.atlascode",
-		"github.vscode-pull-request-github",
-		"me-dutour-mathieu.vscode-github-actions",
+		"bierner.color-info",
+		"bierner.lit-html",
+		"dbaeumer.vscode-eslint",
+		"esbenp.prettier-vscode",
+		"figma.figma-vscode-extension",
+		"github.copilot",
+		"github.copilot-chat",
 		"github.vscode-github-actions",
+		"github.vscode-pull-request-github",
+		"gruntfuggly.todo-tree",
+		"joshbolduc.story-explorer",
 		"kisstkondoros.csstriggers",
-		"vunguyentuan.vscode-css-variables"
+		"mariusschulz.yarn-lock-syntax",
+		"me-dutour-mathieu.vscode-github-actions",
+		"nrwl.angular-console",
+		"oouo-diogo-perdigao.docthis",
+		"rajdeepchandra.spectrum-design-tokens-for-vscode",
+		"stylelint.vscode-stylelint",
+		"vunguyentuan.vscode-css-variables",
+		"vunguyentuan.vscode-postcss"
 	]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,8 @@
 {
-	"js/ts.implicitProjectConfig.experimentalDecorators": true,
 	"[css]": {
+		"editor.codeActionsOnSave": {
+			"source.fixAll.stylelint": "explicit"
+		},
 		"editor.defaultFormatter": "stylelint.vscode-stylelint"
 	},
 	"[javascript]": {
@@ -48,17 +50,89 @@
 	"atlascode.jira.workingSite": {
 		"baseUrlSuffix": "jira.corp.adobe.com"
 	},
+	"colorInfo.languages": [
+		{
+			"colors": "css",
+			"selector": "css"
+		},
+		{
+			"colors": "css",
+			"selector": "postcss"
+		},
+		{
+			"colors": "css",
+			"selector": "javascript"
+		},
+		{
+			"colors": "css",
+			"selector": "js"
+		},
+		{
+			"colors": "css",
+			"selector": "jsx"
+		},
+		{
+			"colors": "css",
+			"selector": "json"
+		},
+		{
+			"colors": "css",
+			"selector": "svg"
+		},
+		{
+			"colors": "css",
+			"selector": "markdown"
+		},
+		{
+			"colors": "css",
+			"selector": "md"
+		},
+		{
+			"colors": "css",
+			"selector": "mdx"
+		},
+		{
+			"colors": "css",
+			"selector": "html"
+		},
+		{
+			"colors": "css",
+			"selector": "yaml"
+		}
+	],
+	"cssVariables.lookupFiles": [
+		"${workspaceFolder}/tokens/dist/index.css",
+		"${workspaceFolder}/tokens/**/*.css",
+		"${workspaceFolder}/components/*/index.css",
+		"${workspaceFolder}/components/*/themes/*.css"
+	],
+	"docthis.includeDescriptionTag": true,
+	"docthis.inferTypesFromNames": true,
+	"docthis.returnsTag": true,
 	"editor.defaultFormatter": "esbenp.prettier-vscode",
+	"editor.largeFileOptimizations": true,
+	"editor.renderControlCharacters": true,
 	"emmet.includeLanguages": {
 		"postcss": "css"
 	},
 	"emmet.syntaxProfiles": {
 		"postcss": "css"
 	},
+	"eslint.format.enable": true,
 	"eslint.packageManager": "yarn",
+	"eslint.useESLintClass": true,
 	"files.associations": {
 		"*.css": "postcss"
 	},
+	"files.insertFinalNewline": true,
+	"files.trimFinalNewlines": true,
+	"files.trimTrailingWhitespace": true,
+	"github.copilot.enable": {
+		"*": true,
+		"plaintext": false,
+		"scminput": false
+	},
+	"githubIssues.createIssueTriggers": ["TODO", "todo", "FIXME", "ISSUE", "BUG"],
 	"githubIssues.issueBranchTitle": "${author}/${sanitizedIssueTitle}-gh-${issueNumber}",
 	"githubIssues.queries": [
 		{
@@ -92,14 +166,27 @@
 			"query": "is:open mentions:${user}"
 		}
 	],
+	"js/ts.implicitProjectConfig.experimentalDecorators": true,
 	"prettier.configPath": ".prettierrc",
 	"prettier.ignorePath": ".prettierignore",
-	"prettier.prettierPath": "./node_modules/prettier",
+	"prettier.prettierPath": "node_modules/prettier",
+	"stylelint.enable": true,
 	"stylelint.packageManager": "yarn",
+	"stylelint.reportDescriptionlessDisables": true,
+	"stylelint.reportInvalidScopeDisables": true,
 	"stylelint.reportNeedlessDisables": true,
 	"stylelint.validate": ["css", "postcss"],
 	"yaml.schemas": {
-		"~/.vscode/extensions/atlassian.atlascode-3.0.4/resources/schemas/pipelines-schema.json": "bitbucket-pipelines.yml",
-		"./schemas/documentation.schema.json": ["/metadata/*.yml", "/metadata/*.yaml"]
-	}
+		"./schemas/documentation.schema.json": [
+			"/metadata/*.yml",
+			"/metadata/*.yaml"
+		],
+		"~/.vscode/extensions/atlassian.atlascode-3.0.4/resources/schemas/pipelines-schema.json": "bitbucket-pipelines.yml"
+	},
+	"storyExplorer.storiesGlobs": [
+		".storybook/deprecated/*/*.stories.js",
+		".storybook/deprecated/*/*.mdx",
+		"components/*/stories/*.stories.js",
+		"components/*/stories/*.mdx"
+	]
 }


### PR DESCRIPTION
## Description

Alphabetize the suggested VS Code plugins and add DocThis, Figma, and CoPilot suggestions. Also organized and enhanced the settings for our supported plugins to make best use of these tools when installed.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [ ] Open your VS Code application and navigate to extensions (or Shift + Cmd + X). In the search field, enter: `@recommended`. For workspace recommendations, expect the list to match that of the provided extensions.json resource.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] ✨ This pull request is ready to merge. ✨
