### PR TITLE
chore(treeview): remove unused custom property to resolve lint violation

### DIFF
--- a/.changeset/nervous-steaks-provide.md
+++ b/.changeset/nervous-steaks-provide.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/treeview": patch
+---
+
+Use the already defined custom property `--spectrum-treeview-item-border-color-quiet-selected` in place of the direct value. The border color value remains the same.

--- a/components/treeview/index.css
+++ b/components/treeview/index.css
@@ -111,7 +111,7 @@
 
 .spectrum-TreeView--quiet {
 	--mod-treeview-item-background-color-selected: var(--highcontrast-treeview-item-background-color-selected, var(--mod-treeview-item-background-color-quiet-selected, var(--spectrum-treeview-item-background-color-quiet-selected)));
-	--mod-treeview-item-border-color-selected: var(--highcontrast-treeview-item-border-color-selected, var(--mod-treeview-item-border-color-selected-quiet, transparent));
+	--mod-treeview-item-border-color-selected: var(--highcontrast-treeview-item-border-color-selected, var(--mod-treeview-item-border-color-selected-quiet, var(--spectrum-treeview-item-border-color-quiet-selected)));
 }
 
 .spectrum-TreeView--thumbnail {


### PR DESCRIPTION
## Description

Use custom property in place of direct value when defining mod.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
