### PR TITLE
fix(textfield): update border and background color

### DIFF
--- a/.changeset/strong-actors-warn.md
+++ b/.changeset/strong-actors-warn.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/textfield": patch
+---
+
+Updated the textfield border radius and background-color and added the respective `--mod` property.

--- a/components/page/themes/express.css
+++ b/components/page/themes/express.css
@@ -1,0 +1,16 @@
+/*!
+ * Copyright 2024 Adobe. All rights reserved.
+ *
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at <http://www.apache.org/licenses/LICENSE-2.0>
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* @combine .spectrum.spectrum--express */
+
+@import "./spectrum.css";

--- a/components/textfield/dist/metadata.json
+++ b/components/textfield/dist/metadata.json
@@ -227,6 +227,7 @@
   ],
   "global": [
     "--spectrum-animation-duration-100",
+    "--spectrum-border-width-100",
     "--spectrum-character-count-to-field-quiet-extra-large",
     "--spectrum-character-count-to-field-quiet-large",
     "--spectrum-character-count-to-field-quiet-medium",
@@ -247,8 +248,6 @@
     "--spectrum-component-height-75",
     "--spectrum-component-top-to-text-100",
     "--spectrum-corner-radius-100",
-    "--spectrum-disabled-background-color",
-    "--spectrum-disabled-border-color",
     "--spectrum-disabled-content-color",
     "--spectrum-field-edge-to-alert-icon-extra-large",
     "--spectrum-field-edge-to-alert-icon-large",
@@ -291,6 +290,11 @@
     "--spectrum-font-size-300",
     "--spectrum-font-size-75",
     "--spectrum-gray-25",
+    "--spectrum-gray-300",
+    "--spectrum-gray-500",
+    "--spectrum-gray-600",
+    "--spectrum-gray-800",
+    "--spectrum-gray-900",
     "--spectrum-help-text-to-component",
     "--spectrum-negative-border-color-default",
     "--spectrum-negative-border-color-focus",
@@ -324,7 +328,17 @@
     "--spectrum-workflow-icon-size-300",
     "--spectrum-workflow-icon-size-75"
   ],
-  "system-theme": ["--system-textfield-background-color"],
+  "system-theme": [
+    "--system-textfield-background-color",
+    "--system-textfield-background-color-disabled",
+    "--system-textfield-border-color",
+    "--system-textfield-border-color-disabled",
+    "--system-textfield-border-color-focus",
+    "--system-textfield-border-color-focus-hover",
+    "--system-textfield-border-color-hover",
+    "--system-textfield-border-color-keyboard-focus",
+    "--system-textfield-border-width"
+  ],
   "passthroughs": [],
   "high-contrast": [
     "--highcontrast-textfield-border-color",

--- a/components/textfield/index.css
+++ b/components/textfield/index.css
@@ -66,8 +66,6 @@
 	--spectrum-textfield-text-color-readonly: var(--spectrum-neutral-content-color-default);
 
 	/* Disabled Colors */
-	--spectrum-textfield-background-color-disabled: var(--spectrum-disabled-background-color);
-	--spectrum-textfield-border-color-disabled: var(--spectrum-disabled-border-color);
 	--spectrum-textfield-text-color-disabled: var(--spectrum-disabled-content-color);
 
 	/* Invalid Colors */
@@ -504,7 +502,7 @@
 	.spectrum-Textfield.is-disabled:hover &,
 	&:disabled {
 		background-color: var(--mod-textfield-background-color-disabled, var(--spectrum-textfield-background-color-disabled));
-		border-color: transparent;
+		border-color: var(--mod-textfield-border-color-disabled, var(--spectrum-textfield-border-color-disabled));
 		color: var(--highcontrast-textfield-text-color-disabled, var(--mod-textfield-text-color-disabled, var(--spectrum-textfield-text-color-disabled)));
 
 		/* Disable the resize functionality when disabled */

--- a/components/textfield/themes/spectrum-two.css
+++ b/components/textfield/themes/spectrum-two.css
@@ -14,5 +14,14 @@
 @container style(--system: spectrum) {
 	.spectrum-Textfield {
 		--spectrum-textfield-background-color: var(--spectrum-gray-25);
+		--spectrum-textfield-background-color-disabled: var(--spectrum-gray-25);
+
+		--spectrum-textfield-border-color: var(--spectrum-gray-500);
+		--spectrum-textfield-border-color-hover: var(--spectrum-gray-600);
+		--spectrum-textfield-border-color-focus: var(--spectrum-gray-800);
+		--spectrum-textfield-border-color-focus-hover: var(--spectrum-gray-900);
+		--spectrum-textfield-border-color-keyboard-focus: var(--spectrum-gray-900);
+		--spectrum-textfield-border-color-disabled: var(--spectrum-gray-300);
+		--spectrum-textfield-border-width: var(--spectrum-border-width-100);
 	}
 }

--- a/components/textfield/themes/spectrum.css
+++ b/components/textfield/themes/spectrum.css
@@ -18,5 +18,8 @@
 @container style(--system: legacy) {
 	.spectrum-Textfield {
 		--spectrum-textfield-background-color: var(--spectrum-gray-50);
+		--spectrum-textfield-background-color-disabled: var(--spectrum-disabled-background-color);
+
+		--spectrum-textfield-border-color-disabled: var(--spectrum-disabled-border-color);
 	}
 }


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

This PR addresses SWC-574 and updates the textfield border radius and background-color and adds the respective `--mod` property.

### Validation steps

  1. Open the [storybook](url) for the textfield component:
  2. - [ ] Verify the correct background color and border color for Default, Hover, Focus Hover and Disabled state.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

3. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [ ] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
