### PR TITLE
fix(lint-staged): add yarn command to lint staged to ensure the lock file is updated

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -7,7 +7,7 @@ module.exports = {
 		"eslint --fix --cache --no-error-on-unmatched-pattern --quiet"
 	],
 	"package.json": (files) => [
-		"yarn constraints --fix",
+		"yarn constraints --fix && yarn install",
 		`eslint --fix --cache --no-error-on-unmatched-pattern --quiet ${files.join(" ")}`,
 	],
 	"dist/*.css": [


### PR DESCRIPTION
## Description

This PR adds the `yarn` command after `yarn constraints --fix` is invoked in `lint-staged.config.js` to ensure that the lock file is updated and to help prevent build failures.

We'll need to monitor release PRs to verify that this addresses failures when generating release PRs.

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
