### PR TITLE
feat(storybook)!: update chromatic add-on to latest version

### DIFF
--- a/.changeset/tasty-pigs-tickle.md
+++ b/.changeset/tasty-pigs-tickle.md
@@ -1,0 +1,12 @@
+---
+"@spectrum-css/preview": major
+---
+
+Update the Chromatic add-on to the currently maintained package:
+
+- from "@chromaui/addon-visual-tests": "^1.0.0"
+- to "@chromatic-com/storybook": "^3.2.3"
+
+This requires an update to the chromatic.config.json settings, removal of the generic argTypesRegex from the preview config, and a stricter import in the doc blocks.
+
+To support a successful build, our test command must maintain the autodocs and mdx syntax.

--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,9 @@ CHROMATIC_PROJECT_ID="Project:64762974a45b8bc5ca1705a2"
 # Note: the build script here should be defined in .storybook/package.json
 # this is used by the chromatic storybook addon to build the storybook on the fly
 CHROMATIC_BUILD_SCRIPT_NAME="build"
+CHROMATIC_ONLY_CHANGED=true
+CHROMATIC_STORYBOOK_BASE_DIR=".storybook"
+CHROMATIC_ZIP=true
 
 # NX settings
 NX_PREFER_TS_NODE=true

--- a/.storybook/blocks/ColorPalette.jsx
+++ b/.storybook/blocks/ColorPalette.jsx
@@ -1,82 +1,17 @@
 import { ResetWrapper } from "@storybook/components";
-import { styled } from "@storybook/theming";
 import { capitalize } from "lodash-es";
 import React from "react";
-import { ThemeContainer } from "./ThemeContainer";
-import { Body, Heading } from "./Typography";
+import { List } from "./Layouts.jsx";
+import {
+	Swatch,
+	SwatchColors,
+	SwatchGroup,
+	SwatchGroupLabel,
+	SwatchSet,
+} from "./Swatches.jsx";
+import { ThemeContainer } from "./ThemeContainer.jsx";
+import { Body, Heading } from "./Typography.jsx";
 import { fetchToken } from "./utilities.js";
-
-export const SwatchGroupLabel = styled.div`
-	display: flex;
-	flex-direction: column;
-	margin-top: 16px;
-	align-self: flex-start;
-	justify-content: center;
-	text-wrap: nowrap;
-	inline-size: max-content;
-	block-size: ${props => props.size ?? 32}px;
-	color: ${props => `var(--spectrum-neutral-subdued-content-color-default, ${props.theme.defaultText})`};
-`;
-
-export const SwatchSet = styled.div`
-	display: flex;
-	flex-direction: column;
-	align-items: flex-start;
-	gap: 2px;
-	color: ${props => `var(--spectrum-neutral-subdued-content-color-default, ${props.theme.defaultText})`};
-`;
-
-export const Swatch = styled.div`
-	position: relative;
-	inline-size: var(--swatch-size, ${props => props.size ?? 32}px);
-	block-size: var(--swatch-size, ${props => props.size ?? 32}px);
-	outline: none;
-	user-select: none;
-
-	&::before {
-		position: absolute;
-		inset: 0;
-		inline-size: 100%;
-		block-size: 100%;
-		content: "";
-		opacity: 1;
-
-		border: 1px solid rgba(0, 0, 0, 51%);
-
-		border-radius: ${props => `${props.theme.appBorderRadius}px` ?? `var(--spectrum-corner-radius-100, 4px)`};
-		${props => props.background && `background: ${props.background};`}
-	}
-
-	.spectrum--dark &::before,
-	.spectrum--darkest &::before {
-		border-color: rgba(255, 255, 255, 51%);
-	}
-`;
-
-export const SwatchColors = styled.div`
-	display: inline-flex;
-	flex-direction: row;
-	flex-wrap: wrap;
-	gap: ${props => props.size > 0 ? (props.size * 0.2) : 8}px;
-	align-items: flex-start;
-	justify-content: flex-start;
-`;
-
-export const SwatchGroup = styled.div`
-	position: relative;
-	display: flex;
-	flex-direction: column;
-	flex: 1;
-`;
-
-const List = styled.div`
-	display: grid;
-	gap: 24px;
-	grid-template-columns: 1fr auto;
-	grid-template-rows: auto;
-	align-items: center;
-	justify-content: center;
-`;
 
 /**
  * A single color row your styleguide showing title, subtitle and one or more colors, used

--- a/.storybook/blocks/ComponentDetails.jsx
+++ b/.storybook/blocks/ComponentDetails.jsx
@@ -4,82 +4,13 @@ import { styled } from "@storybook/theming";
 import React, { useEffect, useState } from "react";
 
 import { Body, Code, Heading } from "./Typography.jsx";
+import { DDefinition, DList, DTerm } from "./Layouts.jsx";
 import { fetchToken } from "./utilities.js";
 
 import AdobeSVG from "../assets/images/adobe_logo.svg?raw";
 import GitHubSVG from "../assets/images/github_logo.svg?raw";
 import NpmSVG from "../assets/images/npm_logo.svg?raw";
 import WCSVG from "../assets/images/wc_logo.svg?raw";
-
-export const DList = styled.dl`
-	display: grid;
-	grid-template-columns: max-content 1fr;
-	column-gap: 20px;
-	row-gap: 14px;
-	padding-block: 0.75rem;
-	margin-block: 0.5rem 2.5rem;
-	border-block: ${props => !props.skipBorder ? "1px solid hsla(203deg, 50%, 30%, 15%)" : "0"};
-
-	& & {
-		border-block: 0px;
-		margin-block: 0;
-		padding-inline-start: 0.75rem;
-		padding-block-start: 0.25rem;
-	}
-
-	details > & {
-		margin-inline-start: 12px;
-	}
-`;
-
-export const DTerm = styled.dt`
-	font-weight: ${props => props.theme.typography.weight.bold ?? "bold"};
-	padding: 0;
-	margin: 0;
-	font-size: ${props => props.theme.typography.size.s};
-`;
-
-export const Details = styled.details`
-	cursor: pointer;
-	grid-column: 1 / 3;
-	padding: 0;
-
-	&[open] > summary::before {
-		transform: rotate(90deg);
-	}
-`;
-
-export const Summary = styled.summary`
-	display: inline-flex;
-	align-items: center;
-	font-weight: ${props => props.theme.typography.weight.bold ?? "bold"};
-	padding: 0;
-	padding-block-end: 0.75rem;
-	margin: 0;
-	font-size: ${props => props.theme.typography.size.s};
-	list-style: none;
-
-	&::-webkit-details-marker {
-		display: none;
-	}
-
-	&::before {
-		content: '';
-		width: 10px;
-		height: 10px;
-		background-image: url('data:image/svg+xml,<svg focusable="false" aria-hidden="true" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><path d="M3 9.95a.875.875 0 0 1-.615-1.498L5.88 5 2.385 1.547A.875.875 0 0 1 3.615.302L7.74 4.377a.876.876 0 0 1 0 1.246L3.615 9.698A.87.87 0 0 1 3 9.95"></path></svg>');
-		background-size: cover;
-		margin-inline-end: .75em;
-		transition: 0.2s;
-	}
-`;
-
-export const DDefinition = styled.dd`
-	font-style: normal;
-	padding: 0;
-	margin: 0;
-	font-size: ${props => props.theme.typography.size.s};
-`;
 
 export const DSet = ({ term, children }) => {
 	return (

--- a/.storybook/blocks/Layouts.jsx
+++ b/.storybook/blocks/Layouts.jsx
@@ -1,0 +1,97 @@
+import { styled } from "@storybook/theming";
+
+export const Container = styled.section`
+    color: var(--spectrum-neutral-content-color-default);
+    background-color: var(--spectrum-background-layer-1-color);
+    display: ${props => props.display ?? "flex" };
+    padding-inline: 48px 24px;
+    padding-block: 60px;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 60px;
+    border-radius: 16px;
+`;
+
+export const List = styled.div`
+	display: grid;
+	gap: 24px;
+	grid-template-columns: 1fr auto;
+	grid-template-rows: auto;
+	align-items: center;
+	justify-content: center;
+`;
+
+export const DList = styled.dl`
+	display: grid;
+	grid-template-columns: max-content 1fr;
+	column-gap: 20px;
+	row-gap: 14px;
+	padding-block: 0.75rem;
+	margin-block: 0.5rem 2.5rem;
+	border-block: ${props => !props.skipBorder ? "1px solid hsla(203deg, 50%, 30%, 15%)" : "0"};
+
+	& & {
+		border-block: 0px;
+		margin-block: 0;
+		padding-inline-start: 0.75rem;
+		padding-block-start: 0.25rem;
+	}
+
+	details > & {
+		margin-inline-start: 12px;
+	}
+`;
+
+export const DTerm = styled.dt`
+	font-weight: ${props => props.theme.typography.weight.bold ?? "bold"};
+	padding: 0;
+	margin: 0;
+	font-size: ${props => props.theme.typography.size.s};
+`;
+
+export const DDefinition = styled.dd`
+	font-style: normal;
+	padding: 0;
+	margin: 0;
+	font-size: ${props => props.theme.typography.size.s};
+`;
+
+export const Details = styled.details`
+	cursor: pointer;
+	grid-column: 1 / 3;
+	padding: 0;
+
+	&[open] > summary::before {
+		transform: rotate(90deg);
+	}
+`;
+
+export const Summary = styled.summary`
+	display: inline-flex;
+	align-items: center;
+	font-weight: ${props => props.theme.typography.weight.bold ?? "bold"};
+	padding: 0;
+	padding-block-end: 0.75rem;
+	margin: 0;
+	font-size: ${props => props.theme.typography.size.s};
+	list-style: none;
+
+	&::-webkit-details-marker {
+		display: none;
+	}
+
+	&::before {
+		content: '';
+		width: 10px;
+		height: 10px;
+		background-image: url('data:image/svg+xml,<svg focusable="false" aria-hidden="true" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><path d="M3 9.95a.875.875 0 0 1-.615-1.498L5.88 5 2.385 1.547A.875.875 0 0 1 3.615.302L7.74 4.377a.876.876 0 0 1 0 1.246L3.615 9.698A.87.87 0 0 1 3 9.95"></path></svg>');
+		background-size: cover;
+		margin-inline-end: .75em;
+		transition: 0.2s;
+	}
+`;
+
+export const Table = styled.table`
+	--mod-table-cursor-row-default: auto;
+	padding-block: 10px;
+`;

--- a/.storybook/blocks/PropertiesTable.jsx
+++ b/.storybook/blocks/PropertiesTable.jsx
@@ -1,15 +1,9 @@
 import { DocsContext, useOf } from "@storybook/blocks";
 import { NAVIGATE_URL } from "@storybook/core-events";
-import { styled } from "@storybook/theming";
 import React, { useContext } from 'react';
-
+import { Table } from "./Layouts.jsx";
 import { ThemeContainer } from "./ThemeContainer.jsx";
 import { Body, Code, LinkableHeading } from "./Typography.jsx";
-
-export const Table = styled.table`
-	--mod-table-cursor-row-default: auto;
-	padding-block: 10px;
-`;
 
 /**
  * Displays the modifiable custom properties for a component based on the metadata provided in the story.

--- a/.storybook/blocks/Swatches.jsx
+++ b/.storybook/blocks/Swatches.jsx
@@ -1,0 +1,64 @@
+import { styled } from "@storybook/theming";
+
+export const SwatchGroupLabel = styled.div`
+	display: flex;
+	flex-direction: column;
+	margin-top: 16px;
+	align-self: flex-start;
+	justify-content: center;
+	text-wrap: nowrap;
+	inline-size: max-content;
+	block-size: ${props => props.size ?? 32}px;
+	color: ${props => `var(--spectrum-neutral-subdued-content-color-default, ${props.theme.defaultText})`};
+`;
+
+export const SwatchSet = styled.div`
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 2px;
+	color: ${props => `var(--spectrum-neutral-subdued-content-color-default, ${props.theme.defaultText})`};
+`;
+
+export const Swatch = styled.div`
+	position: relative;
+	inline-size: var(--swatch-size, ${props => props.size ?? 32}px);
+	block-size: var(--swatch-size, ${props => props.size ?? 32}px);
+	outline: none;
+	user-select: none;
+
+	&::before {
+		position: absolute;
+		inset: 0;
+		inline-size: 100%;
+		block-size: 100%;
+		content: "";
+		opacity: 1;
+
+		border: 1px solid rgba(0, 0, 0, 51%);
+
+		border-radius: ${props => `${props.theme.appBorderRadius}px` ?? `var(--spectrum-corner-radius-100, 4px)`};
+		${props => props.background && `background: ${props.background};`}
+	}
+
+	.spectrum--dark &::before,
+	.spectrum--darkest &::before {
+		border-color: rgba(255, 255, 255, 51%);
+	}
+`;
+
+export const SwatchColors = styled.div`
+	display: inline-flex;
+	flex-direction: row;
+	flex-wrap: wrap;
+	gap: ${props => props.size > 0 ? (props.size * 0.2) : 8}px;
+	align-items: flex-start;
+	justify-content: flex-start;
+`;
+
+export const SwatchGroup = styled.div`
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	flex: 1;
+`;

--- a/.storybook/blocks/ThemeContainer.jsx
+++ b/.storybook/blocks/ThemeContainer.jsx
@@ -1,20 +1,9 @@
 import { DocsContext } from "@storybook/blocks";
-import { styled, ThemeProvider } from "@storybook/theming";
+import { ThemeProvider } from "@storybook/theming";
 import React, { useContext } from "react";
+import { Container } from "./Layouts.jsx";
 
-import "@spectrum-css/tokens/dist/index.css";
-
-const Container = styled.section`
-    color: var(--spectrum-neutral-content-color-default);
-    background-color: var(--spectrum-background-layer-1-color);
-    display: ${props => props.display ?? "flex" };
-    padding-inline: 48px 24px;
-    padding-block: 60px;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 60px;
-    border-radius: 16px;
-`;
+import tokenStyles from "@spectrum-css/tokens/dist/index.css?raw";
 
 /**
  * A container that wraps the children in a themed context
@@ -35,6 +24,7 @@ export const ThemeContainer = ({ color, scale, children, ...props }) => {
 
     return (
         <ThemeProvider theme={theme}>
+            <style>{tokenStyles}</style>
             <Container {...props} className={`spectrum spectrum--${theme.color} spectrum--${theme.scale}`}>
                 {children}
             </Container>

--- a/.storybook/blocks/Typography.jsx
+++ b/.storybook/blocks/Typography.jsx
@@ -1,5 +1,5 @@
 import { styled } from "@storybook/theming";
-import { fetchToken } from "./utilities";
+import { fetchToken } from "./utilities.js";
 
 export const Heading = styled.h3`
     font-family: ${({ theme }) => theme.typography.fontFamily};

--- a/.storybook/blocks/index.js
+++ b/.storybook/blocks/index.js
@@ -13,6 +13,8 @@
 
 export * from "./ColorPalette.jsx";
 export * from "./ComponentDetails.jsx";
+export * from "./Layouts.jsx";
 export * from "./PropertiesTable.jsx";
+export * from "./Swatches.jsx";
 export * from "./ThemeContainer.jsx";
 export * from "./Typography.jsx";

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -65,8 +65,8 @@ export default {
 		"@etchteam/storybook-addon-status",
 		// https://github.com/storybookjs/storybook/tree/next/code/addons/interactions
 		"@storybook/addon-interactions",
-		// https://www.chromatic.com/docs/visual-testing-addon/
-		"@chromaui/addon-visual-tests",
+		// https://docs.chromatic.com/docs/visual-tests-addon/
+		"@chromatic-com/storybook",
 		// https://storybook.js.org/addons/@storybook/addon-designs/
 		"@storybook/addon-designs",
 	],
@@ -101,6 +101,19 @@ export default {
 				alias: components.map(component => ({ find: `@spectrum-css/${component}`, replacement: path.resolve(__dirname, `../components/${component}`) })),
 			}
 		});
+	},
+	build: {
+		test: {
+			disabledAddons: [
+				"@whitespace/storybook-addon-html",
+				"@etchteam/storybook-addon-status",
+				"@storybook/addon-interactions",
+			],
+			disableBlocks: false,
+			disableAutoDocs: false,
+			disableMDXEntries: false,
+			disableDocgen: false,
+		},
 	},
 	framework: "@storybook/web-components-vite",
 	typescript: {

--- a/.storybook/package.json
+++ b/.storybook/package.json
@@ -25,7 +25,7 @@
 	},
 	"module": "main.js",
 	"scripts": {
-		"build": "cross-env NODE_ENV=development storybook build --config-dir . --output-dir ./storybook-static"
+		"build": "cross-env NODE_ENV=development storybook build --stats-json --config-dir ."
 	},
 	"dependencies": {
 		"@adobe/spectrum-css-workflow-icons": "^1.5.4",
@@ -35,7 +35,7 @@
 	},
 	"devDependencies": {
 		"@babel/core": "^7.26.0",
-		"@chromaui/addon-visual-tests": "^1.0.0",
+		"@chromatic-com/storybook": "^3.2.3",
 		"@etchteam/storybook-addon-status": "^5.0.0",
 		"@storybook/addon-a11y": "^8.4.7",
 		"@storybook/addon-actions": "^8.4.7",

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -35,7 +35,6 @@ export const parameters = {
 	panelPosition: "bottom",
 	showToolbar: true,
 	isFullscreen: false,
-	actions: { argTypesRegex: "^on.*" },
 	options: {
 		storySort: {
 			method: "alphabetical-by-kind",

--- a/.storybook/templates/DocumentationTemplate.mdx
+++ b/.storybook/templates/DocumentationTemplate.mdx
@@ -1,5 +1,3 @@
-{/* DocumentationTemplate.mdx */}
-
 import {
   Meta,
   Title,
@@ -10,8 +8,6 @@ import {
   Stories,
 } from "@storybook/blocks";
 import { ComponentDetails, TaggedReleases, PropertiesTable } from "../blocks";
-
-{/* 👇 The isTemplate property is required to tell Storybook that this is a template */}
 
 <Meta isTemplate />
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 		"clean": "yarn cleaner tag:component --skip-nx-cache",
 		"clean:bundle": "nx clean bundle --skip-nx-cache",
 		"clean:docs": "rimraf dist",
+		"clean:env": "rm -rf .env .storybook/chromatic.config.json",
 		"clean:preview": "nx clean storybook --skip-nx-cache",
 		"cleaner": "nx run-many --target clean --projects",
 		"compare": "cross-env NODE_ENV=production node --no-warnings ./tasks/compare-compiled-output.js",

--- a/tasks/chromatic-config-creation.sh
+++ b/tasks/chromatic-config-creation.sh
@@ -14,12 +14,12 @@ env="$(pwd)/.env"
 config_path="$(pwd)/.storybook/chromatic.config.json"
 
 create_config() {
-    [[ ! -f "$1" || -f "$2" ]] && return
+	[[ ! -f "$1" || -f "$2" ]] && return
 
-    echo "🪄 Using .env to generate a local chromatic.config.json"
+	echo "🪄 Using .env to generate a local chromatic.config.json"
 
-    # Initialize the chromatic config file
-    echo "{" > $2
+	# Initialize the chromatic config file
+	echo "{" > $2
 
 	# Read in the local env example, line-by-line and look for variable names
 	while IFS= read -r line; do
@@ -31,30 +31,35 @@ create_config() {
 				continue
 			fi
 
-            # Remove the CHROMATIC_ prefix and convert to lower case
-            while IFS='_' read -ra split; do
-                for i in "${!split[@]}"; do
-                    [[ "${split[$i]}" = "CHROMATIC" ]] && unset "split[$i]"
-                    split[$i]=$(tr '[:upper:]' '[:lower:]' <<< ${split[$i]})
-                    # If the part is the first in the array, capitalize it
-                    [[ $i > 1 ]] && split[$i]=$(tr '[:lower:]' '[:upper:]' <<< ${split[$i]:0:1})${split[$i]:1}
-                done
+			# Remove the CHROMATIC_ prefix and convert to lower case
+			while IFS='_' read -ra split; do
+				for i in "${!split[@]}"; do
+					[[ "${split[$i]}" = "CHROMATIC" ]] && unset "split[$i]"
+					split[$i]=$(tr '[:upper:]' '[:lower:]' <<< ${split[$i]})
+					# If the part is the first in the array, capitalize it
+					[[ $i > 1 ]] && split[$i]=$(tr '[:lower:]' '[:upper:]' <<< ${split[$i]:0:1})${split[$i]:1}
+				done
 
-                key=$(printf "%s" "${split[@]}")
-            done <<< "${parts[0]}"
+				key=$(printf "%s" "${split[@]}")
+			done <<< "${parts[0]}"
 
-            # Write the key/value pair to the chromatic config file
-            echo "  \"${key}\": \"${parts[1]//\"/}\"," >> $2
+			# Write the key/value pair to the chromatic config file
+			# if the value is a boolean, skip the quotation marks
+			if [[ "${parts[1]}" == "true" || "${parts[1]}" == "false" ]]; then
+				echo "  \"${key}\": ${parts[1]}," >> $2
+			else
+				echo "  \"${key}\": \"${parts[1]//\"/}\"," >> $2
+			fi
 
 		done <<< "$line"
 	done < $1
 
-    # Remove the last comma from the chromatic config file
-    sed '$ s/,$//' $2 > $2.tmp && mv $2.tmp $2
+	# Remove the last comma from the chromatic config file
+	sed '$ s/,$//' $2 > $2.tmp && mv $2.tmp $2
 
-    # Close the chromatic config file
-    echo "}" >> $2
-    echo "" >> $2
+	# Close the chromatic config file
+	echo "}" >> $2
+	echo "" >> $2
 }
 
 create_config $env $config_path

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,18 +5,6 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@0no-co/graphql.web@npm:^1.0.5":
-  version: 1.0.7
-  resolution: "@0no-co/graphql.web@npm:1.0.7"
-  peerDependencies:
-    graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
-  peerDependenciesMeta:
-    graphql:
-      optional: true
-  checksum: 10c0/4744a6c327e0a2d564c8f4720ef08dcece6c3b8373f52208ff29f7086f90e18d211c59cc222c229f1e3241abd1fc6e30377dc1dadac491bbb25706f29dea626a
-  languageName: node
-  linkType: hard
-
 "@actions/artifact@npm:^2.2.1":
   version: 2.2.1
   resolution: "@actions/artifact@npm:2.2.1"
@@ -706,7 +694,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.3.1":
   version: 7.24.8
   resolution: "@babel/runtime@npm:7.24.8"
   dependencies:
@@ -1050,22 +1038,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@chromaui/addon-visual-tests@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "@chromaui/addon-visual-tests@npm:1.0.0"
+"@chromatic-com/storybook@npm:^3.2.3":
+  version: 3.2.3
+  resolution: "@chromatic-com/storybook@npm:3.2.3"
   dependencies:
-    "@storybook/design-system": "npm:^7.15.15"
-    "@urql/exchange-auth": "npm:^2.1.6"
-    chromatic: "npm:^10.6.0"
-    date-fns: "npm:^2.30.0"
+    chromatic: "npm:^11.15.0"
     filesize: "npm:^10.0.12"
     jsonfile: "npm:^6.1.0"
-    pluralize: "npm:^8.0.0"
-    ts-dedent: "npm:^2.2.0"
-    urql: "npm:^4.0.3"
-    uuid: "npm:^9.0.0"
-    zod: "npm:^3.22.2"
-  checksum: 10c0/c060f4e13cccd8d7f6ad956c224166895881850c102a384b0560e9d92438f1e4787aec08f06e92452bb7d431e503cca4118087d33a251ffd53a24ba23304c061
+    react-confetti: "npm:^6.1.0"
+    strip-ansi: "npm:^7.1.0"
+  peerDependencies:
+    storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
+  checksum: 10c0/23c59b7d225347d4af8cb6a7596da3417dc3abc2d5036c4ef5cee2852b994a16b5996a1bd1a584bb56e97266d85ce9ae7daeeac296b3060d6b80b14cad10d9d1
   languageName: node
   linkType: hard
 
@@ -1803,22 +1787,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/use-insertion-effect-with-fallbacks@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "@emotion/use-insertion-effect-with-fallbacks@npm:1.0.1"
-  peerDependencies:
-    react: ">=16.8.0"
-  checksum: 10c0/a15b2167940e3a908160687b73fc4fcd81e59ab45136b6967f02c7c419d9a149acd22a416b325c389642d4f1c3d33cf4196cad6b618128b55b7c74f6807a240b
-  languageName: node
-  linkType: hard
-
-"@emotion/weak-memoize@npm:^0.3.0":
-  version: 0.3.1
-  resolution: "@emotion/weak-memoize@npm:0.3.1"
-  checksum: 10c0/ed514b3cb94bbacece4ac2450d98898066c0a0698bdeda256e312405ca53634cb83c75889b25cd8bbbe185c80f4c05a1f0a0091e1875460ba6be61d0334f0b8a
-  languageName: node
-  linkType: hard
-
 "@esbuild/aix-ppc64@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/aix-ppc64@npm:0.21.5"
@@ -2265,19 +2233,6 @@ __metadata:
   version: 2.0.3
   resolution: "@humanwhocodes/object-schema@npm:2.0.3"
   checksum: 10c0/80520eabbfc2d32fe195a93557cef50dfe8c8905de447f022675aaf66abc33ae54098f5ea78548d925aa671cd4ab7c7daa5ad704fe42358c9b5e7db60f80696c
-  languageName: node
-  linkType: hard
-
-"@hypnosphi/create-react-context@npm:^0.3.1":
-  version: 0.3.1
-  resolution: "@hypnosphi/create-react-context@npm:0.3.1"
-  dependencies:
-    gud: "npm:^1.0.0"
-    warning: "npm:^4.0.3"
-  peerDependencies:
-    prop-types: ^15.0.0
-    react: ">=0.14.0"
-  checksum: 10c0/e8072221f9f9c2c47c3ebc5bc6079f9a71938e181d2b4aa3e1d3922707bc097336d5260dad088cf47c1d6e1ff34839fa21f2505a95bddda0d7548c5a955b5691
   languageName: node
   linkType: hard
 
@@ -4467,7 +4422,7 @@ __metadata:
   dependencies:
     "@adobe/spectrum-css-workflow-icons": "npm:^1.5.4"
     "@babel/core": "npm:^7.26.0"
-    "@chromaui/addon-visual-tests": "npm:^1.0.0"
+    "@chromatic-com/storybook": "npm:^3.2.3"
     "@etchteam/storybook-addon-status": "npm:^5.0.0"
     "@spectrum-css/bundle": "workspace:^"
     "@spectrum-css/tokens": "workspace:^"
@@ -5250,44 +5205,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/channels@npm:7.6.20":
-  version: 7.6.20
-  resolution: "@storybook/channels@npm:7.6.20"
-  dependencies:
-    "@storybook/client-logger": "npm:7.6.20"
-    "@storybook/core-events": "npm:7.6.20"
-    "@storybook/global": "npm:^5.0.0"
-    qs: "npm:^6.10.0"
-    telejson: "npm:^7.2.0"
-    tiny-invariant: "npm:^1.3.1"
-  checksum: 10c0/5aaa3e06a27750ffc48be6a5375dc286e1de5ae6c54f8318338afa2bbea68e37842f8eb17ce509c5587af173289640e78a4bbec3f234be9395bd08a0e1820308
-  languageName: node
-  linkType: hard
-
-"@storybook/client-logger@npm:7.6.20":
-  version: 7.6.20
-  resolution: "@storybook/client-logger@npm:7.6.20"
-  dependencies:
-    "@storybook/global": "npm:^5.0.0"
-  checksum: 10c0/cd1a9cb0a484a1585d5b4a918b20335ba8bd6655ae0051ba30c729b75678bafca62b8ef124fecd5c5883debf41d93a1827cf7bdf08df666f64de3cc15864be54
-  languageName: node
-  linkType: hard
-
 "@storybook/components@npm:8.4.7, @storybook/components@npm:^8.4.7":
   version: 8.4.7
   resolution: "@storybook/components@npm:8.4.7"
   peerDependencies:
     storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
   checksum: 10c0/7c1eb12fe2310a306f3c2f77a499c3a0caeb4694d4af8dde418f3b2d2ac8a3549b3f56cdc4629b9c15d79177c72e8668dd781a71bf257948f799b0e9cba201fa
-  languageName: node
-  linkType: hard
-
-"@storybook/core-events@npm:7.6.20":
-  version: 7.6.20
-  resolution: "@storybook/core-events@npm:7.6.20"
-  dependencies:
-    ts-dedent: "npm:^2.0.0"
-  checksum: 10c0/4ee2cc7ca6d7cae579befab640bfe1e8b30243305f73e7d731e40aa1295ff5fc1b6c61561929d2e4db315f7c4f5b3cfdf0ddc3746b3660d34b0dd3911a55d4ad
   languageName: node
   linkType: hard
 
@@ -5341,42 +5264,6 @@ __metadata:
   dependencies:
     type-fest: "npm:^2.19.0"
   checksum: 10c0/c5329fc13e7d762049b5c91df1bc1c0e510a1a898c401b72b68f1ff64139a85ab64a92f8e681d2fcb226c0a4a55d0f23b569b2bdb517e0f067bd05ea46228356
-  languageName: node
-  linkType: hard
-
-"@storybook/csf@npm:^0.1.2":
-  version: 0.1.3
-  resolution: "@storybook/csf@npm:0.1.3"
-  dependencies:
-    type-fest: "npm:^2.19.0"
-  checksum: 10c0/9a3542651943c8215cce49a88e85cb9217cf1a25ddc440687eb42d54e160bc2523eded19a6dabf52e940054e4e296c6e9906f0f3f7aff7b4dcf7bfc4e96280a8
-  languageName: node
-  linkType: hard
-
-"@storybook/design-system@npm:^7.15.15":
-  version: 7.15.17
-  resolution: "@storybook/design-system@npm:7.15.17"
-  dependencies:
-    "@emotion/weak-memoize": "npm:^0.3.0"
-    "@storybook/source-loader": "npm:^7.6.6"
-    "@storybook/theming": "npm:^7.6.6"
-    "@types/pluralize": "npm:^0.0.29"
-    "@types/prismjs": "npm:^1.16.6"
-    "@types/react-modal": "npm:^3.12.1"
-    "@types/uuid": "npm:^8.3.1"
-    copy-to-clipboard: "npm:^3.3.1"
-    human-format: "npm:^0.11.0"
-    pluralize: "npm:^8.0.0"
-    polished: "npm:^3.6.4"
-    prismjs: "npm:1.25.0"
-    react-github-button: "npm:^0.1.11"
-    react-modal: "npm:^3.11.2"
-    react-popper-tooltip: "npm:^2.11.1"
-    uuid: "npm:^3.3.3"
-  peerDependencies:
-    react: ^15.0.0 || ^16.0.0 || ^17.0.0
-    react-dom: ^15.0.0 || ^16.0.0 || ^17.0.0
-  checksum: 10c0/116ffbc542e8ef4c686e0c6afeb9240a4d7219fc85054c52c0984497b6aea4b72f4fb60f4778ab246c66595aac6adae6e06ade5b89bcec65f58c8032c88854c1
   languageName: node
   linkType: hard
 
@@ -5438,19 +5325,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/source-loader@npm:^7.6.6":
-  version: 7.6.20
-  resolution: "@storybook/source-loader@npm:7.6.20"
-  dependencies:
-    "@storybook/csf": "npm:^0.1.2"
-    "@storybook/types": "npm:7.6.20"
-    estraverse: "npm:^5.2.0"
-    lodash: "npm:^4.17.21"
-    prettier: "npm:^2.8.0"
-  checksum: 10c0/8f5beb589dfc9896dbf16819018f6ac168dc906d0c6a2a887684cf7c39f9323495d1da35a8c1a514dfd01e91ace38d76a811e3cc665e33ef73955589713a8ead
-  languageName: node
-  linkType: hard
-
 "@storybook/test-runner@npm:^0.21.0":
   version: 0.21.0
   resolution: "@storybook/test-runner@npm:0.21.0"
@@ -5506,33 +5380,6 @@ __metadata:
   peerDependencies:
     storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
   checksum: 10c0/20a4975478063cea616ce6ab6b1e9ec181af1424280678ed74dc5afc15b828c043e843696a1643601331c4fd266169ec4bcc5bb43fd2f1f3c01c0e21443a658a
-  languageName: node
-  linkType: hard
-
-"@storybook/theming@npm:^7.6.6":
-  version: 7.6.20
-  resolution: "@storybook/theming@npm:7.6.20"
-  dependencies:
-    "@emotion/use-insertion-effect-with-fallbacks": "npm:^1.0.0"
-    "@storybook/client-logger": "npm:7.6.20"
-    "@storybook/global": "npm:^5.0.0"
-    memoizerific: "npm:^1.11.3"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: 10c0/7ab97d6a93837900391212ac1638a247d2ccac55bd1261bb34739a11f226040c47da5fc5fde120d4829a3f068b55ce34a2d42c0b14bcfa71e97b18a4288161f3
-  languageName: node
-  linkType: hard
-
-"@storybook/types@npm:7.6.20":
-  version: 7.6.20
-  resolution: "@storybook/types@npm:7.6.20"
-  dependencies:
-    "@storybook/channels": "npm:7.6.20"
-    "@types/babel__core": "npm:^7.0.0"
-    "@types/express": "npm:^4.7.0"
-    file-system-cache: "npm:2.3.0"
-  checksum: 10c0/148ba54a43a247291d43e06585688279a6ea52ea0e227bab3f28d589adb02b5f436862e49a6c943940da81204662bcfc87922f61011518a554b0d3c83b0293aa
   languageName: node
   linkType: hard
 
@@ -5803,7 +5650,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/babel__core@npm:^7.0.0, @types/babel__core@npm:^7.1.14":
+"@types/babel__core@npm:^7.1.14":
   version: 7.20.5
   resolution: "@types/babel__core@npm:7.20.5"
   dependencies:
@@ -5844,25 +5691,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/body-parser@npm:*":
-  version: 1.19.5
-  resolution: "@types/body-parser@npm:1.19.5"
-  dependencies:
-    "@types/connect": "npm:*"
-    "@types/node": "npm:*"
-  checksum: 10c0/aebeb200f25e8818d8cf39cd0209026750d77c9b85381cdd8deeb50913e4d18a1ebe4b74ca9b0b4d21952511eeaba5e9fbbf739b52731a2061e206ec60d568df
-  languageName: node
-  linkType: hard
-
-"@types/connect@npm:*":
-  version: 3.4.38
-  resolution: "@types/connect@npm:3.4.38"
-  dependencies:
-    "@types/node": "npm:*"
-  checksum: 10c0/2e1cdba2c410f25649e77856505cd60223250fa12dff7a503e492208dbfdd25f62859918f28aba95315251fd1f5e1ffbfca1e25e73037189ab85dd3f8d0a148c
-  languageName: node
-  linkType: hard
-
 "@types/conventional-commits-parser@npm:^5.0.0":
   version: 5.0.0
   resolution: "@types/conventional-commits-parser@npm:5.0.0"
@@ -5876,30 +5704,6 @@ __metadata:
   version: 1.0.5
   resolution: "@types/estree@npm:1.0.5"
   checksum: 10c0/b3b0e334288ddb407c7b3357ca67dbee75ee22db242ca7c56fe27db4e1a31989cb8af48a84dd401deb787fe10cc6b2ab1ee82dc4783be87ededbe3d53c79c70d
-  languageName: node
-  linkType: hard
-
-"@types/express-serve-static-core@npm:^4.17.33":
-  version: 4.19.5
-  resolution: "@types/express-serve-static-core@npm:4.19.5"
-  dependencies:
-    "@types/node": "npm:*"
-    "@types/qs": "npm:*"
-    "@types/range-parser": "npm:*"
-    "@types/send": "npm:*"
-  checksum: 10c0/ba8d8d976ab797b2602c60e728802ff0c98a00f13d420d82770f3661b67fa36ea9d3be0b94f2ddd632afe1fbc6e41620008b01db7e4fabdd71a2beb5539b0725
-  languageName: node
-  linkType: hard
-
-"@types/express@npm:^4.7.0":
-  version: 4.17.21
-  resolution: "@types/express@npm:4.17.21"
-  dependencies:
-    "@types/body-parser": "npm:*"
-    "@types/express-serve-static-core": "npm:^4.17.33"
-    "@types/qs": "npm:*"
-    "@types/serve-static": "npm:*"
-  checksum: 10c0/12e562c4571da50c7d239e117e688dc434db1bac8be55613294762f84fd77fbd0658ccd553c7d3ab02408f385bc93980992369dd30e2ecd2c68c358e6af8fabf
   languageName: node
   linkType: hard
 
@@ -5925,13 +5729,6 @@ __metadata:
   dependencies:
     "@types/unist": "npm:^2"
   checksum: 10c0/16daac35d032e656defe1f103f9c09c341a6dc553c7ec17b388274076fa26e904a71ea5ea41fd368a6d5f1e9e53be275c80af7942b9c466d8511d261c9529c7e
-  languageName: node
-  linkType: hard
-
-"@types/http-errors@npm:*":
-  version: 2.0.4
-  resolution: "@types/http-errors@npm:2.0.4"
-  checksum: 10c0/494670a57ad4062fee6c575047ad5782506dd35a6b9ed3894cea65830a94367bd84ba302eb3dde331871f6d70ca287bfedb1b2cf658e6132cd2cbd427ab56836
   languageName: node
   linkType: hard
 
@@ -5987,13 +5784,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/mime@npm:^1":
-  version: 1.3.5
-  resolution: "@types/mime@npm:1.3.5"
-  checksum: 10c0/c2ee31cd9b993804df33a694d5aa3fa536511a49f2e06eeab0b484fef59b4483777dbb9e42a4198a0809ffbf698081fdbca1e5c2218b82b91603dfab10a10fbc
-  languageName: node
-  linkType: hard
-
 "@types/node@npm:*":
   version: 20.14.11
   resolution: "@types/node@npm:20.14.11"
@@ -6007,81 +5797,6 @@ __metadata:
   version: 12.20.55
   resolution: "@types/node@npm:12.20.55"
   checksum: 10c0/3b190bb0410047d489c49bbaab592d2e6630de6a50f00ba3d7d513d59401d279972a8f5a598b5bb8ddc1702f8a2f4ec57a65d93852f9c329639738e7053637d1
-  languageName: node
-  linkType: hard
-
-"@types/pluralize@npm:^0.0.29":
-  version: 0.0.29
-  resolution: "@types/pluralize@npm:0.0.29"
-  checksum: 10c0/840796fa1db158eb4d9787758d134736e29d9a8035f5b0cbad06e3801fc64b79112ba944c83f9a1a5b94da08703f505b8315b7e0f28bfc0f8e9e1ccfead7b083
-  languageName: node
-  linkType: hard
-
-"@types/prismjs@npm:^1.16.6":
-  version: 1.26.4
-  resolution: "@types/prismjs@npm:1.26.4"
-  checksum: 10c0/996be7d119779c4cbe66e58342115a12d35a02226dae3aaa4a744c9652d5a3939c93c26182e18156965ac4f93575ebb309c3469c36f52e60ee5c0f8f27e874df
-  languageName: node
-  linkType: hard
-
-"@types/prop-types@npm:*":
-  version: 15.7.12
-  resolution: "@types/prop-types@npm:15.7.12"
-  checksum: 10c0/1babcc7db6a1177779f8fde0ccc78d64d459906e6ef69a4ed4dd6339c920c2e05b074ee5a92120fe4e9d9f1a01c952f843ebd550bee2332fc2ef81d1706878f8
-  languageName: node
-  linkType: hard
-
-"@types/qs@npm:*":
-  version: 6.9.14
-  resolution: "@types/qs@npm:6.9.14"
-  checksum: 10c0/11ad1eb7f6d7c216002789959d88acc7c43f72854fa4335f01de0df41b4c4024668dace8a37ba12270314345ede0ec6b07f93053a45e7bd4cd7318a3dcf0b6b8
-  languageName: node
-  linkType: hard
-
-"@types/range-parser@npm:*":
-  version: 1.2.7
-  resolution: "@types/range-parser@npm:1.2.7"
-  checksum: 10c0/361bb3e964ec5133fa40644a0b942279ed5df1949f21321d77de79f48b728d39253e5ce0408c9c17e4e0fd95ca7899da36841686393b9f7a1e209916e9381a3c
-  languageName: node
-  linkType: hard
-
-"@types/react-modal@npm:^3.12.1":
-  version: 3.16.3
-  resolution: "@types/react-modal@npm:3.16.3"
-  dependencies:
-    "@types/react": "npm:*"
-  checksum: 10c0/dfcf52fa4b5d5c203aa47ffaafade369836cb9f891e9b60e7056bf5fdfc508ebec7971bb3d4c4018f422953c1c79948755ef19da3e816c28d7c5fdacf9466af8
-  languageName: node
-  linkType: hard
-
-"@types/react@npm:*":
-  version: 18.3.3
-  resolution: "@types/react@npm:18.3.3"
-  dependencies:
-    "@types/prop-types": "npm:*"
-    csstype: "npm:^3.0.2"
-  checksum: 10c0/fe455f805c5da13b89964c3d68060cebd43e73ec15001a68b34634604a78140e6fc202f3f61679b9d809dde6d7a7c2cb3ed51e0fd1462557911db09879b55114
-  languageName: node
-  linkType: hard
-
-"@types/send@npm:*":
-  version: 0.17.4
-  resolution: "@types/send@npm:0.17.4"
-  dependencies:
-    "@types/mime": "npm:^1"
-    "@types/node": "npm:*"
-  checksum: 10c0/7f17fa696cb83be0a104b04b424fdedc7eaba1c9a34b06027239aba513b398a0e2b7279778af521f516a397ced417c96960e5f50fcfce40c4bc4509fb1a5883c
-  languageName: node
-  linkType: hard
-
-"@types/serve-static@npm:*":
-  version: 1.15.7
-  resolution: "@types/serve-static@npm:1.15.7"
-  dependencies:
-    "@types/http-errors": "npm:*"
-    "@types/node": "npm:*"
-    "@types/send": "npm:*"
-  checksum: 10c0/26ec864d3a626ea627f8b09c122b623499d2221bbf2f470127f4c9ebfe92bd8a6bb5157001372d4c4bd0dd37a1691620217d9dc4df5aa8f779f3fd996b1c60ae
   languageName: node
   linkType: hard
 
@@ -6112,13 +5827,6 @@ __metadata:
   version: 2.0.10
   resolution: "@types/unist@npm:2.0.10"
   checksum: 10c0/5f247dc2229944355209ad5c8e83cfe29419fa7f0a6d557421b1985a1500444719cc9efcc42c652b55aab63c931813c88033e0202c1ac684bcd4829d66e44731
-  languageName: node
-  linkType: hard
-
-"@types/uuid@npm:^8.3.1":
-  version: 8.3.4
-  resolution: "@types/uuid@npm:8.3.4"
-  checksum: 10c0/b9ac98f82fcf35962317ef7dc44d9ac9e0f6fdb68121d384c88fe12ea318487d5585d3480fa003cf28be86a3bbe213ca688ba786601dce4a97724765eb5b1cf2
   languageName: node
   linkType: hard
 
@@ -6158,28 +5866,6 @@ __metadata:
   version: 1.2.0
   resolution: "@ungap/structured-clone@npm:1.2.0"
   checksum: 10c0/8209c937cb39119f44eb63cf90c0b73e7c754209a6411c707be08e50e29ee81356dca1a848a405c8bdeebfe2f5e4f831ad310ae1689eeef65e7445c090c6657d
-  languageName: node
-  linkType: hard
-
-"@urql/core@npm:^5.0.0":
-  version: 5.0.4
-  resolution: "@urql/core@npm:5.0.4"
-  dependencies:
-    "@0no-co/graphql.web": "npm:^1.0.5"
-    wonka: "npm:^6.3.2"
-  checksum: 10c0/3aec9420ef930cfdb0dc4635588bb2727884f9691cb56e074440b225d7dbf7a1c0d60c9fd35b1dac53fe7e7ca9d5d4d3a33fd001734096f9dfacb404df919751
-  languageName: node
-  linkType: hard
-
-"@urql/exchange-auth@npm:^2.1.6":
-  version: 2.2.0
-  resolution: "@urql/exchange-auth@npm:2.2.0"
-  dependencies:
-    "@urql/core": "npm:^5.0.0"
-    wonka: "npm:^6.3.2"
-  peerDependencies:
-    "@urql/core": ^5.0.0
-  checksum: 10c0/75141d592640ebfa15781bfedaf36d878fa7adfc9b73421f57c31b01d099c0c2388bf1b4cf2ebf3ffbb4634f7f6837d2018175f543d1e5d9362dc9d0a09aef9b
   languageName: node
   linkType: hard
 
@@ -7819,12 +7505,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chromatic@npm:^10.6.0":
-  version: 10.9.6
-  resolution: "chromatic@npm:10.9.6"
+"chromatic@npm:^11.15.0":
+  version: 11.20.2
+  resolution: "chromatic@npm:11.20.2"
   peerDependencies:
-    "@chromatic-com/cypress": ^0.5.2 || ^1.0.0
-    "@chromatic-com/playwright": ^0.5.2 || ^1.0.0
+    "@chromatic-com/cypress": ^0.*.* || ^1.0.0
+    "@chromatic-com/playwright": ^0.*.* || ^1.0.0
   peerDependenciesMeta:
     "@chromatic-com/cypress":
       optional: true
@@ -7834,7 +7520,7 @@ __metadata:
     chroma: dist/bin.js
     chromatic: dist/bin.js
     chromatic-cli: dist/bin.js
-  checksum: 10c0/73fc169cc23ae2ff45259d533c0129fda2cdcb1bc6269987b51fc79c01ed85b205fc46099768e522725b83ed343433a42572f8d95a30c04a51d0df9ccac67f7b
+  checksum: 10c0/9f60e966fc7dc22df920649e3860493dbf7c86ea34d96e9818e4450c7572e47b8554a3ecec273881184303ee9098ca15b4c85d519b37138ee0399387b1356b7d
   languageName: node
   linkType: hard
 
@@ -8333,15 +8019,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"copy-to-clipboard@npm:^3.3.1":
-  version: 3.3.3
-  resolution: "copy-to-clipboard@npm:3.3.3"
-  dependencies:
-    toggle-selection: "npm:^1.0.6"
-  checksum: 10c0/3ebf5e8ee00601f8c440b83ec08d838e8eabb068c1fae94a9cda6b42f288f7e1b552f3463635f419af44bf7675afc8d0390d30876cf5c2d5d35f86d9c56a3e5f
-  languageName: node
-  linkType: hard
-
 "core-util-is@npm:~1.0.0":
   version: 1.0.3
   resolution: "core-util-is@npm:1.0.3"
@@ -8722,13 +8399,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"csstype@npm:^3.0.2":
-  version: 3.1.3
-  resolution: "csstype@npm:3.1.3"
-  checksum: 10c0/80c089d6f7e0c5b2bd83cf0539ab41474198579584fa10d86d0cafe0642202343cbc119e076a0b1aece191989477081415d66c9fefbf3c957fc2fc4b7009f248
-  languageName: node
-  linkType: hard
-
 "currently-unhandled@npm:^0.4.1":
   version: 0.4.1
   resolution: "currently-unhandled@npm:0.4.1"
@@ -8819,15 +8489,6 @@ __metadata:
     extended: "npm:~0.0.3"
     is-extended: "npm:~0.0.3"
   checksum: 10c0/c1a0c6742ab0fd245be65e07b9df64a60829faceea3c08d64e5a522eb35b87d9b9d7705ff26d69e3106e0b52543e8b3d15da9cfd91e58c920c71ac93e54fd774
-  languageName: node
-  linkType: hard
-
-"date-fns@npm:^2.30.0":
-  version: 2.30.0
-  resolution: "date-fns@npm:2.30.0"
-  dependencies:
-    "@babel/runtime": "npm:^7.21.0"
-  checksum: 10c0/e4b521fbf22bc8c3db332bbfb7b094fd3e7627de0259a9d17c7551e2d2702608a7307a449206065916538e384f37b181565447ce2637ae09828427aed9cb5581
   languageName: node
   linkType: hard
 
@@ -8925,20 +8586,6 @@ __metadata:
   version: 5.0.2
   resolution: "deep-eql@npm:5.0.2"
   checksum: 10c0/7102cf3b7bb719c6b9c0db2e19bf0aa9318d141581befe8c7ce8ccd39af9eaa4346e5e05adef7f9bd7015da0f13a3a25dcfe306ef79dc8668aedbecb658dd247
-  languageName: node
-  linkType: hard
-
-"deep-equal@npm:^1.1.1":
-  version: 1.1.2
-  resolution: "deep-equal@npm:1.1.2"
-  dependencies:
-    is-arguments: "npm:^1.1.1"
-    is-date-object: "npm:^1.0.5"
-    is-regex: "npm:^1.1.4"
-    object-is: "npm:^1.1.5"
-    object-keys: "npm:^1.1.1"
-    regexp.prototype.flags: "npm:^1.5.1"
-  checksum: 10c0/cd85d822d18e9b3e1532d0f6ba412d229aa9d22881d70da161674428ae96e47925191296f7cda29306bac252889007da40ed8449363bd1c96c708acb82068a00
   languageName: node
   linkType: hard
 
@@ -10135,13 +9782,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"exenv@npm:^1.2.0":
-  version: 1.2.2
-  resolution: "exenv@npm:1.2.2"
-  checksum: 10c0/4e96b355a6b9b9547237288ca779dd673b2e698458b409e88b50df09feb7c85ef94c07354b6b87bc3ed0193a94009a6f7a3c71956da12f45911c0d0f5aa3caa0
-  languageName: node
-  linkType: hard
-
 "exit-on-epipe@npm:, exit-on-epipe@npm:~1.0.1":
   version: 1.0.1
   resolution: "exit-on-epipe@npm:1.0.1"
@@ -10438,16 +10078,6 @@ __metadata:
   dependencies:
     flat-cache: "npm:^5.0.0"
   checksum: 10c0/07b0a4f062dc0aa258f3e1b06ac083ea25313f5e289943e146fafdaf3315dcc031635545eea7fe98fe5598b91d6c7f48dba7a251dd7ac20108a6ebf7d00b0b1c
-  languageName: node
-  linkType: hard
-
-"file-system-cache@npm:2.3.0":
-  version: 2.3.0
-  resolution: "file-system-cache@npm:2.3.0"
-  dependencies:
-    fs-extra: "npm:11.1.1"
-    ramda: "npm:0.29.0"
-  checksum: 10c0/43de19f0db32e6546bb7abeecb1d6ea83c1eca23b38905c9415a29f6219cc9d6d87b0c1a6aca92c46a0f1bc276241a339f2f68b8aa0ca5c2eb64b6e1e3e4da01
   languageName: node
   linkType: hard
 
@@ -10779,17 +10409,6 @@ __metadata:
   version: 0.1.0
   resolution: "fs-exists-sync@npm:0.1.0"
   checksum: 10c0/3067957c9394aabfce5f7351b6a70fcc423483131c7c0fa9ba8e48cbe00ecd866fb98e43e3c534b60e03354a520cfc27e9dc488bd057317c66b97714ad9bf673
-  languageName: node
-  linkType: hard
-
-"fs-extra@npm:11.1.1":
-  version: 11.1.1
-  resolution: "fs-extra@npm:11.1.1"
-  dependencies:
-    graceful-fs: "npm:^4.2.0"
-    jsonfile: "npm:^6.0.1"
-    universalify: "npm:^2.0.0"
-  checksum: 10c0/a2480243d7dcfa7d723c5f5b24cf4eba02a6ccece208f1524a2fbde1c629492cfb9a59e4b6d04faff6fbdf71db9fdc8ef7f396417a02884195a625f5d8dc9427
   languageName: node
   linkType: hard
 
@@ -11297,13 +10916,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"gud@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "gud@npm:1.0.0"
-  checksum: 10c0/a4db6edc18e2c4e3a22dc9e639e40a4e5650d53dae9cf384a96d5380dfa17ddda376cf6b7797a5c30d140d2532e5a69d167bdb70c2c151dd673253bac6b027f3
-  languageName: node
-  linkType: hard
-
 "handlebars@npm:^4.7.8":
   version: 4.7.8
   resolution: "handlebars@npm:4.7.8"
@@ -11606,13 +11218,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"human-format@npm:^0.11.0":
-  version: 0.11.0
-  resolution: "human-format@npm:0.11.0"
-  checksum: 10c0/83cc87af67036b4abb6dc585533fcc232279373f8a3a7a4fc1f6d988f6aa35664f986adb818d04d9de3dee240648ec94a9944a8ab1852df21eb67c254e991ea7
-  languageName: node
-  linkType: hard
-
 "human-id@npm:^1.0.2":
   version: 1.0.2
   resolution: "human-id@npm:1.0.2"
@@ -11890,7 +11495,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-arguments@npm:^1.0.4, is-arguments@npm:^1.1.1":
+"is-arguments@npm:^1.0.4":
   version: 1.1.1
   resolution: "is-arguments@npm:1.1.1"
   dependencies:
@@ -11977,7 +11582,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-date-object@npm:^1.0.1, is-date-object@npm:^1.0.5":
+"is-date-object@npm:^1.0.1":
   version: 1.0.5
   resolution: "is-date-object@npm:1.0.5"
   dependencies:
@@ -13636,7 +13241,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loose-envify@npm:^1.0.0, loose-envify@npm:^1.1.0, loose-envify@npm:^1.4.0":
+"loose-envify@npm:^1.1.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
   dependencies:
@@ -14655,16 +14260,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object-is@npm:^1.1.5":
-  version: 1.1.6
-  resolution: "object-is@npm:1.1.6"
-  dependencies:
-    call-bind: "npm:^1.0.7"
-    define-properties: "npm:^1.2.1"
-  checksum: 10c0/506af444c4dce7f8e31f34fc549e2fb8152d6b9c4a30c6e62852badd7f520b579c679af433e7a072f9d78eb7808d230dc12e1cf58da9154dfbf8813099ea0fe0
-  languageName: node
-  linkType: hard
-
 "object-keys@npm:^1.1.1":
   version: 1.1.1
   resolution: "object-keys@npm:1.1.1"
@@ -15395,35 +14990,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pluralize@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "pluralize@npm:8.0.0"
-  checksum: 10c0/2044cfc34b2e8c88b73379ea4a36fc577db04f651c2909041b054c981cd863dd5373ebd030123ab058d194ae615d3a97cfdac653991e499d10caf592e8b3dc33
-  languageName: node
-  linkType: hard
-
-"polished@npm:^3.6.4":
-  version: 3.7.2
-  resolution: "polished@npm:3.7.2"
-  dependencies:
-    "@babel/runtime": "npm:^7.12.5"
-  checksum: 10c0/c36439946b5bfbac16c06dd7b00a89f45e07410427344e909c540ce3ddeb9b44d2ae9cc035a9d77f4551e07b9803419ae77767aec85958a0978158a95c0115d8
-  languageName: node
-  linkType: hard
-
 "polished@npm:^4.2.2":
   version: 4.3.1
   resolution: "polished@npm:4.3.1"
   dependencies:
     "@babel/runtime": "npm:^7.17.8"
   checksum: 10c0/45480d4c7281a134281cef092f6ecc202a868475ff66a390fee6e9261386e16f3047b4de46a2f2e1cf7fb7aa8f52d30b4ed631a1e3bcd6f303ca31161d4f07fe
-  languageName: node
-  linkType: hard
-
-"popper.js@npm:^1.14.4":
-  version: 1.16.1
-  resolution: "popper.js@npm:1.16.1"
-  checksum: 10c0/1c1a826f757edb5b8c2049dfd7a9febf6ae1e9d0e51342fc715b49a0c1020fced250d26484619883651e097c5764bbcacd2f31496e3646027f079dd83e072681
   languageName: node
   linkType: hard
 
@@ -16629,7 +16201,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^2.5.1, prettier@npm:^2.7.1, prettier@npm:^2.8.0":
+"prettier@npm:^2.5.1, prettier@npm:^2.7.1":
   version: 2.8.8
   resolution: "prettier@npm:2.8.8"
   bin:
@@ -16691,13 +16263,6 @@ __metadata:
   bin:
     printj: ./bin/printj.njs
   checksum: 10c0/511ebf3a1eb3269d91ac709083039c32dbee05ad71918ac20fb960df03d24cf072b09ec22a3cb0897f31c48233f10312596e3f4e43dfc6269e6977b0679a68ec
-  languageName: node
-  linkType: hard
-
-"prismjs@npm:1.25.0":
-  version: 1.25.0
-  resolution: "prismjs@npm:1.25.0"
-  checksum: 10c0/0c3853a6c815b23a07bef77700f60a40b2a12018a383a75cd7d108718717b73927c809e7dd08ac0ae9f16fbe1e005b337262bc95952cf9cfc91914f986b07bd3
   languageName: node
   linkType: hard
 
@@ -16772,17 +16337,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prop-types@npm:^15.5.10, prop-types@npm:^15.6.1, prop-types@npm:^15.7.2":
-  version: 15.8.1
-  resolution: "prop-types@npm:15.8.1"
-  dependencies:
-    loose-envify: "npm:^1.4.0"
-    object-assign: "npm:^4.1.1"
-    react-is: "npm:^16.13.1"
-  checksum: 10c0/59ece7ca2fb9838031d73a48d4becb9a7cc1ed10e610517c7d8f19a1e02fa47f7c27d557d8a5702bec3cfeccddc853579832b43f449e54635803f277b1c78077
-  languageName: node
-  linkType: hard
-
 "property-information@npm:^5.0.0":
   version: 5.6.0
   resolution: "property-information@npm:5.6.0"
@@ -16813,15 +16367,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:^6.10.0":
-  version: 6.12.3
-  resolution: "qs@npm:6.12.3"
-  dependencies:
-    side-channel: "npm:^1.0.6"
-  checksum: 10c0/243ddcc8f49dab78fc51041f7f64c500b47c671c45a101a8aca565d8537cb562921da7ef1a831b4a7051596ec88bb35a0d5e25a240025e8b32c6bfb69f00bf2f
-  languageName: node
-  linkType: hard
-
 "queue-microtask@npm:^1.2.2":
   version: 1.2.3
   resolution: "queue-microtask@npm:1.2.3"
@@ -16843,10 +16388,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ramda@npm:0.29.0":
-  version: 0.29.0
-  resolution: "ramda@npm:0.29.0"
-  checksum: 10c0/b00eaaf1c62b06a99affa1d583e256bd65ad27ab9d0ef512f55d7d93b842e7cd244a4a09179f61fdd8548362e409323867a2b0477cbd0626b5644eb6ac7c53da
+"react-confetti@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "react-confetti@npm:6.1.0"
+  dependencies:
+    tween-functions: "npm:^1.2.0"
+  peerDependencies:
+    react: ^16.3.0 || ^17.0.1 || ^18.0.0
+  checksum: 10c0/5b4eb23eef564695f6db1d25b294ed31d5fa21ff4092c6a38e641f85cd10e3e0b50014366e3ac0f7cf772e73faaecd14614e5b11a5531336fa769dda8068ab59
   languageName: node
   linkType: hard
 
@@ -16862,22 +16411,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-github-button@npm:^0.1.11":
-  version: 0.1.11
-  resolution: "react-github-button@npm:0.1.11"
-  dependencies:
-    prop-types: "npm:^15.5.10"
-  checksum: 10c0/e00fa4f3b2dee74f45fff0c9d68d7d75eefa495d27a56ef2e2391f9600623d16b8a9f99c1d35a7b4f620dfb95dd8ed0b1a76fbbfece4be0843cd507c17a37dfa
-  languageName: node
-  linkType: hard
-
-"react-is@npm:^16.13.1":
-  version: 16.13.1
-  resolution: "react-is@npm:16.13.1"
-  checksum: 10c0/33977da7a5f1a287936a0c85639fec6ca74f4f15ef1e59a6bc20338fc73dc69555381e211f7a3529b8150a1f71e4225525b41b60b52965bda53ce7d47377ada1
-  languageName: node
-  linkType: hard
-
 "react-is@npm:^17.0.1":
   version: 17.0.2
   resolution: "react-is@npm:17.0.2"
@@ -16889,58 +16422,6 @@ __metadata:
   version: 18.3.1
   resolution: "react-is@npm:18.3.1"
   checksum: 10c0/f2f1e60010c683479e74c63f96b09fb41603527cd131a9959e2aee1e5a8b0caf270b365e5ca77d4a6b18aae659b60a86150bb3979073528877029b35aecd2072
-  languageName: node
-  linkType: hard
-
-"react-lifecycles-compat@npm:^3.0.0":
-  version: 3.0.4
-  resolution: "react-lifecycles-compat@npm:3.0.4"
-  checksum: 10c0/1d0df3c85af79df720524780f00c064d53a9dd1899d785eddb7264b378026979acbddb58a4b7e06e7d0d12aa1494fd5754562ee55d32907b15601068dae82c27
-  languageName: node
-  linkType: hard
-
-"react-modal@npm:^3.11.2":
-  version: 3.16.1
-  resolution: "react-modal@npm:3.16.1"
-  dependencies:
-    exenv: "npm:^1.2.0"
-    prop-types: "npm:^15.7.2"
-    react-lifecycles-compat: "npm:^3.0.0"
-    warning: "npm:^4.0.3"
-  peerDependencies:
-    react: ^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18
-    react-dom: ^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18
-  checksum: 10c0/7b56e2c505b2b924736c471a34754a4211df40ac2d6fb0949cf095aea5e65d3326bd9f111fa7898acf40afa54f526809ad8aa47e02b8328663d11422568dc7b1
-  languageName: node
-  linkType: hard
-
-"react-popper-tooltip@npm:^2.11.1":
-  version: 2.11.1
-  resolution: "react-popper-tooltip@npm:2.11.1"
-  dependencies:
-    "@babel/runtime": "npm:^7.9.2"
-    react-popper: "npm:^1.3.7"
-  peerDependencies:
-    react: ^16.6.0
-    react-dom: ^16.6.0
-  checksum: 10c0/f81278f1ea87899ffa57fed85c2531fa583ebca424ae5522e3a1b05c5635c014b3467391e77fb9c48bbc8e7b9f1050fa9302e8ee6134a9333858b5a6e0ae1b49
-  languageName: node
-  linkType: hard
-
-"react-popper@npm:^1.3.7":
-  version: 1.3.11
-  resolution: "react-popper@npm:1.3.11"
-  dependencies:
-    "@babel/runtime": "npm:^7.1.2"
-    "@hypnosphi/create-react-context": "npm:^0.3.1"
-    deep-equal: "npm:^1.1.1"
-    popper.js: "npm:^1.14.4"
-    prop-types: "npm:^15.6.1"
-    typed-styles: "npm:^0.0.7"
-    warning: "npm:^4.0.2"
-  peerDependencies:
-    react: 0.14.x || ^15.0.0 || ^16.0.0 || ^17.0.0
-  checksum: 10c0/d5dd1d0d4b5a3407134681b42a079fce525c94bce892ad177515d54a8cf64203eecbc30231476367e916aaff91221f5b6abd5afc207a86c698f35b7254178488
   languageName: node
   linkType: hard
 
@@ -17097,7 +16578,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"regexp.prototype.flags@npm:^1.5.1, regexp.prototype.flags@npm:^1.5.2":
+"regexp.prototype.flags@npm:^1.5.2":
   version: 1.5.2
   resolution: "regexp.prototype.flags@npm:1.5.2"
   dependencies:
@@ -17578,7 +17059,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"side-channel@npm:^1.0.4, side-channel@npm:^1.0.6":
+"side-channel@npm:^1.0.4":
   version: 1.0.6
   resolution: "side-channel@npm:1.0.6"
   dependencies:
@@ -18579,15 +18060,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"telejson@npm:^7.2.0":
-  version: 7.2.0
-  resolution: "telejson@npm:7.2.0"
-  dependencies:
-    memoizerific: "npm:^1.11.3"
-  checksum: 10c0/d26e6cc93e54bfdcdb207b49905508c5db45862e811a2e2193a735409e47b14530e1c19351618a3e03ad2fd4ffc3759364fcd72851aba2df0300fab574b6151c
-  languageName: node
-  linkType: hard
-
 "temp-dir@npm:^3.0.0":
   version: 3.0.0
   resolution: "temp-dir@npm:3.0.0"
@@ -18751,13 +18223,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"toggle-selection@npm:^1.0.6":
-  version: 1.0.6
-  resolution: "toggle-selection@npm:1.0.6"
-  checksum: 10c0/f2cf1f2c70f374fd87b0cdc8007453ba9e981c4305a8bf4eac10a30e62ecdfd28bca7d18f8f15b15a506bf8a7bfb20dbe3539f0fcf2a2c8396c1a78d53e1f179
-  languageName: node
-  linkType: hard
-
 "toml-j0.4@npm:^1.0.10":
   version: 1.1.1
   resolution: "toml-j0.4@npm:1.1.1"
@@ -18906,6 +18371,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tween-functions@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "tween-functions@npm:1.2.0"
+  checksum: 10c0/7e59295b8b0ee4132ed2fe335f56a9db5c87056dad6b6fd3011be72239fd20398003ddb4403bc98ad9f5c94468890830f64016edbbde35581faf95b32cda8305
+  languageName: node
+  linkType: hard
+
 "twirp-ts@npm:^2.5.0":
   version: 2.5.0
   resolution: "twirp-ts@npm:2.5.0"
@@ -19039,13 +18511,6 @@ __metadata:
     is-typed-array: "npm:^1.1.13"
     possible-typed-array-names: "npm:^1.0.0"
   checksum: 10c0/74253d7dc488eb28b6b2711cf31f5a9dcefc9c41b0681fd1c178ed0a1681b4468581a3626d39cd4df7aee3d3927ab62be06aa9ca74e5baf81827f61641445b77
-  languageName: node
-  linkType: hard
-
-"typed-styles@npm:^0.0.7":
-  version: 0.0.7
-  resolution: "typed-styles@npm:0.0.7"
-  checksum: 10c0/ec159f0e538364750cf9b8f19136375df64ad364fda355e6f7a7216ebffc67f18b436722c5c6853c89f70e6507eb69e5061ceb9334fa1f54902c0f6be1b985fe
   languageName: node
   linkType: hard
 
@@ -19297,19 +18762,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"urql@npm:^4.0.3":
-  version: 4.1.0
-  resolution: "urql@npm:4.1.0"
-  dependencies:
-    "@urql/core": "npm:^5.0.0"
-    wonka: "npm:^6.3.2"
-  peerDependencies:
-    "@urql/core": ^5.0.0
-    react: ">= 16.8.0"
-  checksum: 10c0/135245bd9fcc74c0c7577115dd48a90104271b5351ff2936fdb9e14d5d974841daf90a48a1e2bfb3497a2bd44401c05bed90806eb475ab26dc5ae34eb4b5578f
-  languageName: node
-  linkType: hard
-
 "util-deprecate@npm:^1.0.1, util-deprecate@npm:^1.0.2, util-deprecate@npm:~1.0.1":
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
@@ -19342,15 +18794,6 @@ __metadata:
     is-typed-array: "npm:^1.1.3"
     which-typed-array: "npm:^1.1.2"
   checksum: 10c0/c27054de2cea2229a66c09522d0fa1415fb12d861d08523a8846bf2e4cbf0079d4c3f725f09dcb87493549bcbf05f5798dce1688b53c6c17201a45759e7253f3
-  languageName: node
-  linkType: hard
-
-"uuid@npm:^3.3.3":
-  version: 3.4.0
-  resolution: "uuid@npm:3.4.0"
-  bin:
-    uuid: ./bin/uuid
-  checksum: 10c0/1c13950df865c4f506ebfe0a24023571fa80edf2e62364297a537c80af09c618299797bbf2dbac6b1f8ae5ad182ba474b89db61e0e85839683991f7e08795347
   languageName: node
   linkType: hard
 
@@ -19493,15 +18936,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"warning@npm:^4.0.2, warning@npm:^4.0.3":
-  version: 4.0.3
-  resolution: "warning@npm:4.0.3"
-  dependencies:
-    loose-envify: "npm:^1.0.0"
-  checksum: 10c0/aebab445129f3e104c271f1637fa38e55eb25f968593e3825bd2f7a12bd58dc3738bb70dc8ec85826621d80b4acfed5a29ebc9da17397c6125864d72301b937e
-  languageName: node
-  linkType: hard
-
 "wcwidth@npm:^1.0.1":
   version: 1.0.1
   resolution: "wcwidth@npm:1.0.1"
@@ -19621,13 +19055,6 @@ __metadata:
   dependencies:
     string-width: "npm:^1.0.2 || 2 || 3 || 4"
   checksum: 10c0/1d9c2a3e36dfb09832f38e2e699c367ef190f96b82c71f809bc0822c306f5379df87bab47bed27ea99106d86447e50eb972d3c516c2f95782807a9d082fbea95
-  languageName: node
-  linkType: hard
-
-"wonka@npm:^6.3.2":
-  version: 6.3.4
-  resolution: "wonka@npm:6.3.4"
-  checksum: 10c0/77329eea673da07717476e1b8f1a22f1e1a4f261bb9a58fa446c03d3da13dbd5b254664f8aded5928d953f33ee5b399a17a4f70336e8b236e478209c0e78cda4
   languageName: node
   linkType: hard
 
@@ -19955,12 +19382,5 @@ __metadata:
     compress-commons: "npm:^6.0.2"
     readable-stream: "npm:^4.0.0"
   checksum: 10c0/50f2fb30327fb9d09879abf7ae2493705313adf403e794b030151aaae00009162419d60d0519e807673ec04d442e140c8879ca14314df0a0192de3b233e8f28b
-  languageName: node
-  linkType: hard
-
-"zod@npm:^3.22.2":
-  version: 3.23.8
-  resolution: "zod@npm:3.23.8"
-  checksum: 10c0/8f14c87d6b1b53c944c25ce7a28616896319d95bc46a9660fe441adc0ed0a81253b02b5abdaeffedbeb23bdd25a0bf1c29d2c12dd919aef6447652dd295e3e69
   languageName: node
   linkType: hard


### PR DESCRIPTION
## Description

Chromatic moved away from `@chromaui/addon-visual-tests` to the `@chromatic-com/storybook` package.

This requires an update to the `chromatic.config.json` settings, removal of the generic argTypesRegex from the preview config, and a stricter import in the doc blocks (i.e., `fileName.js` not just `fileName`).

To support a successful build, our test command must maintain the autodocs and mdx syntax which requires we add this information to our build instructions in the .storybook/main.js file.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

Expect to be able to run Storybook locally, connect to the Chromatic add-on in the component panel, and kick off a manual re-run of VRTs.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
