### PR TITLE
fix: use new tag to hide storybook foundations stories

### DIFF
--- a/.changeset/plenty-trees-act.md
+++ b/.changeset/plenty-trees-act.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/preview": patch
+---
+
+Updates the tags used by the stories in the "Foundations" documentation, so hidden stories remain hidden on the sidebar.

--- a/.storybook/foundations/corner-rounding/action-button-corner-rounding.stories.js
+++ b/.storybook/foundations/corner-rounding/action-button-corner-rounding.stories.js
@@ -14,7 +14,7 @@ export default {
 			handles: ["click .spectrum-ActionButton:not([disabled])"],
 		},
 	},
-	tags: ['foundation'],
+	tags: ['!dev'],
 };
 
 const ActionButton = (args, context) => html`

--- a/.storybook/foundations/corner-rounding/checkbox-corner-rounding.stories.js
+++ b/.storybook/foundations/corner-rounding/checkbox-corner-rounding.stories.js
@@ -15,14 +15,10 @@ export default {
 			handles: ['click input[type="checkbox"]'],
 		},
 	},
-	tags: ['foundation'],
+	tags: ['!dev'],
 };
 
-const Checkbox = ({
-	customStyles = {},
-	isChecked = false,
-	...args
-} = {}, context = {}) => html`
+const Checkbox = (args = {}, context = {}) => html`
 	<div style="padding: 1rem 0;">
 		${Template({ ...args, iconName: undefined }, context)}
 	</div>

--- a/.storybook/foundations/corner-rounding/corner-rounding.stories.js
+++ b/.storybook/foundations/corner-rounding/corner-rounding.stories.js
@@ -10,10 +10,10 @@ export default {
 	args: {
 		rootClass: "spectrum-Foundations-Example-CornerRounding",
 	},
-	tags: ["foundation"],
+	tags: ["!dev"],
 };
 
-const CornerRadiusGroup = ({ customStyles = {}, ...args }, context) => html`
+const CornerRadiusGroup = (args = {}, context = {}) => html`
 	<div>
 		<table class="spectrum-Foundations-Example-CornerRounding-table">
 			<thead>

--- a/.storybook/foundations/down-state/button-down-state.stories.js
+++ b/.storybook/foundations/down-state/button-down-state.stories.js
@@ -13,7 +13,7 @@ export default {
 			handles: ["click .spectrum-Button"],
 		},
 	},
-	tags: ["foundation"],
+	tags: ["!dev"],
 };
 
 export const ButtonDownState = Template.bind({});

--- a/.storybook/foundations/down-state/checkbox-down-state.stories.js
+++ b/.storybook/foundations/down-state/checkbox-down-state.stories.js
@@ -13,7 +13,7 @@ export default {
 			handles: ["click input[type=\"checkbox\"]"],
 		},
 	},
-	tags: ["foundation"],
+	tags: ["!dev"],
 };
 
 export const CheckboxDownState = Template.bind({});

--- a/.storybook/foundations/drop-shadow/drop-shadow.stories.js
+++ b/.storybook/foundations/drop-shadow/drop-shadow.stories.js
@@ -7,7 +7,7 @@ export default {
 	description:
 		"Drop shadows draw attention and give the appearance of depth. By default, this style is used to show elevation, when content appears on top of other content.",
 	component: "Drop shadow",
-	tags: ["foundation"],
+	tags: ["!dev"],
 };
 
 const DropShadowSwatch = ({
@@ -19,9 +19,9 @@ const DropShadowSwatch = ({
 			class=${classMap({
 				[rootClass]: true,
 				[`${rootClass}--${variant}-drop-shadow`]:
-					typeof variant !== undefined && !!isDropShadow,
+					typeof variant !== "undefined" && !!isDropShadow,
 				[`${rootClass}--${variant}-box-shadow`]:
-					typeof variant !== undefined && !isDropShadow,
+					typeof variant !== "undefined" && !isDropShadow,
 			})}
 		></div>
 `;


### PR DESCRIPTION
## Description

Storybook foundations pages now display as a single page on the sidebar, as they did previously. This fixes the issue where they were appearing as folders with example stories nested within. These now use the newer `!dev` tag to hide them. The custom `foundation` tag was previously used to hide them, but this tag is no longer used.
    
This also fixes some linter errors that were encountered during commit; a couple unused variables and incorrect `typeof` comparisons.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [x] Foundations pages display as a single page in the sidebar
- [x] Foundations pages display as they did previously

## Screenshots

<img width="288" alt="Screenshot 2025-01-03 at 11 59 13 AM" src="https://github.com/user-attachments/assets/8291b758-f79e-41f2-bc6f-18a77118d10a" />

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [ ] ✨ This pull request is ready to merge. ✨
