### PR TITLE
docs: add storybook migrated badge

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -85,6 +85,11 @@ export const parameters = {
 				color: "#fff",
 				description: "Should not be used and will not receive updates.",
 			},
+			migrated: {
+				background: "rgb(84, 36, 219)",
+				color: "#fff",
+				description: "Migrated to Spectrum 2.",
+			},
 		},
 	},
 	// Set an empty object to avoid the "undefined" value in the ComponentDetails doc block

--- a/components/actionbutton/stories/actionbutton.stories.js
+++ b/components/actionbutton/stories/actionbutton.stories.js
@@ -103,7 +103,10 @@ export default {
 			story: {
 				height: "auto",
 			},
-		}
+		},
+		status: {
+			type: "migrated",
+		},
 	},
 	decorators: [
 		withDownStateDimensionCapture,

--- a/components/actiongroup/stories/actiongroup.stories.js
+++ b/components/actiongroup/stories/actiongroup.stories.js
@@ -99,6 +99,9 @@ export default {
 		},
 		packageJson,
 		metadata,
+		status: {
+			type: "migrated",
+		},
 	},
 	tags: ["migrated"],
 };

--- a/components/alertbanner/stories/alertbanner.stories.js
+++ b/components/alertbanner/stories/alertbanner.stories.js
@@ -75,6 +75,9 @@ export default {
 		},
 		packageJson,
 		metadata,
+		status: {
+			type: "migrated",
+		},
 	},
 	tags: ["migrated"],
 };

--- a/components/avatar/stories/avatar.stories.js
+++ b/components/avatar/stories/avatar.stories.js
@@ -59,6 +59,9 @@ export default {
 		},
 		packageJson,
 		metadata,
+		status: {
+			type: "migrated",
+		},
 	},
 	tags: ["migrated"],
 };

--- a/components/breadcrumb/stories/breadcrumb.stories.js
+++ b/components/breadcrumb/stories/breadcrumb.stories.js
@@ -139,6 +139,9 @@ export default {
 		},
 		packageJson,
 		metadata,
+		status: {
+			type: "migrated",
+		}
 	},
 };
 

--- a/components/button/stories/button.stories.js
+++ b/components/button/stories/button.stories.js
@@ -101,6 +101,9 @@ export default {
 		},
 		packageJson,
 		metadata,
+		status: {
+			type: "migrated",
+		},
 	},
 	decorators: [
 		withDownStateDimensionCapture,

--- a/components/buttongroup/stories/buttongroup.stories.js
+++ b/components/buttongroup/stories/buttongroup.stories.js
@@ -64,6 +64,9 @@ export default {
 		},
 		packageJson,
 		metadata,
+		status: {
+			type: "migrated",
+		},
 	},
 	tags: ["migrated"],
 };

--- a/components/checkbox/stories/checkbox.stories.js
+++ b/components/checkbox/stories/checkbox.stories.js
@@ -61,6 +61,9 @@ export default {
 		},
 		packageJson,
 		metadata,
+		status: {
+			type: "migrated",
+		},
 	},
 };
 

--- a/components/closebutton/stories/closebutton.stories.js
+++ b/components/closebutton/stories/closebutton.stories.js
@@ -52,6 +52,9 @@ export default {
 		},
 		packageJson,
 		metadata,
+		status: {
+			type: "migrated",
+		},
 	},
 	tags: ["migrated"],
 };

--- a/components/coachmark/stories/coachmark.stories.js
+++ b/components/coachmark/stories/coachmark.stories.js
@@ -5,9 +5,9 @@ import metadata from "../dist/metadata.json";
 import packageJson from "../package.json";
 import { CoachMarkGroup } from "./coachmark.test.js";
 import {
-	Template,
-	CoachmarkMenuStatesTemplate,
 	CoachMarkMediaOptionsTemplate,
+	CoachmarkMenuStatesTemplate,
+	Template,
 } from "./template.js";
 
 /**
@@ -98,6 +98,9 @@ export default {
 			story: {
 				height: "525px",
 			},
+		},
+		status: {
+			type: "migrated",
 		},
 	},
 };

--- a/components/colorarea/stories/colorarea.stories.js
+++ b/components/colorarea/stories/colorarea.stories.js
@@ -49,6 +49,9 @@ export default {
 		},
 		packageJson,
 		metadata,
+		status: {
+			type: "migrated",
+		},
 	},
 	tags: ["migrated"],
 };

--- a/components/colorhandle/stories/colorhandle.stories.js
+++ b/components/colorhandle/stories/colorhandle.stories.js
@@ -52,6 +52,9 @@ export default {
 		},
 		packageJson,
 		metadata,
+		status: {
+			type: "migrated",
+		},
 	},
 };
 

--- a/components/colorloupe/stories/colorloupe.stories.js
+++ b/components/colorloupe/stories/colorloupe.stories.js
@@ -45,6 +45,9 @@ export default {
 		},
 		packageJson,
 		metadata,
+		status: {
+			type: "migrated",
+		},
 	},
 	tags: ["migrated"],
 };

--- a/components/colorslider/stories/colorslider.stories.js
+++ b/components/colorslider/stories/colorslider.stories.js
@@ -71,6 +71,9 @@ export default {
 		},
 		packageJson,
 		metadata,
+		status: {
+			type: "migrated",
+		},
 	},
 };
 

--- a/components/colorwheel/stories/colorwheel.stories.js
+++ b/components/colorwheel/stories/colorwheel.stories.js
@@ -63,6 +63,9 @@ export default {
 		},
 		packageJson,
 		metadata,
+		status: {
+			type: "migrated",
+		},
 	},
 };
 

--- a/components/dial/stories/dial.stories.js
+++ b/components/dial/stories/dial.stories.js
@@ -35,6 +35,9 @@ export default {
 	parameters: {
 		packageJson,
 		metadata,
+		status: {
+			type: "migrated",
+		},
 	},
 	tags: ["migrated"],
 };

--- a/components/dialog/stories/dialog.stories.js
+++ b/components/dialog/stories/dialog.stories.js
@@ -1,8 +1,8 @@
 import { withUnderlayWrapper } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isOpen, size } from "@spectrum-css/preview/types";
-import { Template as Table } from "@spectrum-css/table/stories/template.js";
 import { Template as Steplist } from "@spectrum-css/steplist/stories/template.js";
+import { Template as Table } from "@spectrum-css/table/stories/template.js";
 import { Template as Typography } from "@spectrum-css/typography/stories/template.js";
 import metadata from "../dist/metadata.json";
 import packageJson from "../package.json";
@@ -163,6 +163,9 @@ export default {
 		packageJson,
 		metadata,
 		layout: "fullscreen",
+		status: {
+			type: "migrated",
+		},
 	},
 	decorators: [
 		withUnderlayWrapper,

--- a/components/divider/stories/divider.stories.js
+++ b/components/divider/stories/divider.stories.js
@@ -38,6 +38,9 @@ export default {
 		},
 		packageJson,
 		metadata,
+		status: {
+			type: "migrated",
+		},
 	},
 };
 

--- a/components/dropzone/stories/dropzone.stories.js
+++ b/components/dropzone/stories/dropzone.stories.js
@@ -46,6 +46,9 @@ export default {
 		},
 		packageJson,
 		metadata,
+		status: {
+			type: "migrated",
+		},
 	},
 };
 

--- a/components/fieldgroup/stories/fieldgroup.stories.js
+++ b/components/fieldgroup/stories/fieldgroup.stories.js
@@ -96,6 +96,9 @@ export default {
 		},
 		packageJson,
 		metadata,
+		status: {
+			type: "migrated",
+		},
 	},
 };
 

--- a/components/fieldlabel/stories/fieldlabel.stories.js
+++ b/components/fieldlabel/stories/fieldlabel.stories.js
@@ -52,6 +52,9 @@ export default {
 		},
 		packageJson,
 		metadata,
+		status: {
+			type: "migrated",
+		},
 	},
 	tags: ["migrated"],
 };

--- a/components/form/stories/form.stories.js
+++ b/components/form/stories/form.stories.js
@@ -107,6 +107,9 @@ export default {
 	parameters: {
 		packageJson,
 		metadata,
+		status: {
+			type: "migrated",
+		},
 	},
 	tags: ["migrated"],
 };

--- a/components/helptext/stories/helptext.stories.js
+++ b/components/helptext/stories/helptext.stories.js
@@ -63,6 +63,9 @@ export default {
 		},
 		packageJson,
 		metadata,
+		status: {
+			type: "migrated",
+		},
 	},
 };
 

--- a/components/icon/stories/icon.stories.js
+++ b/components/icon/stories/icon.stories.js
@@ -98,6 +98,9 @@ export default {
 			type: "figma",
 			url: "https://www.figma.com/design/9qeVZSJ9t0kv6r7njzgHx7/S2-%2F-Styles-visualizer-(WIP)?node-id=295-24257&t=ZC7fyaQ0VQYQ5VYM-1",
 		},
+		status: {
+			type: "migrated",
+		},
 	},
 };
 

--- a/components/illustratedmessage/stories/illustratedmessage.stories.js
+++ b/components/illustratedmessage/stories/illustratedmessage.stories.js
@@ -75,6 +75,9 @@ export default {
 		},
 		packageJson,
 		metadata,
+		status: {
+			type: "migrated",
+		},
 		layout: "centered"
 	},
 };

--- a/components/infieldbutton/stories/infieldbutton.stories.js
+++ b/components/infieldbutton/stories/infieldbutton.stories.js
@@ -59,6 +59,9 @@ export default {
 		},
 		packageJson,
 		metadata,
+		status: {
+			type: "migrated",
+		},
 	},
 	decorators: [
 		withDownStateDimensionCapture,

--- a/components/infieldprogresscircle/stories/infieldprogresscircle.stories.js
+++ b/components/infieldprogresscircle/stories/infieldprogresscircle.stories.js
@@ -30,7 +30,10 @@ export default {
 		},
 		packageJson,
 		metadata,
-	}
+		status: {
+			type: "migrated",
+		},
+	},
 };
 
 export const Default = InfieldProgressCircleGroup.bind({});

--- a/components/inlinealert/stories/inlinealert.stories.js
+++ b/components/inlinealert/stories/inlinealert.stories.js
@@ -101,6 +101,9 @@ export default {
 		},
 		packageJson,
 		metadata,
+		status: {
+			type: "migrated",
+		},
 	},
 };
 

--- a/components/link/stories/link.stories.js
+++ b/components/link/stories/link.stories.js
@@ -89,7 +89,10 @@ export default {
 		},
 		packageJson,
 		metadata,
-	}
+		status: {
+			type: "migrated",
+		},
+	},
 };
 
 export const Default = LinkGroup.bind({});

--- a/components/opacitycheckerboard/stories/opacitycheckerboard.stories.js
+++ b/components/opacitycheckerboard/stories/opacitycheckerboard.stories.js
@@ -42,6 +42,9 @@ export default {
 	parameters: {
 		packageJson,
 		metadata,
+		status: {
+			type: "migrated",
+		},
 	},
 	tags: ["migrated"],
 };

--- a/components/pagination/stories/pagination.stories.js
+++ b/components/pagination/stories/pagination.stories.js
@@ -70,6 +70,9 @@ export default {
 		},
 		packageJson,
 		metadata,
+		status: {
+			type: "migrated",
+		},
 	},
 	tags: ["migrated"],
 };

--- a/components/picker/stories/picker.stories.js
+++ b/components/picker/stories/picker.stories.js
@@ -145,6 +145,9 @@ export default {
 		downState: {
 			selectors: [".spectrum-Picker:not(:disabled, .is-disabled, .is-loading)"],
 		},
+		status: {
+			type: "migrated",
+		},
 	},
 	decorators: [
 		withDownStateDimensionCapture,

--- a/components/popover/stories/popover.stories.js
+++ b/components/popover/stories/popover.stories.js
@@ -98,6 +98,9 @@ export default {
 		},
 		packageJson,
 		metadata,
+		status: {
+			type: "migrated",
+		},
 	},
 };
 

--- a/components/progressbar/stories/progressbar.stories.js
+++ b/components/progressbar/stories/progressbar.stories.js
@@ -98,6 +98,9 @@ export default {
 		},
 		packageJson,
 		metadata,
+		status: {
+			type: "migrated",
+		},
 	},
 	tags: ["migrated"],
 };

--- a/components/progresscircle/stories/progresscircle.stories.js
+++ b/components/progresscircle/stories/progresscircle.stories.js
@@ -45,6 +45,9 @@ export default {
 		},
 		packageJson,
 		metadata,
+		status: {
+			type: "migrated",
+		},
 	},
 };
 

--- a/components/radio/stories/radio.stories.js
+++ b/components/radio/stories/radio.stories.js
@@ -66,6 +66,9 @@ export default {
 		},
 		packageJson,
 		metadata,
+		status: {
+			type: "migrated",
+		},
 	},
 };
 

--- a/components/rating/stories/rating.stories.js
+++ b/components/rating/stories/rating.stories.js
@@ -1,6 +1,6 @@
+import { Sizes } from "@spectrum-css/preview/decorators";
 import { disableDefaultModes } from "@spectrum-css/preview/modes";
 import { isDisabled, isEmphasized, isFocused, isReadOnly, size } from "@spectrum-css/preview/types";
-import { Sizes } from "@spectrum-css/preview/decorators";
 import metadata from "../dist/metadata.json";
 import packageJson from "../package.json";
 import { RatingGroup } from "./rating.test.js";
@@ -76,6 +76,9 @@ export default {
 		},
 		packageJson,
 		metadata,
+		status: {
+			type: "migrated",
+		},
 	},
 };
 

--- a/components/search/stories/search.stories.js
+++ b/components/search/stories/search.stories.js
@@ -71,15 +71,15 @@ export default {
 				"click .spectrum-Search-icon",
 			],
 		},
-		status: {
-			type: "migrated",
-		},
 		design: {
 			type: "figma",
 			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=13670-229",
 		},
 		packageJson,
 		metadata,
+		status: {
+			type: "migrated",
+		},
 	},
 };
 

--- a/components/statuslight/stories/statuslight.stories.js
+++ b/components/statuslight/stories/statuslight.stories.js
@@ -75,6 +75,9 @@ export default {
 		},
 		packageJson,
 		metadata,
+		status: {
+			type: "migrated",
+		},
 	},
 	tags: ["migrated"],
 };

--- a/components/switch/stories/switch.stories.js
+++ b/components/switch/stories/switch.stories.js
@@ -45,6 +45,9 @@ export default {
 		},
 		packageJson,
 		metadata,
+		status: {
+			type: "migrated",
+		},
 	},
 	tags: ["migrated"],
 };

--- a/components/textfield/stories/textarea.stories.js
+++ b/components/textfield/stories/textarea.stories.js
@@ -30,7 +30,10 @@ export default {
 			type: "figma",
 			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=725-2579",
 		},
-	}
+		status: {
+			type: "migrated",
+		},
+	},
 };
 
 export const Default = TextAreaGroup.bind({});

--- a/components/textfield/stories/textfield.stories.js
+++ b/components/textfield/stories/textfield.stories.js
@@ -154,6 +154,9 @@ export default {
 		},
 		packageJson,
 		metadata,
+		status: {
+			type: "migrated",
+		},
 	},
 };
 

--- a/components/thumbnail/stories/thumbnail.stories.js
+++ b/components/thumbnail/stories/thumbnail.stories.js
@@ -94,6 +94,9 @@ export default {
 		},
 		packageJson,
 		metadata,
+		status: {
+			type: "migrated",
+		},
 	},
 	tags: ["migrated"],
 };

--- a/components/toast/stories/toast.stories.js
+++ b/components/toast/stories/toast.stories.js
@@ -65,6 +65,9 @@ export default {
 			url: "https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2-%2F-Desktop?node-id=2666-4482",
 		},
 		metadata,
+		status: {
+			type: "migrated",
+		},
 	},
 };
 

--- a/components/tooltip/stories/tooltip.stories.js
+++ b/components/tooltip/stories/tooltip.stories.js
@@ -96,6 +96,9 @@ export default {
 		},
 		packageJson,
 		metadata,
+		status: {
+			type: "migrated",
+		},
 	},
 	tags: ["migrated"],
 };


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

This work adds the "migrated" status to S2 migrated components. A new indigo badge should appear on component pages for a S2-migrated components. 🥳 This will be really nice to have once `spectrum-two` has merged into our `main` branch, especially if not all components have been migrated!

### Jira/Specs
CSS-1192
CSS-604 (epic for S2 Migration)

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

- [ ] Pull down the branch to run locally.
- [ ] Check that the `status: { type: "migrated" }` parameter has been added to each S2 migrated component, according to the list in the S2 Migration epic. All components have an associated ticket, EXCEPT FOR:
    - [ ] The progress bar ticket looks like it's missing from the epic, but it was migrated here: https://github.com/adobe/spectrum-css/pull/2659 👍 
    - [ ] The status light ticket looks like it's missing from the epic, but it was migrated here: https://github.com/adobe/spectrum-css/pull/2818 👍 
    - [ ] The switch ticket looks like it's missing from the epic, but it was migrated here: https://github.com/adobe/spectrum-css/pull/2651 👍 
    - [ ] The dial component is marked as migrated, but I believe this is a "one-off" component. There are no designs. 👍 
    - [ ] The field group component is marked as migrated, probably because that component is just collections of [checkboxes](https://github.com/adobe/spectrum-css/pull/3531) and collections of [radios](https://github.com/adobe/spectrum-css/pull/3555) (both of which _have_ been migrated). 👍 
    - [ ] The form component is marked as migrated for a similar reason. All nested components in the form, aside from [number field](https://github.com/adobe/spectrum-css/pull/3681) (which is in-progress), have been migrated. 👍 
    - [ ] Pagination is marked as migrated for a similar reason. All nested components have been migrated. 👍 
- [ ] Visit a few of the migrated components' docs pages, for instance, [dialog](https://pr-3690--spectrum-css.netlify.app/?path=/docs/components-dialog--docs), [picker](https://pr-3690--spectrum-css.netlify.app/?path=/docs/components-picker--docs), [avatar](https://pr-3690--spectrum-css.netlify.app/?path=/docs/components-avatar--docs), [text area](https://pr-3690--spectrum-css.netlify.app/?path=/docs/components-text-area--docs), [illustrated message](https://pr-3690--spectrum-css.netlify.app/?path=/docs/components-illustrated-message--docs). Each migrated component should now have an indigo badge marking it as "migrated."

<img width="479" alt="Screenshot 2025-05-05 at 12 34 23 PM" src="https://github.com/user-attachments/assets/bd749540-d001-46fe-b498-963b22529469" />

- [ ] With the project running locally, pick a non-migrated component (like side nav or table). In the `parameters` object in the component's CSF, add: 
```
status: {
  type: "migrated",
}
```
- Back in your browser, verify the newly added status renders. Just make sure not to commit this change 😉 


### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [x] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
