### PR TITLE
chore(spectrum-two): config ci updates

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -112,9 +112,7 @@ jobs:
                         - '*.md'
                         - .storybook/*.md
                         - .storybook/*/*.md
-                        - .storybook/*/*.mdx
                         - components/*/*.md
-                        - components/*/stories/*.mdx
                         - plugins/*/*.md
                         - tokens/*.md
                         - tools/*/*.md

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -116,10 +116,11 @@ jobs:
                   reporter: github-pr-review
                   filter_mode: diff_context
                 #   eslint_flags: "components/*/stories/*.js"
-                  eslint_flags: "${{ inputs.eslint_added_files }} ${{ inputs.eslint_modified_files }}"
+                  eslint_flags: "--config ${{ github.workspace }}/.eslintrc ${{ inputs.eslint_added_files }} ${{ inputs.eslint_modified_files }}"
 
             - name: Run markdownlint on documentation
               uses: reviewdog/action-markdownlint@v0.26.2
+              if: ${{ inputs.mdlint_added_files != '' || inputs.mdlint_modified_files != '' }}
               with:
                 reporter: github-pr-review
                 filter_mode: diff_context


### PR DESCRIPTION
## Description

A few minor CI updates for linting:

- Remove *.mdx files from markdownlint as they don't adhere to the same guidelines
- Add the eslint config
- Only run markdownlint if markdown files are present

## How and where has this been tested?

Please tag yourself on the tests you've marked complete to confirm the tests have been run by someone other than the author.

### Validation steps

- [x] I expect *.mdx files not to trigger the markdownlinter (@rise-erpelding)
- [x] I expect eslint to use the local .eslintrc configuration
- [x] I expect markdownlint to run only if *.md changes are present

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] ✨ This pull request is ready to merge. ✨
