### PR TITLE
fix(stepper): focus/focus+hover/keyboardFocus border colors

### DIFF
--- a/.changeset/sharp-spiders-complain.md
+++ b/.changeset/sharp-spiders-complain.md
@@ -1,0 +1,6 @@
+---
+"@spectrum-css/stepper": patch
+---
+
+- Updates `--spectrum-stepper-border-color-focus-hover` from `gray-800` to `gray-900`.
+- Updates `--spectrum-stepper-buttons-border-color-keyboard-focus` from `gray-900` to `gray-800` to match the rest of the border color on keyboardFocus.

--- a/components/stepper/themes/spectrum-two.css
+++ b/components/stepper/themes/spectrum-two.css
@@ -17,7 +17,7 @@
 		--spectrum-stepper-border-color-default: var(--spectrum-gray-500);
 		--spectrum-stepper-border-color-hover: var(--spectrum-gray-600);
 		--spectrum-stepper-border-color-focus: var(--spectrum-gray-800);
-		--spectrum-stepper-border-color-focus-hover: var(--spectrum-gray-800);
+		--spectrum-stepper-border-color-focus-hover: var(--spectrum-gray-900);
 		--spectrum-stepper-border-color-keyboard-focus: var(--spectrum-gray-800);
 
 		--spectrum-stepper-buttons-border-style: none;
@@ -26,7 +26,7 @@
 		--spectrum-stepper-buttons-background-color: var(--spectrum-gray-100);
 		--spectrum-stepper-buttons-border-color-hover: var(--spectrum-gray-600);
 		--spectrum-stepper-buttons-border-color-focus: var(--spectrum-gray-800);
-		--spectrum-stepper-buttons-border-color-keyboard-focus: var(--spectrum-gray-900);
+		--spectrum-stepper-buttons-border-color-keyboard-focus: var(--spectrum-gray-800);
 
 		--spectrum-stepper-button-border-width: var(--spectrum-border-width-100);
 


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description
SWC got some design feedback on stepper for S2 foundations to "update the stepper focus hover border color to gray-900 (currently its 800)." This PR should address that by updating the values for `focus-hover` from `gray-800` to `gray-900`, as well as update the stepper buttons' border color for `keyboard-focus` to `gray-800`, matching the nested textfield's keyboard-focus color.

### Jira/Specs
This work relates to [SWC-576](https://jira.corp.adobe.com/browse/SWC-576) and [SWC-501](https://jira.corp.adobe.com/browse/SWC-501) I believe. 🤔 

### Video walkthrough
[PR description and validation instructions](https://adobe-my.sharepoint.com/:v:/p/for00418/EW81Rx6hYlRAmWrGrzJTeqsBFEK5zabyIBllmXUC8Izl5Q?e=e0kjfF)
<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

- [x] Pull down the repo to run locally or [visit the deploy preview](https://pr-3621--spectrum-css.netlify.app/) [@cdransf]
- [x] [Navigate to the stepper testing view](https://pr-3621--spectrum-css.netlify.app/?path=/story/components-stepper--default&globals=testingPreview:!true).
- [x] In your browser, inspect the `.spectrum-Stepper` parent element of the Focused stepper test. [@cdransf]
- [x] By turning on the `hover` state in your inspector, verify the `.spectrum-Stepper-buttons` have a border color that resolves to `gray-900` via the `stepper-border-color-focus-hover` variable. [@cdransf]
- [x] Then inspect the nested `.spectrum-Stepper-input` element. [@cdransf]
- [x] When you turn on the `hover` for that element in your inspector, the border color should also resolve to `gray-900` via `textfield-border-color-focus-hover`. [@cdransf]
- [x] Inspect the keyboard-focused stepper in the testing grids. [@cdransf]
- [x] Check that both border colors of `.spectrum-Stepper-buttons` and `.spectrum-Stepper-input` elements resolve to `gray-800`. (no need to check the hover states for this one!) [@cdransf]

**Note:** I did find it slightly easier to visually see the differences here by toggling dark mode on in the Storybook toolbar.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] ✨ This pull request is ready to merge. ✨
