### PR TITLE
chore(menu): remove keyboard focus outline in spectrum-two

### DIFF
--- a/.changeset/hip-panthers-breathe.md
+++ b/.changeset/hip-panthers-breathe.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/menu": patch
+---
+
+removed keyboard focus outline in spectrum-two

--- a/components/menu/themes/spectrum-two.css
+++ b/components/menu/themes/spectrum-two.css
@@ -23,6 +23,6 @@
 		--spectrum-menu-item-focus-indicator-shadow: none;
 		--spectrum-menu-item-focus-indicator-offset: var(--spectrum-spacing-50);
 		--spectrum-menu-item-spacing-multiplier: 1;
-		--spectrum-menu-item-focus-indicator-outline-style: solid;
+		--spectrum-menu-item-focus-indicator-outline-style: none;
 	}
 }


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

removed keyboard focus outline in spectrum-two

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
1. Open the [storybook](https://pr-3595--spectrum-css.netlify.app/?path=/story/components-menu--default) for the menu component:
  - [x] Verify that keyboard focused menu item has no blue color ring. [@cdransf]

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->
Old:
<img width="427" alt="Screenshot 2025-03-03 at 2 32 56 PM" src="https://github.com/user-attachments/assets/790bf51d-f543-471e-8ee1-ada5a6438c70" />
New:
<img width="531" alt="Screenshot 2025-03-03 at 2 33 10 PM" src="https://github.com/user-attachments/assets/464f449f-6278-412b-b7cb-51bbc2fda9b8" />


## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
