### PR TITLE
chore: block major renovate bumps on main branch

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,6 +11,11 @@
 	"rangeStrategy": "bump",
 	"packageRules": [
 		{
+			"matchUpdateTypes": ["major"],
+			"matchBaseBranches": ["main"],
+			"enabled": false
+		},
+		{
 			"groupName": "storybook ecosystem",
 			"matchPackageNames": ["storybook", "@storybook/*", "@types/storybook*"],
 			"enabled": false


### PR DESCRIPTION
## Description

Currently, Renovate bot opens PRs against main with proposed breaking change updates to our dependencies. I think we should block those changes for now while we continue to focus on our spectrum-two efforts.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
