### PR TITLE
build: add lint and format to token assets

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,7 +5,6 @@
 **/node_modules
 
 # Static utility assets
-tokens/custom-*/*.css
 site/includes/*.js
 
 # Compiled and generated files

--- a/tokens/custom-express/custom-dark-vars.css
+++ b/tokens/custom-express/custom-dark-vars.css
@@ -14,13 +14,12 @@
 /* This file contains overrides and additions to core tokens */
 
 .spectrum--express.spectrum--dark {
-  /* Drop Zone background color rgb */
-  --spectrum-drop-zone-background-color-rgb: var(--spectrum-indigo-900-rgb); /* var(--spectrum-accent-color-900);*/
-  --spectrum-well-border-color: rgba(var(--spectrum-white-rgb), 0.05);
+	/* Drop Zone background color rgb */
+	--spectrum-drop-zone-background-color-rgb: var(--spectrum-indigo-900-rgb); /* var(--spectrum-accent-color-900);*/
+	--spectrum-well-border-color: rgba(var(--spectrum-white-rgb), 0.05);
 
-
-  --spectrum-assetcard-border-color-selected: var(--spectrum-indigo-700);
-  --spectrum-assetcard-border-color-selected-hover: var(--spectrum-indigo-700);
-  --spectrum-assetcard-border-color-selected-down: var(--spectrum-indigo-800);
-  --spectrum-assetcard-selectionindicator-background-color-ordered: var(--spectrum-indigo-700);
+	--spectrum-assetcard-border-color-selected: var(--spectrum-indigo-700);
+	--spectrum-assetcard-border-color-selected-hover: var(--spectrum-indigo-700);
+	--spectrum-assetcard-border-color-selected-down: var(--spectrum-indigo-800);
+	--spectrum-assetcard-selectionindicator-background-color-ordered: var(--spectrum-indigo-700);
 }

--- a/tokens/custom-express/custom-darkest-vars.css
+++ b/tokens/custom-express/custom-darkest-vars.css
@@ -14,13 +14,12 @@
 /* This file contains overrides and additions to core tokens */
 
 .spectrum--express.spectrum--darkest {
-  /* Drop Zone background color rgb */
-  --spectrum-drop-zone-background-color-rgb: var(--spectrum-indigo-900-rgb); /* var(--spectrum-accent-color-900);*/
-  --spectrum-well-border-color: rgba(var(--spectrum-white-rgb), 0.05);
+	/* Drop Zone background color rgb */
+	--spectrum-drop-zone-background-color-rgb: var(--spectrum-indigo-900-rgb); /* var(--spectrum-accent-color-900);*/
+	--spectrum-well-border-color: rgba(var(--spectrum-white-rgb), 0.05);
 
-
-  --spectrum-assetcard-border-color-selected: var(--spectrum-indigo-700);
-  --spectrum-assetcard-border-color-selected-hover: var(--spectrum-indigo-700);
-  --spectrum-assetcard-border-color-selected-down: var(--spectrum-indigo-800);
-  --spectrum-assetcard-selectionindicator-background-color-ordered: var(--spectrum-indigo-700);
+	--spectrum-assetcard-border-color-selected: var(--spectrum-indigo-700);
+	--spectrum-assetcard-border-color-selected-hover: var(--spectrum-indigo-700);
+	--spectrum-assetcard-border-color-selected-down: var(--spectrum-indigo-800);
+	--spectrum-assetcard-selectionindicator-background-color-ordered: var(--spectrum-indigo-700);
 }

--- a/tokens/custom-express/custom-large-vars.css
+++ b/tokens/custom-express/custom-large-vars.css
@@ -14,12 +14,12 @@
 /* This file contains overrides and additions to core tokens */
 
 .spectrum--express.spectrum--large {
-  --spectrum-colorwheel-path: "M 118 118 m -118 0 a 118 118 0 1 0 236 0 a 118 118 0 1 0 -236 0.2 M 118 118 m -92 0 a 92 92 0 1 0 184 0 a 92 92 0 1 0 -184 0";
-  --spectrum-colorwheel-path-borders: "M 120 120 m -120 0 a 120 120 0 1 0 240 0 a 120 120 0 1 0 -240 0.2 M 120 120 m -90 0 a 90 90 0 1 0 180 0 a 90 90 0 1 0 -180 0";
+	--spectrum-colorwheel-path: "M 118 118 m -118 0 a 118 118 0 1 0 236 0 a 118 118 0 1 0 -236 0.2 M 118 118 m -92 0 a 92 92 0 1 0 184 0 a 92 92 0 1 0 -184 0";
+	--spectrum-colorwheel-path-borders: "M 120 120 m -120 0 a 120 120 0 1 0 240 0 a 120 120 0 1 0 -240 0.2 M 120 120 m -90 0 a 90 90 0 1 0 180 0 a 90 90 0 1 0 -180 0";
 
-  --spectrum-dialog-confirm-border-radius: 8px;
+	--spectrum-dialog-confirm-border-radius: 8px;
 
-  --spectrum-dial-border-radius: 15px;
+	--spectrum-dial-border-radius: 15px;
 
-  --spectrum-assetcard-focus-ring-border-radius: 12px;
+	--spectrum-assetcard-focus-ring-border-radius: 12px;
 }

--- a/tokens/custom-express/custom-light-vars.css
+++ b/tokens/custom-express/custom-light-vars.css
@@ -15,13 +15,12 @@
 
 .spectrum--express.spectrum--light,
 .spectrum--express.spectrum--lightest {
-  /* Drop Zone background color rgb */
-  --spectrum-drop-zone-background-color-rgb: var(--spectrum-indigo-800-rgb); /* var(--spectrum-accent-color-800);*/
-  --spectrum-well-border-color: rgba(var(--spectrum-black-rgb), 0.05);
+	/* Drop Zone background color rgb */
+	--spectrum-drop-zone-background-color-rgb: var(--spectrum-indigo-800-rgb); /* var(--spectrum-accent-color-800);*/
+	--spectrum-well-border-color: rgba(var(--spectrum-black-rgb), 0.05);
 
-
-  --spectrum-assetcard-border-color-selected: var(--spectrum-indigo-900);
-  --spectrum-assetcard-border-color-selected-hover: var(--spectrum-indigo-900);
-  --spectrum-assetcard-border-color-selected-down: var(--spectrum-indigo-1000);
-  --spectrum-assetcard-selectionindicator-background-color-ordered: var(--spectrum-indigo-900);
+	--spectrum-assetcard-border-color-selected: var(--spectrum-indigo-900);
+	--spectrum-assetcard-border-color-selected-hover: var(--spectrum-indigo-900);
+	--spectrum-assetcard-border-color-selected-down: var(--spectrum-indigo-1000);
+	--spectrum-assetcard-selectionindicator-background-color-ordered: var(--spectrum-indigo-900);
 }

--- a/tokens/custom-express/custom-medium-vars.css
+++ b/tokens/custom-express/custom-medium-vars.css
@@ -14,12 +14,12 @@
 /* This file contains overrides and additions to core tokens */
 
 .spectrum--express.spectrum--medium {
-  --spectrum-colorwheel-path: "M 94 94 m -94 0 a 94 94 0 1 0 188 0 a 94 94 0 1 0 -188 0.2 M 94 94 m -74 0 a 74 74 0 1 0 148 0 a 74 74 0 1 0 -148 0";
-  --spectrum-colorwheel-path-borders: "M 96 96 m -96 0 a 96 96 0 1 0 192 0 a 96 96 0 1 0 -192 0.2 M 96 96 m -72 0 a 72 72 0 1 0 144 0 a 72 72 0 1 0 -144 0";
+	--spectrum-colorwheel-path: "M 94 94 m -94 0 a 94 94 0 1 0 188 0 a 94 94 0 1 0 -188 0.2 M 94 94 m -74 0 a 74 74 0 1 0 148 0 a 74 74 0 1 0 -148 0";
+	--spectrum-colorwheel-path-borders: "M 96 96 m -96 0 a 96 96 0 1 0 192 0 a 96 96 0 1 0 -192 0.2 M 96 96 m -72 0 a 72 72 0 1 0 144 0 a 72 72 0 1 0 -144 0";
 
-  --spectrum-dialog-confirm-border-radius: 6px;
+	--spectrum-dialog-confirm-border-radius: 6px;
 
-  --spectrum-dial-border-radius: 12px;
+	--spectrum-dial-border-radius: 12px;
 
-  --spectrum-assetcard-focus-ring-border-radius: 10px;
+	--spectrum-assetcard-focus-ring-border-radius: 10px;
 }

--- a/tokens/custom-express/custom-vars.css
+++ b/tokens/custom-express/custom-vars.css
@@ -14,5 +14,5 @@
 /* This file contains overrides and additions to core tokens */
 
 .spectrum--express {
-  --system: express;
+	--system: express;
 }

--- a/tokens/custom-spectrum/custom-dark-vars.css
+++ b/tokens/custom-spectrum/custom-dark-vars.css
@@ -14,61 +14,61 @@
 /* This file contains overrides and additions to core tokens */
 
 .spectrum--dark {
-  --spectrum-menu-item-background-color-default: rgba(255, 255, 255, 0); /* --spectrum-gray-900 */
-  --spectrum-menu-item-background-color-hover: var(--spectrum-transparent-white-200);
-  --spectrum-menu-item-background-color-down: var(--spectrum-transparent-white-200);
-  --spectrum-menu-item-background-color-key-focus: var(--spectrum-transparent-white-200);
+	--spectrum-menu-item-background-color-default: rgba(255, 255, 255, 0); /* --spectrum-gray-900 */
+	--spectrum-menu-item-background-color-hover: var(--spectrum-transparent-white-200);
+	--spectrum-menu-item-background-color-down: var(--spectrum-transparent-white-200);
+	--spectrum-menu-item-background-color-key-focus: var(--spectrum-transparent-white-200);
 
-  /* Drop Zone background color rgb */
-  --spectrum-drop-zone-background-color-rgb: var( --spectrum-blue-900-rgb); /* var(--spectrum-accent-color-900);*/
+	/* Drop Zone background color rgb */
+	--spectrum-drop-zone-background-color-rgb: var(--spectrum-blue-900-rgb); /* var(--spectrum-accent-color-900);*/
 
-  /* Drop Indicator color rgb */
-  --spectrum-dropindicator-color: var(--spectrum-blue-700);
+	/* Drop Indicator color rgb */
+	--spectrum-dropindicator-color: var(--spectrum-blue-700);
 
-  --spectrum-calendar-day-background-color-selected: rgba(var(--spectrum-blue-800-rgb), 0.15);
-  --spectrum-calendar-day-background-color-hover: rgba(var(--spectrum-white-rgb), 0.07);
-  --spectrum-calendar-day-today-background-color-selected-hover: rgba(var(--spectrum-blue-800-rgb), 0.25);
-  --spectrum-calendar-day-background-color-selected-hover: rgba(var(--spectrum-blue-800-rgb), 0.25);
-  --spectrum-calendar-day-background-color-down: var(--spectrum-transparent-white-200);
-  --spectrum-calendar-day-background-color-cap-selected: rgba(var(--spectrum-blue-800-rgb), 0.25);
-  --spectrum-calendar-day-background-color-key-focus: rgba(var(--spectrum-white-rgb), 0.07);
-  --spectrum-calendar-day-border-color-key-focus: var(--spectrum-blue-700);
+	--spectrum-calendar-day-background-color-selected: rgba(var(--spectrum-blue-800-rgb), 0.15);
+	--spectrum-calendar-day-background-color-hover: rgba(var(--spectrum-white-rgb), 0.07);
+	--spectrum-calendar-day-today-background-color-selected-hover: rgba(var(--spectrum-blue-800-rgb), 0.25);
+	--spectrum-calendar-day-background-color-selected-hover: rgba(var(--spectrum-blue-800-rgb), 0.25);
+	--spectrum-calendar-day-background-color-down: var(--spectrum-transparent-white-200);
+	--spectrum-calendar-day-background-color-cap-selected: rgba(var(--spectrum-blue-800-rgb), 0.25);
+	--spectrum-calendar-day-background-color-key-focus: rgba(var(--spectrum-white-rgb), 0.07);
+	--spectrum-calendar-day-border-color-key-focus: var(--spectrum-blue-700);
 
-  --spectrum-card-selected-background-color-rgb: var(--spectrum-blue-500-rgb);
+	--spectrum-card-selected-background-color-rgb: var(--spectrum-blue-500-rgb);
 
-  --spectrum-badge-label-icon-color-primary: var(--spectrum-black);
+	--spectrum-badge-label-icon-color-primary: var(--spectrum-black);
 
-  --spectrum-coach-indicator-ring-default-color: var(--spectrum-blue-700);
-  --spectrum-coach-indicator-ring-dark-color: var(--spectrum-gray-900);
-  --spectrum-coach-indicator-ring-light-color: var(--spectrum-gray-50);
+	--spectrum-coach-indicator-ring-default-color: var(--spectrum-blue-700);
+	--spectrum-coach-indicator-ring-dark-color: var(--spectrum-gray-900);
+	--spectrum-coach-indicator-ring-light-color: var(--spectrum-gray-50);
 
-  --spectrum-well-border-color: rgba(var(--spectrum-white-rgb), 0.05);
+	--spectrum-well-border-color: rgba(var(--spectrum-white-rgb), 0.05);
 
-  --spectrum-steplist-current-marker-color-key-focus: var(--spectrum-blue-700);
+	--spectrum-steplist-current-marker-color-key-focus: var(--spectrum-blue-700);
 
-  --spectrum-treeview-item-background-color-quiet-selected: rgba(var(--spectrum-gray-900-rgb), 0.07);
-  --spectrum-treeview-item-background-color-selected: rgba(var(--spectrum-blue-800-rgb), 0.15);
+	--spectrum-treeview-item-background-color-quiet-selected: rgba(var(--spectrum-gray-900-rgb), 0.07);
+	--spectrum-treeview-item-background-color-selected: rgba(var(--spectrum-blue-800-rgb), 0.15);
 
-  --spectrum-logic-button-and-background-color: var(--spectrum-blue-800);
-  --spectrum-logic-button-and-border-color: var(--spectrum-blue-800);
-  --spectrum-logic-button-and-background-color-hover: var(--spectrum-blue-1000);
-  --spectrum-logic-button-and-border-color-hover: var(--spectrum-blue-1000);
+	--spectrum-logic-button-and-background-color: var(--spectrum-blue-800);
+	--spectrum-logic-button-and-border-color: var(--spectrum-blue-800);
+	--spectrum-logic-button-and-background-color-hover: var(--spectrum-blue-1000);
+	--spectrum-logic-button-and-border-color-hover: var(--spectrum-blue-1000);
 
-  --spectrum-logic-button-or-background-color: var(--spectrum-magenta-700);
-  --spectrum-logic-button-or-border-color: var(--spectrum-magenta-700);
-  --spectrum-logic-button-or-background-color-hover: var(--spectrum-magenta-900);
-  --spectrum-logic-button-or-border-color-hover: var(--spectrum-magenta-900);
+	--spectrum-logic-button-or-background-color: var(--spectrum-magenta-700);
+	--spectrum-logic-button-or-border-color: var(--spectrum-magenta-700);
+	--spectrum-logic-button-or-background-color-hover: var(--spectrum-magenta-900);
+	--spectrum-logic-button-or-border-color-hover: var(--spectrum-magenta-900);
 
-  --spectrum-assetcard-border-color-selected: var(--spectrum-blue-800);
-  --spectrum-assetcard-border-color-selected-hover: var(--spectrum-blue-800);
-  --spectrum-assetcard-border-color-selected-down: var(--spectrum-blue-900);
-  --spectrum-assetcard-selectionindicator-background-color-ordered: var(--spectrum-blue-800);
-  --spectrum-assestcard-focus-indicator-color: var(--spectrum-blue-700);
+	--spectrum-assetcard-border-color-selected: var(--spectrum-blue-800);
+	--spectrum-assetcard-border-color-selected-hover: var(--spectrum-blue-800);
+	--spectrum-assetcard-border-color-selected-down: var(--spectrum-blue-900);
+	--spectrum-assetcard-selectionindicator-background-color-ordered: var(--spectrum-blue-800);
+	--spectrum-assestcard-focus-indicator-color: var(--spectrum-blue-700);
 
-  --spectrum-assetlist-item-background-color-selected-hover: rgba(var(--spectrum-blue-800-rgb), 0.25);
-  --spectrum-assetlist-item-background-color-selected: rgba(var(--spectrum-blue-800-rgb), 0.15);
-  --spectrum-assetlist-border-color-key-focus: var(--spectrum-blue-700);
+	--spectrum-assetlist-item-background-color-selected-hover: rgba(var(--spectrum-blue-800-rgb), 0.25);
+	--spectrum-assetlist-item-background-color-selected: rgba(var(--spectrum-blue-800-rgb), 0.15);
+	--spectrum-assetlist-border-color-key-focus: var(--spectrum-blue-700);
 
-  --spectrum-swatch-border-color: rgba(255, 255, 255, 51%);
-  --spectrum-swatch-border-color-light: rgba(255, 255, 255, 20%);
+	--spectrum-swatch-border-color: rgba(255, 255, 255, 51%);
+	--spectrum-swatch-border-color-light: rgba(255, 255, 255, 20%);
 }

--- a/tokens/custom-spectrum/custom-darkest-vars.css
+++ b/tokens/custom-spectrum/custom-darkest-vars.css
@@ -14,61 +14,61 @@
 /* This file contains overrides and additions to core tokens */
 
 .spectrum--darkest {
-  --spectrum-menu-item-background-color-default: rgba(255, 255, 255, 0); /* --spectrum-gray-900 */
-  --spectrum-menu-item-background-color-hover: var(--spectrum-transparent-white-200);
-  --spectrum-menu-item-background-color-down: var(--spectrum-transparent-white-200);
-  --spectrum-menu-item-background-color-key-focus: var(--spectrum-transparent-white-200);
+	--spectrum-menu-item-background-color-default: rgba(255, 255, 255, 0); /* --spectrum-gray-900 */
+	--spectrum-menu-item-background-color-hover: var(--spectrum-transparent-white-200);
+	--spectrum-menu-item-background-color-down: var(--spectrum-transparent-white-200);
+	--spectrum-menu-item-background-color-key-focus: var(--spectrum-transparent-white-200);
 
-  /* Drop Zone background color rgb */
-  --spectrum-drop-zone-background-color-rgb: var( --spectrum-blue-900-rgb); /* var(--spectrum-accent-color-900);*/
+	/* Drop Zone background color rgb */
+	--spectrum-drop-zone-background-color-rgb: var(--spectrum-blue-900-rgb); /* var(--spectrum-accent-color-900);*/
 
-  /* Drop Indicator color rgb */
-  --spectrum-dropindicator-color: var(--spectrum-blue-700);
+	/* Drop Indicator color rgb */
+	--spectrum-dropindicator-color: var(--spectrum-blue-700);
 
-  --spectrum-calendar-day-background-color-selected: rgba(var(--spectrum-blue-800-rgb), 0.2);
-  --spectrum-calendar-day-background-color-hover: rgba(var(--spectrum-white-rgb), 0.08);
-  --spectrum-calendar-day-today-background-color-selected-hover: rgba(var(--spectrum-blue-800-rgb), 0.3);
-  --spectrum-calendar-day-background-color-selected-hover: rgba(var(--spectrum-blue-800-rgb), 0.3);
-  --spectrum-calendar-day-background-color-down: rgba(var(--spectrum-white-rgb), 0.15);
-  --spectrum-calendar-day-background-color-cap-selected: rgba(var(--spectrum-blue-800-rgb), 0.3);
-  --spectrum-calendar-day-background-color-key-focus: rgba(var(--spectrum-white-rgb), 0.08);
-  --spectrum-calendar-day-border-color-key-focus: var(--spectrum-blue-700);
+	--spectrum-calendar-day-background-color-selected: rgba(var(--spectrum-blue-800-rgb), 0.2);
+	--spectrum-calendar-day-background-color-hover: rgba(var(--spectrum-white-rgb), 0.08);
+	--spectrum-calendar-day-today-background-color-selected-hover: rgba(var(--spectrum-blue-800-rgb), 0.3);
+	--spectrum-calendar-day-background-color-selected-hover: rgba(var(--spectrum-blue-800-rgb), 0.3);
+	--spectrum-calendar-day-background-color-down: rgba(var(--spectrum-white-rgb), 0.15);
+	--spectrum-calendar-day-background-color-cap-selected: rgba(var(--spectrum-blue-800-rgb), 0.3);
+	--spectrum-calendar-day-background-color-key-focus: rgba(var(--spectrum-white-rgb), 0.08);
+	--spectrum-calendar-day-border-color-key-focus: var(--spectrum-blue-700);
 
-  --spectrum-card-selected-background-color-rgb: var(--spectrum-blue-600-rgb);
+	--spectrum-card-selected-background-color-rgb: var(--spectrum-blue-600-rgb);
 
-  --spectrum-badge-label-icon-color-primary: var(--spectrum-black);
+	--spectrum-badge-label-icon-color-primary: var(--spectrum-black);
 
-  --spectrum-coach-indicator-ring-default-color: var(--spectrum-blue-700);
-  --spectrum-coach-indicator-ring-dark-color: var(--spectrum-gray-900);
-  --spectrum-coach-indicator-ring-light-color: var(--spectrum-gray-50);
+	--spectrum-coach-indicator-ring-default-color: var(--spectrum-blue-700);
+	--spectrum-coach-indicator-ring-dark-color: var(--spectrum-gray-900);
+	--spectrum-coach-indicator-ring-light-color: var(--spectrum-gray-50);
 
-  --spectrum-well-border-color: rgba(var(--spectrum-white-rgb), 0.05);
+	--spectrum-well-border-color: rgba(var(--spectrum-white-rgb), 0.05);
 
-  --spectrum-steplist-current-marker-color-key-focus: var(--spectrum-blue-700);
+	--spectrum-steplist-current-marker-color-key-focus: var(--spectrum-blue-700);
 
-  --spectrum-treeview-item-background-color-quiet-selected: rgba(var(--spectrum-gray-900-rgb), 0.08);
-  --spectrum-treeview-item-background-color-selected: rgba(var(--spectrum-blue-800-rgb), 0.2);
+	--spectrum-treeview-item-background-color-quiet-selected: rgba(var(--spectrum-gray-900-rgb), 0.08);
+	--spectrum-treeview-item-background-color-selected: rgba(var(--spectrum-blue-800-rgb), 0.2);
 
-  --spectrum-logic-button-and-background-color: var(--spectrum-blue-800);
-  --spectrum-logic-button-and-border-color: var(--spectrum-blue-800);
-  --spectrum-logic-button-and-background-color-hover: var(--spectrum-blue-1000);
-  --spectrum-logic-button-and-border-color-hover: var(--spectrum-blue-1000);
+	--spectrum-logic-button-and-background-color: var(--spectrum-blue-800);
+	--spectrum-logic-button-and-border-color: var(--spectrum-blue-800);
+	--spectrum-logic-button-and-background-color-hover: var(--spectrum-blue-1000);
+	--spectrum-logic-button-and-border-color-hover: var(--spectrum-blue-1000);
 
-  --spectrum-logic-button-or-background-color: var(--spectrum-magenta-700);
-  --spectrum-logic-button-or-border-color: var(--spectrum-magenta-700);
-  --spectrum-logic-button-or-background-color-hover: var(--spectrum-magenta-900);
-  --spectrum-logic-button-or-border-color-hover: var(--spectrum-magenta-900);
+	--spectrum-logic-button-or-background-color: var(--spectrum-magenta-700);
+	--spectrum-logic-button-or-border-color: var(--spectrum-magenta-700);
+	--spectrum-logic-button-or-background-color-hover: var(--spectrum-magenta-900);
+	--spectrum-logic-button-or-border-color-hover: var(--spectrum-magenta-900);
 
-  --spectrum-assetcard-border-color-selected: var(--spectrum-blue-800);
-  --spectrum-assetcard-border-color-selected-hover: var(--spectrum-blue-800);
-  --spectrum-assetcard-border-color-selected-down: var(--spectrum-blue-900);
-  --spectrum-assetcard-selectionindicator-background-color-ordered: var(--spectrum-blue-800);
-  --spectrum-assestcard-focus-indicator-color: var(--spectrum-blue-700);
+	--spectrum-assetcard-border-color-selected: var(--spectrum-blue-800);
+	--spectrum-assetcard-border-color-selected-hover: var(--spectrum-blue-800);
+	--spectrum-assetcard-border-color-selected-down: var(--spectrum-blue-900);
+	--spectrum-assetcard-selectionindicator-background-color-ordered: var(--spectrum-blue-800);
+	--spectrum-assestcard-focus-indicator-color: var(--spectrum-blue-700);
 
-  --spectrum-assetlist-item-background-color-selected-hover: rgba(var(--spectrum-blue-800-rgb), 0.3);
-  --spectrum-assetlist-item-background-color-selected: rgba(var(--spectrum-blue-800-rgb), 0.2);
-  --spectrum-assetlist-border-color-key-focus: var(--spectrum-blue-700);
+	--spectrum-assetlist-item-background-color-selected-hover: rgba(var(--spectrum-blue-800-rgb), 0.3);
+	--spectrum-assetlist-item-background-color-selected: rgba(var(--spectrum-blue-800-rgb), 0.2);
+	--spectrum-assetlist-border-color-key-focus: var(--spectrum-blue-700);
 
-  --spectrum-swatch-border-color: rgba(255, 255, 255, 51%);
-  --spectrum-swatch-border-color-light: rgba(255, 255, 255, 20%);
+	--spectrum-swatch-border-color: rgba(255, 255, 255, 51%);
+	--spectrum-swatch-border-color-light: rgba(255, 255, 255, 20%);
 }

--- a/tokens/custom-spectrum/custom-large-vars.css
+++ b/tokens/custom-spectrum/custom-large-vars.css
@@ -14,112 +14,112 @@
 /* This file contains overrides and additions to core tokens */
 
 .spectrum--large {
-  --spectrum-slider-tick-mark-height: 13px;
-  --spectrum-slider-ramp-track-height: 20px;
+	--spectrum-slider-tick-mark-height: 13px;
+	--spectrum-slider-ramp-track-height: 20px;
 
-  --spectrum-colorwheel-path: "M 119 119 m -119 0 a 119 119 0 1 0 238 0 a 119 119 0 1 0 -238 0.2 M 119 119 m -91 0 a 91 91 0 1 0 182 0 a 91 91 0 1 0 -182 0";
-  --spectrum-colorwheel-path-borders: "M 120 120 m -120 0 a 120 120 0 1 0 240 0 a 120 120 0 1 0 -240 0.2 M 120 120 m -90 0 a 90 90 0 1 0 180 0 a 90 90 0 1 0 -180 0";
-  --spectrum-colorwheel-colorarea-container-size: 182px;
+	--spectrum-colorwheel-path: "M 119 119 m -119 0 a 119 119 0 1 0 238 0 a 119 119 0 1 0 -238 0.2 M 119 119 m -91 0 a 91 91 0 1 0 182 0 a 91 91 0 1 0 -182 0";
+	--spectrum-colorwheel-path-borders: "M 120 120 m -120 0 a 120 120 0 1 0 240 0 a 120 120 0 1 0 -240 0.2 M 120 120 m -90 0 a 90 90 0 1 0 180 0 a 90 90 0 1 0 -180 0";
+	--spectrum-colorwheel-colorarea-container-size: 182px;
 
-  --spectrum-colorloupe-checkerboard-fill: url(#checkerboard-secondary);
+	--spectrum-colorloupe-checkerboard-fill: url(#checkerboard-secondary);
 
-  --spectrum-contextual-help-content-spacing: var(--spectrum-spacing-200);
+	--spectrum-contextual-help-content-spacing: var(--spectrum-spacing-200);
 
-  --spectrum-menu-item-selectable-edge-to-text-not-selected-small: 34px;
-  --spectrum-menu-item-selectable-edge-to-text-not-selected-medium: 42px;
-  --spectrum-menu-item-selectable-edge-to-text-not-selected-large: 47px;
-  --spectrum-menu-item-selectable-edge-to-text-not-selected-extra-large: 54px;
+	--spectrum-menu-item-selectable-edge-to-text-not-selected-small: 34px;
+	--spectrum-menu-item-selectable-edge-to-text-not-selected-medium: 42px;
+	--spectrum-menu-item-selectable-edge-to-text-not-selected-large: 47px;
+	--spectrum-menu-item-selectable-edge-to-text-not-selected-extra-large: 54px;
 
-  --spectrum-menu-item-checkmark-height-small: 12px;
-  --spectrum-menu-item-checkmark-height-medium: 14px;
-  --spectrum-menu-item-checkmark-height-large: 16px;
-  --spectrum-menu-item-checkmark-height-extra-large: 16px;
+	--spectrum-menu-item-checkmark-height-small: 12px;
+	--spectrum-menu-item-checkmark-height-medium: 14px;
+	--spectrum-menu-item-checkmark-height-large: 16px;
+	--spectrum-menu-item-checkmark-height-extra-large: 16px;
 
-  --spectrum-menu-item-checkmark-width-small: 12px;
-  --spectrum-menu-item-checkmark-width-medium: 14px;
-  --spectrum-menu-item-checkmark-width-large: 16px;
-  --spectrum-menu-item-checkmark-width-extra-large: 16px;
+	--spectrum-menu-item-checkmark-width-small: 12px;
+	--spectrum-menu-item-checkmark-width-medium: 14px;
+	--spectrum-menu-item-checkmark-width-large: 16px;
+	--spectrum-menu-item-checkmark-width-extra-large: 16px;
 
-  --spectrum-rating-icon-spacing: var(--spectrum-spacing-100);
+	--spectrum-rating-icon-spacing: var(--spectrum-spacing-100);
 
-  --spectrum-button-top-to-text-small: 6px;
-  --spectrum-button-bottom-to-text-small: 5px;
-  --spectrum-button-top-to-text-medium: 9px;
-  --spectrum-button-bottom-to-text-medium: 10px;
-  --spectrum-button-top-to-text-large: 12px;
-  --spectrum-button-bottom-to-text-large: 13px;
-  --spectrum-button-top-to-text-extra-large: 16px;
-  --spectrum-button-bottom-to-text-extra-large: 17px;
+	--spectrum-button-top-to-text-small: 6px;
+	--spectrum-button-bottom-to-text-small: 5px;
+	--spectrum-button-top-to-text-medium: 9px;
+	--spectrum-button-bottom-to-text-medium: 10px;
+	--spectrum-button-top-to-text-large: 12px;
+	--spectrum-button-bottom-to-text-large: 13px;
+	--spectrum-button-top-to-text-extra-large: 16px;
+	--spectrum-button-bottom-to-text-extra-large: 17px;
 
-  --spectrum-alert-banner-close-button-spacing: var(--spectrum-spacing-200);
-  --spectrum-alert-banner-edge-to-divider: var(--spectrum-spacing-200);
-  --spectrum-alert-banner-edge-to-button: var(--spectrum-spacing-200);
-  --spectrum-alert-banner-text-to-button-vertical: var(--spectrum-spacing-200);
+	--spectrum-alert-banner-close-button-spacing: var(--spectrum-spacing-200);
+	--spectrum-alert-banner-edge-to-divider: var(--spectrum-spacing-200);
+	--spectrum-alert-banner-edge-to-button: var(--spectrum-spacing-200);
+	--spectrum-alert-banner-text-to-button-vertical: var(--spectrum-spacing-200);
 
-  --spectrum-alert-dialog-padding: var(--spectrum-spacing-400);
-  --spectrum-alert-dialog-description-to-buttons: var(--spectrum-spacing-600);
+	--spectrum-alert-dialog-padding: var(--spectrum-spacing-400);
+	--spectrum-alert-dialog-description-to-buttons: var(--spectrum-spacing-600);
 
-  --spectrum-coach-indicator-gap: 8px;
-  --spectrum-coach-indicator-ring-diameter: 20px;
-  --spectrum-coach-indicator-quiet-ring-diameter: 10px;
+	--spectrum-coach-indicator-gap: 8px;
+	--spectrum-coach-indicator-ring-diameter: 20px;
+	--spectrum-coach-indicator-quiet-ring-diameter: 10px;
 
-  --spectrum-coachmark-buttongroup-display: none;
-  --spectrum-coachmark-buttongroup-mobile-display: flex;
-  --spectrum-coachmark-menu-display: none;
-  --spectrum-coachmark-menu-mobile-display: inline-flex;
+	--spectrum-coachmark-buttongroup-display: none;
+	--spectrum-coachmark-buttongroup-mobile-display: flex;
+	--spectrum-coachmark-menu-display: none;
+	--spectrum-coachmark-menu-mobile-display: inline-flex;
 
-  --spectrum-well-padding: 20px;
-  --spectrum-well-margin-top: 5px;
-  --spectrum-well-min-width: 300px;
-  --spectrum-well-border-radius: 5px;
+	--spectrum-well-padding: 20px;
+	--spectrum-well-margin-top: 5px;
+	--spectrum-well-min-width: 300px;
+	--spectrum-well-border-radius: 5px;
 
-  /* XXL and XXS icon sizes are not within the design spec and are planned to be deprecated in Spectrum 2. */
-  --spectrum-workflow-icon-size-xxl: 40px;
-  --spectrum-workflow-icon-size-xxs: 15px;
+	/* XXL and XXS icon sizes are not within the design spec and are planned to be deprecated in Spectrum 2. */
+	--spectrum-workflow-icon-size-xxl: 40px;
+	--spectrum-workflow-icon-size-xxs: 15px;
 
-  --spectrum-treeview-item-indentation-medium: 20px;
-  --spectrum-treeview-item-indentation-small: 15px;
-  --spectrum-treeview-item-indentation-large: 25px;
-  --spectrum-treeview-item-indentation-extra-large: 30px;
-  --spectrum-treeview-indicator-inset-block-start: 6px;
-  --spectrum-treeview-item-min-block-size-thumbnail-offset-medium: 2px;
+	--spectrum-treeview-item-indentation-medium: 20px;
+	--spectrum-treeview-item-indentation-small: 15px;
+	--spectrum-treeview-item-indentation-large: 25px;
+	--spectrum-treeview-item-indentation-extra-large: 30px;
+	--spectrum-treeview-indicator-inset-block-start: 6px;
+	--spectrum-treeview-item-min-block-size-thumbnail-offset-medium: 2px;
 
-  --spectrum-dialog-confirm-entry-animation-distance: 25px;
-  --spectrum-dialog-confirm-hero-height: 160px;
-  --spectrum-dialog-confirm-border-radius: 5px;
-  --spectrum-dialog-confirm-title-text-size: 19px;
-  --spectrum-dialog-confirm-description-text-size: 15px;
-  --spectrum-dialog-confirm-padding-grid: 24px;
+	--spectrum-dialog-confirm-entry-animation-distance: 25px;
+	--spectrum-dialog-confirm-hero-height: 160px;
+	--spectrum-dialog-confirm-border-radius: 5px;
+	--spectrum-dialog-confirm-title-text-size: 19px;
+	--spectrum-dialog-confirm-description-text-size: 15px;
+	--spectrum-dialog-confirm-padding-grid: 24px;
 
-  --spectrum-datepicker-initial-width: 160px;
-  --spectrum-datepicker-generic-padding: 15px;
-  --spectrum-datepicker-dash-line-height: 30px;
-  --spectrum-datepicker-width-quiet-first: 90px;
-  --spectrum-datepicker-width-quiet-second: 20px;
-  --spectrum-datepicker-datetime-width-first: 45px;
-  --spectrum-datepicker-invalid-icon-to-button: 10px;
-  --spectrum-datepicker-invalid-icon-to-button-quiet: 9px;
-  --spectrum-datepicker-input-datetime-width: 30px;
+	--spectrum-datepicker-initial-width: 160px;
+	--spectrum-datepicker-generic-padding: 15px;
+	--spectrum-datepicker-dash-line-height: 30px;
+	--spectrum-datepicker-width-quiet-first: 90px;
+	--spectrum-datepicker-width-quiet-second: 20px;
+	--spectrum-datepicker-datetime-width-first: 45px;
+	--spectrum-datepicker-invalid-icon-to-button: 10px;
+	--spectrum-datepicker-invalid-icon-to-button-quiet: 9px;
+	--spectrum-datepicker-input-datetime-width: 30px;
 
-  --spectrum-pagination-textfield-width: 60px;
-  --spectrum-pagination-item-inline-spacing: 6px;
+	--spectrum-pagination-textfield-width: 60px;
+	--spectrum-pagination-item-inline-spacing: 6px;
 
-  --spectrum-dial-border-radius: 20px;
-  --spectrum-dial-handle-position: 10px;
-  --spectrum-dial-handle-block-margin: 20px;
-  --spectrum-dial-handle-inline-margin: 20px;
-  --spectrum-dial-controls-margin: 10px;
-  --spectrum-dial-label-gap-y: 6px;
-  --spectrum-dial-label-container-top-to-text: 5px;
+	--spectrum-dial-border-radius: 20px;
+	--spectrum-dial-handle-position: 10px;
+	--spectrum-dial-handle-block-margin: 20px;
+	--spectrum-dial-handle-inline-margin: 20px;
+	--spectrum-dial-controls-margin: 10px;
+	--spectrum-dial-label-gap-y: 6px;
+	--spectrum-dial-label-container-top-to-text: 5px;
 
-  --spectrum-assetcard-focus-ring-border-radius: 9px;
-  --spectrum-assetcard-selectionindicator-margin: 15px;
-  --spectrum-assetcard-title-font-size: var(--spectrum-heading-size-xxs);
-  --spectrum-assetcard-header-content-font-size: var(--spectrum-heading-size-xxs);
-  --spectrum-assetcard-content-font-size: var(--spectrum-body-size-xs);
+	--spectrum-assetcard-focus-ring-border-radius: 9px;
+	--spectrum-assetcard-selectionindicator-margin: 15px;
+	--spectrum-assetcard-title-font-size: var(--spectrum-heading-size-xxs);
+	--spectrum-assetcard-header-content-font-size: var(--spectrum-heading-size-xxs);
+	--spectrum-assetcard-content-font-size: var(--spectrum-body-size-xs);
 
-  --spectrum-tooltip-animation-distance: 5px;
+	--spectrum-tooltip-animation-distance: 5px;
 
-  --spectrum-ui-icon-medium-display: none;
-  --spectrum-ui-icon-large-display: block;
+	--spectrum-ui-icon-medium-display: none;
+	--spectrum-ui-icon-large-display: block;
 }

--- a/tokens/custom-spectrum/custom-light-vars.css
+++ b/tokens/custom-spectrum/custom-light-vars.css
@@ -15,61 +15,61 @@
 
 .spectrum--light,
 .spectrum--lightest {
-  --spectrum-menu-item-background-color-default: rgba(0, 0, 0, 0); /* --spectrum-gray-900 */
-  --spectrum-menu-item-background-color-hover: var(--spectrum-transparent-black-200);
-  --spectrum-menu-item-background-color-down: var(--spectrum-transparent-black-200);
-  --spectrum-menu-item-background-color-key-focus: var(--spectrum-transparent-black-200);
+	--spectrum-menu-item-background-color-default: rgba(0, 0, 0, 0); /* --spectrum-gray-900 */
+	--spectrum-menu-item-background-color-hover: var(--spectrum-transparent-black-200);
+	--spectrum-menu-item-background-color-down: var(--spectrum-transparent-black-200);
+	--spectrum-menu-item-background-color-key-focus: var(--spectrum-transparent-black-200);
 
-  /* Drop Zone background color rgb */
-  --spectrum-drop-zone-background-color-rgb: var(--spectrum-blue-800-rgb); /* var(--spectrum-accent-color-800);*/
+	/* Drop Zone background color rgb */
+	--spectrum-drop-zone-background-color-rgb: var(--spectrum-blue-800-rgb); /* var(--spectrum-accent-color-800);*/
 
-  /* Drop Indicator color rgb */
-  --spectrum-dropindicator-color: var(--spectrum-blue-800);
+	/* Drop Indicator color rgb */
+	--spectrum-dropindicator-color: var(--spectrum-blue-800);
 
-  --spectrum-calendar-day-background-color-selected: rgba(var(--spectrum-blue-900-rgb), 0.1);
-  --spectrum-calendar-day-background-color-hover: rgba(var(--spectrum-black-rgb), 0.06);
-  --spectrum-calendar-day-today-background-color-selected-hover: rgba(var(--spectrum-blue-900-rgb), 0.2);
-  --spectrum-calendar-day-background-color-selected-hover: rgba(var(--spectrum-blue-900-rgb), 0.2);
-  --spectrum-calendar-day-background-color-down: var(--spectrum-transparent-black-200);
-  --spectrum-calendar-day-background-color-cap-selected: rgba(var(--spectrum-blue-900-rgb), 0.2);
-  --spectrum-calendar-day-background-color-key-focus: rgba(var(--spectrum-black-rgb), 0.06);
-  --spectrum-calendar-day-border-color-key-focus: var(--spectrum-blue-800);
+	--spectrum-calendar-day-background-color-selected: rgba(var(--spectrum-blue-900-rgb), 0.1);
+	--spectrum-calendar-day-background-color-hover: rgba(var(--spectrum-black-rgb), 0.06);
+	--spectrum-calendar-day-today-background-color-selected-hover: rgba(var(--spectrum-blue-900-rgb), 0.2);
+	--spectrum-calendar-day-background-color-selected-hover: rgba(var(--spectrum-blue-900-rgb), 0.2);
+	--spectrum-calendar-day-background-color-down: var(--spectrum-transparent-black-200);
+	--spectrum-calendar-day-background-color-cap-selected: rgba(var(--spectrum-blue-900-rgb), 0.2);
+	--spectrum-calendar-day-background-color-key-focus: rgba(var(--spectrum-black-rgb), 0.06);
+	--spectrum-calendar-day-border-color-key-focus: var(--spectrum-blue-800);
 
-  --spectrum-card-selected-background-color-rgb: var(--spectrum-blue-900-rgb);
+	--spectrum-card-selected-background-color-rgb: var(--spectrum-blue-900-rgb);
 
-  --spectrum-badge-label-icon-color-primary: var(--spectrum-white);
+	--spectrum-badge-label-icon-color-primary: var(--spectrum-white);
 
-  --spectrum-coach-indicator-ring-default-color: var(--spectrum-blue-800);
-  --spectrum-coach-indicator-ring-dark-color: var(--spectrum-gray-900);
-  --spectrum-coach-indicator-ring-light-color: var(--spectrum-gray-50);
+	--spectrum-coach-indicator-ring-default-color: var(--spectrum-blue-800);
+	--spectrum-coach-indicator-ring-dark-color: var(--spectrum-gray-900);
+	--spectrum-coach-indicator-ring-light-color: var(--spectrum-gray-50);
 
-  --spectrum-well-border-color: var(--spectrum-black);
+	--spectrum-well-border-color: var(--spectrum-black);
 
-  --spectrum-steplist-current-marker-color-key-focus: var(--spectrum-blue-800);
+	--spectrum-steplist-current-marker-color-key-focus: var(--spectrum-blue-800);
 
-  --spectrum-treeview-item-background-color-quiet-selected: rgba(var(--spectrum-gray-900-rgb), 0.06);
-  --spectrum-treeview-item-background-color-selected: rgba(var(--spectrum-blue-900-rgb), 0.1);
+	--spectrum-treeview-item-background-color-quiet-selected: rgba(var(--spectrum-gray-900-rgb), 0.06);
+	--spectrum-treeview-item-background-color-selected: rgba(var(--spectrum-blue-900-rgb), 0.1);
 
-  --spectrum-logic-button-and-background-color: var(--spectrum-blue-900);
-  --spectrum-logic-button-and-border-color: var(--spectrum-blue-900);
-  --spectrum-logic-button-and-background-color-hover: var(--spectrum-blue-1100);
-  --spectrum-logic-button-and-border-color-hover: var(--spectrum-blue-1100);
+	--spectrum-logic-button-and-background-color: var(--spectrum-blue-900);
+	--spectrum-logic-button-and-border-color: var(--spectrum-blue-900);
+	--spectrum-logic-button-and-background-color-hover: var(--spectrum-blue-1100);
+	--spectrum-logic-button-and-border-color-hover: var(--spectrum-blue-1100);
 
-  --spectrum-logic-button-or-background-color: var(--spectrum-magenta-900);
-  --spectrum-logic-button-or-border-color: var(--spectrum-magenta-900);
-  --spectrum-logic-button-or-background-color-hover: var(--spectrum-magenta-1100);
-  --spectrum-logic-button-or-border-color-hover: var(--spectrum-magenta-1100);
+	--spectrum-logic-button-or-background-color: var(--spectrum-magenta-900);
+	--spectrum-logic-button-or-border-color: var(--spectrum-magenta-900);
+	--spectrum-logic-button-or-background-color-hover: var(--spectrum-magenta-1100);
+	--spectrum-logic-button-or-border-color-hover: var(--spectrum-magenta-1100);
 
-  --spectrum-assetcard-border-color-selected: var(--spectrum-blue-900);
-  --spectrum-assetcard-border-color-selected-hover: var(--spectrum-blue-900);
-  --spectrum-assetcard-border-color-selected-down: var(--spectrum-blue-1000);
-  --spectrum-assetcard-selectionindicator-background-color-ordered: var(--spectrum-blue-900);
-  --spectrum-assestcard-focus-indicator-color: var(--spectrum-blue-800);
+	--spectrum-assetcard-border-color-selected: var(--spectrum-blue-900);
+	--spectrum-assetcard-border-color-selected-hover: var(--spectrum-blue-900);
+	--spectrum-assetcard-border-color-selected-down: var(--spectrum-blue-1000);
+	--spectrum-assetcard-selectionindicator-background-color-ordered: var(--spectrum-blue-900);
+	--spectrum-assestcard-focus-indicator-color: var(--spectrum-blue-800);
 
-  --spectrum-assetlist-item-background-color-selected-hover: rgba(var(--spectrum-blue-900-rgb),0.2);
-  --spectrum-assetlist-item-background-color-selected: rgba(var(--spectrum-blue-900-rgb),0.1);
-  --spectrum-assetlist-border-color-key-focus: var(--spectrum-blue-800);
+	--spectrum-assetlist-item-background-color-selected-hover: rgba(var(--spectrum-blue-900-rgb), 0.2);
+	--spectrum-assetlist-item-background-color-selected: rgba(var(--spectrum-blue-900-rgb), 0.1);
+	--spectrum-assetlist-border-color-key-focus: var(--spectrum-blue-800);
 
-  --spectrum-swatch-border-color: rgba(0, 0, 0, 51%);
-  --spectrum-swatch-border-color-light: rgba(0, 0, 0, 20%);
+	--spectrum-swatch-border-color: rgba(0, 0, 0, 51%);
+	--spectrum-swatch-border-color-light: rgba(0, 0, 0, 20%);
 }

--- a/tokens/custom-spectrum/custom-medium-vars.css
+++ b/tokens/custom-spectrum/custom-medium-vars.css
@@ -14,111 +14,111 @@
 /* This file contains overrides and additions to core tokens */
 
 .spectrum--medium {
-  --spectrum-slider-tick-mark-height: 10px;
-  --spectrum-slider-ramp-track-height: 16px;
+	--spectrum-slider-tick-mark-height: 10px;
+	--spectrum-slider-ramp-track-height: 16px;
 
-  --spectrum-colorwheel-path: "M 95 95 m -95 0 a 95 95 0 1 0 190 0 a 95 95 0 1 0 -190 0.2 M 95 95 m -73 0 a 73 73 0 1 0 146 0 a 73 73 0 1 0 -146 0";
-  --spectrum-colorwheel-path-borders: "M 96 96 m -96 0 a 96 96 0 1 0 192 0 a 96 96 0 1 0 -192 0.2 M 96 96 m -72 0 a 72 72 0 1 0 144 0 a 72 72 0 1 0 -144 0";
-  --spectrum-colorwheel-colorarea-container-size: 144px;
+	--spectrum-colorwheel-path: "M 95 95 m -95 0 a 95 95 0 1 0 190 0 a 95 95 0 1 0 -190 0.2 M 95 95 m -73 0 a 73 73 0 1 0 146 0 a 73 73 0 1 0 -146 0";
+	--spectrum-colorwheel-path-borders: "M 96 96 m -96 0 a 96 96 0 1 0 192 0 a 96 96 0 1 0 -192 0.2 M 96 96 m -72 0 a 72 72 0 1 0 144 0 a 72 72 0 1 0 -144 0";
+	--spectrum-colorwheel-colorarea-container-size: 144px;
 
-  --spectrum-colorloupe-checkerboard-fill: url(#checkerboard-primary);
+	--spectrum-colorloupe-checkerboard-fill: url(#checkerboard-primary);
 
-  --spectrum-contextual-help-content-spacing: var(--spectrum-spacing-100);
+	--spectrum-contextual-help-content-spacing: var(--spectrum-spacing-100);
 
-  --spectrum-menu-item-selectable-edge-to-text-not-selected-small: 28px;
-  --spectrum-menu-item-selectable-edge-to-text-not-selected-medium: 32px;
-  --spectrum-menu-item-selectable-edge-to-text-not-selected-large: 38px;
-  --spectrum-menu-item-selectable-edge-to-text-not-selected-extra-large: 45px;
+	--spectrum-menu-item-selectable-edge-to-text-not-selected-small: 28px;
+	--spectrum-menu-item-selectable-edge-to-text-not-selected-medium: 32px;
+	--spectrum-menu-item-selectable-edge-to-text-not-selected-large: 38px;
+	--spectrum-menu-item-selectable-edge-to-text-not-selected-extra-large: 45px;
 
-  --spectrum-menu-item-checkmark-height-small: 10px;
-  --spectrum-menu-item-checkmark-height-medium: 10px;
-  --spectrum-menu-item-checkmark-height-large: 12px;
-  --spectrum-menu-item-checkmark-height-extra-large: 14px;
+	--spectrum-menu-item-checkmark-height-small: 10px;
+	--spectrum-menu-item-checkmark-height-medium: 10px;
+	--spectrum-menu-item-checkmark-height-large: 12px;
+	--spectrum-menu-item-checkmark-height-extra-large: 14px;
 
-  --spectrum-menu-item-checkmark-width-small: 10px;
-  --spectrum-menu-item-checkmark-width-medium: 10px;
-  --spectrum-menu-item-checkmark-width-large: 12px;
-  --spectrum-menu-item-checkmark-width-extra-large: 14px;
+	--spectrum-menu-item-checkmark-width-small: 10px;
+	--spectrum-menu-item-checkmark-width-medium: 10px;
+	--spectrum-menu-item-checkmark-width-large: 12px;
+	--spectrum-menu-item-checkmark-width-extra-large: 14px;
 
-  --spectrum-rating-icon-spacing: var(--spectrum-spacing-75);
+	--spectrum-rating-icon-spacing: var(--spectrum-spacing-75);
 
-  --spectrum-button-top-to-text-small: 5px;
-  --spectrum-button-bottom-to-text-small: 4px;
-  --spectrum-button-top-to-text-medium: 7px;
-  --spectrum-button-bottom-to-text-medium: 8px;
-  --spectrum-button-top-to-text-large: 10px;
-  --spectrum-button-bottom-to-text-large: 10px;
-  --spectrum-button-top-to-text-extra-large: 13px;
-  --spectrum-button-bottom-to-text-extra-large: 13px;
+	--spectrum-button-top-to-text-small: 5px;
+	--spectrum-button-bottom-to-text-small: 4px;
+	--spectrum-button-top-to-text-medium: 7px;
+	--spectrum-button-bottom-to-text-medium: 8px;
+	--spectrum-button-top-to-text-large: 10px;
+	--spectrum-button-bottom-to-text-large: 10px;
+	--spectrum-button-top-to-text-extra-large: 13px;
+	--spectrum-button-bottom-to-text-extra-large: 13px;
 
-  --spectrum-alert-banner-close-button-spacing: var(--spectrum-spacing-100);
-  --spectrum-alert-banner-edge-to-divider: var(--spectrum-spacing-100);
-  --spectrum-alert-banner-edge-to-button: var(--spectrum-spacing-100);
-  --spectrum-alert-banner-text-to-button-vertical: var(--spectrum-spacing-100);
+	--spectrum-alert-banner-close-button-spacing: var(--spectrum-spacing-100);
+	--spectrum-alert-banner-edge-to-divider: var(--spectrum-spacing-100);
+	--spectrum-alert-banner-edge-to-button: var(--spectrum-spacing-100);
+	--spectrum-alert-banner-text-to-button-vertical: var(--spectrum-spacing-100);
 
-  --spectrum-alert-dialog-padding: var(--spectrum-spacing-500);
-  --spectrum-alert-dialog-description-to-buttons: var(--spectrum-spacing-700);
+	--spectrum-alert-dialog-padding: var(--spectrum-spacing-500);
+	--spectrum-alert-dialog-description-to-buttons: var(--spectrum-spacing-700);
 
-  --spectrum-coach-indicator-gap: 6px;
-  --spectrum-coach-indicator-ring-diameter: var(--spectrum-spacing-300);
-  --spectrum-coach-indicator-quiet-ring-diameter: var(--spectrum-spacing-100);
+	--spectrum-coach-indicator-gap: 6px;
+	--spectrum-coach-indicator-ring-diameter: var(--spectrum-spacing-300);
+	--spectrum-coach-indicator-quiet-ring-diameter: var(--spectrum-spacing-100);
 
-  --spectrum-coachmark-buttongroup-display: flex;
-  --spectrum-coachmark-buttongroup-mobile-display: none;
-  --spectrum-coachmark-menu-display: inline-flex;
-  --spectrum-coachmark-menu-mobile-display: none;
-  --spectrum-well-padding: var(--spectrum-spacing-300);
-  --spectrum-well-margin-top: var(--spectrum-spacing-75);
-  --spectrum-well-min-width: 240px;
-  --spectrum-well-border-radius: var(--spectrum-spacing-75);
+	--spectrum-coachmark-buttongroup-display: flex;
+	--spectrum-coachmark-buttongroup-mobile-display: none;
+	--spectrum-coachmark-menu-display: inline-flex;
+	--spectrum-coachmark-menu-mobile-display: none;
+	--spectrum-well-padding: var(--spectrum-spacing-300);
+	--spectrum-well-margin-top: var(--spectrum-spacing-75);
+	--spectrum-well-min-width: 240px;
+	--spectrum-well-border-radius: var(--spectrum-spacing-75);
 
-  /* XXL and XXS icon sizes are not within the design spec and are planned to be deprecated in Spectrum 2. */
-  --spectrum-workflow-icon-size-xxl: 32px;
-  --spectrum-workflow-icon-size-xxs: 12px;
+	/* XXL and XXS icon sizes are not within the design spec and are planned to be deprecated in Spectrum 2. */
+	--spectrum-workflow-icon-size-xxl: 32px;
+	--spectrum-workflow-icon-size-xxs: 12px;
 
-  --spectrum-treeview-item-indentation-medium: var(--spectrum-spacing-300);
-  --spectrum-treeview-item-indentation-small: var(--spectrum-spacing-200);
-  --spectrum-treeview-item-indentation-large: 20px;
-  --spectrum-treeview-item-indentation-extra-large: var(--spectrum-spacing-400);
-  --spectrum-treeview-indicator-inset-block-start: 5px;
-  --spectrum-treeview-item-min-block-size-thumbnail-offset-medium: 0px;
+	--spectrum-treeview-item-indentation-medium: var(--spectrum-spacing-300);
+	--spectrum-treeview-item-indentation-small: var(--spectrum-spacing-200);
+	--spectrum-treeview-item-indentation-large: 20px;
+	--spectrum-treeview-item-indentation-extra-large: var(--spectrum-spacing-400);
+	--spectrum-treeview-indicator-inset-block-start: 5px;
+	--spectrum-treeview-item-min-block-size-thumbnail-offset-medium: 0px;
 
-  --spectrum-dialog-confirm-entry-animation-distance: 20px;
-  --spectrum-dialog-confirm-hero-height: 128px;
-  --spectrum-dialog-confirm-border-radius: 4px;
-  --spectrum-dialog-confirm-title-text-size: 18px;
-  --spectrum-dialog-confirm-description-text-size: 14px;
-  --spectrum-dialog-confirm-padding-grid: 40px;
+	--spectrum-dialog-confirm-entry-animation-distance: 20px;
+	--spectrum-dialog-confirm-hero-height: 128px;
+	--spectrum-dialog-confirm-border-radius: 4px;
+	--spectrum-dialog-confirm-title-text-size: 18px;
+	--spectrum-dialog-confirm-description-text-size: 14px;
+	--spectrum-dialog-confirm-padding-grid: 40px;
 
-  --spectrum-datepicker-initial-width: 128px;
-  --spectrum-datepicker-generic-padding: var(--spectrum-spacing-200);
-  --spectrum-datepicker-dash-line-height: 24px;
-  --spectrum-datepicker-width-quiet-first: 72px;
-  --spectrum-datepicker-width-quiet-second: 16px;
-  --spectrum-datepicker-datetime-width-first: 36px;
-  --spectrum-datepicker-invalid-icon-to-button: 8px;
-  --spectrum-datepicker-invalid-icon-to-button-quiet: 7px;
-  --spectrum-datepicker-input-datetime-width: var(--spectrum-spacing-400);
+	--spectrum-datepicker-initial-width: 128px;
+	--spectrum-datepicker-generic-padding: var(--spectrum-spacing-200);
+	--spectrum-datepicker-dash-line-height: 24px;
+	--spectrum-datepicker-width-quiet-first: 72px;
+	--spectrum-datepicker-width-quiet-second: 16px;
+	--spectrum-datepicker-datetime-width-first: 36px;
+	--spectrum-datepicker-invalid-icon-to-button: 8px;
+	--spectrum-datepicker-invalid-icon-to-button-quiet: 7px;
+	--spectrum-datepicker-input-datetime-width: var(--spectrum-spacing-400);
 
-  --spectrum-pagination-textfield-width: var(--spectrum-spacing-700);
-  --spectrum-pagination-item-inline-spacing: 5px;
+	--spectrum-pagination-textfield-width: var(--spectrum-spacing-700);
+	--spectrum-pagination-item-inline-spacing: 5px;
 
-  --spectrum-dial-border-radius: 16px;
-  --spectrum-dial-handle-position: 8px;
-  --spectrum-dial-handle-block-margin: 16px;
-  --spectrum-dial-handle-inline-margin: 16px;
-  --spectrum-dial-controls-margin: 8px;
-  --spectrum-dial-label-gap-y: 5px;
-  --spectrum-dial-label-container-top-to-text: 4px;
+	--spectrum-dial-border-radius: 16px;
+	--spectrum-dial-handle-position: 8px;
+	--spectrum-dial-handle-block-margin: 16px;
+	--spectrum-dial-handle-inline-margin: 16px;
+	--spectrum-dial-controls-margin: 8px;
+	--spectrum-dial-label-gap-y: 5px;
+	--spectrum-dial-label-container-top-to-text: 4px;
 
-  --spectrum-assetcard-focus-ring-border-radius: 8px;
-  --spectrum-assetcard-selectionindicator-margin: 12px;
-  --spectrum-assetcard-title-font-size: var(--spectrum-heading-size-xs);
-  --spectrum-assetcard-header-content-font-size: var(--spectrum-heading-size-xs);
-  --spectrum-assetcard-content-font-size: var(--spectrum-body-size-s);
+	--spectrum-assetcard-focus-ring-border-radius: 8px;
+	--spectrum-assetcard-selectionindicator-margin: 12px;
+	--spectrum-assetcard-title-font-size: var(--spectrum-heading-size-xs);
+	--spectrum-assetcard-header-content-font-size: var(--spectrum-heading-size-xs);
+	--spectrum-assetcard-content-font-size: var(--spectrum-body-size-s);
 
-  --spectrum-tooltip-animation-distance: var(--spectrum-spacing-75);
+	--spectrum-tooltip-animation-distance: var(--spectrum-spacing-75);
 
-  --spectrum-ui-icon-medium-display: block;
-  --spectrum-ui-icon-large-display: none;
+	--spectrum-ui-icon-medium-display: block;
+	--spectrum-ui-icon-large-display: none;
 }

--- a/tokens/custom-spectrum/custom-vars.css
+++ b/tokens/custom-spectrum/custom-vars.css
@@ -13,48 +13,48 @@
 
 /* This file contains overrides and additions to core tokens */
 .spectrum {
-  --system: spectrum;
-  --spectrum-animation-linear: cubic-bezier(0, 0, 1, 1);
-  --spectrum-animation-duration-0: 0ms;
-  --spectrum-animation-duration-100: 130ms;
-  --spectrum-animation-duration-200: 160ms;
-  --spectrum-animation-duration-300: 190ms;
-  --spectrum-animation-duration-400: 220ms;
-  --spectrum-animation-duration-500: 250ms;
-  --spectrum-animation-duration-600: 300ms;
-  --spectrum-animation-duration-700: 350ms;
-  --spectrum-animation-duration-800: 400ms;
-  --spectrum-animation-duration-900: 450ms;
-  --spectrum-animation-duration-1000: 500ms;
-  --spectrum-animation-duration-2000: 1000ms;
-  --spectrum-animation-duration-4000: 2000ms;
-  --spectrum-animation-duration-6000: 3000ms;
-  --spectrum-animation-ease-in-out: cubic-bezier(.45, 0, .40, 1);
-  --spectrum-animation-ease-in: cubic-bezier(.50, 0, 1, 1);
-  --spectrum-animation-ease-out: cubic-bezier(0, 0, 0.40, 1);
-  --spectrum-animation-ease-linear: cubic-bezier(0, 0, 1, 1);
+	--system: spectrum;
+	--spectrum-animation-linear: cubic-bezier(0, 0, 1, 1);
+	--spectrum-animation-duration-0: 0ms;
+	--spectrum-animation-duration-100: 130ms;
+	--spectrum-animation-duration-200: 160ms;
+	--spectrum-animation-duration-300: 190ms;
+	--spectrum-animation-duration-400: 220ms;
+	--spectrum-animation-duration-500: 250ms;
+	--spectrum-animation-duration-600: 300ms;
+	--spectrum-animation-duration-700: 350ms;
+	--spectrum-animation-duration-800: 400ms;
+	--spectrum-animation-duration-900: 450ms;
+	--spectrum-animation-duration-1000: 500ms;
+	--spectrum-animation-duration-2000: 1000ms;
+	--spectrum-animation-duration-4000: 2000ms;
+	--spectrum-animation-duration-6000: 3000ms;
+	--spectrum-animation-ease-in-out: cubic-bezier(0.45, 0, 0.4, 1);
+	--spectrum-animation-ease-in: cubic-bezier(0.5, 0, 1, 1);
+	--spectrum-animation-ease-out: cubic-bezier(0, 0, 0.4, 1);
+	--spectrum-animation-ease-linear: cubic-bezier(0, 0, 1, 1);
 
-  --spectrum-sans-font-family-stack: adobe-clean, var(--spectrum-sans-serif-font-family), 'Source Sans Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Ubuntu, 'Trebuchet MS', 'Lucida Grande', sans-serif;
-  --spectrum-sans-serif-font: var(--spectrum-sans-font-family-stack);
+	--spectrum-sans-font-family-stack: adobe-clean, var(--spectrum-sans-serif-font-family), "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, "Trebuchet MS", "Lucida Grande", sans-serif;
+	--spectrum-sans-serif-font: var(--spectrum-sans-font-family-stack);
 
-  --spectrum-serif-font-family-stack: adobe-clean-serif, var(--spectrum-serif-font-family), 'Source Serif Pro', Georgia, serif;
-  --spectrum-serif-font: var(--spectrum-serif-font-family-stack);
+	--spectrum-serif-font-family-stack: adobe-clean-serif, var(--spectrum-serif-font-family), "Source Serif Pro", Georgia, serif;
+	--spectrum-serif-font: var(--spectrum-serif-font-family-stack);
 
-  --spectrum-code-font-family-stack: 'Source Code Pro', Monaco, monospace;
+	--spectrum-code-font-family-stack: "Source Code Pro", Monaco, monospace;
 
-  --spectrum-font-family-ar: myriad-arabic, adobe-clean, "Source Sans Pro", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, ubuntu, "Trebuchet MS", "Lucida Grande", sans-serif;
-  --spectrum-font-family-he: myriad-hebrew, adobe-clean, "Source Sans Pro", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, ubuntu, "Trebuchet MS", "Lucida Grande", sans-serif;
+	--spectrum-font-family-ar: myriad-arabic, adobe-clean, "Source Sans Pro", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, ubuntu, "Trebuchet MS", "Lucida Grande", sans-serif;
+	--spectrum-font-family-he: myriad-hebrew, adobe-clean, "Source Sans Pro", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, ubuntu, "Trebuchet MS", "Lucida Grande", sans-serif;
 
-  --spectrum-font-family: var(--spectrum-sans-font-family-stack);
-  --spectrum-font-style: var(--spectrum-default-font-style);
-  --spectrum-font-size: var(--spectrum-font-size-100);
+	--spectrum-font-family: var(--spectrum-sans-font-family-stack);
+	--spectrum-font-style: var(--spectrum-default-font-style);
+	--spectrum-font-size: var(--spectrum-font-size-100);
 
-  --spectrum-cjk-font-family-stack: adobe-clean-han-japanese, var(--spectrum-cjk-font-family), sans-serif;
-  --spectrum-cjk-font: var(--spectrum-code-font-family-stack);
+	--spectrum-cjk-font-family-stack: adobe-clean-han-japanese, var(--spectrum-cjk-font-family), sans-serif;
+	--spectrum-cjk-font: var(--spectrum-code-font-family-stack);
 
-  /* static white / black background color for docs containers */
-  --spectrum-docs-static-white-background-color: rgb(15, 121, 125);
-  --spectrum-docs-static-black-background-color: rgb(181, 209, 211);
+    /* static white / black background color for docs containers */
+    --spectrum-docs-static-white-background-color: rgb(15, 121, 125);
+    --spectrum-docs-static-black-background-color: rgb(181, 209, 211);
 
-  --spectrum-coach-indicator-ring-static-white-color: var(--spectrum-white);
+    --spectrum-coach-indicator-ring-static-white-color: var(--spectrum-white);
 }

--- a/tokens/dist/css/express/custom-large-vars.css
+++ b/tokens/dist/css/express/custom-large-vars.css
@@ -12,12 +12,12 @@
  */
 
 .spectrum--express.spectrum--large{
-  --spectrum-colorwheel-path:"M 118 118 m -118 0 a 118 118 0 1 0 236 0 a 118 118 0 1 0 -236 0.2 M 118 118 m -92 0 a 92 92 0 1 0 184 0 a 92 92 0 1 0 -184 0";
-  --spectrum-colorwheel-path-borders:"M 120 120 m -120 0 a 120 120 0 1 0 240 0 a 120 120 0 1 0 -240 0.2 M 120 120 m -90 0 a 90 90 0 1 0 180 0 a 90 90 0 1 0 -180 0";
+	--spectrum-colorwheel-path:"M 118 118 m -118 0 a 118 118 0 1 0 236 0 a 118 118 0 1 0 -236 0.2 M 118 118 m -92 0 a 92 92 0 1 0 184 0 a 92 92 0 1 0 -184 0";
+	--spectrum-colorwheel-path-borders:"M 120 120 m -120 0 a 120 120 0 1 0 240 0 a 120 120 0 1 0 -240 0.2 M 120 120 m -90 0 a 90 90 0 1 0 180 0 a 90 90 0 1 0 -180 0";
 
-  --spectrum-dialog-confirm-border-radius:8px;
+	--spectrum-dialog-confirm-border-radius:8px;
 
-  --spectrum-dial-border-radius:15px;
+	--spectrum-dial-border-radius:15px;
 
-  --spectrum-assetcard-focus-ring-border-radius:12px;
+	--spectrum-assetcard-focus-ring-border-radius:12px;
 }

--- a/tokens/dist/css/express/custom-medium-vars.css
+++ b/tokens/dist/css/express/custom-medium-vars.css
@@ -12,12 +12,12 @@
  */
 
 .spectrum--express.spectrum--medium{
-  --spectrum-colorwheel-path:"M 94 94 m -94 0 a 94 94 0 1 0 188 0 a 94 94 0 1 0 -188 0.2 M 94 94 m -74 0 a 74 74 0 1 0 148 0 a 74 74 0 1 0 -148 0";
-  --spectrum-colorwheel-path-borders:"M 96 96 m -96 0 a 96 96 0 1 0 192 0 a 96 96 0 1 0 -192 0.2 M 96 96 m -72 0 a 72 72 0 1 0 144 0 a 72 72 0 1 0 -144 0";
+	--spectrum-colorwheel-path:"M 94 94 m -94 0 a 94 94 0 1 0 188 0 a 94 94 0 1 0 -188 0.2 M 94 94 m -74 0 a 74 74 0 1 0 148 0 a 74 74 0 1 0 -148 0";
+	--spectrum-colorwheel-path-borders:"M 96 96 m -96 0 a 96 96 0 1 0 192 0 a 96 96 0 1 0 -192 0.2 M 96 96 m -72 0 a 72 72 0 1 0 144 0 a 72 72 0 1 0 -144 0";
 
-  --spectrum-dialog-confirm-border-radius:6px;
+	--spectrum-dialog-confirm-border-radius:6px;
 
-  --spectrum-dial-border-radius:12px;
+	--spectrum-dial-border-radius:12px;
 
-  --spectrum-assetcard-focus-ring-border-radius:10px;
+	--spectrum-assetcard-focus-ring-border-radius:10px;
 }

--- a/tokens/dist/css/express/custom-vars.css
+++ b/tokens/dist/css/express/custom-vars.css
@@ -12,5 +12,5 @@
  */
 
 .spectrum--express{
-  --system:express;
+	--system:express;
 }

--- a/tokens/dist/css/express/dark-vars.css
+++ b/tokens/dist/css/express/dark-vars.css
@@ -12,12 +12,11 @@
  */
 
 .spectrum--express.spectrum--dark{
-  --spectrum-drop-zone-background-color-rgb:var(--spectrum-indigo-900-rgb);
-  --spectrum-well-border-color:rgba(var(--spectrum-white-rgb), 0.05);
+	--spectrum-drop-zone-background-color-rgb:var(--spectrum-indigo-900-rgb);
+	--spectrum-well-border-color:rgba(var(--spectrum-white-rgb), 0.05);
 
-
-  --spectrum-assetcard-border-color-selected:var(--spectrum-indigo-700);
-  --spectrum-assetcard-border-color-selected-hover:var(--spectrum-indigo-700);
-  --spectrum-assetcard-border-color-selected-down:var(--spectrum-indigo-800);
-  --spectrum-assetcard-selectionindicator-background-color-ordered:var(--spectrum-indigo-700);
+	--spectrum-assetcard-border-color-selected:var(--spectrum-indigo-700);
+	--spectrum-assetcard-border-color-selected-hover:var(--spectrum-indigo-700);
+	--spectrum-assetcard-border-color-selected-down:var(--spectrum-indigo-800);
+	--spectrum-assetcard-selectionindicator-background-color-ordered:var(--spectrum-indigo-700);
 }

--- a/tokens/dist/css/express/darkest-vars.css
+++ b/tokens/dist/css/express/darkest-vars.css
@@ -12,12 +12,11 @@
  */
 
 .spectrum--express.spectrum--darkest{
-  --spectrum-drop-zone-background-color-rgb:var(--spectrum-indigo-900-rgb);
-  --spectrum-well-border-color:rgba(var(--spectrum-white-rgb), 0.05);
+	--spectrum-drop-zone-background-color-rgb:var(--spectrum-indigo-900-rgb);
+	--spectrum-well-border-color:rgba(var(--spectrum-white-rgb), 0.05);
 
-
-  --spectrum-assetcard-border-color-selected:var(--spectrum-indigo-700);
-  --spectrum-assetcard-border-color-selected-hover:var(--spectrum-indigo-700);
-  --spectrum-assetcard-border-color-selected-down:var(--spectrum-indigo-800);
-  --spectrum-assetcard-selectionindicator-background-color-ordered:var(--spectrum-indigo-700);
+	--spectrum-assetcard-border-color-selected:var(--spectrum-indigo-700);
+	--spectrum-assetcard-border-color-selected-hover:var(--spectrum-indigo-700);
+	--spectrum-assetcard-border-color-selected-down:var(--spectrum-indigo-800);
+	--spectrum-assetcard-selectionindicator-background-color-ordered:var(--spectrum-indigo-700);
 }

--- a/tokens/dist/css/express/global-vars.css
+++ b/tokens/dist/css/express/global-vars.css
@@ -49,5 +49,5 @@
   --spectrum-heading-cjk-font-weight:var(--spectrum-black-font-weight);
   --spectrum-heading-sans-serif-emphasized-font-weight:var(--spectrum-black-font-weight);
   --spectrum-heading-serif-emphasized-font-weight:var(--spectrum-black-font-weight);
-  --system:express;
+	--system:express;
 }

--- a/tokens/dist/css/express/large-vars.css
+++ b/tokens/dist/css/express/large-vars.css
@@ -62,12 +62,12 @@
   --spectrum-drop-shadow-x:0px;
   --spectrum-drop-shadow-y:4px;
   --spectrum-drop-shadow-blur:16px;
-  --spectrum-colorwheel-path:"M 118 118 m -118 0 a 118 118 0 1 0 236 0 a 118 118 0 1 0 -236 0.2 M 118 118 m -92 0 a 92 92 0 1 0 184 0 a 92 92 0 1 0 -184 0";
-  --spectrum-colorwheel-path-borders:"M 120 120 m -120 0 a 120 120 0 1 0 240 0 a 120 120 0 1 0 -240 0.2 M 120 120 m -90 0 a 90 90 0 1 0 180 0 a 90 90 0 1 0 -180 0";
+	--spectrum-colorwheel-path:"M 118 118 m -118 0 a 118 118 0 1 0 236 0 a 118 118 0 1 0 -236 0.2 M 118 118 m -92 0 a 92 92 0 1 0 184 0 a 92 92 0 1 0 -184 0";
+	--spectrum-colorwheel-path-borders:"M 120 120 m -120 0 a 120 120 0 1 0 240 0 a 120 120 0 1 0 -240 0.2 M 120 120 m -90 0 a 90 90 0 1 0 180 0 a 90 90 0 1 0 -180 0";
 
-  --spectrum-dialog-confirm-border-radius:8px;
+	--spectrum-dialog-confirm-border-radius:8px;
 
-  --spectrum-dial-border-radius:15px;
+	--spectrum-dial-border-radius:15px;
 
-  --spectrum-assetcard-focus-ring-border-radius:12px;
+	--spectrum-assetcard-focus-ring-border-radius:12px;
 }

--- a/tokens/dist/css/express/light-vars.css
+++ b/tokens/dist/css/express/light-vars.css
@@ -12,12 +12,11 @@
  */
 
 .spectrum--express.spectrum--light,.spectrum--express.spectrum--lightest{
-  --spectrum-drop-zone-background-color-rgb:var(--spectrum-indigo-800-rgb);
-  --spectrum-well-border-color:rgba(var(--spectrum-black-rgb), 0.05);
+	--spectrum-drop-zone-background-color-rgb:var(--spectrum-indigo-800-rgb);
+	--spectrum-well-border-color:rgba(var(--spectrum-black-rgb), 0.05);
 
-
-  --spectrum-assetcard-border-color-selected:var(--spectrum-indigo-900);
-  --spectrum-assetcard-border-color-selected-hover:var(--spectrum-indigo-900);
-  --spectrum-assetcard-border-color-selected-down:var(--spectrum-indigo-1000);
-  --spectrum-assetcard-selectionindicator-background-color-ordered:var(--spectrum-indigo-900);
+	--spectrum-assetcard-border-color-selected:var(--spectrum-indigo-900);
+	--spectrum-assetcard-border-color-selected-hover:var(--spectrum-indigo-900);
+	--spectrum-assetcard-border-color-selected-down:var(--spectrum-indigo-1000);
+	--spectrum-assetcard-selectionindicator-background-color-ordered:var(--spectrum-indigo-900);
 }

--- a/tokens/dist/css/express/medium-vars.css
+++ b/tokens/dist/css/express/medium-vars.css
@@ -62,12 +62,12 @@
   --spectrum-drop-shadow-x:0px;
   --spectrum-drop-shadow-y:4px;
   --spectrum-drop-shadow-blur:16px;
-  --spectrum-colorwheel-path:"M 94 94 m -94 0 a 94 94 0 1 0 188 0 a 94 94 0 1 0 -188 0.2 M 94 94 m -74 0 a 74 74 0 1 0 148 0 a 74 74 0 1 0 -148 0";
-  --spectrum-colorwheel-path-borders:"M 96 96 m -96 0 a 96 96 0 1 0 192 0 a 96 96 0 1 0 -192 0.2 M 96 96 m -72 0 a 72 72 0 1 0 144 0 a 72 72 0 1 0 -144 0";
+	--spectrum-colorwheel-path:"M 94 94 m -94 0 a 94 94 0 1 0 188 0 a 94 94 0 1 0 -188 0.2 M 94 94 m -74 0 a 74 74 0 1 0 148 0 a 74 74 0 1 0 -148 0";
+	--spectrum-colorwheel-path-borders:"M 96 96 m -96 0 a 96 96 0 1 0 192 0 a 96 96 0 1 0 -192 0.2 M 96 96 m -72 0 a 72 72 0 1 0 144 0 a 72 72 0 1 0 -144 0";
 
-  --spectrum-dialog-confirm-border-radius:6px;
+	--spectrum-dialog-confirm-border-radius:6px;
 
-  --spectrum-dial-border-radius:12px;
+	--spectrum-dial-border-radius:12px;
 
-  --spectrum-assetcard-focus-ring-border-radius:10px;
+	--spectrum-assetcard-focus-ring-border-radius:10px;
 }

--- a/tokens/dist/css/spectrum/custom-large-vars.css
+++ b/tokens/dist/css/spectrum/custom-large-vars.css
@@ -12,110 +12,110 @@
  */
 
 .spectrum--large{
-  --spectrum-slider-tick-mark-height:13px;
-  --spectrum-slider-ramp-track-height:20px;
+	--spectrum-slider-tick-mark-height:13px;
+	--spectrum-slider-ramp-track-height:20px;
 
-  --spectrum-colorwheel-path:"M 119 119 m -119 0 a 119 119 0 1 0 238 0 a 119 119 0 1 0 -238 0.2 M 119 119 m -91 0 a 91 91 0 1 0 182 0 a 91 91 0 1 0 -182 0";
-  --spectrum-colorwheel-path-borders:"M 120 120 m -120 0 a 120 120 0 1 0 240 0 a 120 120 0 1 0 -240 0.2 M 120 120 m -90 0 a 90 90 0 1 0 180 0 a 90 90 0 1 0 -180 0";
-  --spectrum-colorwheel-colorarea-container-size:182px;
+	--spectrum-colorwheel-path:"M 119 119 m -119 0 a 119 119 0 1 0 238 0 a 119 119 0 1 0 -238 0.2 M 119 119 m -91 0 a 91 91 0 1 0 182 0 a 91 91 0 1 0 -182 0";
+	--spectrum-colorwheel-path-borders:"M 120 120 m -120 0 a 120 120 0 1 0 240 0 a 120 120 0 1 0 -240 0.2 M 120 120 m -90 0 a 90 90 0 1 0 180 0 a 90 90 0 1 0 -180 0";
+	--spectrum-colorwheel-colorarea-container-size:182px;
 
-  --spectrum-colorloupe-checkerboard-fill:url(#checkerboard-secondary);
+	--spectrum-colorloupe-checkerboard-fill:url(#checkerboard-secondary);
 
-  --spectrum-contextual-help-content-spacing:var(--spectrum-spacing-200);
+	--spectrum-contextual-help-content-spacing:var(--spectrum-spacing-200);
 
-  --spectrum-menu-item-selectable-edge-to-text-not-selected-small:34px;
-  --spectrum-menu-item-selectable-edge-to-text-not-selected-medium:42px;
-  --spectrum-menu-item-selectable-edge-to-text-not-selected-large:47px;
-  --spectrum-menu-item-selectable-edge-to-text-not-selected-extra-large:54px;
+	--spectrum-menu-item-selectable-edge-to-text-not-selected-small:34px;
+	--spectrum-menu-item-selectable-edge-to-text-not-selected-medium:42px;
+	--spectrum-menu-item-selectable-edge-to-text-not-selected-large:47px;
+	--spectrum-menu-item-selectable-edge-to-text-not-selected-extra-large:54px;
 
-  --spectrum-menu-item-checkmark-height-small:12px;
-  --spectrum-menu-item-checkmark-height-medium:14px;
-  --spectrum-menu-item-checkmark-height-large:16px;
-  --spectrum-menu-item-checkmark-height-extra-large:16px;
+	--spectrum-menu-item-checkmark-height-small:12px;
+	--spectrum-menu-item-checkmark-height-medium:14px;
+	--spectrum-menu-item-checkmark-height-large:16px;
+	--spectrum-menu-item-checkmark-height-extra-large:16px;
 
-  --spectrum-menu-item-checkmark-width-small:12px;
-  --spectrum-menu-item-checkmark-width-medium:14px;
-  --spectrum-menu-item-checkmark-width-large:16px;
-  --spectrum-menu-item-checkmark-width-extra-large:16px;
+	--spectrum-menu-item-checkmark-width-small:12px;
+	--spectrum-menu-item-checkmark-width-medium:14px;
+	--spectrum-menu-item-checkmark-width-large:16px;
+	--spectrum-menu-item-checkmark-width-extra-large:16px;
 
-  --spectrum-rating-icon-spacing:var(--spectrum-spacing-100);
+	--spectrum-rating-icon-spacing:var(--spectrum-spacing-100);
 
-  --spectrum-button-top-to-text-small:6px;
-  --spectrum-button-bottom-to-text-small:5px;
-  --spectrum-button-top-to-text-medium:9px;
-  --spectrum-button-bottom-to-text-medium:10px;
-  --spectrum-button-top-to-text-large:12px;
-  --spectrum-button-bottom-to-text-large:13px;
-  --spectrum-button-top-to-text-extra-large:16px;
-  --spectrum-button-bottom-to-text-extra-large:17px;
+	--spectrum-button-top-to-text-small:6px;
+	--spectrum-button-bottom-to-text-small:5px;
+	--spectrum-button-top-to-text-medium:9px;
+	--spectrum-button-bottom-to-text-medium:10px;
+	--spectrum-button-top-to-text-large:12px;
+	--spectrum-button-bottom-to-text-large:13px;
+	--spectrum-button-top-to-text-extra-large:16px;
+	--spectrum-button-bottom-to-text-extra-large:17px;
 
-  --spectrum-alert-banner-close-button-spacing:var(--spectrum-spacing-200);
-  --spectrum-alert-banner-edge-to-divider:var(--spectrum-spacing-200);
-  --spectrum-alert-banner-edge-to-button:var(--spectrum-spacing-200);
-  --spectrum-alert-banner-text-to-button-vertical:var(--spectrum-spacing-200);
+	--spectrum-alert-banner-close-button-spacing:var(--spectrum-spacing-200);
+	--spectrum-alert-banner-edge-to-divider:var(--spectrum-spacing-200);
+	--spectrum-alert-banner-edge-to-button:var(--spectrum-spacing-200);
+	--spectrum-alert-banner-text-to-button-vertical:var(--spectrum-spacing-200);
 
-  --spectrum-alert-dialog-padding:var(--spectrum-spacing-400);
-  --spectrum-alert-dialog-description-to-buttons:var(--spectrum-spacing-600);
+	--spectrum-alert-dialog-padding:var(--spectrum-spacing-400);
+	--spectrum-alert-dialog-description-to-buttons:var(--spectrum-spacing-600);
 
-  --spectrum-coach-indicator-gap:8px;
-  --spectrum-coach-indicator-ring-diameter:20px;
-  --spectrum-coach-indicator-quiet-ring-diameter:10px;
+	--spectrum-coach-indicator-gap:8px;
+	--spectrum-coach-indicator-ring-diameter:20px;
+	--spectrum-coach-indicator-quiet-ring-diameter:10px;
 
-  --spectrum-coachmark-buttongroup-display:none;
-  --spectrum-coachmark-buttongroup-mobile-display:flex;
-  --spectrum-coachmark-menu-display:none;
-  --spectrum-coachmark-menu-mobile-display:inline-flex;
+	--spectrum-coachmark-buttongroup-display:none;
+	--spectrum-coachmark-buttongroup-mobile-display:flex;
+	--spectrum-coachmark-menu-display:none;
+	--spectrum-coachmark-menu-mobile-display:inline-flex;
 
-  --spectrum-well-padding:20px;
-  --spectrum-well-margin-top:5px;
-  --spectrum-well-min-width:300px;
-  --spectrum-well-border-radius:5px;
-  --spectrum-workflow-icon-size-xxl:40px;
-  --spectrum-workflow-icon-size-xxs:15px;
+	--spectrum-well-padding:20px;
+	--spectrum-well-margin-top:5px;
+	--spectrum-well-min-width:300px;
+	--spectrum-well-border-radius:5px;
+	--spectrum-workflow-icon-size-xxl:40px;
+	--spectrum-workflow-icon-size-xxs:15px;
 
-  --spectrum-treeview-item-indentation-medium:20px;
-  --spectrum-treeview-item-indentation-small:15px;
-  --spectrum-treeview-item-indentation-large:25px;
-  --spectrum-treeview-item-indentation-extra-large:30px;
-  --spectrum-treeview-indicator-inset-block-start:6px;
-  --spectrum-treeview-item-min-block-size-thumbnail-offset-medium:2px;
+	--spectrum-treeview-item-indentation-medium:20px;
+	--spectrum-treeview-item-indentation-small:15px;
+	--spectrum-treeview-item-indentation-large:25px;
+	--spectrum-treeview-item-indentation-extra-large:30px;
+	--spectrum-treeview-indicator-inset-block-start:6px;
+	--spectrum-treeview-item-min-block-size-thumbnail-offset-medium:2px;
 
-  --spectrum-dialog-confirm-entry-animation-distance:25px;
-  --spectrum-dialog-confirm-hero-height:160px;
-  --spectrum-dialog-confirm-border-radius:5px;
-  --spectrum-dialog-confirm-title-text-size:19px;
-  --spectrum-dialog-confirm-description-text-size:15px;
-  --spectrum-dialog-confirm-padding-grid:24px;
+	--spectrum-dialog-confirm-entry-animation-distance:25px;
+	--spectrum-dialog-confirm-hero-height:160px;
+	--spectrum-dialog-confirm-border-radius:5px;
+	--spectrum-dialog-confirm-title-text-size:19px;
+	--spectrum-dialog-confirm-description-text-size:15px;
+	--spectrum-dialog-confirm-padding-grid:24px;
 
-  --spectrum-datepicker-initial-width:160px;
-  --spectrum-datepicker-generic-padding:15px;
-  --spectrum-datepicker-dash-line-height:30px;
-  --spectrum-datepicker-width-quiet-first:90px;
-  --spectrum-datepicker-width-quiet-second:20px;
-  --spectrum-datepicker-datetime-width-first:45px;
-  --spectrum-datepicker-invalid-icon-to-button:10px;
-  --spectrum-datepicker-invalid-icon-to-button-quiet:9px;
-  --spectrum-datepicker-input-datetime-width:30px;
+	--spectrum-datepicker-initial-width:160px;
+	--spectrum-datepicker-generic-padding:15px;
+	--spectrum-datepicker-dash-line-height:30px;
+	--spectrum-datepicker-width-quiet-first:90px;
+	--spectrum-datepicker-width-quiet-second:20px;
+	--spectrum-datepicker-datetime-width-first:45px;
+	--spectrum-datepicker-invalid-icon-to-button:10px;
+	--spectrum-datepicker-invalid-icon-to-button-quiet:9px;
+	--spectrum-datepicker-input-datetime-width:30px;
 
-  --spectrum-pagination-textfield-width:60px;
-  --spectrum-pagination-item-inline-spacing:6px;
+	--spectrum-pagination-textfield-width:60px;
+	--spectrum-pagination-item-inline-spacing:6px;
 
-  --spectrum-dial-border-radius:20px;
-  --spectrum-dial-handle-position:10px;
-  --spectrum-dial-handle-block-margin:20px;
-  --spectrum-dial-handle-inline-margin:20px;
-  --spectrum-dial-controls-margin:10px;
-  --spectrum-dial-label-gap-y:6px;
-  --spectrum-dial-label-container-top-to-text:5px;
+	--spectrum-dial-border-radius:20px;
+	--spectrum-dial-handle-position:10px;
+	--spectrum-dial-handle-block-margin:20px;
+	--spectrum-dial-handle-inline-margin:20px;
+	--spectrum-dial-controls-margin:10px;
+	--spectrum-dial-label-gap-y:6px;
+	--spectrum-dial-label-container-top-to-text:5px;
 
-  --spectrum-assetcard-focus-ring-border-radius:9px;
-  --spectrum-assetcard-selectionindicator-margin:15px;
-  --spectrum-assetcard-title-font-size:var(--spectrum-heading-size-xxs);
-  --spectrum-assetcard-header-content-font-size:var(--spectrum-heading-size-xxs);
-  --spectrum-assetcard-content-font-size:var(--spectrum-body-size-xs);
+	--spectrum-assetcard-focus-ring-border-radius:9px;
+	--spectrum-assetcard-selectionindicator-margin:15px;
+	--spectrum-assetcard-title-font-size:var(--spectrum-heading-size-xxs);
+	--spectrum-assetcard-header-content-font-size:var(--spectrum-heading-size-xxs);
+	--spectrum-assetcard-content-font-size:var(--spectrum-body-size-xs);
 
-  --spectrum-tooltip-animation-distance:5px;
+	--spectrum-tooltip-animation-distance:5px;
 
-  --spectrum-ui-icon-medium-display:none;
-  --spectrum-ui-icon-large-display:block;
+	--spectrum-ui-icon-medium-display:none;
+	--spectrum-ui-icon-large-display:block;
 }

--- a/tokens/dist/css/spectrum/custom-medium-vars.css
+++ b/tokens/dist/css/spectrum/custom-medium-vars.css
@@ -12,109 +12,109 @@
  */
 
 .spectrum--medium{
-  --spectrum-slider-tick-mark-height:10px;
-  --spectrum-slider-ramp-track-height:16px;
+	--spectrum-slider-tick-mark-height:10px;
+	--spectrum-slider-ramp-track-height:16px;
 
-  --spectrum-colorwheel-path:"M 95 95 m -95 0 a 95 95 0 1 0 190 0 a 95 95 0 1 0 -190 0.2 M 95 95 m -73 0 a 73 73 0 1 0 146 0 a 73 73 0 1 0 -146 0";
-  --spectrum-colorwheel-path-borders:"M 96 96 m -96 0 a 96 96 0 1 0 192 0 a 96 96 0 1 0 -192 0.2 M 96 96 m -72 0 a 72 72 0 1 0 144 0 a 72 72 0 1 0 -144 0";
-  --spectrum-colorwheel-colorarea-container-size:144px;
+	--spectrum-colorwheel-path:"M 95 95 m -95 0 a 95 95 0 1 0 190 0 a 95 95 0 1 0 -190 0.2 M 95 95 m -73 0 a 73 73 0 1 0 146 0 a 73 73 0 1 0 -146 0";
+	--spectrum-colorwheel-path-borders:"M 96 96 m -96 0 a 96 96 0 1 0 192 0 a 96 96 0 1 0 -192 0.2 M 96 96 m -72 0 a 72 72 0 1 0 144 0 a 72 72 0 1 0 -144 0";
+	--spectrum-colorwheel-colorarea-container-size:144px;
 
-  --spectrum-colorloupe-checkerboard-fill:url(#checkerboard-primary);
+	--spectrum-colorloupe-checkerboard-fill:url(#checkerboard-primary);
 
-  --spectrum-contextual-help-content-spacing:var(--spectrum-spacing-100);
+	--spectrum-contextual-help-content-spacing:var(--spectrum-spacing-100);
 
-  --spectrum-menu-item-selectable-edge-to-text-not-selected-small:28px;
-  --spectrum-menu-item-selectable-edge-to-text-not-selected-medium:32px;
-  --spectrum-menu-item-selectable-edge-to-text-not-selected-large:38px;
-  --spectrum-menu-item-selectable-edge-to-text-not-selected-extra-large:45px;
+	--spectrum-menu-item-selectable-edge-to-text-not-selected-small:28px;
+	--spectrum-menu-item-selectable-edge-to-text-not-selected-medium:32px;
+	--spectrum-menu-item-selectable-edge-to-text-not-selected-large:38px;
+	--spectrum-menu-item-selectable-edge-to-text-not-selected-extra-large:45px;
 
-  --spectrum-menu-item-checkmark-height-small:10px;
-  --spectrum-menu-item-checkmark-height-medium:10px;
-  --spectrum-menu-item-checkmark-height-large:12px;
-  --spectrum-menu-item-checkmark-height-extra-large:14px;
+	--spectrum-menu-item-checkmark-height-small:10px;
+	--spectrum-menu-item-checkmark-height-medium:10px;
+	--spectrum-menu-item-checkmark-height-large:12px;
+	--spectrum-menu-item-checkmark-height-extra-large:14px;
 
-  --spectrum-menu-item-checkmark-width-small:10px;
-  --spectrum-menu-item-checkmark-width-medium:10px;
-  --spectrum-menu-item-checkmark-width-large:12px;
-  --spectrum-menu-item-checkmark-width-extra-large:14px;
+	--spectrum-menu-item-checkmark-width-small:10px;
+	--spectrum-menu-item-checkmark-width-medium:10px;
+	--spectrum-menu-item-checkmark-width-large:12px;
+	--spectrum-menu-item-checkmark-width-extra-large:14px;
 
-  --spectrum-rating-icon-spacing:var(--spectrum-spacing-75);
+	--spectrum-rating-icon-spacing:var(--spectrum-spacing-75);
 
-  --spectrum-button-top-to-text-small:5px;
-  --spectrum-button-bottom-to-text-small:4px;
-  --spectrum-button-top-to-text-medium:7px;
-  --spectrum-button-bottom-to-text-medium:8px;
-  --spectrum-button-top-to-text-large:10px;
-  --spectrum-button-bottom-to-text-large:10px;
-  --spectrum-button-top-to-text-extra-large:13px;
-  --spectrum-button-bottom-to-text-extra-large:13px;
+	--spectrum-button-top-to-text-small:5px;
+	--spectrum-button-bottom-to-text-small:4px;
+	--spectrum-button-top-to-text-medium:7px;
+	--spectrum-button-bottom-to-text-medium:8px;
+	--spectrum-button-top-to-text-large:10px;
+	--spectrum-button-bottom-to-text-large:10px;
+	--spectrum-button-top-to-text-extra-large:13px;
+	--spectrum-button-bottom-to-text-extra-large:13px;
 
-  --spectrum-alert-banner-close-button-spacing:var(--spectrum-spacing-100);
-  --spectrum-alert-banner-edge-to-divider:var(--spectrum-spacing-100);
-  --spectrum-alert-banner-edge-to-button:var(--spectrum-spacing-100);
-  --spectrum-alert-banner-text-to-button-vertical:var(--spectrum-spacing-100);
+	--spectrum-alert-banner-close-button-spacing:var(--spectrum-spacing-100);
+	--spectrum-alert-banner-edge-to-divider:var(--spectrum-spacing-100);
+	--spectrum-alert-banner-edge-to-button:var(--spectrum-spacing-100);
+	--spectrum-alert-banner-text-to-button-vertical:var(--spectrum-spacing-100);
 
-  --spectrum-alert-dialog-padding:var(--spectrum-spacing-500);
-  --spectrum-alert-dialog-description-to-buttons:var(--spectrum-spacing-700);
+	--spectrum-alert-dialog-padding:var(--spectrum-spacing-500);
+	--spectrum-alert-dialog-description-to-buttons:var(--spectrum-spacing-700);
 
-  --spectrum-coach-indicator-gap:6px;
-  --spectrum-coach-indicator-ring-diameter:var(--spectrum-spacing-300);
-  --spectrum-coach-indicator-quiet-ring-diameter:var(--spectrum-spacing-100);
+	--spectrum-coach-indicator-gap:6px;
+	--spectrum-coach-indicator-ring-diameter:var(--spectrum-spacing-300);
+	--spectrum-coach-indicator-quiet-ring-diameter:var(--spectrum-spacing-100);
 
-  --spectrum-coachmark-buttongroup-display:flex;
-  --spectrum-coachmark-buttongroup-mobile-display:none;
-  --spectrum-coachmark-menu-display:inline-flex;
-  --spectrum-coachmark-menu-mobile-display:none;
-  --spectrum-well-padding:var(--spectrum-spacing-300);
-  --spectrum-well-margin-top:var(--spectrum-spacing-75);
-  --spectrum-well-min-width:240px;
-  --spectrum-well-border-radius:var(--spectrum-spacing-75);
-  --spectrum-workflow-icon-size-xxl:32px;
-  --spectrum-workflow-icon-size-xxs:12px;
+	--spectrum-coachmark-buttongroup-display:flex;
+	--spectrum-coachmark-buttongroup-mobile-display:none;
+	--spectrum-coachmark-menu-display:inline-flex;
+	--spectrum-coachmark-menu-mobile-display:none;
+	--spectrum-well-padding:var(--spectrum-spacing-300);
+	--spectrum-well-margin-top:var(--spectrum-spacing-75);
+	--spectrum-well-min-width:240px;
+	--spectrum-well-border-radius:var(--spectrum-spacing-75);
+	--spectrum-workflow-icon-size-xxl:32px;
+	--spectrum-workflow-icon-size-xxs:12px;
 
-  --spectrum-treeview-item-indentation-medium:var(--spectrum-spacing-300);
-  --spectrum-treeview-item-indentation-small:var(--spectrum-spacing-200);
-  --spectrum-treeview-item-indentation-large:20px;
-  --spectrum-treeview-item-indentation-extra-large:var(--spectrum-spacing-400);
-  --spectrum-treeview-indicator-inset-block-start:5px;
-  --spectrum-treeview-item-min-block-size-thumbnail-offset-medium:0px;
+	--spectrum-treeview-item-indentation-medium:var(--spectrum-spacing-300);
+	--spectrum-treeview-item-indentation-small:var(--spectrum-spacing-200);
+	--spectrum-treeview-item-indentation-large:20px;
+	--spectrum-treeview-item-indentation-extra-large:var(--spectrum-spacing-400);
+	--spectrum-treeview-indicator-inset-block-start:5px;
+	--spectrum-treeview-item-min-block-size-thumbnail-offset-medium:0px;
 
-  --spectrum-dialog-confirm-entry-animation-distance:20px;
-  --spectrum-dialog-confirm-hero-height:128px;
-  --spectrum-dialog-confirm-border-radius:4px;
-  --spectrum-dialog-confirm-title-text-size:18px;
-  --spectrum-dialog-confirm-description-text-size:14px;
-  --spectrum-dialog-confirm-padding-grid:40px;
+	--spectrum-dialog-confirm-entry-animation-distance:20px;
+	--spectrum-dialog-confirm-hero-height:128px;
+	--spectrum-dialog-confirm-border-radius:4px;
+	--spectrum-dialog-confirm-title-text-size:18px;
+	--spectrum-dialog-confirm-description-text-size:14px;
+	--spectrum-dialog-confirm-padding-grid:40px;
 
-  --spectrum-datepicker-initial-width:128px;
-  --spectrum-datepicker-generic-padding:var(--spectrum-spacing-200);
-  --spectrum-datepicker-dash-line-height:24px;
-  --spectrum-datepicker-width-quiet-first:72px;
-  --spectrum-datepicker-width-quiet-second:16px;
-  --spectrum-datepicker-datetime-width-first:36px;
-  --spectrum-datepicker-invalid-icon-to-button:8px;
-  --spectrum-datepicker-invalid-icon-to-button-quiet:7px;
-  --spectrum-datepicker-input-datetime-width:var(--spectrum-spacing-400);
+	--spectrum-datepicker-initial-width:128px;
+	--spectrum-datepicker-generic-padding:var(--spectrum-spacing-200);
+	--spectrum-datepicker-dash-line-height:24px;
+	--spectrum-datepicker-width-quiet-first:72px;
+	--spectrum-datepicker-width-quiet-second:16px;
+	--spectrum-datepicker-datetime-width-first:36px;
+	--spectrum-datepicker-invalid-icon-to-button:8px;
+	--spectrum-datepicker-invalid-icon-to-button-quiet:7px;
+	--spectrum-datepicker-input-datetime-width:var(--spectrum-spacing-400);
 
-  --spectrum-pagination-textfield-width:var(--spectrum-spacing-700);
-  --spectrum-pagination-item-inline-spacing:5px;
+	--spectrum-pagination-textfield-width:var(--spectrum-spacing-700);
+	--spectrum-pagination-item-inline-spacing:5px;
 
-  --spectrum-dial-border-radius:16px;
-  --spectrum-dial-handle-position:8px;
-  --spectrum-dial-handle-block-margin:16px;
-  --spectrum-dial-handle-inline-margin:16px;
-  --spectrum-dial-controls-margin:8px;
-  --spectrum-dial-label-gap-y:5px;
-  --spectrum-dial-label-container-top-to-text:4px;
+	--spectrum-dial-border-radius:16px;
+	--spectrum-dial-handle-position:8px;
+	--spectrum-dial-handle-block-margin:16px;
+	--spectrum-dial-handle-inline-margin:16px;
+	--spectrum-dial-controls-margin:8px;
+	--spectrum-dial-label-gap-y:5px;
+	--spectrum-dial-label-container-top-to-text:4px;
 
-  --spectrum-assetcard-focus-ring-border-radius:8px;
-  --spectrum-assetcard-selectionindicator-margin:12px;
-  --spectrum-assetcard-title-font-size:var(--spectrum-heading-size-xs);
-  --spectrum-assetcard-header-content-font-size:var(--spectrum-heading-size-xs);
-  --spectrum-assetcard-content-font-size:var(--spectrum-body-size-s);
+	--spectrum-assetcard-focus-ring-border-radius:8px;
+	--spectrum-assetcard-selectionindicator-margin:12px;
+	--spectrum-assetcard-title-font-size:var(--spectrum-heading-size-xs);
+	--spectrum-assetcard-header-content-font-size:var(--spectrum-heading-size-xs);
+	--spectrum-assetcard-content-font-size:var(--spectrum-body-size-s);
 
-  --spectrum-tooltip-animation-distance:var(--spectrum-spacing-75);
+	--spectrum-tooltip-animation-distance:var(--spectrum-spacing-75);
 
-  --spectrum-ui-icon-medium-display:block;
-  --spectrum-ui-icon-large-display:none;
+	--spectrum-ui-icon-medium-display:block;
+	--spectrum-ui-icon-large-display:none;
 }

--- a/tokens/dist/css/spectrum/custom-vars.css
+++ b/tokens/dist/css/spectrum/custom-vars.css
@@ -12,48 +12,48 @@
  */
 
 .spectrum{
-  --system:spectrum;
-  --spectrum-animation-linear:cubic-bezier(0, 0, 1, 1);
-  --spectrum-animation-duration-0:0ms;
-  --spectrum-animation-duration-100:130ms;
-  --spectrum-animation-duration-200:160ms;
-  --spectrum-animation-duration-300:190ms;
-  --spectrum-animation-duration-400:220ms;
-  --spectrum-animation-duration-500:250ms;
-  --spectrum-animation-duration-600:300ms;
-  --spectrum-animation-duration-700:350ms;
-  --spectrum-animation-duration-800:400ms;
-  --spectrum-animation-duration-900:450ms;
-  --spectrum-animation-duration-1000:500ms;
-  --spectrum-animation-duration-2000:1000ms;
-  --spectrum-animation-duration-4000:2000ms;
-  --spectrum-animation-duration-6000:3000ms;
-  --spectrum-animation-ease-in-out:cubic-bezier(.45, 0, .40, 1);
-  --spectrum-animation-ease-in:cubic-bezier(.50, 0, 1, 1);
-  --spectrum-animation-ease-out:cubic-bezier(0, 0, 0.40, 1);
-  --spectrum-animation-ease-linear:cubic-bezier(0, 0, 1, 1);
+	--system:spectrum;
+	--spectrum-animation-linear:cubic-bezier(0, 0, 1, 1);
+	--spectrum-animation-duration-0:0ms;
+	--spectrum-animation-duration-100:130ms;
+	--spectrum-animation-duration-200:160ms;
+	--spectrum-animation-duration-300:190ms;
+	--spectrum-animation-duration-400:220ms;
+	--spectrum-animation-duration-500:250ms;
+	--spectrum-animation-duration-600:300ms;
+	--spectrum-animation-duration-700:350ms;
+	--spectrum-animation-duration-800:400ms;
+	--spectrum-animation-duration-900:450ms;
+	--spectrum-animation-duration-1000:500ms;
+	--spectrum-animation-duration-2000:1000ms;
+	--spectrum-animation-duration-4000:2000ms;
+	--spectrum-animation-duration-6000:3000ms;
+	--spectrum-animation-ease-in-out:cubic-bezier(0.45, 0, 0.4, 1);
+	--spectrum-animation-ease-in:cubic-bezier(0.5, 0, 1, 1);
+	--spectrum-animation-ease-out:cubic-bezier(0, 0, 0.4, 1);
+	--spectrum-animation-ease-linear:cubic-bezier(0, 0, 1, 1);
 
-  --spectrum-sans-font-family-stack:adobe-clean, var(--spectrum-sans-serif-font-family), "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, "Trebuchet MS", "Lucida Grande", sans-serif;
-  --spectrum-sans-serif-font:var(--spectrum-sans-font-family-stack);
+	--spectrum-sans-font-family-stack:adobe-clean, var(--spectrum-sans-serif-font-family), "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, "Trebuchet MS", "Lucida Grande", sans-serif;
+	--spectrum-sans-serif-font:var(--spectrum-sans-font-family-stack);
 
-  --spectrum-serif-font-family-stack:adobe-clean-serif, var(--spectrum-serif-font-family), "Source Serif Pro", Georgia, serif;
-  --spectrum-serif-font:var(--spectrum-serif-font-family-stack);
+	--spectrum-serif-font-family-stack:adobe-clean-serif, var(--spectrum-serif-font-family), "Source Serif Pro", Georgia, serif;
+	--spectrum-serif-font:var(--spectrum-serif-font-family-stack);
 
-  --spectrum-code-font-family-stack:"Source Code Pro", Monaco, monospace;
+	--spectrum-code-font-family-stack:"Source Code Pro", Monaco, monospace;
 
-  --spectrum-font-family-ar:myriad-arabic, adobe-clean, "Source Sans Pro", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, ubuntu, "Trebuchet MS", "Lucida Grande", sans-serif;
-  --spectrum-font-family-he:myriad-hebrew, adobe-clean, "Source Sans Pro", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, ubuntu, "Trebuchet MS", "Lucida Grande", sans-serif;
+	--spectrum-font-family-ar:myriad-arabic, adobe-clean, "Source Sans Pro", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, ubuntu, "Trebuchet MS", "Lucida Grande", sans-serif;
+	--spectrum-font-family-he:myriad-hebrew, adobe-clean, "Source Sans Pro", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, ubuntu, "Trebuchet MS", "Lucida Grande", sans-serif;
 
-  --spectrum-font-family:var(--spectrum-sans-font-family-stack);
-  --spectrum-font-style:var(--spectrum-default-font-style);
-  --spectrum-font-size:var(--spectrum-font-size-100);
+	--spectrum-font-family:var(--spectrum-sans-font-family-stack);
+	--spectrum-font-style:var(--spectrum-default-font-style);
+	--spectrum-font-size:var(--spectrum-font-size-100);
 
-  --spectrum-cjk-font-family-stack:adobe-clean-han-japanese, var(--spectrum-cjk-font-family), sans-serif;
-  --spectrum-cjk-font:var(--spectrum-code-font-family-stack);
-  --spectrum-docs-static-white-background-color-rgb:15, 121, 125;
-  --spectrum-docs-static-white-background-color:rgba(var(--spectrum-docs-static-white-background-color-rgb));
-  --spectrum-docs-static-black-background-color-rgb:181, 209, 211;
-  --spectrum-docs-static-black-background-color:rgba(var(--spectrum-docs-static-black-background-color-rgb));
+	--spectrum-cjk-font-family-stack:adobe-clean-han-japanese, var(--spectrum-cjk-font-family), sans-serif;
+	--spectrum-cjk-font:var(--spectrum-code-font-family-stack);
+    --spectrum-docs-static-white-background-color-rgb:15, 121, 125;
+    --spectrum-docs-static-white-background-color:rgba(var(--spectrum-docs-static-white-background-color-rgb));
+    --spectrum-docs-static-black-background-color-rgb:181, 209, 211;
+    --spectrum-docs-static-black-background-color:rgba(var(--spectrum-docs-static-black-background-color-rgb));
 
-  --spectrum-coach-indicator-ring-static-white-color:var(--spectrum-white);
+    --spectrum-coach-indicator-ring-static-white-color:var(--spectrum-white);
 }

--- a/tokens/dist/css/spectrum/dark-vars.css
+++ b/tokens/dist/css/spectrum/dark-vars.css
@@ -12,65 +12,65 @@
  */
 
 .spectrum--dark{
-  --spectrum-menu-item-background-color-default-rgb:255, 255, 255;
-  --spectrum-menu-item-background-color-default-opacity:0;
-  --spectrum-menu-item-background-color-default:rgba(var(--spectrum-menu-item-background-color-default-rgb), var(--spectrum-menu-item-background-color-default-opacity));
-  --spectrum-menu-item-background-color-hover:var(--spectrum-transparent-white-200);
-  --spectrum-menu-item-background-color-down:var(--spectrum-transparent-white-200);
-  --spectrum-menu-item-background-color-key-focus:var(--spectrum-transparent-white-200);
-  --spectrum-drop-zone-background-color-rgb:var( --spectrum-blue-900-rgb);
-  --spectrum-dropindicator-color:var(--spectrum-blue-700);
+	--spectrum-menu-item-background-color-default-rgb:255, 255, 255;
+	--spectrum-menu-item-background-color-default-opacity:0;
+	--spectrum-menu-item-background-color-default:rgba(var(--spectrum-menu-item-background-color-default-rgb), var(--spectrum-menu-item-background-color-default-opacity));
+	--spectrum-menu-item-background-color-hover:var(--spectrum-transparent-white-200);
+	--spectrum-menu-item-background-color-down:var(--spectrum-transparent-white-200);
+	--spectrum-menu-item-background-color-key-focus:var(--spectrum-transparent-white-200);
+	--spectrum-drop-zone-background-color-rgb:var(--spectrum-blue-900-rgb);
+	--spectrum-dropindicator-color:var(--spectrum-blue-700);
 
-  --spectrum-calendar-day-background-color-selected:rgba(var(--spectrum-blue-800-rgb), 0.15);
-  --spectrum-calendar-day-background-color-hover:rgba(var(--spectrum-white-rgb), 0.07);
-  --spectrum-calendar-day-today-background-color-selected-hover:rgba(var(--spectrum-blue-800-rgb), 0.25);
-  --spectrum-calendar-day-background-color-selected-hover:rgba(var(--spectrum-blue-800-rgb), 0.25);
-  --spectrum-calendar-day-background-color-down:var(--spectrum-transparent-white-200);
-  --spectrum-calendar-day-background-color-cap-selected:rgba(var(--spectrum-blue-800-rgb), 0.25);
-  --spectrum-calendar-day-background-color-key-focus:rgba(var(--spectrum-white-rgb), 0.07);
-  --spectrum-calendar-day-border-color-key-focus:var(--spectrum-blue-700);
+	--spectrum-calendar-day-background-color-selected:rgba(var(--spectrum-blue-800-rgb), 0.15);
+	--spectrum-calendar-day-background-color-hover:rgba(var(--spectrum-white-rgb), 0.07);
+	--spectrum-calendar-day-today-background-color-selected-hover:rgba(var(--spectrum-blue-800-rgb), 0.25);
+	--spectrum-calendar-day-background-color-selected-hover:rgba(var(--spectrum-blue-800-rgb), 0.25);
+	--spectrum-calendar-day-background-color-down:var(--spectrum-transparent-white-200);
+	--spectrum-calendar-day-background-color-cap-selected:rgba(var(--spectrum-blue-800-rgb), 0.25);
+	--spectrum-calendar-day-background-color-key-focus:rgba(var(--spectrum-white-rgb), 0.07);
+	--spectrum-calendar-day-border-color-key-focus:var(--spectrum-blue-700);
 
-  --spectrum-card-selected-background-color-rgb:var(--spectrum-blue-500-rgb);
+	--spectrum-card-selected-background-color-rgb:var(--spectrum-blue-500-rgb);
 
-  --spectrum-badge-label-icon-color-primary:var(--spectrum-black);
+	--spectrum-badge-label-icon-color-primary:var(--spectrum-black);
 
-  --spectrum-coach-indicator-ring-default-color:var(--spectrum-blue-700);
-  --spectrum-coach-indicator-ring-dark-color:var(--spectrum-gray-900);
-  --spectrum-coach-indicator-ring-light-color:var(--spectrum-gray-50);
+	--spectrum-coach-indicator-ring-default-color:var(--spectrum-blue-700);
+	--spectrum-coach-indicator-ring-dark-color:var(--spectrum-gray-900);
+	--spectrum-coach-indicator-ring-light-color:var(--spectrum-gray-50);
 
-  --spectrum-well-border-color:rgba(var(--spectrum-white-rgb), 0.05);
+	--spectrum-well-border-color:rgba(var(--spectrum-white-rgb), 0.05);
 
-  --spectrum-steplist-current-marker-color-key-focus:var(--spectrum-blue-700);
+	--spectrum-steplist-current-marker-color-key-focus:var(--spectrum-blue-700);
 
-  --spectrum-treeview-item-background-color-quiet-selected:rgba(var(--spectrum-gray-900-rgb), 0.07);
-  --spectrum-treeview-item-background-color-selected:rgba(var(--spectrum-blue-800-rgb), 0.15);
+	--spectrum-treeview-item-background-color-quiet-selected:rgba(var(--spectrum-gray-900-rgb), 0.07);
+	--spectrum-treeview-item-background-color-selected:rgba(var(--spectrum-blue-800-rgb), 0.15);
 
-  --spectrum-logic-button-and-background-color:var(--spectrum-blue-800);
-  --spectrum-logic-button-and-border-color:var(--spectrum-blue-800);
-  --spectrum-logic-button-and-background-color-hover:var(--spectrum-blue-1000);
-  --spectrum-logic-button-and-border-color-hover:var(--spectrum-blue-1000);
+	--spectrum-logic-button-and-background-color:var(--spectrum-blue-800);
+	--spectrum-logic-button-and-border-color:var(--spectrum-blue-800);
+	--spectrum-logic-button-and-background-color-hover:var(--spectrum-blue-1000);
+	--spectrum-logic-button-and-border-color-hover:var(--spectrum-blue-1000);
 
-  --spectrum-logic-button-or-background-color:var(--spectrum-magenta-700);
-  --spectrum-logic-button-or-border-color:var(--spectrum-magenta-700);
-  --spectrum-logic-button-or-background-color-hover:var(--spectrum-magenta-900);
-  --spectrum-logic-button-or-border-color-hover:var(--spectrum-magenta-900);
+	--spectrum-logic-button-or-background-color:var(--spectrum-magenta-700);
+	--spectrum-logic-button-or-border-color:var(--spectrum-magenta-700);
+	--spectrum-logic-button-or-background-color-hover:var(--spectrum-magenta-900);
+	--spectrum-logic-button-or-border-color-hover:var(--spectrum-magenta-900);
 
-  --spectrum-assetcard-border-color-selected:var(--spectrum-blue-800);
-  --spectrum-assetcard-border-color-selected-hover:var(--spectrum-blue-800);
-  --spectrum-assetcard-border-color-selected-down:var(--spectrum-blue-900);
-  --spectrum-assetcard-selectionindicator-background-color-ordered:var(--spectrum-blue-800);
-  --spectrum-assestcard-focus-indicator-color:var(--spectrum-blue-700);
+	--spectrum-assetcard-border-color-selected:var(--spectrum-blue-800);
+	--spectrum-assetcard-border-color-selected-hover:var(--spectrum-blue-800);
+	--spectrum-assetcard-border-color-selected-down:var(--spectrum-blue-900);
+	--spectrum-assetcard-selectionindicator-background-color-ordered:var(--spectrum-blue-800);
+	--spectrum-assestcard-focus-indicator-color:var(--spectrum-blue-700);
 
-  --spectrum-assetlist-item-background-color-selected-hover:rgba(var(--spectrum-blue-800-rgb), 0.25);
-  --spectrum-assetlist-item-background-color-selected:rgba(var(--spectrum-blue-800-rgb), 0.15);
-  --spectrum-assetlist-border-color-key-focus:var(--spectrum-blue-700);
+	--spectrum-assetlist-item-background-color-selected-hover:rgba(var(--spectrum-blue-800-rgb), 0.25);
+	--spectrum-assetlist-item-background-color-selected:rgba(var(--spectrum-blue-800-rgb), 0.15);
+	--spectrum-assetlist-border-color-key-focus:var(--spectrum-blue-700);
 
-  --spectrum-swatch-border-color-rgb:255, 255, 255;
+	--spectrum-swatch-border-color-rgb:255, 255, 255;
 
-  --spectrum-swatch-border-color-opacity:0.51;
+	--spectrum-swatch-border-color-opacity:0.51;
 
-  --spectrum-swatch-border-color:rgba(var(--spectrum-swatch-border-color-rgb), var(--spectrum-swatch-border-color-opacity));
-  --spectrum-swatch-border-color-light-rgb:255, 255, 255;
-  --spectrum-swatch-border-color-light-opacity:0.2;
-  --spectrum-swatch-border-color-light:rgba(var(--spectrum-swatch-border-color-light-rgb), var(--spectrum-swatch-border-color-light-opacity));
+	--spectrum-swatch-border-color:rgba(var(--spectrum-swatch-border-color-rgb), var(--spectrum-swatch-border-color-opacity));
+	--spectrum-swatch-border-color-light-rgb:255, 255, 255;
+	--spectrum-swatch-border-color-light-opacity:0.2;
+	--spectrum-swatch-border-color-light:rgba(var(--spectrum-swatch-border-color-light-rgb), var(--spectrum-swatch-border-color-light-opacity));
 }

--- a/tokens/dist/css/spectrum/darkest-vars.css
+++ b/tokens/dist/css/spectrum/darkest-vars.css
@@ -12,65 +12,65 @@
  */
 
 .spectrum--darkest{
-  --spectrum-menu-item-background-color-default-rgb:255, 255, 255;
-  --spectrum-menu-item-background-color-default-opacity:0;
-  --spectrum-menu-item-background-color-default:rgba(var(--spectrum-menu-item-background-color-default-rgb), var(--spectrum-menu-item-background-color-default-opacity));
-  --spectrum-menu-item-background-color-hover:var(--spectrum-transparent-white-200);
-  --spectrum-menu-item-background-color-down:var(--spectrum-transparent-white-200);
-  --spectrum-menu-item-background-color-key-focus:var(--spectrum-transparent-white-200);
-  --spectrum-drop-zone-background-color-rgb:var( --spectrum-blue-900-rgb);
-  --spectrum-dropindicator-color:var(--spectrum-blue-700);
+	--spectrum-menu-item-background-color-default-rgb:255, 255, 255;
+	--spectrum-menu-item-background-color-default-opacity:0;
+	--spectrum-menu-item-background-color-default:rgba(var(--spectrum-menu-item-background-color-default-rgb), var(--spectrum-menu-item-background-color-default-opacity));
+	--spectrum-menu-item-background-color-hover:var(--spectrum-transparent-white-200);
+	--spectrum-menu-item-background-color-down:var(--spectrum-transparent-white-200);
+	--spectrum-menu-item-background-color-key-focus:var(--spectrum-transparent-white-200);
+	--spectrum-drop-zone-background-color-rgb:var(--spectrum-blue-900-rgb);
+	--spectrum-dropindicator-color:var(--spectrum-blue-700);
 
-  --spectrum-calendar-day-background-color-selected:rgba(var(--spectrum-blue-800-rgb), 0.2);
-  --spectrum-calendar-day-background-color-hover:rgba(var(--spectrum-white-rgb), 0.08);
-  --spectrum-calendar-day-today-background-color-selected-hover:rgba(var(--spectrum-blue-800-rgb), 0.3);
-  --spectrum-calendar-day-background-color-selected-hover:rgba(var(--spectrum-blue-800-rgb), 0.3);
-  --spectrum-calendar-day-background-color-down:rgba(var(--spectrum-white-rgb), 0.15);
-  --spectrum-calendar-day-background-color-cap-selected:rgba(var(--spectrum-blue-800-rgb), 0.3);
-  --spectrum-calendar-day-background-color-key-focus:rgba(var(--spectrum-white-rgb), 0.08);
-  --spectrum-calendar-day-border-color-key-focus:var(--spectrum-blue-700);
+	--spectrum-calendar-day-background-color-selected:rgba(var(--spectrum-blue-800-rgb), 0.2);
+	--spectrum-calendar-day-background-color-hover:rgba(var(--spectrum-white-rgb), 0.08);
+	--spectrum-calendar-day-today-background-color-selected-hover:rgba(var(--spectrum-blue-800-rgb), 0.3);
+	--spectrum-calendar-day-background-color-selected-hover:rgba(var(--spectrum-blue-800-rgb), 0.3);
+	--spectrum-calendar-day-background-color-down:rgba(var(--spectrum-white-rgb), 0.15);
+	--spectrum-calendar-day-background-color-cap-selected:rgba(var(--spectrum-blue-800-rgb), 0.3);
+	--spectrum-calendar-day-background-color-key-focus:rgba(var(--spectrum-white-rgb), 0.08);
+	--spectrum-calendar-day-border-color-key-focus:var(--spectrum-blue-700);
 
-  --spectrum-card-selected-background-color-rgb:var(--spectrum-blue-600-rgb);
+	--spectrum-card-selected-background-color-rgb:var(--spectrum-blue-600-rgb);
 
-  --spectrum-badge-label-icon-color-primary:var(--spectrum-black);
+	--spectrum-badge-label-icon-color-primary:var(--spectrum-black);
 
-  --spectrum-coach-indicator-ring-default-color:var(--spectrum-blue-700);
-  --spectrum-coach-indicator-ring-dark-color:var(--spectrum-gray-900);
-  --spectrum-coach-indicator-ring-light-color:var(--spectrum-gray-50);
+	--spectrum-coach-indicator-ring-default-color:var(--spectrum-blue-700);
+	--spectrum-coach-indicator-ring-dark-color:var(--spectrum-gray-900);
+	--spectrum-coach-indicator-ring-light-color:var(--spectrum-gray-50);
 
-  --spectrum-well-border-color:rgba(var(--spectrum-white-rgb), 0.05);
+	--spectrum-well-border-color:rgba(var(--spectrum-white-rgb), 0.05);
 
-  --spectrum-steplist-current-marker-color-key-focus:var(--spectrum-blue-700);
+	--spectrum-steplist-current-marker-color-key-focus:var(--spectrum-blue-700);
 
-  --spectrum-treeview-item-background-color-quiet-selected:rgba(var(--spectrum-gray-900-rgb), 0.08);
-  --spectrum-treeview-item-background-color-selected:rgba(var(--spectrum-blue-800-rgb), 0.2);
+	--spectrum-treeview-item-background-color-quiet-selected:rgba(var(--spectrum-gray-900-rgb), 0.08);
+	--spectrum-treeview-item-background-color-selected:rgba(var(--spectrum-blue-800-rgb), 0.2);
 
-  --spectrum-logic-button-and-background-color:var(--spectrum-blue-800);
-  --spectrum-logic-button-and-border-color:var(--spectrum-blue-800);
-  --spectrum-logic-button-and-background-color-hover:var(--spectrum-blue-1000);
-  --spectrum-logic-button-and-border-color-hover:var(--spectrum-blue-1000);
+	--spectrum-logic-button-and-background-color:var(--spectrum-blue-800);
+	--spectrum-logic-button-and-border-color:var(--spectrum-blue-800);
+	--spectrum-logic-button-and-background-color-hover:var(--spectrum-blue-1000);
+	--spectrum-logic-button-and-border-color-hover:var(--spectrum-blue-1000);
 
-  --spectrum-logic-button-or-background-color:var(--spectrum-magenta-700);
-  --spectrum-logic-button-or-border-color:var(--spectrum-magenta-700);
-  --spectrum-logic-button-or-background-color-hover:var(--spectrum-magenta-900);
-  --spectrum-logic-button-or-border-color-hover:var(--spectrum-magenta-900);
+	--spectrum-logic-button-or-background-color:var(--spectrum-magenta-700);
+	--spectrum-logic-button-or-border-color:var(--spectrum-magenta-700);
+	--spectrum-logic-button-or-background-color-hover:var(--spectrum-magenta-900);
+	--spectrum-logic-button-or-border-color-hover:var(--spectrum-magenta-900);
 
-  --spectrum-assetcard-border-color-selected:var(--spectrum-blue-800);
-  --spectrum-assetcard-border-color-selected-hover:var(--spectrum-blue-800);
-  --spectrum-assetcard-border-color-selected-down:var(--spectrum-blue-900);
-  --spectrum-assetcard-selectionindicator-background-color-ordered:var(--spectrum-blue-800);
-  --spectrum-assestcard-focus-indicator-color:var(--spectrum-blue-700);
+	--spectrum-assetcard-border-color-selected:var(--spectrum-blue-800);
+	--spectrum-assetcard-border-color-selected-hover:var(--spectrum-blue-800);
+	--spectrum-assetcard-border-color-selected-down:var(--spectrum-blue-900);
+	--spectrum-assetcard-selectionindicator-background-color-ordered:var(--spectrum-blue-800);
+	--spectrum-assestcard-focus-indicator-color:var(--spectrum-blue-700);
 
-  --spectrum-assetlist-item-background-color-selected-hover:rgba(var(--spectrum-blue-800-rgb), 0.3);
-  --spectrum-assetlist-item-background-color-selected:rgba(var(--spectrum-blue-800-rgb), 0.2);
-  --spectrum-assetlist-border-color-key-focus:var(--spectrum-blue-700);
+	--spectrum-assetlist-item-background-color-selected-hover:rgba(var(--spectrum-blue-800-rgb), 0.3);
+	--spectrum-assetlist-item-background-color-selected:rgba(var(--spectrum-blue-800-rgb), 0.2);
+	--spectrum-assetlist-border-color-key-focus:var(--spectrum-blue-700);
 
-  --spectrum-swatch-border-color-rgb:255, 255, 255;
+	--spectrum-swatch-border-color-rgb:255, 255, 255;
 
-  --spectrum-swatch-border-color-opacity:0.51;
+	--spectrum-swatch-border-color-opacity:0.51;
 
-  --spectrum-swatch-border-color:rgba(var(--spectrum-swatch-border-color-rgb), var(--spectrum-swatch-border-color-opacity));
-  --spectrum-swatch-border-color-light-rgb:255, 255, 255;
-  --spectrum-swatch-border-color-light-opacity:0.2;
-  --spectrum-swatch-border-color-light:rgba(var(--spectrum-swatch-border-color-light-rgb), var(--spectrum-swatch-border-color-light-opacity));
+	--spectrum-swatch-border-color:rgba(var(--spectrum-swatch-border-color-rgb), var(--spectrum-swatch-border-color-opacity));
+	--spectrum-swatch-border-color-light-rgb:255, 255, 255;
+	--spectrum-swatch-border-color-light-opacity:0.2;
+	--spectrum-swatch-border-color-light:rgba(var(--spectrum-swatch-border-color-light-rgb), var(--spectrum-swatch-border-color-light-opacity));
 }

--- a/tokens/dist/css/spectrum/global-vars.css
+++ b/tokens/dist/css/spectrum/global-vars.css
@@ -51,48 +51,48 @@
   --spectrum-heading-cjk-font-weight:var(--spectrum-extra-bold-font-weight);
   --spectrum-heading-sans-serif-emphasized-font-weight:var(--spectrum-bold-font-weight);
   --spectrum-heading-serif-emphasized-font-weight:var(--spectrum-bold-font-weight);
-  --system:spectrum;
-  --spectrum-animation-linear:cubic-bezier(0, 0, 1, 1);
-  --spectrum-animation-duration-0:0ms;
-  --spectrum-animation-duration-100:130ms;
-  --spectrum-animation-duration-200:160ms;
-  --spectrum-animation-duration-300:190ms;
-  --spectrum-animation-duration-400:220ms;
-  --spectrum-animation-duration-500:250ms;
-  --spectrum-animation-duration-600:300ms;
-  --spectrum-animation-duration-700:350ms;
-  --spectrum-animation-duration-800:400ms;
-  --spectrum-animation-duration-900:450ms;
-  --spectrum-animation-duration-1000:500ms;
-  --spectrum-animation-duration-2000:1000ms;
-  --spectrum-animation-duration-4000:2000ms;
-  --spectrum-animation-duration-6000:3000ms;
-  --spectrum-animation-ease-in-out:cubic-bezier(.45, 0, .40, 1);
-  --spectrum-animation-ease-in:cubic-bezier(.50, 0, 1, 1);
-  --spectrum-animation-ease-out:cubic-bezier(0, 0, 0.40, 1);
-  --spectrum-animation-ease-linear:cubic-bezier(0, 0, 1, 1);
+	--system:spectrum;
+	--spectrum-animation-linear:cubic-bezier(0, 0, 1, 1);
+	--spectrum-animation-duration-0:0ms;
+	--spectrum-animation-duration-100:130ms;
+	--spectrum-animation-duration-200:160ms;
+	--spectrum-animation-duration-300:190ms;
+	--spectrum-animation-duration-400:220ms;
+	--spectrum-animation-duration-500:250ms;
+	--spectrum-animation-duration-600:300ms;
+	--spectrum-animation-duration-700:350ms;
+	--spectrum-animation-duration-800:400ms;
+	--spectrum-animation-duration-900:450ms;
+	--spectrum-animation-duration-1000:500ms;
+	--spectrum-animation-duration-2000:1000ms;
+	--spectrum-animation-duration-4000:2000ms;
+	--spectrum-animation-duration-6000:3000ms;
+	--spectrum-animation-ease-in-out:cubic-bezier(0.45, 0, 0.4, 1);
+	--spectrum-animation-ease-in:cubic-bezier(0.5, 0, 1, 1);
+	--spectrum-animation-ease-out:cubic-bezier(0, 0, 0.4, 1);
+	--spectrum-animation-ease-linear:cubic-bezier(0, 0, 1, 1);
 
-  --spectrum-sans-font-family-stack:adobe-clean, var(--spectrum-sans-serif-font-family), "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, "Trebuchet MS", "Lucida Grande", sans-serif;
-  --spectrum-sans-serif-font:var(--spectrum-sans-font-family-stack);
+	--spectrum-sans-font-family-stack:adobe-clean, var(--spectrum-sans-serif-font-family), "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, "Trebuchet MS", "Lucida Grande", sans-serif;
+	--spectrum-sans-serif-font:var(--spectrum-sans-font-family-stack);
 
-  --spectrum-serif-font-family-stack:adobe-clean-serif, var(--spectrum-serif-font-family), "Source Serif Pro", Georgia, serif;
-  --spectrum-serif-font:var(--spectrum-serif-font-family-stack);
+	--spectrum-serif-font-family-stack:adobe-clean-serif, var(--spectrum-serif-font-family), "Source Serif Pro", Georgia, serif;
+	--spectrum-serif-font:var(--spectrum-serif-font-family-stack);
 
-  --spectrum-code-font-family-stack:"Source Code Pro", Monaco, monospace;
+	--spectrum-code-font-family-stack:"Source Code Pro", Monaco, monospace;
 
-  --spectrum-font-family-ar:myriad-arabic, adobe-clean, "Source Sans Pro", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, ubuntu, "Trebuchet MS", "Lucida Grande", sans-serif;
-  --spectrum-font-family-he:myriad-hebrew, adobe-clean, "Source Sans Pro", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, ubuntu, "Trebuchet MS", "Lucida Grande", sans-serif;
+	--spectrum-font-family-ar:myriad-arabic, adobe-clean, "Source Sans Pro", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, ubuntu, "Trebuchet MS", "Lucida Grande", sans-serif;
+	--spectrum-font-family-he:myriad-hebrew, adobe-clean, "Source Sans Pro", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, ubuntu, "Trebuchet MS", "Lucida Grande", sans-serif;
 
-  --spectrum-font-family:var(--spectrum-sans-font-family-stack);
-  --spectrum-font-style:var(--spectrum-default-font-style);
-  --spectrum-font-size:var(--spectrum-font-size-100);
+	--spectrum-font-family:var(--spectrum-sans-font-family-stack);
+	--spectrum-font-style:var(--spectrum-default-font-style);
+	--spectrum-font-size:var(--spectrum-font-size-100);
 
-  --spectrum-cjk-font-family-stack:adobe-clean-han-japanese, var(--spectrum-cjk-font-family), sans-serif;
-  --spectrum-cjk-font:var(--spectrum-code-font-family-stack);
-  --spectrum-docs-static-white-background-color-rgb:15, 121, 125;
-  --spectrum-docs-static-white-background-color:rgba(var(--spectrum-docs-static-white-background-color-rgb));
-  --spectrum-docs-static-black-background-color-rgb:181, 209, 211;
-  --spectrum-docs-static-black-background-color:rgba(var(--spectrum-docs-static-black-background-color-rgb));
+	--spectrum-cjk-font-family-stack:adobe-clean-han-japanese, var(--spectrum-cjk-font-family), sans-serif;
+	--spectrum-cjk-font:var(--spectrum-code-font-family-stack);
+    --spectrum-docs-static-white-background-color-rgb:15, 121, 125;
+    --spectrum-docs-static-white-background-color:rgba(var(--spectrum-docs-static-white-background-color-rgb));
+    --spectrum-docs-static-black-background-color-rgb:181, 209, 211;
+    --spectrum-docs-static-black-background-color:rgba(var(--spectrum-docs-static-black-background-color-rgb));
 
-  --spectrum-coach-indicator-ring-static-white-color:var(--spectrum-white);
+    --spectrum-coach-indicator-ring-static-white-color:var(--spectrum-white);
 }

--- a/tokens/dist/css/spectrum/large-vars.css
+++ b/tokens/dist/css/spectrum/large-vars.css
@@ -60,110 +60,110 @@
   --spectrum-corner-radius-200:10px;
   --spectrum-drop-shadow-y:2px;
   --spectrum-drop-shadow-blur:6px;
-  --spectrum-slider-tick-mark-height:13px;
-  --spectrum-slider-ramp-track-height:20px;
+	--spectrum-slider-tick-mark-height:13px;
+	--spectrum-slider-ramp-track-height:20px;
 
-  --spectrum-colorwheel-path:"M 119 119 m -119 0 a 119 119 0 1 0 238 0 a 119 119 0 1 0 -238 0.2 M 119 119 m -91 0 a 91 91 0 1 0 182 0 a 91 91 0 1 0 -182 0";
-  --spectrum-colorwheel-path-borders:"M 120 120 m -120 0 a 120 120 0 1 0 240 0 a 120 120 0 1 0 -240 0.2 M 120 120 m -90 0 a 90 90 0 1 0 180 0 a 90 90 0 1 0 -180 0";
-  --spectrum-colorwheel-colorarea-container-size:182px;
+	--spectrum-colorwheel-path:"M 119 119 m -119 0 a 119 119 0 1 0 238 0 a 119 119 0 1 0 -238 0.2 M 119 119 m -91 0 a 91 91 0 1 0 182 0 a 91 91 0 1 0 -182 0";
+	--spectrum-colorwheel-path-borders:"M 120 120 m -120 0 a 120 120 0 1 0 240 0 a 120 120 0 1 0 -240 0.2 M 120 120 m -90 0 a 90 90 0 1 0 180 0 a 90 90 0 1 0 -180 0";
+	--spectrum-colorwheel-colorarea-container-size:182px;
 
-  --spectrum-colorloupe-checkerboard-fill:url(#checkerboard-secondary);
+	--spectrum-colorloupe-checkerboard-fill:url(#checkerboard-secondary);
 
-  --spectrum-contextual-help-content-spacing:var(--spectrum-spacing-200);
+	--spectrum-contextual-help-content-spacing:var(--spectrum-spacing-200);
 
-  --spectrum-menu-item-selectable-edge-to-text-not-selected-small:34px;
-  --spectrum-menu-item-selectable-edge-to-text-not-selected-medium:42px;
-  --spectrum-menu-item-selectable-edge-to-text-not-selected-large:47px;
-  --spectrum-menu-item-selectable-edge-to-text-not-selected-extra-large:54px;
+	--spectrum-menu-item-selectable-edge-to-text-not-selected-small:34px;
+	--spectrum-menu-item-selectable-edge-to-text-not-selected-medium:42px;
+	--spectrum-menu-item-selectable-edge-to-text-not-selected-large:47px;
+	--spectrum-menu-item-selectable-edge-to-text-not-selected-extra-large:54px;
 
-  --spectrum-menu-item-checkmark-height-small:12px;
-  --spectrum-menu-item-checkmark-height-medium:14px;
-  --spectrum-menu-item-checkmark-height-large:16px;
-  --spectrum-menu-item-checkmark-height-extra-large:16px;
+	--spectrum-menu-item-checkmark-height-small:12px;
+	--spectrum-menu-item-checkmark-height-medium:14px;
+	--spectrum-menu-item-checkmark-height-large:16px;
+	--spectrum-menu-item-checkmark-height-extra-large:16px;
 
-  --spectrum-menu-item-checkmark-width-small:12px;
-  --spectrum-menu-item-checkmark-width-medium:14px;
-  --spectrum-menu-item-checkmark-width-large:16px;
-  --spectrum-menu-item-checkmark-width-extra-large:16px;
+	--spectrum-menu-item-checkmark-width-small:12px;
+	--spectrum-menu-item-checkmark-width-medium:14px;
+	--spectrum-menu-item-checkmark-width-large:16px;
+	--spectrum-menu-item-checkmark-width-extra-large:16px;
 
-  --spectrum-rating-icon-spacing:var(--spectrum-spacing-100);
+	--spectrum-rating-icon-spacing:var(--spectrum-spacing-100);
 
-  --spectrum-button-top-to-text-small:6px;
-  --spectrum-button-bottom-to-text-small:5px;
-  --spectrum-button-top-to-text-medium:9px;
-  --spectrum-button-bottom-to-text-medium:10px;
-  --spectrum-button-top-to-text-large:12px;
-  --spectrum-button-bottom-to-text-large:13px;
-  --spectrum-button-top-to-text-extra-large:16px;
-  --spectrum-button-bottom-to-text-extra-large:17px;
+	--spectrum-button-top-to-text-small:6px;
+	--spectrum-button-bottom-to-text-small:5px;
+	--spectrum-button-top-to-text-medium:9px;
+	--spectrum-button-bottom-to-text-medium:10px;
+	--spectrum-button-top-to-text-large:12px;
+	--spectrum-button-bottom-to-text-large:13px;
+	--spectrum-button-top-to-text-extra-large:16px;
+	--spectrum-button-bottom-to-text-extra-large:17px;
 
-  --spectrum-alert-banner-close-button-spacing:var(--spectrum-spacing-200);
-  --spectrum-alert-banner-edge-to-divider:var(--spectrum-spacing-200);
-  --spectrum-alert-banner-edge-to-button:var(--spectrum-spacing-200);
-  --spectrum-alert-banner-text-to-button-vertical:var(--spectrum-spacing-200);
+	--spectrum-alert-banner-close-button-spacing:var(--spectrum-spacing-200);
+	--spectrum-alert-banner-edge-to-divider:var(--spectrum-spacing-200);
+	--spectrum-alert-banner-edge-to-button:var(--spectrum-spacing-200);
+	--spectrum-alert-banner-text-to-button-vertical:var(--spectrum-spacing-200);
 
-  --spectrum-alert-dialog-padding:var(--spectrum-spacing-400);
-  --spectrum-alert-dialog-description-to-buttons:var(--spectrum-spacing-600);
+	--spectrum-alert-dialog-padding:var(--spectrum-spacing-400);
+	--spectrum-alert-dialog-description-to-buttons:var(--spectrum-spacing-600);
 
-  --spectrum-coach-indicator-gap:8px;
-  --spectrum-coach-indicator-ring-diameter:20px;
-  --spectrum-coach-indicator-quiet-ring-diameter:10px;
+	--spectrum-coach-indicator-gap:8px;
+	--spectrum-coach-indicator-ring-diameter:20px;
+	--spectrum-coach-indicator-quiet-ring-diameter:10px;
 
-  --spectrum-coachmark-buttongroup-display:none;
-  --spectrum-coachmark-buttongroup-mobile-display:flex;
-  --spectrum-coachmark-menu-display:none;
-  --spectrum-coachmark-menu-mobile-display:inline-flex;
+	--spectrum-coachmark-buttongroup-display:none;
+	--spectrum-coachmark-buttongroup-mobile-display:flex;
+	--spectrum-coachmark-menu-display:none;
+	--spectrum-coachmark-menu-mobile-display:inline-flex;
 
-  --spectrum-well-padding:20px;
-  --spectrum-well-margin-top:5px;
-  --spectrum-well-min-width:300px;
-  --spectrum-well-border-radius:5px;
-  --spectrum-workflow-icon-size-xxl:40px;
-  --spectrum-workflow-icon-size-xxs:15px;
+	--spectrum-well-padding:20px;
+	--spectrum-well-margin-top:5px;
+	--spectrum-well-min-width:300px;
+	--spectrum-well-border-radius:5px;
+	--spectrum-workflow-icon-size-xxl:40px;
+	--spectrum-workflow-icon-size-xxs:15px;
 
-  --spectrum-treeview-item-indentation-medium:20px;
-  --spectrum-treeview-item-indentation-small:15px;
-  --spectrum-treeview-item-indentation-large:25px;
-  --spectrum-treeview-item-indentation-extra-large:30px;
-  --spectrum-treeview-indicator-inset-block-start:6px;
-  --spectrum-treeview-item-min-block-size-thumbnail-offset-medium:2px;
+	--spectrum-treeview-item-indentation-medium:20px;
+	--spectrum-treeview-item-indentation-small:15px;
+	--spectrum-treeview-item-indentation-large:25px;
+	--spectrum-treeview-item-indentation-extra-large:30px;
+	--spectrum-treeview-indicator-inset-block-start:6px;
+	--spectrum-treeview-item-min-block-size-thumbnail-offset-medium:2px;
 
-  --spectrum-dialog-confirm-entry-animation-distance:25px;
-  --spectrum-dialog-confirm-hero-height:160px;
-  --spectrum-dialog-confirm-border-radius:5px;
-  --spectrum-dialog-confirm-title-text-size:19px;
-  --spectrum-dialog-confirm-description-text-size:15px;
-  --spectrum-dialog-confirm-padding-grid:24px;
+	--spectrum-dialog-confirm-entry-animation-distance:25px;
+	--spectrum-dialog-confirm-hero-height:160px;
+	--spectrum-dialog-confirm-border-radius:5px;
+	--spectrum-dialog-confirm-title-text-size:19px;
+	--spectrum-dialog-confirm-description-text-size:15px;
+	--spectrum-dialog-confirm-padding-grid:24px;
 
-  --spectrum-datepicker-initial-width:160px;
-  --spectrum-datepicker-generic-padding:15px;
-  --spectrum-datepicker-dash-line-height:30px;
-  --spectrum-datepicker-width-quiet-first:90px;
-  --spectrum-datepicker-width-quiet-second:20px;
-  --spectrum-datepicker-datetime-width-first:45px;
-  --spectrum-datepicker-invalid-icon-to-button:10px;
-  --spectrum-datepicker-invalid-icon-to-button-quiet:9px;
-  --spectrum-datepicker-input-datetime-width:30px;
+	--spectrum-datepicker-initial-width:160px;
+	--spectrum-datepicker-generic-padding:15px;
+	--spectrum-datepicker-dash-line-height:30px;
+	--spectrum-datepicker-width-quiet-first:90px;
+	--spectrum-datepicker-width-quiet-second:20px;
+	--spectrum-datepicker-datetime-width-first:45px;
+	--spectrum-datepicker-invalid-icon-to-button:10px;
+	--spectrum-datepicker-invalid-icon-to-button-quiet:9px;
+	--spectrum-datepicker-input-datetime-width:30px;
 
-  --spectrum-pagination-textfield-width:60px;
-  --spectrum-pagination-item-inline-spacing:6px;
+	--spectrum-pagination-textfield-width:60px;
+	--spectrum-pagination-item-inline-spacing:6px;
 
-  --spectrum-dial-border-radius:20px;
-  --spectrum-dial-handle-position:10px;
-  --spectrum-dial-handle-block-margin:20px;
-  --spectrum-dial-handle-inline-margin:20px;
-  --spectrum-dial-controls-margin:10px;
-  --spectrum-dial-label-gap-y:6px;
-  --spectrum-dial-label-container-top-to-text:5px;
+	--spectrum-dial-border-radius:20px;
+	--spectrum-dial-handle-position:10px;
+	--spectrum-dial-handle-block-margin:20px;
+	--spectrum-dial-handle-inline-margin:20px;
+	--spectrum-dial-controls-margin:10px;
+	--spectrum-dial-label-gap-y:6px;
+	--spectrum-dial-label-container-top-to-text:5px;
 
-  --spectrum-assetcard-focus-ring-border-radius:9px;
-  --spectrum-assetcard-selectionindicator-margin:15px;
-  --spectrum-assetcard-title-font-size:var(--spectrum-heading-size-xxs);
-  --spectrum-assetcard-header-content-font-size:var(--spectrum-heading-size-xxs);
-  --spectrum-assetcard-content-font-size:var(--spectrum-body-size-xs);
+	--spectrum-assetcard-focus-ring-border-radius:9px;
+	--spectrum-assetcard-selectionindicator-margin:15px;
+	--spectrum-assetcard-title-font-size:var(--spectrum-heading-size-xxs);
+	--spectrum-assetcard-header-content-font-size:var(--spectrum-heading-size-xxs);
+	--spectrum-assetcard-content-font-size:var(--spectrum-body-size-xs);
 
-  --spectrum-tooltip-animation-distance:5px;
+	--spectrum-tooltip-animation-distance:5px;
 
-  --spectrum-ui-icon-medium-display:none;
-  --spectrum-ui-icon-large-display:block;
+	--spectrum-ui-icon-medium-display:none;
+	--spectrum-ui-icon-large-display:block;
 }

--- a/tokens/dist/css/spectrum/light-vars.css
+++ b/tokens/dist/css/spectrum/light-vars.css
@@ -12,65 +12,65 @@
  */
 
 .spectrum--light,.spectrum--lightest{
-  --spectrum-menu-item-background-color-default-rgb:0, 0, 0;
-  --spectrum-menu-item-background-color-default-opacity:0;
-  --spectrum-menu-item-background-color-default:rgba(var(--spectrum-menu-item-background-color-default-rgb), var(--spectrum-menu-item-background-color-default-opacity));
-  --spectrum-menu-item-background-color-hover:var(--spectrum-transparent-black-200);
-  --spectrum-menu-item-background-color-down:var(--spectrum-transparent-black-200);
-  --spectrum-menu-item-background-color-key-focus:var(--spectrum-transparent-black-200);
-  --spectrum-drop-zone-background-color-rgb:var(--spectrum-blue-800-rgb);
-  --spectrum-dropindicator-color:var(--spectrum-blue-800);
+	--spectrum-menu-item-background-color-default-rgb:0, 0, 0;
+	--spectrum-menu-item-background-color-default-opacity:0;
+	--spectrum-menu-item-background-color-default:rgba(var(--spectrum-menu-item-background-color-default-rgb), var(--spectrum-menu-item-background-color-default-opacity));
+	--spectrum-menu-item-background-color-hover:var(--spectrum-transparent-black-200);
+	--spectrum-menu-item-background-color-down:var(--spectrum-transparent-black-200);
+	--spectrum-menu-item-background-color-key-focus:var(--spectrum-transparent-black-200);
+	--spectrum-drop-zone-background-color-rgb:var(--spectrum-blue-800-rgb);
+	--spectrum-dropindicator-color:var(--spectrum-blue-800);
 
-  --spectrum-calendar-day-background-color-selected:rgba(var(--spectrum-blue-900-rgb), 0.1);
-  --spectrum-calendar-day-background-color-hover:rgba(var(--spectrum-black-rgb), 0.06);
-  --spectrum-calendar-day-today-background-color-selected-hover:rgba(var(--spectrum-blue-900-rgb), 0.2);
-  --spectrum-calendar-day-background-color-selected-hover:rgba(var(--spectrum-blue-900-rgb), 0.2);
-  --spectrum-calendar-day-background-color-down:var(--spectrum-transparent-black-200);
-  --spectrum-calendar-day-background-color-cap-selected:rgba(var(--spectrum-blue-900-rgb), 0.2);
-  --spectrum-calendar-day-background-color-key-focus:rgba(var(--spectrum-black-rgb), 0.06);
-  --spectrum-calendar-day-border-color-key-focus:var(--spectrum-blue-800);
+	--spectrum-calendar-day-background-color-selected:rgba(var(--spectrum-blue-900-rgb), 0.1);
+	--spectrum-calendar-day-background-color-hover:rgba(var(--spectrum-black-rgb), 0.06);
+	--spectrum-calendar-day-today-background-color-selected-hover:rgba(var(--spectrum-blue-900-rgb), 0.2);
+	--spectrum-calendar-day-background-color-selected-hover:rgba(var(--spectrum-blue-900-rgb), 0.2);
+	--spectrum-calendar-day-background-color-down:var(--spectrum-transparent-black-200);
+	--spectrum-calendar-day-background-color-cap-selected:rgba(var(--spectrum-blue-900-rgb), 0.2);
+	--spectrum-calendar-day-background-color-key-focus:rgba(var(--spectrum-black-rgb), 0.06);
+	--spectrum-calendar-day-border-color-key-focus:var(--spectrum-blue-800);
 
-  --spectrum-card-selected-background-color-rgb:var(--spectrum-blue-900-rgb);
+	--spectrum-card-selected-background-color-rgb:var(--spectrum-blue-900-rgb);
 
-  --spectrum-badge-label-icon-color-primary:var(--spectrum-white);
+	--spectrum-badge-label-icon-color-primary:var(--spectrum-white);
 
-  --spectrum-coach-indicator-ring-default-color:var(--spectrum-blue-800);
-  --spectrum-coach-indicator-ring-dark-color:var(--spectrum-gray-900);
-  --spectrum-coach-indicator-ring-light-color:var(--spectrum-gray-50);
+	--spectrum-coach-indicator-ring-default-color:var(--spectrum-blue-800);
+	--spectrum-coach-indicator-ring-dark-color:var(--spectrum-gray-900);
+	--spectrum-coach-indicator-ring-light-color:var(--spectrum-gray-50);
 
-  --spectrum-well-border-color:var(--spectrum-black);
+	--spectrum-well-border-color:var(--spectrum-black);
 
-  --spectrum-steplist-current-marker-color-key-focus:var(--spectrum-blue-800);
+	--spectrum-steplist-current-marker-color-key-focus:var(--spectrum-blue-800);
 
-  --spectrum-treeview-item-background-color-quiet-selected:rgba(var(--spectrum-gray-900-rgb), 0.06);
-  --spectrum-treeview-item-background-color-selected:rgba(var(--spectrum-blue-900-rgb), 0.1);
+	--spectrum-treeview-item-background-color-quiet-selected:rgba(var(--spectrum-gray-900-rgb), 0.06);
+	--spectrum-treeview-item-background-color-selected:rgba(var(--spectrum-blue-900-rgb), 0.1);
 
-  --spectrum-logic-button-and-background-color:var(--spectrum-blue-900);
-  --spectrum-logic-button-and-border-color:var(--spectrum-blue-900);
-  --spectrum-logic-button-and-background-color-hover:var(--spectrum-blue-1100);
-  --spectrum-logic-button-and-border-color-hover:var(--spectrum-blue-1100);
+	--spectrum-logic-button-and-background-color:var(--spectrum-blue-900);
+	--spectrum-logic-button-and-border-color:var(--spectrum-blue-900);
+	--spectrum-logic-button-and-background-color-hover:var(--spectrum-blue-1100);
+	--spectrum-logic-button-and-border-color-hover:var(--spectrum-blue-1100);
 
-  --spectrum-logic-button-or-background-color:var(--spectrum-magenta-900);
-  --spectrum-logic-button-or-border-color:var(--spectrum-magenta-900);
-  --spectrum-logic-button-or-background-color-hover:var(--spectrum-magenta-1100);
-  --spectrum-logic-button-or-border-color-hover:var(--spectrum-magenta-1100);
+	--spectrum-logic-button-or-background-color:var(--spectrum-magenta-900);
+	--spectrum-logic-button-or-border-color:var(--spectrum-magenta-900);
+	--spectrum-logic-button-or-background-color-hover:var(--spectrum-magenta-1100);
+	--spectrum-logic-button-or-border-color-hover:var(--spectrum-magenta-1100);
 
-  --spectrum-assetcard-border-color-selected:var(--spectrum-blue-900);
-  --spectrum-assetcard-border-color-selected-hover:var(--spectrum-blue-900);
-  --spectrum-assetcard-border-color-selected-down:var(--spectrum-blue-1000);
-  --spectrum-assetcard-selectionindicator-background-color-ordered:var(--spectrum-blue-900);
-  --spectrum-assestcard-focus-indicator-color:var(--spectrum-blue-800);
+	--spectrum-assetcard-border-color-selected:var(--spectrum-blue-900);
+	--spectrum-assetcard-border-color-selected-hover:var(--spectrum-blue-900);
+	--spectrum-assetcard-border-color-selected-down:var(--spectrum-blue-1000);
+	--spectrum-assetcard-selectionindicator-background-color-ordered:var(--spectrum-blue-900);
+	--spectrum-assestcard-focus-indicator-color:var(--spectrum-blue-800);
 
-  --spectrum-assetlist-item-background-color-selected-hover:rgba(var(--spectrum-blue-900-rgb),0.2);
-  --spectrum-assetlist-item-background-color-selected:rgba(var(--spectrum-blue-900-rgb),0.1);
-  --spectrum-assetlist-border-color-key-focus:var(--spectrum-blue-800);
+	--spectrum-assetlist-item-background-color-selected-hover:rgba(var(--spectrum-blue-900-rgb), 0.2);
+	--spectrum-assetlist-item-background-color-selected:rgba(var(--spectrum-blue-900-rgb), 0.1);
+	--spectrum-assetlist-border-color-key-focus:var(--spectrum-blue-800);
 
-  --spectrum-swatch-border-color-rgb:0, 0, 0;
+	--spectrum-swatch-border-color-rgb:0, 0, 0;
 
-  --spectrum-swatch-border-color-opacity:0.51;
+	--spectrum-swatch-border-color-opacity:0.51;
 
-  --spectrum-swatch-border-color:rgba(var(--spectrum-swatch-border-color-rgb), var(--spectrum-swatch-border-color-opacity));
-  --spectrum-swatch-border-color-light-rgb:0, 0, 0;
-  --spectrum-swatch-border-color-light-opacity:0.2;
-  --spectrum-swatch-border-color-light:rgba(var(--spectrum-swatch-border-color-light-rgb), var(--spectrum-swatch-border-color-light-opacity));
+	--spectrum-swatch-border-color:rgba(var(--spectrum-swatch-border-color-rgb), var(--spectrum-swatch-border-color-opacity));
+	--spectrum-swatch-border-color-light-rgb:0, 0, 0;
+	--spectrum-swatch-border-color-light-opacity:0.2;
+	--spectrum-swatch-border-color-light:rgba(var(--spectrum-swatch-border-color-light-rgb), var(--spectrum-swatch-border-color-light-opacity));
 }

--- a/tokens/dist/css/spectrum/medium-vars.css
+++ b/tokens/dist/css/spectrum/medium-vars.css
@@ -60,109 +60,109 @@
   --spectrum-corner-radius-200:8px;
   --spectrum-drop-shadow-y:1px;
   --spectrum-drop-shadow-blur:4px;
-  --spectrum-slider-tick-mark-height:10px;
-  --spectrum-slider-ramp-track-height:16px;
+	--spectrum-slider-tick-mark-height:10px;
+	--spectrum-slider-ramp-track-height:16px;
 
-  --spectrum-colorwheel-path:"M 95 95 m -95 0 a 95 95 0 1 0 190 0 a 95 95 0 1 0 -190 0.2 M 95 95 m -73 0 a 73 73 0 1 0 146 0 a 73 73 0 1 0 -146 0";
-  --spectrum-colorwheel-path-borders:"M 96 96 m -96 0 a 96 96 0 1 0 192 0 a 96 96 0 1 0 -192 0.2 M 96 96 m -72 0 a 72 72 0 1 0 144 0 a 72 72 0 1 0 -144 0";
-  --spectrum-colorwheel-colorarea-container-size:144px;
+	--spectrum-colorwheel-path:"M 95 95 m -95 0 a 95 95 0 1 0 190 0 a 95 95 0 1 0 -190 0.2 M 95 95 m -73 0 a 73 73 0 1 0 146 0 a 73 73 0 1 0 -146 0";
+	--spectrum-colorwheel-path-borders:"M 96 96 m -96 0 a 96 96 0 1 0 192 0 a 96 96 0 1 0 -192 0.2 M 96 96 m -72 0 a 72 72 0 1 0 144 0 a 72 72 0 1 0 -144 0";
+	--spectrum-colorwheel-colorarea-container-size:144px;
 
-  --spectrum-colorloupe-checkerboard-fill:url(#checkerboard-primary);
+	--spectrum-colorloupe-checkerboard-fill:url(#checkerboard-primary);
 
-  --spectrum-contextual-help-content-spacing:var(--spectrum-spacing-100);
+	--spectrum-contextual-help-content-spacing:var(--spectrum-spacing-100);
 
-  --spectrum-menu-item-selectable-edge-to-text-not-selected-small:28px;
-  --spectrum-menu-item-selectable-edge-to-text-not-selected-medium:32px;
-  --spectrum-menu-item-selectable-edge-to-text-not-selected-large:38px;
-  --spectrum-menu-item-selectable-edge-to-text-not-selected-extra-large:45px;
+	--spectrum-menu-item-selectable-edge-to-text-not-selected-small:28px;
+	--spectrum-menu-item-selectable-edge-to-text-not-selected-medium:32px;
+	--spectrum-menu-item-selectable-edge-to-text-not-selected-large:38px;
+	--spectrum-menu-item-selectable-edge-to-text-not-selected-extra-large:45px;
 
-  --spectrum-menu-item-checkmark-height-small:10px;
-  --spectrum-menu-item-checkmark-height-medium:10px;
-  --spectrum-menu-item-checkmark-height-large:12px;
-  --spectrum-menu-item-checkmark-height-extra-large:14px;
+	--spectrum-menu-item-checkmark-height-small:10px;
+	--spectrum-menu-item-checkmark-height-medium:10px;
+	--spectrum-menu-item-checkmark-height-large:12px;
+	--spectrum-menu-item-checkmark-height-extra-large:14px;
 
-  --spectrum-menu-item-checkmark-width-small:10px;
-  --spectrum-menu-item-checkmark-width-medium:10px;
-  --spectrum-menu-item-checkmark-width-large:12px;
-  --spectrum-menu-item-checkmark-width-extra-large:14px;
+	--spectrum-menu-item-checkmark-width-small:10px;
+	--spectrum-menu-item-checkmark-width-medium:10px;
+	--spectrum-menu-item-checkmark-width-large:12px;
+	--spectrum-menu-item-checkmark-width-extra-large:14px;
 
-  --spectrum-rating-icon-spacing:var(--spectrum-spacing-75);
+	--spectrum-rating-icon-spacing:var(--spectrum-spacing-75);
 
-  --spectrum-button-top-to-text-small:5px;
-  --spectrum-button-bottom-to-text-small:4px;
-  --spectrum-button-top-to-text-medium:7px;
-  --spectrum-button-bottom-to-text-medium:8px;
-  --spectrum-button-top-to-text-large:10px;
-  --spectrum-button-bottom-to-text-large:10px;
-  --spectrum-button-top-to-text-extra-large:13px;
-  --spectrum-button-bottom-to-text-extra-large:13px;
+	--spectrum-button-top-to-text-small:5px;
+	--spectrum-button-bottom-to-text-small:4px;
+	--spectrum-button-top-to-text-medium:7px;
+	--spectrum-button-bottom-to-text-medium:8px;
+	--spectrum-button-top-to-text-large:10px;
+	--spectrum-button-bottom-to-text-large:10px;
+	--spectrum-button-top-to-text-extra-large:13px;
+	--spectrum-button-bottom-to-text-extra-large:13px;
 
-  --spectrum-alert-banner-close-button-spacing:var(--spectrum-spacing-100);
-  --spectrum-alert-banner-edge-to-divider:var(--spectrum-spacing-100);
-  --spectrum-alert-banner-edge-to-button:var(--spectrum-spacing-100);
-  --spectrum-alert-banner-text-to-button-vertical:var(--spectrum-spacing-100);
+	--spectrum-alert-banner-close-button-spacing:var(--spectrum-spacing-100);
+	--spectrum-alert-banner-edge-to-divider:var(--spectrum-spacing-100);
+	--spectrum-alert-banner-edge-to-button:var(--spectrum-spacing-100);
+	--spectrum-alert-banner-text-to-button-vertical:var(--spectrum-spacing-100);
 
-  --spectrum-alert-dialog-padding:var(--spectrum-spacing-500);
-  --spectrum-alert-dialog-description-to-buttons:var(--spectrum-spacing-700);
+	--spectrum-alert-dialog-padding:var(--spectrum-spacing-500);
+	--spectrum-alert-dialog-description-to-buttons:var(--spectrum-spacing-700);
 
-  --spectrum-coach-indicator-gap:6px;
-  --spectrum-coach-indicator-ring-diameter:var(--spectrum-spacing-300);
-  --spectrum-coach-indicator-quiet-ring-diameter:var(--spectrum-spacing-100);
+	--spectrum-coach-indicator-gap:6px;
+	--spectrum-coach-indicator-ring-diameter:var(--spectrum-spacing-300);
+	--spectrum-coach-indicator-quiet-ring-diameter:var(--spectrum-spacing-100);
 
-  --spectrum-coachmark-buttongroup-display:flex;
-  --spectrum-coachmark-buttongroup-mobile-display:none;
-  --spectrum-coachmark-menu-display:inline-flex;
-  --spectrum-coachmark-menu-mobile-display:none;
-  --spectrum-well-padding:var(--spectrum-spacing-300);
-  --spectrum-well-margin-top:var(--spectrum-spacing-75);
-  --spectrum-well-min-width:240px;
-  --spectrum-well-border-radius:var(--spectrum-spacing-75);
-  --spectrum-workflow-icon-size-xxl:32px;
-  --spectrum-workflow-icon-size-xxs:12px;
+	--spectrum-coachmark-buttongroup-display:flex;
+	--spectrum-coachmark-buttongroup-mobile-display:none;
+	--spectrum-coachmark-menu-display:inline-flex;
+	--spectrum-coachmark-menu-mobile-display:none;
+	--spectrum-well-padding:var(--spectrum-spacing-300);
+	--spectrum-well-margin-top:var(--spectrum-spacing-75);
+	--spectrum-well-min-width:240px;
+	--spectrum-well-border-radius:var(--spectrum-spacing-75);
+	--spectrum-workflow-icon-size-xxl:32px;
+	--spectrum-workflow-icon-size-xxs:12px;
 
-  --spectrum-treeview-item-indentation-medium:var(--spectrum-spacing-300);
-  --spectrum-treeview-item-indentation-small:var(--spectrum-spacing-200);
-  --spectrum-treeview-item-indentation-large:20px;
-  --spectrum-treeview-item-indentation-extra-large:var(--spectrum-spacing-400);
-  --spectrum-treeview-indicator-inset-block-start:5px;
-  --spectrum-treeview-item-min-block-size-thumbnail-offset-medium:0px;
+	--spectrum-treeview-item-indentation-medium:var(--spectrum-spacing-300);
+	--spectrum-treeview-item-indentation-small:var(--spectrum-spacing-200);
+	--spectrum-treeview-item-indentation-large:20px;
+	--spectrum-treeview-item-indentation-extra-large:var(--spectrum-spacing-400);
+	--spectrum-treeview-indicator-inset-block-start:5px;
+	--spectrum-treeview-item-min-block-size-thumbnail-offset-medium:0px;
 
-  --spectrum-dialog-confirm-entry-animation-distance:20px;
-  --spectrum-dialog-confirm-hero-height:128px;
-  --spectrum-dialog-confirm-border-radius:4px;
-  --spectrum-dialog-confirm-title-text-size:18px;
-  --spectrum-dialog-confirm-description-text-size:14px;
-  --spectrum-dialog-confirm-padding-grid:40px;
+	--spectrum-dialog-confirm-entry-animation-distance:20px;
+	--spectrum-dialog-confirm-hero-height:128px;
+	--spectrum-dialog-confirm-border-radius:4px;
+	--spectrum-dialog-confirm-title-text-size:18px;
+	--spectrum-dialog-confirm-description-text-size:14px;
+	--spectrum-dialog-confirm-padding-grid:40px;
 
-  --spectrum-datepicker-initial-width:128px;
-  --spectrum-datepicker-generic-padding:var(--spectrum-spacing-200);
-  --spectrum-datepicker-dash-line-height:24px;
-  --spectrum-datepicker-width-quiet-first:72px;
-  --spectrum-datepicker-width-quiet-second:16px;
-  --spectrum-datepicker-datetime-width-first:36px;
-  --spectrum-datepicker-invalid-icon-to-button:8px;
-  --spectrum-datepicker-invalid-icon-to-button-quiet:7px;
-  --spectrum-datepicker-input-datetime-width:var(--spectrum-spacing-400);
+	--spectrum-datepicker-initial-width:128px;
+	--spectrum-datepicker-generic-padding:var(--spectrum-spacing-200);
+	--spectrum-datepicker-dash-line-height:24px;
+	--spectrum-datepicker-width-quiet-first:72px;
+	--spectrum-datepicker-width-quiet-second:16px;
+	--spectrum-datepicker-datetime-width-first:36px;
+	--spectrum-datepicker-invalid-icon-to-button:8px;
+	--spectrum-datepicker-invalid-icon-to-button-quiet:7px;
+	--spectrum-datepicker-input-datetime-width:var(--spectrum-spacing-400);
 
-  --spectrum-pagination-textfield-width:var(--spectrum-spacing-700);
-  --spectrum-pagination-item-inline-spacing:5px;
+	--spectrum-pagination-textfield-width:var(--spectrum-spacing-700);
+	--spectrum-pagination-item-inline-spacing:5px;
 
-  --spectrum-dial-border-radius:16px;
-  --spectrum-dial-handle-position:8px;
-  --spectrum-dial-handle-block-margin:16px;
-  --spectrum-dial-handle-inline-margin:16px;
-  --spectrum-dial-controls-margin:8px;
-  --spectrum-dial-label-gap-y:5px;
-  --spectrum-dial-label-container-top-to-text:4px;
+	--spectrum-dial-border-radius:16px;
+	--spectrum-dial-handle-position:8px;
+	--spectrum-dial-handle-block-margin:16px;
+	--spectrum-dial-handle-inline-margin:16px;
+	--spectrum-dial-controls-margin:8px;
+	--spectrum-dial-label-gap-y:5px;
+	--spectrum-dial-label-container-top-to-text:4px;
 
-  --spectrum-assetcard-focus-ring-border-radius:8px;
-  --spectrum-assetcard-selectionindicator-margin:12px;
-  --spectrum-assetcard-title-font-size:var(--spectrum-heading-size-xs);
-  --spectrum-assetcard-header-content-font-size:var(--spectrum-heading-size-xs);
-  --spectrum-assetcard-content-font-size:var(--spectrum-body-size-s);
+	--spectrum-assetcard-focus-ring-border-radius:8px;
+	--spectrum-assetcard-selectionindicator-margin:12px;
+	--spectrum-assetcard-title-font-size:var(--spectrum-heading-size-xs);
+	--spectrum-assetcard-header-content-font-size:var(--spectrum-heading-size-xs);
+	--spectrum-assetcard-content-font-size:var(--spectrum-body-size-s);
 
-  --spectrum-tooltip-animation-distance:var(--spectrum-spacing-75);
+	--spectrum-tooltip-animation-distance:var(--spectrum-spacing-75);
 
-  --spectrum-ui-icon-medium-display:block;
-  --spectrum-ui-icon-large-display:none;
+	--spectrum-ui-icon-medium-display:block;
+	--spectrum-ui-icon-large-display:none;
 }

--- a/tokens/project.json
+++ b/tokens/project.json
@@ -45,6 +45,8 @@
 			},
 			"outputs": []
 		},
+		"format": {},
+		"lint": {},
 		"style-dictionary": {
 			"dependsOn": ["clean"],
 			"executor": "@nxkit/style-dictionary:build",

--- a/tokens/tasks/token-rollup.js
+++ b/tokens/tasks/token-rollup.js
@@ -11,6 +11,8 @@
  * governing permissions and limitations under the License.
  */
 
+/* eslint-disable no-console */
+
 const fs = require("fs");
 const fsp = fs.promises;
 const path = require("path");

--- a/tokens/utilities/style-dictionary.utils.js
+++ b/tokens/utilities/style-dictionary.utils.js
@@ -83,7 +83,8 @@ module.exports = function ({ setName, subSystemName } = {}) {
 			) {
 				return true;
 			}
-		} else {
+		}
+		else {
 			if (!tokenSets.includes(setName)) return false;
 
 			if (!subSystemName && tokenSets.length === 1) {


### PR DESCRIPTION
## Description

Remove tokens assets from the .prettierignore logic to simplify making changes to the `custom-*/*.css` files.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

@jawinn 
- [x] `yarn linter tokens`: should successfully run and report no needed changes
- [x] `yarn formatter tokens`: should pass and make no additional changes to the assets

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] ✨ This pull request is ready to merge. ✨
