### PR TITLE
fix(constraints): run constraints and update lockfile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,12 +23,14 @@ jobs:
           cache: yarn
 
       - name: Install Dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install --immutable
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1
         with:
+          version: yarn version:packages
+
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
           title: "chore: release"
           commit: "chore: release"

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -8,7 +8,6 @@ module.exports = {
 	],
 	"package.json": (files) => [
 		"yarn constraints --fix",
-		"yarn install",
 		`eslint --fix --cache --no-error-on-unmatched-pattern --quiet ${files.join(" ")}`,
 	],
 	"dist/*.css": [

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
 		"tester": "cross-env NODE_ENV=development nx run storybook:test:scope",
 		"validate": "yarn validator tag:component",
 		"validator": "nx run-many --target validate --verbose --projects",
-		"version:packages": "changeset version && yarn --mode=\"update-lockfile\""
+		"version:packages": "changeset version && yarn constraints --fix && yarn install"
 	},
 	"workspaces": [
 		"components/*",


### PR DESCRIPTION
## Description

This PR modifies the `version:packages` command to run `yarn constraints --fix && yarn install` after `changeset version`. This command now runs in `release.yml` prior to the execution of `yarn release`.

We'll need to monitor release PRs to verify that this addresses failures when generating release PRs.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
