### PR TITLE
ci: declare permissions on release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,10 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   release:
     name: Release


### PR DESCRIPTION
The `Release` workflow runs `changesets/action@v1`, which on `push` to `main`/`spectrum-two` either opens a "Release PR" (when there are unreleased changesets) or publishes packages to npm (when a release is being landed). Both paths use the workflow's `GITHUB_TOKEN` -- the action needs `contents: write` to push the release commit / tag and `pull-requests: write` to open and update the release PR.

This patch sets that minimum at workflow scope, matching the explicit permission blocks already declared by `build.yml` (`contents: read`, `pull-requests: write`), `publish-site.yml` (same shape), `release-snapshot.yml` (per-job `contents: write`, `id-token: write`), and the rest of the hardened workflows here. With it set:

- the workflow token can't be widened by a future change to the repo default
- the SLSA / OpenSSF Scorecard `Token-Permissions` check passes for this file
- if `changesets/action` or any reachable third-party action is ever compromised (cf. `tj-actions/changed-files` CVE-2025-30066), the explicit scope keeps it inside the contents + pull-requests boundary rather than whatever the default grants

The npm publish path uses `NPM_TOKEN` (external secret), so the workflow token doesn't need `packages:` scope for that.

No behavioural change.