### PR TITLE
chore: regenerate yarn.lock after merge

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4038,7 +4038,7 @@ __metadata:
     "@spectrum-css/opacitycheckerboard": "npm:4.1.0"
     "@spectrum-css/page": "npm:9.1.0"
     "@spectrum-css/pagination": "npm:10.1.0"
-    "@spectrum-css/picker": "npm:9.1.2"
+    "@spectrum-css/picker": "npm:9.1.3"
     "@spectrum-css/pickerbutton": "npm:6.1.1"
     "@spectrum-css/popover": "npm:8.2.0"
     "@spectrum-css/progressbar": "npm:6.1.0"
@@ -4051,7 +4051,7 @@ __metadata:
     "@spectrum-css/splitview": "npm:7.1.0"
     "@spectrum-css/statuslight": "npm:9.1.0"
     "@spectrum-css/steplist": "npm:7.1.0"
-    "@spectrum-css/stepper": "npm:7.1.1"
+    "@spectrum-css/stepper": "npm:7.1.2"
     "@spectrum-css/swatch": "npm:8.1.2"
     "@spectrum-css/swatchgroup": "npm:5.1.0"
     "@spectrum-css/switch": "npm:6.1.0"
@@ -4896,7 +4896,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@spectrum-css/picker@npm:9.1.2, @spectrum-css/picker@workspace:components/picker":
+"@spectrum-css/picker@npm:9.1.3, @spectrum-css/picker@workspace:components/picker":
   version: 0.0.0-use.local
   resolution: "@spectrum-css/picker@workspace:components/picker"
   dependencies:
@@ -5139,7 +5139,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@spectrum-css/slider@workspace:components/slider"
   dependencies:
-    "@spectrum-css/stepper": "npm:7.1.1"
+    "@spectrum-css/stepper": "npm:7.1.2"
     "@spectrum-css/tokens": "npm:16.0.1"
   peerDependencies:
     "@spectrum-css/stepper": ">=7.0.0 <8.0.0"
@@ -5199,7 +5199,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@spectrum-css/stepper@npm:7.1.1, @spectrum-css/stepper@workspace:components/stepper":
+"@spectrum-css/stepper@npm:7.1.2, @spectrum-css/stepper@workspace:components/stepper":
   version: 0.0.0-use.local
   resolution: "@spectrum-css/stepper@workspace:components/stepper"
   dependencies:
@@ -5310,7 +5310,7 @@ __metadata:
   dependencies:
     "@spectrum-css/icon": "npm:9.1.0"
     "@spectrum-css/menu": "npm:9.1.1"
-    "@spectrum-css/picker": "npm:9.1.2"
+    "@spectrum-css/picker": "npm:9.1.3"
     "@spectrum-css/tokens": "npm:16.0.1"
   peerDependencies:
     "@spectrum-css/icon": ">=9.0.0 <10.0.0"


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

After our most recent merge, the `yarn.lock` hadn't been updated and CI was failing.

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [ ] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
