### PR TITLE
chore: update renovate to refresh lockfile 1x a month

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -37,5 +37,9 @@
 		}
 	],
 	"rebaseWhen": "behind-base-branch",
-	"reviewers": ["team:spectrum-css-maintainers"]
+	"reviewers": ["team:spectrum-css-maintainers"],
+	"lockFileMaintenance": {
+		"enabled": true,
+		"extends": ["schedule:monthly"]
+	}
 }


### PR DESCRIPTION
## Description

This update adds monthly lockfile maintenance to Renovate configuration to ensure dependency lockfiles are regularly refreshed. The primary goal is to keep `caniusedb` and other indirect dependencies up-to-date, even when they're not direct project dependencies.

## Motivation and context

Lockfiles can become stale over time, especially for indirect dependencies like `caniusedb` that are pulled in by other packages. By enabling monthly lockfile maintenance, we ensure that:

- Indirect dependencies are regularly updated to their latest compatible versions
- Security vulnerabilities in transitive dependencies are addressed more promptly
- Build consistency is maintained across different environments
- The project benefits from performance improvements and bug fixes in underlying packages

This change helps maintain the overall health and security of the dependency tree without requiring manual intervention.

## Author's checklist

- [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
- [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [x] I have added automated tests to cover my changes.
- [x] I have included a well-written changeset if my change needs to be published.
- [x] I have included updated documentation if my change required it.

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] Verify Renovate configuration is valid

    1. Go to the `.github/renovate.json` file
    2. Check that the `lockFileMaintenance` section is properly configured
    3. Expect monthly scheduling to be enabled

- [ ] Confirm lockfile maintenance behavior

    1. Wait for the next monthly Renovate run
    2. Check that lockfiles are updated appropriately
    3. Expect `caniusedb` and other indirect dependencies to be refreshed
