### PR TITLE
fix(lint-staged): remove conflicting flag for prettier command

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,7 +1,7 @@
 module.exports = {
 	"*.css": [
 		"stylelint --fix --cache --allow-empty-input --report-descriptionless-disables --report-invalid-scope-disables --report-needless-disables",
-		"prettier --no-config --no-error-on-unmatched-pattern --ignore-unknown --log-level silent --write --config .prettierrc",
+		"prettier --no-error-on-unmatched-pattern --ignore-unknown --log-level silent --write --config .prettierrc",
 	],
 	"*.{js,json},!package.json": [
 		"eslint --fix --cache --no-error-on-unmatched-pattern"


### PR DESCRIPTION
## Description

This fixes the `prettier` portion of our lint stage hooked by removing the `--no-config` flag that conflicts with the final `--config .prettierrc` flag.

## How and where has this been tested?

Verified by removing the flag in question and running a test commit.

### Validation steps

1. Pull down the branch.
2. Install project dependencies using `yarn`.
3. Make a small change to a `*.css` file.
4. Commit the file to verify the lint-staged hook runs successfully.
5. Reset your branch. Do not push the change.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
