### PR TITLE
docs(avatar): update sizing documentation

### DIFF
--- a/components/avatar/stories/avatar.stories.js
+++ b/components/avatar/stories/avatar.stories.js
@@ -75,19 +75,7 @@ export const Default = AvatarGroup.bind({});
 Default.args = {};
 
 // ********* DOCS ONLY ********* //
-/** Avatar sizes scale exponentially, based on the Spectrum type scale. These range from size-50 to size-700, with the default size for an avatar being `100`. An avatar can also be customized to fit appropriately for your context.
- *
- * Avatar is available in many sizes using the required `.spectrum-Avatar--size<number>` class. The available size classes are:
-
-- `spectrum-Avatar--size50`
-- `spectrum-Avatar--size75`
-- `spectrum-Avatar--size100`
-- `spectrum-Avatar--size200`
-- `spectrum-Avatar--size300`
-- `spectrum-Avatar--size400`
-- `spectrum-Avatar--size500`
-- `spectrum-Avatar--size600`
-- `spectrum-Avatar--size700`
+/** Avatar is available in many sizes and scales exponentially, based on the Spectrum type scale. These sizes range from size-50 to size-1500, using the required `.spectrum-Avatar--size<number>` class. The default size for an avatar is `100`. An avatar can also be customized to fit appropriately for your context.
 */
 export const Sizing = (args, context) => Sizes({
 	Template,


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->
This PR updates the sizing documentation for avatar. There was an older table that listed the available sizes, but only for S1 avatars. The S2 avatar has more sizes available, so the Sizing story has now been updated to reflect that.

No changeset or VRTs needed since this was a documentation update only.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

- [x] Pull down the branch or visit the [deploy preview.](https://pr-3483--spectrum-css.netlify.app/?path=/docs/guides-contributing--docs) [@castastrophe]
- [x] [Visit the avatar documentation page.](https://pr-3483--spectrum-css.netlify.app/?path=/docs/components-avatar--docs) [@castastrophe]
- [x] Verify the `Sizing` documentation reflects the new S2 avatar sizes, with a range from 50 to 1500 (as opposed to the S1 50 to 700 range). The documentation should be free of grammar mistakes and be understandable/clear. The list of sizes has been removed. [@castastrophe]

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
