### PR TITLE
fix(button): revert primary button content color

### DIFF
--- a/.changeset/metal-bees-bake.md
+++ b/.changeset/metal-bees-bake.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/button": patch
+---
+
+Revert primary button content color to spectrum-white to bring back white color in both dark and light themes.

--- a/components/button/themes/spectrum.css
+++ b/components/button/themes/spectrum.css
@@ -23,10 +23,10 @@
 		--mod-button-background-color-focus: var(--spectrum-gray-200);
 
 		&.spectrum-Button--primary {
-			--mod-button-content-color-default: var(--spectrum-gray-50);
-			--mod-button-content-color-hover: var(--spectrum-gray-50);
-			--mod-button-content-color-down: var(--spectrum-gray-50);
-			--mod-button-content-color-focus: var(--spectrum-gray-50);
+			--mod-button-content-color-default: var(--spectrum-white);
+			--mod-button-content-color-hover: var(--spectrum-white);
+			--mod-button-content-color-down: var(--spectrum-white);
+			--mod-button-content-color-focus: var(--spectrum-white);
 
 			&.spectrum-Button--outline {
 				--mod-button-background-color-hover: var(--spectrum-gray-300);


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

Reverts S1 and Express Primary filled button content color to use the [same tokens](https://github.com/adobe/spectrum-css/blob/3182da4812ed183b163739a956ebbc290ae19328/components/button/themes/spectrum.css#L130) it used prior to Foundations. Because the primary button is a gray color in both dark and light themes, content color should be white regardless of theme.

Current `main` branch:
![image](https://github.com/user-attachments/assets/6e601c89-518d-40df-ad8b-b73269186dd1)

Previous `main` [(before foundations)](https://pr-3524--spectrum-css.netlify.app/?path=/story/components-button--default&globals=color:dark;testingPreview:!true):
![image](https://github.com/user-attachments/assets/4e3a871c-5124-40fc-b780-b06d2cba5da9)

Current PR:
![image](https://github.com/user-attachments/assets/7e319dc0-57e5-479e-8d8e-0649f79d2ca8)

Note that the design [spec](https://spectrum.adobe.com/page/button/) calls for the `neutral-content-color-default`, `neutral-content-color-hover`, etc. to be used--these appear not to have been used because they work nicely in the dark theme but are close in color to the button background in the light theme.

[CSS-1107](https://jira.corp.adobe.com/browse/CSS-1107)

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
Check out the branch locally or check out the deploy [preview](https://pr-3550--spectrum-css.netlify.app/?path=/story/components-button--default&globals=context:legacy;color:dark;testingPreview:!true).
- [x] Compare the primary [button](https://pr-3550--spectrum-css.netlify.app/?path=/story/components-button--default&globals=context:legacy;color:dark;testingPreview:!true) in the dark S1 theme to the previous `main` [version](https://pr-3524--spectrum-css.netlify.app/?path=/story/components-button--default&globals=color:dark;testingPreview:!true) before Foundations. Both should use `spectrum-white` (255, 255, 255) for the content color. @marissahuysentruyt 
- [x] This fix should also address the primary hover, focus, and active content color to use `spectrum-white` @marissahuysentruyt 
- [x] Switch the theme to Express and confirm the same @marissahuysentruyt 
- [x] Confirm that there are no other regressions within button in the dark theme (for instance, for secondary button, disabled, static color, etc.)
- [x] Switch to light mode for S1 and Express to confirm that there are no regressions there

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
