### PR TITLE
fix: reduce excess stylelint warnings from bundle module

### DIFF
--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -224,7 +224,7 @@ module.exports = {
 		},
 		{
 			/* Validate that the legacy themes don't introduce any new selectors or custom properties */
-			files: ["components/*/themes/express.css", "components/*/themes/spectrum-two.css"],
+			files: ["components/*/themes/express.css", "components/*/themes/spectrum.css"],
 			rules: {
 				"spectrum-tools/no-unused-custom-properties": null,
 				"selector-class-pattern": [

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -224,7 +224,7 @@ module.exports = {
 		},
 		{
 			/* Validate that the legacy themes don't introduce any new selectors or custom properties */
-			files: ["components/*/themes/*.css", "!components/*/themes/spectrum.css"],
+			files: ["components/*/themes/express.css", "components/*/themes/spectrum-two.css"],
 			rules: {
 				"spectrum-tools/no-unused-custom-properties": null,
 				"selector-class-pattern": [

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -14,6 +14,9 @@ module.exports = {
 		"@spectrum-tools/stylelint-theme-alignment",
 		// "stylelint-high-performance-animation",
 	],
+	ignoreFiles: [
+		"tools/bundle/dist/*.css",
+	],
 	rules: {
 		/** --------------------------------------------------------------
 		 * Disabled rules
@@ -233,6 +236,18 @@ module.exports = {
 						ignoreList: [/^--mod-/],
 					},
 				],
+			}
+		},
+		{
+			/* Module CSS file classes have an underscore before classes, and use underscores instead of a dash as separators (e.g. _spectrum_well) */
+			files: ["tools/bundle/**/*.module.css"],
+			rules: {
+				"selector-class-pattern": [
+					"^_spectrum$|^(_)?(spectrum|is|u)(_|-)[A-Za-z0-9-_]+", {
+						resolveNestedSelectors: true
+					}
+				],
+				"keyframes-name-pattern": null,
 			}
 		},
 	],

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -15,7 +15,18 @@ module.exports = {
 		// "stylelint-high-performance-animation",
 	],
 	ignoreFiles: [
-		"tools/bundle/dist/*.css",
+		// Static utility assets
+		"tokens/custom-*/*.css",
+		"tools/generator/**/*.css",
+		// Compiled and generated files
+		"**/dist/**",
+		".storybook/storybook-static/**/*.css",
+		"**/*-generated.css",
+		"tools/bundle/src/*.css",
+		"**/node_modules/**",
+		// Test files
+		"plugins/*/expected/*.css",
+		"plugins/*/fixtures/*.css",
 	],
 	rules: {
 		/** --------------------------------------------------------------
@@ -240,7 +251,7 @@ module.exports = {
 		},
 		{
 			/* Module CSS file classes have an underscore before classes, and use underscores instead of a dash as separators (e.g. _spectrum_well) */
-			files: ["tools/bundle/**/*.module.css"],
+			files: ["*.module.css"],
 			rules: {
 				"selector-class-pattern": [
 					"^_spectrum$|^(_)?(spectrum|is|u)(_|-)[A-Za-z0-9-_]+", {


### PR DESCRIPTION
## Description

Fixes large number of stylelint warnings appearing after yarn start. These were the result of stylelint running on the
`tools/bundle/dist/index.module.css` file.

- Adds stylelint override to better lint module files that have a different class format.
- Add ignoreFiles for the tools/bundle/dist, as stylelint should not be running on the dist folders during this step; it seems to be disregarding the .stylelintignore file.

CSS-1155

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

Pull down the branch locally and:
- [x] `yarn install` and `yarn start`. After Storybook starts up (after loader and pages are functional), you should not see the 9k stylelint warnings related to "._" classes expecting to match pattern. No `[stylelint]` labeled warnings should appear for the bundle dist file.
- [x] To test the rule override, delete the `ignoreFiles` property in the root `stylelint.config.js` and run `yarn start` again. There should only be a few dozen stylelint warnings for the module file, instead of 9k.

## Screenshots

Original problem:

![Screenshot 2025-03-13 at 4 56 52 PM](https://github.com/user-attachments/assets/37295bf4-8d31-48b0-93aa-8f953e579e57)

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] ✨ This pull request is ready to merge. ✨
