### PR TITLE
fix(icon): fix for icons not loading

### DIFF
--- a/components/icon/stories/template.js
+++ b/components/icon/stories/template.js
@@ -34,7 +34,7 @@ export const Template = ({
 	fill,
 	id,
 	customClasses = [],
-	useRef = false,
+	useRef = true,
 	...globals
 }) => {
 	const { scale } = globals;


### PR DESCRIPTION
## Description

Icons were not loading on the `spectrum-two` branch. The `require` statements in the `fetchIconSVG` function are not working, but that function no longer exists in `main`. This is a light touch update so icons appear for the current work, until `spectrum-two` is back up to date with main.

This updates the default `useRef` to true in the Icon component, so icons use the spritesheet version. `useRef` is not set to anything other than the default in the repo.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [ ] Icons are loading again -- Icon component workflow and UI
- [ ] Icons are appearing again in other components

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [ ] ✨ This pull request is ready to merge. ✨
