### PR TITLE
chore(stylelint): remove stylelint disable comments

### DIFF
--- a/.changeset/serious-pumpkins-share.md
+++ b/.changeset/serious-pumpkins-share.md
@@ -1,0 +1,6 @@
+---
+"@spectrum-css/closebutton": patch
+"@spectrum-css/search": patch
+---
+
+Removes unnecessary stylelint-disable comments now that rule is disabled in config.

--- a/components/closebutton/index.css
+++ b/components/closebutton/index.css
@@ -117,7 +117,6 @@ a.spectrum-CloseButton {
 	@extend %spectrum-AnchorButton;
 }
 
-/* stylelint-disable-next-line no-duplicate-selectors -- Allow variable definitions to appear at the top */
 .spectrum-CloseButton {
 	@extend %spectrum-BaseButton;
 

--- a/components/search/index.css
+++ b/components/search/index.css
@@ -224,7 +224,6 @@
 }
 
 /* Quiet Variant */
-/* stylelint-disable-next-line no-duplicate-selectors */
 .spectrum-Search--quiet {
 	.spectrum-Search-clearButton .spectrum-ClearButton-icon {
 		transform: translateX(var(--mod-search-quiet-button-offset, var(--spectrum-search-quiet-button-offset)));


### PR DESCRIPTION
## Description

Removes unnecessary stylelint-disable comments now that rule is disabled in config.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
