### PR TITLE
fix(stylelint): adjust selector-class-pattern regular expression to allow .spectrum class

### DIFF
--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -90,7 +90,7 @@ module.exports = {
 		],
 		"selector-attribute-quotes": "always",
 		"selector-class-pattern": [
-			"^(spectrum-|is-|u-)[A-Za-z0-9-]+", {
+			"^(?:spectrum|is|u)(?:-[A-Za-z0-9-]+)?$", {
 				resolveNestedSelectors: true
 			}
 		],


### PR DESCRIPTION
## Description

Adjusts `selector-class-pattern` stylelint regular expression to allow `.spectrum` class

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
