### PR TITLE
fix: resolve buggy line numbers display in addon

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,23 +1,23 @@
 import { setConsoleOptions } from "@storybook/addon-console";
 import {
-	withActions,
-	withArgEvents,
-	withContextWrapper,
-	withIconSpriteSheet,
-	withLanguageWrapper,
-	withReducedMotionWrapper,
-	withTestingPreviewWrapper,
-	withTextDirectionWrapper
+  withActions,
+  withArgEvents,
+  withContextWrapper,
+  withIconSpriteSheet,
+  withLanguageWrapper,
+  withReducedMotionWrapper,
+  withTestingPreviewWrapper,
+  withTextDirectionWrapper
 } from "./decorators";
 import {
-	FontLoader,
-	IconLoader,
+  FontLoader,
+  IconLoader,
 } from "./loaders";
 import modes from "./modes";
 import DocumentationTemplate from "./templates/DocumentationTemplate.mdx";
 import {
-	argTypes,
-	globalTypes
+  argTypes,
+  globalTypes
 } from "./types";
 
 import "./assets/base.css";
@@ -80,7 +80,7 @@ export const parameters = {
 			htmlWhitespaceSensitivity: "ignore",
 		},
 		highlighter: {
-			showLineNumbers: true,
+			showLineNumbers: false,
 			wrapLines: true,
 		},
 	},


### PR DESCRIPTION
The `@whitespace/storybook-addon-html` seems to have started to double up on its line numbers, showing two complete sets of numbers when switching to the tab in the storybook console. Changing its config setting seems to fix the issue.

<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
1. Pull this branch down locally and start Storybook (`yarn start`)
2. View any component's non-docs story or stories.
3. Validate that only one set of line numbers is shown for the source code.
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

## Screenshots

Before!
<img width="673" alt="Screenshot 2025-01-10 at 3 21 47 PM" src="https://github.com/user-attachments/assets/ad1b887b-f2a2-44e5-99e5-8df2c69ff8a4" />

After!
<img width="666" alt="Screenshot 2025-01-10 at 3 20 17 PM" src="https://github.com/user-attachments/assets/a092a758-f649-4bce-858b-8995f91120bd" />

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [ ] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
