### PR TITLE
docs(textarea): add corrected guidelines link and rootClass

### DIFF
--- a/components/textfield/stories/textarea.stories.js
+++ b/components/textfield/stories/textarea.stories.js
@@ -18,6 +18,7 @@ export default {
 	},
 	args: {
 		...Textfield.args,
+		rootClass: "spectrum-Textfield--multiline",
 		labelText: "Comments"
 	},
 	parameters: {

--- a/components/textfield/stories/textarea.template.js
+++ b/components/textfield/stories/textarea.template.js
@@ -4,14 +4,13 @@ import { Template as Textfield } from "./template";
 
 export const Template = ({
 	customClasses = [],
-	rootClass = "spectrum-Textfield",
+	rootClass = "spectrum-Textfield--multiline",
 	size = "m",
 	multiline = true,
 	...item
 } = {}, context = {}) => Textfield({
 	customClasses: [
 		rootClass,
-		typeof size !== "undefined" ? `${rootClass}--size${size.toUpperCase()}` : null,
 		...customClasses
 	],
 	size,


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

Similar to progress bar and meter, text field and text area are now "nested" components. Recently, [meter was updated to include its own `rootClass`](https://github.com/adobe/spectrum-css/pull/3231) argument to ensure it was delivering the correct Spectrum guidelines URL. Text area will need the same treatment. Before these changes, the text area guidance resource link was navigating to the text _field_ page instead of the text _area_ page.

- Adds a `.spectrum-Textfield--multiline` rootClass to textarea component. It shouldn't overwrite/interfere with the textfield component in the text area template.
- adds an additional spectrum object to contain the text area guidance link & new rootClass

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

- [x] Pull down the branch to run locally, or [use the deploy preview](https://pr-3326--spectrum-css.netlify.app/preview/?path=/docs/components-text-area--docs)
- [x] On[ the text area docs page](https://pr-3326--spectrum-css.netlify.app/preview/?path=/docs/components-text-area--docs), click on the "Spectrum guidelines" resource link.
- [x] This link should navigate you to this page: https://spectrum.adobe.com/page/text-area/
    - Previously, it was navigating to the text field guidance: https://spectrum.adobe.com/page/text-field/
- [ ] When inspecting any of the text area templates, no additional classes should have been added. Only `spectrum-Textfield`, `spectrum-Textfield--size*` and `spectrum-Textfield--multiline` should be applied. (3 in total)
- [ ] Styles for `.spectrum-Textfield` should still be applied. No visual regressions should have been introduced.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
