### PR TITLE
chore(stylelint): config updates

### DIFF
--- a/components/clearbutton/index.css
+++ b/components/clearbutton/index.css
@@ -1,15 +1,16 @@
+
 /*!
- * Copyright 2024 Adobe. All rights reserved.
- *
- * This file is licensed to you under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License. You may obtain a copy
- * of the License at <http://www.apache.org/licenses/LICENSE-2.0>
- *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
- * OF ANY KIND, either express or implied. See the License for the specific language
- * governing permissions and limitations under the License.
- */
+* Copyright 2024 Adobe. All rights reserved.
+*
+* This file is licensed to you under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License. You may obtain a copy
+* of the License at <http://www.apache.org/licenses/LICENSE-2.0>
+*
+* Unless required by applicable law or agreed to in writing, software distributed under
+* the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+* OF ANY KIND, either express or implied. See the License for the specific language
+* governing permissions and limitations under the License.
+*/
 
 @import "./themes/express.css";
 

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -23,6 +23,7 @@ module.exports = {
 		"declaration-empty-line-before": null,
 		"import-notation": null,
 		"no-descending-specificity": null,
+		"no-duplicate-selectors": null,
 
 		/** --------------------------------------------------------------
 		 * Customized rule settings


### PR DESCRIPTION
## Description

- [x] disables `no-duplicate-selectors` as we use duplicate selectors to diffentiate custom property and rule declarations

## How and where has this been tested?

Verified locally in VS Code + config.

### Validation steps

1. Fetch the branch.
2. Open a file with duplicate selectors like `components/clearbutton/index.css`. Verify that there's no longer a lint violation for the duplicate selectors.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

3. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
