### PR TITLE
fix(azure-preview-workflow): update resource url to remove + use same token pattern

### DIFF
--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -131,7 +131,8 @@ jobs:
           AZURE_STORAGE_SAS_TOKEN: ${{ secrets.AZURE_STORAGE_SAS_TOKEN }}
           PR_HASH: ${{ steps.pr_hash.outputs.hash }}
         run: |
+          CLEAN_SAS_TOKEN=$(echo "${AZURE_STORAGE_SAS_TOKEN}" | tr -d '\n\r\t ')
           echo "Cleaning up deployment: ${PR_HASH}/"
-          azcopy remove "https://spectrumcss.z13.web.core.windows.net/\$web/${PR_HASH}/?${AZURE_STORAGE_SAS_TOKEN}" \
+          azcopy remove "https://spectrumcss.blob.core.windows.net/\$web/${PR_HASH}/?${CLEAN_SAS_TOKEN}" \
             --recursive || echo "Cleanup completed (some files may not exist)"
           echo "Cleanup completed for PR deployment: ${PR_HASH}/"

--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -28,6 +28,12 @@ permissions:
   contents: read
   pull-requests: write
 
+env:
+  AZCOPY_AUTO_LOGIN_TYPE: SPN
+  AZCOPY_SPA_APPLICATION_ID: ${{ secrets.AZURE_CLIENT_ID }}
+  AZCOPY_SPA_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+  AZCOPY_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+
 jobs:
   build_and_deploy_job:
     if: github.event_name == 'pull_request' && github.event.action != 'closed'
@@ -88,13 +94,11 @@ jobs:
       - name: Deploy to Azure Blob Storage
         id: deploy
         env:
-          AZURE_STORAGE_SAS_TOKEN: ${{ secrets.AZURE_STORAGE_SAS_TOKEN }}
           PR_HASH: ${{ steps.pr_hash.outputs.hash }}
         run: |
-          CLEAN_SAS_TOKEN=$(echo "${AZURE_STORAGE_SAS_TOKEN}" | tr -d '\n\r\t ')
           echo "Uploading Storybook to ${PR_HASH}"
           azcopy copy "/home/runner/work/spectrum-css/spectrum-css/dist/*" --log-level=INFO \
-            "https://spectrumcss.blob.core.windows.net/\$web/${PR_HASH}/?${CLEAN_SAS_TOKEN}" \
+            "https://spectrumcss.blob.core.windows.net/\$web/${PR_HASH}/" \
             --recursive \
             --from-to LocalBlob
           docs_url="https://spectrumcss.z13.web.core.windows.net/${PR_HASH}"
@@ -128,11 +132,9 @@ jobs:
           sudo mv azcopy /usr/local/bin/
       - name: Clean up PR deployment
         env:
-          AZURE_STORAGE_SAS_TOKEN: ${{ secrets.AZURE_STORAGE_SAS_TOKEN }}
           PR_HASH: ${{ steps.pr_hash.outputs.hash }}
         run: |
-          CLEAN_SAS_TOKEN=$(echo "${AZURE_STORAGE_SAS_TOKEN}" | tr -d '\n\r\t ')
           echo "Cleaning up deployment: ${PR_HASH}/"
-          azcopy remove "https://spectrumcss.blob.core.windows.net/\$web/${PR_HASH}/?${CLEAN_SAS_TOKEN}" \
+          azcopy remove "https://spectrumcss.blob.core.windows.net/\$web/${PR_HASH}/" \
             --recursive || echo "Cleanup completed (some files may not exist)"
           echo "Cleanup completed for PR deployment: ${PR_HASH}/"


### PR DESCRIPTION
## Description

`CSS-1249`

<mark>Verified: closed this PR, checked Azure admin and clean up succeeded. Pertinent run: https://github.com/adobe/spectrum-css/actions/runs/15861350315</mark>

- [x] Fixes failing removal portion of job by correcting URL param for remove command.
- [x] Carries over logic from deploy step to clean and apply token when running remove command.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
