### PR TITLE
chore(combobox, datepicker,et all): add displayLabel arg

### DIFF
--- a/components/combobox/stories/template.js
+++ b/components/combobox/stories/template.js
@@ -67,6 +67,7 @@ const Combobox = ({
 				name: "field",
 				isReadOnly,
 				value,
+				displayLabel: false,
 				onclick: function () {
 					if (!isOpen) updateArgs({ isOpen: true });
 				},

--- a/components/datepicker/stories/template.js
+++ b/components/datepicker/stories/template.js
@@ -64,6 +64,7 @@ export const DatePicker = ({
 				name: "field",
 				id: triggerId,
 				value: selectedDay ? new Date(selectedDay).toLocaleDateString(lang) : undefined,
+				displayLabel: false,
 				onclick: function () {
 					if (!isOpen) updateArgs({ isOpen: true });
 				},

--- a/components/form/stories/form.stories.js
+++ b/components/form/stories/form.stories.js
@@ -51,6 +51,7 @@ export default {
 						...passthroughs,
 						multiline: true,
 						name: "field",
+						displayLabel: false,
 					}, context),
 				],
 			}, {
@@ -61,6 +62,7 @@ export default {
 						...passthroughs,
 						type: "email",
 						name: "email",
+						displayLabel: false,
 					}, context),
 				],
 			}, {
@@ -71,6 +73,7 @@ export default {
 						...passthroughs,
 						placeholder: "Select a country",
 						name: "country",
+						displayLabel: false,
 					}, context),
 				],
 			}, {

--- a/components/pagination/stories/template.js
+++ b/components/pagination/stories/template.js
@@ -33,6 +33,7 @@ export const Template = ({
 				size,
 				value: "1",
 				customClasses: [`${rootClass}-textfield`],
+				displayLabel: false,
 			}, context)}
 			<span class="${rootClass}-counter">of 89 pages</span>
 			${ActionButton({

--- a/components/search/stories/template.js
+++ b/components/search/stories/template.js
@@ -41,6 +41,7 @@ export const Template = ({
 				customInputClasses: [`${rootClass}-input`],
 				customIconClasses: [`${rootClass}-icon`],
 				autocomplete: false,
+				displayLabel: false,
 			}, context)}
 			${ClearButton({
 					isDisabled,

--- a/components/stepper/stories/template.js
+++ b/components/stepper/stories/template.js
@@ -70,6 +70,7 @@ export const Template = ({
 				id: id ? `${id}-input` : undefined,
 				customClasses: [`${rootClass}-textfield`],
 				customInputClasses: [`${rootClass}-input`],
+				displayLabel: false,
 			}, context)}
 			${when(!hideStepper, () => html`
 				<span class="${rootClass}-buttons">


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

After rebasing the search field migration branch, I noticed that the icons were placed awkwardly. I realized that the nested textfield in my search component was just missing a `displayLabel: false` argument. That arg was updated in the textfield S2 migration, to be set to `true` on default (based on guidance that "a textfield should always have a label"), but because search isn't utilizing the field label that ships with textfield, that arg should be set to `false`. Without the displayLabel arg set to false in the following components, the textfield was still rendering an additional label, and offsetting the icon & button within search.

After scanning the repo, the following components needed similar `displayValue: false` args: 
combobox, datepicker, form, pagination, stepper

### Jira/Specs
CSS-1174

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

- [ ] Pull down the branch to run locally or visit the deploy preview.
- [ ] Navigate to each component's docs page. Ensure that nothing looks "broken" and most of the styles are acceptable.
    - [ ] combobox
    - [ ] date picker
    - [ ] form
    - [ ] pagination
    - [ ] search
    - [ ] stepper/number field
- [ ] By comparison, compare the fixed components to a recent deploy preview for `spectrum-two`:
    - [ ] combobox
    - [ ] date picker
    - [ ] form
    - [ ] pagination
    - [ ] search
    - [ ] stepper/number field

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] ✨ This pull request is ready to merge. ✨
