### PR TITLE
fix: resolve s2 branch build errors

### DIFF
--- a/components/opacitycheckerboard/stories/template.js
+++ b/components/opacitycheckerboard/stories/template.js
@@ -13,7 +13,6 @@ export const Template = ({
 	customStyles = {},
 	id = getRandomId("opacity-checkerboard"),
 	content = [],
-	size,
 	role,
 } = {}) => {
 	return html`


### PR DESCRIPTION
## Description

- Resolves linting error in opacitycheckerboard: `'size' is assigned a value but never used  no-unused-vars`

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

 - [x] `yarn linter opacitycheckerboard` no longer shows the error `'size' is assigned a value but never used`

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [ ] ✨ This pull request is ready to merge. ✨
