### PR TITLE
chore: disable storybook updates via renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,18 +13,6 @@
 		{
 			"groupName": "storybook ecosystem",
 			"matchPackageNames": ["storybook", "@storybook/*", "@types/storybook*"],
-			"matchUpdateTypes": ["minor", "patch"]
-		},
-		{
-			"groupName": "storybook ecosystem (disabled)",
-			"matchPackageNames": [
-				"storybook",
-				"@storybook/*",
-				"@types/storybook*",
-				"@chromatic-com/storybook"
-			],
-			"matchUpdateTypes": ["major"],
-			"baseBranches": ["main"],
 			"enabled": false
 		},
 		{


### PR DESCRIPTION
## Description

Renovate is aggressively trying to get us to update our Storybook so I'm disabling this for now until we have time to debug the JSDoc issue fully.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] ✨ This pull request is ready to merge. ✨
