### PR TITLE
fix(readme): corrects path to css illutration png in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <h1 align="center">Spectrum CSS</h1>
 <h3 align="center">A CSS-implementation of the Spectrum design language</h3>
 
-<img src="assets/spectrum-css_illustration_desktop.png">
+<img src=".storybook/assets/images/spectrum-css_illustration_desktop.png">
 
 ## Features
 


### PR DESCRIPTION
## Description

Corrects the path in the project readme to point to the relocated image file.

## Screenshots

<img width="922" alt="Screenshot 2025-03-03 at 4 08 16 PM" src="https://github.com/user-attachments/assets/0d9b52a6-4748-498f-b597-e2bdf21d916c" />

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
