### PR TITLE
fix(tooltip,textfield,sidenav): update deprecated css

### DIFF
--- a/.changeset/chubby-mirrors-wish.md
+++ b/.changeset/chubby-mirrors-wish.md
@@ -1,0 +1,6 @@
+---
+"@spectrum-css/sidenav": patch
+"@spectrum-css/tooltip": patch
+---
+
+Replace deprecated `word-break: break-word` with `overflow-wrap: break-word` to align with modern CSS standards and improve cross-browser compatibility. This property was deprecated in Chrome 44 (July 2015) in favor of the standardized `overflow-wrap` property.

--- a/components/sidenav/index.css
+++ b/components/sidenav/index.css
@@ -216,6 +216,9 @@
 	.spectrum-SideNav-link-text {
 		margin-block-start: var(--mod-sidenav-top-to-label, var(--spectrum-sidenav-top-to-label));
 		margin-block-end: var(--mod-sidenav-bottom-to-label, var(--spectrum-sidenav-bottom-to-label));
+
+		/* Allow overflow-wrap to work and prevent text overflow */
+		inline-size: 100%;
 	}
 
 	.spectrum-Icon {

--- a/components/sidenav/index.css
+++ b/components/sidenav/index.css
@@ -189,7 +189,7 @@
 	display: inline-flex;
 	justify-content: start;
 	box-sizing: border-box;
-	word-break: break-word;
+	overflow-wrap: break-word;
 	hyphens: auto;
 	cursor: pointer;
 	transition:

--- a/components/tooltip/index.css
+++ b/components/tooltip/index.css
@@ -301,6 +301,9 @@
 	line-height: var(--mod-tooltip-line-height, var(--spectrum-tooltip-line-height));
 	margin-block-start: var(--mod-tooltip-spacing-block-start, var(--spectrum-tooltip-spacing-block-start));
 	margin-block-end: var(--mod-tooltip-spacing-block-end, var(--spectrum-tooltip-spacing-block-end));
+
+	/* Allow overflow-wrap to work and prevent text overflow */
+	inline-size: 100%;
 }
 
 /****** Tooltip Placement and Animation Direction ******/

--- a/components/tooltip/index.css
+++ b/components/tooltip/index.css
@@ -87,7 +87,7 @@
 	font-size: var(--mod-tooltip-font-size, var(--spectrum-tooltip-font-size));
 	font-weight: var(--mod-tooltip-font-weight, var(--spectrum-tooltip-font-weight));
 	line-height: var(--mod-tooltip-line-height, var(--spectrum-tooltip-line-height));
-	word-break: break-word;
+	overflow-wrap: break-word;
 	-webkit-font-smoothing: antialiased;
 
 	cursor: default;


### PR DESCRIPTION
## Description

_[Aligns with PR](https://github.com/adobe/spectrum-web-components/pull/5504) by @castastrophe on SWC_

Replace deprecated `word-break: break-word` with `overflow-wrap: break-word` to align with modern CSS standards and improve cross-browser compatibility. This property was deprecated in Chrome 44 (July 2015) in favor of the standardized [overflow-wrap](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap) property.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [ ] [Review tooltip](https://spectrumcss.z13.web.core.windows.net/pr-4044/index.html?path=/docs/components-tooltip--docs) and modify the content property to add a long enough text string that needs to break, and ensure it doesn't cause layout overflow
- [ ] [Review sidenav](https://spectrumcss.z13.web.core.windows.net/pr-4044/index.html?path=/docs/components-side-nav--docs) and modify the content of a link to add a long enough text string that needs to break, and ensure it doesn't cause layout overflow

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] I have tested these changes in Windows High Contrast mode.
- [x] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
