### PR TITLE
fix(button): s1/express static outline variant content color

### DIFF
--- a/.changeset/happy-frogs-flash.md
+++ b/.changeset/happy-frogs-flash.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/button": patch
+---
+
+Adjust S1/Express static outline variant content color (from transparent-black/white to solid black/white) to fix unintentional regression.

--- a/components/button/themes/spectrum.css
+++ b/components/button/themes/spectrum.css
@@ -62,6 +62,11 @@
 				--spectrum-button-background-color-down: var(--spectrum-transparent-white-400);
 				--spectrum-button-background-color-focus: var(--spectrum-transparent-white-300);
 
+				--spectrum-button-content-color-default: var(--spectrum-white);
+				--spectrum-button-content-color-hover: var(--spectrum-white);
+				--spectrum-button-content-color-down: var(--spectrum-white);
+				--spectrum-button-content-color-focus: var(--spectrum-white);
+
 				--spectrum-button-border-color-default: var(--spectrum-transparent-white-800);
 				--spectrum-button-border-color-hover: var(--spectrum-transparent-white-900);
 				--spectrum-button-border-color-down: var(--spectrum-transparent-white-900);
@@ -73,6 +78,11 @@
 				--spectrum-button-background-color-hover: var(--spectrum-transparent-white-300);
 				--spectrum-button-background-color-down: var(--spectrum-transparent-white-400);
 				--spectrum-button-background-color-focus: var(--spectrum-transparent-white-300);
+
+				--spectrum-button-content-color-default: var(--spectrum-white);
+				--spectrum-button-content-color-hover: var(--spectrum-white);
+				--spectrum-button-content-color-down: var(--spectrum-white);
+				--spectrum-button-content-color-focus: var(--spectrum-white);
 
 				&.spectrum-Button--outline {
 					--spectrum-button-border-color-default: var(--spectrum-transparent-white-300);
@@ -99,6 +109,11 @@
 				--spectrum-button-background-color-down: var(--spectrum-transparent-black-400);
 				--spectrum-button-background-color-focus: var(--spectrum-transparent-black-300);
 
+				--spectrum-button-content-color-default: var(--spectrum-black);
+				--spectrum-button-content-color-hover: var(--spectrum-black);
+				--spectrum-button-content-color-down: var(--spectrum-black);
+				--spectrum-button-content-color-focus: var(--spectrum-black);
+
 				--spectrum-button-border-color-default: var(--spectrum-transparent-black-400);
 				--spectrum-button-border-color-hover: var(--spectrum-transparent-black-500);
 				--spectrum-button-border-color-down: var(--spectrum-transparent-black-600);
@@ -110,6 +125,11 @@
 				--spectrum-button-background-color-hover: var(--spectrum-transparent-black-300);
 				--spectrum-button-background-color-down: var(--spectrum-transparent-black-400);
 				--spectrum-button-background-color-focus: var(--spectrum-transparent-black-300);
+
+				--spectrum-button-content-color-default: var(--spectrum-black);
+				--spectrum-button-content-color-hover: var(--spectrum-black);
+				--spectrum-button-content-color-down: var(--spectrum-black);
+				--spectrum-button-content-color-focus: var(--spectrum-black);
 
 				&.spectrum-Button--outline {
 					--spectrum-button-border-color-default: var(--spectrum-transparent-black-300);


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

Adjusts S1/Express themes' static outline button content colors back to their original--they should deviate from S2 designs and be solid colors rather than having transparency.

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
1. Open the PR [preview](https://pr-3665--spectrum-css.netlify.app/?path=/story/components-button--default&globals=testingPreview:!true) and verify: [@castastrophe]
 - [x] S1 Static white outline button's content color (text/icon) should be white (255, 255, 255) with no transparency
 - [x] S1 Static black outline button's content color (text/icon) should be black (0, 0, 0) with no transparency
 - [x] Express static white outline button's content color (text/icon) should be white (255, 255, 255) with no transparency
 - [x] Express Static black outline button's content color (text/icon) should be black (0, 0, 0) with no transparency
 - [x] Content colors for static variants in S2 should not be affected and should continue to have transparency (for instance `rgb(0, 0, 0, 0.84)`

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

3. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [ ] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
