### PR TITLE
fix(closebutton): t-shirt sizing variable fix

### DIFF
--- a/.changeset/funny-jobs-relax.md
+++ b/.changeset/funny-jobs-relax.md
@@ -1,0 +1,7 @@
+---
+"@spectrum-css/closebutton": patch
+---
+
+CloseButton
+
+- Remove hardcoded tokens for sizing in favor of component sizing. Remove mapping to height & width separately in favor of using the existing "--spectrum-closebutton-size" property.

--- a/.storybook/decorators/utilities.js
+++ b/.storybook/decorators/utilities.js
@@ -7,28 +7,28 @@ import { capitalize } from "lodash-es";
 /**
  * Renders a heading or code block that identifies the test case and is ignored by the snapshots.
  * @param {Object} props
- * @param {string} props.type - The type of heading or code block to render.
+ * @param {string} props.semantics - The type of heading or code block to render.
  * @param {string} props.content - The content to render in the heading or code block.
  * @param {string} props.size - The size of the heading to render.
  * @param {string} props.weight - The weight of the heading to render.
  * @param {string[]} props.customClasses - Additional classes to apply to the heading or code block.
  */
 const Heading = ({
-	type = "heading",
+	semantics = "heading",
 	content,
 	size = "l",
 	weight,
 	customClasses = [],
 } = {}) => {
 	return Typography({
-		semantics: type === "code" ? "code" : "detail",
+		semantics,
 		size,
 		weight,
 		content,
 		skipLineBreak: true,
 		customClasses: ["chromatic-ignore", ...customClasses],
 		customStyles: {
-			"color": type !== "code" ? "var(--spectrum-heading-color)" : undefined,
+			"color": semantics === "detail" ? "var(--spectrum-heading-color)" : undefined,
 		}
 	});
 };
@@ -48,18 +48,26 @@ const Heading = ({
 export const Container = ({
 	heading,
 	content,
-	type = "heading",
+	type = "detail",
 	level = 1,
 	direction = "row",
 	withBorder = true,
 	containerStyles = {},
 	wrapperStyles = {},
 } = {}) => {
-	let headingConfig = { size: "l" };
+	const headingConfig = { size: "l", semantics: type };
 	let gap = 40;
 
 	if (level > 1) {
-		headingConfig = { size: "s", weight: "light" };
+		headingConfig.size = "s";
+		headingConfig.weight = "light";
+	}
+
+	if (level > 3) {
+		headingConfig.size = "xxs";
+		headingConfig.semantics = "heading";
+		containerStyles["padding-block-start"] = "8px";
+		wrapperStyles["padding-block-start"] = "12px";
 	}
 
 	if (level === 2) {
@@ -91,7 +99,6 @@ export const Container = ({
 		>
 			${when(heading, () => Heading({
 				...headingConfig,
-				type,
 				content: heading
 			}))}
 			<div

--- a/components/closebutton/index.css
+++ b/components/closebutton/index.css
@@ -15,12 +15,6 @@
 @import "@spectrum-css/commons/basebutton.css";
 
 .spectrum-CloseButton {
-	/* Hardcoded tokens */
-	--spectrum-closebutton-size-300: 24px;
-	--spectrum-closebutton-size-400: 32px;
-	--spectrum-closebutton-size-500: 40px;
-	--spectrum-closebutton-size-600: 48px;
-
 	/* Cross icon */
 	--spectrum-closebutton-icon-color-default: var(--spectrum-neutral-content-color-default);
 	--spectrum-closebutton-icon-color-hover: var(--spectrum-neutral-content-color-hover);
@@ -33,50 +27,36 @@
 	--spectrum-closebutton-focus-indicator-gap: var(--spectrum-focus-indicator-gap);
 	--spectrum-closebutton-focus-indicator-color: var(--spectrum-focus-indicator-color);
 
-	/* Size */
-	--spectrum-closebutton-height: var(--spectrum-component-height-100);
-	--spectrum-closebutton-width: var(--spectrum-closebutton-height);
-	--spectrum-closebutton-size: var(--spectrum-closebutton-size-400);
-	--spectrum-closebutton-border-radius: var(--spectrum-closebutton-size-400);
-
 	--spectrum-closebutton-animation-duration: var(--spectrum-animation-duration-100);
-}
-
-/* @deprecated .spectrum-Closebutton--sizeS */
-.spectrum-CloseButton--sizeS,
-.spectrum-Closebutton--sizeS {
-	--spectrum-closebutton-height: var(--spectrum-component-height-75);
-	--spectrum-closebutton-width: var(--spectrum-closebutton-height);
-	--spectrum-closebutton-size: var(--spectrum-closebutton-size-300);
-	--spectrum-closebutton-border-radius: var(--spectrum-closebutton-size-300);
 }
 
 /* @deprecated .spectrum-Closebutton--sizeM */
 .spectrum-CloseButton,
 .spectrum-CloseButton--sizeM,
 .spectrum-Closebutton--sizeM {
-	--spectrum-closebutton-height: var(--spectrum-component-height-100);
-	--spectrum-closebutton-width: var(--spectrum-closebutton-height);
-	--spectrum-closebutton-size: var(--spectrum-closebutton-size-400);
-	--spectrum-closebutton-border-radius: var(--spectrum-closebutton-size-400);
+	--spectrum-closebutton-size: var(--spectrum-component-height-100);
+	--spectrum-closebutton-border-radius: var(--spectrum-component-height-100);
+}
+
+/* @deprecated .spectrum-Closebutton--sizeS */
+.spectrum-CloseButton--sizeS,
+.spectrum-Closebutton--sizeS {
+	--spectrum-closebutton-size: var(--spectrum-component-height-75);
+	--spectrum-closebutton-border-radius: var(--spectrum-component-height-75);
 }
 
 /* @deprecated .spectrum-Closebutton--sizeL */
 .spectrum-CloseButton--sizeL,
 .spectrum-Closebutton--sizeL {
-	--spectrum-closebutton-height: var(--spectrum-component-height-200);
-	--spectrum-closebutton-width: var(--spectrum-closebutton-height);
-	--spectrum-closebutton-size: var(--spectrum-closebutton-size-500);
-	--spectrum-closebutton-border-radius: var(--spectrum-closebutton-size-500);
+	--spectrum-closebutton-size: var(--spectrum-component-height-200);
+	--spectrum-closebutton-border-radius: var(--spectrum-component-height-200);
 }
 
 /* @deprecated .spectrum-Closebutton--sizeXL */
 .spectrum-CloseButton--sizeXL,
 .spectrum-Closebutton--sizeXL {
-	--spectrum-closebutton-height: var(--spectrum-component-height-300);
-	--spectrum-closebutton-width: var(--spectrum-closebutton-height);
-	--spectrum-closebutton-size: var(--spectrum-closebutton-size-600);
-	--spectrum-closebutton-border-radius: var(--spectrum-closebutton-size-600);
+	--spectrum-closebutton-size: var(--spectrum-component-height-300);
+	--spectrum-closebutton-border-radius: var(--spectrum-component-height-300);
 }
 
 .spectrum-CloseButton--staticWhite {
@@ -137,11 +117,12 @@ a.spectrum-CloseButton {
 	@extend %spectrum-AnchorButton;
 }
 
+/* stylelint-disable-next-line no-duplicate-selectors -- Allow variable definitions to appear at the top */
 .spectrum-CloseButton {
 	@extend %spectrum-BaseButton;
 
-	block-size: var(--mod-closebutton-height, var(--spectrum-closebutton-height));
-	inline-size: var(--mod-closebutton-width, var(--spectrum-closebutton-width));
+	block-size: var(--mod-closebutton-height, var(--spectrum-closebutton-size));
+	inline-size: var(--mod-closebutton-width, var(--mod-closebutton-height, var(--spectrum-closebutton-size)));
 
 	position: relative;
 

--- a/components/closebutton/metadata/metadata.json
+++ b/components/closebutton/metadata/metadata.json
@@ -101,22 +101,16 @@
     "--spectrum-closebutton-focus-indicator-color",
     "--spectrum-closebutton-focus-indicator-gap",
     "--spectrum-closebutton-focus-indicator-thickness",
-    "--spectrum-closebutton-height",
     "--spectrum-closebutton-icon-color-default",
     "--spectrum-closebutton-icon-color-disabled",
     "--spectrum-closebutton-icon-color-down",
     "--spectrum-closebutton-icon-color-focus",
     "--spectrum-closebutton-icon-color-hover",
     "--spectrum-closebutton-size",
-    "--spectrum-closebutton-size-300",
-    "--spectrum-closebutton-size-400",
-    "--spectrum-closebutton-size-500",
-    "--spectrum-closebutton-size-600",
     "--spectrum-closebutton-static-background-color-default",
     "--spectrum-closebutton-static-background-color-down",
     "--spectrum-closebutton-static-background-color-focus",
-    "--spectrum-closebutton-static-background-color-hover",
-    "--spectrum-closebutton-width"
+    "--spectrum-closebutton-static-background-color-hover"
   ],
   "global": [
     "--spectrum-animation-duration-100",

--- a/components/closebutton/stories/closebutton.stories.js
+++ b/components/closebutton/stories/closebutton.stories.js
@@ -54,6 +54,7 @@ export default {
 export const Default = CloseButtonGroup.bind({});
 Default.args = {};
 
+// ********* DOCS ONLY ********* //
 /**
  * Close button provides a "large" icon size option, for displaying a larger cross icon for each component size.
  * When using this option, the following UI icons should be used:
@@ -76,18 +77,9 @@ SizingLargeIcons.args = {
 	iconSize: "large",
 };
 SizingLargeIcons.tags = ["!dev"];
-
-// ********* VRT ONLY ********* //
-export const WithForcedColors = CloseButtonGroup.bind({});
-WithForcedColors.tags = ["!autodocs", "!dev"];
-WithForcedColors.parameters = {
-	chromatic: {
-		forcedColors: "active",
-		modes: disableDefaultModes
-	},
+SizingLargeIcons.parameters = {
+	chromatic: { disableSnapshot: true },
 };
-
-// ********* DOCS ONLY ********* //
 
 /**
 * Close buttons come in four different sizes: small, medium, large, and extra-large. By default ("regular" icon size), the cross icon
@@ -137,4 +129,15 @@ StaticBlack.args = {
 StaticBlack.tags = ["!dev"];
 StaticBlack.parameters = {
 	chromatic: { disableSnapshot: true },
+};
+
+
+// ********* VRT ONLY ********* //
+export const WithForcedColors = CloseButtonGroup.bind({});
+WithForcedColors.tags = ["!autodocs", "!dev"];
+WithForcedColors.parameters = {
+	chromatic: {
+		forcedColors: "active",
+		modes: disableDefaultModes
+	},
 };

--- a/components/closebutton/stories/closebutton.test.js
+++ b/components/closebutton/stories/closebutton.test.js
@@ -1,8 +1,20 @@
-import { Variants } from "@spectrum-css/preview/decorators";
+import { ArgGrid, Variants } from "@spectrum-css/preview/decorators";
 import { Template } from "./template.js";
 
-export const CloseButtonGroup = Variants({
+const CloseButtons = (args, context) => ArgGrid({
 	Template,
+	argKey: "iconSize",
+	withBorder: false,
+	level: 4,
+	labels: {
+		"regular": "Default icon",
+		"large": "Large icon",
+	},
+	...args,
+}, context);
+
+export const CloseButtonGroup = Variants({
+	Template: CloseButtons,
 	stateDirection: "row",
 	sizeDirection: "row",
 	testData: [


### PR DESCRIPTION
## Description

Remove hardcoded tokens for CloseButton sizing in favor of component sizing. Remove mapping to height & width separately in favor of using the existing `--spectrum-closebutton-size` property.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [x] Expect to see accurate t-shirt sizing for closebutton.

![](https://snapshots.chromatic.com/snapshots/64762974a45b8bc5ca1705a2-670d9ffc4f2e4e703b249743/capture-ebf3e4c.png)
### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] ✨ This pull request is ready to merge. ✨
