### PR TITLE
fix(search): remove duplicate isdisabled arg

### DIFF
--- a/components/search/stories/template.js
+++ b/components/search/stories/template.js
@@ -41,13 +41,12 @@ export const Template = ({
 			ActionButton({
 				iconName: "Search",
 				isDisabled,
+				isHovered,
 				size,
 				isFocused: !isDisabled && (isFocused || isKeyboardFocused),
 				isQuiet: true,
 				customClasses: [
 					`${rootClass}-actionButton`,
-					isHovered && "is-hover",
-					isDisabled && "is-disabled",
 				],
 				onclick: () => {
 					updateArgs({ isCollapsed: !isCollapsed });


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

I noticed there were accidentally 2 `isDisabled` arguments passed to the action button subcomponent found within the collapsed search field.

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

- [ ] Pull down the branch to run locally or [visit the deploy preview](https://spectrumcss.z13.web.core.windows.net/pr-4136/index.html?path=/).
- [ ] In the `search/stories/template.js` file, verify there is only one `isDisabled` argument passed to the nested `ActionButton`. 
    - [ ] The line `isDisabled && "is-disabled"` has been removed from the customClasses object, in favor of passing `isDisabled` a single time to action button.

#### Additional validation
- [ ] [Navigate to the default search field story page](https://spectrumcss.z13.web.core.windows.net/pr-4136/index.html?path=/story/components-search-field--default) and toggle the `isCollapsed` and `isDisabled` args to `true`.
- [ ] With the `TAB` key, attempt to focus on the collapsed search field's action button.
- [ ] Verify that the blue focus indicator is not visible.
- [ ] Verify no visual regressions have been introduced.

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [ ] ✨ This pull request is ready to merge. ✨
