### PR TITLE
chore(picker): updated border-color for open not hover state of picker

### DIFF
--- a/.changeset/angry-boats-walk.md
+++ b/.changeset/angry-boats-walk.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/picker": patch
+---
+
+Updated border-color for Open not hover state of picker from --spectrum-gray-900 to --spectrum-gray-800 as specified in the spec

--- a/components/picker/dist/metadata.json
+++ b/components/picker/dist/metadata.json
@@ -281,6 +281,7 @@
     "--spectrum-gray-500",
     "--spectrum-gray-600",
     "--spectrum-gray-700",
+    "--spectrum-gray-800",
     "--spectrum-gray-900",
     "--spectrum-line-height-100",
     "--spectrum-negative-border-color-default",

--- a/components/picker/themes/spectrum-two.css
+++ b/components/picker/themes/spectrum-two.css
@@ -21,7 +21,7 @@
 		--spectrum-picker-background-color-key-focus: var(--spectrum-gray-200);
 
 		--spectrum-picker-border-color-default: var(--spectrum-gray-500);
-		--spectrum-picker-border-color-default-open: var(--spectrum-neutral-content-color-focus);
+		--spectrum-picker-border-color-default-open: var(--spectrum-gray-800);
 		--spectrum-picker-border-color-hover: var(--spectrum-gray-600);
 		--spectrum-picker-border-color-hover-open: var(--spectrum-gray-900);
 		--spectrum-picker-border-color-active: var(--spectrum-gray-700);


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

Updated border-color for Open not hover state of picker from --spectrum-gray-900 to --spectrum-gray-800 as specified in the spec
https://jira.corp.adobe.com/browse/SDS-14609
https://jira.corp.adobe.com/browse/SWC-641

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](https://pr-3607--spectrum-css.netlify.app/) for the button component:
    - [ ] Open the picker and validate that the border color is `var(--spectrum-gray-800)` using inspect element by searching for `--system-picker-border-color-default-open`
    


### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [ ] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
