### PR TITLE
fix(thumbnail): incorrect opacity variable used

### DIFF
--- a/.changeset/green-ants-accept.md
+++ b/.changeset/green-ants-accept.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/thumbnail": minor
+---
+
+Typo in the "--spectrum-thumbnail-border-color-opacity", should have been "--spectrum-thumbnail-border-opacity". Thumbnail border was rendering as 0% opacity but should have been 10%.

--- a/components/thumbnail/index.css
+++ b/components/thumbnail/index.css
@@ -18,7 +18,7 @@
 	--spectrum-thumbnail-border-width: var(--spectrum-border-width-100);
 
 	/* @todo Refactor with --spectrum-thumbnail-border-color once gray rgb token is no longer necessary to workaround nested rgb color token value using rgba(). */
-	--spectrum-thumbnail-border-color-rgba: rgba(var(--spectrum-gray-800-rgb), var(--spectrum-thumbnail-border-color-opacity));
+	--spectrum-thumbnail-border-color-rgba: rgba(var(--spectrum-gray-800-rgb), var(--spectrum-thumbnail-border-opacity));
 	--spectrum-thumbnail-layer-border-width-inner: var(--spectrum-border-width-400);
 	--spectrum-thumbnail-layer-border-color-inner: var(--spectrum-white);
 	--spectrum-thumbnail-layer-border-width-outer: var(--spectrum-border-width-100);
@@ -213,12 +213,13 @@
 /* Windows High Contrast Mode */
 @media (forced-colors: active) {
 	.spectrum-Thumbnail {
-		/* Allow checkerboard pattern to be visible. */
-		forced-color-adjust: none;
 		--highcontrast-thumbnail-border-color-selected: Highlight;
 		--highcontrast-thumbnail-focus-indicator-color: Highlight;
 		--highcontrast-thumbnail-border-color: CanvasText;
 		--highcontrast-thumbnail-layer-border-color-inner: Canvas;
 		--highcontrast-thumbnail-layer-border-color-outer: CanvasText;
+
+		/* Allow checkerboard pattern to be visible. */
+		forced-color-adjust: none;
 	}
 }

--- a/components/thumbnail/metadata/metadata.json
+++ b/components/thumbnail/metadata/metadata.json
@@ -45,9 +45,9 @@
     "--mod-thumbnail-size"
   ],
   "component": [
-    "--spectrum-thumbnail-border-color-opacity",
     "--spectrum-thumbnail-border-color-rgba",
     "--spectrum-thumbnail-border-color-selected",
+    "--spectrum-thumbnail-border-opacity",
     "--spectrum-thumbnail-border-radius",
     "--spectrum-thumbnail-border-width",
     "--spectrum-thumbnail-border-width-selected",


### PR DESCRIPTION
## Description

Found a bug in the `thumbnail/index.css` file for the following variable stack:

```
--spectrum-thumbnail-border-color-rgba: rgba(var(--spectrum-gray-800-rgb), var(--spectrum-thumbnail-border-opacity));
```

**Typo**: `--spectrum-thumbnail-border-color-opacity` should have been `--spectrum-thumbnail-border-opacity`. Thumbnail border was rendering as 0% opacity but should have been 10%.


## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [ ] Expect the border of the thumbnail to be a very light gray rather than transparent.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [x] ✨ This pull request is ready to merge. ✨
