### PR TITLE
fix(menu): move s1/express focus indicator to right side for rtl

### DIFF
--- a/.changeset/green-ghosts-collect.md
+++ b/.changeset/green-ghosts-collect.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/menu": patch
+---
+
+Adjusts RTL mode menu item focus indicator side for S1/Express.

--- a/components/menu/dist/metadata.json
+++ b/components/menu/dist/metadata.json
@@ -89,7 +89,6 @@
     ".spectrum-Menu-item:active > .spectrum-Menu-itemLabel",
     ".spectrum-Menu-item:active > .spectrum-Menu-itemValue",
     ".spectrum-Menu-item:active > .spectrum-Menu-sectionHeading",
-    ".spectrum-Menu-item:dir(rtl)",
     ".spectrum-Menu-item:focus",
     ".spectrum-Menu-item:focus > .spectrum-Menu-checkmark",
     ".spectrum-Menu-item:focus > .spectrum-Menu-chevron",
@@ -134,11 +133,12 @@
     ".spectrum-Menu.spectrum-Menu--sizeL",
     ".spectrum-Menu.spectrum-Menu--sizeS",
     ".spectrum-Menu.spectrum-Menu--sizeXL",
+    ".spectrum-Menu:dir(rtl)",
     ".spectrum-Menu:lang(ja)",
     ".spectrum-Menu:lang(ko)",
     ".spectrum-Menu:lang(zh)",
-    "[dir=\"rtl\"] .spectrum-Menu .spectrum-Menu-chevron",
-    "[dir=\"rtl\"] .spectrum-Menu-item"
+    "[dir=\"rtl\"] .spectrum-Menu",
+    "[dir=\"rtl\"] .spectrum-Menu .spectrum-Menu-chevron"
   ],
   "modifiers": [
     "--mod-menu-back-heading-color",

--- a/components/menu/index.css
+++ b/components/menu/index.css
@@ -67,7 +67,7 @@
 		.spectrum-Menu-item--collapsible.is-open {
 			&:hover,
 			&:focus-within {
-				box-shadow: inset calc(var(--mod-menu-item-focus-indicator-width, var(--spectrum-menu-item-focus-indicator-width)) * var(--spectrum-menu-item-focus-indicator-direction-scalar, 1)) 0 0 0 var(--highcontrast-menu-item-focus-indicator-color, var(--mod-menu-item-focus-indicator-color, var(--spectrum-menu-item-focus-indicator-color)));
+				box-shadow: var(--spectrum-menu-item-focus-indicator-shadow) var(--spectrum-menu-item-focus-indicator-border-width) 0 0 0 var(--spectrum-menu-item-focus-indicator-color-default);
 			}
 
 			&:hover,
@@ -87,7 +87,7 @@
 	--spectrum-menu-item-label-line-height: var(--spectrum-line-height-100);
 	--spectrum-menu-item-label-line-height-cjk: var(--spectrum-cjk-line-height-100);
 	--spectrum-menu-item-label-to-description-spacing: var(--spectrum-menu-item-label-to-description);
-	--spectrum-menu-item-focus-indicator-width: var(--spectrum-border-width-200);
+	--spectrum-menu-item-focus-indicator-width: var(--mod-menu-item-focus-indicator-width, var(--spectrum-border-width-200));
 	--spectrum-menu-item-focus-indicator-color: var(--spectrum-blue-800);
 	--spectrum-menu-item-label-to-value-area-min-spacing: var(--spectrum-spacing-100);
 
@@ -167,7 +167,7 @@
 	--spectrum-menu-item-collapsible-no-icon-submenu-item-padding-x-start: calc((var(--spectrum-menu-item-label-inline-edge-to-content) + var(--spectrum-menu-item-checkmark-width) + var(--spectrum-menu-item-label-text-to-visual) + var(--spectrum-menu-item-focus-indicator-width)));
 
 	--spectrum-menu-item-focus-indicator-color-default: var(--highcontrast-menu-item-focus-indicator-color, var(--mod-menu-item-focus-indicator-color, var(--spectrum-menu-item-focus-indicator-color)));
-	--spectrum-menu-item-focus-indicator-border-width: calc(var(--mod-menu-item-focus-indicator-width, var(--spectrum-menu-item-focus-indicator-width)) * var(--spectrum-menu-item-focus-indicator-direction-scalar, 1));
+	--spectrum-menu-item-focus-indicator-border-width: calc(var(--spectrum-menu-item-focus-indicator-width) * var(--spectrum-menu-item-focus-indicator-direction-scalar, 1));
 
 	&.spectrum-Menu--sizeS {
 		--spectrum-menu-item-min-height: var(--spectrum-component-height-75);
@@ -248,6 +248,10 @@
 		--spectrum-menu-item-top-to-checkmark: var(--spectrum-menu-item-top-to-selected-icon-extra-large);
 
 		--spectrum-menu-back-icon-margin: var(--spectrum-navigational-indicator-top-to-back-icon-extra-large);
+	}
+
+	&:dir(rtl) {
+		--spectrum-menu-item-focus-indicator-direction-scalar: -1;
 	}
 }
 
@@ -396,7 +400,7 @@
 	padding-block-end: var(--mod-menu-item-bottom-edge-to-text, var(--spectrum-menu-item-bottom-edge-to-text));
 	padding-inline: var(--mod-menu-item-label-inline-edge-to-content, var(--spectrum-menu-item-label-inline-edge-to-content));
 
-	margin: calc((var(--spectrum-menu-item-focus-indicator-offset) + var(--spectrum-menu-item-focus-indicator-border-width)) * var(--spectrum-menu-item-spacing-multiplier));
+	margin: calc((var(--spectrum-menu-item-focus-indicator-offset) + var(--spectrum-menu-item-focus-indicator-width)) * var(--spectrum-menu-item-spacing-multiplier));
 	text-decoration: none;
 
 	display: grid;
@@ -482,10 +486,6 @@
 			fill: var(--highcontrast-menu-item-color-focus, var(--mod-menu-checkmark-icon-color-focus, var(--spectrum-menu-checkmark-icon-color-focus)));
 			color: var(--highcontrast-menu-item-color-focus, var(--mod-menu-checkmark-icon-color-focus, var(--spectrum-menu-checkmark-icon-color-focus)));
 		}
-	}
-
-	&:dir(rtl) {
-		--spectrum-menu-item-focus-indicator-direction-scalar: -1;
 	}
 
 	&:hover {
@@ -603,7 +603,7 @@
 .spectrum-Menu-item:focus-visible,
 .spectrum-Menu-back:focus-visible {
 	box-shadow: var(--spectrum-menu-item-focus-indicator-shadow) var(--spectrum-menu-item-focus-indicator-border-width) 0 0 0 var(--spectrum-menu-item-focus-indicator-color-default);
-	outline: var(--spectrum-menu-item-focus-indicator-border-width) var(--spectrum-menu-item-focus-indicator-outline-style) var(--spectrum-menu-item-focus-indicator-color-default);
+	outline: var(--spectrum-menu-item-focus-indicator-width) var(--spectrum-menu-item-focus-indicator-outline-style) var(--spectrum-menu-item-focus-indicator-color-default);
 	outline-offset: var(--spectrum-menu-item-focus-indicator-offset);
 	border-radius: var(--spectrum-menu-item-corner-radius);
 }


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

Resolves an issue with the focus indicator for S1 and Express, in which the focus indicator appears on the left side for both LTR and RTL modes. The focus indicator in these themes should always be on the start-side, therefore, it should appear on the left side for LTR, and on the right side for RTL. This was something we overlooked in #3530.

This changes the scope of `--spectrum-menu-item-focus-indicator-direction-scalar` so that it can be used in the definition for `--spectrum-menu-item-focus-indicator-border-width`.

This does in some cases make `--spectrum-menu-item-focus-indicator-border-width` negative, which causes issues for `outline` and `margin` properties using it, so those have been reverted to use `--spectrum-menu-item-focus-indicator-width` instead.

[SWC-581](https://jira.corp.adobe.com/browse/SWC-581)

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->
1. Check out the PR from the local branch or use the PR preview to view the Menu component.
2. Check out S1 and Express, Right to left mode to confirm fix
    - [x] Menu focus indicator should appear on the right side of the menu item (see screen shot in the section below) for the default menu story [@castastrophe]
    - [x] Menu focus indicator should appear on the right side of the menu item (see screen shot in the section below) for the collapsible menu story [@castastrophe]
4. Check out S1 and Express, Left to right mode to confirm no regressions
    - [x] Menu focus indicator in the default menu story should appear on the left side of the menu item (should not have any changes from how it looked before) [@castastrophe]
    - [x] Menu focus indicator in the collapsible menu story should appear on the left side of the menu item (should not have any changes from how it looked before) [@castastrophe]
6. Check out S2, Right to left and Left to right mode to confirm no regressions
    - [x] Menu focus indicator in default menu should be a full outline around the menu item with rounded corners, as before (should not experience any regressions) - **especially check RTL** [@castastrophe]
    - [x] Menu focus indicator in collapsible menu should be a full outline around the menu item with rounded corners, as before (should not experience any regressions)  [@castastrophe]

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

8. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

Before, focus indicator is on the left side for RTL:
![image](https://github.com/user-attachments/assets/f033cec7-bb00-4c21-9042-bf8b5201a42f)

After, focus indicator is on the right side for RTL:
![image](https://github.com/user-attachments/assets/596d8539-c4ac-437f-9797-6d5678993e60)

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] ~~I have updated relevant storybook stories and templates.~~
- [x] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
