### PR TITLE
feat(infield-progress-cirlce): new component, sharing tokens from progress circle

### DIFF
--- a/.changeset/flat-snails-admire.md
+++ b/.changeset/flat-snails-admire.md
@@ -1,0 +1,7 @@
+---
+"@spectrum-css/infieldprogresscircle": major
+---
+
+## Infield Progresscircle S2 Migration
+
+In-field progress circle is a new component created to replace progress circle (size S) in t-shirt size components. The button, textfield, combo box, and picker `template.js` files have all been updated to call for infield progress circles. This component comes in four sizes: (S, M, L, XL), has updated color variants (default, white, black), and has a unified track thickness.

--- a/components/button/stories/template.js
+++ b/components/button/stories/template.js
@@ -1,6 +1,6 @@
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
+import { Template as InfieldProgressCircle } from "@spectrum-css/infieldprogresscircle/stories/template.js";
 import { Container, getRandomId } from "@spectrum-css/preview/decorators";
-import { Template as ProgressCircle } from "@spectrum-css/progresscircle/stories/template.js";
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
@@ -89,15 +89,12 @@ export const Template = ({
 			Icon({ iconName, setName: iconSet, size }, context)
 		)}
 		${when(isPending, () =>
-			ProgressCircle(
-				{
-					size: "s",
-					testId: "progress-circle",
-					staticColor,
-					isIndeterminate: true,
-				},
-				context
-			)
+			InfieldProgressCircle({
+				size: size,
+				staticColor,
+				isIndeterminate: true,
+				testId: "infield-progress-circle"
+			}, context)
 		)}
 	</button>
 	`;

--- a/components/combobox/stories/template.js
+++ b/components/combobox/stories/template.js
@@ -63,7 +63,7 @@ const Combobox = ({
 				],
 				customInputClasses: [`${rootClass}-input`],
 				isLoading,
-				customProgressCircleClasses: ["spectrum-Combobox-progress-circle"],
+				customInfieldProgressCircleClasses: ["spectrum-Combobox-progress-circle"],
 				name: "field",
 				isReadOnly,
 				value,

--- a/components/infieldprogresscircle/README.md
+++ b/components/infieldprogresscircle/README.md
@@ -4,4 +4,4 @@
 
 This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
 
-See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/infieldprogresscircle).
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/) and [Spectrum CSS on GitHub](https://github.com/adobe/spectrum-css) for details.

--- a/components/infieldprogresscircle/README.md
+++ b/components/infieldprogresscircle/README.md
@@ -1,0 +1,7 @@
+# @spectrum-css/infieldprogresscircle
+
+> The Spectrum CSS infield progress circle component
+
+This package is part of the [Spectrum CSS project](https://github.com/adobe/spectrum-css).
+
+See the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/infieldprogresscircle).

--- a/components/infieldprogresscircle/dist/metadata.json
+++ b/components/infieldprogresscircle/dist/metadata.json
@@ -1,0 +1,25 @@
+{
+  "sourceFile": "index.css",
+  "selectors": [
+    ".spectrum-InfieldProgressCircle",
+    ".spectrum-InfieldProgressCircle .spectrum-ProgressCircle-fill",
+    ".spectrum-InfieldProgressCircle--sizeL",
+    ".spectrum-InfieldProgressCircle--sizeS",
+    ".spectrum-InfieldProgressCircle--sizeXL"
+  ],
+  "modifiers": [],
+  "component": [
+    "--spectrum-in-field-progress-circle-edge-to-fill",
+    "--spectrum-in-field-progress-circle-size-100",
+    "--spectrum-in-field-progress-circle-size-200",
+    "--spectrum-in-field-progress-circle-size-300",
+    "--spectrum-in-field-progress-circle-size-75",
+    "--spectrum-infieldprogresscircle-padding-block"
+  ],
+  "global": ["--spectrum-progress-circle-thickness-small"],
+  "passthroughs": [
+    "--mod-progress-circle-size",
+    "--mod-progress-circle-thickness"
+  ],
+  "high-contrast": []
+}

--- a/components/infieldprogresscircle/index.css
+++ b/components/infieldprogresscircle/index.css
@@ -1,0 +1,37 @@
+/*!
+Copyright 2025 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+.spectrum-InfieldProgressCircle {
+	--mod-progress-circle-thickness: var(--spectrum-progress-circle-thickness-small);
+	--mod-progress-circle-size: var(--spectrum-in-field-progress-circle-size-100);
+	--spectrum-infieldprogresscircle-padding-block: var(--spectrum-in-field-progress-circle-edge-to-fill);
+}
+
+.spectrum-InfieldProgressCircle--sizeS {
+	--mod-progress-circle-size: var(--spectrum-in-field-progress-circle-size-75);
+}
+
+.spectrum-InfieldProgressCircle--sizeL {
+	--mod-progress-circle-size: var(--spectrum-in-field-progress-circle-size-200);
+}
+
+.spectrum-InfieldProgressCircle--sizeXL {
+	--mod-progress-circle-size: var(--spectrum-in-field-progress-circle-size-300);
+}
+
+.spectrum-InfieldProgressCircle {
+	padding-block: var(--spectrum-infieldprogresscircle-padding-block);
+
+	.spectrum-ProgressCircle-fill {
+		stroke-linecap: square;
+	}
+}

--- a/components/infieldprogresscircle/package.json
+++ b/components/infieldprogresscircle/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@spectrum-css/infieldprogresscircle",
+  "version": "0.0.0",
+  "description": "The Spectrum CSS infieldprogresscircle component",
+  "license": "Apache-2.0",
+  "author": "Adobe",
+  "homepage": "https://opensource.adobe.com/spectrum-css/infieldprogresscircle",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/adobe/spectrum-css.git",
+    "directory": "components/infieldprogresscircle"
+  },
+  "bugs": {
+    "url": "https://github.com/adobe/spectrum-css/issues"
+  },
+  "exports": {
+    ".": "./dist/index.css",
+    "./*.md": "./*.md",
+    "./dist/*": "./dist/*",
+    "./index.css": "./dist/index.css",
+    "./metadata.json": "./dist/metadata.json",
+    "./package.json": "./package.json",
+    "./stories/*": "./stories/*"
+  },
+  "main": "dist/index.css",
+  "files": [
+    "dist/*",
+    "*.md",
+    "package.json",
+    "stories/*",
+    "metadata/*"
+  ],
+  "peerDependencies": {
+    "@spectrum-css/tokens": ">=14.0.0-next.0"
+  },
+  "devDependencies": {
+    "@spectrum-css/tokens": "workspace:^"
+  },
+  "keywords": [
+    "spectrum",
+    "css",
+    "design system",
+    "adobe"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "spectrum": [
+    {
+      "guidelines": "https://spectrum.adobe.com/page/progress-circle",
+      "rootClass": "spectrum-InfieldProgressCircle",
+      "swc": "https://opensource.adobe.com/spectrum-web-components/components/progress-circle/"
+    }
+  ]
+}

--- a/components/infieldprogresscircle/package.json
+++ b/components/infieldprogresscircle/package.json
@@ -4,7 +4,7 @@
   "description": "The Spectrum CSS infieldprogresscircle component",
   "license": "Apache-2.0",
   "author": "Adobe",
-  "homepage": "https://opensource.adobe.com/spectrum-css/infieldprogresscircle",
+  "homepage": "https://opensource.adobe.com/spectrum-css/?path=/docs/components-in-field-progress-circle--docs",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/spectrum-css.git",
@@ -17,30 +17,27 @@
     ".": "./dist/index.css",
     "./*.md": "./*.md",
     "./dist/*": "./dist/*",
+    "./index-*.css": "./dist/index-*.css",
     "./index.css": "./dist/index.css",
     "./metadata.json": "./dist/metadata.json",
     "./package.json": "./package.json",
     "./stories/*": "./stories/*"
   },
   "main": "dist/index.css",
-  "files": [
-    "dist/*",
-    "*.md",
-    "package.json",
-    "stories/*",
-    "metadata/*"
-  ],
   "peerDependencies": {
-    "@spectrum-css/tokens": ">=14.0.0-next.0"
+    "@spectrum-css/tokens": ">=16"
   },
   "devDependencies": {
-    "@spectrum-css/tokens": "workspace:^"
+    "@spectrum-css/tokens": "16.0.0"
   },
   "keywords": [
+    "design-system",
     "spectrum",
-    "css",
-    "design system",
-    "adobe"
+    "spectrum-css",
+    "adobe",
+    "adobe-spectrum",
+    "component",
+    "css"
   ],
   "publishConfig": {
     "access": "public"

--- a/components/infieldprogresscircle/project.json
+++ b/components/infieldprogresscircle/project.json
@@ -1,0 +1,17 @@
+{
+	"$schema": "../../node_modules/nx/schemas/project-schema.json",
+	"name": "infieldprogresscircle",
+	"tags": ["component"],
+	"targets": {
+		"build": {},
+		"clean": {},
+		"compare": {},
+		"format": {},
+		"lint": {},
+		"report": {},
+		"test": {
+			"defaultConfiguration": "scope"
+		},
+		"validate": {}
+	}
+}

--- a/components/infieldprogresscircle/stories/infieldprogresscircle.stories.js
+++ b/components/infieldprogresscircle/stories/infieldprogresscircle.stories.js
@@ -1,58 +1,43 @@
 import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import { isIndeterminate, size, staticColor } from "@spectrum-css/preview/types";
+import { size } from "@spectrum-css/preview/types";
+import { default as ProgressCircle } from "@spectrum-css/progresscircle/stories/progresscircle.stories.js";
 import metadata from "../dist/metadata.json";
 import packageJson from "../package.json";
-import { ProgressCircleGroup } from "./progresscircle.test.js";
+import { InfieldProgressCircleGroup } from "./infieldprogresscircle.test.js";
 import { Template } from "./template.js";
 
 /**
- * Progress circles show the progression of a system operation such as downloading, uploading, processing, etc. in a visual way. They can represent determinate or indeterminate progress.
- */
+ * In-field progress circles are used in t-shirt size components such as [buttons](/docs/components-button--docs), [combo boxes](/docs/components-combobox--docs), and [pickers](/docs/components-picker--docs). The in-field progress circle can be used in place of an icon or in tight spaces when space is limited both vertically and horizontally.
+*/
+
 export default {
-	title: "Progress circle",
-	component: "ProgressCircle",
+	title: "In-field progress circle",
+	component: "InfieldProgressCircle",
 	argTypes: {
-		size: size(["s", "m", "l"]),
-		isIndeterminate,
-		staticColor,
-		value: {
-			name: "Percent filled",
-			type: { name: "number" },
-			table: {
-				type: { summary: "number" },
-				category: "Content",
-			},
-			control: {
-				type: "range",
-				min: 0,
-				max: 100
-			},
-			if: { arg: "isIndeterminate", truthy: false },
-		}
+		...ProgressCircle.argTypes,
+		size: size(["s", "m", "l", "xl"]),
 	},
 	args: {
-		rootClass: "spectrum-ProgressCircle",
-		size: "m",
-		isIndeterminate: false,
-		staticColor: undefined,
-		value: 43
+		...ProgressCircle.args,
+		rootClass: "spectrum-InfieldProgressCircle",
 	},
 	parameters: {
+		...ProgressCircle.parameters,
 		design: {
 			type: "figma",
-			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=13061-181",
+			url: "https://www.figma.com/design/eoZHKJH9a3LJkHYCGt60Vb/S2-token-specs?node-id=14970-6050",
 		},
 		packageJson,
 		metadata,
-	},
+	}
 };
 
-export const Default = ProgressCircleGroup.bind({});
+export const Default = InfieldProgressCircleGroup.bind({});
 Default.args = {};
 
 // ********* VRT ONLY ********* //
-export const WithForcedColors = ProgressCircleGroup.bind({});
+export const WithForcedColors = InfieldProgressCircleGroup.bind({});
 WithForcedColors.args = Default.args;
 WithForcedColors.tags = ["!autodocs", "!dev"];
 WithForcedColors.parameters = {
@@ -65,7 +50,7 @@ WithForcedColors.parameters = {
 // ********* DOCS ONLY ********* //
 
 export const Sizing = (args, context) => Sizes({
-	Template: Template,
+	Template,
 	withHeading: false,
 	withBorder: false,
 	...args,
@@ -80,7 +65,7 @@ Sizing.parameters = {
  * The indeterminate progress circle displays a repeating animation for the inner fill.
  */
 export const Indeterminate = (args, context) => Sizes({
-	Template: Template,
+	Template,
 	withHeading: false,
 	withBorder: false,
 	...args,
@@ -98,7 +83,6 @@ StaticWhiteDeterminate.tags = ["!dev"];
 StaticWhiteDeterminate.storyName = "Static white, default";
 StaticWhiteDeterminate.args = {
 	staticColor: "white",
-	isIndeterminate: false,
 };
 StaticWhiteDeterminate.parameters = {
 	chromatic: { disableSnapshot: true },
@@ -120,7 +104,6 @@ StaticBlackDeterminate.tags = ["!dev"];
 StaticBlackDeterminate.storyName = "Static black, default";
 StaticBlackDeterminate.args = {
 	staticColor: "black",
-	isIndeterminate: false,
 };
 StaticBlackDeterminate.parameters = {
 	chromatic: { disableSnapshot: true },

--- a/components/infieldprogresscircle/stories/infieldprogresscircle.test.js
+++ b/components/infieldprogresscircle/stories/infieldprogresscircle.test.js
@@ -1,0 +1,25 @@
+import { Variants } from "@spectrum-css/preview/decorators";
+import { Template } from "./template.js";
+
+export const InfieldProgressCircleGroup = Variants({
+	Template,
+	testData: [
+		{
+			testHeading: "Default",
+		},
+		{
+			testHeading: "Static white",
+			staticColor: "white",
+		},
+		{
+			testHeading: "Static black",
+			staticColor: "black",
+		},
+	],
+	stateData: [
+		{
+			testHeading: "Indeterminate",
+			isIndeterminate: true,
+		}
+	]
+});

--- a/components/infieldprogresscircle/stories/template.js
+++ b/components/infieldprogresscircle/stories/template.js
@@ -1,0 +1,21 @@
+import { Template as ProgressCircle } from "@spectrum-css/progresscircle/stories/template.js";
+import { capitalize } from "lodash-es";
+import "../index.css";
+
+export const Template = ({
+	customClasses = [],
+	rootClass = "spectrum-InfieldProgressCircle",
+	size = "m",
+	staticColor,
+	...item
+} = {}, context = {}) => ProgressCircle({
+	customClasses: [
+		rootClass,
+		typeof size !== "undefined" ? `${rootClass}--size${size.toUpperCase()}` : null,
+		typeof staticColor !== "undefined" ? `${rootClass}--static${capitalize(staticColor)}` : null,
+		...customClasses
+	].filter(Boolean),
+	size,
+	staticColor,
+	...item
+}, context );

--- a/components/picker/stories/template.js
+++ b/components/picker/stories/template.js
@@ -1,9 +1,9 @@
 import { Template as FieldLabel } from "@spectrum-css/fieldlabel/stories/template.js";
 import { Template as HelpText } from "@spectrum-css/helptext/stories/template.js";
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
+import { Template as InfieldProgressCircle } from "@spectrum-css/infieldprogresscircle/stories/template.js";
 import { Template as Popover } from "@spectrum-css/popover/stories/template.js";
 import { Container, getRandomId } from "@spectrum-css/preview/decorators";
-import { Template as ProgressCircle } from "@spectrum-css/progresscircle/stories/template.js";
 import { Template as Switch } from "@spectrum-css/switch/stories/template.js";
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
@@ -78,8 +78,8 @@ export const Picker = ({
 			}
 			<span class="${rootClass}-label is-placeholder">${placeholder}</span>
 			${when(isLoading, () =>
-				ProgressCircle({
-					size: "s",
+				InfieldProgressCircle({
+					size: size,
 					isIndeterminate: true,
 				}, context)
 			)}

--- a/components/textfield/stories/template.js
+++ b/components/textfield/stories/template.js
@@ -1,8 +1,8 @@
 import { Template as FieldLabel } from "@spectrum-css/fieldlabel/stories/template.js";
 import { Template as HelpText } from "@spectrum-css/helptext/stories/template.js";
 import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
+import { Template as InfieldProgressCircle } from "@spectrum-css/infieldprogresscircle/stories/template.js";
 import { Container, getRandomId } from "@spectrum-css/preview/decorators";
-import { Template as ProgressCircle } from "@spectrum-css/progresscircle/stories/template.js";
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
@@ -18,7 +18,7 @@ import "../index.css";
  * @property {string[]} [customClasses=[]]
  * @property {string[]} [customInputClasses=[]]
  * @property {string[]} [customIconClasses=[]]
- * @property {string[]} [customProgressCircleClasses=[]]
+ * @property {string[]} [customInfieldProgressCircleClasses=[]]
  * @property {Record<string, string>} [customStyles={}]
  * @property {boolean} [isInvalid=false]
  * @property {boolean} [isValid=false]
@@ -58,7 +58,7 @@ export const Template = ({
 	customClasses = [],
 	customInputClasses = [],
 	customIconClasses = [],
-	customProgressCircleClasses = [],
+	customInfieldProgressCircleClasses = [],
 	isInvalid = false,
 	isValid = false,
 	multiline = false,
@@ -196,10 +196,10 @@ export const Template = ({
 				})}
 			/>`
 		)}
-		${when(isLoading, () => ProgressCircle({
+		${when(isLoading, () => InfieldProgressCircle({
 			isIndeterminate: true,
-			size: "s",
-			customClasses: customProgressCircleClasses,
+			size: size,
+			customClasses: customInfieldProgressCircleClasses,
 		}, context))}
 		${when(helpText, () =>
 			HelpText({

--- a/tools/bundle/package.json
+++ b/tools/bundle/package.json
@@ -74,6 +74,7 @@
 		"@spectrum-css/icon": "workspace:^",
 		"@spectrum-css/illustratedmessage": "workspace:^",
 		"@spectrum-css/infieldbutton": "workspace:^",
+		"@spectrum-css/infieldprogresscircle": "workspace:^",
 		"@spectrum-css/inlinealert": "workspace:^",
 		"@spectrum-css/link": "workspace:^",
 		"@spectrum-css/logicbutton": "workspace:^",

--- a/tools/bundle/src/index.css
+++ b/tools/bundle/src/index.css
@@ -66,6 +66,7 @@
 @import "@spectrum-css/icon";
 @import "@spectrum-css/illustratedmessage";
 @import "@spectrum-css/infieldbutton";
+@import "@spectrum-css/infieldprogresscircle";
 @import "@spectrum-css/inlinealert";
 @import "@spectrum-css/link";
 @import "@spectrum-css/logicbutton";

--- a/yarn.lock
+++ b/yarn.lock
@@ -3902,6 +3902,7 @@ __metadata:
     "@spectrum-css/icon": "workspace:^"
     "@spectrum-css/illustratedmessage": "workspace:^"
     "@spectrum-css/infieldbutton": "workspace:^"
+    "@spectrum-css/infieldprogresscircle": "workspace:^"
     "@spectrum-css/inlinealert": "workspace:^"
     "@spectrum-css/link": "workspace:^"
     "@spectrum-css/logicbutton": "workspace:^"
@@ -4437,6 +4438,16 @@ __metadata:
   peerDependenciesMeta:
     "@spectrum-css/icon":
       optional: true
+  languageName: unknown
+  linkType: soft
+
+"@spectrum-css/infieldprogresscircle@workspace:^, @spectrum-css/infieldprogresscircle@workspace:components/infieldprogresscircle":
+  version: 0.0.0-use.local
+  resolution: "@spectrum-css/infieldprogresscircle@workspace:components/infieldprogresscircle"
+  dependencies:
+    "@spectrum-css/tokens": "workspace:^"
+  peerDependencies:
+    "@spectrum-css/tokens": ">=14.0.0-next.0"
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4445,9 +4445,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@spectrum-css/infieldprogresscircle@workspace:components/infieldprogresscircle"
   dependencies:
-    "@spectrum-css/tokens": "workspace:^"
+    "@spectrum-css/tokens": "npm:16.0.0"
   peerDependencies:
-    "@spectrum-css/tokens": ">=14.0.0-next.0"
+    "@spectrum-css/tokens": ">=16"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Description

The infield progresscirlce is a subcomponent of the progress circle which is used in button, combobox, textfield and picker template files. It's smaller in block size and has its own t-shirt sizing.


## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

  1. Open the storybook for the infield progress circle:
    - [x] Toggle Intedeterminate mode
    - [x] Exists in combobox, button, picker components isLoading states


### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [ ] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
