### PR TITLE
chore(search): move custom property to resolve lint violation

### DIFF
--- a/.changeset/gold-pens-clean.md
+++ b/.changeset/gold-pens-clean.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/search": patch
+---
+
+Resolves lint violation in search by moving spectrum-search-color custom property above style declarations.

--- a/components/search/index.css
+++ b/components/search/index.css
@@ -162,12 +162,12 @@
 }
 
 .spectrum-Search-icon {
+	--spectrum-search-color: var(--highcontrast-search-color-default, var(--mod-search-color-default, var(--spectrum-search-color-default)));
+
 	display: block;
 	position: absolute;
 	inset-block: 0;
 	margin-block: auto;
-
-	--spectrum-search-color: var(--highcontrast-search-color-default, var(--mod-search-color-default, var(--spectrum-search-color-default)));
 	color: var(--spectrum-search-color);
 
 	.spectrum-Search-textfield:hover & {


### PR DESCRIPTION
## Description

Resolves lint violation in search by moving spectrum-search-color custom property above style declarations.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨