### PR TITLE
chore(vscode-settings): remove deprecated property; disable postcss validate

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -119,7 +119,6 @@
 		"postcss": "css"
 	},
 	"eslint.format.enable": true,
-	"eslint.packageManager": "yarn",
 	"eslint.useESLintClass": true,
 	"files.associations": {
 		"*.css": "postcss"
@@ -167,6 +166,7 @@
 		}
 	],
 	"js/ts.implicitProjectConfig.experimentalDecorators": true,
+	"postcss.validate": false,
 	"prettier.configPath": ".prettierrc",
 	"prettier.ignorePath": ".prettierignore",
 	"prettier.prettierPath": "node_modules/prettier",


### PR DESCRIPTION
## Description

- Removes deprecated `aslant.packageManager` setting
- Adds `postcss.validate: false` as `postcss.validate` conflicts with our `stylelint` and `posts`

## How and where has this been tested?

Verified locally. Removing the following:

```
"at-rule-no-unknown": [
  true,
  {
    ignoreAtRules: ["extend", "container", "each", "include", "mixin"],
  },
],
```

Raises a lint violation against `at-rule-no-unknown`, establishing that `ignoreAtRules` is being applied (as no exceptions are now being defined in the rule definition).

Restoring the rule then returns our `unknownAtRules` violation which is attributed to `postcss`.

Adding `postcss.validate: false` to the workspace settings resolves the issue. Additionally — removing `"extend"` from `ignoreAtRules` and restarting the stylelint server in VS Code causes stylelint to surface a violation — we can then rely on stylelint to provide coverage for syntax violations like this.

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
