### PR TITLE
docs(.git*): removes remaining reference(s) to Netlify in the codebase

### DIFF
--- a/.github/GUIDE.md
+++ b/.github/GUIDE.md
@@ -66,7 +66,7 @@ Runs stylelint or eslint if any relevant assets have been updated in this PR.
 
 ##### 📝 Publish documentation site
 
-After the build and visual regression tests have passed, this will build the documentation site and publish it to Netlify.
+After the build and visual regression tests have passed, this will build the documentation site and publish it to Azure.
 
 ##### 📸 Visual regression testing
 
@@ -92,7 +92,7 @@ Builds the `main` branch and outputs the compiled assets as artifacts.
 
 ##### 📝 2. Publish site
 
-Publish the documentation site to Netlify.
+Publish the documentation site to Azure.
 
 ##### 📸 3. Visual regression testing
 

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -5,7 +5,7 @@ name:
     # - Build the base branch and the PR branch
     # - Compare the compiled output of the two branches
     # - Run visual regression tests on the PR branch
-    # - Publish the PR branch to Netlify for review
+    # - Publish the PR branch to Azure for review
     # -------------------------------------------------------------
 
 on:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -4,7 +4,7 @@ name: Build and verify production
     # - Build the main branch
     # - Report on the compiled output
     # - Run visual regression tests
-    # - Publish the PR branch to Netlify
+    # - Publish the PR branch to Azure
     # -------------------------------------------------------------
 
 on:
@@ -58,8 +58,8 @@ jobs:
         secrets: inherit
 
     # -------------------------------------------------------------
-    # PUBLISH TO NETLIFY --- #
-    # Publish to netlify by leveraging the previous build and then building the site as well
+    # PUBLISH TO AZURE --- #
+    # Publish to azure by leveraging the previous build and then building the site as well
     # -------------------------------------------------------------
     publish_site:
         name: Publish

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 # Not committing the map assets, these are dev-only
 *.map
 
-# Recommended update re:https://docs.netlify.com/integrations/frameworks/eleventy/
+# Not committing node_modules
 **/node_modules/**
 
 temp


### PR DESCRIPTION
## Description

`CSS-1263`

Minor documentation and comment changes to remove lingering Netlify references on the `spectrum-two` branch. Netlify is changed to Azure where appropriate and a comment in the `.gitignore` was updated as, while the rule is still valid, we haven't used 11ty for documentation in some time.

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [ ] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
