### PR TITLE
fix(alertbanner): change system variable from spectrum to legacy

### DIFF
--- a/.changeset/metal-eels-protect.md
+++ b/.changeset/metal-eels-protect.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/alertbanner": patch
+---
+
+In the alert banner spectrum.css (the S1 stylesheet), --system: legacy was corrected in the container query.

--- a/components/alertbanner/themes/spectrum.css
+++ b/components/alertbanner/themes/spectrum.css
@@ -15,7 +15,7 @@
 
 @import "./spectrum-two.css";
 
-@container style(--system: spectrum) {
+@container style(--system: legacy) {
 	.spectrum-AlertBanner {
 		--spectrum-alert-banner-neutral-background: var(--spectrum-neutral-subdued-background-color-default);
 	}


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

Noted in #3609, we found that the alert banner contained `--system: spectrum` (which should indicate S2 design/theming) in the `spectrum.css` or S1 stylesheet. This PR corrects that 👍 

No style changes should have occurred in this work.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->
- [ ] Pull down the branch to run locally or [visit the deploy preview](https://pr-3624--spectrum-css.netlify.app/).
- [ ] [Visit the alert banner docs page](https://pr-3624--spectrum-css.netlify.app/?path=/docs/components-alert-banner--docs) in the S2 context.
- [ ] Inspect the `.spectrum-AlertBanner--neutral` element.
- [ ] Verify the background color is set to `--spectrum-alert-banner-neutral-background`, which should resolve to `--spectrum-neutral-subdued-background-color-default` and `gray-700`.
- [ ] [Visit the alert banner docs page in the S1 context](https://pr-3624--spectrum-css.netlify.app/?path=/docs/components-alert-banner--docs&globals=context:legacy).
- [ ] Verify the background color is set to `--spectrum-alert-banner-neutral-background`, which should resolve to `--spectrum-neutral-subdued-background-color-default` and `gray-600`.
- [ ] In your code editor, search the repo for `--system: spectrum` (which points to S2 design tokens), but filter by files that are `*/themes/spectrum.css`, which corresponds to the S1 design tokens. Nothing should be returned.
    - If the combobox spectrum.css file gets return for having `--system: spectrum` in the S1 file, this is addressed in #3609.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
