### PR TITLE
fix(actionbutton): prevent diacritic clipping in thai

### DIFF
--- a/.changeset/calm-ears-think.md
+++ b/.changeset/calm-ears-think.md
@@ -1,0 +1,7 @@
+---
+"@spectrum-css/actiongroup": patch
+---
+
+Action group
+
+`flex: 1` has now changed to `flex-grow: 1` in the `.spectrum-ActionGroup--justified .spectrum-ActionGroup-item` selector to specify the desired behavior of justified action groups.

--- a/.changeset/fair-badgers-repeat.md
+++ b/.changeset/fair-badgers-repeat.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/actionbutton": patch
+---
+
+Adds line-height on `.spectrum-ActionButton-label` in order to accommodate text with diacritics that may be cut off vertically.

--- a/components/actionbutton/index.css
+++ b/components/actionbutton/index.css
@@ -234,6 +234,7 @@ a.spectrum-ActionButton {
 .spectrum-ActionButton-label {
 	@extend %spectrum-ButtonLabel;
 	pointer-events: none;
+	line-height: var(--spectrum-actionbutton-height);
 
 	font-size: var(--mod-actionbutton-font-size, var(--spectrum-actionbutton-font-size));
 	white-space: nowrap;

--- a/components/actionbutton/stories/actionbutton.test.js
+++ b/components/actionbutton/stories/actionbutton.test.js
@@ -75,6 +75,10 @@ export const ActionButtonGroup = Variants({
 			testHeading: "Static white",
 			staticColor: "white",
 		},
+		{
+			testHeading: "Internationalization (Thai)",
+			label: "ล้างทั้งหมด",
+		},
 	],
 	stateData: [{
 		testHeading: "Disabled",

--- a/components/actiongroup/index.css
+++ b/components/actiongroup/index.css
@@ -154,5 +154,5 @@
 }
 
 .spectrum-ActionGroup--justified .spectrum-ActionGroup-item {
-	flex: 1;
+	flex-grow: 1;
 }


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

Recently, another bug was captured in relation to the diacritics and tone marks getting cut off in the action button when the text is Thai: https://jira.corp.adobe.com/browse/CCEX-131368. 

This PR attempts to fix that bug by adding padding to the action button's label, allowing for the diacritics to overflow into the padding space, and no longer get cut off. A similar solution was implemented recently for picker (https://github.com/adobe/spectrum-css/pull/2914) 

If we decide that adding padding is causing VRT diffs or other unexpected issues we want to avoid, we could explore using line height as well (a PR for the same picker issue mentioned above was closed in favor of the padding fix instead: https://github.com/adobe/spectrum-css/pull/2913)

The 2 commits related to adding and then removing the Thai text were meant to be temporary and serve as validation purposes. These could be removed/dropped before merging (or we could just clean up the squash commit message)

BEFORE 🚫

action button
<img width="848" alt="Screenshot 2024-10-15 at 12 15 58 PM" src="https://github.com/user-attachments/assets/9a5d14b0-cb2d-4a99-b188-81bc90fde9f7">

action group
<img width="460" alt="Screenshot 2024-10-18 at 1 41 39 PM" src="https://github.com/user-attachments/assets/62b0ce01-42da-4c1f-b9f0-d1dbc09368eb">

AFTER ✅ 

action button
<img width="838" alt="Screenshot 2024-10-15 at 12 16 46 PM" src="https://github.com/user-attachments/assets/255bad2f-df12-4a3f-acad-fcf3274f4160">

action group
<img width="475" alt="Screenshot 2024-10-18 at 1 43 31 PM" src="https://github.com/user-attachments/assets/e070f506-6f34-4921-a6a9-b43c2f475378">

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

I tested the deploy preview in AssistivLabs, for WHCM in Chrome, Edge, Firefox. 

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

- [ ] Pull down the branch to run locally or visit [the deploy preview](https://pr-3256--spectrum-css.netlify.app/preview/?path=/docs/guides-contributing--docs)
- [ ] [Visit the action button story page](https://pr-3256--spectrum-css.netlify.app/preview/?path=/story/components-action-button--default)
- [ ] Change the action button text in the controls to Thai: "ล้างทั้งหมด"
    - [ ] Alternatively, if you're viewing the branch locally, you can checkout the second commit (`git checkout 35c9809de3fd760ff8f3848f2c031a4164d849a0`) to see the Thai text
- [ ] Verify that the tone marks and diacritics are no longer getting cut off visually (especially over the fourth character)
    - [ ] When viewing [the default action button story in production](https://opensource.adobe.com/spectrum-css/preview/index.html?path=/story/components-action-button--default), changing the label text to "ล้างทั้งหมด" causes the topmost diacritic to get cut off over the fourth character.
- [ ] When viewing [the action button testing preview](https://pr-3256--spectrum-css.netlify.app/preview/?path=/story/components-action-button--default&globals=testingPreview:!true), a new Internationalization test case appears, with the Thai characters (with no clipping of tone marks)
- [ ] Visit [the action group testing preview](https://pr-3256--spectrum-css.netlify.app/preview/?path=/story/components-action-group--default&globals=testingPreview:!true)
- [ ] Verify the action buttons in the vertical-justified action group are now the same height (32px) as all other buttons (this is an expected VRT)

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [ ] ✨ This pull request is ready to merge. ✨
