### PR TITLE
fix(slider): offset variant border radius bug fix

### DIFF
--- a/.changeset/rude-jokes-judge.md
+++ b/.changeset/rude-jokes-judge.md
@@ -4,36 +4,6 @@
 
 # Slider: offset variant track fix
 
-The border radius styles were not being applied to the second instance of the `spectrum-Slider-track` when the offset variant is activated. The reason for this bug is because when the `offset` is selected, the template structure changes as `spectrum-Slider-fill` gets added to the slider. This likely negated the initial declaration of the border radius styles written below:
-
-```css
-.spectrum-Slider-track {
-	&:first-of-type {
-		&::before {
-			border-start-start-radius: var(
-				--mod-slider-track-corner-radius,
-				var(--spectrum-slider-track-corner-radius)
-			);
-			border-end-start-radius: var(
-				--mod-slider-track-corner-radius,
-				var(--spectrum-slider-track-corner-radius)
-			);
-		}
-	}
-
-	&:last-of-type {
-		&::before {
-			border-start-end-radius: var(
-				--mod-slider-track-corner-radius,
-				var(--spectrum-slider-track-corner-radius)
-			);
-			border-end-end-radius: var(
-				--mod-slider-track-corner-radius,
-				var(--spectrum-slider-track-corner-radius)
-			);
-		}
-	}
-}
-```
+The border radius styles were not being applied to the second instance of the `spectrum-Slider-track` when the offset variant is activated. The reason for this bug is because when the `offset` is selected, the template structure changes as `spectrum-Slider-fill` gets added to the slider.
 
 Adding a sibling combinator `&~.spectrum-Slider-track` to `spectrum-Slider-track` when offset is activated resolved the issue.

--- a/.changeset/rude-jokes-judge.md
+++ b/.changeset/rude-jokes-judge.md
@@ -1,0 +1,39 @@
+---
+"@spectrum-css/slider": minor
+---
+
+# Slider: offset variant track fix
+
+The border radius styles were not being applied to the second instance of the `spectrum-Slider-track` when the offset variant is activated. The reason for this bug is because when the `offset` is selected, the template structure changes as `spectrum-Slider-fill` gets added to the slider. This likely negated the initial declaration of the border radius styles written below:
+
+```css
+.spectrum-Slider-track {
+	&:first-of-type {
+		&::before {
+			border-start-start-radius: var(
+				--mod-slider-track-corner-radius,
+				var(--spectrum-slider-track-corner-radius)
+			);
+			border-end-start-radius: var(
+				--mod-slider-track-corner-radius,
+				var(--spectrum-slider-track-corner-radius)
+			);
+		}
+	}
+
+	&:last-of-type {
+		&::before {
+			border-start-end-radius: var(
+				--mod-slider-track-corner-radius,
+				var(--spectrum-slider-track-corner-radius)
+			);
+			border-end-end-radius: var(
+				--mod-slider-track-corner-radius,
+				var(--spectrum-slider-track-corner-radius)
+			);
+		}
+	}
+}
+```
+
+Adding a sibling combinator `&~.spectrum-Slider-track` to `spectrum-Slider-track` when offset is activated resolved the issue.

--- a/components/slider/dist/metadata.json
+++ b/components/slider/dist/metadata.json
@@ -62,6 +62,7 @@
     ".spectrum-Slider-ticks ~ .spectrum-Slider-handleContainer .spectrum-Slider-handle",
     ".spectrum-Slider-track",
     ".spectrum-Slider-track ~ .spectrum-Slider-track",
+    ".spectrum-Slider-track ~ .spectrum-Slider-track:before",
     ".spectrum-Slider-track:before",
     ".spectrum-Slider-track:first-of-type:before",
     ".spectrum-Slider-track:last-of-type:before",

--- a/components/slider/index.css
+++ b/components/slider/index.css
@@ -627,6 +627,8 @@
 	.spectrum-Slider-track {
 		&:not(:first-of-type, :last-of-type)::before {
 			background: var(--highcontrast-slider-filled-track-fill-color, var(--mod-slider-track-fill-color, var(--spectrum-slider-track-fill-color)));
+			border-start-end-radius: 0;
+			border-end-end-radius: 0;
 		}
 	}
 }

--- a/components/slider/index.css
+++ b/components/slider/index.css
@@ -537,6 +537,12 @@
 	&::before {
 		background: var(--highcontrast-slider-track-color-static, var(--mod-slider-track-color, var(--spectrum-slider-track-color)));
 	}
+
+	/* Styles below are applied to the sibling spectrum-Slider-track when filled-offset variant is activated */
+	& ~ .spectrum-Slider-track::before {
+		border-start-end-radius: var(--mod-slider-track-corner-radius, var(--spectrum-slider-track-corner-radius));
+		border-end-end-radius: var(--mod-slider-track-corner-radius, var(--spectrum-slider-track-corner-radius));
+	}
 }
 
 /* All variants other than filled-offset get a new track color for highcontrast mode */


### PR DESCRIPTION
## Slider: offset variant track fix

The border radius styles were not being applied to the second instance of the `spectrum-Slider-track` when the offset variant is activated. The reason for this bug is because when the `offset` is selected, the template structure changes as `spectrum-Slider-fill` gets added to the slider. 

Adding a sibling combinator `&~.spectrum-Slider-track` to `spectrum-Slider-track` when offset is activated resolved the issue.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps


### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots
<img width="643" alt="Screenshot 2025-03-10 at 2 47 15 PM" src="https://github.com/user-attachments/assets/5e3f7e8c-367c-4125-8fae-8ac0a3312304" />


## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [ ] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
