### PR TITLE
fix(swatch): support gradient input

### DIFF
--- a/.changeset/seven-dogs-help.md
+++ b/.changeset/seven-dogs-help.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/swatch": patch
+---
+
+Allow --spectrum-picked-color to pass in gradient values to swatch [CSS-204]

--- a/.storybook/decorators/utilities.js
+++ b/.storybook/decorators/utilities.js
@@ -298,11 +298,13 @@ export const ArgGrid = ({
 		heading,
 		direction,
 		withBorder: withWrapperBorder,
-		wrapperStyles: containerStyles,
+		containerStyles,
+		wrapperStyles,
 		content: options.map((opt, index) => Container({
 			heading: labels[opt] ?? capitalize(opt),
 			level,
 			withBorder,
+			containerStyles,
 			wrapperStyles,
 			content: Template({
 				...args,
@@ -368,6 +370,7 @@ export const Sizes = ({
 export const Variants = ({
 	Template,
 	TestTemplate,
+	SizeTemplate,
 	// Test data defaults to an empty array so that we at least get the base component
 	testData = [{}],
 	stateData = [],
@@ -385,6 +388,10 @@ export const Variants = ({
 	// If no separate test template is provided, use the default template
 	if (typeof TestTemplate === "undefined") {
 		TestTemplate = Template;
+	}
+
+	if (typeof SizeTemplate === "undefined") {
+		SizeTemplate = TestTemplate;
 	}
 
 	const staticColor = {
@@ -486,7 +493,7 @@ export const Variants = ({
 								...containerStyles,
 							},
 							// if the test has multiple states, pass the wrapper styles to that container, otherwise use it here
-							wrapperStyles: withStates ? { backgroundColor } : combinedStyles,
+							wrapperStyles: withStates ? { backgroundColor, ...containerStyles } : combinedStyles,
 							content: html`
 								${when(withStates, () =>
 									States({
@@ -507,8 +514,9 @@ export const Variants = ({
 				<!-- If sizing exists for the component, it will render all sizes for testing -->
 				${when(withSizes, () =>
 					Sizes({
-						Template: TestTemplate,
+						Template: SizeTemplate,
 						wrapperStyles,
+						containerStyles,
 						direction: sizeDirection,
 						...args
 					}, context)

--- a/components/alertbanner/stories/alertbanner.test.js
+++ b/components/alertbanner/stories/alertbanner.test.js
@@ -4,9 +4,6 @@ import { Template } from "./template.js";
 export const AlertBannerGroup = Variants({
 	Template,
 	stateDirection: "column",
-	containerStyles: {
-		"inline-size": "100%",
-	},
 	wrapperStyles: {
 		"inline-size": "100%",
 	},

--- a/components/buttongroup/stories/buttongroup.stories.js
+++ b/components/buttongroup/stories/buttongroup.stories.js
@@ -74,7 +74,9 @@ Default.tags = ["!autodocs"];
 export const Horizontal = ButtonGroup.bind({});
 Horizontal.tags = ["!dev"];
 Horizontal.args = Default.args;
-
+Horizontal.parameters = {
+	chromatic: { disableSnapshot: true },
+};
 
 /**
  * Spacing for the Small t-shirt size.
@@ -83,6 +85,9 @@ export const HorizontalSmall = ButtonGroup.bind({});
 HorizontalSmall.tags = ["!dev"];
 HorizontalSmall.args = {
 	size: "s"
+};
+HorizontalSmall.parameters = {
+	chromatic: { disableSnapshot: true },
 };
 
 /**
@@ -93,6 +98,9 @@ Vertical.tags = ["!dev"];
 Vertical.args = {
 	vertical: true,
 };
+Vertical.parameters = {
+	chromatic: { disableSnapshot: true },
+};
 
 /**
  * Spacing for the Small t-shirt size.
@@ -102,6 +110,9 @@ VerticalSmall.tags = ["!dev"];
 VerticalSmall.args = {
 	vertical: true,
 	size: "s"
+};
+VerticalSmall.parameters = {
+	chromatic: { disableSnapshot: true },
 };
 
 /**
@@ -125,6 +136,9 @@ Disabled.args = {
 			isDisabled: true,
 		},
 	]
+};
+Disabled.parameters = {
+	chromatic: { disableSnapshot: true },
 };
 
 

--- a/components/picker/stories/picker.stories.js
+++ b/components/picker/stories/picker.stories.js
@@ -126,10 +126,6 @@ export default {
 				],
 			}, context)
 		],
-		// Make sure container flex layout does not misalign sibling elements such as field label in Template()
-		wrapperStyles: {
-			display: "block",
-		},
 	},
 	parameters: {
 		docs: {
@@ -185,7 +181,7 @@ Standard.parameters = {
 
 /**
  * This example shows the picker with a selected value.
- * A picker can also have [help text](?path=/docs/components-help-text--docs) below the field to give extra context or instruction about what a user should select. 
+ * A picker can also have [help text](?path=/docs/components-help-text--docs) below the field to give extra context or instruction about what a user should select.
  */
 export const SelectedValue = ClosedAndOpenTemplate.bind({});
 SelectedValue.storyName = "Default with value and help text";
@@ -217,10 +213,10 @@ SelectedValue.parameters = {
 };
 
 /**
- * Pickers come in four different sizes: small, medium, large, and extra-large. 
- * 
+ * Pickers come in four different sizes: small, medium, large, and extra-large.
+ *
  * At each of these sizes, the following chevron UI icon should be used:
- * 
+ *
  * | Picker size    | UI icon size |
  * |----------------|--------------|
  * | small          | `Chevron75`  |
@@ -366,7 +362,7 @@ WithWorkflowIcon.parameters = {
  * Labels can be placed either on top or on the side. Top labels are the default and are recommended because
  * they work better with long copy, localization, and responsive layouts. Side labels are most useful when vertical
  * space is limited.
- * 
+ *
  * When using the side label, the `spectrum-Picker--sideLabel` class is added to the Picker.
  */
 export const WithSideLabel = Template.bind({});

--- a/components/picker/stories/picker.test.js
+++ b/components/picker/stories/picker.test.js
@@ -1,8 +1,9 @@
 import { Variants } from "@spectrum-css/preview/decorators";
+import { html } from "lit";
 import { Template } from "./template.js";
 
 export const PickerGroup = Variants({
-	Template,
+	Template: (args, context) => html`<div>${Template(args, context)}</div>`,
 	wrapperStyles: {
 		"align-items": "flex-start",
 		"min-block-size": "auto",

--- a/components/swatch/index.css
+++ b/components/swatch/index.css
@@ -112,7 +112,7 @@
 	}
 
 	&.is-selected {
-		background-color: var(--highcontrast-swatch-background-color-selected, var(--mod-swatch-inner-border-color-selected, var(--spectrum-swatch-inner-border-color-selected)));
+		background: var(--highcontrast-swatch-background-color-selected, var(--mod-swatch-inner-border-color-selected, var(--spectrum-swatch-inner-border-color-selected)));
 
 		.spectrum-Swatch-fill {
 			clip-path: polygon(
@@ -136,12 +136,10 @@
 		}
 	}
 
-	/* Swatch fill: Image, Gradient, SVG */
+	/* Swatch fill: Image or SVG */
 	&.is-image {
-		.spectrum-Swatch-fill {
-			&::before {
-				background-color: transparent;
-			}
+		.spectrum-Swatch-fill::before {
+			background: transparent;
 		}
 	}
 
@@ -159,7 +157,7 @@
 	/* Swatch fill: Not fill with Slash */
 	&.is-nothing {
 		.spectrum-Swatch-fill {
-			background-color: var(--spectrum-picked-color, transparent);
+			background: var(--spectrum-picked-color, transparent);
 			background-image: none;
 
 			&::after {
@@ -244,7 +242,7 @@
 		inset: 0;
 		z-index: 0;
 
-		background-color: var(--spectrum-picked-color, transparent);
+		background: var(--spectrum-picked-color, transparent);
 
 		/* Swatch border */
 		box-shadow: inset 0 0 0 var(--mod-swatch-border-thickness, var(--spectrum-swatch-border-thickness)) var(--highcontrast-swatch-border-color, var(--mod-swatch-border-color, var(--spectrum-swatch-border-color)));
@@ -258,7 +256,7 @@
 		&::before {
 			box-shadow: none;
 
-			background-color: var(--spectrum-picked-color, transparent);
+			background: var(--spectrum-picked-color, transparent);
 		}
 	}
 }

--- a/components/swatch/stories/swatch.stories.js
+++ b/components/swatch/stories/swatch.stories.js
@@ -20,6 +20,7 @@ export default {
 		size: size(["xs", "s", "m", "l"]),
 		swatchColor: {
 			name: "Color",
+			description: "Supports standard color input or any valid input for the <code>background</code> property such as, <code>linear-gradient(red, blue)</code>.",
 			type: { name: "string", required: true },
 			table: {
 				type: { summary: "string" },
@@ -74,16 +75,6 @@ export default {
 				category: "Content",
 			},
 			control: { type: "file", accept: ".svg,.png,.jpg,.jpeg,.webc" },
-		},
-		gradient: {
-			name: "Gradient",
-			description: "The gradient preview within the swatch. Input a gradient example, such as <code>linear-gradient(red, blue)</code>.",
-			type: { name: "string" },
-			table: {
-				type: { summary: "string" },
-				category: "Component",
-			},
-			control: "text",
 		},
 		isMixedValue: {
 			name: "Mixed value",
@@ -228,7 +219,7 @@ MixedValue.parameters = {
 
 export const Gradient = Template.bind({});
 Gradient.args = {
-	gradient: "linear-gradient(to right, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, 0) 100%)",
+	swatchColor: "linear-gradient(to right, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, 0) 100%)",
 };
 Gradient.tags = ["!dev"];
 Gradient.parameters = {

--- a/components/swatch/stories/swatch.test.js
+++ b/components/swatch/stories/swatch.test.js
@@ -1,14 +1,60 @@
-import { Variants } from "@spectrum-css/preview/decorators";
+import { Container, Variants } from "@spectrum-css/preview/decorators";
+import exampleImage from "../../../.storybook/assets/images/example-ava@2x.png";
 import { Template } from "./template.js";
+
+export const Swatches = (args, context) => {
+	return Container({
+		withBorder: false,
+		containerStyles: {
+			"flex-grow": "1",
+			"align-items": "stretch",
+		},
+		wrapperStyles: {
+			"gap": "40px",
+			"justify-content": "space-around"
+		},
+		level: 2,
+		content: [
+			Template(args, context),
+			Template({
+				...args,
+				rounding: "none",
+				borderStyle: "noBorder",
+				swatchColor: "linear-gradient(to right, rgba(154, 116, 200, 0.5), rgb(174, 216, 230))",
+			}, context),
+			Template({
+				...args,
+				rounding: "full",
+				borderStyle: "lightBorder",
+				swatchColor: `center / contain no-repeat url("${exampleImage}")`,
+			}, context),
+			Template({
+				...args,
+				isMixedValue: true,
+			}, context),
+			Template({
+				...args,
+				swatchColor: undefined,
+				imageUrl: undefined,
+			}, context),
+		],
+	});
+};
 
 export const SwatchGroup = Variants({
 	Template,
+	SizeTemplate: Swatches,
+	sizeDirection: "column",
+	containerStyles: {
+		"flex-grow": "1",
+		"align-items": "stretch",
+	},
 	testData: [
 		{
-			testHeading: "Default",
+			testHeading: "RGB",
 		},
 		{
-			testHeading: "Color with opacity",
+			testHeading: "RGBA (opacity)",
 			swatchColor: "rgba(174, 216, 230, 0.3)"
 		},
 		{
@@ -26,7 +72,6 @@ export const SwatchGroup = Variants({
 		{
 			testHeading: "No border",
 			borderStyle: "noBorder",
-			rounding: "none",
 		},
 		{
 			testHeading: "Shape: rectangle",
@@ -34,8 +79,11 @@ export const SwatchGroup = Variants({
 		},
 		{
 			testHeading: "Gradient",
-			gradient: "linear-gradient(to right, rgba(0, 0, 0, 88%), rgb(174, 216, 230))",
-			swatchColor: "rgba(174, 216, 230, 0.3)",
+			swatchColor: "linear-gradient(to right, rgba(154, 116, 200, 0.5), rgb(174, 216, 230))",
+		},
+		{
+			testHeading: "Image as background",
+			swatchColor: `center / contain no-repeat url("${exampleImage}")`,
 		},
 		{
 			testHeading: "Image",
@@ -52,10 +100,9 @@ export const SwatchGroup = Variants({
 			isDisabled: true,
 		},
 		{
-			testHeading: "No color/empty",
+			testHeading: "Empty",
 			swatchColor: undefined,
-			imageUrl: "",
-			gradient: "",
+			imageUrl: undefined,
 			isMixedValue: false,
 			borderStyle: "default",
 		},

--- a/components/swatch/stories/template.js
+++ b/components/swatch/stories/template.js
@@ -16,7 +16,6 @@ export const Template = ({
 	borderStyle = "default",
 	shape = "square",
 	imageUrl,
-	gradient,
 	isMixedValue = false,
 	isSelected = false,
 	isDisabled = false,
@@ -49,7 +48,7 @@ export const Template = ({
 				[`${rootClass}--${borderStyle}`]: typeof borderStyle !== "undefined" && borderStyle !== "default",
 				"is-selected": !isDisabled && isSelected,
 				"is-disabled": isDisabled,
-				"is-image": (["undefined", "transparent"].every(g => typeof gradient !== g)) || isMixedValue || typeof imageUrl !== "undefined",
+				"is-image": isMixedValue || typeof imageUrl !== "undefined",
 				"is-mixedValue": !isDisabled && isMixedValue,
 				[`${rootClass}--rectangle`]: typeof shape !== "undefined" && shape !== "square",
 				"is-nothing": !isDisabled && (typeof swatchColor === "undefined" || swatchColor === "transparent"),
@@ -73,37 +72,29 @@ export const Template = ({
 				updateArgs({ isSelected: !isSelected });
 			}}
 		>
-			${when((typeof imageUrl !== "undefined" || typeof gradient !== "undefined") && !isDisabled && !isMixedValue, () => html`
+			${when((typeof imageUrl !== "undefined") && !isDisabled && !isMixedValue, () => html`
 				${when(imageUrl, () => html`
 					<div class="${rootClass}-fill" >
 						<img src="${imageUrl}" alt="" class="${rootClass}-image" />
 					</div>
-				`,
-				() => html`
-					${OpacityCheckerboard({
+				`)}
+			`,
+			() => html`
+				${OpacityCheckerboard({
 						customClasses: [`${rootClass}-fill`],
 						content: [
-							html`<div class='spectrum-Swatch-image' style='background: ${gradient}'></div>`
-						],
-					}, context)}
-				`
-				)}`,
-				() => html`
-					${OpacityCheckerboard({
-							customClasses: [`${rootClass}-fill`],
-							content: [
-								...(isDisabled ? [Icon({
-									customClasses: [`${rootClass}-disabledIcon`],
-									setName: "workflow",
-									iconName: "Cancel",
-								}, context)] : []),
-								...(isMixedValue ? [Icon({
-									customClasses: [`${rootClass}-mixedValueIcon`],
-									setName: "ui",
-									iconName: "Dash",
-								}, context)] : []),
-							]
-						})}
+							...(isDisabled ? [Icon({
+								customClasses: [`${rootClass}-disabledIcon`],
+								setName: "workflow",
+								iconName: "Cancel",
+							}, context)] : []),
+							...(isMixedValue ? [Icon({
+								customClasses: [`${rootClass}-mixedValueIcon`],
+								setName: "ui",
+								iconName: "Dash",
+							}, context)] : []),
+						]
+					})}
 				`
 			)}
 	`;

--- a/components/tabs/stories/tabs.test.js
+++ b/components/tabs/stories/tabs.test.js
@@ -18,7 +18,7 @@ const ExampleLabelOnlyTabContent = [
 export const TabsGroups = Variants({
 	Template,
 	wrapperStyles: {
-		"gap": "80px",
+		"column-gap": "80px",
 	},
 	testData: [
 		{


### PR DESCRIPTION
## Description

Addresses #1460 

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

Open the [storybook](https://opensource.adobe.com/spectrum-css/?path=/story/components-swatch--default) for the swatch component:
- [x] Pass in `linear-gradient(to right, rgba(255, 230, 100, 1) 0%, rgba(0, 0, 0, 0) 100%)` to the Color input and expect to see a yellow gradient from left to right

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

3. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [ ] ✨ This pull request is ready to merge. ✨
