### PR TITLE
fix(treeview): update Treeview margin and focus border to use Spectrum tokens

### DIFF
--- a/components/treeview/index.css
+++ b/components/treeview/index.css
@@ -13,7 +13,7 @@
 
 .spectrum-TreeView {
 	--spectrum-treeview-line-height: var(--spectrum-line-height-200);
-	--spectrum-treeview-margin-block: 1em;
+	--spectrum-treeview-margin-block: var(--spectrum-spacing-300);;
 	--spectrum-treeview-font-size: var(--spectrum-font-size-100);
 
 	--spectrum-treeview-item-min-block-size: var(--spectrum-component-height-100);
@@ -28,7 +28,7 @@
 	--spectrum-treeview-heading-color: var(--spectrum-heading-color);
 
 	--spectrum-treeview-item-border-size: var(--spectrum-border-width-200);
-	--spectrum-treeview-item-border-size-selected: 1px;
+	--spectrum-treeview-item-border-size-selected: var(--spectrum-divider-thickness-small);
 	--spectrum-treeview-item-border-radius: 0px;
 
 	--spectrum-treeview-item-border-color-selected: var(--spectrum-blue-800);

--- a/components/treeview/metadata/metadata.json
+++ b/components/treeview/metadata/metadata.json
@@ -154,6 +154,7 @@
     "--spectrum-disclosure-indicator-top-to-disclosure-icon-large",
     "--spectrum-disclosure-indicator-top-to-disclosure-icon-medium",
     "--spectrum-disclosure-indicator-top-to-disclosure-icon-small",
+    "--spectrum-divider-thickness-small",
     "--spectrum-font-size-100",
     "--spectrum-font-size-200",
     "--spectrum-font-size-300",
@@ -166,6 +167,7 @@
     "--spectrum-line-height-200",
     "--spectrum-logical-rotation",
     "--spectrum-neutral-content-color-default",
+    "--spectrum-spacing-300",
     "--spectrum-text-to-visual-75"
   ],
   "system-theme": [],


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

No specific issue for this change. While working on a Treeview implementation, I noticed two lines of the CSS where we could use Spectrum tokens.

## How and where has this been tested?

Tested locally by:
- Adding the changes to my existing Tree View implementation
- Running `spectrum-css` Storybook locally

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

Validate visual Tree View before and after, specifically for margin and focus border visual differences. They should be identical.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
