### PR TITLE
fix: correct the display of checkbox read-only state

### DIFF
--- a/.changeset/afraid-dogs-worry.md
+++ b/.changeset/afraid-dogs-worry.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/checkbox": patch
+---
+
+This removes some unnecessary read-only styles. Read-only just needs to override disabled styles. Otherwise it uses the normal styles (for both default and emphasized).

--- a/.changeset/gold-deers-smash.md
+++ b/.changeset/gold-deers-smash.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/fieldgroup": minor
+---
+
+The previous display of the read-only state checkboxes did not match up with any guidelines. This update removes the read-only specific styles for checkbox within the fieldgroup component, so that the boxes are still displayed and commas are not appended to the label. This includes the removal of `--spectrum-fieldgroup-readonly-delimiter` as it is no longer needed.

--- a/components/checkbox/index.css
+++ b/components/checkbox/index.css
@@ -13,13 +13,11 @@
 
 @import "./themes/express.css";
 
-/* checkbox/index.css
- *
+/*
  * .spectrum-Checkbox-box::before is the Checkbox "box"
  * .spectrum-Checkbox-box::after is the focus indicator
  */
 
-/* Component tokens by t-shirt size */
 .spectrum-Checkbox {
 	/* Color */
 	--spectrum-checkbox-content-color-default: var(--spectrum-neutral-content-color-default);
@@ -176,41 +174,25 @@
 		}
 	}
 
-	/*
-   * Read-Only
-   *
-   * readonly is not a valid attribute for input[type="checkbox"]
-   * so we borrow the immutability of a disabled checkbox
-   * while using the colors of a default checkbox
-   */
+	/* Read-only */
 	&.is-readOnly {
-		border-color: var(--highcontrast-checkbox-color-default, var(--mod-checkbox-control-selected-color-default, var(--spectrum-checkbox-control-selected-color-default)));
-
-		&:hover {
-			.spectrum-Checkbox-box::before {
-				border-color: var(--highcontrast-checkbox-color-default, var(--mod-checkbox-control-selected-color-default, var(--spectrum-checkbox-control-selected-color-default)));
-			}
+		.spectrum-Checkbox-input {
+			cursor: default;
 		}
 
-		&:active {
-			.spectrum-Checkbox-box::before {
-				border-color: var(--highcontrast-checkbox-selected-color-default, var(--mod-checkbox-control-selected-color-default, var(--spectrum-checkbox-control-selected-color-default)));
+		/* Overrides disabled styles */
+		.spectrum-Checkbox-input,
+		.spectrum-Checkbox-input:checked {
+			&:disabled + .spectrum-Checkbox-box {
+				&::before {
+					border-color: var(--highcontrast-checkbox-color-default, var(--mod-checkbox-control-selected-color-default, var(--spectrum-checkbox-control-selected-color-default)));
+					background-color: var(--highcontrast-checkbox-background-color-default, var(--mod-checkbox-checkmark-color, var(--spectrum-checkbox-checkmark-color)));
+				}
 			}
-		}
-	}
 
-	&.is-readOnly .spectrum-Checkbox-input,
-	&.is-readOnly .spectrum-Checkbox-input:checked {
-		&:disabled + .spectrum-Checkbox-box {
-			&::before {
-				border-color: var(--highcontrast-checkbox-color-default, var(--mod-checkbox-control-selected-color-default, var(--spectrum-checkbox-control-selected-color-default)));
-				background-color: var(--highcontrast-checkbox-background-color-default, var(--mod-checkbox-checkmark-color, var(--spectrum-checkbox-checkmark-color)));
+			&:disabled ~ .spectrum-Checkbox-label {
+				color: var(--highcontrast-checkbox-color-default, var(--mod-checkbox-content-color-default, var(--spectrum-checkbox-content-color-default)));
 			}
-		}
-
-		&:disabled ~ .spectrum-Checkbox-label {
-			forced-color-adjust: none;
-			color: var(--highcontrast-checkbox-color-default, var(--mod-checkbox-content-color-default, var(--spectrum-checkbox-content-color-default)));
 		}
 	}
 

--- a/components/checkbox/index.css
+++ b/components/checkbox/index.css
@@ -183,11 +183,9 @@
 		/* Overrides disabled styles */
 		.spectrum-Checkbox-input,
 		.spectrum-Checkbox-input:checked {
-			&:disabled + .spectrum-Checkbox-box {
-				&::before {
-					border-color: var(--highcontrast-checkbox-color-default, var(--mod-checkbox-control-selected-color-default, var(--spectrum-checkbox-control-selected-color-default)));
-					background-color: var(--highcontrast-checkbox-background-color-default, var(--mod-checkbox-checkmark-color, var(--spectrum-checkbox-checkmark-color)));
-				}
+			&:disabled + .spectrum-Checkbox-box::before {
+				border-color: var(--highcontrast-checkbox-color-default, var(--mod-checkbox-control-selected-color-default, var(--spectrum-checkbox-control-selected-color-default)));
+				background-color: var(--highcontrast-checkbox-background-color-default, var(--mod-checkbox-checkmark-color, var(--spectrum-checkbox-checkmark-color)));
 			}
 
 			&:disabled ~ .spectrum-Checkbox-label {

--- a/components/checkbox/metadata/metadata.json
+++ b/components/checkbox/metadata/metadata.json
@@ -67,13 +67,11 @@
     ".spectrum-Checkbox.is-invalid.is-indeterminate:hover .spectrum-Checkbox-label",
     ".spectrum-Checkbox.is-invalid:hover .spectrum-Checkbox-box:before",
     ".spectrum-Checkbox.is-invalid:hover .spectrum-Checkbox-input:checked + .spectrum-Checkbox-box",
-    ".spectrum-Checkbox.is-readOnly",
+    ".spectrum-Checkbox.is-readOnly .spectrum-Checkbox-input",
     ".spectrum-Checkbox.is-readOnly .spectrum-Checkbox-input:checked:disabled + .spectrum-Checkbox-box:before",
     ".spectrum-Checkbox.is-readOnly .spectrum-Checkbox-input:checked:disabled ~ .spectrum-Checkbox-label",
     ".spectrum-Checkbox.is-readOnly .spectrum-Checkbox-input:disabled + .spectrum-Checkbox-box:before",
     ".spectrum-Checkbox.is-readOnly .spectrum-Checkbox-input:disabled ~ .spectrum-Checkbox-label",
-    ".spectrum-Checkbox.is-readOnly:active .spectrum-Checkbox-box:before",
-    ".spectrum-Checkbox.is-readOnly:hover .spectrum-Checkbox-box:before",
     ".spectrum-Checkbox:active .spectrum-Checkbox-box:before",
     ".spectrum-Checkbox:active .spectrum-Checkbox-input:checked + .spectrum-Checkbox-box:before",
     ".spectrum-Checkbox:active .spectrum-Checkbox-label",
@@ -234,7 +232,6 @@
     "--highcontrast-checkbox-highlight-color-default",
     "--highcontrast-checkbox-highlight-color-down",
     "--highcontrast-checkbox-highlight-color-focus",
-    "--highcontrast-checkbox-highlight-color-hover",
-    "--highcontrast-checkbox-selected-color-default"
+    "--highcontrast-checkbox-highlight-color-hover"
   ]
 }

--- a/components/checkbox/stories/checkbox.stories.js
+++ b/components/checkbox/stories/checkbox.stories.js
@@ -4,16 +4,16 @@ import { isChecked, isDisabled, isEmphasized, isIndeterminate, isInvalid, isRead
 import metadata from "../metadata/metadata.json";
 import packageJson from "../package.json";
 import { CheckboxGroup } from "./checkbox.test.js";
-import { AllVariantsCheckboxGroup, DocsCheckboxGroup, } from "./template.js";
+import { AllVariantsCheckboxGroup, DocsCheckboxGroup, Template } from "./template.js";
 
 /**
  * Checkboxes allow users to select multiple items from a list of individual items, or mark one individual item as selected.
  *
  * ## Usage notes
  *
- * Checkboxes should not be used on their own. They should always be used within a [field group](/docs/components-field-group--docs). Invalid checkboxes are indicated with an alert [help text](/docs/components-help-text--docs) when included in a Field group.
- *
- * When the label is too long for the horizontal space available, it wraps to form another line.
+ * - Checkboxes should not be used on their own. They should always be used within a [field group](/docs/components-field-group--docs).
+ * - Invalid checkboxes are indicated with an alert [help text](/docs/components-help-text--docs) when included in a field group.
+ * - For more information about the read-only state, see the [read-only checkboxes](/docs/components-field-group--docs#read-only-checkboxes) section of the field group documentation.
  */
 export default {
 	title: "Checkbox",
@@ -62,6 +62,11 @@ Default.args = {
 };
 Default.tags = ["!autodocs"];
 
+/**
+ * Checkboxes can be selected, not selected, or in an indeterminate state. They are in an indeterminate state (shown with a dash icon) when they represent both selected and not selected values.
+ *
+ * When the label is too long for the horizontal space available, it wraps to form another line.
+ */
 export const DefaultVariants = AllVariantsCheckboxGroup.bind({});
 DefaultVariants.tags = ["!dev"];
 DefaultVariants.parameters = {
@@ -90,6 +95,21 @@ Sizing.args = {};
 Sizing.tags = ["!dev"];
 Sizing.parameters = {
 	chromatic: { disableSnapshot: true },
+};
+
+/**
+ * The class `is-readOnly` is applied to checkboxes in the read-only state. It's worth noting that `<input type="checkbox">` HTML elements do not have a native `readonly` attribute, and the intended behavior is up to the implementation:
+ * - Read-only checkboxes are immutable, i.e. their checked state cannot be changed.
+ * - Unlike disabled checkboxes, the checkbox should remain focusable.
+ */
+export const ReadOnly = Template.bind({});
+ReadOnly.storyName = "Read-only";
+ReadOnly.args = {
+	isReadOnly: true,
+};
+ReadOnly.tags = ["!dev"];
+ReadOnly.parameters = {
+	chromatic: { disableSnapshot: true }
 };
 
 // ********* VRT ONLY ********* //

--- a/components/checkbox/stories/checkbox.test.js
+++ b/components/checkbox/stories/checkbox.test.js
@@ -28,6 +28,10 @@ export const CheckboxGroup = Variants({
 			isChecked: true,
 		},
 		{
+			testHeading: "Indeterminate",
+			isIndeterminate: true,
+		},
+		{
 			testHeading: "Invalid",
 			isInvalid: true,
 		},
@@ -35,6 +39,11 @@ export const CheckboxGroup = Variants({
 			testHeading: "Invalid, checked",
 			isInvalid: true,
 			isChecked: true,
+		},
+		{
+			testHeading: "Invalid, indeterminate",
+			isInvalid: true,
+			isIndeterminate: true,
 		},
 		{
 			testHeading: "Disabled",
@@ -46,7 +55,8 @@ export const CheckboxGroup = Variants({
 			isChecked: true,
 		},
 		{
-			testHeading: "Indeterminate",
+			testHeading: "Disabled, indeterminate",
+			isDisabled: true,
 			isIndeterminate: true,
 		},
 		{
@@ -55,6 +65,16 @@ export const CheckboxGroup = Variants({
 		},
 		{
 			testHeading: "Read-only, checked",
+			isReadOnly: true,
+			isChecked: true,
+		},
+		{
+			testHeading: "Read-only, indeterminate",
+			isReadOnly: true,
+			isIndeterminate: true,
+		},
+		{
+			testHeading: "Read-only, checked, disabled",
 			isReadOnly: true,
 			isChecked: true,
 		},

--- a/components/checkbox/stories/template.js
+++ b/components/checkbox/stories/template.js
@@ -50,7 +50,7 @@ export const Template = ({
 					typeof size !== "undefined",
 				[`${rootClass}--emphasized`]: isEmphasized,
 				["is-indeterminate"]: isIndeterminate,
-				["is-disabled"]: isDisabled|| isReadOnly,
+				["is-disabled"]: isDisabled,
 				["is-invalid"]: isInvalid,
 				["is-readOnly"]: isReadOnly,
 				...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
@@ -62,13 +62,19 @@ export const Template = ({
 				type="checkbox"
 				class="${rootClass}-input"
 				aria-labelledby=${ifDefined(ariaLabelledby)}
+				aria-disabled=${ifDefined(isReadOnly ? "true" : undefined)}
 				?checked=${isChecked}
-				?disabled=${isDisabled || isReadOnly}
+				?disabled=${isDisabled}
 				title=${ifDefined(title)}
 				value=${ifDefined(value)}
-				@change=${function() {
-					if (isDisabled) return;
-					updateArgs({ isChecked: !isChecked });
+				@change=${(e) => {
+					if (isReadOnly) {
+						// Make checked value immutable for read-only.
+						e.preventDefault();
+						e.target.checked = !e.target.checked;
+					}
+					if (isDisabled || isReadOnly) return;
+					updateArgs?.({ isChecked: e.target.checked });
 				}}
 				id=${ifDefined(id ? `${id}-input` : undefined)}
 			/>
@@ -103,21 +109,19 @@ export const DocsCheckboxGroup = (args, context) => Container({
 			...args,
 			context,
 			iconName: undefined,
+			label: "Unchecked",
 		})}
 		${Template({
 			...args,
 			context,
 			isChecked: true,
+			label: "Checked",
 		})}
 		${Template({
 			...args,
 			context,
 			isIndeterminate: true,
-		})}
-		${Template({
-			...args,
-			context,
-			isDisabled: true,
+			label: "Indeterminate",
 		})}
 		${Template({
 			...args,

--- a/components/fieldgroup/index.css
+++ b/components/fieldgroup/index.css
@@ -11,17 +11,8 @@
  * governing permissions and limitations under the License.
  */
 
-/* fieldgroup/index.css
- *
- * fieldgroup contains four component dependences:
- * radio, checkbox, helptext, fieldlabel
- *
- */
-
-/* custom properties */
 .spectrum-FieldGroup {
 	--spectrum-fieldgroup-margin: var(--spectrum-spacing-300);
-	--spectrum-fieldgroup-readonly-delimiter: "\002c";
 }
 
 /* field group */
@@ -62,20 +53,6 @@
 		/* move help text down to new row */
 		.spectrum-HelpText {
 			flex-basis: 100%;
-		}
-	}
-}
-
-/* read-only checkbox group */
-.spectrum-FieldGroup {
-	.spectrum-Checkbox.is-readOnly {
-		.spectrum-Checkbox-box {
-			display: none;
-		}
-
-		/* read-only checkbox fields delimited by commas */
-		&:not(:last-child) .spectrum-Checkbox-label::after {
-			content: var(--spectrum-fieldgroup-readonly-delimiter);
 		}
 	}
 }

--- a/components/fieldgroup/metadata/metadata.json
+++ b/components/fieldgroup/metadata/metadata.json
@@ -2,8 +2,6 @@
   "sourceFile": "index.css",
   "selectors": [
     ".spectrum-FieldGroup",
-    ".spectrum-FieldGroup .spectrum-Checkbox.is-readOnly .spectrum-Checkbox-box",
-    ".spectrum-FieldGroup .spectrum-Checkbox.is-readOnly:not(:last-child) .spectrum-Checkbox-label:after",
     ".spectrum-FieldGroup--horizontal .spectrum-FieldGroupInputLayout",
     ".spectrum-FieldGroup--horizontal .spectrum-FieldGroupInputLayout .spectrum-FieldGroup-item:not(:last-child)",
     ".spectrum-FieldGroup--horizontal .spectrum-FieldGroupInputLayout .spectrum-HelpText",
@@ -13,10 +11,7 @@
     ".spectrum-FieldGroupInputLayout"
   ],
   "modifiers": [],
-  "component": [
-    "--spectrum-fieldgroup-margin",
-    "--spectrum-fieldgroup-readonly-delimiter"
-  ],
+  "component": ["--spectrum-fieldgroup-margin"],
   "global": ["--spectrum-spacing-300"],
   "system-theme": [],
   "passthroughs": [],

--- a/components/fieldgroup/stories/fieldgroup.mdx
+++ b/components/fieldgroup/stories/fieldgroup.mdx
@@ -50,13 +50,13 @@ A horizontal group of fields:
 
 ### Invalid
 
-An invalid group of fields:
+An invalid group of radio buttons or checkboxes is signified by negative help text.
 
-#### Invalid Radio
+#### Invalid Radios
 
 <Canvas of={FieldGroupStories.InvalidRadio} />
 
-#### Invalid Checkbox
+#### Invalid Checkboxes
 
 <Canvas of={FieldGroupStories.InvalidCheckbox} />
 

--- a/components/fieldgroup/stories/fieldgroup.stories.js
+++ b/components/fieldgroup/stories/fieldgroup.stories.js
@@ -271,13 +271,16 @@ HorizontalSideLabelCheckbox.parameters = {
 };
 
 /**
- * A group of read-only checkboxes that have been checked. In U.S. English, use commas to delineate items within read-only checkbox groups. In other languages, use the locale-specific formatting.
+ * Implementations should include the following behavior for read-only checkboxes:
+ * - Read-only checkboxes are immutable, i.e. their checked state cannot be changed.
+ * - Unlike disabled checkbox groups, the normally focusable elements of a checkbox group should remain focusable.
  */
 export const ReadOnly = Template.bind({});
 ReadOnly.tags = ["!dev"];
 ReadOnly.args = {
 	isReadOnly: true,
 	inputType: "checkbox",
+	helpText: undefined,
 };
 ReadOnly.parameters = {
 	chromatic: { disableSnapshot: true },

--- a/components/fieldgroup/stories/fieldgroup.stories.js
+++ b/components/fieldgroup/stories/fieldgroup.stories.js
@@ -7,14 +7,18 @@ import { FieldGroupSet } from "./fieldgroup.test.js";
 import { Template } from "./template.js";
 
 /**
- * A field group is a group of fields, usually radios (also known as a radio group) or checkboxes
+ * A field group is a group of fields which are usually radios (also known as a radio group) or checkboxes
  * (also known as a checkbox group). A field group is composed of a field label, a group of radio
- * inputs or checkboxes, and an optional help text component. The field label within the field group
- * can be used to mark a field group as optional or required. The field group items other than the
- * label must be wrapped in a nested `div` with `.spectrum-FieldGroupInputLayout` to control their
- * layout separately from the label. Help text may or may not appear below a field group and is
- * necessary when denoting invalid checkbox fields, invalid radio button fields, and required
- * fields. Invalid radio buttons and checkboxes are signified by negative help text.
+ * inputs or checkboxes, and an optional help text component.
+ *
+ * ## Usage notes
+ *
+ * - **Markup:** The field group items other than the label must be wrapped in a nested `div` with the `spectrum-FieldGroupInputLayout`
+ * class to control their layout separately from the label. The class `spectrum-FieldGroup-item` should also be applied to each checkbox or radio.
+ * - **Roles:** For radio groups, the attribute `role="radiogroup"` should be used. For a checkbox group, use `role="group"`.
+ * - **Field label:** The field label within the field group can be used to mark a field group as [optional or required](#required-or-optional).
+ * - **Help text:** Help text may or may not appear below a field group and is necessary when denoting invalid
+ * checkbox fields, invalid radio button fields, and required fields.
  */
 export default {
 	title: "Field group",
@@ -182,8 +186,7 @@ InvalidCheckbox.parameters = {
 
 /**
  * Field groups can be marked as optional or required, depending on the situation.
- *
-* If required, the field group must either contain a "(required)" label or an asterisk. If an asterisk is used, help text must explain what the asterisk means.
+ * If required, the field group must either contain a "(required)" label or an asterisk. If an asterisk is used, help text must explain what the asterisk means.
  */
 export const Required = Template.bind({});
 Required.tags = ["!dev"];

--- a/components/fieldgroup/stories/template.js
+++ b/components/fieldgroup/stories/template.js
@@ -1,6 +1,7 @@
 import { Template as CheckBox } from "@spectrum-css/checkbox/stories/template.js";
 import { Template as FieldLabel } from "@spectrum-css/fieldlabel/stories/template.js";
 import { Template as HelpText } from "@spectrum-css/helptext/stories/template.js";
+import { getRandomId } from "@spectrum-css/preview/decorators";
 import { Template as Radio } from "@spectrum-css/radio/stories/template.js";
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
@@ -25,6 +26,8 @@ export const Template = (
 	} = {},
 	context = {},
 ) => {
+	const groupLabelId = getRandomId("group-label");
+
 	return html`
 		<div
 			class=${classMap({
@@ -38,6 +41,7 @@ export const Template = (
 			aria-invalid=${ifDefined(isInvalid ? "true" : undefined)}
 			aria-readonly=${ifDefined(isReadOnly && inputType == "radio" ? "true" : undefined)}
 			aria-required=${ifDefined(isRequired ? "true" : undefined)}
+			aria-labelledby=${ifDefined(label ? groupLabelId : undefined)}
 		>
 			${when(label, () =>
 				FieldLabel(
@@ -46,6 +50,7 @@ export const Template = (
 						label,
 						isRequired,
 						alignment: labelPosition === "side" ? "right" : "top",
+						id: groupLabelId,
 					},
 					context,
 				),

--- a/components/fieldgroup/stories/template.js
+++ b/components/fieldgroup/stories/template.js
@@ -69,12 +69,13 @@ export const Template = (
 							name: "field-group-example",
 							customClasses: [`${rootClass}-item`],
 						}, context))
-						: items.map((item) =>
+						: items.map((item, i) =>
 						CheckBox({
 							...item,
 							isReadOnly,
 							isRequired,
 							customClasses: [`${rootClass}-item`],
+							...(isReadOnly ? {isChecked: i === 1} : {}),
 						}, context)
 				)}
 				${when(helpText, () =>


### PR DESCRIPTION
## Description

As noted in CSS-833, the CSS, SWC, and RSP implementations of read-only checkboxes/checkbox groups, and the docs surrounding them, conflicted with each other. After discussing with the design team, it was decided that the first step would be for CSS to bring our visual styles in line with React's implementation.

**Field group:**
- This PR updates field group to remove the additional checkbox read-only styles that were causing the box to not display and for commas to be appended.
- Template: added `aria-labeledby` connected to the group label, so this is announced as a group by the screen reader.

**Checkbox:**
- Removes some unnecessary read-only CSS. Read-only just needs to override disabled styles. It was confirmed with PJ on the design team that otherwise it uses default styles (for both default and emphasized; React also displays this).
- Template: The checkboxes are made sure to be shown as both focusable and immutable. Some JS was added to prevent the checkbox value from changing.
- Template: `disabled` attribute removed when read-only. Read-only still needs to be focusable / in the tab order.
- Template: Added `aria-disabled="true"` when read-only, so screen readers do not announce as a normal interactive checkbox. For VoiceOver, this will add "dimmed" now and won't announce the shortcut to check or uncheck. Note that I've not used `aria-readonly` like as seen in React Spectrum as it is not announced by the screen reader (any differently than a normal checkbox) and MDN states that it is ["not relevant" for input with type checkbox](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-readonly).
- Adds additional VRT tests to cover some missing combination of states

This also updates all of the docs surrounding these things and adds a new storybook Docs example for Checkbox. The field group usage notes have been cleaned up as well.

CSS-1004

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [x] Field group docs page: read-only example shows full checkbox with boxes and no added commas, and read-only colors
- [x] Checkbox docs page: read-only example shows full checkbox with boxes and no added commas, and read-only colors
- [x] Checkbox docs page: read-only default shows default colors and read-only emphasized shows emphasized colors (should include the blue, which is different than it was previously) @marissahuysentruyt 
- [x] Checkbox testing preview: additional test cases appear and cover the usage of read-only @marissahuysentruyt 
- [x] Review and proofread docs for both examples
- [x] Read-only checkbox is immutable in both docs and stories (clicking does not change checkedness)
- [x] Read-only checkboxes are focusable
- [x] Field group of checkboxes is announced as a group by screen reader (VoiceOver) @marissahuysentruyt 
- [x] Read only checkboxes are announced as dimmed/disabled by screen reader @marissahuysentruyt 

### Regression testing

Expected changes:
- Additional tests added
- Read-only checked for emphasized now displays with blue
- Field group read-only no longer shows comma display (see screenshots)

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

Before:
![Screenshot 2024-10-25 at 4 24 36 PM](https://github.com/user-attachments/assets/5a8347cf-1c77-4655-af24-3e4d686eb040)

After:
![Screenshot 2024-10-25 at 4 26 27 PM](https://github.com/user-attachments/assets/4cfbd8f0-8add-4c2a-954f-94007a82c0c8)

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
