### PR TITLE
feat(colorloupe): migrate to s2 drop-shadow tokens

### DIFF
--- a/components/colorloupe/index.css
+++ b/components/colorloupe/index.css
@@ -9,87 +9,84 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 .spectrum-ColorLoupe {
-  --spectrum-colorloupe-width: var(--spectrum-color-loupe-width);
-  --spectrum-colorloupe-height: var(--spectrum-color-loupe-height);
+	--spectrum-colorloupe-width: var(--spectrum-color-loupe-width);
+	--spectrum-colorloupe-height: var(--spectrum-color-loupe-height);
 
-  --spectrum-colorloupe-offset: var(--spectrum-color-loupe-bottom-to-color-handle);
-  --spectrum-colorloupe-animation-distance: 8px; /* TODO: replace with forthcoming animation token */
+	--spectrum-colorloupe-offset: var(--spectrum-color-loupe-bottom-to-color-handle);
+	--spectrum-colorloupe-animation-distance: 8px; /* TODO: replace with forthcoming animation token */
 
-  --spectrum-colorloupe-drop-shadow-x: var(--spectrum-drop-shadow-x);
-  --spectrum-colorloupe-drop-shadow-y: var(--spectrum-color-loupe-drop-shadow-y);
-  --spectrum-colorloupe-drop-shadow-blur: var(--spectrum-color-loupe-drop-shadow-blur);
-  --spectrum-colorloupe-drop-shadow-color: var(--spectrum-color-loupe-drop-shadow-color);
+	--spectrum-colorloupe-drop-shadow-x: var(--spectrum-drop-shadow-elevated-x);
+	--spectrum-colorloupe-drop-shadow-y: var(--spectrum-drop-shadow-elevated-y);
+	--spectrum-colorloupe-drop-shadow-blur: var(--spectrum-drop-shadow-elevated-blur);
+	--spectrum-colorloupe-drop-shadow-color: var(--spectrum-drop-shadow-elevated-color);
 
-  --spectrum-colorloupe-outer-border-width: var(--spectrum-color-loupe-outer-border-width);
-  --spectrum-colorloupe-inner-border-width: var(--spectrum-color-loupe-inner-border-width);
-  --spectrum-colorloupe-outer-border-color: var(--spectrum-color-loupe-outer-border);
-  --spectrum-colorloupe-inner-border-color: var(--spectrum-color-loupe-inner-border);
+	--spectrum-colorloupe-outer-border-width: var(--spectrum-color-loupe-outer-border-width);
+	--spectrum-colorloupe-inner-border-width: var(--spectrum-color-loupe-inner-border-width);
+	--spectrum-colorloupe-outer-border-color: var(--spectrum-color-loupe-outer-border);
+	--spectrum-colorloupe-inner-border-color: var(--spectrum-color-loupe-inner-border);
 
-  --spectrum-colorloupe-checkerboard-dark-color: var(--spectrum-opacity-checkerboard-square-dark);
-  --spectrum-colorloupe-checkerboard-light-color: var(--spectrum-opacity-checkerboard-square-light);
+	--spectrum-colorloupe-checkerboard-dark-color: var(--spectrum-opacity-checkerboard-square-dark);
+	--spectrum-colorloupe-checkerboard-light-color: var(--spectrum-opacity-checkerboard-square-light);
 }
 
 .spectrum-ColorLoupe {
-  inline-size: var(--spectrum-colorloupe-width);
-  block-size:  var(--spectrum-colorloupe-height);
+	inline-size: var(--spectrum-colorloupe-width);
+	block-size: var(--spectrum-colorloupe-height);
 
-  position: absolute;
-  transform: translate(0, var(--mod-colorloupe-animation-distance, var(--spectrum-colorloupe-animation-distance)));
-  opacity: 0;
-  transform-origin: bottom center;
-  inset-block-end: calc((var(--spectrum-color-handle-size) - var(--spectrum-color-handle-outer-border-width)) + var(--mod-colorloupe-offset, var(--spectrum-colorloupe-offset)));
-  inset-inline-end: calc(50% - (var(--spectrum-colorloupe-width) / 2));
+	position: absolute;
+	transform: translate(0, var(--mod-colorloupe-animation-distance, var(--spectrum-colorloupe-animation-distance)));
+	opacity: 0;
+	transform-origin: bottom center;
+	inset-block-end: calc((var(--spectrum-color-handle-size) - var(--spectrum-color-handle-outer-border-width)) + var(--mod-colorloupe-offset, var(--spectrum-colorloupe-offset)));
+	inset-inline-end: calc(50% - (var(--spectrum-colorloupe-width) / 2));
 
-  transition: transform 100ms ease-in-out, opacity 125ms ease-in-out;
-  pointer-events: none;
+	transition:
+		transform 100ms ease-in-out,
+		opacity 125ms ease-in-out;
+	pointer-events: none;
 
-  filter:drop-shadow(
-    var(--mod-colorloupe-drop-shadow-x, var(--spectrum-colorloupe-drop-shadow-x))
-    var(--mod-colorloupe-drop-shadow-y, var(--spectrum-colorloupe-drop-shadow-y))
-    var(--mod-colorloupe-drop-shadow-blur, var(--spectrum-colorloupe-drop-shadow-blur))
-    var(--mod-colorloupe-drop-shadow-color, var(--spectrum-colorloupe-drop-shadow-color))
-  );
+	filter: drop-shadow(var(--mod-colorloupe-drop-shadow-x, var(--spectrum-colorloupe-drop-shadow-x)) var(--mod-colorloupe-drop-shadow-y, var(--spectrum-colorloupe-drop-shadow-y)) var(--mod-colorloupe-drop-shadow-blur, var(--spectrum-colorloupe-drop-shadow-blur)) var(--mod-colorloupe-drop-shadow-color, var(--spectrum-colorloupe-drop-shadow-color)));
 
-  &:dir(rtl) {
-    inset-inline-end: calc(50% - (var(--spectrum-colorloupe-width) / 2) - 1px);;
-  }
+	&:dir(rtl) {
+		inset-inline-end: calc(50% - (var(--spectrum-colorloupe-width) / 2) - 1px);
+	}
 
-  &.is-open {
-    transform: translate(0, 0);
-    opacity: 1;
-  }
+	&.is-open {
+		transform: translate(0, 0);
+		opacity: 1;
+	}
 }
 
 .spectrum-ColorLoupe-inner-border {
-  /* Undefined variable allows custom stylesheet or JS to pass the value to this element */
-  fill: var(--spectrum-picked-color);
-  stroke: var(--mod-colorloupe-inner-border-color, var(--spectrum-colorloupe-inner-border-color));
-  stroke-width: var(--mod-colorloupe-inner-border-width, var(--spectrum-colorloupe-inner-border-width));
+	/* Undefined variable allows custom stylesheet or JS to pass the value to this element */
+	fill: var(--spectrum-picked-color);
+	stroke: var(--mod-colorloupe-inner-border-color, var(--spectrum-colorloupe-inner-border-color));
+	stroke-width: var(--mod-colorloupe-inner-border-width, var(--spectrum-colorloupe-inner-border-width));
 }
 
 .spectrum-ColorLoupe-outer-border {
-  fill: none;
-  stroke: var(--highcontrast-colorloupe-outer-border-color, var(--mod-colorloupe-outer-border-color, var(--spectrum-colorloupe-outer-border-color)));
-  stroke-width: calc(var(--mod-colorloupe-outer-border-width, var(--spectrum-colorloupe-outer-border-width)) + 2px);
+	fill: none;
+	stroke: var(--highcontrast-colorloupe-outer-border-color, var(--mod-colorloupe-outer-border-color, var(--spectrum-colorloupe-outer-border-color)));
+	stroke-width: calc(var(--mod-colorloupe-outer-border-width, var(--spectrum-colorloupe-outer-border-width)) + 2px);
 }
 
 /* The checkerboard classes use opacity checkerboard tokens for dark and light color.
  The opacity-checkerboard-square-size token is not able to be used witin the SVG pattern and instead colorloupe.yml is using two different patterns toggled by --spectrum-colorloupe-checkerboard-fill */
 
 .spectrum-ColorLoupe-checkerboard-pattern {
-  fill: var(--spectrum-colorloupe-checkerboard-dark-color);
+	fill: var(--spectrum-colorloupe-checkerboard-dark-color);
 }
 
 .spectrum-ColorLoupe-checkerboard-background {
-  fill: var(--spectrum-colorloupe-checkerboard-light-color);
+	fill: var(--spectrum-colorloupe-checkerboard-light-color);
 }
 
 .spectrum-ColorLoupe-checkerboard-fill {
-  fill: var(--spectrum-colorloupe-checkerboard-fill);
+	fill: var(--spectrum-colorloupe-checkerboard-fill);
 }
 
 @media (forced-colors: active) {
-  .spectrum-ColorLoupe {
-    --highcontrast-colorloupe-outer-border-color: CanvasText;
-  }
+	.spectrum-ColorLoupe {
+		--highcontrast-colorloupe-outer-border-color: CanvasText;
+	}
 }


### PR DESCRIPTION
## Description

Migrates color loupe to Spectrum 2 tokens. According to the [S2 token spec](https://www.figma.com/design/eoZHKJH9a3LJkHYCGt60Vb/S2-token-specs?node-id=9596-3359&t=o1lmG0VUo1R6zDuL-4) for color loupe, the only updated tokens concern the drop shadow. Color loupe now uses the new drop shadow tokens `drop-shadow-elevated-x`, `drop-shadow-elevated-y`, `drop-shadow-elevated-blur`, and `drop-shadow-elevated-color` rather than specific color loupe tokens.

[CSS-707](https://jira.corp.adobe.com/browse/CSS-707)

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
- Confirm that the color loupe component for S2 is using the tokens listed in the S2 token spec
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [ ] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
