### PR TITLE
docs: adds tag for migrated components

### DIFF
--- a/components/actionbutton/stories/actionbutton.stories.js
+++ b/components/actionbutton/stories/actionbutton.stories.js
@@ -108,6 +108,7 @@ export default {
 	decorators: [
 		withDownStateDimensionCapture,
 	],
+	tags: ["migrated"],
 };
 
 export const Default = ActionButtonGroup.bind({});

--- a/components/breadcrumb/stories/breadcrumb.stories.js
+++ b/components/breadcrumb/stories/breadcrumb.stories.js
@@ -140,6 +140,7 @@ export default {
 		packageJson,
 		metadata,
 	},
+	tags: ["migrated"],
 };
 
 /**

--- a/components/checkbox/stories/checkbox.stories.js
+++ b/components/checkbox/stories/checkbox.stories.js
@@ -62,6 +62,7 @@ export default {
 		packageJson,
 		metadata,
 	},
+	tags: ["migrated"],
 };
 
 export const Default = CheckboxGroup.bind({});

--- a/components/coachmark/stories/coachmark.stories.js
+++ b/components/coachmark/stories/coachmark.stories.js
@@ -100,6 +100,7 @@ export default {
 			},
 		},
 	},
+	tags: ["migrated"],
 };
 
 export const Default = CoachMarkGroup.bind({});

--- a/components/colorhandle/stories/colorhandle.stories.js
+++ b/components/colorhandle/stories/colorhandle.stories.js
@@ -53,6 +53,7 @@ export default {
 		packageJson,
 		metadata,
 	},
+	tags: ["migrated"],
 };
 
 /**

--- a/components/colorslider/stories/colorslider.stories.js
+++ b/components/colorslider/stories/colorslider.stories.js
@@ -72,6 +72,7 @@ export default {
 		packageJson,
 		metadata,
 	},
+	tags: ["migrated"],
 };
 
 /**

--- a/components/colorwheel/stories/colorwheel.stories.js
+++ b/components/colorwheel/stories/colorwheel.stories.js
@@ -64,6 +64,7 @@ export default {
 		packageJson,
 		metadata,
 	},
+	tags: ["migrated"],
 };
 
 export const Default = ColorWheelGroup.bind({});

--- a/components/divider/stories/divider.stories.js
+++ b/components/divider/stories/divider.stories.js
@@ -39,6 +39,7 @@ export default {
 		packageJson,
 		metadata,
 	},
+	tags: ["migrated"],
 };
 
 /**

--- a/components/dropzone/stories/dropzone.stories.js
+++ b/components/dropzone/stories/dropzone.stories.js
@@ -47,6 +47,7 @@ export default {
 		packageJson,
 		metadata,
 	},
+	tags: ["migrated"],
 };
 
 export const Default = DropzoneGroup.bind({});

--- a/components/fieldgroup/stories/fieldgroup.stories.js
+++ b/components/fieldgroup/stories/fieldgroup.stories.js
@@ -97,6 +97,7 @@ export default {
 		packageJson,
 		metadata,
 	},
+	tags: ["migrated"],
 };
 
 export const Default = FieldGroupSet.bind({});

--- a/components/helptext/stories/helptext.stories.js
+++ b/components/helptext/stories/helptext.stories.js
@@ -64,6 +64,7 @@ export default {
 		packageJson,
 		metadata,
 	},
+	tags: ["migrated"],
 };
 
 /**

--- a/components/icon/stories/icon.stories.js
+++ b/components/icon/stories/icon.stories.js
@@ -99,6 +99,7 @@ export default {
 			url: "https://www.figma.com/design/9qeVZSJ9t0kv6r7njzgHx7/S2-%2F-Styles-visualizer-(WIP)?node-id=295-24257&t=ZC7fyaQ0VQYQ5VYM-1",
 		},
 	},
+	tags: ["migrated"],
 };
 
 export const Default = IconGroup.bind({});

--- a/components/illustratedmessage/stories/illustratedmessage.stories.js
+++ b/components/illustratedmessage/stories/illustratedmessage.stories.js
@@ -77,6 +77,7 @@ export default {
 		metadata,
 		layout: "centered"
 	},
+	tags: ["migrated"],
 };
 
 export const Default = IllustratedMessageGroup.bind({});

--- a/components/infieldbutton/stories/infieldbutton.stories.js
+++ b/components/infieldbutton/stories/infieldbutton.stories.js
@@ -63,6 +63,7 @@ export default {
 	decorators: [
 		withDownStateDimensionCapture,
 	],
+	tags: ["migrated"],
 };
 
 export const Default = InfieldButtonGroup.bind({});

--- a/components/infieldprogresscircle/stories/infieldprogresscircle.stories.js
+++ b/components/infieldprogresscircle/stories/infieldprogresscircle.stories.js
@@ -30,7 +30,8 @@ export default {
 		},
 		packageJson,
 		metadata,
-	}
+	},
+	tags: ["migrated"],
 };
 
 export const Default = InfieldProgressCircleGroup.bind({});

--- a/components/inlinealert/stories/inlinealert.stories.js
+++ b/components/inlinealert/stories/inlinealert.stories.js
@@ -6,7 +6,7 @@ import { AlertsWithStyleOptions } from "./template.js";
 
 /**
  * In-line alerts display a non-modal message associated with objects in a view. These are often used in form validation, providing a place to aggregate feedback related to multiple fields.
- * 
+ *
  * In-line alerts have five different variants: neutral (default), informative, positive, notice, and negative. Each variant is available with three fill styles (treatment): border (default), subtle, and bold.
  */
 export default {
@@ -102,6 +102,7 @@ export default {
 		packageJson,
 		metadata,
 	},
+	tags: ["migrated"],
 };
 
 /**

--- a/components/link/stories/link.stories.js
+++ b/components/link/stories/link.stories.js
@@ -89,7 +89,8 @@ export default {
 		},
 		packageJson,
 		metadata,
-	}
+	},
+	tags: ["migrated"],
 };
 
 export const Default = LinkGroup.bind({});

--- a/components/meter/stories/meter.stories.js
+++ b/components/meter/stories/meter.stories.js
@@ -48,7 +48,6 @@ export default {
 		packageJson,
 		metadata,
 	},
-	tags: ["migrated"],
 };
 
 /**

--- a/components/popover/stories/popover.stories.js
+++ b/components/popover/stories/popover.stories.js
@@ -99,6 +99,7 @@ export default {
 		packageJson,
 		metadata,
 	},
+	tags: ["migrated"],
 };
 
 /**

--- a/components/progresscircle/stories/progresscircle.stories.js
+++ b/components/progresscircle/stories/progresscircle.stories.js
@@ -46,6 +46,7 @@ export default {
 		packageJson,
 		metadata,
 	},
+	tags: ["migrated"],
 };
 
 export const Default = ProgressCircleGroup.bind({});

--- a/components/radio/stories/radio.stories.js
+++ b/components/radio/stories/radio.stories.js
@@ -67,6 +67,7 @@ export default {
 		packageJson,
 		metadata,
 	},
+	tags: ["migrated"],
 };
 
 export const Default = RadioGroup.bind({});

--- a/components/rating/stories/rating.stories.js
+++ b/components/rating/stories/rating.stories.js
@@ -77,6 +77,7 @@ export default {
 		packageJson,
 		metadata,
 	},
+	tags: ["migrated"],
 };
 
 /**

--- a/components/search/stories/search.stories.js
+++ b/components/search/stories/search.stories.js
@@ -81,6 +81,7 @@ export default {
 		packageJson,
 		metadata,
 	},
+	tags: ["migrated"],
 };
 
 export const Default = SearchGroup.bind({});

--- a/components/textfield/stories/textarea.stories.js
+++ b/components/textfield/stories/textarea.stories.js
@@ -30,7 +30,8 @@ export default {
 			type: "figma",
 			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=725-2579",
 		},
-	}
+	},
+	tags: ["migrated"],
 };
 
 export const Default = TextAreaGroup.bind({});

--- a/components/textfield/stories/textfield.stories.js
+++ b/components/textfield/stories/textfield.stories.js
@@ -155,6 +155,7 @@ export default {
 		packageJson,
 		metadata,
 	},
+	tags: ["migrated"],
 };
 
 export const Default = TextFieldGroup.bind({});

--- a/components/toast/stories/toast.stories.js
+++ b/components/toast/stories/toast.stories.js
@@ -66,6 +66,7 @@ export default {
 		},
 		metadata,
 	},
+	tags: ["migrated"],
 };
 
 /**


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

Some of our migrated components from 2024 (like textfield, search, switch, button, etc), had the migrated tag added to the components' metadata. You could find `tags: ["migrated"]` in the story files. However, at some point we stopped adding that tag, and because we've gotten back to migrated S2 components, it would probably be good to add this tag to all of our currently migrated components.

This work adds that migrated tag to the components that are missing it as of 5 May 2025. 


### Jira
CSS-1191 (ticket for this work)
CSS-604 (epic for S2 Migration)

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

- [ ] Pull down the branch to be able search.
- [ ] Search for `tags: ["migrated"]` in the repo. You should get 45 components returned 🥳 
- [ ] Compare the results to the list in the S2 Migration epic. All components found during your search should have an associated ticket, EXCEPT FOR:
    - [ ] The progress bar ticket looks like it's missing from the epic, but it was migrated here: https://github.com/adobe/spectrum-css/pull/2659 👍 
    - [ ] The status light ticket looks like it's missing from the epic, but it was migrated here: https://github.com/adobe/spectrum-css/pull/2818 👍 
    - [ ] The switch ticket looks like it's missing from the epic, but it was migrated here: https://github.com/adobe/spectrum-css/pull/2651 👍 
    - [ ] The dial component is marked as migrated, but I believe this is a "one-off" component. There are no designs. 👍 
    - [ ] The field group component is marked as migrated, probably because that component is just collections of [checkboxes](https://github.com/adobe/spectrum-css/pull/3531) and collections of [radios](https://github.com/adobe/spectrum-css/pull/3555) (both of which _have_ been migrated). 👍 
    - [ ] The form component is marked as migrated for a similar reason. All nested components in the form, aside from [number field](https://github.com/adobe/spectrum-css/pull/3681) (which is in-progress), have been migrated. 👍 
    - [ ] Pagination is marked as migrated for a similar reason. All nested components have been migrated. 👍 

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
