### PR TITLE
build: constraints added to linting

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -12,6 +12,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "minor",
-  "bumpVersionsWithWorkspaceProtocolOnly": true,
   "ignore": []
 }

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -11,6 +11,6 @@
   "linked": [],
   "access": "public",
   "baseBranch": "main",
-  "updateInternalDependencies": "minor",
+  "updateInternalDependencies": "patch",
   "ignore": []
 }

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -6,6 +6,9 @@ module.exports = {
 	"*.{js,json}": [
 		"eslint --fix --cache --no-error-on-unmatched-pattern --quiet"
 	],
+	"package.json": [
+		"yarn constraints --fix"
+	],
 	"dist/*.css": [
 		"prettier --no-config --no-error-on-unmatched-pattern --ignore-unknown --log-level silent --write --config .prettierrc"
 	],

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -9,7 +9,10 @@ const fg = require("fast-glob");
 
 module.exports = defineConfig({
 	async constraints({ Yarn }) {
-		// Fetch a list of all the component workspaces using a glob pattern
+		/**
+		 * Fetch a list of all the component workspaces using a glob pattern
+		 * @type {string[]} components
+		 */
 		const components = fg.sync("components/*", {
 			cwd: __dirname,
 			onlyDirectories: true,
@@ -49,7 +52,47 @@ module.exports = defineConfig({
 			return ["design-system", "spectrum", "spectrum-css", "adobe", "adobe-spectrum", ...additionalKeywords];
 		}
 
-		for (const workspace of Yarn.workspaces()) {
+		/**
+		 * This function rolls up all the component package.json
+		 * requirements for all workspaces into a single function
+		 * to simplify into a readable set of operations
+		 * @param {Workspace} workspace
+		 * @param {string} folderName
+		 * @returns {void}
+		 */
+		function updateComponentPackageJson(workspace, folderName) {
+			// Only update the homepage if it does not already exist
+			if (!workspace.manifest.homepage) {
+				workspace.set("homepage", `https://opensource.adobe.com/spectrum-css/?path=/docs/components-${folderName}--docs`);
+			}
+
+			workspace.set("publishConfig.access", "public");
+			workspace.set("keywords", keywords(["component", "css"]));
+			workspace.set("main", "dist/index.css");
+			workspace.set("exports", {
+				".": "./dist/index.css",
+				"./*.md": "./*.md",
+				"./dist/*": "./dist/*",
+				"./index-*.css": "./dist/index-*.css",
+				"./index.css": "./dist/index.css",
+				"./metadata.json": "./dist/metadata.json",
+				"./package.json": "./package.json",
+				"./stories/*": "./stories/*"
+			});
+		}
+
+		/**
+		 * This function rolls up all the package.json requirements
+		 * for all workspaces into a single function to simplify
+		 * the workspace for loop into a readable set of operations
+		 * @param {Workspace} workspace
+		 * @returns {void}
+		 */
+		function updatePackageJson(workspace) {
+			const isRoot = workspace.cwd === ".";
+			const isComponent = components.includes(workspace.cwd);
+			const isToken = workspace.cwd === "tokens";
+
 			/**
 			 * -------------- GLOBAL --------------
 			 * Global configuration for all workspaces
@@ -61,9 +104,7 @@ module.exports = defineConfig({
 			workspace.set("repository.url", "https://github.com/adobe/spectrum-css.git");
 
 			// We don't need to set the directory for the root workspace
-			if (workspace.cwd !== ".") {
-				workspace.set("repository.directory", workspace.cwd);
-			}
+			if (!isRoot) workspace.set("repository.directory", workspace.cwd);
 
 			workspace.set("bugs.url", "https://github.com/adobe/spectrum-css/issues");
 
@@ -71,39 +112,20 @@ module.exports = defineConfig({
 			 * -------------- COMPONENTS --------------
 			 * Process the components workspaces with component-specific configuration
 			 */
-			if (components.includes(workspace.cwd)) {
+			if (isComponent) {
 				const folderName = workspace.cwd?.split("/")?.[1];
-
-				// Only update the homepage if it does not already exist
-				if (!workspace.manifest.homepage) {
-					workspace.set("homepage", `https://opensource.adobe.com/spectrum-css/?path=/docs/components-${folderName}--docs`);
-				}
-
-				workspace.set("publishConfig.access", "public");
-				workspace.set("keywords", keywords(["component", "css"]));
-				workspace.set("main", "dist/index.css");
-				workspace.set("exports", {
-					".": "./dist/index.css",
-					"./*.md": "./*.md",
-					"./dist/*": "./dist/*",
-					"./index-*.css": "./dist/index-*.css",
-					"./index.css": "./dist/index.css",
-					"./metadata.json": "./dist/metadata.json",
-					"./package.json": "./package.json",
-					"./stories/*": "./stories/*"
-				});
-
+				updateComponentPackageJson(workspace, folderName);
 				validateLocalPackages(workspace);
 			}
 			/**
 			 * -------------- TOKENS --------------
 			 * Process the tokens workspace with token-specific configuration
 			 */
-			else if (workspace.cwd === "tokens") {
+			else if (isToken) {
 				workspace.set("homepage", "https://opensource.adobe.com/spectrum-css");
 				workspace.set("publishConfig.access", "public");
 				workspace.set("keywords", keywords(["tokens", "css"]));
-				workspace.set("main", "dist/index.css");
+				workspace.set("main", "dist/css/index.css");
 
 				validateLocalPackages(workspace);
 			}
@@ -113,13 +135,17 @@ module.exports = defineConfig({
 				 * All other workspaces should have at least the following configuration
 				 */
 				if (!workspace.manifest.keywords) {
-					workspace.set("keywords", keywords([]));
+					workspace.set("keywords", keywords());
 				}
 
 				if (!workspace.manifest.homepage) {
 					workspace.set("homepage", "https://opensource.adobe.com/spectrum-css/");
 				}
 			}
+		}
+
+		for (const workspace of Yarn.workspaces()) {
+			updatePackageJson(workspace);
 		}
 	},
 });

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -144,6 +144,10 @@ module.exports = defineConfig({
 			}
 		}
 
+		/**
+		 * This loop iterates over all the workspaces in the project
+		 * and updates the package.json file with the necessary
+		 */
 		for (const workspace of Yarn.workspaces()) {
 			updatePackageJson(workspace);
 		}


### PR DESCRIPTION
## Description

Remove the `bumpVersionsWithWorkspaceProtocolOnly` setting from the Changeset config and downgrade the `updateInternalDependencies` from `minor` to `patch` to ensure local dependencies stay tightly aligned.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [ ] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
