### PR TITLE
test(checkbox): add more coverage for checkbox

### DIFF
--- a/components/checkbox/stories/checkbox.stories.js
+++ b/components/checkbox/stories/checkbox.stories.js
@@ -1,6 +1,6 @@
 import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
-import { isChecked, isDisabled, isEmphasized, isIndeterminate, isInvalid, isReadOnly, size } from "@spectrum-css/preview/types";
+import { isChecked, isDisabled, isEmphasized, isHovered, isIndeterminate, isInvalid, isReadOnly, size } from "@spectrum-css/preview/types";
 import metadata from "../dist/metadata.json";
 import packageJson from "../package.json";
 import { CheckboxGroup } from "./checkbox.test.js";
@@ -30,6 +30,7 @@ export default {
 			control: { type: "text" },
 		},
 		isEmphasized,
+		isHovered,
 		isInvalid,
 		isDisabled,
 		isChecked,
@@ -43,6 +44,7 @@ export default {
 		isChecked: false,
 		isDisabled: false,
 		isEmphasized: false,
+		isHovered: false,
 		isIndeterminate: false,
 		isInvalid: false,
 		isReadOnly: false,

--- a/components/checkbox/stories/checkbox.test.js
+++ b/components/checkbox/stories/checkbox.test.js
@@ -28,6 +28,11 @@ export const CheckboxGroup = Variants({
 			isChecked: true,
 		},
 		{
+			testHeading: "Checked, hovered",
+			isChecked: true,
+			isHovered: true,
+		},
+		{
 			testHeading: "Indeterminate",
 			isIndeterminate: true,
 		},
@@ -39,6 +44,12 @@ export const CheckboxGroup = Variants({
 			testHeading: "Invalid, checked",
 			isInvalid: true,
 			isChecked: true,
+		},
+		{
+			testHeading: "Invalid, checked, hovered",
+			isInvalid: true,
+			isChecked: true,
+			isHovered: true,
 		},
 		{
 			testHeading: "Invalid, indeterminate",
@@ -55,6 +66,11 @@ export const CheckboxGroup = Variants({
 			isChecked: true,
 		},
 		{
+			testHeading: "Disabled, checked, hovered",
+			isDisabled: true,
+			isChecked: true,
+		},
+		{
 			testHeading: "Disabled, indeterminate",
 			isDisabled: true,
 			isIndeterminate: true,
@@ -67,6 +83,12 @@ export const CheckboxGroup = Variants({
 			testHeading: "Read-only, checked",
 			isReadOnly: true,
 			isChecked: true,
+		},
+		{
+			testHeading: "Read-only, checked, hovered",
+			isReadOnly: true,
+			isChecked: true,
+			isHovered: true,
 		},
 		{
 			testHeading: "Read-only, indeterminate",

--- a/components/checkbox/stories/template.js
+++ b/components/checkbox/stories/template.js
@@ -17,6 +17,7 @@ export const Template = ({
 	label,
 	isChecked = false,
 	isEmphasized = false,
+	isHovered = false,
 	isIndeterminate = false,
 	isDisabled = false,
 	isInvalid = false,
@@ -55,6 +56,7 @@ export const Template = ({
 				["is-indeterminate"]: isIndeterminate,
 				["is-disabled"]: isDisabled,
 				["is-invalid"]: isInvalid,
+				["is-hover"]: isHovered && !isDisabled,
 				["is-readOnly"]: isReadOnly,
 				...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
 			})}

--- a/components/form/stories/form.stories.js
+++ b/components/form/stories/form.stories.js
@@ -1,4 +1,3 @@
-import { Template as Checkbox } from "@spectrum-css/checkbox/stories/template.js";
 import { Template as Fieldgroup } from "@spectrum-css/fieldgroup/stories/template.js";
 import { Template as Picker } from "@spectrum-css/picker/stories/template.js";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
@@ -80,18 +79,19 @@ export default {
 				content: [
 					(passthroughs, context) => Fieldgroup({
 						layout: "horizontal",
+						inputType: "checkbox",
 						items: [
-							Checkbox({
+							{
 								...passthroughs,
 								label: "Kittens",
 								customClasses: ["spectrum-FieldGroup-item"],
-							}, context),
-							Checkbox({
+							},
+							{
 								...passthroughs,
 								label: "Puppies",
 								customClasses: ["spectrum-FieldGroup-item"],
-							}, context),]
-					}),
+							}]
+					}, context),
 				],
 			},{
 				label: "Age",


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

This PR adds several tests and more Storybook support for hovers through the shared type control. Additionally, this PR should address the regressions found on the form docs page, where some inputs (based on work from https://github.com/adobe/spectrum-css/pull/3227 and https://github.com/adobe/spectrum-css/pull/3165) no longer had labels.

### Jira/Specs
Related: [CSS-1139](https://jira.corp.adobe.com/browse/CSS-1139)

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

- [x] Pull down the branch to run locally or [visit the deploy preview](https://pr-3625--spectrum-css.netlify.app/?path=/docs/guides-contributing--docs).
- [x] [Visit the checkbox testing page](https://pr-3625--spectrum-css.netlify.app/?path=/story/components-checkbox--default&globals=testingPreview:!true).
- [x] Verify in each context that the new test cases appear & render as expected. Nothing should look broken. 🤞 
    - `checked+hovered`
    - `invalid+checked+hovered`
    - `disabled+checked+hovered`
    - `readonly+checked+hovered`
- [x] [Visit the form docs page](https://pr-3625--spectrum-css.netlify.app/?path=/docs/components-form--docs&globals=testingPreview:!true).
- [x] Ensure that the checkbox inputs now have labels for 🐱 and 🐶 ("kittens" and "puppies").

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

Before 🚫 
<img width="237" alt="Screenshot 2025-03-12 at 12 13 02 PM" src="https://github.com/user-attachments/assets/604d2e72-43e4-48a4-8cdb-1ee723abac36" />

After ✅ 
<img width="238" alt="Screenshot 2025-03-12 at 12 13 27 PM" src="https://github.com/user-attachments/assets/0621a6f4-b8d2-4b3d-b1a2-1ad064938808" />

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [ ] ✨ This pull request is ready to merge. ✨
