### PR TITLE
test(combobox): corrects cases where open combobox stories and testing previews could overlap adjacent components

### DIFF
--- a/components/combobox/stories/combobox.stories.js
+++ b/components/combobox/stories/combobox.stories.js
@@ -171,6 +171,11 @@ DefaultGroup.args = Default.args;
 DefaultGroup.tags = ["!dev"];
 DefaultGroup.parameters = {
 	chromatic: { disableSnapshot: true },
+	docs: {
+		story: {
+			height: "360px",
+		},
+	},
 };
 
 export const QuietGroup = VariantGroup.bind({});
@@ -182,6 +187,11 @@ QuietGroup.args = {
 QuietGroup.tags = ["!dev"];
 QuietGroup.parameters = {
 	chromatic: { disableSnapshot: true },
+	docs: {
+		story: {
+			height: "360px",
+		},
+	},
 };
 
 /**

--- a/components/combobox/stories/combobox.test.js
+++ b/components/combobox/stories/combobox.test.js
@@ -4,9 +4,6 @@ import { Template } from "./template.js";
 export const ComboBoxGroup = Variants({
 	Template,
 	sizeDirection: "row",
-	wrapperStyles: {
-		"align-items": "flex-start",
-	},
 	testData: [
 		{
 			testHeading: "Default",
@@ -20,11 +17,17 @@ export const ComboBoxGroup = Variants({
 		{
 			testHeading: "Open",
 			isOpen: true,
+			wrapperStyles: {
+				"min-block-size": "250px",
+			},
 		},
 		{
 			testHeading: "Quiet + open",
 			isQuiet: true,
 			isOpen: true,
+			wrapperStyles: {
+				"min-block-size": "250px",
+			},
 		},
 		{
 			testHeading: "With field label top",


### PR DESCRIPTION
## Description

`CSS-1132`

Fixes spacing for open combobox tests and stories.

- Adds fixes size to `parameters.docs.story` in combobox story file.
- Adds `min-inline-block-size` to `wrapperStyles` for `open` stories.

### Validation steps

1. Open the branch preview.
2. Navigate to the `combobox` docs.
3. Verify that `open` component variations do not overlap adjacent components.
4. Open the `combobox` component and enable the testing preview view.
5. Verify that `open` component variations do not overlap adjacent components.

## Screenshots

<img width="1335" alt="Screenshot 2025-02-20 at 10 02 14 AM" src="https://github.com/user-attachments/assets/ff3a8e21-72dc-433d-9821-84d2cb3e9cfe" />

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
