### PR TITLE
chore: update with latest from main

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -135,6 +135,8 @@ jobs:
             styles_modified_files: ${{ needs.changed_files.outputs.styles_modified_files }}
             eslint_added_files: ${{ needs.changed_files.outputs.eslint_added_files }}
             eslint_modified_files: ${{ needs.changed_files.outputs.eslint_modified_files }}
+            mdlint_added_files: ${{ needs.changed_files.outputs.mdlint_added_files }}
+            mdlint_modified_files: ${{ needs.changed_files.outputs.mdlint_modified_files }}
         secrets: inherit
 
     # -------------------------------------------------------------


### PR DESCRIPTION
## Description

Bringing over the markdown lint variable fix in the GitHub Actions workflow. We expect this to help limit the scope of what the markdown lint GitHub tool will flag for changes in a pull request.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
