### PR TITLE
chore(stylelint): move property declarations + disable violation

### DIFF
--- a/.changeset/quick-paws-lick.md
+++ b/.changeset/quick-paws-lick.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/colorwheel": patch
+---
+
+Moves custom properties to resolve declaration order lint violation. Disable unused property violation and add comment as disable statement description.

--- a/components/colorwheel/index.css
+++ b/components/colorwheel/index.css
@@ -35,6 +35,10 @@
 }
 
 .spectrum-ColorWheel {
+	/* stylelint-disable spectrum-tools/no-unused-custom-properties, custom-property-pattern -- --track-width and --border-width to be used with JS in calculating the clip-path paths and colorarea-container-size */
+	--track-width: var(--mod-colorwheel-track-width, var(--spectrum-colorwheel-track-width));
+	--border-width: var(--mod-colorwheel-border-width, var(--spectrum-colorwheel-border-width));
+
 	position: relative;
 	display: block;
 	min-inline-size: var(--mod-colorwheel-min-width, var(--spectrum-colorwheel-min-width));
@@ -46,10 +50,6 @@
 	&.is-focused {
 		z-index: 2;
 	}
-
-	/* --track-width and --border-width to be used with JS in calculating the clip-path paths and colorarea-container-size */
-	--track-width: var(--mod-colorwheel-track-width, var(--spectrum-colorwheel-track-width));
-	--border-width: var(--mod-colorwheel-border-width, var(--spectrum-colorwheel-border-width));
 
 	&.is-disabled {
 		pointer-events: none;


### PR DESCRIPTION
## Description

Moves custom properties to resolve declaration order lint violation. Disable unused property violation and add comment as disable statement description.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
