### PR TITLE
fix(pickerbutton): correct states' background colors

### DIFF
--- a/.changeset/kind-walls-fix.md
+++ b/.changeset/kind-walls-fix.md
@@ -1,0 +1,9 @@
+---
+"@spectrum-css/pickerbutton": patch
+---
+
+Updates background colors for the picker button to match S2-foundations design specs.
+
+default state: gray-50 to gray-100
+hover state: gray-100 to gray-200
+key-focus state: gray-100 to gray-200

--- a/components/pickerbutton/dist/metadata.json
+++ b/components/pickerbutton/dist/metadata.json
@@ -126,7 +126,6 @@
     "--spectrum-font-size-75",
     "--spectrum-gray-100",
     "--spectrum-gray-200",
-    "--spectrum-gray-50",
     "--spectrum-neutral-content-color-default",
     "--spectrum-neutral-content-color-down",
     "--spectrum-neutral-content-color-hover",

--- a/components/pickerbutton/themes/spectrum-two.css
+++ b/components/pickerbutton/themes/spectrum-two.css
@@ -13,10 +13,10 @@
 
 @container style(--system: spectrum) {
 	.spectrum-PickerButton {
-		--spectrum-picker-button-background-color: var(--spectrum-gray-50);
-		--spectrum-picker-button-background-color-hover: var(--spectrum-gray-100);
+		--spectrum-picker-button-background-color: var(--spectrum-gray-100);
+		--spectrum-picker-button-background-color-hover: var(--spectrum-gray-200);
 		--spectrum-picker-button-background-color-down: var(--spectrum-gray-200);
-		--spectrum-picker-button-background-color-key-focus: var(--spectrum-gray-100);
+		--spectrum-picker-button-background-color-key-focus: var(--spectrum-gray-200);
 
 		--spectrum-picker-button-border-color: none;
 		--spectrum-picker-button-border-radius: var(--spectrum-corner-radius-75);


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->
Further design feedback was given regarding the nested picker button within combobox:

Default state: gray-100 background color expected.
Button: Hover state: gray-200 background color expected.
Button: Down state: gray-200 background color expected.
Button: Keyboard focus state: gray-200 background color expected.

This PR addresses these requests and fixes the custom property references within picker button's `spectrum-two.css` theme file.

### Jira/Specs
[SWC-582](https://jira.corp.adobe.com/browse/SWC-582)
[Figma SWC feedback](https://www.figma.com/design/JAyGhxAD6s9mD6vbTJNVHD/Design-QA-for-SWC-foundations?node-id=399-10335&m=dev)
[Slack thread (in temp-s2-foundations-delivery)](https://adobedesign.slack.com/archives/C06Q3G5HJUX/p1742248946161009?thread_ts=1741699553.838139&cid=C06Q3G5HJUX)

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->
- [x] Pull down the branch to run locally or [visit the deploy preview](https://pr-3630--spectrum-css.netlify.app/). [@cdransf]
- [x] [Visit the combobox testing preview](https://pr-3630--spectrum-css.netlify.app/?path=/story/components-combobox--default&globals=testingPreview:!true). [@cdransf]
- [x] Inspect the `spectrum-PickerButton-fill` element in the default combobox. [@cdransf]
- [x] Verify it has a background color that resolves to `gray-100`.  [@cdransf]
- [x] Inspect the parent element, `spectrum-PickerButton` and turn on the hover state in your browser's dev tools. [@cdransf]
- [x] Verify `spectrum-PickerButton-fill`'s background color changes to `gray-200`, then remove the forced hover state. [@cdransf]
- [x] Repeat the last two steps with the `:active` state instead of hover. `spectrum-PickerButton-fill` should still have a `gray-200` background in its active/down state. [@cdransf]
- [x] Inspect the `spectrum-PickerButton-fill` of the keyboard-focused combobox. [@cdransf]
- [x] Lastly, this background color should also be `gray-200`. [@cdransf]

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have tested these changes in Windows High Contrast mode.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] ✨ This pull request is ready to merge. ✨
