### PR TITLE
fix(search): removes calc and replaces w/fixed value

### DIFF
--- a/.changeset/itchy-bikes-join.md
+++ b/.changeset/itchy-bikes-join.md
@@ -1,0 +1,7 @@
+---
+"@spectrum-css/search": minor
+---
+
+This change removes the existing calc function used to calculate the padding-inline-end for S1 and the quiet variant in favor of a simpler value with a mod preceding a static value.
+
+This change removes the `--mod-search-quiet-button-offset` mod.

--- a/components/search/index.css
+++ b/components/search/index.css
@@ -204,7 +204,7 @@
 
 	.spectrum-Search-input {
 		padding-inline-start: calc(var(--mod-search-edge-to-visual, var(--spectrum-search-edge-to-visual)) - var(--mod-search-border-width, var(--spectrum-search-border-width)) + var(--mod-search-icon-size, var(--spectrum-search-icon-size)) + var(--mod-search-text-to-icon, var(--spectrum-search-text-to-icon)));
-		padding-inline-end: calc(var(--mod-search-button-inline-size, var(--spectrum-search-button-inline-size)) - var(--mod-search-border-width, var(--spectrum-search-border-width)));
+		padding-inline-end: var(--mod-search-button-inline-size, var(--spectrum-search-button-inline-size));
 	}
 }
 
@@ -223,7 +223,7 @@
 	&.spectrum-Search .spectrum-Search-input {
 		border-radius: var(--mod-search-border-radius, var(--spectrum-search-border-radius));
 		padding-inline-start: calc(var(--mod-search-edge-to-visual, var(--spectrum-search-edge-to-visual)) + var(--mod-search-icon-size, var(--spectrum-search-icon-size)) + var(--mod-search-text-to-icon, var(--spectrum-search-text-to-icon)));
-		padding-inline-end: calc(var(--mod-search-button-inline-size, var(--spectrum-search-button-inline-size)) - var(--mod-search-quiet-button-offset, calc(var(--mod-search-block-size, var(--spectrum-search-block-size)) / 2 - var(--mod-search-icon-size, var(--spectrum-search-icon-size)) / 2)));
+		padding-inline-end: var(--mod-search-button-inline-size, var(--spectrum-search-button-inline-size));
 		padding-block-start: var(--mod-search-top-to-text, var(--spectrum-search-top-to-text));
 	}
 }

--- a/components/search/metadata/metadata.json
+++ b/components/search/metadata/metadata.json
@@ -61,7 +61,6 @@
     "--mod-search-inline-size",
     "--mod-search-line-height",
     "--mod-search-min-inline-size",
-    "--mod-search-quiet-button-offset",
     "--mod-search-text-to-icon",
     "--mod-search-to-help-text",
     "--mod-search-top-to-text"

--- a/components/search/metadata/mods.md
+++ b/components/search/metadata/mods.md
@@ -30,7 +30,6 @@
 | `--mod-search-inline-size`               |
 | `--mod-search-line-height`               |
 | `--mod-search-min-inline-size`           |
-| `--mod-search-quiet-button-offset`       |
 | `--mod-search-text-to-icon`              |
 | `--mod-search-to-help-text`              |
 | `--mod-search-top-to-text`               |


### PR DESCRIPTION
## Description

For `CSS-1052`.

This change removes the existing calc function used to calculate the padding-inline-end for S1 and the quiet variant in favor of a simpler value with a mod preceding a static value.

This change removes the `--mod-search-quiet-button-offset` mod.

With this change the blue area referenced in #3297 no longer extends under the bounding box of the clear button. The user can safely click on the blue area after this change to edit text and the touch area for the clear button is preserved. The `cursor` UI changes to the `pointer` state when hovering over the clear button as a visual indicator of the button's interactivity.

## How and where has this been tested?

Verified locally in Storybook.

### Validation steps

1. Open the Storybook URL for the PR (or fetch the branch and run it locally).
2. Navigate to the search component.
3. Enter a long string in the search input that fills the field.
4. Verify that the text is truncated and the field renders as expected.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

5. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

**Previous state:**
![image](https://github.com/user-attachments/assets/cb4aab4f-b0f3-4eb0-b04e-eeb1b5878575)

**Current state:**
<img width="591" alt="Screenshot 2024-11-05 at 3 52 24 PM" src="https://github.com/user-attachments/assets/e0b41967-c40c-42b2-b4da-a040c2ad117d">

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
