### PR TITLE
chore(typography): fallback sizing for detail at xxs

### DIFF
--- a/components/typography/stories/template.js
+++ b/components/typography/stories/template.js
@@ -44,6 +44,10 @@ export const Template = (args = {}, context = {}) => {
 				if (["body", "code"].includes(semantics)) {
 					size = "xs";
 				}
+				// Detail doesn't support xxs, use s instead
+				else if (["detail"].includes(semantics)) {
+					size = "s";
+				}
 				break;
 			case "xs":
 				if (["detail"].includes(semantics)) {


### PR DESCRIPTION
## Description

I noticed in the visual regression tests that the detail heading is still showing at default medium sizing when at "XXS"; ideally it should default to "S".

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [x] Expect the testing grid to show the detail heading as `--sizeS` at the "XXS" sizing set.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
