### PR TITLE
chore(stylelint-badge): create property for forced-colors value to satisfy lint requirements

### DIFF
--- a/.changeset/silver-pianos-develop.md
+++ b/.changeset/silver-pianos-develop.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/badge": minor
+---
+
+Assigns CanvasText to custom property to satisfy linting requirements.

--- a/components/badge/index.css
+++ b/components/badge/index.css
@@ -68,6 +68,8 @@
 	--spectrum-badge-icon-spacing-horizontal: var(--spectrum-component-edge-to-visual-100);
 	--spectrum-badge-icon-spacing-vertical-top: var(--spectrum-component-top-to-workflow-icon-100);
 	--spectrum-badge-icon-only-spacing-horizontal: var(--spectrum-component-edge-to-visual-only-100);
+
+	--highcontrast-spectrum-badge-border-color: CanvasText;
 }
 
 /* text and icon color is black for these background colors */
@@ -146,7 +148,7 @@
 /* windows high contrast mode */
 @media (forced-colors: active) {
 	.spectrum-Badge {
-		border-color: CanvasText; /* stylelint-disable-line declaration-property-value-no-unknown */
+		border-color:  var(--highcontrast-spectrum-badge-border-color);
 	}
 }
 

--- a/components/badge/index.css
+++ b/components/badge/index.css
@@ -69,7 +69,7 @@
 	--spectrum-badge-icon-spacing-vertical-top: var(--spectrum-component-top-to-workflow-icon-100);
 	--spectrum-badge-icon-only-spacing-horizontal: var(--spectrum-component-edge-to-visual-only-100);
 
-	--highcontrast-spectrum-badge-border-color: CanvasText;
+	--highcontrast-badge-border-color: CanvasText;
 }
 
 /* text and icon color is black for these background colors */

--- a/components/badge/index.css
+++ b/components/badge/index.css
@@ -148,7 +148,7 @@
 /* windows high contrast mode */
 @media (forced-colors: active) {
 	.spectrum-Badge {
-		border-color:  var(--highcontrast-spectrum-badge-border-color);
+		border-color:  var(--highcontrast-badge-border-color);
 	}
 }
 

--- a/components/badge/metadata/metadata.json
+++ b/components/badge/metadata/metadata.json
@@ -177,5 +177,5 @@
   ],
   "system-theme": [],
   "passthroughs": [],
-  "high-contrast": ["--highcontrast-spectrum-badge-border-color"]
+  "high-contrast": ["--highcontrast-badge-border-color"]
 }

--- a/components/badge/metadata/metadata.json
+++ b/components/badge/metadata/metadata.json
@@ -177,5 +177,5 @@
   ],
   "system-theme": [],
   "passthroughs": [],
-  "high-contrast": []
+  "high-contrast": ["--highcontrast-spectrum-badge-border-color"]
 }


### PR DESCRIPTION
## Description

Assigns `CanvasText` to custom property to satisfy linting requirements.

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
