### PR TITLE
feat(thumbnail-opacity-checkboard): S2 migration

### DIFF
--- a/.changeset/afraid-ladybugs-smile.md
+++ b/.changeset/afraid-ladybugs-smile.md
@@ -1,0 +1,7 @@
+---
+"@spectrum-css/thumbnail": major
+---
+
+# thumbnail-pacity-checkerboard S2 migration
+
+Adds thumbnail specific `thumbnail-opacity-checkerboard-square-size` token aliased to `--spectrum-opacity-checkerboard-size`. This impacts the display of the `opacity-checkerboard` when used within the `thumbnail` component.

--- a/.changeset/twenty-tables-know.md
+++ b/.changeset/twenty-tables-know.md
@@ -1,4 +1,5 @@
 ---
+"@spectrum-css/opacitycheckerboard": major
 "@spectrum-css/thumbnail": major
 ---
 

--- a/.changeset/twenty-tables-know.md
+++ b/.changeset/twenty-tables-know.md
@@ -3,6 +3,6 @@
 "@spectrum-css/thumbnail": major
 ---
 
-# thumbnail-pacity-checkerboard S2 migration
+# thumbnail-opacity-checkerboard S2 migration
 
 Adds thumbnail specific `thumbnail-opacity-checkerboard-square-size` token aliased to `--spectrum-opacity-checkerboard-size`. This impacts the display of the `opacity-checkerboard` when used within the `thumbnail` component.

--- a/.changeset/twenty-tables-know.md
+++ b/.changeset/twenty-tables-know.md
@@ -1,8 +1,10 @@
 ---
 "@spectrum-css/opacitycheckerboard": major
-"@spectrum-css/thumbnail": major
+"@spectrum-css/thumbnail": minor
 ---
 
 # thumbnail-opacity-checkerboard S2 migration
 
 Adds thumbnail specific `thumbnail-opacity-checkerboard-square-size` token aliased to `--spectrum-opacity-checkerboard-size`. This impacts the display of the `opacity-checkerboard` when used within the `thumbnail` component.
+
+This also corrects an issue with a token name in the `thumbnail` component by renaming `--spectrum-thumbnail-border-color-opacity` to `--spectrum-thumbnail-border-opacity`.

--- a/components/opacitycheckerboard/index.css
+++ b/components/opacitycheckerboard/index.css
@@ -8,53 +8,22 @@ express or implied. See the License for the specific language governing
 permissions and limitations under the License. */
 
 .spectrum-OpacityCheckerboard {
-	--spectrum-opacity-checkerboard-dark: var(
-		--spectrum-opacity-checkerboard-square-dark
-	);
-	--spectrum-opacity-checkerboard-light: var(
-		--spectrum-opacity-checkerboard-square-light
-	);
-	--spectrum-opacity-checkerboard-size: var(
-		--spectrum-opacity-checkerboard-square-size-medium
-	);
+	--spectrum-opacity-checkerboard-dark: var(--spectrum-opacity-checkerboard-square-dark);
+	--spectrum-opacity-checkerboard-light: var(--spectrum-opacity-checkerboard-square-light);
+	--spectrum-opacity-checkerboard-size: var(--spectrum-opacity-checkerboard-square-size-medium);
 	--spectrum-opacity-checkerboard-position: left top;
 }
 
 .spectrum-OpacityCheckerboard--sizeS {
-	--spectrum-opacity-checkerboard-size: var(
-		--spectrum-opacity-checkerboard-square-size-small
-	);
+	--spectrum-opacity-checkerboard-size: var(--spectrum-opacity-checkerboard-square-size-small);
 }
 
 .spectrum-OpacityCheckerboard {
-	background: repeating-conic-gradient(
-			var(
-					--mod-opacity-checkerboard-light,
-					var(--spectrum-opacity-checkerboard-light)
-				)
-				0% 25%,
-			var(
-					--mod-opacity-checkerboard-dark,
-					var(--spectrum-opacity-checkerboard-dark)
-				)
-				0% 50%
-		)
-		var(
-			--mod-opacity-checkerboard-position,
-			var(--spectrum-opacity-checkerboard-position)
-		) /
-		calc(
-			var(
-					--mod-opacity-checkerboard-size,
-					var(--spectrum-opacity-checkerboard-size)
-				) * 2
-		)
-		calc(
-			var(
-					--mod-opacity-checkerboard-size,
-					var(--spectrum-opacity-checkerboard-size)
-				) * 2
-		);
+	background: repeating-conic-gradient(var(--mod-opacity-checkerboard-light, var(--spectrum-opacity-checkerboard-light)) 0% 25%, var(--mod-opacity-checkerboard-dark, var(--spectrum-opacity-checkerboard-dark)) 0% 50%) var(--mod-opacity-checkerboard-position, var(--spectrum-opacity-checkerboard-position)) / calc(var(--mod-opacity-checkerboard-size, var(--spectrum-opacity-checkerboard-size)) * 2) calc(var(--mod-opacity-checkerboard-size, var(--spectrum-opacity-checkerboard-size)) * 2);
+
+	.spectrum-Thumbnail & {
+		--spectrum-opacity-checkerboard-size: var(--spectrum-thumbnail-opacity-checkerboard-square- size);
+	}
 }
 
 @media (forced-colors: active) {

--- a/components/opacitycheckerboard/index.css
+++ b/components/opacitycheckerboard/index.css
@@ -22,7 +22,7 @@ permissions and limitations under the License. */
 	background: repeating-conic-gradient(var(--mod-opacity-checkerboard-light, var(--spectrum-opacity-checkerboard-light)) 0% 25%, var(--mod-opacity-checkerboard-dark, var(--spectrum-opacity-checkerboard-dark)) 0% 50%) var(--mod-opacity-checkerboard-position, var(--spectrum-opacity-checkerboard-position)) / calc(var(--mod-opacity-checkerboard-size, var(--spectrum-opacity-checkerboard-size)) * 2) calc(var(--mod-opacity-checkerboard-size, var(--spectrum-opacity-checkerboard-size)) * 2);
 
 	.spectrum-Thumbnail & {
-		--spectrum-opacity-checkerboard-size: var(--spectrum-thumbnail-opacity-checkerboard-square- size);
+		--spectrum-opacity-checkerboard-size: var(--spectrum-thumbnail-opacity-checkerboard-square-size);
 	}
 }
 

--- a/components/thumbnail/index.css
+++ b/components/thumbnail/index.css
@@ -92,10 +92,6 @@ governing permissions and limitations under the License.
 
 	border-radius: var(--mod-thumbnail-border-radius, var(--spectrum-thumbnail-border-radius));
 
-	& .spectrum-OpacityCheckerboard {
-		--spectrum-opacity-checkerboard-size: var(--spectrum-thumbnail-opacity-checkerboard-square-size);
-	}
-
 	&::before {
 		content: "";
 		z-index: 2;

--- a/components/thumbnail/index.css
+++ b/components/thumbnail/index.css
@@ -33,6 +33,10 @@ governing permissions and limitations under the License.
 	--spectrum-thumbnail-color-opacity-disabled: var(--spectrum-thumbnail-opacity-disabled);
 }
 
+.spectrum-OpacityCheckerboard {
+	--spectrum-opacity-checkerboard-size: var(--spectrum-thumbnail-opacity-checkerboard-square-size);
+}
+
 .spectrum-Thumbnail--size50 {
 	--spectrum-thumbnail-size: var(--spectrum-thumbnail-size-50);
 }

--- a/components/thumbnail/index.css
+++ b/components/thumbnail/index.css
@@ -92,6 +92,10 @@ governing permissions and limitations under the License.
 
 	border-radius: var(--mod-thumbnail-border-radius, var(--spectrum-thumbnail-border-radius));
 
+	& .spectrum-OpacityCheckerboard {
+		--spectrum-opacity-checkerboard-size: var(--spectrum-thumbnail-opacity-checkerboard-square-size);
+	}
+
 	&::before {
 		content: "";
 		z-index: 2;
@@ -122,10 +126,6 @@ governing permissions and limitations under the License.
 		.spectrum-Thumbnail-image-wrapper {
 			overflow: hidden;
 			border-radius: var(--mod-thumbnail-border-radius, var(--spectrum-thumbnail-border-radius));
-		}
-
-		& .spectrum-OpacityCheckerboard {
-			--spectrum-opacity-checkerboard-size: var(--spectrum-thumbnail-opacity-checkerboard-square- size);
 		}
 	}
 	/* stylelint-enable selector-pseudo-class-no-unknown */

--- a/components/thumbnail/index.css
+++ b/components/thumbnail/index.css
@@ -33,10 +33,6 @@ governing permissions and limitations under the License.
 	--spectrum-thumbnail-color-opacity-disabled: var(--spectrum-thumbnail-opacity-disabled);
 }
 
-.spectrum-OpacityCheckerboard {
-	--spectrum-opacity-checkerboard-size: var(--spectrum-thumbnail-opacity-checkerboard-square-size);
-}
-
 .spectrum-Thumbnail--size50 {
 	--spectrum-thumbnail-size: var(--spectrum-thumbnail-size-50);
 }
@@ -126,6 +122,10 @@ governing permissions and limitations under the License.
 		.spectrum-Thumbnail-image-wrapper {
 			overflow: hidden;
 			border-radius: var(--mod-thumbnail-border-radius, var(--spectrum-thumbnail-border-radius));
+		}
+
+		& .spectrum-OpacityCheckerboard {
+			--spectrum-opacity-checkerboard-size: var(--spectrum-thumbnail-opacity-checkerboard-square- size);
 		}
 	}
 	/* stylelint-enable selector-pseudo-class-no-unknown */

--- a/components/thumbnail/index.css
+++ b/components/thumbnail/index.css
@@ -17,7 +17,7 @@ governing permissions and limitations under the License.
 	--spectrum-thumbnail-border-width: var(--spectrum-border-width-100);
 
 	/* @todo Refactor with --spectrum-thumbnail-border-color once gray rgb token is no longer necessary to workaround nested rgb color token value using rgba(). */
-	--spectrum-thumbnail-border-color-rgba: rgba(var(--spectrum-gray-800-rgb), var(--spectrum-thumbnail-border-color-opacity));
+	--spectrum-thumbnail-border-color-rgba: rgba(var(--spectrum-gray-800-rgb), var(--spectrum-thumbnail-border-opacity));
 	--spectrum-thumbnail-layer-border-width-inner: var(--spectrum-border-width-400);
 	--spectrum-thumbnail-layer-border-color-inner: var(--spectrum-white);
 	--spectrum-thumbnail-layer-border-width-outer: var(--spectrum-border-width-100);

--- a/components/thumbnail/stories/template.js
+++ b/components/thumbnail/stories/template.js
@@ -113,9 +113,6 @@ export const Template = ({
 			${OpacityCheckerboard({
 				rootClass: backgroundColor ? `${rootClass}-image-wrapper` : undefined,
 				customClasses: isLayer ? [`${rootClass}-layer-inner`] : !backgroundColor ? [`${rootClass}-image-wrapper`] : [],
-				customStyles: {
-					"--spectrum-opacity-checkerboard-size": "var(--spectrum-thumbnail-opacity-checkerboard-square-size)"
-				},
 				content: image ? [image] : [],
 			})}
 		</div>


### PR DESCRIPTION
## Description

`CSS-1056`

This is a follow up to CSS-1023, implementing the `thumbnail-opacity-checkerboard-square-size` that is specific to the `thumbnail` component but targeted at the `opacity-checkerboard`.

Adds thumbnail specific `--spectrum-opacity-checkerboard-size` token. This impacts the display of the `opacity-checkerboard` when used within the `thumbnail` component.

### Validation steps

1. Run Storybook locally or open the link for the PR.
2. Navigate to the `thumbnail` component.
3. Verify that no regressions are visible.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨