### PR TITLE
chore: patch tj-actions vulnerability

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -95,7 +95,7 @@ jobs:
         steps:
             - name: Get changed files
               id: changed-files
-              uses: tj-actions/changed-files@v45
+              uses: step-security/changed-files@v45
               with:
                   files_yaml: |
                       styles:


### PR DESCRIPTION
## Description

Due to a high vulnerability security issue with the tj-actions package for changed-files, that GitHub Action has been blocked in our allowlist. To retain this functionality, we have leveraged the patched clone by step-security, as documented [here](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised).

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] ✨ This pull request is ready to merge. ✨
