### PR TITLE
docs(storybook): add documentation to filter s2 components

### DIFF
--- a/.storybook/guides/s2_migration.mdx
+++ b/.storybook/guides/s2_migration.mdx
@@ -13,6 +13,10 @@ import GrayMigrationGuide from "../assets/images/gray_migration-guide.png";
 - Search within: Use a search field with a separate control to filter the search instead.
 - Split button: Use a button group to show any additional actions related to the most critical action. Reference [Spectrum documentation](https://spectrum.corp.adobe.com/page/button-group/#Use-a-button-group-to-show-additional-actions) for more information.
 
+## Migrated components
+
+You can find a list of components that have been fully migrated to Spectrum 2 by filtering the components by the `migrated` tag. In the Storybook search field, click the filter button and select the `migrated` checkbox. The list of components should update to display only components that have been tagged as migrated.
+
 ## Grays
 
 <img


### PR DESCRIPTION
<!--
  Note: Before sending a pull request, ensure there's an issue filed for the change to track the work.
   - Search for (issues)[https://github.com/adobe/spectrum-css/issues]
   - If there's no issue, please [file it](https://github.com/adobe/spectrum-css/issues/new/choose) and tag @pfulton or @castastrophe for feedback.
-->
## Description

<!-- Describe what you changed and link to relevant issue(s) (e.g., #000) -->

This PR adds a small section of documentation regarding S2-migrated components. There is a built in filter in the Storybook toolbar for tags, so the docs point consumers to that filter.

<img width="390" height="181" alt="Screenshot 2025-08-25 at 11 23 33 AM" src="https://github.com/user-attachments/assets/779f19bb-54fb-4c42-9f8b-c64b919af371" />

### Jira/Specs
CSS-1259

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps
<!--
  Include steps for the PR reviewer that explain how they should test your PR. Example test outline:
  1. Open the [storybook](url) for the button component:
    - [ ] Hover over the button and validate the new hover background color is applied
    - [x] Click the button and validate the new active background color is applied [@castastrophe]
-->

- [x] Pull down the branch to run locally, or [visit the deploy preview](https://spectrumcss.z13.web.core.windows.net/pr-4155/index.html?path=/).
- [x] [Visit the "Migration Guide" page](https://spectrumcss.z13.web.core.windows.net/pr-4155/index.html?path=/docs/guides-migration-guide--docs).
- [x] Verify that the new "Migrated components" section is grammatically correct, and makes sense.
- [x] Follow the instructions in that ☝️ section. Verify that the list of components in the sidebar changes to the components that CSS has already migrated to S2. 
    - [x] There are 4 components that seem to be missing: accordion, action bar, clear button, combobox. This scope doesn't include investigating why those are not appearing in the migrated component list, when they all include the `type: "migrated"` and `status: { type: "migrated"}` code. 🤷‍♀️  

### Regression testing

Validate:

1. The documentation pages for at least two other components are still loading, including:

- [ ] The pages render correctly, are accessible, and are responsive.

2. If components have been modified, VRTs have been run on this branch:

- [ ] VRTs have been run and looked at.
- [ ] Any VRT changes have been accepted (by reviewer and/or PR author), or there are no changes.

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

<img width="731" height="184" alt="Screenshot 2025-08-25 at 11 22 04 AM" src="https://github.com/user-attachments/assets/f96a6322-266a-4037-8880-8eb327b1a408" />

## To-do list

<!-- Put an "x" to indicate you've done each of the following. Add/remove additional tasks, as needed. -->

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [ ] I have updated relevant storybook stories and templates.
- [ ] I have tested these changes in Windows High Contrast mode.
- [ ] If my change impacts **other components**, I have tested to make sure they don't break.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [ ] ✨ This pull request is ready to merge. ✨
