### PR TITLE
chore: add minReleaseAge to renovate [SWC-1244] (S2)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,6 +10,10 @@
 	"labels": ["dependencies", "skip_vrt", "ready-for-review"],
 	"packageRules": [
 		{
+			"matchDatasources": ["npm"],
+			"minimumReleaseAge": "1 month"
+		},
+		{
 			"matchUpdateTypes": ["major"],
 			"matchBaseBranches": ["main"],
 			"enabled": false


### PR DESCRIPTION
 have included updated documentation if my change required it.

## Reviewer's checklist

- [x] Includes a Github Issue with appropriate flag or Jira ticket number without a link

### Manual review test cases

- [TBD] Verify Renovate continues to propose updates for packages older than 1 month
    1. Go to Renovate dashboard
    2. Check that existing packages older than 1 month still receive updates
    3. Expect normal update behavior for mature packages

- [TBD] Confirm newly released packages (< 1 month old) are not automatically updated
    1. Check Renovate logs for recent package releases
    2. Verify that packages released within the last month are not updated
    3. Expect these packages to be skipped until they reach 1 month age
