### PR TITLE
chore(popover): add missing metadata update from build

### DIFF
--- a/components/popover/dist/metadata.json
+++ b/components/popover/dist/metadata.json
@@ -142,7 +142,6 @@
     "--spectrum-animation-duration-0",
     "--spectrum-animation-duration-100",
     "--spectrum-background-layer-2-color",
-    "--spectrum-border-width-100",
     "--spectrum-corner-radius-large-default",
     "--spectrum-drop-shadow-elevated-blur",
     "--spectrum-drop-shadow-elevated-color",


### PR DESCRIPTION
## Description

Adds a missing change to a metadata file that is generated after `yarn build`.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [ ] `yarn build` no longer generates any changed metadata files. Verify check in Github no longer fails.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] ✨ This pull request is ready to merge. ✨
