### PR TITLE
fix(search): change keyfocus border to gray-800

### DIFF
--- a/.changeset/stupid-chefs-brush.md
+++ b/.changeset/stupid-chefs-brush.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/search": patch
+---
+
+Change S2 theme border color to gray-800 on keyfocus per design request in order to align with text field.

--- a/components/search/themes/spectrum-two.css
+++ b/components/search/themes/spectrum-two.css
@@ -17,7 +17,7 @@
 		--spectrum-search-border-color-hover: var(--spectrum-gray-600);
 		--spectrum-search-border-color-focus: var(--spectrum-gray-800);
 		--spectrum-search-border-color-focus-hover: var(--spectrum-gray-900);
-		--spectrum-search-border-color-key-focus: var(--spectrum-gray-900);
+		--spectrum-search-border-color-key-focus: var(--spectrum-gray-800);
 
 		--spectrum-search-background-color: var(--spectrum-gray-25);
 		--spectrum-search-background-color-disabled: var(--spectrum-gray-25);

--- a/components/search/themes/spectrum.css
+++ b/components/search/themes/spectrum.css
@@ -20,5 +20,6 @@
 		--spectrum-search-background-color-disabled: var(--spectrum-disabled-background-color);
 		--spectrum-search-border-color-disabled: var(--spectrum-disabled-background-color);
 		--spectrum-search-background-color: var(--spectrum-gray-50);
+		--spectrum-search-border-color-key-focus: var(--spectrum-gray-900);
 	}
 }


### PR DESCRIPTION
## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->
This ticket relates to S2 Foundations Fast Follows for Search. In design verification, it was determined that the border color should be adjusted to `gray-800` in order to match the design spec for Textfield. This PR makes this change so that we can release a new version of search for https://github.com/adobe/spectrum-web-components/pull/5157

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [ ] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
