### PR TITLE
fix(checkbox): corrects invalid+checked+hover background color

### DIFF
--- a/.changeset/blue-wasps-talk.md
+++ b/.changeset/blue-wasps-talk.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/checkbox": patch
+---
+
+Adds a `::before` pseudo element to properly target the `.spectrum-Checkbox-input:checked + .spectrum-Checkbox-box` element. The selector update, specifically in the invalid+checked+hover state should now get the proper error background color, as opposed to the default background color.

--- a/components/checkbox/dist/metadata.json
+++ b/components/checkbox/dist/metadata.json
@@ -66,7 +66,7 @@
     ".spectrum-Checkbox.is-invalid.is-indeterminate:hover .spectrum-Checkbox-input:checked + .spectrum-Checkbox-box:before",
     ".spectrum-Checkbox.is-invalid.is-indeterminate:hover .spectrum-Checkbox-label",
     ".spectrum-Checkbox.is-invalid:hover .spectrum-Checkbox-box:before",
-    ".spectrum-Checkbox.is-invalid:hover .spectrum-Checkbox-input:checked + .spectrum-Checkbox-box",
+    ".spectrum-Checkbox.is-invalid:hover .spectrum-Checkbox-input:checked + .spectrum-Checkbox-box:before",
     ".spectrum-Checkbox.is-readOnly .spectrum-Checkbox-input",
     ".spectrum-Checkbox.is-readOnly .spectrum-Checkbox-input:checked:disabled + .spectrum-Checkbox-box:before",
     ".spectrum-Checkbox.is-readOnly .spectrum-Checkbox-input:checked:disabled ~ .spectrum-Checkbox-label",

--- a/components/checkbox/index.css
+++ b/components/checkbox/index.css
@@ -158,7 +158,7 @@
 		}
 
 		&:hover {
-			.spectrum-Checkbox-input:checked + .spectrum-Checkbox-box,
+			.spectrum-Checkbox-input:checked + .spectrum-Checkbox-box::before,
 			.spectrum-Checkbox-box::before {
 				border-color: var(--highcontrast-checkbox-color-hover, var(--mod-checkbox-invalid-color-hover, var(--spectrum-checkbox-invalid-color-hover)));
 			}
@@ -280,6 +280,7 @@
 		}
 	}
 
+	/* TODO: Because this selector was moved to the default variant's styles, this selector block can be deleted when it is safe to make changes to selectors. */
 	/* Invalid Hover States */
 	&.is-invalid:hover {
 		&.is-indeterminate .spectrum-Checkbox-box,


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

This PR addresses the regression we noticed in the invalid checkboxes, where the default hover color was "winning" out over the invalid hover color. To avoid this bug in the future, #3625 adds several tests and more Storybook support for hovers through the shared type control.

This PR includes adding a `::before` selector in the `is-invalid` hover state.

It should be noted that there is more opportunity to refactor here. I noticed that the emphasized+invalid+checked+hovered state was behaving as expected. If that selector block (marked with a `TODO` in commit https://github.com/adobe/spectrum-css/pull/3617/commits/ea8741a7f04a8bfa3b2a6deb6d18452ba7cb1d29) gets consolidated or moved into the default `.spectrum-Checkbox`, it seemed like it could safely be removed and all the styles would cascade as expected. [The first commit in this PR](https://github.com/adobe/spectrum-css/pull/3617/commits/77a098d9fed051aa7a069ae8abe61f0050e18ef9) reorganizes the emphasized invalid+checked+hovered css to be included with the default invalid+checked+hovered css, but that felt too repetitive. So instead, adding a `::before` pseudo element appropriately targeted the invalid hovered checkboxes. Both approaches unfortunately led to selector changes.

### Jira/Specs
[CSS-1139](https://jira.corp.adobe.com/browse/CSS-1139)

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

- [x] Pull down the branch to run locally or [visit the deploy preview](https://pr-3617--spectrum-css.netlify.app/?path=/docs/guides-contributing--docs). [@cdransf]
- [x] [Visit the checkbox docs page](https://pr-3617--spectrum-css.netlify.app/?path=/docs/components-checkbox--docs). [@cdransf]
- [x] Inspect the invalid set of checkboxes in the default story canvas.  [@cdransf]
- [x] Verify that when a `.spectrum-Checkbox` element is hovered, the `.spectrum-Checkbox-box::before` pseudo element has a border color of `--spectrum-checkbox-invalid-color-hover: var(--spectrum-negative-color-1000);`. This applies to all 3 states (unchecked, checked, indeterminate). [@cdransf]
- [x] Repeat the steps above with the invalid set of checkboxes in the emphasized styling to verify no regressions have occurred. [@cdransf]
- [x] Confirm that the changes seen in the S2 foundations theme have been corrected in [S1](https://pr-3617--spectrum-css.netlify.app/?path=/docs/components-checkbox--docs&globals=context:legacy) and [Express](https://pr-3617--spectrum-css.netlify.app/?path=/docs/components-checkbox--docs&globals=context:express) themes. [@cdransf]


### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

Before 🚫 
<img width="217" alt="Screenshot 2025-03-12 at 10 54 10 AM" src="https://github.com/user-attachments/assets/c04bfb10-2fb4-4030-8c28-9d336bd77b04" />

After ✅ 
<img width="233" alt="Screenshot 2025-03-12 at 10 54 27 AM" src="https://github.com/user-attachments/assets/181dbe41-cc28-4e1f-acff-3a88d3bcf278" />

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] ✨ This pull request is ready to merge. ✨
