### PR TITLE
fix(slider): corrects contrast bug caused by template default arg

### DIFF
--- a/components/slider/stories/template.js
+++ b/components/slider/stories/template.js
@@ -21,7 +21,7 @@ export const Template = ({
 	values = [],
 	variant,
 	labelPosition,
-	fillColor = "rgb(213, 213, 213)",
+	fillColor,
 	showTicks = false,
 	showTickLabels = false,
 	isDisabled = false,
@@ -127,8 +127,8 @@ export const Template = ({
 			})}
 			id=${ifDefined(id)}
 			style=${styleMap({
+				"--spectrum-slider-track-color": fillColor ? fillColor : undefined,
 				"inline-size": "240px",
-				["--spectrum-slider-track-color"]: fillColor,
 				...customStyles,
 			})}
 			role=${ifDefined(values.length > 1 ? "group" : undefined)}


### PR DESCRIPTION
## Description

Corrects the contrast issue observed between the fill element and slider track that caused the fill element to be difficult to see.

- Adjusts colors per design feedback.
- Removes default control/template value that caused contrast issue in dark modew.

### Validation steps

1. Open Storybook URL
2. Navigate to slider
3. Change theme from light to dark
4. Enable testing preview
5. Scroll to filled offset and verify offset and track have sufficient contrast

## Screenshots

<img width="305" alt="image" src="https://github.com/user-attachments/assets/d5da8527-2ab6-473d-83e8-69a33cb4d053" />

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
