### PR TITLE
fix(storybook): remove workspace dependency references

### DIFF
--- a/.changeset/ten-owls-beam.md
+++ b/.changeset/ten-owls-beam.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/preview": patch
+---
+
+Remove the internal workspace:^ dependency syntax for the Storybook package so that it can be leveraged externally without throwing errors.

--- a/.storybook/package.json
+++ b/.storybook/package.json
@@ -40,10 +40,10 @@
 	},
 	"dependencies": {
 		"@adobe/spectrum-css-workflow-icons": "^1.5.4",
-		"@spectrum-css/bundle": "workspace:^",
+		"@spectrum-css/bundle": "1.0.0",
 		"@spectrum-css/tokens": "16.0.1",
 		"@spectrum-css/tokens-legacy": "npm:@spectrum-css/tokens@^15.2.0",
-		"@spectrum-css/ui-icons": "workspace:^"
+		"@spectrum-css/ui-icons": "1.1.2"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.26.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3915,7 +3915,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@spectrum-css/bundle@workspace:^, @spectrum-css/bundle@workspace:tools/bundle":
+"@spectrum-css/bundle@npm:1.0.0, @spectrum-css/bundle@workspace:tools/bundle":
   version: 0.0.0-use.local
   resolution: "@spectrum-css/bundle@workspace:tools/bundle"
   dependencies:
@@ -4928,10 +4928,10 @@ __metadata:
     "@babel/core": "npm:^7.26.0"
     "@chromatic-com/storybook": "npm:^3.2.3"
     "@etchteam/storybook-addon-status": "npm:^5.0.0"
-    "@spectrum-css/bundle": "workspace:^"
+    "@spectrum-css/bundle": "npm:1.0.0"
     "@spectrum-css/tokens": "npm:16.0.1"
     "@spectrum-css/tokens-legacy": "npm:@spectrum-css/tokens@^15.2.0"
-    "@spectrum-css/ui-icons": "workspace:^"
+    "@spectrum-css/ui-icons": "npm:1.1.2"
     "@storybook/addon-a11y": "npm:^8.4.7"
     "@storybook/addon-actions": "npm:^8.4.7"
     "@storybook/addon-designs": "npm:^8.0.4"
@@ -5472,7 +5472,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@spectrum-css/ui-icons@workspace:^, @spectrum-css/ui-icons@workspace:ui-icons":
+"@spectrum-css/ui-icons@npm:1.1.2, @spectrum-css/ui-icons@workspace:ui-icons":
   version: 0.0.0-use.local
   resolution: "@spectrum-css/ui-icons@workspace:ui-icons"
   dependencies:


### PR DESCRIPTION
## Description

To allow external projects to leverage our assets (such as our lovely doc blocks), internal references need to be explicit instead of using "workspace:^" or it throws an error when trying to install.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

Expect no regressions in VRTs or the docs site.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] ✨ This pull request is ready to merge. ✨
