### PR TITLE
chore(field-group): update field group tests

### DIFF
--- a/components/fieldgroup/stories/fieldgroup.test.js
+++ b/components/fieldgroup/stories/fieldgroup.test.js
@@ -1,4 +1,3 @@
-import { Template as Checkbox } from "@spectrum-css/checkbox/stories/template.js";
 import { Variants } from "@spectrum-css/preview/decorators";
 import { Template } from "./template.js";
 
@@ -7,47 +6,51 @@ export const FieldGroupSet = Variants({
 	testData: [
 		{
 			testHeading: "Default",
+			inputType: "radio",
 		},
 		{
-			testHeading: "Horizontal",
+			testHeading: "Vertical checkboxes",
+			layout: "vertical",
+			inputType: "checkbox",
+			helpText: "Make a selection.",
+		},
+		{
+			testHeading: "Horizontal radios",
 			layout: "horizontal",
-			items: [
-				(passthroughs, context) => Checkbox({
-					...passthroughs,
-					id: "apple",
-					label: "Apples are best",
-					customClasses: ["spectrum-FieldGroup-item"],
-				}, context),
-				(passthroughs, context) => Checkbox({
-					...passthroughs,
-					id: "banana",
-					label: "Bananas forever",
-					customClasses: ["spectrum-FieldGroup-item"],
-				}, context),
-				(passthroughs, context) => Checkbox({
-					...passthroughs,
-					id: "cherry",
-					label: "Cherries ftw",
-					customClasses: ["spectrum-FieldGroup-item"],
-				}, context),
-			],
+			inputType: "radio",
 		},
 		{
-			testHeading: "Label position: side",
+			testHeading: "Horizontal checkboxes",
+			layout: "horizontal",
+			inputType: "checkbox",
+			helpText: "Make a selection.",
+		},
+		{
+			testHeading: "Radios label position: side",
 			label: "Pick one:",
 			labelPosition: "side",
-			helpText: "Select an option to continue.",
+			inputType: "radio",
+		},
+		{
+			testHeading: "Checkboxes label position: side",
+			label: "Choose:",
+			labelPosition: "side",
+			inputType: "checkbox",
+			helpText: "Make a selection.",
 		},
 	],
 	stateData: [
 		{
 			testHeading: "Invalid",
 			isInvalid: true,
-			helpText: "Select an option to continue.",
 		},
 		{
 			testHeading: "Read-only",
 			isReadOnly: true,
+		},
+		{
+			testHeading: "Required",
+			isRequired: true,
 		},
 	]
 });

--- a/components/fieldgroup/stories/fieldgroup.test.js
+++ b/components/fieldgroup/stories/fieldgroup.test.js
@@ -6,18 +6,14 @@ export const FieldGroupSet = Variants({
 	testData: [
 		{
 			testHeading: "Default",
-			inputType: "radio",
 		},
 		{
 			testHeading: "Vertical checkboxes",
-			layout: "vertical",
 			inputType: "checkbox",
-			helpText: "Make a selection.",
 		},
 		{
 			testHeading: "Horizontal radios",
 			layout: "horizontal",
-			inputType: "radio",
 		},
 		{
 			testHeading: "Horizontal checkboxes",
@@ -29,14 +25,25 @@ export const FieldGroupSet = Variants({
 			testHeading: "Radios label position: side",
 			label: "Pick one:",
 			labelPosition: "side",
-			inputType: "radio",
 		},
 		{
 			testHeading: "Checkboxes label position: side",
-			label: "Choose:",
 			labelPosition: "side",
 			inputType: "checkbox",
-			helpText: "Make a selection.",
+		},
+		{
+			testHeading: "Horizontal radios label position: side",
+			label: "Pick one:",
+			labelPosition: "side",
+			layout: "horizontal",
+			inputType: "radio",
+		},
+		{
+			testHeading: "Horizontal checkboxes label position: side",
+			label: "Pick one:",
+			labelPosition: "side",
+			layout: "horizontal",
+			inputType: "checkbox",
 		},
 	],
 	stateData: [
@@ -49,8 +56,12 @@ export const FieldGroupSet = Variants({
 			isReadOnly: true,
 		},
 		{
-			testHeading: "Required",
+			testHeading: "Required: asterisk",
 			isRequired: true,
+		},
+		{
+			testHeading: "Optional",
+			helpText: "",
 		},
 	]
 });


### PR DESCRIPTION
## Description

- Removes hardcoded templates from test cases
- Sets input type(s) to differentiate tests
- Adds additional cases/variations to provide parity between the two input types (checkbox/radio)

## How and where has this been tested?

Verified locally in Storybook.

### Validation steps

1. Fetch the branch and run Storybook locally or access the URL for the PR.
2. Navigate to the field group component.
3. Enable the `Show testing preview` for the component.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

4. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<img width="1748" alt="Screenshot 2024-10-16 at 8 20 50 AM" src="https://github.com/user-attachments/assets/ceb2e3b1-8340-4731-989d-648897c64f90">
<img width="1746" alt="Screenshot 2024-10-16 at 8 20 43 AM" src="https://github.com/user-attachments/assets/acbd890b-7ff5-4f59-9dc0-3c8fcbaf76b7">

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
