### PR TITLE
chore: revert renovate config to bump packages with updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -31,7 +31,6 @@
 			"matchPackageNames": ["stylelint", "stylelint-**"]
 		}
 	],
-	"bumpVersion": "patch",
 	"rebaseWhen": "behind-base-branch",
 	"reviewers": ["team:spectrum-css-maintainers"]
 }


### PR DESCRIPTION
This update did not function as we expected. The setting in question is now attempting to bump the version of our repo's packages when dependencies are updated.