### PR TITLE
docs(combobox): remove separate tab focus for nested pickerbutton

### DIFF
--- a/components/combobox/stories/template.js
+++ b/components/combobox/stories/template.js
@@ -89,6 +89,7 @@ const Combobox = ({
 				onclick: function () {
 					updateArgs({ isOpen: !isOpen });
 				},
+				tabindex: "-1",
 			}, context)}
 		</div>
 	`;

--- a/components/pickerbutton/stories/template.js
+++ b/components/pickerbutton/stories/template.js
@@ -25,6 +25,7 @@ export const Template = ({
 	isRounded = false,
 	customStyles = {},
 	onclick,
+	tabindex,
 } = {}, context = {}) => {
 	const { updateArgs } = context;
 
@@ -54,6 +55,7 @@ export const Template = ({
 				if (isDisabled) return;
 				updateArgs({ isOpen: !isOpen });
 			}}
+			tabindex=${ifDefined(tabindex)}
 		>
 			<div class="${rootClass}-fill">
 				${when(label, () => html`


### PR DESCRIPTION
## Description

The Picker Button that is nested within Combobox was previously tab focusable, separately from the Combobox itself. This update gives it a negative `tabindex`, making it consistent with the intended behavior and SWC implementation. This adds a `tabindex` option to the Picker Button template to facilitate this change.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [x] In Combobox, only the whole component receives tab focus; the picker button no longer has a separate tab focus.
- [x] The `tabindex` attribute is not added to picker button when used elsewhere. 

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] ✨ This pull request is ready to merge. ✨
