### PR TITLE
chore(stylelint): remove container from at-rule-no-unknown

### DIFF
--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -41,7 +41,7 @@ module.exports = {
 		"at-rule-no-unknown": [
 			true,
 			{
-				ignoreAtRules: ["extend", "container", "each", "include", "mixin"],
+				ignoreAtRules: ["extend", "each", "include", "mixin"],
 			},
 		],
 		"block-no-empty": [true, {


### PR DESCRIPTION
## Description

Removes `container` from `at-rule-no-unknown` at the exception is no longer necessary. `@container` 

### Validation steps

1. Fetch the branch
2. Add an `@container` declaration to a CSS file
3. Restart stylelint
4. Verify the rule isn't marked as a stylelint violation

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨