### PR TITLE
fix(menu): update menu item border radius

### DIFF
--- a/.changeset/shiny-files-chew.md
+++ b/.changeset/shiny-files-chew.md
@@ -2,4 +2,4 @@
 "@spectrum-css/menu": patch
 ---
 
-Updated the menu item border radius and added the respective `--mod` property.
+Updated the menu item border radius in Spectrum 2.

--- a/.changeset/shiny-files-chew.md
+++ b/.changeset/shiny-files-chew.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/menu": patch
+---
+
+Updated the menu item border radius and added the respective `--mod` property.

--- a/components/menu/dist/metadata.json
+++ b/components/menu/dist/metadata.json
@@ -169,6 +169,7 @@
     "--mod-menu-item-checkmark-height",
     "--mod-menu-item-checkmark-width",
     "--mod-menu-item-collapsible-no-icon-submenu-item-padding-x-start",
+    "--mod-menu-item-corner-radius",
     "--mod-menu-item-description-color-default",
     "--mod-menu-item-description-color-disabled",
     "--mod-menu-item-description-color-down",
@@ -250,6 +251,7 @@
     "--spectrum-menu-item-checkmark-width-medium",
     "--spectrum-menu-item-checkmark-width-small",
     "--spectrum-menu-item-collapsible-no-icon-submenu-item-padding-x-start",
+    "--spectrum-menu-item-corner-radius",
     "--spectrum-menu-item-description-color-default",
     "--spectrum-menu-item-description-color-disabled",
     "--spectrum-menu-item-description-color-down",
@@ -332,6 +334,7 @@
     "--spectrum-component-top-to-text-200",
     "--spectrum-component-top-to-text-300",
     "--spectrum-component-top-to-text-75",
+    "--spectrum-corner-radius-100",
     "--spectrum-disabled-content-color",
     "--spectrum-divider-thickness-medium",
     "--spectrum-divider-thickness-small",
@@ -376,7 +379,8 @@
   "system-theme": [
     "--system-menu-item-background-color-down",
     "--system-menu-item-background-color-hover",
-    "--system-menu-item-background-color-key-focus"
+    "--system-menu-item-background-color-key-focus",
+    "--system-menu-item-corner-radius"
   ],
   "passthroughs": [
     "--mod-checkbox-text-to-control",

--- a/components/menu/dist/metadata.json
+++ b/components/menu/dist/metadata.json
@@ -169,7 +169,6 @@
     "--mod-menu-item-checkmark-height",
     "--mod-menu-item-checkmark-width",
     "--mod-menu-item-collapsible-no-icon-submenu-item-padding-x-start",
-    "--mod-menu-item-corner-radius",
     "--mod-menu-item-description-color-default",
     "--mod-menu-item-description-color-disabled",
     "--mod-menu-item-description-color-down",

--- a/components/menu/index.css
+++ b/components/menu/index.css
@@ -370,6 +370,8 @@
 	position: relative;
 	align-items: center;
 
+	border-radius: var(--mod-menu-item-corner-radius, var(--spectrum-menu-item-corner-radius));
+
 	box-sizing: border-box;
 
 	background-color: var(--highcontrast-menu-item-background-color-default, var(--mod-menu-item-background-color-default, var(--spectrum-menu-item-background-color-default)));

--- a/components/menu/index.css
+++ b/components/menu/index.css
@@ -370,7 +370,7 @@
 	position: relative;
 	align-items: center;
 
-	border-radius: var(--mod-menu-item-corner-radius, var(--spectrum-menu-item-corner-radius));
+	border-radius: var(--spectrum-menu-item-corner-radius);
 
 	box-sizing: border-box;
 

--- a/components/menu/themes/spectrum-two.css
+++ b/components/menu/themes/spectrum-two.css
@@ -16,5 +16,6 @@
 		--spectrum-menu-item-background-color-hover: rgba(var(--spectrum-gray-1000-rgb), var(--spectrum-transparent-black-200-opacity));
 		--spectrum-menu-item-background-color-down: rgba(var(--spectrum-gray-1000-rgb), var(--spectrum-transparent-black-200-opacity));
 		--spectrum-menu-item-background-color-key-focus: rgba(var(--spectrum-gray-1000-rgb), var(--spectrum-transparent-black-200-opacity));
+		--spectrum-menu-item-corner-radius: var(--spectrum-corner-radius-100);
 	}
 }

--- a/components/menu/themes/spectrum.css
+++ b/components/menu/themes/spectrum.css
@@ -20,5 +20,6 @@
 		--spectrum-menu-item-background-color-hover: rgba(var(--spectrum-gray-900-rgb), var(--spectrum-transparent-black-200-opacity));
 		--spectrum-menu-item-background-color-down: rgba(var(--spectrum-gray-900-rgb), var(--spectrum-transparent-black-200-opacity));
 		--spectrum-menu-item-background-color-key-focus: rgba(var(--spectrum-gray-900-rgb), var(--spectrum-transparent-black-200-opacity));
+		--spectrum-menu-item-corner-radius: 0;
 	}
 }


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

This PR addresses the incorrect border radius for menu items in Spectrum 2, by updating the value to be `corner-radius-100` (`8px`) to align with the Spectrum 2 designs.


### Validation steps

  1. Open the [storybook](url) for the menu component:
  2. - [ ] Verify the correct 8px rounding is applied to menu items in the hover, down, and keyboard states.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

3. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [ ] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
