### PR TITLE
chore(stylelint-assetlist): adjust declaration order to resolve lint violation

### DIFF
--- a/.changeset/wild-crabs-allow.md
+++ b/.changeset/wild-crabs-allow.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/assetlist": minor
+---
+
+Resolves a linting violation in the assetlist component by moving forced-color-adjust after token declarations.

--- a/components/assetlist/index.css
+++ b/components/assetlist/index.css
@@ -173,12 +173,13 @@
 
 @media (forced-colors: active) {
 	.spectrum-AssetList-item {
-		forced-color-adjust: none;
 		--highcontrast-assetlist-border-color-key-focus: Highlight;
 		--highcontrast-assetlist-item-background-color-hover: Highlight;
 		--highcontrast-assetlist-item-background-color-selected-hover: Highlight;
 		--highcontrast-assetlist-label-color: ButtonText;
 		--highcontrast-assetlist-item-background-color-selected: SelectedItem;
+
+		forced-color-adjust: none;
 
 		&:hover,
 		&.is-selected,


### PR DESCRIPTION
## Description

Moves `forced-color` rule after custom properties to satisfy lint rules.

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
