### PR TITLE
fix(CSS-1009): stylelint clean-up for unused custom properties

### DIFF
--- a/.changeset/few-icons-kneel.md
+++ b/.changeset/few-icons-kneel.md
@@ -1,0 +1,8 @@
+---
+"@spectrum-css/datepicker": patch
+"@spectrum-css/dropzone": patch
+"@spectrum-css/search": patch
+"@spectrum-css/menu": patch
+---
+
+Add passthrough markers to prevent unnecessary warnings about unused custom properties

--- a/.changeset/khaki-pugs-rescue.md
+++ b/.changeset/khaki-pugs-rescue.md
@@ -1,0 +1,6 @@
+---
+"@spectrum-css/colorslider": patch
+"@spectrum-css/slider": patch
+---
+
+Remove duplicate references

--- a/.changeset/wise-apricots-repeat.md
+++ b/.changeset/wise-apricots-repeat.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-tools/stylelint-no-unused-custom-properties": patch
+---
+
+Minor logic clean-up for more efficient escapes when checking for warnings.

--- a/components/colorslider/index.css
+++ b/components/colorslider/index.css
@@ -11,15 +11,7 @@
  * governing permissions and limitations under the License.
  */
 
-.spectrum-ColorSlider {
-	/* @todo Refactor with --spectrum-color-slider-border-color once gray rgb token is no longer necessary to workaround nested rgb color token value using rgba(). */
-	--spectrum-color-slider-border-color-rgba: rgba(var(--spectrum-gray-900-rgb), var(--spectrum-color-slider-border-opacity));
-
-	/* Settings for nested Color handle */
-	--mod-colorhandle-hitarea-border-radius: var(--mod-color-slider-handle-hitarea-border-radius, 0px);
-}
-
-@media (forced-colors: active) {
+ @media (forced-colors: active) {
 	.spectrum-ColorSlider {
 		--highcontrast-color-slider-border-color: CanvasText;
 		--highcontrast-color-slider-border-color-disabled: GrayText;
@@ -29,6 +21,12 @@
 }
 
 .spectrum-ColorSlider {
+	/* @todo Refactor with --spectrum-color-slider-border-color once gray rgb token is no longer necessary to workaround nested rgb color token value using rgba(). */
+	--spectrum-color-slider-border-color-rgba: rgba(var(--spectrum-gray-900-rgb), var(--spectrum-color-slider-border-opacity));
+
+	/* Settings for nested Color handle */
+	--mod-colorhandle-hitarea-border-radius: var(--mod-color-slider-handle-hitarea-border-radius, 0px);
+
 	position: relative;
 	display: block;
 
@@ -61,11 +59,6 @@
 	block-size: var(--mod-color-slider-vertical-height, var(--mod-color-slider-length, var(--spectrum-color-slider-length)));
 	min-inline-size: 0;
 	inline-size: var(--mod-color-slider-vertical-control-track-width, var(--mod-color-slider-control-track-height, var(--spectrum-color-control-track-width)));
-
-	.spectrum-ColorSlider-handle {
-		inset-inline-start: 50%;
-		inset-block-start: 0;
-	}
 
 	.spectrum-ColorSlider-handle {
 		inset-inline-start: 50%;

--- a/components/datepicker/index.css
+++ b/components/datepicker/index.css
@@ -91,10 +91,11 @@
 }
 
 .spectrum-DatePicker:not(.spectrum-DatePicker--quiet, .is-disabled) {
-	/* ensures picker button border color matches the textfield border color */
+	/* @passthrough -- ensures picker button border color matches the textfield border color */
 	--mod-picker-button-border-color: var(--highcontrast-datepicker-pickerbutton-border-color, var(--mod-datepicker-pickerbutton-border-color, var(--spectrum-datepicker-pickerbutton-border-color)));
 
 	&.is-invalid {
+		/* @passthrough */
 		--mod-picker-button-border-color: var(--highcontrast-datepicker-pickerbutton-border-color, var(--mod-datepicker-pickerbutton-border-color-invalid, var(--spectrum-datepicker-pickerbutton-border-color-invalid)));
 	}
 }

--- a/components/dropzone/index.css
+++ b/components/dropzone/index.css
@@ -55,7 +55,7 @@
 	--spectrum-drop-zone-content-background-color: var(--spectrum-accent-visual-color);
 	--spectrum-drop-zone-content-color: var(--spectrum-white);
 
-	/* Settings for a nested illustrated message */
+	/* @passthrough start -- settings for a nested illustrated message */
 	--mod-illustrated-message-content-maximum-width: var(--mod-drop-zone-content-maximum-width, var(--spectrum-drop-zone-content-maximum-width));
 	--mod-illustrated-message-illustration-color: var(--mod-drop-zone-illustration-color, var(--spectrum-drop-zone-illustration-color));
 	--mod-illustrated-message-title-to-heading: var(--mod-drop-zone-illustration-to-heading, var(--spectrum-drop-zone-illustration-to-heading));
@@ -75,11 +75,13 @@
 	--mod-illustrated-message-description-font-size: var(--mod-drop-zone-body-font-size, var(--spectrum-drop-zone-body-font-size));
 	--mod-illustrated-message-description-line-height: var(--mod-drop-zone-body-line-height, var(--spectrum-drop-zone-body-line-height));
 	--mod-illustrated-message-description-color: var(--mod-drop-zone-body-color, var(--spectrum-drop-zone-body-color));
+	/* @passthrough end */
 
-	/* Settings for a nested actionbutton */
+	/* @passthrough start -- settings for a nested actionbutton */
 	--mod-actionbutton-font-size: var(--mod-drop-zone-content-font-size, var(--spectrum-drop-zone-content-font-size));
 	--mod-actionbutton-label-color: var(--mod-drop-zone-content-color, var(--spectrum-drop-zone-content-color));
 	--mod-actionbutton-edge-to-text: var(--mod-drop-zone-content-edge-to-text, var(--spectrum-drop-zone-content-edge-to-text));
+	/* @passthrough end */
 
 	/* cjk language support */
 	&:lang(ja),
@@ -166,7 +168,7 @@
 
 		--highcontrast-drop-zone-border-color-hover: Highlight;
 
-		/* Updated values for a nested illustrated message when in a high contrast state */
+		/* @passthrough -- updated values for a nested illustrated message when in a high contrast state */
 		--highcontrast-illustrated-message-illustration-color: var(--highcontrast-drop-zone-illustration-color);
 	}
 }

--- a/components/menu/index.css
+++ b/components/menu/index.css
@@ -208,16 +208,20 @@
 		.spectrum-Menu-item:hover,
 		.spectrum-Menu-item:focus {
 			.spectrum-Menu-itemCheckbox {
+				/* @passthrough start */
 				--highcontrast-checkbox-highlight-color-hover: ButtonText;
 				--highcontrast-checkbox-highlight-color-default: ButtonText;
+				/* @passthrough end */
 			}
 
 			.spectrum-Menu-itemSwitch {
+				/* @passthrough start */
 				--highcontrast-switch-handle-border-color-hover: ButtonText;
 				--highcontrast-switch-handle-border-color-selected-default: ButtonText;
 				--highcontrast-switch-handle-border-color-selected-hover: ButtonText;
 				--highcontrast-switch-background-color-selected-default: ButtonText;
 				--highcontrast-switch-background-color-selected-hover: ButtonText;
+				/* @passthrough end */
 			}
 		}
 
@@ -395,7 +399,6 @@
 
 .spectrum-Menu-item {
 	display: grid;
-	/* stylelint-disable declaration-block-no-redundant-longhand-properties */
 	grid-template-areas:
 		".            chevronAreaCollapsible .             headingIconArea  sectionHeadingArea  .         .           .                 "
 		"selectedArea chevronAreaCollapsible checkmarkArea iconArea labelArea        valueArea actionsArea chevronAreaDrillIn"
@@ -412,7 +415,6 @@
 	grid-template-columns: auto auto;
 	grid-template-rows: 1fr auto;
 }
-/* stylelint-enable declaration-block-no-redundant-longhand-properties */
 
 .spectrum-Menu-item .spectrum-Menu-item .spectrum-Menu-itemLabel {
 	grid-area: submenuItemLabelArea;

--- a/components/search/index.css
+++ b/components/search/index.css
@@ -52,7 +52,7 @@
 	--spectrum-search-background-color-disabled: var(--spectrum-disabled-background-color);
 	--spectrum-search-border-color-disabled: var(--spectrum-disabled-background-color);
 
-	/* Settings for nested Textfield component. */
+	/* @passthrough start -- settings for nested Textfield component */
 	--mod-textfield-font-family: var(--mod-search-font-family, var(--spectrum-search-font-family));
 	--mod-textfield-font-weight: var(--mod-search-font-weight, var(--spectrum-search-font-weight));
 
@@ -79,6 +79,7 @@
 
 	--mod-textfield-background-color: var(--mod-search-background-color, var(--spectrum-search-background-color));
 	--mod-textfield-background-color-disabled: var(--mod-search-background-color-disabled, var(--spectrum-search-background-color-disabled));
+	/* @passthrough end */
 }
 
 .spectrum-Search--sizeS {

--- a/components/slider/index.css
+++ b/components/slider/index.css
@@ -105,9 +105,7 @@
 	--spectrum-slider-track-handleoffset: var(--spectrum-slider-handle-gap);
 
 	--spectrum-slider-range-track-reset: 0;
-}
 
-.spectrum-Slider {
 	position: relative;
 
 	/* Don't let z-index'd child elements float above other things on the page */
@@ -391,6 +389,7 @@
 	inset-block-start: var(--mod-slider-input-top-size, var(--spectrum-slider-input-top-size));
 	inset-inline-start: var(--mod-slider-input-left, var(--spectrum-slider-input-left));
 	overflow: hidden;
+
 	/* stylelint-disable-next-line number-max-precision -- @todo Look into replacing with opacity 0. The tiny opacity value appears to be a workaround for a ChromeVox legacy bug (circa 2018). */
 	opacity: 0.000001;
 	cursor: default;

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -89,7 +89,11 @@ module.exports = {
 			},
 		],
 		"selector-attribute-quotes": "always",
-		"selector-class-pattern": ["^(spectrum-|is-)[A-Za-z0-9-]+", { resolveNestedSelectors: true }],
+		"selector-class-pattern": [
+			"^(spectrum-|is-|u-)[A-Za-z0-9-]+", {
+				resolveNestedSelectors: true
+			}
+		],
 		"selector-not-notation": "complex",
 		"value-keyword-case": [
 			"lower",
@@ -149,8 +153,7 @@ module.exports = {
 					/^--mod-/,
 					/^--highcontrast-/,
 					/^--system-/,
-					/^--spectrum-(global|alias|component)-/,
-					/^--spectrum-animation-/,
+					/^--spectrum-picked-color$/,
 				],
 				skipDependencies: false,
 				disableFix: true,
@@ -161,7 +164,7 @@ module.exports = {
 		"spectrum-tools/no-unused-custom-properties": [
 			true,
 			{
-				ignoreList: [/^--mod-/, /^--highcontrast-/, /^--system-/],
+				ignoreList: [/^--mod-/],
 				disableFix: true,
 				severity: "warning",
 			},


### PR DESCRIPTION
## Description

The biggest update not included in a changeset is to the stylelint config. Updates include:

- Adding the legacy `u-` prefix support to the allowed class names
- Removing the legacy token structure from the ignore list for unknown custom properties
- Adding `--spectrum-picked-color` as an ignored unknown value
- Removing `--highcontrast` and `--system` as ignored prefixes for the unused custom properties (those should show up as used or there's likely an error in the styles)

See changesets for details on other updates.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [x] `yarn linter dropzone` - expect to see no more lint warnings logged
- [x] `yarn linter datepicker` - expect to see only performance and max-nesting depth errors
- [x] `yarn linter dial` - expect to see no error for the "u-isGrabbing" class name

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have tested these changes in Windows High Contrast mode.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] ✨ This pull request is ready to merge. ✨
