### PR TITLE
chore(rating): create property for forced-colors value to satisfy lint requirements

### DIFF
--- a/.changeset/flat-ads-compete.md
+++ b/.changeset/flat-ads-compete.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/rating": patch
+---
+
+Assigns CanvasText to custom property to satisfy linting requirements.

--- a/components/rating/index.css
+++ b/components/rating/index.css
@@ -247,9 +247,10 @@
 		--highcontrast-rating-emphasized-icon-color-default: Highlight;
 		--highcontrast-rating-emphasized-icon-color-hover: Highlight;
 		--highcontrast-rating-emphasized-icon-color-down: Highlight;
+		--highcontrast-rating-focus-color-outline: CanvasText;
 
 		&.is-focused {
-			outline: 1px solid CanvasText; /* stylelint-disable-line declaration-property-value-no-unknown */
+			outline: 1px solid var(--highcontrast-rating-focus-color-outline);
 		}
 
 		&:hover .spectrum-Rating-icon.is-currentValue::after {

--- a/components/rating/metadata/metadata.json
+++ b/components/rating/metadata/metadata.json
@@ -118,6 +118,7 @@
     "--highcontrast-rating-emphasized-icon-color-down",
     "--highcontrast-rating-emphasized-icon-color-hover",
     "--highcontrast-rating-emphasized-icon-color-key-focus",
+    "--highcontrast-rating-focus-color-outline",
     "--highcontrast-rating-focus-indicator-color",
     "--highcontrast-rating-icon-color-default",
     "--highcontrast-rating-icon-color-disabled",


### PR DESCRIPTION
## Description

Assigns CanvasText to custom property to satisfy linting requirements.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨