### PR TITLE
fix(tooltip): restore negative and informative semantic variants

### DIFF
--- a/.changeset/stale-pans-carry.md
+++ b/.changeset/stale-pans-carry.md
@@ -1,0 +1,12 @@
+---
+"@spectrum-css/tooltip": minor
+---
+
+#### S2: restore negative and informative semantic variants
+
+This restores the negative and informative tooltip semantic variant styles, story controls and test cases. Icons have been removed for all variants as they are not present in the specifications provided by design.
+
+##### Restored mods
+
+`--mod-tooltip-background-color-informative`
+`--mod-tooltip-background-color-negative"`

--- a/components/tooltip/dist/metadata.json
+++ b/components/tooltip/dist/metadata.json
@@ -374,8 +374,6 @@
   "passthroughs": [],
   "high-contrast": [
     "--highcontrast-tooltip-background-color-default",
-    "--highcontrast-tooltip-background-color-informative",
-    "--highcontrast-tooltip-background-color-negative",
     "--highcontrast-tooltip-border-width"
   ]
 }

--- a/components/tooltip/dist/metadata.json
+++ b/components/tooltip/dist/metadata.json
@@ -35,6 +35,8 @@
     ".spectrum-Tooltip--end-top.is-open:dir(rtl)",
     ".spectrum-Tooltip--end.is-open",
     ".spectrum-Tooltip--end.is-open:dir(rtl)",
+    ".spectrum-Tooltip--info",
+    ".spectrum-Tooltip--info .spectrum-Tooltip-tip",
     ".spectrum-Tooltip--left",
     ".spectrum-Tooltip--left .spectrum-Tooltip-tip",
     ".spectrum-Tooltip--left .spectrum-Tooltip-tip:dir(rtl)",
@@ -47,6 +49,8 @@
     ".spectrum-Tooltip--left-top .spectrum-Tooltip-tip:dir(rtl)",
     ".spectrum-Tooltip--left-top.is-open",
     ".spectrum-Tooltip--left.is-open",
+    ".spectrum-Tooltip--negative",
+    ".spectrum-Tooltip--negative .spectrum-Tooltip-tip",
     ".spectrum-Tooltip--right",
     ".spectrum-Tooltip--right .spectrum-Tooltip-tip",
     ".spectrum-Tooltip--right .spectrum-Tooltip-tip:dir(rtl)",
@@ -302,6 +306,8 @@
     "--mod-overlay-animation-duration-opened",
     "--mod-tooltip-animation-distance",
     "--mod-tooltip-background-color-default",
+    "--mod-tooltip-background-color-informative",
+    "--mod-tooltip-background-color-negative",
     "--mod-tooltip-border-radius",
     "--mod-tooltip-cjk-line-height",
     "--mod-tooltip-content-color",
@@ -324,8 +330,9 @@
   "component": [
     "--spectrum-tooltip-animation-distance",
     "--spectrum-tooltip-animation-duration",
-    "--spectrum-tooltip-backgound-color-default-neutral",
     "--spectrum-tooltip-background-color-default",
+    "--spectrum-tooltip-background-color-informative",
+    "--spectrum-tooltip-background-color-negative",
     "--spectrum-tooltip-border-radius",
     "--spectrum-tooltip-cjk-line-height",
     "--spectrum-tooltip-content-color",
@@ -358,14 +365,17 @@
     "--spectrum-corner-radius-400",
     "--spectrum-font-size-75",
     "--spectrum-gray-25",
+    "--spectrum-informative-background-color-default",
+    "--spectrum-negative-background-color-default",
     "--spectrum-neutral-background-color-default",
-    "--spectrum-neutral-subdued-background-color-default",
     "--spectrum-regular-font-weight",
     "--spectrum-spacing-75"
   ],
   "passthroughs": [],
   "high-contrast": [
     "--highcontrast-tooltip-background-color-default",
+    "--highcontrast-tooltip-background-color-informative",
+    "--highcontrast-tooltip-background-color-negative",
     "--highcontrast-tooltip-border-width"
   ]
 }

--- a/components/tooltip/index.css
+++ b/components/tooltip/index.css
@@ -14,8 +14,6 @@
 @import "@spectrum-css/commons/overlay.css";
 
 .spectrum-Tooltip {
-	--spectrum-tooltip-backgound-color-default-neutral: var(--spectrum-neutral-subdued-background-color-default);
-
 	--spectrum-tooltip-animation-duration: var(--spectrum-animation-duration-100);
 	--spectrum-tooltip-animation-distance: var(--spectrum-spacing-75);
 
@@ -43,6 +41,10 @@
 	--spectrum-tooltip-content-color: var(--spectrum-gray-25);
 	--spectrum-tooltip-background-color-default: var(--spectrum-neutral-background-color-default);
 
+	/* colors */
+	--spectrum-tooltip-background-color-informative: var(--spectrum-informative-background-color-default);
+	--spectrum-tooltip-background-color-negative: var(--spectrum-negative-background-color-default);
+
 	/* tip */
 	--spectrum-tooltip-tip-block-size: var(--spectrum-tooltip-tip-height);
 
@@ -57,6 +59,7 @@
 
 	--highcontrast-tooltip-border-width: 0px;
 }
+
 .spectrum-Tooltip {
 	@extend %spectrum-overlay;
 
@@ -102,6 +105,15 @@
 	}
 }
 
+/****** Variants ******/
+.spectrum-Tooltip--info {
+	background-color: var(--highcontrast-tooltip-background-color-informative, var(--mod-tooltip-background-color-informative, var(--spectrum-tooltip-background-color-informative)));
+}
+
+.spectrum-Tooltip--negative {
+	background-color: var(--highcontrast-tooltip-background-color-negative, var(--mod-tooltip-background-color-negative, var(--spectrum-tooltip-background-color-negative)));
+}
+
 .spectrum-Tooltip.is-open {
 	@extend %spectrum-overlay--open;
 }
@@ -124,6 +136,14 @@
 	clip-path: polygon(0 0, 100% var(--mod-tooltip-tip-height-percentage, var(--spectrum-tooltip-tip-height-percentage)), 0 100%);
 
 	border-radius: 0 0 0 var(--mod-tooltip-tip-corner-radius, var(--spectrum-tooltip-tip-corner-radius));
+
+	.spectrum-Tooltip--info & {
+		background-color: var(--highcontrast-tooltip-background-color-informative, var(--mod-tooltip-background-color-informative, var(--spectrum-tooltip-background-color-informative)));
+	}
+
+	.spectrum-Tooltip--negative & {
+		background-color: var(--highcontrast-tooltip-background-color-negative, var(--mod-tooltip-background-color-negative, var(--spectrum-tooltip-background-color-negative)));
+	}
 
 	/*** Tip Placement ***/
 	/* tip is horizontal at bottom pointing down ▽ */
@@ -576,11 +596,13 @@
 @media (forced-colors: active) {
 	.spectrum-Tooltip {
 		--highcontrast-tooltip-border-width: 1px;
-        
+
 		border: var(--highcontrast-tooltip-border-width) solid CanvasText;
 	}
 
 	.spectrum-Tooltip-tip {
 		--highcontrast-tooltip-background-color-default: CanvasText;
+		--highcontrast-tooltip-background-color-informative: CanvasText;
+		--highcontrast-tooltip-background-color-negative: CanvasText;
 	}
 }

--- a/components/tooltip/index.css
+++ b/components/tooltip/index.css
@@ -107,11 +107,11 @@
 
 /****** Variants ******/
 .spectrum-Tooltip--info {
-	background-color: var(--highcontrast-tooltip-background-color-informative, var(--mod-tooltip-background-color-informative, var(--spectrum-tooltip-background-color-informative)));
+	background-color: var(--highcontrast-tooltip-background-color-default, var(--mod-tooltip-background-color-informative, var(--spectrum-tooltip-background-color-informative)));
 }
 
 .spectrum-Tooltip--negative {
-	background-color: var(--highcontrast-tooltip-background-color-negative, var(--mod-tooltip-background-color-negative, var(--spectrum-tooltip-background-color-negative)));
+	background-color: var(--highcontrast-tooltip-background-color-default, var(--mod-tooltip-background-color-negative, var(--spectrum-tooltip-background-color-negative)));
 }
 
 .spectrum-Tooltip.is-open {
@@ -138,11 +138,11 @@
 	border-radius: 0 0 0 var(--mod-tooltip-tip-corner-radius, var(--spectrum-tooltip-tip-corner-radius));
 
 	.spectrum-Tooltip--info & {
-		background-color: var(--highcontrast-tooltip-background-color-informative, var(--mod-tooltip-background-color-informative, var(--spectrum-tooltip-background-color-informative)));
+		background-color: var(--highcontrast-tooltip-background-color-default, var(--mod-tooltip-background-color-informative, var(--spectrum-tooltip-background-color-informative)));
 	}
 
 	.spectrum-Tooltip--negative & {
-		background-color: var(--highcontrast-tooltip-background-color-negative, var(--mod-tooltip-background-color-negative, var(--spectrum-tooltip-background-color-negative)));
+		background-color: var(--highcontrast-tooltip-background-color-default, var(--mod-tooltip-background-color-negative, var(--spectrum-tooltip-background-color-negative)));
 	}
 
 	/*** Tip Placement ***/
@@ -602,7 +602,5 @@
 
 	.spectrum-Tooltip-tip {
 		--highcontrast-tooltip-background-color-default: CanvasText;
-		--highcontrast-tooltip-background-color-informative: CanvasText;
-		--highcontrast-tooltip-background-color-negative: CanvasText;
 	}
 }

--- a/components/tooltip/stories/template.js
+++ b/components/tooltip/stories/template.js
@@ -1,4 +1,3 @@
-import { Template as Icon } from "@spectrum-css/icon/stories/template.js";
 import { Container } from "@spectrum-css/preview/decorators";
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
@@ -18,18 +17,7 @@ export const Template = ({
 	showOnHover = false,
 	customStyles = {},
 	customClasses = [],
-} = {}, context = {}) => {
-	let variantIcon;
-	if (variant === "info") {
-		variantIcon = "Info";
-	}
-	else if (variant === "positive") {
-		variantIcon = "CheckmarkCircle";
-	}
-	else if (variant === "negative") {
-		variantIcon = "Alert";
-	}
-
+} = {}) => {
 	if (showOnHover) {
 		document.addEventListener("DOMContentLoaded", () => {
 			[...document.querySelectorAll(`.${rootClass}`)].forEach(tooltip => {
@@ -42,6 +30,8 @@ export const Template = ({
 		<span
 			class=${classMap({
 				[rootClass]: true,
+				[`${rootClass}--${variant}`]:
+					typeof variant !== "undefined" && variant !== "neutral",
 				[`${rootClass}--${placement}`]: typeof placement !== "undefined",
 				"is-open": isOpen,
 				"is-focused": isFocused,
@@ -49,14 +39,6 @@ export const Template = ({
 			})}
 			style=${styleMap(customStyles)}
 		>
-			${when(variantIcon, () =>
-				Icon({
-					iconName: variantIcon,
-					setName: "workflow",
-					size: "m",
-					customClasses: [`${rootClass}-typeIcon`],
-				}, context)
-			)}
 			${when(label, () => html`
 				<span class=${classMap({
 					[`${rootClass}-label`]: true
@@ -145,7 +127,6 @@ export const SemanticVariantGroup = (args, context) => {
 	const variants = [
 		"neutral",
 		"info",
-		"positive",
 		"negative",
 	];
 

--- a/components/tooltip/stories/tooltip.stories.js
+++ b/components/tooltip/stories/tooltip.stories.js
@@ -21,6 +21,16 @@ export default {
 			},
 			control: "text",
 		},
+		variant: {
+			name: "Variant",
+			type: { name: "string" },
+			table: {
+				type: { summary: "string" },
+				category: "Component",
+			},
+			options: ["neutral", "info", "negative"],
+			control: "inline-radio",
+		},
 		placement: {
 			name: "Placement",
 			description: "The placement of the tooltip relative to the source. Note that placements that start with left/right do not change with text direction, but start/end placements do.",
@@ -76,6 +86,7 @@ export default {
 		isOpen: true,
 		isFocused: false,
 		showOnHover: false,
+		variant: "neutral",
 		label: "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
 	},
 	parameters: {
@@ -123,14 +134,10 @@ ShowOnHover.parameters = {
 
 /**
  * By default, tooltips are the neutral variant. This is the most common variant because most tooltips are used to only
- * disclose additional information, without conveying a semantic meaning. The neutral variant never includes an icon.
+ * disclose additional information, without conveying a semantic meaning.
  *
- * Tooltips also come in other semantic variants: informative (blue), positive (green), and negative (red). These use
+ * Tooltips also come in other semantic variants: informative (blue) and negative (red). These use
  * [semantic colors](https://spectrum.adobe.com/page/color-system/#Color-semantics) to communicate the meaning.
- *
- * These semantic variants include an icon to supplement the messaging. These icons are predefined and can not be
- * customized. Unless it's being used to provide context about the exact same icon, a semantic tooltip should always
- * show an icon. Doing this is essential for helping users with color vision deficiency to discern the message tone.
  */
 export const SemanticVariants = SemanticVariantGroup.bind({});
 SemanticVariants.tags = ["!dev"];

--- a/components/tooltip/stories/tooltip.test.js
+++ b/components/tooltip/stories/tooltip.test.js
@@ -5,7 +5,7 @@ import { Template } from "./template.js";
 export const PlacementVariants = Variants({
 	Template,
 	testData: [
-		...["neutral", "info", "positive", "negative"].map(variant => ({
+		...["neutral", "info", "negative"].map(variant => ({
 			testHeading: capitalize(variant),
 			variant,
 		})),


### PR DESCRIPTION
## Description

This restores the negative and informative tooltip semantic variant styles, story controls and test cases. Icons have been removed for all variants as they are not present in the specifications provided by design.

##### Restored mods

`--mod-tooltip-background-color-informative`
`--mod-tooltip-background-color-negative"`

### Validation steps

1. Open the Storybook link for this PR.
2. Navigate to the `Default` story for the tooltip component.
3. Select the informative and negative tooltip styles in controls and verify that they match the Figma design(s).

## Screenshots

![Screenshot 2025-03-25 at 10 39 32 AM](https://github.com/user-attachments/assets/af0f6c9f-c5c1-4c7b-a0e9-da58ba0f7a18)

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
