### PR TITLE
chore(swatch): updates the add swatch icon to use the ui rather than workflow icon

### DIFF
--- a/.changeset/dirty-melons-look.md
+++ b/.changeset/dirty-melons-look.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/swatch": patch
+---
+
+Updates the add swatch icon to use the ui rather than workflow icon

--- a/components/swatch/stories/template.js
+++ b/components/swatch/stories/template.js
@@ -118,9 +118,14 @@ export const Template = ({
 							}, context)] : []),
 							...(isAddSwatch ? [Icon({
 								customClasses: [`${rootClass}-icon`],
-								setName: "workflow",
+								setName: "ui",
 								size,
-								iconName: "Add",
+								iconName: "Add" + ({
+									xs: "75",
+									s: "75",
+									m: "100",
+									l: "200",
+								}[size] || "100"),
 								useRef: false,
 							}, context)] : []),
 						]


### PR DESCRIPTION
## Description

When the `swatch` component was originally migrated we only had the `workflow` add icon. This updates the component to use the `ui` icon now that the latter is available.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
