### PR TITLE
chore(storybook): remove foundations snapshots

### DIFF
--- a/.storybook/foundations/corner-rounding/action-button-corner-rounding.stories.js
+++ b/.storybook/foundations/corner-rounding/action-button-corner-rounding.stories.js
@@ -96,3 +96,6 @@ const ActionButtonTable = (args, context) => {
 
 export const ActionButtonExamples = ActionButtonTable.bind({});
 ActionButtonExamples.args = {};
+ActionButtonExamples.parameters = {
+	chromatic: { disableSnapshot: true },
+};

--- a/.storybook/foundations/corner-rounding/checkbox-corner-rounding.stories.js
+++ b/.storybook/foundations/corner-rounding/checkbox-corner-rounding.stories.js
@@ -86,3 +86,6 @@ const CheckboxTable = (args, context) => {
 
 export const CheckboxExamples = CheckboxTable.bind({});
 CheckboxExamples.args = {};
+CheckboxExamples.parameters = {
+	chromatic: { disableSnapshot: true },
+};

--- a/.storybook/foundations/corner-rounding/corner-rounding.stories.js
+++ b/.storybook/foundations/corner-rounding/corner-rounding.stories.js
@@ -86,3 +86,6 @@ const CornerRadiusGroup = (args = {}, context = {}) => html`
 
 export const CornerRounding = CornerRadiusGroup.bind({});
 CornerRounding.args = {};
+CornerRounding.parameters = {
+	chromatic: { disableSnapshot: true },
+};

--- a/.storybook/foundations/down-state/button-down-state.stories.js
+++ b/.storybook/foundations/down-state/button-down-state.stories.js
@@ -25,3 +25,6 @@ ButtonDownState.args = {
 		"--spectrum-downstate-height": "32px"
 	}
 };
+ButtonDownState.parameters = {
+	chromatic: { disableSnapshot: true },
+};

--- a/.storybook/foundations/down-state/checkbox-down-state.stories.js
+++ b/.storybook/foundations/down-state/checkbox-down-state.stories.js
@@ -20,3 +20,6 @@ export const CheckboxDownState = Template.bind({});
 CheckboxDownState.args = {
 	label: "Checkbox",
 };
+CheckboxDownState.parameters = {
+	chromatic: { disableSnapshot: true },
+};

--- a/.storybook/foundations/drop-shadow/drop-shadow.stories.js
+++ b/.storybook/foundations/drop-shadow/drop-shadow.stories.js
@@ -57,11 +57,17 @@ DropShadowEmphasizedDefault.args = {
 	variant: "emphasized-default",
 	isDropShadow: true,
 };
+DropShadowEmphasizedDefault.parameters = {
+	chromatic: { disableSnapshot: true },
+};
 
 export const DropShadowEmphasizedHover = DropShadowVariant.bind({});
 DropShadowEmphasizedHover.args = {
 	variant: "emphasized-hover",
 	isDropShadow: true,
+};
+DropShadowEmphasizedHover.parameters = {
+	chromatic: { disableSnapshot: true },
 };
 
 export const DropShadowElevated = DropShadowVariant.bind({});
@@ -69,11 +75,17 @@ DropShadowElevated.args = {
 	variant: "elevated",
 	isDropShadow: true,
 };
+DropShadowElevated.parameters = {
+	chromatic: { disableSnapshot: true },
+};
 
 export const BoxShadowEmphasizedDefault = DropShadowVariant.bind({});
 BoxShadowEmphasizedDefault.args = {
 	variant: "emphasized-default",
 	isDropShadow: false,
+};
+BoxShadowEmphasizedDefault.parameters = {
+	chromatic: { disableSnapshot: true },
 };
 
 export const BoxShadowEmphasizedHover = DropShadowVariant.bind({});
@@ -81,9 +93,15 @@ BoxShadowEmphasizedHover.args = {
 	variant: "emphasized-hover",
 	isDropShadow: false,
 };
+BoxShadowEmphasizedHover.parameters = {
+	chromatic: { disableSnapshot: true },
+};
 
 export const BoxShadowElevated = DropShadowVariant.bind({});
 BoxShadowElevated.args = {
 	variant: "elevated",
 	isDropShadow: false,
+};
+BoxShadowElevated.parameters = {
+	chromatic: { disableSnapshot: true },
 };


### PR DESCRIPTION
## Description

I noticed we were taking a few baseline snapshots of our foundations documentation and since these concepts are being validated within the components and we don't ship the foundations code, I thought we could remove these from our baselines.

## To-do list

- [x] I have read the [contribution guidelines](/.github/CONTRIBUTING.md).
- [x] I have updated relevant storybook stories and templates.
- [x] If my change impacts **documentation**, I have updated the documentation accordingly.
- [x] ✨ This pull request is ready to merge. ✨
