### PR TITLE
chore: renovate config to bump packages with updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -31,6 +31,7 @@
 			"matchPackageNames": ["stylelint", "stylelint-**"]
 		}
 	],
+	"bumpVersion": "patch",
 	"rebaseWhen": "behind-base-branch",
 	"reviewers": ["team:spectrum-css-maintainers"]
 }


### PR DESCRIPTION
## Description

I noticed that the renovate tool is bumping the lock files but not reflecting the update in the packages. This configuration setting should remedy that: https://docs.renovatebot.com/configuration-options/#bumpversion

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] ✨ This pull request is ready to merge. ✨
