### PR TITLE
fix(menu): updated bg color for legacy theme

### DIFF
--- a/.changeset/tasty-islands-accept.md
+++ b/.changeset/tasty-islands-accept.md
@@ -1,0 +1,6 @@
+---
+"@spectrum-css/menu": minor
+"@spectrum-css/tokens": minor
+---
+
+updated menu-item bg color for legacy theme

--- a/components/menu/themes/spectrum.css
+++ b/components/menu/themes/spectrum.css
@@ -17,8 +17,9 @@
 
 @container style(--system: legacy) {
 	.spectrum-Menu {
-		--spectrum-menu-item-background-color-hover: rgba(var(--spectrum-gray-900-rgb), var(--spectrum-transparent-black-200-opacity));
-		--spectrum-menu-item-background-color-down: rgba(var(--spectrum-gray-900-rgb), var(--spectrum-transparent-black-200-opacity));
-		--spectrum-menu-item-background-color-key-focus: rgba(var(--spectrum-gray-900-rgb), var(--spectrum-transparent-black-200-opacity));
-	}
+		--spectrum-menu-item-background-color-default: var(--spectrum-transparent-black-100);
+		--spectrum-menu-item-background-color-hover: rgba(var(--spectrum-gray-900), var(--spectrum-transparent-black-200-opacity));
+		--spectrum-menu-item-background-color-down: rgba(var(--spectrum-gray-900), var(--spectrum-transparent-black-200-opacity));
+		--spectrum-menu-item-background-color-key-focus: rgba(var(--spectrum-gray-900), var(--spectrum-transparent-black-200-opacity));
+    }
 }

--- a/tokens/dist/css/components/express/index.css
+++ b/tokens/dist/css/components/express/index.css
@@ -1956,10 +1956,10 @@
 	--system-menu-checkmark-display-shown: block;
 	--system-menu-checkmark-display: var(--system-menu-checkmark-display-shown);
 	--system-menu-item-collapsible-no-icon-sub-item-padding-x-start: calc(var(--system-menu-item-label-inline-edge-to-content) + var(--system-menu-item-checkmark-width) + var(--system-menu-item-label-text-to-visual) + var(--system-menu-item-focus-indicator-width));
-	--system-menu-item-background-color-default: transparent;
-	--system-menu-item-background-color-hover: rgba(var(--spectrum-gray-900-rgb), var(--spectrum-transparent-black-200-opacity));
-	--system-menu-item-background-color-down: rgba(var(--spectrum-gray-900-rgb), var(--spectrum-transparent-black-200-opacity));
-	--system-menu-item-background-color-key-focus: rgba(var(--spectrum-gray-900-rgb), var(--spectrum-transparent-black-200-opacity));
+	--system-menu-item-background-color-default: var(--spectrum-transparent-black-100);
+	--system-menu-item-background-color-hover: rgba(var(--spectrum-gray-900), var(--spectrum-transparent-black-200-opacity));
+	--system-menu-item-background-color-down: rgba(var(--spectrum-gray-900), var(--spectrum-transparent-black-200-opacity));
+	--system-menu-item-background-color-key-focus: rgba(var(--spectrum-gray-900), var(--spectrum-transparent-black-200-opacity));
 	--system-menu-item-min-height: var(--spectrum-component-height-100);
 	--system-menu-size-m-item-min-height: var(--spectrum-component-height-100);
 	--system-menu-item-icon-height: var(--spectrum-workflow-icon-size-100);

--- a/tokens/dist/css/components/express/menu.css
+++ b/tokens/dist/css/components/express/menu.css
@@ -58,10 +58,10 @@
 	--system-menu-checkmark-display-shown: block;
 	--system-menu-checkmark-display: var(--system-menu-checkmark-display-shown);
 	--system-menu-item-collapsible-no-icon-sub-item-padding-x-start: calc(var(--system-menu-item-label-inline-edge-to-content) + var(--system-menu-item-checkmark-width) + var(--system-menu-item-label-text-to-visual) + var(--system-menu-item-focus-indicator-width));
-	--system-menu-item-background-color-default: transparent;
-	--system-menu-item-background-color-hover: rgba(var(--spectrum-gray-900-rgb), var(--spectrum-transparent-black-200-opacity));
-	--system-menu-item-background-color-down: rgba(var(--spectrum-gray-900-rgb), var(--spectrum-transparent-black-200-opacity));
-	--system-menu-item-background-color-key-focus: rgba(var(--spectrum-gray-900-rgb), var(--spectrum-transparent-black-200-opacity));
+	--system-menu-item-background-color-default: var(--spectrum-transparent-black-100);
+	--system-menu-item-background-color-hover: rgba(var(--spectrum-gray-900), var(--spectrum-transparent-black-200-opacity));
+	--system-menu-item-background-color-down: rgba(var(--spectrum-gray-900), var(--spectrum-transparent-black-200-opacity));
+	--system-menu-item-background-color-key-focus: rgba(var(--spectrum-gray-900), var(--spectrum-transparent-black-200-opacity));
 	--system-menu-item-min-height: var(--spectrum-component-height-100);
 	--system-menu-size-m-item-min-height: var(--spectrum-component-height-100);
 	--system-menu-item-icon-height: var(--spectrum-workflow-icon-size-100);

--- a/tokens/dist/css/components/spectrum/index.css
+++ b/tokens/dist/css/components/spectrum/index.css
@@ -1956,10 +1956,10 @@
 	--system-menu-checkmark-display-shown: block;
 	--system-menu-checkmark-display: var(--system-menu-checkmark-display-shown);
 	--system-menu-item-collapsible-no-icon-sub-item-padding-x-start: calc(var(--system-menu-item-label-inline-edge-to-content) + var(--system-menu-item-checkmark-width) + var(--system-menu-item-label-text-to-visual) + var(--system-menu-item-focus-indicator-width));
-	--system-menu-item-background-color-default: transparent;
-	--system-menu-item-background-color-hover: rgba(var(--spectrum-gray-900-rgb), var(--spectrum-transparent-black-200-opacity));
-	--system-menu-item-background-color-down: rgba(var(--spectrum-gray-900-rgb), var(--spectrum-transparent-black-200-opacity));
-	--system-menu-item-background-color-key-focus: rgba(var(--spectrum-gray-900-rgb), var(--spectrum-transparent-black-200-opacity));
+	--system-menu-item-background-color-default: var(--spectrum-transparent-black-100);
+	--system-menu-item-background-color-hover: rgba(var(--spectrum-gray-900), var(--spectrum-transparent-black-200-opacity));
+	--system-menu-item-background-color-down: rgba(var(--spectrum-gray-900), var(--spectrum-transparent-black-200-opacity));
+	--system-menu-item-background-color-key-focus: rgba(var(--spectrum-gray-900), var(--spectrum-transparent-black-200-opacity));
 	--system-menu-item-min-height: var(--spectrum-component-height-100);
 	--system-menu-size-m-item-min-height: var(--spectrum-component-height-100);
 	--system-menu-item-icon-height: var(--spectrum-workflow-icon-size-100);

--- a/tokens/dist/css/components/spectrum/menu.css
+++ b/tokens/dist/css/components/spectrum/menu.css
@@ -58,10 +58,10 @@
 	--system-menu-checkmark-display-shown: block;
 	--system-menu-checkmark-display: var(--system-menu-checkmark-display-shown);
 	--system-menu-item-collapsible-no-icon-sub-item-padding-x-start: calc(var(--system-menu-item-label-inline-edge-to-content) + var(--system-menu-item-checkmark-width) + var(--system-menu-item-label-text-to-visual) + var(--system-menu-item-focus-indicator-width));
-	--system-menu-item-background-color-default: transparent;
-	--system-menu-item-background-color-hover: rgba(var(--spectrum-gray-900-rgb), var(--spectrum-transparent-black-200-opacity));
-	--system-menu-item-background-color-down: rgba(var(--spectrum-gray-900-rgb), var(--spectrum-transparent-black-200-opacity));
-	--system-menu-item-background-color-key-focus: rgba(var(--spectrum-gray-900-rgb), var(--spectrum-transparent-black-200-opacity));
+	--system-menu-item-background-color-default: var(--spectrum-transparent-black-100);
+	--system-menu-item-background-color-hover: rgba(var(--spectrum-gray-900), var(--spectrum-transparent-black-200-opacity));
+	--system-menu-item-background-color-down: rgba(var(--spectrum-gray-900), var(--spectrum-transparent-black-200-opacity));
+	--system-menu-item-background-color-key-focus: rgba(var(--spectrum-gray-900), var(--spectrum-transparent-black-200-opacity));
 	--system-menu-item-min-height: var(--spectrum-component-height-100);
 	--system-menu-size-m-item-min-height: var(--spectrum-component-height-100);
 	--system-menu-item-icon-height: var(--spectrum-workflow-icon-size-100);


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

This PR updates the background-color-default for menu-item in legacy theme.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

 - [ ] No expected changes to `metadata.json`

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

Previously:


## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
