### PR TITLE
fix(checkbox): update box color to neutral in s2

### DIFF
--- a/.changeset/odd-seahorses-hunt.md
+++ b/.changeset/odd-seahorses-hunt.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/checkbox": patch
+---
+
+updated deselected (default) border color of the box to be neutral content color default in spectrum-two

--- a/components/checkbox/dist/metadata.json
+++ b/components/checkbox/dist/metadata.json
@@ -188,7 +188,6 @@
     "--spectrum-font-size-300",
     "--spectrum-font-size-75",
     "--spectrum-gray-50",
-    "--spectrum-gray-600",
     "--spectrum-gray-700",
     "--spectrum-gray-800",
     "--spectrum-line-height-100",

--- a/components/checkbox/themes/spectrum-two.css
+++ b/components/checkbox/themes/spectrum-two.css
@@ -13,7 +13,7 @@
 
 @container style(--system: spectrum) {
 	.spectrum-Checkbox {
-		--spectrum-checkbox-control-color-default: var(--spectrum-gray-600);
+		--spectrum-checkbox-control-color-default: var(--spectrum-neutral-content-color-default);
 		--spectrum-checkbox-control-color-hover: var(--spectrum-gray-700);
 		--spectrum-checkbox-control-color-down: var(--spectrum-gray-800);
 		--spectrum-checkbox-control-color-focus: var(--spectrum-gray-700);

--- a/components/checkbox/themes/spectrum.css
+++ b/components/checkbox/themes/spectrum.css
@@ -17,6 +17,7 @@
 
 @container style(--system: legacy) {
 	.spectrum-Checkbox {
+		--spectrum-checkbox-control-color-default: var(--spectrum-gray-600);
 		--spectrum-checkbox-checkmark-color: var(--spectrum-gray-75);
 		--spectrum-checkbox-control-corner-radius: var(--spectrum-corner-radius-75);
 	}


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->
Update deselected border color of checkbox to neutral.
[SWC-498](https://jira.corp.adobe.com/browse/SWC-498)

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](https://pr-3573--spectrum-css.netlify.app/?path=/story/components-checkbox--default) for the component:
    - [  ] Verify that the `--system-checkbox-control-color-default` is now pointing to `var(--spectrum-neutral-content-color-default)` for s2


### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
