### PR TITLE
fix(link): fixes keyboard focus shift by changing padding to outline-offset

### DIFF
--- a/.changeset/lovely-geckos-hammer.md
+++ b/.changeset/lovely-geckos-hammer.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/link": minor
+---
+
+Fixes keyboard focus shift by changing padding to outline-offset

--- a/components/link/index.css
+++ b/components/link/index.css
@@ -64,7 +64,7 @@
 		--mod-link-text-color: var(--mod-link-text-color-focus, var(--spectrum-accent-content-color-key-focus));
 
 		outline: var(--spectrum-link-focus-indicator-thickness) solid var(--highcontrast-link-focus-indicator-color, var(--spectrum-link-focus-indicator-color));
-		padding: var(--spectrum-link-focus-indicator-gap);
+		outline-offset: var(--spectrum-link-focus-indicator-gap);
 		border-radius: var(--spectrum-link-corner-radius);
 	}
 


### PR DESCRIPTION
## Description

The previous implementation with padding would cause the component to shift when focused using the keyboard. Replacing `padding` with `outline-offset` resolves this issue.

## How and where has this been tested?

Verified locally in Storybook.

### Validation steps

1. Open the deployment link for this PR.
2. Navigate to the `link` component docs page.
3. Focus the link component using your keyboard.
4. Verify that the focused link state no longer causes a layout shift.

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
