### PR TITLE
fix(switch): active down state specificity

### DIFF
--- a/components/switch/index.css
+++ b/components/switch/index.css
@@ -229,7 +229,7 @@
 		border-color: var(--highcontrast-switch-border-color-hover, var(--mod-switch-border-color-hover, var(--spectrum-switch-border-color-hover)));
 	}
 
-	.spectrum-Switch:active & {
+	.spectrum-Switch.spectrum-Switch:active & {
 		border-color: var(--highcontrast-switch-border-color-down, var(--mod-switch-border-color-down, var(--spectrum-switch-border-color-down)));
 	}
 
@@ -246,7 +246,7 @@
 			border-color: var(--highcontrast-switch-border-color-selected-hover, var(--mod-switch-border-color-selected-hover, var(--spectrum-switch-border-color-selected-hover)));
 		}
 
-		.spectrum-Switch:active & {
+		.spectrum-Switch.spectrum-Switch:active & {
 			background-color: var(--highcontrast-switch-background-color-selected-down, var(--mod-switch-background-color-selected-down, var(--spectrum-switch-background-color-selected-down)));
 			border-color: var(--highcontrast-switch-border-color-selected-down, var(--mod-switch-border-color-selected-down, var(--spectrum-switch-border-color-selected-down)));
 		}
@@ -283,7 +283,7 @@
 			background-color: var(--highcontrast-switch-handle-background-color-hover, var(--mod-switch-handle-background-color-hover, var(--spectrum-switch-handle-background-color-hover)));
 		}
 
-		.spectrum-Switch:active & {
+		.spectrum-Switch.spectrum-Switch:active & {
 			background-color: var(--highcontrast-switch-handle-background-color-down, var(--mod-switch-handle-background-color-down, var(--spectrum-switch-handle-background-color-down)));
 		}
 


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->
[CSS-1176](https://jira.corp.adobe.com/secure/RapidBoard.jspa?rapidView=43656&projectKey=CSS&view=detail&selectedIssue=CSS-1176#)

RE

> This looks like the regression was caused by the postcss plugin that adds @media (hover: hover). In the dist, it moves the hover CSS near the end off the CSS, changing its intended specificity from where it appears in the code; :hover is written to be before :active and I can see that the active state works correctly if postcss-hover-media-feature is temporarily disabled. 

- Adds specificity to active down state to maintain active down state styles when active.

Note:We should consider conducting an audit to check for any additional hover specificity regressions introduced by this plugin.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](http://localhost:8080/?path=/story/components-accordion--default) for the switch component:
    - [ ] Verify the active state color is applied when Switch is active. The active state color in S2 is the same color as the hover state but the active down state color should still be applied to support mods. 
    - [ ] Change active down mods to verify color change is being applied when Switch is active
-->

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [ ] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
