### PR TITLE
chore(popover): fix dismissible spelling

### DIFF
--- a/components/popover/stories/popover.stories.js
+++ b/components/popover/stories/popover.stories.js
@@ -246,7 +246,7 @@ DialogStyle.args = {
 		(passthroughs, context) => Dialog({
 			showModal: false,
 			size: "s",
-			isDismissable: false,
+			isDismissible: false,
 			heading: "Example heading",
 			hasFooter: false,
 			footer: [""],

--- a/components/popover/stories/popover.test.js
+++ b/components/popover/stories/popover.test.js
@@ -139,7 +139,7 @@ export const PopoverGroup = Variants({
 				(passthroughs, context) => Dialog({
 					showModal: false,
 					size: "s",
-					isDismissable: false,
+					isDismissible: false,
 					heading: "Example heading",
 					hasFooter: false,
 					footer: [""],


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

This PR corrects the spelling of the `dismissible` arg in the dialog-style popover. In #https://github.com/adobe/spectrum-css/pull/2860, the arg spelling was updated, and we must have missed correcting the spelling in this popover story. 

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

- [ ] Pull down the branch to run locally or use the deploy preview.
- [ ] Spot check a few pages to make sure things run and render as expected. 
- [ ] Visit the popover docs page. Verify the "dialog-style content" story renders with no close button (which is expected 👍 ). There should be no regressions.
- [ ] While running the project locally, edit the `DialogStyle` popover story so that the dialog shows the close button. Set `isDismissible: true`. (you'll revert this change after validating!)
- [ ] On the docs page, the close button in the popover should render appropriately. With the misspelled arg, this was not working properly.
<img width="510" alt="Screenshot 2025-05-05 at 11 16 26 AM" src="https://github.com/user-attachments/assets/bd7e7d9d-c7c9-413d-a74d-0cff224581d8" />


### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [ ] ✨ This pull request is ready to merge. ✨
