### PR TITLE
chore: add minReleaseAge to renovate [SWC-1244]

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,6 +11,10 @@
 	"rangeStrategy": "bump",
 	"packageRules": [
 		{
+		"matchDatasources": ["npm"],
+		"minimumReleaseAge": "1 month"
+		},
+		{
 			"matchUpdateTypes": ["major"],
 			"matchBaseBranches": ["main"],
 			"enabled": false


### PR DESCRIPTION
## Description

Added `minimumReleaseAge` configuration to Renovate settings to prevent automatic updates to npm packages that are less than 1 month old. This configuration is applied specifically to npm datasource packages through the `packageRules` array in `.github/renovate.json`.

## Motivation and context

This change is required to maintain stability in our dependency ecosystem by preventing the automatic adoption of newly released packages that may contain bugs or breaking changes. By waiting 1 month before allowing updates to new packages, we give the community and maintainers time to identify and report issues, reducing the risk of introducing unstable dependencies into the project.

- Configuration added to prevent adoption of potentially unstable newly released packages
- Reduces risk of breaking changes from packages with insufficient testing time

## Related issue(s)

- SWC-1244

## Author's checklist

-   [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
-   [x] I have included updated documentation if my change required it.

## Reviewer's checklist

- [x] Includes a Github Issue with appropriate flag or Jira ticket number without a link

### Manual review test cases

- [TBD] Verify Renovate continues to propose updates for packages older than 1 month
    1. Go to Renovate dashboard
    2. Check that existing packages older than 1 month still receive updates
    3. Expect normal update behavior for mature packages

- [TBD] Confirm newly released packages (< 1 month old) are not automatically updated
    1. Check Renovate logs for recent package releases
    2. Verify that packages released within the last month are not updated
    3. Expect these packages to be skipped until they reach 1 month age

### Device review

- [x] Did it pass in Desktop?
- [x] Did it pass in (emulated) Mobile?
- [x] Did it pass in (emulated) iPad?