### PR TITLE
chore(storybook): add 404 page

### DIFF
--- a/.storybook/assets/404.html
+++ b/.storybook/assets/404.html
@@ -15,6 +15,12 @@
         background-color: var(--spectrum-background-layer-1-color);
       }
 
+      header {
+        max-width: 1000px;
+        margin: auto;
+        padding-block-start: 4rem;
+      }
+
       main {
         --spectrum-neutral-content-color-default: rgb(34, 34, 34);
 
@@ -59,15 +65,40 @@
         margin-block: 16px;
       }
 
+      .spectrum-logo {
+        display: block;
+      }
+
+      svg {
+        block-size: auto;
+        inline-size: 100%;
+        max-inline-size: 150px;
+        max-block-size: 100px;
+      }
+
     </style>
   </head>
   <body>
+    <header>
+      <a class="spectrum-logo" href="https://opensource.adobe.com/spectrum-css/" aria-label="Spectrum CSS">
+        <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="spectrum-Site-logo spectrum-Icon spectrum-Icon--sizeXL" version="1.1" id="Layer_1" x="0" y="0" viewBox="0 0 190 26" focusable="false" aria-hidden="true" aria-label="Adobe logo" xml:space="preserve">
+          <g style="fill:#FA0F00">
+            <polygon points="19,0 30,0 30,26"/>
+            <polygon points="11.1,0 0,0 0,26"/>
+            <polygon points="15,9.6 22.1,26 17.5,26 15.4,20.8 10.2,20.8"/>
+          </g>
+          <text x="38" y="20" style="color: rgb(0,0,0);font-size: 22px;font-family: adobe-clean,'Source Sans Pro',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Ubuntu,'Trebuchet MS','Lucida Grande',sans-serif; font-weight: 700; height: 28px; line-height: 28.6px;">
+              Spectrum CSS
+          </text>
+          </svg>
+      </a>
+    </header>
     <main>
-      <h1>404</h1>
+      <h1>404: Page not found</h1>
       <section>
         <img src="/spectrum_illustration_2x.png" alt="">
         <h2>It's not you. It's us.</h2>
-        <p>We've made lots of changes recently to our documentation site. In preparation for Spectrum 2, we've been hard at work migrating our documentation here, to Storybook.</p>
+        <p>We've made lots of changes to the Spectrum CSS documentation site, including consolidating all of the documentation and moving it to a single location within Storybook.</p>
         <p>If you're looking for information on Spectrum CSS components, let's get you back to <a href="https://opensource.adobe.com/spectrum-css/">our landing page</a>. From there, experiment with all of our components to your heart's content!
         </p>
       </section>

--- a/.storybook/assets/404.html
+++ b/.storybook/assets/404.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Page not found</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+    <link rel="icon" type="image/svg+xml" href="./favicon.svg">
+    <style>
+      body {
+        --spectrum-background-layer-1-color: rgb(253, 253, 253);
+
+        margin: 0;
+        padding: 0;
+        block-size: 100vh;
+        background-color: var(--spectrum-background-layer-1-color);
+      }
+
+      main {
+        --spectrum-neutral-content-color-default: rgb(34, 34, 34);
+
+        color: var(--spectrum-neutral-content-color-default);
+        display: flex;
+        padding-inline: 20px;
+        padding-block: 4rem;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 60px;
+        max-width: 1000px;
+        margin: auto;
+      }
+
+      img {
+        max-inline-size: 100%;
+        margin-block: -20px 20px;
+      }
+
+      h1, h2, p {
+        --spectrum-sans-font-family-stack: "Nunito Sans",-apple-system,".SFNSText-Regular","San Francisco",BlinkMacSystemFont,"Segoe UI","Helvetica Neue",Helvetica,Arial,sans-serif;
+
+        -webkit-font-smoothing: antialiased;
+        font-family: var(--spectrum-sans-font-family-stack);
+      }
+
+      h1 {
+        font-weight: 700;
+        font-size: 32px;
+        margin-block: 20px 8px;
+      }
+
+      h2 {
+        font-size: 24px;
+        margin-block: 20px 8px;
+        padding-block-end: 4px;
+      }
+
+      p {
+        font-size: 14px;
+        line-height: 24px;
+        margin-block: 16px;
+      }
+
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>404</h1>
+      <section>
+        <img src="/spectrum_illustration_2x.png" alt="">
+        <h2>It's not you. It's us.</h2>
+        <p>We've made lots of changes recently to our documentation site. In preparation for Spectrum 2, we've been hard at work migrating our documentation here, to Storybook.</p>
+        <p>If you're looking for information on Spectrum CSS components, let's get you back to <a href="https://opensource.adobe.com/spectrum-css/">our landing page</a>. From there, experiment with all of our components to your heart's content!
+        </p>
+      </section>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->
This PR adds a custom `404.html` file to the static `assets` directory. Users may likely encounter several invalid links once we finalize our Storybook as our documentation site. This page aims to provide a link so users can get to the Storybook landing page and navigate to their components from there.

No changeset was added since no component CSS was altered.

### Jira/Issue
[CSS-1054](https://jira.corp.adobe.com/browse/CSS-1054)

Before 🚫 
This is the default 404 page with a GitHub pages site.
<img width="1609" alt="Screenshot 2024-11-13 at 1 17 33 PM" src="https://github.com/user-attachments/assets/d30c0dcc-dce1-4a46-be49-0c33ff030360">

After ✅ 
This is our custom 404 page.
<img width="1607" alt="Screenshot 2024-11-13 at 1 17 58 PM" src="https://github.com/user-attachments/assets/19cd2782-c94c-4288-8dfc-5e0540f33caa">

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

- [x] [Visit the deploy preview](https://pr-3386--spectrum-css.netlify.app/) (validation can only occur in a build. The 404 doesn't render on localhost) @rise-erpelding 
- [x] Verify that no regressions have occurred on several pages.
- [x] In the browser, attempt to navigate to a page that doesn't exist by replacing `?path=/docs/guides-contributing--docs` in the URL with something.
- [x] Proofread the 404 content. Ensure there are no spelling or grammar errors, and that the content makes sense.
- [x] Verify the link back to the landing page works and is keyboard accessible.
    - Note: this will navigate you back to the old docs site, as opposed to the Storybook landing page we have now. This URL should be the one Storybook eventually points to once we finalize the migration, so don't be alarmed.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [ ] ✨ This pull request is ready to merge. ✨
