### PR TITLE
fix(textarea + textfield): move help text to resolve rendering issue

### DIFF
--- a/components/textfield/stories/template.js
+++ b/components/textfield/stories/template.js
@@ -188,15 +188,15 @@ export const Template = ({
 			size: "s",
 			customClasses: customProgressCircleClasses,
 		}, context))}
-		${when(helpText, () =>
-				HelpText({
-					text: helpText,
-					variant: isInvalid ? "negative" : "neutral",
-					size,
-					hideIcon: true,
-					isDisabled
-				}, context ))}
 	</div>
+	${when(helpText, () =>
+		HelpText({
+			text: helpText,
+			variant: isInvalid ? "negative" : "neutral",
+			size,
+			hideIcon: true,
+			isDisabled
+		}, context ))}
 	`;
 };
 


### PR DESCRIPTION
## Description

This template update seeks to resolve the visual bug outlined in [CSS-1008](https://jira.corp.adobe.com/browse/CSS-1008) wherein the keyboard focus state drawn with an `::after` element is rendered beneath the help text.

This issue was caused by the `::after` element being attached to the DOM node enclosing the underlying input. When the help text is inserted into this node, it increases the height of the parent, visually displaying the focus indicator. Rather than refactor how this indicator is drawn, I propose moving the help text out of the parent node and rendering it without impacting the indicator.

## How and where has this been tested?

Locally in Storybook.

### Validation steps

1. Fetch the branch and run it locally, or access the Storybook URL for the PR.
2. Navigate to the textfield component, enable keyboard focus, the quiet appearance variant and add help text.
3. Verify that the indicator displays as expected without being displaced by the help text.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

4. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<img width="281" alt="Screenshot 2024-10-28 at 4 18 55 PM" src="https://github.com/user-attachments/assets/dcca0c97-2158-423f-9b69-38d5bfcbd1eb">

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
