### PR TITLE
fix(infield-button): updated border color for disabled state

### DIFF
--- a/.changeset/popular-trains-sniff.md
+++ b/.changeset/popular-trains-sniff.md
@@ -1,0 +1,7 @@
+---
+"@spectrum-css/infieldbutton": patch
+---
+
+### Infield button and stepper fast follows
+
+- Updated infield button disabled border color to use `--spectrum-gray-300` for spectrum-two theme and `--spectrum-gray-200` for other themes.

--- a/components/infieldbutton/dist/metadata.json
+++ b/components/infieldbutton/dist/metadata.json
@@ -132,6 +132,7 @@
     "--spectrum-disabled-content-color",
     "--spectrum-gray-100",
     "--spectrum-gray-200",
+    "--spectrum-gray-300",
     "--spectrum-neutral-content-color-default",
     "--spectrum-neutral-content-color-down",
     "--spectrum-neutral-content-color-hover",
@@ -146,6 +147,7 @@
     "--system-infield-button-border-radius",
     "--system-infield-button-border-radius-reset",
     "--system-infield-button-border-width",
+    "--system-infield-button-disabled-border-color",
     "--system-infield-button-stacked-bottom-border-radius-end-start",
     "--system-infield-button-stacked-top-border-radius-start-start"
   ],

--- a/components/infieldbutton/index.css
+++ b/components/infieldbutton/index.css
@@ -38,7 +38,7 @@
 		--mod-infield-button-background-color-hover: var(--mod-infield-button-background-color-hover-disabled, var(--spectrum-disabled-background-color));
 		--mod-infield-button-background-color-down: var(--mod-infield-button-background-color-down-disabled, var(--spectrum-disabled-background-color));
 
-		--mod-infield-button-border-color: var(--mod-infield-button-border-color-disabled, var(--spectrum-disabled-background-color));
+		--mod-infield-button-border-color: var(--mod-infield-button-border-color-disabled, var(--spectrum-infield-button-border-color));
 
 		--mod-infield-button-icon-color: var(--mod-infield-button-icon-color-disabled, var(--spectrum-disabled-content-color));
 		--mod-infield-button-icon-color-hover: var(--mod-infield-button-icon-color-hover-disabled, var(--spectrum-disabled-content-color));

--- a/components/infieldbutton/themes/spectrum-two.css
+++ b/components/infieldbutton/themes/spectrum-two.css
@@ -27,5 +27,9 @@
 		--spectrum-infield-button-background-color-hover: var(--spectrum-gray-200);
 		--spectrum-infield-button-background-color-down: var(--spectrum-gray-200);
 		--spectrum-infield-button-background-color-key-focus: var(--spectrum-gray-200);
+
+		&:disabled {
+			--spectrum-infield-button-border-color: var(--spectrum-gray-300);
+		}
 	}
 }

--- a/components/infieldbutton/themes/spectrum.css
+++ b/components/infieldbutton/themes/spectrum.css
@@ -21,5 +21,9 @@
 		--spectrum-infield-button-background-color-hover: var(--spectrum-gray-200);
 		--spectrum-infield-button-background-color-down: var(--spectrum-gray-300);
 		--spectrum-infield-button-background-color-key-focus: var(--spectrum-gray-200);
+
+		&:disabled {
+			--spectrum-infield-button-border-color: var(--spectrum-gray-200);
+		}
 	}
 }


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

The design feedback for number field revealed some requests regarding the border colors of the stepper/number field, and most recently related to the nested infield button. This PR aims to address that feedback.

Updates the value of disabled border of infield-button
```
Disabled state (in-field button)
Expected: gray-300 border
```

Additional feedback included: 
- Focus hover state (textfield)
_Expected: gray-900 border_ ✅ 
- Default state (in-field button)
_Expected: gray-100 button background_ ✅ 
- Disabled state (in-field button)
_Expected: gray-300 border_ ✅ 
- Hover state (in-field button)
_Expected: gray-200 button background_ ✅ 
- Key focus state (in-field button)
~~_Expected: gray-200 button background_
_Expected: gray-900 chevron color_~~

The green checkmarks above are styles that are already found for the stepper/number field styles in the CSS repo. The PRs that addressed these already can be found here:
https://github.com/adobe/spectrum-css/pull/3536 (for the infield button background color corrections)
https://github.com/adobe/spectrum-css/pull/3621 (for the focus+hover border color correction)

**NOTE:** We received some updated feedback from design regarding the key focus state, which means that no further CSS changes were necessary!

- Key focus state (in-field button)
_Expected: gray-100 button background (incorrectly had this as gray-200 originally)_ ✅ 
_Expected: gray-800 chevron color (incorrectly had this as gray-900 originally)_ ✅ 


<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

### Jira/Specs
SWC-576

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

- [x] Pull down the branch to run locally or [visit the deploy preview](https://pr-3615--spectrum-css.netlify.app/?path=/docs/guides-contributing--docs). [@cdransf]
- [x] [Navigate to the infield button docs page](https://pr-3615--spectrum-css.netlify.app/?path=/docs/components-in-field-button--docs). [@cdransf]
- [x] Inspect the disabled infield button.
- [x] Verify the border color in the S2 context resolves to `gray-300`. [@cdransf]
<img width="89" alt="Screenshot 2025-04-03 at 11 57 58 AM" src="https://github.com/user-attachments/assets/5db13b30-760b-4691-b526-e4fc71e17877" />

### Additional validation (the remaining validation steps likely were already completed in #3536  and #3621. This CSS already exists and functions as design expects 🥳 )
- [x] Verify the border color of the infield button resolves to `gray-200` in both the [S1](https://pr-3615--spectrum-css.netlify.app/?path=/docs/components-in-field-button--docs&globals=context:legacy) and [Express](https://pr-3615--spectrum-css.netlify.app/?path=/docs/components-in-field-button--docs&globals=context:express) contexts. [@cdransf]
<img width="92" alt="Screenshot 2025-04-03 at 11 59 58 AM" src="https://github.com/user-attachments/assets/94e14abc-be5f-40f1-91d7-ae3ee9f607fe" />
<img width="73" alt="Screenshot 2025-04-03 at 11 59 34 AM" src="https://github.com/user-attachments/assets/bc2eb447-babb-4f80-89a5-031b13b110c0" />

- [x] [Navigate to the stepper testing grid](https://pr-3615--spectrum-css.netlify.app/?path=/story/components-stepper--default&globals=testingPreview:!true). [@cdransf]
- [x] Inspect the default stepper. Verify the nested infield button has a background color of `gray-100`. [@cdransf]
<img width="201" alt="Screenshot 2025-04-03 at 12 02 19 PM" src="https://github.com/user-attachments/assets/5ade1fbf-d184-4c8a-af65-a1107399b266" />

- [x] Inspect the hover state stepper. Inspect the `.spectrum-InfieldButton` element (one of the stepper buttons) and turn on the `:hover` state in your dev tools. Verify the nested infield button has a background color of `gray-200`. [@cdransf]
<img width="308" alt="Screenshot 2025-04-03 at 5 02 43 PM" src="https://github.com/user-attachments/assets/686bcbb0-a410-4ebb-82c1-ea94acca6764" />

- [x] Inspect the keyboardFocus state stepper. Verify the nested infield button also has a background color of `gray-100`. [@cdransf]
- [x] Still in the keyboardFocus stepper, inspect the chevron within the infield button. It should have a color of `gray-800`. [@cdransf]
<img width="520" alt="Screenshot 2025-04-04 at 4 27 25 PM" src="https://github.com/user-attachments/assets/9a1334a6-aa37-4fcf-ad72-1653b60e8f61" />

- [x] Inspect the focus state stepper. In your browser dev tools, turn on the `:hover` state of `.spectrum-Stepper` and `.spectrum-Stepper-textfield`. [@cdransf]
- [x] Verify in this focus+hover state, verify the textfield has a border of `gray-900`. [@cdransf]
<img width="449" alt="Screenshot 2025-04-03 at 12 11 05 PM" src="https://github.com/user-attachments/assets/e7a1d18f-efa9-4acd-a308-ecc268dc4fa9" />

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->
Before 🚫 
<img width="66" alt="Screenshot 2025-04-04 at 4 48 12 PM" src="https://github.com/user-attachments/assets/7ec23118-55d6-4408-8631-c7a00376143f" />
<img width="251" alt="Screenshot 2025-04-04 at 4 51 38 PM" src="https://github.com/user-attachments/assets/d27984e7-66ec-4275-ae61-e3e0b5266b2f" />

After ✅ 
<img width="60" alt="Screenshot 2025-04-04 at 4 47 58 PM" src="https://github.com/user-attachments/assets/78fad88d-746f-484c-b638-12354d92d6d4" />
<img width="390" alt="Screenshot 2025-04-04 at 4 51 32 PM" src="https://github.com/user-attachments/assets/587cc603-76c1-4f30-afb6-1846e7433486" />

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] ✨ This pull request is ready to merge. ✨
