### PR TITLE
test(alertbanner): updates alertbanner test file to restore text and action button label control functionality

### DIFF
--- a/components/alertbanner/stories/alertbanner.stories.js
+++ b/components/alertbanner/stories/alertbanner.stories.js
@@ -61,7 +61,7 @@ export default {
 		isOpen: false,
 		variant: "neutral",
 		actionButtonText: "Action",
-		text: "Alert banner message. Use a short phrase to describe what's happening.",
+		text: "Your trial has expired",
 		showCloseButton: true,
 	},
 	parameters: {

--- a/components/alertbanner/stories/alertbanner.test.js
+++ b/components/alertbanner/stories/alertbanner.test.js
@@ -2,7 +2,7 @@ import { Variants } from "@spectrum-css/preview/decorators";
 import { Template } from "./template.js";
 
 export const AlertBannerGroup = Variants({
-	Template: Template,
+	Template,
 	TestTemplate: Template,
 	stateDirection: "column",
 	wrapperStyles: {


### PR DESCRIPTION
## Description

`CSS-1245`

This removes an unnecessary test template that was overriding the Storybook controls for the alert text, action button label and semantic variants. Removing this template restores the functionality of all said controls and the previously displayed, fixed variants can be viewed using the controls or testing preview.

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
