### PR TITLE
chore: spectrum-two fixes

### DIFF
--- a/components/picker/stories/picker.stories.js
+++ b/components/picker/stories/picker.stories.js
@@ -97,7 +97,7 @@ export default {
 		},
 		isHovered,
 		isActive,
-		content: { table: { disable: true } },
+		popoverContent: { table: { disable: true } },
 	},
 	args: {
 		rootClass: "spectrum-Picker",

--- a/components/picker/stories/template.js
+++ b/components/picker/stories/template.js
@@ -64,8 +64,7 @@ export const Picker = ({
 			id=${id}
 			style=${styleMap(customStyles)}
 			type="button"
-			@click=${() => {
-				if (window.isChromatic()) return;
+			@click=${function() {
 				updateArgs({ isOpen: !isOpen });
 			}}
 			aria-labelledby=${ifDefined(ariaLabeledBy)}
@@ -195,12 +194,6 @@ export const Template = ({
 				}, context)
 			)}
 		</div>`;
-
-	// Make sure there is a wrapper around sibling components when using the Chromatic
-	// template, so their layout is not affected by the flex and grid layouts used.
-	if (window.isChromatic()) {
-		return html`<div style="position: relative;">${markup}</div>`;
-	}
 	return markup;
 };
 

--- a/components/picker/stories/template.js
+++ b/components/picker/stories/template.js
@@ -109,6 +109,7 @@ export const Template = ({
 	size = "m",
 	label,
 	labelPosition = "top",
+	placeholder,
 	helpText,
 	isQuiet = false,
 	isOpen = false,
@@ -125,7 +126,7 @@ export const Template = ({
 		// Helps ensure that Popover appears below the Picker, with side labels layout.
 		display: "block",
 	},
-	content = [],
+	popoverContent = [],
 } = {}, context = {}) => {
 	const pickerMarkup = Picker({
 		size,
@@ -134,17 +135,18 @@ export const Template = ({
 		isInvalid,
 		isDisabled,
 		isLoading,
-		content,
+		placeholder,
+		popoverContent,
 		labelPosition,
 		ariaLabeledBy: fieldLabelId,
 	}, context);
 
-	const popoverMarkup = content.length !== 0 ? Popover({
+	const popoverMarkup = popoverContent.length !== 0 ? Popover({
 		isOpen: isOpen && !isDisabled && !isLoading,
 		withTip: false,
 		position: "bottom",
 		isQuiet,
-		content,
+		content: popoverContent,
 		size,
 		customStyles: customPopoverStyles,
 	}, context) : "";

--- a/components/tooltip/stories/template.js
+++ b/components/tooltip/stories/template.js
@@ -12,6 +12,7 @@ export const Template = ({
 	rootClass = "spectrum-Tooltip",
 	label,
 	placement,
+	variant = "neutral",
 	isOpen = true,
 	isFocused = false,
 	showOnHover = false,


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

This PR reimplements some fixes for the `spectrum-two` branch after a rebase. 

1. Adds a missing `variant = "neutral"` default arg to the tooltip template. This should alleviate the errors on the docs page.

Before 🚫 
<img width="1064" alt="Screenshot 2025-01-08 at 4 51 59 PM" src="https://github.com/user-attachments/assets/22789ef8-df48-4725-8247-4609b178e714" />

After ✅ 
<img width="1081" alt="Screenshot 2025-01-08 at 4 51 36 PM" src="https://github.com/user-attachments/assets/a4fc6425-7518-431b-b88a-382c64959e3e" />

2. An additional fix on the steplist docs page occurred since the `WithTooltip` story calls for the tooltip component. 🥳 

Before 🚫 
<img width="1068" alt="Screenshot 2025-01-22 at 10 20 01 AM" src="https://github.com/user-attachments/assets/3649ebec-b904-4631-adb8-9181b4dd7adf" />

After ✅ 
<img width="1096" alt="Screenshot 2025-01-22 at 10 22 00 AM" src="https://github.com/user-attachments/assets/efda7a47-7f9e-4a8e-aa99-ee02051b6490" />

3. The calls to `window.isChromatic` have been removed.  It also corrects the arg names for picker, in order for them to be properly passed to the popover used in the template and render the content. This should alleviate all errors and most of the missing content on the docs page. (additional styling and content changes will need to be addressed in a separate PR).

Before 🚫 
<img width="1045" alt="Screenshot 2025-01-22 at 9 53 23 AM" src="https://github.com/user-attachments/assets/c3fa0fd9-056a-4bd7-ac8f-cc60f73485e2" />

After ✅ 
<img width="1052" alt="Screenshot 2025-01-22 at 10 04 48 AM" src="https://github.com/user-attachments/assets/2a7ea06c-c0e8-497b-928c-72186233cacc" />

4. An additional fix on the form docs page occurred since the examples we use contain the picker component. 🥳 

Before 🚫 
<img width="742" alt="Screenshot 2025-01-22 at 9 53 35 AM" src="https://github.com/user-attachments/assets/b350b14e-3c03-4af9-b44c-f8554875c9c4" />

After ✅ 
<img width="1077" alt="Screenshot 2025-01-22 at 10 04 55 AM" src="https://github.com/user-attachments/assets/7211fb23-1288-4374-ba99-d0959cdad80a" />

5. An additional fix on the tabs docs page occurred since the Overflow story calls for the picker component. 🥳 

Before 🚫
<img width="1127" alt="Screenshot 2025-01-22 at 10 11 01 AM" src="https://github.com/user-attachments/assets/e379a7d1-9287-499d-95a9-d3c0322f8b62" />


After ✅ 
<img width="1099" alt="Screenshot 2025-01-22 at 10 11 33 AM" src="https://github.com/user-attachments/assets/0728d305-46e5-4e38-af12-716758939e2e" />


## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

- Pull down the branch to run locally or use the deploy preview.
- Visit the picker docs page. 
- Verify no errors referencing the `variant is not defined` appear in place of the `WithTooltip` story canvas. Each story step in the steplist should have a rendered tooltip with step number content.
- Visit the form docs page. 
- Similarly to the picker docs, now errors should occur regarding `window.isChromatic()`. All form components should render with a closed picker component that displays the placeholder text.
- Visit the tooltip docs page.
- Verify there are no errors referencing `variant is not defined`. All tooltips should now display as expected.
- Visit the tabs docs page. 
- Similarly to the picker docs, no errors should occur regarding `window.isChromatic()`. The overflow tabs components should render with a closed picker component that displays the first tab item's text & chevron.
- Visit the steplist docs page.
- Verify 

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

6. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] ✨ This pull request is ready to merge. ✨
