### PR TITLE
chore: dialog t-shirt sizing

### DIFF
--- a/.changeset/nasty-pillows-wonder.md
+++ b/.changeset/nasty-pillows-wonder.md
@@ -1,0 +1,13 @@
+---
+"@spectrum-css/dialog": patch
+---
+
+Dialog t-shirt sizes
+
+Adds support for t-shirt sizing class names to dialog CSS. `@deprecated` comments were added to communicate that the old class names (`--small`, `--medium`, and `--large`) will be removed in S2.
+
+| old class name          | new class name                                         |
+| ----------------------- | ------------------------------------------------------ |
+| spectrum-Dialog--small  | spectrum-Dialog--sizeS                                 |
+| spectrum-Dialog--medium | spectrum-Dialog (the default, so no size is necessary) |
+| spectrum-Dialog--large  | spectrum-Dialog--sizeL                                 |

--- a/components/dialog/index.css
+++ b/components/dialog/index.css
@@ -36,15 +36,17 @@
 	--spectrum-dialog-confirm-divider-height: var(--spectrum-spacing-50);
 }
 
-.spectrum-Dialog {
+/* @deprecated .spectrum-Dialog--medium */
+.spectrum-Dialog,
+.spectrum-Dialog--medium {
 	/* Be a flexbox to allow a full sized content area that scrolls */
 	display: flex;
 
 	/* Allow 100% width, taking into account padding */
 	box-sizing: border-box;
 
-	/* Be no bigger than max-width,  but also be 90% if the viewport is smaller than max-width */
-	inline-size: fit-content;
+	/* Be no bigger than max-width, but also be 90% if the viewport is smaller than max-width */
+	inline-size: var(--mod-dialog-confirm-medium-width, var(--spectrum-dialog-confirm-medium-width));
 	min-inline-size: var(--mod-dialog-min-inline-size, var(--spectrum-dialog-min-inline-size));
 	max-inline-size: 100%;
 
@@ -53,14 +55,14 @@
 	outline: none;
 }
 
+/* @deprecated .spectrum-Dialog--small */
+.spectrum-Dialog--sizeS,
 .spectrum-Dialog--small {
 	inline-size: var(--mod-dialog-confirm-small-width, var(--spectrum-dialog-confirm-small-width));
 }
 
-.spectrum-Dialog--medium {
-	inline-size: var(--mod-dialog-confirm-medium-width, var(--spectrum-dialog-confirm-medium-width));
-}
-
+/* @deprecated .spectrum-Dialog--large */
+.spectrum-Dialog--sizeL,
 .spectrum-Dialog--large {
 	inline-size: var(--mod-dialog-confirm-large-width, var(--spectrum-dialog-confirm-large-width));
 }

--- a/components/dialog/metadata/metadata.json
+++ b/components/dialog/metadata/metadata.json
@@ -22,6 +22,8 @@
     ".spectrum-Dialog--medium",
     ".spectrum-Dialog--noDivider .spectrum-Dialog-divider",
     ".spectrum-Dialog--noDivider .spectrum-Dialog-heading",
+    ".spectrum-Dialog--sizeL",
+    ".spectrum-Dialog--sizeS",
     ".spectrum-Dialog--small",
     ".spectrum-Dialog-buttonGroup",
     ".spectrum-Dialog-buttonGroup.spectrum-Dialog-buttonGroup--noFooter",


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

This PR aligns the sizing classes for the dialog component to t-shirt sizing, as most of our other components have done in recent years. The old size modifier classes will be deprecated and removed in S2, so deprecation comments were left in the CSS, along with the addition of the t-shirt classes. 

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

- [ ] Pull down the branch to run locally, or use the deploy preview. 
- [ ] Verify that the old classes are being applied to dialogs, as before. This change introduces NO markup/template/class name changes.
- [ ] Pick a dialog to inspect in the browser. Remove the old class name and add the new class. Ensure that the styles do not change between these classes: 

| old class name | new class name |
| --------- | ---------- |
| spectrum-Dialog--small | spectrum-Dialog--sizeS |
| spectrum-Dialog--medium | spectrum-Dialog (the default, so no size is necessary) |
| spectrum-Dialog--large | spectrum-Dialog--sizeL |

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [ ] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
