### PR TITLE
feat(colorslider): s2 migration

### DIFF
--- a/.changeset/serious-clouds-jam.md
+++ b/.changeset/serious-clouds-jam.md
@@ -1,0 +1,11 @@
+---
+"@spectrum-css/colorslider": minor
+---
+
+# S2 colorslider migration
+
+This migrates the `colorslider` component to S2. Custom properties have been remapped per the design spec.
+
+| Before                    | After                      |
+| ------------------------- | -------------------------- |
+| `--spectrum-gray-900-rgb` | `--spectrum-gray-1000-rgb` |

--- a/components/colorslider/index.css
+++ b/components/colorslider/index.css
@@ -11,28 +11,24 @@
  * governing permissions and limitations under the License.
  */
 
-@media (forced-colors: active) {
-	.spectrum-ColorSlider {
-		--highcontrast-color-slider-border-color: CanvasText;
-		--highcontrast-color-slider-border-color-disabled: GrayText;
-		--highcontrast-color-slider-background-color-disabled: Canvas;
-		forced-color-adjust: none;
-	}
-}
-
 .spectrum-ColorSlider {
+	/* Size and Spacing */
+	--spectrum-color-slider-control-track-width: var(--spectrum-color-control-track-width);
+
 	/* @todo Refactor with --spectrum-color-slider-border-color once gray rgb token is no longer necessary to workaround nested rgb color token value using rgba(). */
-	--spectrum-color-slider-border-color-default: rgba(var(--spectrum-gray-900-rgb), var(--spectrum-color-slider-border-opacity));
+	--spectrum-color-slider-border-color-default: rgba(var(--spectrum-gray-1000-rgb), var(--spectrum-color-slider-border-opacity));
 
 	/* @passthrough -- settings for nested color handle */
 	--mod-colorhandle-hitarea-border-radius: var(--mod-color-slider-handle-hitarea-border-radius, 0px);
+
+	--spectrum-colorslider-fill-color-disabled: var(--spectrum-disabled-background-color);
 
 	position: relative;
 	display: block;
 
 	min-inline-size: var(--mod-color-slider-minimum-length, var(--spectrum-color-slider-minimum-length));
 	inline-size: var(--mod-color-slider-length, var(--spectrum-color-slider-length));
-	block-size: var(--mod-color-slider-control-track-width, var(--spectrum-color-control-track-width));
+	block-size: var(--mod-color-slider-control-track-width, var(--spectrum-color-slider-control-track-width));
 
 	/* Otherwise we randomly drag a file icon */
 	user-select: none;
@@ -59,11 +55,6 @@
 	block-size: var(--mod-color-slider-vertical-height, var(--mod-color-slider-length, var(--spectrum-color-slider-length)));
 	min-inline-size: 0;
 	inline-size: var(--mod-color-slider-vertical-control-track-width, var(--mod-color-slider-control-track-height, var(--spectrum-color-control-track-width)));
-
-	.spectrum-ColorSlider-handle {
-		inset-inline-start: 50%;
-		inset-block-start: 0;
-	}
 }
 
 .spectrum-ColorSlider-handle {
@@ -86,7 +77,7 @@
 
 	.spectrum-ColorSlider.is-disabled & {
 		--spectrum-color-slider-border-color-local: var(--highcontrast-color-slider-border-color-disabled, var(--mod-color-slider-border-color-disabled, var(--spectrum-disabled-background-color)));
-		background: var(--highcontrast-color-slider-background-color-disabled, var(--mod-color-slider-background-color-disabled, var(--spectrum-disabled-background-color)));
+		background: var(--highcontrast-color-slider-background-color-disabled, var(--mod-color-slider-background-color-disabled, var(--spectrum-colorslider-fill-color-disabled)));
 	}
 }
 
@@ -113,4 +104,13 @@
 	z-index: 0;
 	margin: 0;
 	pointer-events: none;
+}
+
+@media (forced-colors: active) {
+	.spectrum-ColorSlider {
+		--highcontrast-color-slider-border-color: CanvasText;
+		--highcontrast-color-slider-border-color-disabled: GrayText;
+		--highcontrast-color-slider-background-color-disabled: Canvas;
+		forced-color-adjust: none;
+	}
 }

--- a/components/colorslider/metadata/metadata.json
+++ b/components/colorslider/metadata/metadata.json
@@ -3,7 +3,6 @@
   "selectors": [
     ".spectrum-ColorSlider",
     ".spectrum-ColorSlider--vertical",
-    ".spectrum-ColorSlider--vertical .spectrum-ColorSlider-handle",
     ".spectrum-ColorSlider-checkerboard",
     ".spectrum-ColorSlider-checkerboard:before",
     ".spectrum-ColorSlider-gradient",
@@ -37,13 +36,15 @@
     "--spectrum-color-slider-border-opacity",
     "--spectrum-color-slider-border-rounding",
     "--spectrum-color-slider-border-width",
+    "--spectrum-color-slider-control-track-width",
     "--spectrum-color-slider-length",
-    "--spectrum-color-slider-minimum-length"
+    "--spectrum-color-slider-minimum-length",
+    "--spectrum-colorslider-fill-color-disabled"
   ],
   "global": [
     "--spectrum-color-control-track-width",
     "--spectrum-disabled-background-color",
-    "--spectrum-gray-900-rgb"
+    "--spectrum-gray-1000-rgb"
   ],
   "passthroughs": ["--mod-colorhandle-hitarea-border-radius"],
   "high-contrast": [


### PR DESCRIPTION
## Description

`CSS-1028`

# S2 colorslider migration

This migrates the `colorslider` component to S2. Custom properties have been remapped per the design spec.

| Before                    | After                      |
| ------------------------- | -------------------------- |
| `--spectrum-gray-900-rgb` | `--spectrum-gray-1000-rgb` |


### Validation steps

1. Open the URL for the PR.
2. Navigate to the `colorslider` component and verify no regressions have occurred.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [ ] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨