### PR TITLE
fix(coachmark): correct invalid token pointers in pagination styles [CSS-1011]

### DIFF
--- a/.changeset/lucky-experts-grow.md
+++ b/.changeset/lucky-experts-grow.md
@@ -2,4 +2,4 @@
 "@spectrum-css/coachmark": minor
 ---
 
-Update coach mark pagination to use provided font-family; update font-weight & line-height references to existing tokens.
+Update coach mark pagination to add `font-family`, using the existing custom property. Update the `font-weight` and `line-height` to reference the correct tokens.

--- a/.changeset/lucky-experts-grow.md
+++ b/.changeset/lucky-experts-grow.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/coachmark": minor
+---
+
+Update coach mark pagination to use provided font-family; update font-weight & line-height references to existing tokens.

--- a/components/coachmark/index.css
+++ b/components/coachmark/index.css
@@ -44,7 +44,7 @@
 	--spectrum-coachmark-content-font-size: var(--spectrum-coach-mark-body-size);
 
 	--spectrum-coachmark-step-color: var(--spectrum-coach-mark-pagination-color);
-	--spectrum-coachmark-step-font-weight: var(--spectrum-body-medium-font-weight);
+	--spectrum-coachmark-step-font-weight: var(--spectrum-body-sans-serif-font-weight);
 	--spectrum-coachmark-step-font-family: var(--spectrum-sans-serif-font);
 	--spectrum-coachmark-step-font-style: var(--spectrum-body-sans-serif-font-style);
 	--spectrum-coachmark-step-line-height: var(--spectrum-body-line-height);
@@ -57,9 +57,7 @@
 	--mod-popover-corner-radius: var(--spectrum-corner-radius-100);
 	--mod-popover-content-area-spacing-vertical: 0;
 	--mod-button-edge-to-visual-only: 9px;
-}
 
-.spectrum-CoachMark {
 	position: relative;
 	min-inline-size: var(--mod-coachmark-min-width, var(--spectrum-coachmark-min-width));
 	max-inline-size: var(--mod-coachmark-max-width, var(--spectrum-coachmark-max-width));
@@ -158,9 +156,10 @@
 	justify-self: start;
 	color: var(--mod-coachmark-step-color, var(--spectrum-coachmark-step-color));
 	font-size: var(--mod-coachmark-step-font-size, var(--spectrum-coachmark-step-font-size));
-	font-weight: var(--mod-coachmark-step-text-font-weight, var(--spectrum-coachmark-step-text-font-weight));
+	font-weight: var(--mod-coachmark-step-text-font-weight, var(--spectrum-coachmark-step-font-weight));
+	font-family: var(--spectrum-coachmark-step-font-family);
 	font-style: var(--mod-coachmark-step-font-style, var(--spectrum-coachmark-step-font-style));
-	line-height: var(--mod-coachmark-step-text-line-height, var(--spectrum-coachmark-step-text-line-height));
+	line-height: var(--mod-coachmark-step-text-line-height, var(--spectrum-coachmark-step-line-height));
 	white-space: nowrap;
 	margin-block-end: calc(var(--mod-coachmark-step-to-bottom, var(--spectrum-coachmark-step-to-bottom)) - var(--mod-coachmark-padding, var(--spectrum-coachmark-padding)));
 }

--- a/components/coachmark/metadata/metadata.json
+++ b/components/coachmark/metadata/metadata.json
@@ -85,8 +85,6 @@
     "--spectrum-coachmark-step-font-style",
     "--spectrum-coachmark-step-font-weight",
     "--spectrum-coachmark-step-line-height",
-    "--spectrum-coachmark-step-text-font-weight",
-    "--spectrum-coachmark-step-text-line-height",
     "--spectrum-coachmark-step-to-bottom",
     "--spectrum-coachmark-title-color",
     "--spectrum-coachmark-title-font-family",
@@ -99,7 +97,6 @@
   "global": [
     "--spectrum-body-color",
     "--spectrum-body-line-height",
-    "--spectrum-body-medium-font-weight",
     "--spectrum-body-sans-serif-font-style",
     "--spectrum-body-sans-serif-font-weight",
     "--spectrum-border-width-100",


### PR DESCRIPTION
## Description

During S2 development, I noticed a regression in pagination styles for the Coach Mark step and discovered this was due to font styles pointing to spectrum tokens that are not defined. There are however unused tokens defined with similar names. This PR points those typography elements to the appropriate styles.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

See comment below for verification via the visual regression test results.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<img width="377" alt="Screenshot 2024-10-22 at 4 12 38 PM" src="https://github.com/user-attachments/assets/bcf24f47-4fc5-494b-9638-2742df403b7c">

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [x] ✨ This pull request is ready to merge. ✨
