### PR TITLE
chore(stylelint): disable stylelint violation; use comment as description

### DIFF
--- a/.changeset/purple-donkeys-hope.md
+++ b/.changeset/purple-donkeys-hope.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/colorhandle": minor
+---
+
+Disables lint violation and moves comment to stylelint-disable description.

--- a/components/colorhandle/index.css
+++ b/components/colorhandle/index.css
@@ -96,7 +96,7 @@
 	block-size: 100%;
 	box-shadow: inset 0 0 0 var(--mod-colorhandle-inner-border-width, var(--spectrum-colorhandle-inner-border-width)) var(--mod-colorhandle-inner-border-color, var(--spectrum-colorhandle-inner-border-color));
 
-	/* Undefined variable allows custom stylesheet or JS to pass the value to this element */
+	/* stylelint-disable-next-line spectrum-tools/no-unknown-custom-properties -- undefined variable allows custom stylesheet or JS to pass the value to this element */
 	background-color: var(--spectrum-picked-color);
 }
 


### PR DESCRIPTION
## Description

Disables lint violation and moves comment to stylelint-disable description.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
