### PR TITLE
fix(combobox): border color fast follows swc-582 

### DIFF
--- a/.changeset/breezy-crews-guess.md
+++ b/.changeset/breezy-crews-guess.md
@@ -1,0 +1,9 @@
+---
+"@spectrum-css/combobox": patch
+---
+
+Fast follow fixes for combobox
+
+- corrects container query for the `--system` reference to "legacy" in the combobox/themes/spectrum.css file
+- corrects the border colors for several combobox states including focus, keyboardFocus, focus+hover, disabled, read-only for all themes
+- adds `--spectrum-combobox-readonly-input-border-color: var(--spectrum-gray-400);` to express.css theme so that the default border and read-only border colors are the same

--- a/components/combobox/dist/metadata.json
+++ b/components/combobox/dist/metadata.json
@@ -125,6 +125,7 @@
     "--mod-combobox-inline-size",
     "--mod-combobox-line-height",
     "--mod-combobox-min-inline-size",
+    "--mod-combobox-readonly-border-color-disabled",
     "--mod-combobox-readonly-input-border-color",
     "--mod-combobox-spacing-block-end-edge-to-text",
     "--mod-combobox-spacing-block-start-edge-to-text",
@@ -171,6 +172,7 @@
     "--spectrum-combobox-line-height",
     "--spectrum-combobox-min-inline-size",
     "--spectrum-combobox-readonly-background-color-disabled",
+    "--spectrum-combobox-readonly-border-color-disabled",
     "--spectrum-combobox-readonly-border-color-invalid-default",
     "--spectrum-combobox-readonly-input-background-color",
     "--spectrum-combobox-readonly-input-border-color",
@@ -252,16 +254,19 @@
   "system-theme": [
     "--system-combobox-background-color-disabled",
     "--system-combobox-border-color-default",
+    "--system-combobox-border-color-disabled",
     "--system-combobox-border-color-focus",
     "--system-combobox-border-color-focus-hover",
     "--system-combobox-border-color-hover",
-    "--system-combobox-border-color-key-focus"
+    "--system-combobox-border-color-key-focus",
+    "--system-combobox-readonly-input-border-color"
   ],
   "passthroughs": [
     "--mod-picker-button-background-color",
     "--mod-picker-button-background-color-disabled",
     "--mod-picker-button-background-color-quiet",
     "--mod-picker-button-border-color",
+    "--mod-picker-button-border-color-disabled",
     "--mod-picker-button-border-color-quiet",
     "--mod-picker-button-border-width",
     "--mod-picker-button-font-color-disabled",

--- a/components/combobox/index.css
+++ b/components/combobox/index.css
@@ -68,7 +68,7 @@
 
 	--mod-textfield-border-width: var(--mod-combobox-border-width, var(--spectrum-combobox-border-width));
 	--mod-textfield-border-color: var(--mod-combobox-border-color-default, var(--spectrum-combobox-border-color-default));
-	--mod-textfield-border-color-disabled: var(--mod-combobox-border-color-disabled, transparent);
+	--mod-textfield-border-color-disabled: var(--mod-combobox-border-color-disabled, var(--spectrum-combobox-border-color-disabled));
 	--mod-textfield-border-color-focus: var(--mod-combobox-border-color-focus, var(--spectrum-combobox-border-color-focus));
 	--mod-textfield-border-color-focus-hover: var(--mod-combobox-border-color-focus-hover, var(--spectrum-combobox-border-color-focus-hover));
 	--mod-textfield-border-color-hover: var(--mod-combobox-border-color-hover, var(--spectrum-combobox-border-color-hover));
@@ -89,15 +89,15 @@
 	--mod-picker-button-background-color: var(--mod-combobox-background-color-default);
 	--mod-picker-button-background-color-disabled: var(--mod-combobox-background-color-disabled);
 	--mod-picker-button-font-color-disabled: var(--mod-combobox-font-color-disabled);
+	--mod-picker-button-border-color-disabled: var(--mod-combobox-border-color-disabled, var(--spectrum-combobox-border-color-disabled));
 	/* @passthroughs end -- settings for nested Picker Button component */
 
 	/*** Read-only Colors ***/
 	--spectrum-combobox-readonly-input-background-color: var(--spectrum-gray-50);
-	--spectrum-combobox-readonly-input-border-color: var(--spectrum-gray-500);
 	--spectrum-combobox-readonly-border-color-invalid-default: var(--spectrum-negative-border-color-default);
 	--spectrum-combobox-readonly-background-color-disabled: var(--spectrum-disabled-background-color);
 	--spectrum-combobox-readonly-text-color-disabled: var(--spectrum-disabled-content-color);
-	--spectrum-combobox-border-color-disabled: var(--spectrum-disabled-border-color);
+	--spectrum-combobox-readonly-border-color-disabled: var(--spectrum-disabled-border-color);
 }
 
 .spectrum-Combobox,
@@ -248,7 +248,7 @@
 
 		&.is-disabled .spectrum-Combobox-input:read-only {
 			background-color: var(--mod-textfield-background-color-disabled, var(--spectrum-combobox-readonly-background-color-disabled));
-			border-color: transparent;
+			border-color: var(--mod-combobox-readonly-border-color-disabled, var(--spectrum-combobox-readonly-border-color-disabled, transparent));
 			color: var(--highcontrast-textfield-text-color-disabled, var(--mod-textfield-text-color-disabled, var(--spectrum-combobox-readonly-text-color-disabled)));
 
 			&:hover {
@@ -435,7 +435,7 @@
 
 			&.is-disabled .spectrum-Combobox-input:read-only {
 				color: var(--highcontrast-textfield-text-color-disabled, var(--mod-textfield-text-color-disabled, var(--spectrum-combobox-readonly-text-color-disabled)));
-				border-color: var(--mod-textfield-border-color-disabled, var(--spectrum-combobox-border-color-disabled));
+				border-color: var(--mod-textfield-border-color-disabled, var(--spectrum-combobox-readonly-border-color-disabled));
 			}
 		}
 	}

--- a/components/combobox/themes/express.css
+++ b/components/combobox/themes/express.css
@@ -22,5 +22,7 @@
 		--spectrum-combobox-border-color-focus: var(--spectrum-gray-900);
 		--spectrum-combobox-border-color-focus-hover: var(--spectrum-gray-800);
 		--spectrum-combobox-border-color-key-focus: var(--spectrum-gray-900);
+
+		--spectrum-combobox-readonly-input-border-color: var(--spectrum-gray-400);
 	}
 }

--- a/components/combobox/themes/spectrum-two.css
+++ b/components/combobox/themes/spectrum-two.css
@@ -19,6 +19,9 @@
 		--spectrum-combobox-border-color-focus-hover: var(--spectrum-gray-900);
 		--spectrum-combobox-border-color-key-focus: var(--spectrum-gray-800);
 
+		--spectrum-combobox-readonly-input-border-color: var(--spectrum-gray-500);
+
 		--spectrum-combobox-background-color-disabled: var(--spectrum-gray-25);
+		--spectrum-combobox-border-color-disabled: var(--spectrum-disabled-border-color);
 	}
 }

--- a/components/combobox/themes/spectrum.css
+++ b/components/combobox/themes/spectrum.css
@@ -21,6 +21,9 @@
 		--spectrum-combobox-border-color-focus-hover: var(--spectrum-gray-600);
 		--spectrum-combobox-border-color-key-focus: var(--spectrum-gray-600);
 
+		--spectrum-combobox-readonly-input-border-color: var(--spectrum-gray-500);
+
 		--spectrum-combobox-background-color-disabled: var(--spectrum-disabled-background-color);
+		--spectrum-combobox-border-color-disabled: transparent;
 	}
 }

--- a/components/combobox/themes/spectrum.css
+++ b/components/combobox/themes/spectrum.css
@@ -15,7 +15,7 @@
 
 @import "./spectrum-two.css";
 
-@container style(--system: spectrum) {
+@container style(--system: legacy) {
 	.spectrum-Combobox {
 		--spectrum-combobox-border-color-focus: var(--spectrum-gray-500);
 		--spectrum-combobox-border-color-focus-hover: var(--spectrum-gray-600);


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->
Some design feedback on the s2 foundations combobox included border color fixes. This PR aims to address those!
- In the default variant, focus+hover state (not shown in the testing grid):
    - border should resolve all the way to `gray-900` (via `--spectrum-combobox-border-color-focus-hover`)
---
- In the default variant, focus state: 
    - border color should resolve to `gray-800` (via `--spectrum-combobox-border-color-focus`)
---
- In the default variant, keyboard focus state: 
    - border should resolve to `gray-800` (via `--spectrum-combobox-border-color-key-focus`)
---
- In the default variant, disabled state: 
    - the background color should resolve to `gray-25` (by way of some textfield mods and `--spectrum-combobox-background-color-disabled`)
    - the border color should resolve to `gray-300` (via some textfield mods and `--spectrum-combobox-border-color-disabled`)
    - the picker button border color should also resolve to `gray-300` (via `--spectrum-combobox-border-color-disabled` and `--spectrum-disabled-background-color`)
    - the picker button background color should also resolve to `gray-100` (via some picker mods and `--spectrum-disabled-background-color`)

Additionally, the `style` query in the `spectrum.css` file was `--system: spectrum` instead of `--system: legacy`, so that has been fixed as well.

### Jira/Specs
[SWC-582](https://jira.corp.adobe.com/browse/SWC-582)

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

@jawinn 
- [x] Pull down the branch or [visit the deploy preview](https://pr-3609--spectrum-css.netlify.app/)
- [x] [Visit the combobox testing grid](https://pr-3609--spectrum-css.netlify.app/?path=/story/components-combobox--default&globals=testingPreview:!true) (for easiest validating) for S2 foundations
- [x] Inspect the focused combobox, and turn on the hover state in your browser inspector (there is no test case for focus+hover, but that's what we want to validate in this PR)
- [x] Verify the border resolves to `gray-900`
- [x] Remove the forced hover state, and inspect the same element
- [x] Verify the border is `gray-800`
- [x] Inspect the keyboard focused combobox
- [x] Verify the border is also `gray-800`
- [x] Inspect the disabled combobox
- [x] Verify the combobox border is `gray-300`. This is aliased many times, through `--spectrum-combobox-*` properties, as well as `--mod-textfield-*` properties
- [x] Verify the combobox background color now resolves to `gray-25`
- [x] Verify the picker button border is also `gray-300`. This is another instance of several layers of picker button mods being defined by `--spectrum-combobox-*` properties
- [x] Verify the picker button background color is `gray-100`. Once more, this is another instance of picker button mods and using `--spectrum-disabled-background-color`.
- [x] Verify no regressions have occurred in the S1 context
~- [ ] Verify no regressions have occurred in the Express context~
- [x] EDIT: Inspect [the read-only combobox in the Express context](https://pr-3609--spectrum-css.netlify.app/?path=/story/components-combobox--default&globals=context:express;testingPreview:!true).
- [x] Confirm that the `.spectrum-Combobox-input` border color resolves to `gray-400` via `--spectrum-combobox-readonly-input-border-color`.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have tested these changes in Windows High Contrast mode.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] ✨ This pull request is ready to merge. ✨
