### PR TITLE
chore(steplist): remove unnecessary vertical-align declaration

### DIFF
--- a/.changeset/strong-geese-yawn.md
+++ b/.changeset/strong-geese-yawn.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/steplist": patch
+---
+
+Resolves stylelint violation by removing vertical-align declaration that is ignored due to preceding display: block declaration.

--- a/components/steplist/index.css
+++ b/components/steplist/index.css
@@ -60,7 +60,6 @@
 	position: relative;
 
 	display: block;
-	vertical-align: top;
 	margin: 0;
 	padding-block-start: var(--mod-steplist-topPadding, var(--spectrum-steplist-topPadding));
 	padding-inline-start: var(--mod-steplist-sidePadding, var(--spectrum-steplist-sidePadding));


### PR DESCRIPTION
## Description

Resolves stylelint violation by removing vertical-align declaration that is ignored due to preceding display: block declaration.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨