### PR TITLE
chore(slider): add comment as description to stylelint disable

### DIFF
--- a/.changeset/wet-bulldogs-shake.md
+++ b/.changeset/wet-bulldogs-shake.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/slider": patch
+---
+
+Resolves violation error by moving todo comment into stylelint disable comment as a description

--- a/components/slider/index.css
+++ b/components/slider/index.css
@@ -129,7 +129,7 @@
 	.spectrum-Slider-labelContainer {
 		margin-block-start: 0;
 
-		.spectrum-Slider-label { 
+		.spectrum-Slider-label {
 			margin-inline-end: var(--mod-slider-value-side-padding-inline, var(--spectrum-slider-value-side-padding-inline));
 		}
 	}
@@ -391,8 +391,8 @@
 	inset-block-start: var(--mod-slider-input-top-size, var(--spectrum-slider-input-top-size));
 	inset-inline-start: var(--mod-slider-input-left, var(--spectrum-slider-input-left));
 	overflow: hidden;
-	/* @todo Look into replacing with opacity 0. The tiny opacity value appears to be a workaround for a ChromeVox legacy bug (circa 2018). */
-	opacity: 0.000001; /* stylelint-disable-line number-max-precision */
+	/* stylelint-disable-next-line number-max-precision -- @todo Look into replacing with opacity 0. The tiny opacity value appears to be a workaround for a ChromeVox legacy bug (circa 2018). */
+	opacity: 0.000001;
 	cursor: default;
 	appearance: none;
 	border: 0;


### PR DESCRIPTION
## Description

Resolves lint violation by moving todo comment into stylelint disable comment as a description

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
