### PR TITLE
docs(splitview): add guidelines link

### DIFF
--- a/components/splitview/package.json
+++ b/components/splitview/package.json
@@ -49,6 +49,7 @@
 	},
 	"spectrum": [
 		{
+			"guidelines": "https://spectrum-contributions.corp.adobe.com/page/drag-bars-thumbs-beta/",
 			"rootClass": "spectrum-SplitView",
 			"swc": "https://opensource.adobe.com/spectrum-web-components/components/split-view/"
 		}


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->
After talking with the design team, Jess liked the idea of CSS's split view component linking to the "drag bars and thumbs" contribution page.

This continues the work from [CSS-772](https://jira.corp.adobe.com/browse/CSS-772) where we were linking CSS components to their design guidelines on the Spectrum or Spectrum contributions site.

No changeset is included with this PR since it affects the package.json only.

### Jira/Specs
[CSS-963](https://jira.corp.adobe.com/browse/CSS-963)
[Slack thread](https://adobedesign.slack.com/archives/G01P2PHJMC6/p1738605814936429?thread_ts=1738603928.182389&cid=G01P2PHJMC6) (about asset list and split view)

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

- [ ] Pull down the branch to run locally or [visit the deploy preview](https://pr-3559--spectrum-css.netlify.app/?path=/docs/guides-contributing--docs)
- [ ] [Visit the split view docs page](https://pr-3559--spectrum-css.netlify.app/?path=/docs/components-split-view--docs)
- [ ] Click the "Design guidelines" resource card
- [ ] Verify you navigate to the "Drag bars and thumbs" Spectrum contributions page.
<img width="1087" alt="Screenshot 2025-02-17 at 11 49 12 AM" src="https://github.com/user-attachments/assets/3dc68c76-965f-4d9c-9b8f-a958e3a29cf5" />

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots
Before 🚫 
<img width="890" alt="Screenshot 2025-02-17 at 11 47 25 AM" src="https://github.com/user-attachments/assets/4028add9-c716-4f52-a684-6bf605e94780" />

After ✅ 
<img width="989" alt="Screenshot 2025-02-17 at 11 47 44 AM" src="https://github.com/user-attachments/assets/36499408-8ddc-4535-8215-a39188e79dda" />

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [ ] ✨ This pull request is ready to merge. ✨
