### PR TITLE
fix(colorloupe): adds correct disabled styles

### DIFF
--- a/.changeset/slow-dogs-yawn.md
+++ b/.changeset/slow-dogs-yawn.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/colorloupe": minor
+---
+
+Color loupes should not be displayed when their color handle is disabled, so this work adds the `.is-disabled` selector to color loupe's CSS, with `opacity: 0`.

--- a/components/colorloupe/index.css
+++ b/components/colorloupe/index.css
@@ -60,6 +60,10 @@
 		transform: translate(0, 0);
 		opacity: 1;
 	}
+
+	&.is-disabled {
+		opacity: 0;
+	}
 }
 
 .spectrum-ColorLoupe-inner-border {

--- a/components/colorloupe/metadata/metadata.json
+++ b/components/colorloupe/metadata/metadata.json
@@ -7,6 +7,7 @@
     ".spectrum-ColorLoupe-checkerboard-pattern",
     ".spectrum-ColorLoupe-inner-border",
     ".spectrum-ColorLoupe-outer-border",
+    ".spectrum-ColorLoupe.is-disabled",
     ".spectrum-ColorLoupe.is-open",
     ".spectrum-ColorLoupe:dir(rtl)",
     "[dir=\"rtl\"] .spectrum-ColorLoupe"


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->
It was noted in #3409 that the color loupe shouldn't display when its color handle is disabled. If a user went to color handle, turned the `withColorLoupe` to true, then tried to disable the color handle, and the color loupe is still rendering. This PR aims to fix that by adding styles for disabled color loupes. There's also the corresponding changeset and udpates to the metadata.json.

Before 🚫 (color loupe testing grid/color handle testing grid)
<img width="387" alt="Screenshot 2025-01-03 at 12 41 38 PM" src="https://github.com/user-attachments/assets/4279a521-aade-4d4c-b020-14e3aa65f12b" />
<img width="421" alt="Screenshot 2025-01-03 at 3 14 02 PM" src="https://github.com/user-attachments/assets/af8bbbe6-ddf8-45b2-a23d-f79613d787c2" />

After ✅ (color loupe testing grid/color handle testing grid)
<img width="393" alt="Screenshot 2025-01-03 at 12 38 04 PM" src="https://github.com/user-attachments/assets/07e4264a-3830-475b-b764-096f7c3fb32e" />
<img width="418" alt="Screenshot 2025-01-03 at 12 37 49 PM" src="https://github.com/user-attachments/assets/a882e541-c961-49c5-b950-6673dc6fe863" />

### Jira/Specs
[CSS-1089](https://jira.corp.adobe.com/browse/CSS-1089)

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->
- [x] Pull down the branch to run locally or visit the deploy preview. [@castastrophe]
  - Go to the [color loupe default story ](https://pr-3453--spectrum-css.netlify.app/?path=/story/components-color-loupe--default)
  - Toggle the disabled control to verify the color loupe isn't visible. ((it should have `opacity: 0` in the inspector)
  - Turn on the [Chromatic preview](https://pr-3453--spectrum-css.netlify.app/?path=/story/components-color-loupe--default&globals=testingPreview:!true) (and if needed reset the color loupe controls)
- [x] Verify the Disabled test case behaves the same way and isn't visible. [@castastrophe]
- [x] Go to the [color handle default story](https://pr-3453--spectrum-css.netlify.app/?path=/story/components-color-handle--default)
  - Turn on both the disabled and withColorLoupe controls. Toggle the disabled control a few times.
  - Verify the color loupe only displays when the color handle is not disabled. [@castastrophe]
  - Turn on the [Chromatic preview](https://pr-3453--spectrum-css.netlify.app/?path=/story/components-color-handle--default&globals=testingPreview:!true) (and if needed reset the color handle controls)
- [x] Verify the With Color Loupe- Disabled test case behaves the same and the color loupe isn't visible. [@castastrophe]

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] ✨ This pull request is ready to merge. ✨
