### PR TITLE
fix(accordion): clean up spacing issues

### DIFF
--- a/.changeset/sweet-badgers-melt.md
+++ b/.changeset/sweet-badgers-melt.md
@@ -1,0 +1,5 @@
+---
+"@spectrum-css/accordion": minor
+---
+
+Changes values of `--spectrum-accordion-item-minimum-height` to align more closely with design spec, this affects the minimum height of accordion items for some combinations of size/density by giving them more space.

--- a/.changeset/sweet-badgers-melt.md
+++ b/.changeset/sweet-badgers-melt.md
@@ -3,3 +3,12 @@
 ---
 
 Changes values of `--spectrum-accordion-item-minimum-height` to align more closely with design spec, this affects the minimum height of accordion items for some combinations of size/density by giving them more space.
+
+New accordion minimum heights will use the heights/tokens:
+
+| Size | Compact                     | Regular                     | Spacious                    |
+| ---- | --------------------------- | --------------------------- | --------------------------- |
+| S    | 24px/`component-height-75`  | 32px/`component-height-100` | 40px/`component-height-200` |
+| M    | 32px/`component-height-100` | 40px/`component-height-200` | 48px/`component-height-300` |
+| L    | 40px/`component-height-200` | 48px/`component-height-300` | 56px/`component-height-400` |
+| XL   | 48px/`component-height-300` | 56px/`component-height-400` | 64px/`component-height-500` |

--- a/components/accordion/dist/metadata.json
+++ b/components/accordion/dist/metadata.json
@@ -193,7 +193,7 @@
     "--spectrum-component-height-200",
     "--spectrum-component-height-300",
     "--spectrum-component-height-400",
-    "--spectrum-component-height-50",
+    "--spectrum-component-height-500",
     "--spectrum-component-height-75",
     "--spectrum-corner-radius-medium-size-extra-large",
     "--spectrum-corner-radius-medium-size-large",

--- a/components/accordion/index.css
+++ b/components/accordion/index.css
@@ -334,7 +334,7 @@
 
 	&:has(+ .spectrum-Accordion-itemDirectActions) {
 		/* set spacing between header and direct actions, whether or not noInlinePadding variant is used */
-		padding-inline-end: var(--mod-accordion-item-header-to-direct-actions-space, var(--spectrum-accordion-item-header-to-direct-actions-space));
+		margin-inline-end: var(--mod-accordion-item-header-to-direct-actions-space, var(--spectrum-accordion-item-header-to-direct-actions-space));
 	}
 }
 

--- a/components/accordion/index.css
+++ b/components/accordion/index.css
@@ -13,7 +13,7 @@
 
 .spectrum-Accordion {
 	/* Layout and spacing */
-	--spectrum-accordion-item-minimum-height: var(--spectrum-component-height-100);
+	--spectrum-accordion-item-minimum-height: var(--spectrum-component-height-200);
 	--spectrum-accordion-item-minimum-width: var(--spectrum-accordion-minimum-width);
 	--spectrum-accordion-item-width: var(--spectrum-field-default-width-medium);
 	--spectrum-accordion-disclosure-indicator-height: var(--spectrum-chevron-icon-size-100);
@@ -93,7 +93,7 @@
 }
 
 .spectrum-Accordion--sizeS {
-	--spectrum-accordion-item-minimum-height: var(--spectrum-component-height-75);
+	--spectrum-accordion-item-minimum-height: var(--spectrum-component-height-100);
 	--spectrum-accordion-item-width: var(--spectrum-accordion-minimum-width); /* small size default width uses this min-width token */
 	--spectrum-accordion-disclosure-indicator-height: var(--spectrum-chevron-icon-size-75);
 	--spectrum-accordion-disclosure-indicator-to-text-space: var(--spectrum-accordion-disclosure-indicator-to-text-small);
@@ -110,7 +110,7 @@
 }
 
 .spectrum-Accordion--sizeL {
-	--spectrum-accordion-item-minimum-height: var(--spectrum-component-height-200);
+	--spectrum-accordion-item-minimum-height: var(--spectrum-component-height-300);
 	--spectrum-accordion-item-width: var(--spectrum-field-default-width-large);
 	--spectrum-accordion-disclosure-indicator-height: var(--spectrum-chevron-icon-size-200);
 	--spectrum-accordion-disclosure-indicator-to-text-space: var(--spectrum-accordion-disclosure-indicator-to-text-large);
@@ -127,7 +127,7 @@
 }
 
 .spectrum-Accordion--sizeXL {
-	--spectrum-accordion-item-minimum-height: var(--spectrum-component-height-300);
+	--spectrum-accordion-item-minimum-height: var(--spectrum-component-height-400);
 	--spectrum-accordion-item-width: var(--spectrum-field-default-width-extra-large);
 	--spectrum-accordion-disclosure-indicator-height: var(--spectrum-chevron-icon-size-300);
 	--spectrum-accordion-disclosure-indicator-to-text-space: var(--spectrum-accordion-disclosure-indicator-to-text-extra-large);
@@ -144,27 +144,27 @@
 }
 
 .spectrum-Accordion--compact {
-	--spectrum-accordion-item-minimum-height: var(--spectrum-component-height-75);
+	--spectrum-accordion-item-minimum-height: var(--spectrum-component-height-100);
 	--spectrum-accordion-item-header-top-to-text-space: var(--spectrum-accordion-top-to-text-compact-medium);
 	--spectrum-accordion-item-header-bottom-to-text-space: var(--spectrum-accordion-bottom-to-text-compact-medium);
 	--spectrum-accordion-top-to-disclosure-indicator: var(--spectrum-field-top-to-disclosure-icon-compact-medium);
 
 	&.spectrum-Accordion--sizeS {
-		--spectrum-accordion-item-minimum-height: var(--spectrum-component-height-50);
+		--spectrum-accordion-item-minimum-height: var(--spectrum-component-height-75);
 		--spectrum-accordion-item-header-top-to-text-space: var(--spectrum-accordion-top-to-text-compact-small);
 		--spectrum-accordion-item-header-bottom-to-text-space: var(--spectrum-accordion-bottom-to-text-compact-small);
 		--spectrum-accordion-top-to-disclosure-indicator: var(--spectrum-field-top-to-disclosure-icon-compact-small);
 	}
 
 	&.spectrum-Accordion--sizeL {
-		--spectrum-accordion-item-minimum-height: var(--spectrum-component-height-100);
+		--spectrum-accordion-item-minimum-height: var(--spectrum-component-height-200);
 		--spectrum-accordion-item-header-top-to-text-space: var(--spectrum-accordion-top-to-text-compact-large);
 		--spectrum-accordion-item-header-bottom-to-text-space: var(--spectrum-accordion-bottom-to-text-compact-large);
 		--spectrum-accordion-top-to-disclosure-indicator: var(--spectrum-field-top-to-disclosure-icon-compact-large);
 	}
 
 	&.spectrum-Accordion--sizeXL {
-		--spectrum-accordion-item-minimum-height: var(--spectrum-component-height-200);
+		--spectrum-accordion-item-minimum-height: var(--spectrum-component-height-300);
 		--spectrum-accordion-item-header-top-to-text-space: var(--spectrum-accordion-top-to-text-compact-extra-large);
 		--spectrum-accordion-item-header-bottom-to-text-space: var(--spectrum-accordion-bottom-to-text-compact-extra-large);
 		--spectrum-accordion-top-to-disclosure-indicator: var(--spectrum-field-top-to-disclosure-icon-compact-extra-large);
@@ -172,27 +172,27 @@
 }
 
 .spectrum-Accordion--spacious {
-	--spectrum-accordion-item-minimum-height: var(--spectrum-component-height-200);
+	--spectrum-accordion-item-minimum-height: var(--spectrum-component-height-300);
 	--spectrum-accordion-item-header-top-to-text-space: var(--spectrum-accordion-top-to-text-spacious-medium);
 	--spectrum-accordion-item-header-bottom-to-text-space: var(--spectrum-accordion-bottom-to-text-spacious-medium);
 	--spectrum-accordion-top-to-disclosure-indicator: var(--spectrum-field-top-to-disclosure-icon-spacious-medium);
 
 	&.spectrum-Accordion--sizeS {
-		--spectrum-accordion-item-minimum-height: var(--spectrum-component-height-100);
+		--spectrum-accordion-item-minimum-height: var(--spectrum-component-height-200);
 		--spectrum-accordion-item-header-top-to-text-space: var(--spectrum-accordion-top-to-text-spacious-small);
 		--spectrum-accordion-item-header-bottom-to-text-space: var(--spectrum-accordion-bottom-to-text-spacious-small);
 		--spectrum-accordion-top-to-disclosure-indicator: var(--spectrum-field-top-to-disclosure-icon-spacious-small);
 	}
 
 	&.spectrum-Accordion--sizeL {
-		--spectrum-accordion-item-minimum-height: var(--spectrum-component-height-300);
+		--spectrum-accordion-item-minimum-height: var(--spectrum-component-height-400);
 		--spectrum-accordion-item-header-top-to-text-space: var(--spectrum-accordion-top-to-text-spacious-large);
 		--spectrum-accordion-item-header-bottom-to-text-space: var(--spectrum-accordion-bottom-to-text-spacious-large);
 		--spectrum-accordion-top-to-disclosure-indicator: var(--spectrum-field-top-to-disclosure-icon-spacious-large);
 	}
 
 	&.spectrum-Accordion--sizeXL {
-		--spectrum-accordion-item-minimum-height: var(--spectrum-component-height-400);
+		--spectrum-accordion-item-minimum-height: var(--spectrum-component-height-500);
 		--spectrum-accordion-item-header-top-to-text-space: var(--spectrum-accordion-top-to-text-spacious-extra-large);
 		--spectrum-accordion-item-header-bottom-to-text-space: var(--spectrum-accordion-bottom-to-text-spacious-extra-large);
 		--spectrum-accordion-top-to-disclosure-indicator: var(--spectrum-field-top-to-disclosure-icon-spacious-extra-large);

--- a/components/accordion/index.css
+++ b/components/accordion/index.css
@@ -272,6 +272,12 @@
 }
 
 .spectrum-Accordion-itemTitle {
+	/* if we use min-height token, sometimes we'll have extra space so we'll need to center the text vertically */
+	display: flex;
+	align-items: center;
+
+	min-block-size: var(--mod-accordion-item-min-block-size, var(--spectrum-accordion-item-min-block-size));
+	box-sizing: border-box; /* respect min-block-size but include padding */
 	padding-block: var(--mod-accordion-item-header-top-to-text-space, var(--spectrum-accordion-item-header-top-to-text-space)) var(--mod-accordion-item-header-bottom-to-text-space, var(--spectrum-accordion-item-header-bottom-to-text-space));
 	padding-inline-end: var(--mod-accordion-edge-to-text-space, var(--spectrum-accordion-edge-to-text-space));
 }

--- a/components/accordion/stories/accordion.stories.js
+++ b/components/accordion/stories/accordion.stories.js
@@ -160,7 +160,7 @@ CustomWidth.args = {
 	},
 };
 CustomWidth.parameters = {
-	chromatic: { disableSnapshot: false },
+	chromatic: { disableSnapshot: true },
 };
 
 /**
@@ -201,6 +201,9 @@ export const DirectActions = Template.bind({});
 DirectActions.tags = ["!dev"];
 DirectActions.args = {
 	items: directActionsContent
+};
+DirectActions.parameters = {
+	chromatic: { disableSnapshot: true },
 };
 
 /**

--- a/components/accordion/stories/accordion.stories.js
+++ b/components/accordion/stories/accordion.stories.js
@@ -149,6 +149,11 @@ WithForcedColors.parameters = {
 /**
  * Accordion items have a default width for each size, but a custom width can also be set to any
  * width that meets or exceeds the minimum width.
+ *
+ * This example also uses the body typography element with class `.spectrum-Body` for the
+ * accordion item's content. If using typography, the t-shirt size of the typography element
+ * may need to be adjusted to match the accordion item's font size. The body typography component
+ * shown here is a size "S," in contrast with the the accordion's "M" size.
  */
 export const CustomWidth = AccordionGroup.bind({});
 CustomWidth.tags = ["!dev"];

--- a/components/accordion/stories/accordion.test.js
+++ b/components/accordion/stories/accordion.test.js
@@ -16,39 +16,20 @@ export const testsContent = new Map([
 	[
 		"Architecture",
 		{
-			content: Typography({
-				semantics: "body",
-				content: [
-					"This is an example of text content within the content area that uses the spectrum-Body typography class on the paragraphs. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit.",
-					Link({
-						url: "https://www.adobe.com/creativecloud/plans.html",
-						text: "Learn more about Adobe Creative Cloud plans and pricing.",
-					}),
-				],
-			}),
+			content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit. Sed finibus dapibus diam et sollicitudin. Phasellus in ipsum nec ante elementum congue eget in leo. Morbi eleifend justo non rutrum venenatis. Fusce cursus et lectus eu facilisis. Ut laoreet felis in magna dignissim feugiat.",
 			isOpen: true,
 		},
 	],
 	[
 		"Nature",
 		{
-			content: Typography({
-				semantics: "body",
-				content: [
-					"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit. Sed finibus dapibus diam et sollicitudin. Phasellus in ipsum nec ante elementum congue eget in leo. Morbi eleifend justo non rutrum venenatis. Fusce cursus et lectus eu facilisis. Ut laoreet felis in magna dignissim feugiat.",
-					Link({
-						url: "https://www.adobe.com/acrobat.html",
-						text: "Learn more about Acrobat.",
-					}),
-				],
-			}),
+			content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit. Sed finibus dapibus diam et sollicitudin. Phasellus in ipsum nec ante elementum congue eget in leo. Morbi eleifend justo non rutrum venenatis. Fusce cursus et lectus eu facilisis. Ut laoreet felis in magna dignissim feugiat.",
 		},
 	],
 	[
 		"Illustrations",
 		{
-			content: "This is an example of text content within the content area that is not wrapped by any typography classes or elements. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit.",
-			isOpen: true,
+			content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eleifend est mollis ligula lobortis, tempus ultricies sapien lacinia. Nulla ut turpis velit. Sed finibus dapibus diam et sollicitudin. Phasellus in ipsum nec ante elementum congue eget in leo. Morbi eleifend justo non rutrum venenatis. Fusce cursus et lectus eu facilisis. Ut laoreet felis in magna dignissim feugiat.",
 		},
 	],
 	[
@@ -80,9 +61,10 @@ export const longerContent = new Map([
 		"Are Adobe products worth it?",
 		{
 			content: Typography({
+				size: "s",
 				semantics: "body",
 				content: [
-					"This is an example of text content within the content area that uses the spectrum-Body typography class on the paragraphs. Adobe makes some of the most widely used software applications in the world, many of which are industry standard.",
+					"Adobe makes some of the most widely used software applications in the world, many of which are industry standard. Get started with free apps like Adobe Acrobat Reader, Aero, Fill & Sign, Photoshop Express, and Adobe Scan. Or consider Creative Cloud, with plans starting at just US$9.99/mo. Every Adobe Creative Cloud plan includes perks like free stock images and fonts, collaboration tools, and cloud storage as well as regular feature updates to deliver the latest technology.",
 					Link({
 						url: "https://www.adobe.com/creativecloud/plans.html",
 						text: "Learn more about Adobe Creative Cloud plans and pricing.",
@@ -96,6 +78,7 @@ export const longerContent = new Map([
 		"Which Adobe product is best for editing PDFs?",
 		{
 			content: Typography({
+				size: "s",
 				semantics: "body",
 				content: [
 					"You can edit PDFs with Adobe Acrobat, which is available in two editions: Standard and Pro. Acrobat Standard provides basic tools to create, edit, and sign PDFs on Windows devices. Acrobat Pro is the complete PDF solution with tools to edit, convert, and sign PDFs across web, mobile, and tablet, as well as on Windows and macOS computers. If you'd like to try before you buy, you can get a free 7-day trial of Acrobat Pro.",
@@ -110,14 +93,14 @@ export const longerContent = new Map([
 	[
 		"How many products does Adobe have?",
 		{
-			content: "This is an example of text content within the content area that is not wrapped by any typography classes or elements. Adobe offers nearly 100 products. Get creative with industry-standard apps like Adobe Photoshop, Illustrator InDesign, and Lightroom. Create, edit, and sign PDFs with Adobe Acrobat and Acrobat Sign. And deliver exceptional customer experiences with our marketing and commerce apps such as Adobe Experience Manager, Campaign, and Target.",
+			content: "Adobe offers nearly 100 products. Get creative with industry-standard apps like Adobe Photoshop, Illustrator, InDesign, and Lightroom. Create, edit, and sign PDFs with Adobe Acrobat and Acrobat Sign. And deliver exceptional customer experiences with our marketing and commerce apps such as adobe experience manager, Campaign, and Target.",
 			isOpen: true,
 		},
 	],
 	[
 		"What are the most popular Adobe products?",
 		{
-			content: "This is an example of text content within the content area that is not wrapped by any typography classes or elements. Adobe makes some of the most widely used software in the world, including popular apps like Acrobat Pro, Photoshop, Illustrator, InDesign, Lightroom, and Premiere Pro.",
+			content: "Adobe makes some of the most widely used software in the world, including popular apps like Acrobat Pro, Photoshop, Illustrator, InDesign, Lightroom, and Premiere Pro.",
 		},
 	],
 ]);


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description
Resolves the previous issue with accordion where, when the action button was added to an item's direct actions area, the action button was taller than the accordion item's height. (This was only an issue with compact XL.)
<img width="261" height="63" alt="image" src="https://github.com/user-attachments/assets/87c06bac-c1ae-4bdd-a4b5-d76b2f98a004" />

The updates made to accordion adjust the spacing tokens so that the action button always fits within the accordion item, although its focus outline may be outside of the accordion item (just as the accordion item's focus outline is outside of the item).
<img width="268" height="66" alt="image" src="https://github.com/user-attachments/assets/6b75332d-db59-4f86-a96f-af8e89ca1315" />

After confirming with design, the tokens used for minimum height have been updated to be more spacious, which better matches the designs. Note that these tokens aren't always used; there is a calculation that sets the min height to the maximum between the token or the sum of the space needed (top & bottom padding + font-size * line-height) to ensure that the accordion item always has enough space even with adjustments to padding, font-size, or line-height.

Since accordion items have more space, some adjustments were also made to center the accordion's itemTitle vertically.

Also addresses a small issue with the hover/key focus state where the itemTitle extends to the edge of the direct actions, this was more noticeable if there was a switch direct action, but not an action button:
Before:
<img width="256" height="57" alt="image" src="https://github.com/user-attachments/assets/3b19a988-4dbf-4d79-9465-debe6be51d08" />
<img width="255" height="62" alt="image" src="https://github.com/user-attachments/assets/9b721af9-f659-4053-9367-11451ed071ef" />
After:
<img width="258" height="65" alt="image" src="https://github.com/user-attachments/assets/4d4519cb-fd98-4e5e-bcbf-3af3858f7f14" />
<img width="258" height="69" alt="image" src="https://github.com/user-attachments/assets/6f8c24b8-f895-4082-b158-03b886b3e19a" />


CSS-1260

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->
Use the PR preview or check out the branch locally:
- [x] Check every combination of t-shirt size/density to confirm that minimum height looks as expected and items are centered/aligned vertically. (@cdransf)
- [x] Check hover state and key focus with switch direct action only to confirm that this looks as expected (@cdransf)
- [x] Check hover state and key focus with both direct actions (switch and action button) to confirm that this looks as expected (@cdransf)
- [x] Check hover state and key focus with no direct actions to confirm that this looks as expected (@cdransf)
- [x] If the line-height is adjusted (for instance if we switch to Japanese), the accordion item will make more space to accommodate that line height. Does this look ok? (It's occurred to me that this does throw the alignment of the disclosure icon off a little bit, are we ok with that for now or do we want to look more closely for a solution that will align the chevron and the text for this use case?) (@cdransf)
- [x] Are there any other items that might be helpful to address re: accordion while we're here? Do tests/documentation look good, for instance? (@cdransf)

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [x] VRTs have been run and looked at.
- [x] Any VRT changes have been accepted (by reviewer and/or PR author), <strike>or there are no changes</strike>.

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [ ] <strike>I have tested these changes in Windows High Contrast mode.</strike>
- [ ] <strike>If my change impacts **other components**, I have tested to make sure they don't break.</strike>
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
