### PR TITLE
chore(tray): adjust declaration order to resovle lint violation

### DIFF
--- a/.changeset/modern-clocks-obey.md
+++ b/.changeset/modern-clocks-obey.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/tray": patch
+---
+
+Resolves stylelint violation by adjusting declaration order

--- a/components/tray/index.css
+++ b/components/tray/index.css
@@ -41,9 +41,10 @@
 }
 
 .spectrum-Tray {
+	--mod-modal-max-width: 100%;
+
 	/* Default to full width when the viewport is in portrait orientation */
 	inline-size: 100%;
-	--mod-modal-max-width: 100%;
 	max-inline-size: 100%;
 
 	max-block-size: calc(100vh - var(--mod-tray-spacing-edge-to-tray-safe-zone, var(--spectrum-tray-spacing-edge-to-tray-safe-zone)));


### PR DESCRIPTION
## Description

Resolves stylelint violation by adjusting declaration order

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
