### PR TITLE
chore(popover): fix alignment of test grid

### DIFF
--- a/components/popover/stories/popover.test.js
+++ b/components/popover/stories/popover.test.js
@@ -73,6 +73,7 @@ export const PopoverGroup = Variants({
 					wrapperStyles["padding-right"] = `${popoverWidth + 20}px`;
 					break;
 				case "left":
+					wrapperStyles["align-items"] = "center";
 					wrapperStyles["block-size"] = `${popoverHeight + 20}px`;
 					wrapperStyles["padding-left"] = `${popoverWidth + 20}px`;
 					break;
@@ -87,6 +88,7 @@ export const PopoverGroup = Variants({
 					wrapperStyles["padding-left"] = `${popoverWidth + 20}px`;
 					break;
 				case "start":
+					wrapperStyles["align-items"] = "center";
 					wrapperStyles["block-size"] = `${popoverHeight + 20}px`;
 					wrapperStyles["padding-inline-start"] = `${popoverWidth + 20}px`;
 					break;
@@ -101,6 +103,7 @@ export const PopoverGroup = Variants({
 					wrapperStyles["padding-inline-start"] = `${popoverWidth + 20}px`;
 					break;
 				case "end":
+					wrapperStyles["align-items"] = "center";
 					wrapperStyles["block-size"] = `${popoverHeight + 20}px`;
 					wrapperStyles["padding-inline-end"] = `${popoverWidth + 20}px`;
 					break;


### PR DESCRIPTION
- centers popover element for left, start and end test cases

<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

This PR adjusts the alignment in the testing grid for `left`, `start`, and `end` test cases.

Before 🚫 

<img width="524" alt="Screenshot 2024-11-06 at 1 13 01 PM" src="https://github.com/user-attachments/assets/c286520f-b494-4ba8-afc8-3592a303351c">

After ✅ 

<img width="524" alt="Screenshot 2024-11-06 at 1 15 31 PM" src="https://github.com/user-attachments/assets/d83e516a-f553-4af9-990f-54a81128d678">

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

- [ ] Pull down the branch to run locally, or visit the deploy preview.
- [ ] Visit the default popover story.
- [ ] Turn on the test grid
- [ ] Verify the popover variants for the `left`, `start`, and `end` test cases no longer eclipse the accompanying test headings. See the "After" screenshot above for reference.
- [ ] VRTs are expected to show this change.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [ ] ✨ This pull request is ready to merge. ✨
