### PR TITLE
chore(swatch): remove unnecessary max nesting depth ignore comments

### DIFF
--- a/components/swatch/index.css
+++ b/components/swatch/index.css
@@ -83,7 +83,6 @@
 }
 
 /* Swatch styles */
-/* stylelint-disable max-nesting-depth */
 .spectrum-Swatch {
 	inline-size: var(--mod-swatch-size, var(--spectrum-swatch-size));
 	block-size: var(--mod-swatch-size, var(--spectrum-swatch-size));
@@ -146,7 +145,7 @@
 
 	&.is-mixedValue {
 		.spectrum-Swatch-fill {
-			/* Undefined variable allows custom stylesheet or JS to pass the value to this element */
+			/* stylelint-disable-next-line -- Undefined variable allows custom stylesheet or JS to pass the value to this element */
 			background: var(--spectrum-picked-color, transparent);
 		}
 
@@ -159,7 +158,7 @@
 	/* Swatch fill: Not fill with Slash */
 	&.is-nothing {
 		.spectrum-Swatch-fill {
-			/* Undefined variable allows custom stylesheet or JS to pass the value to this element */
+			/* stylelint-disable-next-line -- Undefined variable allows custom stylesheet or JS to pass the value to this element */
 			background-color: var(--spectrum-picked-color, transparent);
 			background-image: none;
 
@@ -226,7 +225,6 @@
 		}
 	}
 }
-/* stylelint-enable max-nesting-depth */
 
 .spectrum-Swatch-fill {
 	display: flex;
@@ -250,7 +248,7 @@
 		inset: 0;
 		z-index: 0;
 
-		/* Undefined variable allows custom stylesheet or JS to pass the value to this element */
+		/* stylelint-disable-next-line -- Undefined variable allows custom stylesheet or JS to pass the value to this element */
 		background-color: var(--spectrum-picked-color, transparent);
 
 		/* Swatch border */
@@ -265,7 +263,7 @@
 		&::before {
 			box-shadow: none;
 
-			/* Undefined variable allows custom stylesheet or JS to pass the value to this element */
+			/* stylelint-disable-next-line -- Undefined variable allows custom stylesheet or JS to pass the value to this element */
 			background-color: var(--spectrum-picked-color, transparent);
 		}
 	}
@@ -283,7 +281,7 @@
 	display: none;
 	pointer-events: none;
 
-	/* Undefined variable allows custom stylesheet or JS to pass the value to this element */
+	/* stylelint-disable-next-line -- Undefined variable allows custom stylesheet or JS to pass the value to this element */
 	color: var(--spectrum-picked-color, transparent);
 }
 


### PR DESCRIPTION
## Description

Remove unnecessary stylelint disable for max nesting depth. Move undefined variable comments into stylelint-disable descriptions.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨