### PR TITLE
chore(stylelint): disable stylelint violation; use comment as description

### DIFF
--- a/.changeset/two-mayflies-divide.md
+++ b/.changeset/two-mayflies-divide.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/colorloupe": patch
+---
+
+Disables lint violation and moves comment to stylelint-disable description.

--- a/components/colorloupe/index.css
+++ b/components/colorloupe/index.css
@@ -60,7 +60,7 @@
 }
 
 .spectrum-ColorLoupe-inner-border {
-	/* Undefined variable allows custom stylesheet or JS to pass the value to this element */
+	/* stylelint-disable-next-line spectrum-tools/no-unknown-custom-properties -- undefined variable allows custom stylesheet or JS to pass the value to this element */
 	fill: var(--spectrum-picked-color);
 	stroke: var(--mod-colorloupe-inner-border-color, var(--spectrum-colorloupe-inner-border-color));
 	stroke-width: var(--mod-colorloupe-inner-border-width, var(--spectrum-colorloupe-inner-border-width));


### PR DESCRIPTION
## Description

Disables lint violation and moves comment to stylelint-disable description.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨