### PR TITLE
fix(search): update icon sizing calculation in the quiet variant [CSS-1012]

### DIFF
--- a/.changeset/dirty-suits-mix.md
+++ b/.changeset/dirty-suits-mix.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/search": patch
+---
+
+Deprecated `--mod-workflow-icon-size-100` from the `.spectrum-Search--quiet` calculation of the `--spectrum-search-quiet-button-offset`. Use `--mod-search-icon-size` instead. Deprecated property will be removed in the next breaking change release.

--- a/components/clearbutton/index.css
+++ b/components/clearbutton/index.css
@@ -23,6 +23,17 @@
 	--spectrum-clear-button-icon-color-hover: var(--spectrum-neutral-content-color-hover);
 	--spectrum-clear-button-icon-color-down: var(--spectrum-neutral-content-color-down);
 	--spectrum-clear-button-icon-color-key-focus: var(--spectrum-neutral-content-color-key-focus);
+    
+	block-size: var(--mod-clear-button-height, var(--spectrum-clear-button-height));
+	inline-size: var(--mod-clear-button-width, var(--spectrum-clear-button-width));
+	border-radius: 100%;
+
+	background-color: var(--mod-clear-button-background-color, transparent);
+	margin: 0;
+	padding: var(--mod-clear-button-padding, var(--spectrum-clear-button-padding));
+
+	border: none;
+	color: var(--mod-clear-button-icon-color, var(--spectrum-clear-button-icon-color));
 
 	&.spectrum-ClearButton--sizeS {
 		--spectrum-clear-button-height: var(--spectrum-component-height-75);
@@ -71,23 +82,10 @@
 	&.spectrum-ClearButton--staticWhite {
 		--spectrum-clear-button-icon-color-disabled: var(--spectrum-disabled-static-white-content-color);
 	}
-}
-
-.spectrum-ClearButton {
-	block-size: var(--mod-clear-button-height, var(--spectrum-clear-button-height));
-	inline-size: var(--mod-clear-button-width, var(--spectrum-clear-button-width));
-	border-radius: 100%;
 
 	&:not(:disabled) {
 		cursor: pointer;
 	}
-
-	background-color: var(--mod-clear-button-background-color, transparent);
-	margin: 0;
-	padding: var(--mod-clear-button-padding, var(--spectrum-clear-button-padding));
-
-	border: none;
-	color: var(--mod-clear-button-icon-color, var(--spectrum-clear-button-icon-color));
 
 	> .spectrum-Icon {
 		/* @safari10 Workaround for https://bugs.webkit.org/show_bug.cgi?id=169700 */

--- a/components/search/index.css
+++ b/components/search/index.css
@@ -80,6 +80,15 @@
 	--mod-textfield-background-color: var(--mod-search-background-color, var(--spectrum-search-background-color));
 	--mod-textfield-background-color-disabled: var(--mod-search-background-color-disabled, var(--spectrum-search-background-color-disabled));
 	/* @passthrough end */
+
+	display: inline-block;
+	position: relative;
+	inline-size: var(--mod-search-inline-size, var(--spectrum-search-inline-size));
+	min-inline-size: var(--mod-search-min-inline-size, var(--spectrum-search-min-inline-size));
+
+	.spectrum-HelpText {
+		margin-block-start: var(--mod-search-to-help-text, var(--spectrum-search-to-help-text));
+	}
 }
 
 .spectrum-Search--sizeS {
@@ -100,19 +109,6 @@
 	--spectrum-search-text-to-icon: var(--spectrum-text-to-visual-300);
 }
 
-.spectrum-Search--quiet {
-	--spectrum-search-quiet-button-offset: calc((var(--mod-search-block-size, var(--spectrum-search-block-size)) / 2) - (var(--mod-workflow-icon-size-100, var(--spectrum-workflow-icon-size-100)) / 2));
-	--spectrum-search-background-color: transparent;
-	--spectrum-search-background-color-disabled: transparent;
-	--spectrum-search-border-color-disabled: var(--spectrum-disabled-border-color);
-
-	/* Added specificity, otherwise they are overridden by system specific themes. */
-	&.spectrum-Search {
-		--spectrum-search-border-radius: 0;
-		--spectrum-search-edge-to-visual: var(--spectrum-field-edge-to-visual-quiet);
-	}
-}
-
 @media (forced-colors: active) {
 	.spectrum-Search .spectrum-Search-textfield,
 	.spectrum-Search .spectrum-Search-textfield .spectrum-Search-input {
@@ -128,18 +124,6 @@
 			forced-color-adjust: none;
 			background-color: transparent;
 		}
-	}
-}
-
-/* Standard / Default */
-.spectrum-Search {
-	display: inline-block;
-	position: relative;
-	inline-size: var(--mod-search-inline-size, var(--spectrum-search-inline-size));
-	min-inline-size: var(--mod-search-min-inline-size, var(--spectrum-search-min-inline-size));
-
-	.spectrum-HelpText {
-		margin-block-start: var(--mod-search-to-help-text, var(--spectrum-search-to-help-text));
 	}
 }
 
@@ -198,18 +182,18 @@
 	/* Without this, it gets overridden by .spectrum-Textfield */
 	appearance: none;
 
-	/* Remove the inner padding and cancel buttons for input[type="search"] in Chrome and Safari on macOS. */
-	&::-webkit-search-cancel-button,
-	&::-webkit-search-decoration {
-		appearance: none;
-	}
-
 	block-size: var(--mod-search-block-size, var(--spectrum-search-block-size));
 	padding-block-start: calc(var(--mod-search-top-to-text, var(--spectrum-search-top-to-text)) - var(--mod-search-border-width, var(--spectrum-search-border-width)));
 	padding-block-end: calc(var(--mod-search-bottom-to-text, var(--spectrum-search-bottom-to-text)) - var(--mod-search-border-width, var(--spectrum-search-border-width)));
 
 	font-style: var(--mod-search-font-style, var(--spectrum-search-font-style));
 	line-height: var(--mod-search-line-height, var(--spectrum-search-line-height));
+
+	/* Remove the inner padding and cancel buttons for input[type="search"] in Chrome and Safari on macOS. */
+	&::-webkit-search-cancel-button,
+	&::-webkit-search-decoration {
+		appearance: none;
+	}
 }
 
 /* Standard / Default Only */
@@ -226,14 +210,20 @@
 
 /* Quiet Variant */
 .spectrum-Search--quiet {
-	.spectrum-Search-clearButton .spectrum-ClearButton-icon {
-		transform: translateX(var(--mod-search-quiet-button-offset, var(--spectrum-search-quiet-button-offset)));
+	--spectrum-search-background-color: transparent;
+	--spectrum-search-background-color-disabled: transparent;
+	--spectrum-search-border-color-disabled: var(--spectrum-disabled-border-color);
+
+	/* Added specificity, otherwise they are overridden by system specific themes. */
+	&.spectrum-Search {
+		--spectrum-search-border-radius: 0;
+		--spectrum-search-edge-to-visual: var(--spectrum-field-edge-to-visual-quiet);
 	}
 
 	&.spectrum-Search .spectrum-Search-input {
 		border-radius: var(--mod-search-border-radius, var(--spectrum-search-border-radius));
 		padding-inline-start: calc(var(--mod-search-edge-to-visual, var(--spectrum-search-edge-to-visual)) + var(--mod-search-icon-size, var(--spectrum-search-icon-size)) + var(--mod-search-text-to-icon, var(--spectrum-search-text-to-icon)));
-		padding-inline-end: calc(var(--mod-search-button-inline-size, var(--spectrum-search-button-inline-size)) - var(--mod-search-quiet-button-offset, var(--spectrum-search-quiet-button-offset)));
+		padding-inline-end: calc(var(--mod-search-button-inline-size, var(--spectrum-search-button-inline-size)) - var(--mod-search-quiet-button-offset, calc(var(--mod-search-block-size, var(--spectrum-search-block-size)) / 2 - var(--mod-search-icon-size, var(--spectrum-search-icon-size)) / 2)));
 		padding-block-start: var(--mod-search-top-to-text, var(--spectrum-search-top-to-text));
 	}
 }

--- a/components/search/metadata/metadata.json
+++ b/components/search/metadata/metadata.json
@@ -7,7 +7,6 @@
     ".spectrum-Search .spectrum-Search-textfield",
     ".spectrum-Search .spectrum-Search-textfield .spectrum-Search-input",
     ".spectrum-Search--quiet",
-    ".spectrum-Search--quiet .spectrum-Search-clearButton .spectrum-ClearButton-icon",
     ".spectrum-Search--quiet.spectrum-Search",
     ".spectrum-Search--quiet.spectrum-Search .spectrum-Search-input",
     ".spectrum-Search--sizeL",
@@ -65,8 +64,7 @@
     "--mod-search-quiet-button-offset",
     "--mod-search-text-to-icon",
     "--mod-search-to-help-text",
-    "--mod-search-top-to-text",
-    "--mod-workflow-icon-size-100"
+    "--mod-search-top-to-text"
   ],
   "component": [
     "--spectrum-search-background-color",
@@ -101,7 +99,6 @@
     "--spectrum-search-inline-size",
     "--spectrum-search-line-height",
     "--spectrum-search-min-inline-size",
-    "--spectrum-search-quiet-button-offset",
     "--spectrum-search-text-to-icon",
     "--spectrum-search-to-help-text",
     "--spectrum-search-top-to-text"

--- a/components/search/metadata/mods.md
+++ b/components/search/metadata/mods.md
@@ -34,4 +34,3 @@
 | `--mod-search-text-to-icon`              |
 | `--mod-search-to-help-text`              |
 | `--mod-search-top-to-text`               |
-| `--mod-workflow-icon-size-100`           |

--- a/components/search/stories/search.stories.js
+++ b/components/search/stories/search.stories.js
@@ -83,6 +83,9 @@ HelpText.args = {
 	hasDescription: true,
 };
 HelpText.tags = ["!dev"];
+HelpText.parameters = {
+	chromatic: { disableSnapshot: true },
+};
 
 /**
  * A quiet search field can be used when searching isn’t a high priority action on the page. These search fields have no visible background, and this style works best when a clear layout makes the field easy to recognize. Too many quiet components in a small space can be hard to read.
@@ -92,6 +95,9 @@ Quiet.args = {
 	isQuiet: true,
 };
 Quiet.tags = ["!dev"];
+Quiet.parameters = {
+	chromatic: { disableSnapshot: true },
+};
 
 
 /**


### PR DESCRIPTION
## Description

A bug fix for the Search component's quiet variant. The `--spectrum-search-quiet-button-offset` was being calculated using a static workflow icon size of 100 but the search icon sizing is set using t-shirt sizing and varies. This PR updates the calculation to use the variable `--spectrum-search-icon-size` which updates based on the determined t-shirt size.

This also adds a deprecation notice for the `--mod-workflow-icon-size-100` and suggests the use of the `--mod-search-icon-size` instead.

I didn't add a changeset for the update to clearbutton because it just combines the duplicate selectors for `.spectrum-ClearButton`.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [x] Expect VRTs to reflect the updated offset spacing between the search icon and the Search text in the quiet variant.
- [x] The space between clear icon and the end of the input field should vary based on which t-shirt size is used for the clear icon.

<img width="503" alt="Screenshot 2024-10-22 at 4 56 02 PM" src="https://github.com/user-attachments/assets/c037ba29-b1b1-43c0-942a-c262d1891dd9">

<img width="511" alt="Screenshot 2024-10-22 at 4 56 13 PM" src="https://github.com/user-attachments/assets/d9367c62-bce4-4331-8e2d-a856949d8f1c">

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] ✨ This pull request is ready to merge. ✨
