### PR TITLE
chore(dialog): use isOpen type for open control

### DIFF
--- a/components/dialog/stories/dialog.stories.js
+++ b/components/dialog/stories/dialog.stories.js
@@ -1,6 +1,6 @@
 import { withUnderlayWrapper } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import { size } from "@spectrum-css/preview/types";
+import { isOpen, size } from "@spectrum-css/preview/types";
 import { Template as Table } from "@spectrum-css/table/stories/template.js";
 import { Template as Steplist } from "@spectrum-css/steplist/stories/template.js";
 import { Template as Typography } from "@spectrum-css/typography/stories/template.js";
@@ -54,6 +54,7 @@ export default {
 			},
 			control: "boolean",
 		},
+		isOpen,
 		footer: {
 			name: "Footer text",
 			description: "Text content of the dialog footer. Represents the checkbox label if a checkbox is present, or stands alone if there is no checkbox. Currently only supported in the default layout.",


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

This PR correctly implements the `isOpen` shared type on the dialog pages. This should correct the display of the `isOpen` control.

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->


## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

- [x] Pull down the branch to run locally or [visit the deploy preview](https://pr-3562--spectrum-css.netlify.app/?path=/docs/guides-contributing--docs)
- [x] [Visit the dialog docs page](https://pr-3562--spectrum-css.netlify.app/?path=/docs/components-dialog--docs).
- [x] In the Properties table towards the bottom of the page, verify the "Open" control is capitalized. It should not be displayed or formatted like a variable (i.e. `isOpen`).
<img width="1089" alt="Screenshot 2025-02-17 at 11 19 33 AM" src="https://github.com/user-attachments/assets/ea1cb3f4-2d0b-4416-b62e-1709df9a3d4a" />

- [x] Go to the [default](https://pr-3562--spectrum-css.netlify.app/?path=/story/components-dialog--default), [fullscreen](https://pr-3562--spectrum-css.netlify.app/?path=/story/components-dialog--fullscreen), and [fullscreen takeover](https://pr-3562--spectrum-css.netlify.app/?path=/story/components-dialog--fullscreen-takeover) story pages. 
- [x] Verify the same "Open" control is capitalized and not displayed like the variable on each story page.
<img width="1315" alt="Screenshot 2025-02-17 at 11 22 37 AM" src="https://github.com/user-attachments/assets/dc93b576-4152-41de-b507-53fd44738917" />


### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

Before 🚫 
<img width="926" alt="Screenshot 2025-02-17 at 11 37 41 AM" src="https://github.com/user-attachments/assets/3ca9161e-c834-4fb8-a1af-d3951149843e" />
<img width="1309" alt="Screenshot 2025-02-17 at 11 37 32 AM" src="https://github.com/user-attachments/assets/31ca9bf4-28af-4382-b070-9110d638d817" />

After ✅ 
<img width="1315" alt="Screenshot 2025-02-17 at 11 22 37 AM" src="https://github.com/user-attachments/assets/31f20e18-85db-443c-a3c4-85f5b2aa96f8" />

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [ ] ✨ This pull request is ready to merge. ✨
