### PR TITLE
chore(storybook): link to swc on docs pages

### DIFF
--- a/.storybook/assets/base.css
+++ b/.storybook/assets/base.css
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern -- Targeting pre-defined Storybook classes */
+
 /*!
  * Copyright 2024 Adobe. All rights reserved.
  *
@@ -11,7 +13,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* stylelint-disable selector-class-pattern */
 body {
 	--spectrum-font-family: var(--spectrum-sans-font-family-stack);
 	--spectrum-font-style: var(--spectrum-default-font-style);
@@ -67,4 +68,5 @@ svg:has(symbol):not(:has(use)) {
 	story view), due to Storybook's inline style that sets overflow: auto */
 	overflow: visible !important;
 }
+
 /* stylelint-enable selector-class-pattern */

--- a/.storybook/assets/images/wc_logo.svg
+++ b/.storybook/assets/images/wc_logo.svg
@@ -1,0 +1,28 @@
+<svg viewBox="0 -23.5 256 256" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid">
+        <defs>
+                <linearGradient x1="0%" y1="50%" x2="100%" y2="50%" id="prefix__a">
+                        <stop stop-color="#2A3B8F" offset="0%" />
+                        <stop stop-color="#29ABE2" offset="100%" />
+                </linearGradient>
+                <linearGradient x1="0%" y1="50%" x2="100%" y2="50%" id="prefix__b">
+                        <stop stop-color="#2A3B8F" offset="0%" />
+                        <stop stop-color="#29ABE2" offset="100%" />
+                </linearGradient>
+                <linearGradient x1="100%" y1="50%" x2="0%" y2="50%" id="prefix__c">
+                        <stop stop-color="#B4D44E" offset="0%" />
+                        <stop stop-color="#E7F716" offset="100%" />
+                </linearGradient>
+                <linearGradient x1="100%" y1="50%" x2="0%" y2="50%" id="prefix__d">
+                        <stop stop-color="#B4D44E" offset="0%" />
+                        <stop stop-color="#E7F716" offset="100%" />
+                </linearGradient>
+        </defs>
+        <path fill="#166DA5" d="M255.997 104.029l-27.805 46.82-38.991-47.46 38.991-46.181z" />
+        <path fill="#8FDB69" d="M225.156 158.839l-42.347-50.656-25.408 42.507 39.47 57.687z" />
+        <path fill="#166DA5" d="M224.676 48.898l-41.867 50.816-25.408-42.506L196.871.16z" />
+        <path fill="url(#prefix__a)" opacity=".95" d="M96.997 48.898h127.679L196.552.16h-71.43z" />
+        <path fill="url(#prefix__b)" opacity=".95" d="M182.809 99.874h70.631l-25.408-42.826h-70.791" />
+        <path fill="url(#prefix__c)" opacity=".95" d="M225.156 158.999H96.838l28.124 48.739h71.909z" />
+        <path fill="#010101" d="M124.962 207.738L64.878 103.869 125.761 0H59.924L0 103.869l59.924 103.869z" />
+        <path fill="url(#prefix__d)" opacity=".95" d="M182.809 108.024h70.631l-25.408 42.825h-70.791" />
+</svg>

--- a/.storybook/assets/index.css
+++ b/.storybook/assets/index.css
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern -- Targeting pre-defined Storybook classes */
+
 /*!
  * Copyright 2024 Adobe. All rights reserved.
  *
@@ -11,7 +13,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* stylelint-disable selector-class-pattern */
 body {
 	--spectrum-font-family-ar: myriad-arabic, adobe-clean, "Source Sans Pro", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, ubuntu, "Trebuchet MS", "Lucida Grande", sans-serif;
 	--spectrum-font-family-he: myriad-hebrew, adobe-clean, "Source Sans Pro", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, ubuntu, "Trebuchet MS", "Lucida Grande", sans-serif;
@@ -66,6 +67,15 @@ nav .spectrum-Site-logo {
 	padding: 20px !important;
 }
 
+/* Hide that first divider line in the top navigation */
+div.sb-bar > div > div > span:first-child {
+	display: none;
+}
+
+div.sb-bar > div > div > div > button {
+	background-color: white !important;
+}
+
 .docblock-argstable-body tr td {
 	letter-spacing: unset;
 	font-size: 11px;
@@ -118,4 +128,5 @@ select:focus,
 	border-color: rgb(2, 101, 220) !important;
 	box-shadow: rgb(2, 101, 220) 0 0 0 1px inset !important;
 }
+
 /* stylelint-enable selector-class-pattern */

--- a/.storybook/blocks/ComponentDetails.jsx
+++ b/.storybook/blocks/ComponentDetails.jsx
@@ -5,6 +5,7 @@ import React, { useEffect, useState } from "react";
 import AdobeSVG from "../assets/images/adobe_logo.svg?raw";
 import GitHubSVG from "../assets/images/github_logo.svg?raw";
 import NpmSVG from "../assets/images/npm_logo.svg?raw";
+import WCSVG from "../assets/images/wc_logo.svg?raw";
 import { Body, Code, Heading } from "./Typography.jsx";
 import { fetchToken } from "./utilities.js";
 
@@ -121,6 +122,7 @@ export const ResourceLink = styled.a`
 	border-color: rgb(230, 230, 230);
 	overflow: hidden;
 	color: rgb(0, 0, 0);
+	background-color: rgba(255 255 255 / 80%);
 
 	&:hover {
 		border-color: rgb(213, 213, 213);
@@ -314,6 +316,8 @@ const fetchLogo = (brand) => {
 			return GitHubSVG;
 		case "Adobe":
 			return AdobeSVG;
+		case "WC":
+			return WCSVG;
 	}
 
 	return;
@@ -361,11 +365,16 @@ export const ResourceLinkContent = ({ heading, alt, logo, href }) => {
 export const ResourceListDetails = ({ packageName, spectrumData = [], rootClassName, isDeprecated }) => {
 	if (!packageName) return;
 
-	let href;
+	let swc, href;
 
 	for(let i = 0; i < spectrumData?.length; i++) {
-		if (spectrumData[i]?.guidelines && spectrumData[i]?.rootClass === rootClassName) {
+		const thisComponent = !spectrumData[i]?.rootClass || spectrumData[i]?.rootClass === rootClassName;
+		if (spectrumData[i]?.guidelines && thisComponent) {
 			href = spectrumData[i]?.guidelines;
+		}
+
+		if (spectrumData[i]?.swc && thisComponent) {
+			swc = spectrumData[i]?.swc;
 		}
 	}
 
@@ -374,10 +383,17 @@ export const ResourceListDetails = ({ packageName, spectrumData = [], rootClassN
 			{href ?
 				<ResourceLinkContent
 					className="doc-block-resource-cards"
-					heading="View guidelines"
+					heading="Design guidelines"
 					alt="Spectrum website"
 					logo="Adobe"
 					href={href}/> : ""}
+			{swc ?
+				<ResourceLinkContent
+					className="doc-block-resource-cards"
+					heading="Web components"
+					alt="Spectrum web components"
+					logo="WC"
+					href={swc}/> : ""}
 				<ResourceLinkContent
 					className="doc-block-resource-cards"
 					heading="View package"

--- a/components/accordion/package.json
+++ b/components/accordion/package.json
@@ -52,7 +52,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum-contributions.corp.adobe.com/page/accordion-beta",
-			"rootClass": "spectrum-Accordion"
+			"rootClass": "spectrum-Accordion",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/accordion/"
 		}
 	]
 }

--- a/components/actionbar/package.json
+++ b/components/actionbar/package.json
@@ -58,7 +58,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum.adobe.com/page/action-bar",
-			"rootClass": "spectrum-ActionBar"
+			"rootClass": "spectrum-ActionBar",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/action-bar/"
 		}
 	]
 }

--- a/components/actionbutton/package.json
+++ b/components/actionbutton/package.json
@@ -58,7 +58,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum.adobe.com/page/action-button",
-			"rootClass": "spectrum-ActionButton"
+			"rootClass": "spectrum-ActionButton",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/action-button/"
 		}
 	]
 }

--- a/components/actiongroup/package.json
+++ b/components/actiongroup/package.json
@@ -53,7 +53,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum.adobe.com/page/action-group",
-			"rootClass": "spectrum-ActionGroup"
+			"rootClass": "spectrum-ActionGroup",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/action-group/"
 		}
 	]
 }

--- a/components/actionmenu/package.json
+++ b/components/actionmenu/package.json
@@ -54,5 +54,10 @@
 	],
 	"publishConfig": {
 		"access": "public"
-	}
+	},
+	"spectrum": [
+		{
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/action-menu/"
+		}
+	]
 }

--- a/components/alertbanner/package.json
+++ b/components/alertbanner/package.json
@@ -63,7 +63,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum.adobe.com/page/alert-banner",
-			"rootClass": "spectrum-AlertBanner"
+			"rootClass": "spectrum-AlertBanner",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/alert-banner/"
 		}
 	]
 }

--- a/components/alertdialog/package.json
+++ b/components/alertdialog/package.json
@@ -68,7 +68,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum.adobe.com/page/alert-dialog",
-			"rootClass": "spectrum-AlertDialog"
+			"rootClass": "spectrum-AlertDialog",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/alert-dialog/"
 		}
 	]
 }

--- a/components/asset/package.json
+++ b/components/asset/package.json
@@ -49,7 +49,8 @@
 	},
 	"spectrum": [
 		{
-			"rootClass": "spectrum-Asset"
+			"rootClass": "spectrum-Asset",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/asset/"
 		}
 	]
 }

--- a/components/avatar/package.json
+++ b/components/avatar/package.json
@@ -50,7 +50,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum.adobe.com/page/avatar",
-			"rootClass": "spectrum-Avatar"
+			"rootClass": "spectrum-Avatar",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/avatar/"
 		}
 	]
 }

--- a/components/badge/package.json
+++ b/components/badge/package.json
@@ -57,7 +57,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum.adobe.com/page/badge",
-			"rootClass": "spectrum-Badge"
+			"rootClass": "spectrum-Badge",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/badge/"
 		}
 	]
 }

--- a/components/breadcrumb/package.json
+++ b/components/breadcrumb/package.json
@@ -62,7 +62,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum.adobe.com/page/breadcrumbs",
-			"rootClass": "spectrum-Breadcrumbs"
+			"rootClass": "spectrum-Breadcrumbs",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/breadcrumbs/"
 		}
 	]
 }

--- a/components/button/package.json
+++ b/components/button/package.json
@@ -63,7 +63,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum.adobe.com/page/button",
-			"rootClass": "spectrum-Button"
+			"rootClass": "spectrum-Button",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/button/"
 		}
 	]
 }

--- a/components/buttongroup/package.json
+++ b/components/buttongroup/package.json
@@ -52,7 +52,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum.adobe.com/page/button-group",
-			"rootClass": "spectrum-ButtonGroup"
+			"rootClass": "spectrum-ButtonGroup",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/button-group/"
 		}
 	]
 }

--- a/components/card/package.json
+++ b/components/card/package.json
@@ -82,7 +82,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum.adobe.com/page/cards",
-			"rootClass": "spectrum-Card"
+			"rootClass": "spectrum-Card",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/card/"
 		}
 	]
 }

--- a/components/checkbox/package.json
+++ b/components/checkbox/package.json
@@ -52,7 +52,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum.adobe.com/page/checkbox",
-			"rootClass": "spectrum-Checkbox"
+			"rootClass": "spectrum-Checkbox",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/checkbox/"
 		}
 	]
 }

--- a/components/coachindicator/package.json
+++ b/components/coachindicator/package.json
@@ -50,7 +50,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum-contributions.corp.adobe.com/page/coach-indicator-beta",
-			"rootClass": "spectrum-CoachIndicator"
+			"rootClass": "spectrum-CoachIndicator",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/coach-indicator/"
 		}
 	]
 }

--- a/components/coachmark/package.json
+++ b/components/coachmark/package.json
@@ -67,7 +67,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum.adobe.com/page/coach-mark",
-			"rootClass": "spectrum-CoachMark"
+			"rootClass": "spectrum-CoachMark",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/coachmark/"
 		}
 	]
 }

--- a/components/colorarea/package.json
+++ b/components/colorarea/package.json
@@ -52,7 +52,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum.adobe.com/page/color-area",
-			"rootClass": "spectrum-ColorArea"
+			"rootClass": "spectrum-ColorArea",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/color-area/"
 		}
 	]
 }

--- a/components/colorhandle/package.json
+++ b/components/colorhandle/package.json
@@ -58,7 +58,8 @@
 	},
 	"spectrum": [
 		{
-			"rootClass": "spectrum-ColorHandle"
+			"rootClass": "spectrum-ColorHandle",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/color-handle/"
 		}
 	]
 }

--- a/components/colorloupe/package.json
+++ b/components/colorloupe/package.json
@@ -50,7 +50,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum.adobe.com/page/color-loupe",
-			"rootClass": "spectrum-ColorLoupe"
+			"rootClass": "spectrum-ColorLoupe",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/color-loupe/"
 		}
 	]
 }

--- a/components/colorslider/package.json
+++ b/components/colorslider/package.json
@@ -54,7 +54,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum.adobe.com/page/color-slider",
-			"rootClass": "spectrum-ColorSlider"
+			"rootClass": "spectrum-ColorSlider",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/color-slider/"
 		}
 	]
 }

--- a/components/colorwheel/package.json
+++ b/components/colorwheel/package.json
@@ -64,7 +64,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum.adobe.com/page/color-wheel",
-			"rootClass": "spectrum-ColorWheel"
+			"rootClass": "spectrum-ColorWheel",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/color-wheel/"
 		}
 	]
 }

--- a/components/combobox/package.json
+++ b/components/combobox/package.json
@@ -65,7 +65,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum.adobe.com/page/combo-box",
-			"rootClass": "spectrum-Combobox"
+			"rootClass": "spectrum-Combobox",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/combobox/"
 		}
 	]
 }

--- a/components/contextualhelp/package.json
+++ b/components/contextualhelp/package.json
@@ -61,7 +61,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum.adobe.com/page/contextual-help",
-			"rootClass": "spectrum-ContextualHelp"
+			"rootClass": "spectrum-ContextualHelp",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/contextual-help/"
 		}
 	]
 }

--- a/components/dialog/package.json
+++ b/components/dialog/package.json
@@ -70,7 +70,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum-contributions.corp.adobe.com/page/standard-dialog-beta",
-			"rootClass": "spectrum-Dialog"
+			"rootClass": "spectrum-Dialog",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/dialog/"
 		}
 	]
 }

--- a/components/divider/package.json
+++ b/components/divider/package.json
@@ -50,7 +50,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum.adobe.com/page/divider",
-			"rootClass": "spectrum-Divider"
+			"rootClass": "spectrum-Divider",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/divider/"
 		}
 	]
 }

--- a/components/dropzone/package.json
+++ b/components/dropzone/package.json
@@ -64,7 +64,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum-contributions.corp.adobe.com/page/drop-zone-beta",
-			"rootClass": "spectrum-DropZone"
+			"rootClass": "spectrum-DropZone",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/dropzone/"
 		}
 	]
 }

--- a/components/fieldgroup/package.json
+++ b/components/fieldgroup/package.json
@@ -66,7 +66,8 @@
 	},
 	"spectrum": [
 		{
-			"rootClass": "spectrum-FieldGroup"
+			"rootClass": "spectrum-FieldGroup",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/field-group/"
 		}
 	]
 }

--- a/components/fieldlabel/package.json
+++ b/components/fieldlabel/package.json
@@ -52,7 +52,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum.adobe.com/page/field-label",
-			"rootClass": "spectrum-FieldLabel"
+			"rootClass": "spectrum-FieldLabel",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/field-label/"
 		},
 		{
 			"rootClass": "spectrum-Form"

--- a/components/helptext/package.json
+++ b/components/helptext/package.json
@@ -52,7 +52,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum.adobe.com/page/help-text",
-			"rootClass": "spectrum-HelpText"
+			"rootClass": "spectrum-HelpText",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/help-text/"
 		}
 	]
 }

--- a/components/icon/package.json
+++ b/components/icon/package.json
@@ -50,7 +50,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum.adobe.com/page/iconography",
-			"rootClass": "spectrum-Icon"
+			"rootClass": "spectrum-Icon",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/icon/"
 		}
 	]
 }

--- a/components/illustratedmessage/package.json
+++ b/components/illustratedmessage/package.json
@@ -52,7 +52,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum-contributions.corp.adobe.com/page/illustrated-message-beta",
-			"rootClass": "spectrum-IllustratedMessage"
+			"rootClass": "spectrum-IllustratedMessage",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/illustrated-message/"
 		}
 	]
 }

--- a/components/infieldbutton/package.json
+++ b/components/infieldbutton/package.json
@@ -56,7 +56,8 @@
 	},
 	"spectrum": [
 		{
-			"rootClass": "spectrum-InfieldButton"
+			"rootClass": "spectrum-InfieldButton",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/infield-button/"
 		}
 	]
 }

--- a/components/link/package.json
+++ b/components/link/package.json
@@ -50,7 +50,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum.adobe.com/page/link",
-			"rootClass": "spectrum-Link"
+			"rootClass": "spectrum-Link",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/link/"
 		}
 	]
 }

--- a/components/menu/package.json
+++ b/components/menu/package.json
@@ -74,7 +74,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum.adobe.com/page/menu",
-			"rootClass": "spectrum-Menu"
+			"rootClass": "spectrum-Menu",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/menu/"
 		}
 	]
 }

--- a/components/picker/package.json
+++ b/components/picker/package.json
@@ -69,7 +69,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum.adobe.com/page/picker",
-			"rootClass": "spectrum-Picker"
+			"rootClass": "spectrum-Picker",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/picker/"
 		}
 	]
 }

--- a/components/pickerbutton/package.json
+++ b/components/pickerbutton/package.json
@@ -55,7 +55,8 @@
 	},
 	"spectrum": [
 		{
-			"rootClass": "spectrum-PickerButton"
+			"rootClass": "spectrum-PickerButton",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/picker-button/"
 		}
 	]
 }

--- a/components/popover/package.json
+++ b/components/popover/package.json
@@ -67,7 +67,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum.adobe.com/page/popover",
-			"rootClass": "spectrum-Popover"
+			"rootClass": "spectrum-Popover",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/popover/"
 		}
 	]
 }

--- a/components/progressbar/package.json
+++ b/components/progressbar/package.json
@@ -57,11 +57,13 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum.adobe.com/page/progress-bar",
-			"rootClass": "spectrum-ProgressBar"
+			"rootClass": "spectrum-ProgressBar",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/progress-bar/"
 		},
 		{
 			"guidelines": "https://spectrum.adobe.com/page/meter",
-			"rootClass": "spectrum-Meter"
+			"rootClass": "spectrum-Meter",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/meter/"
 		}
 	]
 }

--- a/components/progresscircle/package.json
+++ b/components/progresscircle/package.json
@@ -50,7 +50,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum.adobe.com/page/progress-circle",
-			"rootClass": "spectrum-ProgressCircle"
+			"rootClass": "spectrum-ProgressCircle",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/progress-circle/"
 		}
 	]
 }

--- a/components/radio/package.json
+++ b/components/radio/package.json
@@ -52,7 +52,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum.adobe.com/page/radio-group",
-			"rootClass": "spectrum-Radio"
+			"rootClass": "spectrum-Radio",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/radio/"
 		}
 	]
 }

--- a/components/search/package.json
+++ b/components/search/package.json
@@ -56,7 +56,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum.adobe.com/page/search-field",
-			"rootClass": "spectrum-Search"
+			"rootClass": "spectrum-Search",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/search/"
 		}
 	]
 }

--- a/components/sidenav/package.json
+++ b/components/sidenav/package.json
@@ -57,7 +57,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum.adobe.com/page/side-navigation",
-			"rootClass": "spectrum-SideNav"
+			"rootClass": "spectrum-SideNav",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/sidenav/"
 		}
 	]
 }

--- a/components/slider/package.json
+++ b/components/slider/package.json
@@ -52,7 +52,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum.adobe.com/page/slider",
-			"rootClass": "spectrum-Slider"
+			"rootClass": "spectrum-Slider",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/slider/"
 		}
 	]
 }

--- a/components/splitview/package.json
+++ b/components/splitview/package.json
@@ -49,7 +49,8 @@
 	},
 	"spectrum": [
 		{
-			"rootClass": "spectrum-SplitView"
+			"rootClass": "spectrum-SplitView",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/split-view/"
 		}
 	]
 }

--- a/components/statuslight/package.json
+++ b/components/statuslight/package.json
@@ -50,7 +50,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum.adobe.com/page/status-light",
-			"rootClass": "spectrum-StatusLight"
+			"rootClass": "spectrum-StatusLight",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/status-light/"
 		}
 	]
 }

--- a/components/swatch/package.json
+++ b/components/swatch/package.json
@@ -52,7 +52,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum.adobe.com/page/swatch",
-			"rootClass": "spectrum-Swatch"
+			"rootClass": "spectrum-Swatch",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/swatch/"
 		}
 	]
 }

--- a/components/swatchgroup/package.json
+++ b/components/swatchgroup/package.json
@@ -52,7 +52,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum.adobe.com/page/swatch-group",
-			"rootClass": "spectrum-SwatchGroup"
+			"rootClass": "spectrum-SwatchGroup",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/swatch-group/"
 		}
 	]
 }

--- a/components/switch/package.json
+++ b/components/switch/package.json
@@ -50,7 +50,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum.adobe.com/page/switch",
-			"rootClass": "spectrum-Switch"
+			"rootClass": "spectrum-Switch",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/switch/"
 		}
 	]
 }

--- a/components/table/package.json
+++ b/components/table/package.json
@@ -69,7 +69,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum.adobe.com/page/table",
-			"rootClass": "spectrum-Table"
+			"rootClass": "spectrum-Table",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/table/"
 		}
 	]
 }

--- a/components/tabs/package.json
+++ b/components/tabs/package.json
@@ -61,7 +61,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum.adobe.com/page/tabs",
-			"rootClass": "spectrum-Tabs"
+			"rootClass": "spectrum-Tabs",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/tabs/"
 		}
 	]
 }

--- a/components/tag/package.json
+++ b/components/tag/package.json
@@ -64,7 +64,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum.adobe.com/page/tag",
-			"rootClass": "spectrum-Tag"
+			"rootClass": "spectrum-Tag",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/tag/"
 		}
 	]
 }

--- a/components/taggroup/package.json
+++ b/components/taggroup/package.json
@@ -52,7 +52,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum-contributions.corp.adobe.com/page/tag-group-beta",
-			"rootClass": "spectrum-TagGroup"
+			"rootClass": "spectrum-TagGroup",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/tags/"
 		}
 	]
 }

--- a/components/textfield/package.json
+++ b/components/textfield/package.json
@@ -57,7 +57,13 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum.adobe.com/page/text-field",
-			"rootClass": "spectrum-Textfield"
+			"rootClass": "spectrum-Textfield",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/textfield/"
+		},
+		{
+			"guidelines": "https://spectrum.adobe.com/page/text-area",
+			"rootClass": "spectrum-Textfield--multiline",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/textarea/"
 		}
 	]
 }

--- a/components/thumbnail/package.json
+++ b/components/thumbnail/package.json
@@ -52,7 +52,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum-contributions.corp.adobe.com/page/thumbnail-beta",
-			"rootClass": "spectrum-Thumbnail"
+			"rootClass": "spectrum-Thumbnail",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/thumbnail/"
 		}
 	]
 }

--- a/components/toast/package.json
+++ b/components/toast/package.json
@@ -56,7 +56,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum.adobe.com/page/toast",
-			"rootClass": "spectrum-Toast"
+			"rootClass": "spectrum-Toast",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/toast/"
 		}
 	]
 }

--- a/components/tooltip/package.json
+++ b/components/tooltip/package.json
@@ -53,7 +53,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum.adobe.com/page/tooltip",
-			"rootClass": "spectrum-Tooltip"
+			"rootClass": "spectrum-Tooltip",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/tooltip/"
 		}
 	]
 }

--- a/components/tray/package.json
+++ b/components/tray/package.json
@@ -68,7 +68,8 @@
 	"spectrum": [
 		{
 			"guidelines": "https://spectrum.adobe.com/page/tray",
-			"rootClass": "spectrum-Tray"
+			"rootClass": "spectrum-Tray",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/tray/"
 		}
 	]
 }

--- a/components/underlay/package.json
+++ b/components/underlay/package.json
@@ -49,7 +49,8 @@
 	},
 	"spectrum": [
 		{
-			"rootClass": "spectrum-Underlay"
+			"rootClass": "spectrum-Underlay",
+			"swc": "https://opensource.adobe.com/spectrum-web-components/components/underlay/"
 		}
 	]
 }


### PR DESCRIPTION
## Description

Add links to the Spectrum Web Components implementations for components that have them. These links are being added to the resource section and will be leveraging the web component technology logo (rather than Adobe) as discussed & approved by the SWC team.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [ ] Expect to see a link to the web component implementation for Accordion in the resource section: [link](https://pr-3356--spectrum-css.netlify.app/preview/?path=/docs/components-accordion--docs)

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
